### PR TITLE
Share the app directory across multiple programs 

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -62,12 +62,27 @@ def xdg_trinity_root(monkeypatch, tmpdir):
     """
     Ensure proper test isolation as well as protecting the real directories.
     """
-    dir_path = tmpdir.mkdir('trinity')
-    monkeypatch.setenv('XDG_TRINITY_ROOT', str(dir_path))
+    trinity_root_dir = str(tmpdir.mkdir('trinity'))
+
+    # The default path that pytest generates are too long to be allowed as
+    # IPC Paths (hard UNIX rule). We are shorten them from something like:
+    # /tmp/pytest-of-<username>/pytest-88/<test-name>_command1_0/trinity
+    # to /tmp/pyt-<username>/88/<test-name>_command1_0/trinity
+
+    fragment1 = 'pytest-of'
+    fragment2 = 'pytest-'
+    expected_fragments = (fragment1, fragment2)
+
+    # If pytest ever changes the tmpdir generation layout, this breaks and we adapt
+    is_expected_path = all(check_str in trinity_root_dir for check_str in expected_fragments)
+    assert is_expected_path, f"Unexpected pytest tmp dir: {trinity_root_dir}, expected fragments: {expected_fragments}"  # noqa: E501
+
+    trinity_root_dir = trinity_root_dir.replace(fragment1, 'pyt-').replace(fragment2, '')
+    monkeypatch.setenv('XDG_TRINITY_ROOT', trinity_root_dir)
 
     assert not is_under_path(os.path.expandvars('$HOME'), get_xdg_trinity_root())
 
-    return Path(str(dir_path))
+    return Path(trinity_root_dir)
 
 
 @pytest.fixture(scope='session')

--- a/tests/core/configuration/test_trinity_config_object.py
+++ b/tests/core/configuration/test_trinity_config_object.py
@@ -9,18 +9,48 @@ from eth_utils import (
 from eth_keys import keys
 
 from trinity._utils.chains import (
+    DATABASE_SOCKET_FILENAME,
     get_data_dir_for_network_id,
     get_local_data_dir,
     get_nodekey_path,
+    JSONRPC_SOCKET_FILENAME,
 )
 from trinity.config import (
     TrinityConfig,
     BeaconAppConfig,
     DATABASE_DIR_NAME,
 )
+from trinity.constants import (
+    IPC_DIR,
+    LOG_DIR,
+    LOG_FILE,
+    PID_DIR
+)
 from trinity._utils.filesystem import (
     is_under_path,
 )
+
+
+@pytest.mark.parametrize(
+    "app_identifier, expected_suffix",
+    (
+        ("beacon", "-beacon"),
+        ("", ""),
+    ),
+)
+def test_trinity_config_app_identifier(xdg_trinity_root, app_identifier, expected_suffix):
+
+    data_dir = get_local_data_dir('muffin', xdg_trinity_root)
+    trinity_config = TrinityConfig(network_id=1, data_dir=data_dir, app_identifier=app_identifier)
+
+    assert trinity_config.network_id == 1
+    assert trinity_config.data_dir == data_dir
+    assert trinity_config.logfile_path == data_dir / (LOG_DIR + expected_suffix) / LOG_FILE
+    assert trinity_config.jsonrpc_ipc_path == data_dir / (IPC_DIR + expected_suffix) / JSONRPC_SOCKET_FILENAME  # noqa: E501
+    assert trinity_config.database_ipc_path == data_dir / (IPC_DIR + expected_suffix) / DATABASE_SOCKET_FILENAME  # noqa: E501
+    assert trinity_config.pid_dir == data_dir / (PID_DIR + expected_suffix)
+    assert trinity_config.database_dir == data_dir / (DATABASE_DIR_NAME + expected_suffix) / "full"
+    assert trinity_config.nodekey_path == get_nodekey_path(data_dir)
 
 
 def test_trinity_config_computed_properties(xdg_trinity_root):

--- a/tests/core/database/test_database_over_ipc_manager.py
+++ b/tests/core/database/test_database_over_ipc_manager.py
@@ -21,6 +21,9 @@ from trinity.db.manager import (
 from trinity.config import (
     TrinityConfig,
 )
+from trinity.initialization import (
+    initialize_data_dir,
+)
 from trinity.constants import ROPSTEN_NETWORK_ID
 from trinity.db.chain import ChainDBProxy
 from trinity.db.base import DBProxy
@@ -47,8 +50,9 @@ def database_server_ipc_path():
     with tempfile.TemporaryDirectory() as temp_dir:
         trinity_config = TrinityConfig(
             network_id=ROPSTEN_NETWORK_ID,
-            data_dir=temp_dir,
+            trinity_root_dir=temp_dir,
         )
+        initialize_data_dir(trinity_config)
 
         manager = get_chaindb_manager(trinity_config, core_db)
         chaindb_server_process = multiprocessing.Process(

--- a/tests/core/initialization/test_is_data_dir_initialized.py
+++ b/tests/core/initialization/test_is_data_dir_initialized.py
@@ -43,6 +43,20 @@ def database_dir(trinity_config, data_dir):
 
 
 @pytest.fixture
+def ipc_dir(trinity_config):
+    os.makedirs(trinity_config.ipc_dir, exist_ok=True)
+    assert os.path.exists(trinity_config.ipc_dir)
+    return trinity_config.ipc_dir
+
+
+@pytest.fixture
+def pid_dir(trinity_config):
+    os.makedirs(trinity_config.pid_dir, exist_ok=True)
+    assert os.path.exists(trinity_config.pid_dir)
+    return trinity_config.ipc_dir
+
+
+@pytest.fixture
 def nodekey(trinity_config, data_dir):
     with open(trinity_config.nodekey_path, 'wb') as nodekey_file:
         nodekey_file.write(b'\x01' * 32)
@@ -79,13 +93,38 @@ def test_not_initialized_without_logfile_path(
     assert not is_data_dir_initialized(trinity_config)
 
 
-def test_full_initialized_data_dir(
+def test_not_initialized_without_ipc_dir(
         trinity_config,
         data_dir,
         database_dir,
         nodekey,
         logfile_dir,
         logfile_path):
+    assert not os.path.exists(trinity_config.ipc_dir)
+    assert not is_data_dir_initialized(trinity_config)
+
+
+def test_not_initialized_without_pid_dir(
+        trinity_config,
+        data_dir,
+        database_dir,
+        nodekey,
+        logfile_dir,
+        logfile_path,
+        ipc_dir):
+    assert not os.path.exists(trinity_config.pid_dir)
+    assert not is_data_dir_initialized(trinity_config)
+
+
+def test_full_initialized_data_dir(
+        trinity_config,
+        data_dir,
+        database_dir,
+        nodekey,
+        logfile_dir,
+        logfile_path,
+        ipc_dir,
+        pid_dir):
     assert is_data_dir_initialized(trinity_config)
 
 
@@ -98,6 +137,8 @@ def test_full_initialized_data_dir_with_custom_nodekey():
     os.makedirs(trinity_config.data_dir, exist_ok=True)
     os.makedirs(trinity_config.database_dir, exist_ok=True)
     os.makedirs(trinity_config.logfile_path, exist_ok=True)
+    os.makedirs(trinity_config.ipc_dir, exist_ok=True)
+    os.makedirs(trinity_config.pid_dir, exist_ok=True)
     trinity_config.logfile_path.touch()
 
     assert trinity_config.nodekey_path is None

--- a/trinity/_utils/chains.py
+++ b/trinity/_utils/chains.py
@@ -54,17 +54,6 @@ def get_data_dir_for_network_id(network_id: int, trinity_root_dir: Path) -> Path
         raise KeyError(f"Unknown network id: `{network_id}`")
 
 
-LOG_DIRNAME = 'logs'
-LOG_FILENAME = 'trinity.log'
-
-
-def get_logfile_path(data_dir: Path) -> Path:
-    """
-    Return the path to the log file.
-    """
-    return data_dir / LOG_DIRNAME / LOG_FILENAME
-
-
 NODEKEY_FILENAME = 'nodekey'
 
 

--- a/trinity/bootstrap.py
+++ b/trinity/bootstrap.py
@@ -108,6 +108,7 @@ BootFn = Callable[[
 
 
 def main_entry(trinity_boot: BootFn,
+               app_identifier: str,
                plugins: Iterable[BasePlugin],
                sub_configs: Iterable[Type[BaseAppConfig]]) -> None:
     event_bus = EventBus(ctx)
@@ -152,7 +153,7 @@ def main_entry(trinity_boot: BootFn,
         setup_log_levels(args.log_levels)
 
     try:
-        trinity_config = TrinityConfig.from_parser_args(args, sub_configs)
+        trinity_config = TrinityConfig.from_parser_args(args, app_identifier, sub_configs)
     except AmbigiousFileSystem:
         parser.error(TRINITY_AMBIGIOUS_FILESYSTEM_INFO)
 

--- a/trinity/config.py
+++ b/trinity/config.py
@@ -306,10 +306,10 @@ class TrinityConfig:
         """
         Return the path to the log file.
         """
-        return self.logdir_path / LOG_FILE
+        return self.log_dir / LOG_FILE
 
     @property
-    def logdir_path(self) -> Path:
+    def log_dir(self) -> Path:
         """
         Return the path of the directory where all log files are stored.
         """

--- a/trinity/constants.py
+++ b/trinity/constants.py
@@ -16,9 +16,16 @@ from eth_keys import (
 from p2p.kademlia import Address, Node
 
 
+# application identifier
+APP_IDENTIFIER_ETH1 = "eth1"
+APP_IDENTIFIER_BEACON = "beacon"
+
 # The file path to the non-python assets
 ASSETS_DIR = Path(__file__).parent / "assets"
-
+IPC_DIR = 'ipcs'
+LOG_DIR = 'logs'
+LOG_FILE = 'trinity.log'
+PID_DIR = 'pids'
 
 # sync modes
 SYNC_FULL = 'full'

--- a/trinity/initialization.py
+++ b/trinity/initialization.py
@@ -78,19 +78,19 @@ def initialize_data_dir(trinity_config: TrinityConfig) -> None:
 
     # Logfile
     should_create_logdir = (
-        not trinity_config.logdir_path.exists() and
-        is_under_path(trinity_config.trinity_root_dir, trinity_config.logdir_path)
+        not trinity_config.log_dir.exists() and
+        is_under_path(trinity_config.trinity_root_dir, trinity_config.log_dir)
     )
     if should_create_logdir:
-        trinity_config.logdir_path.mkdir(parents=True, exist_ok=True)
+        trinity_config.log_dir.mkdir(parents=True, exist_ok=True)
         trinity_config.logfile_path.touch()
-    elif not trinity_config.logdir_path.exists():
+    elif not trinity_config.log_dir.exists():
         # we don't lazily create the base dir for non-default base directories.
         raise MissingPath(
             "The base logging directory provided does not exist: `{0}`".format(
-                trinity_config.logdir_path,
+                trinity_config.log_dir,
             ),
-            trinity_config.logdir_path,
+            trinity_config.log_dir,
         )
 
     # Initialize chain, pid and ipc directories

--- a/trinity/initialization.py
+++ b/trinity/initialization.py
@@ -20,15 +20,19 @@ from trinity._utils.filesystem import (
 
 def is_data_dir_initialized(trinity_config: TrinityConfig) -> bool:
     """
-    - base dir exists
-    - chain data-dir exists
-    - nodekey exists and is non-empty
-    - canonical chain head in db
+    Return ``True`` if the data directory and all expected sub directories exist,
+    otherwise return ``False``
     """
     if not os.path.exists(trinity_config.data_dir):
         return False
 
     if not os.path.exists(trinity_config.database_dir):
+        return False
+
+    if not os.path.exists(trinity_config.pid_dir):
+        return False
+
+    if not os.path.exists(trinity_config.ipc_dir):
         return False
 
     if not trinity_config.logfile_path.parent.exists():
@@ -89,8 +93,10 @@ def initialize_data_dir(trinity_config: TrinityConfig) -> None:
             trinity_config.logdir_path,
         )
 
-    # Chain data-dir
+    # Initialize chain, pid and ipc directories
     os.makedirs(trinity_config.database_dir, exist_ok=True)
+    os.makedirs(trinity_config.pid_dir, exist_ok=True)
+    os.makedirs(trinity_config.ipc_dir, exist_ok=True)
 
     # Nodekey
     if trinity_config.nodekey is None:

--- a/trinity/main.py
+++ b/trinity/main.py
@@ -28,6 +28,7 @@ from trinity.config import (
     Eth1AppConfig,
 )
 from trinity.constants import (
+    APP_IDENTIFIER_ETH1,
     NETWORKING_EVENTBUS_ENDPOINT,
 )
 from trinity.events import (
@@ -66,7 +67,7 @@ def get_all_plugins() -> Iterable[BasePlugin]:
 
 
 def main() -> None:
-    main_entry(trinity_boot, get_all_plugins(), (Eth1AppConfig,))
+    main_entry(trinity_boot, APP_IDENTIFIER_ETH1, get_all_plugins(), (Eth1AppConfig,))
 
 
 def trinity_boot(args: Namespace,

--- a/trinity/main_beacon.py
+++ b/trinity/main_beacon.py
@@ -23,6 +23,9 @@ from trinity.config import (
     TrinityConfig,
     BeaconAppConfig
 )
+from trinity.constants import (
+    APP_IDENTIFIER_BEACON,
+)
 from trinity.events import (
     ShutdownRequest
 )
@@ -42,7 +45,7 @@ from trinity._utils.mp import (
 
 
 def main_beacon() -> None:
-    main_entry(trinity_boot, BASE_PLUGINS, (BeaconAppConfig,))
+    main_entry(trinity_boot, APP_IDENTIFIER_BEACON, BASE_PLUGINS, (BeaconAppConfig,))
 
 
 def trinity_boot(args: Namespace,

--- a/trinity/plugins/builtin/fix_unclean_shutdown/plugin.py
+++ b/trinity/plugins/builtin/fix_unclean_shutdown/plugin.py
@@ -35,7 +35,7 @@ class FixUncleanShutdownPlugin(BaseMainProcessPlugin):
         self.logger.info("Cleaning up unclean shutdown...")
 
         self.logger.info("Searching for process id files in %s..." % trinity_config.data_dir)
-        pidfiles = tuple(trinity_config.data_dir.glob('*.pid'))
+        pidfiles = tuple(trinity_config.pid_dir.glob('*.pid'))
         if len(pidfiles) > 1:
             self.logger.info('Found %d processes from a previous run. Closing...' % len(pidfiles))
         elif len(pidfiles) == 1:


### PR DESCRIPTION
### What was wrong?

The `trinity-beacon` adds support for a new type of client that we need to support running side by side with the existing Ethereum 1 client. This client will have entirely different data, logs, ipc and pid files. 

Based on the discussion in https://github.com/ethereum/py-evm/pull/1603 we want to support running this client out of the same application directory as the Ethereum 1 client which means the application directory layout needs to be modified to support this.

### How was it fixed?

This change introduces multi-app support to trinity by introducing a new `app_identifier` config to the `TrinityConfig`.

Assuming there Ethereum 1 client uses an `app_identifier` of `""`(empty string)  and the Ethereum 2 beacon node uses an `app_identifier` of `beacon` the directory layout looks as follows.

```
/home/cburgdorf/.local/share/trinity
├── mainnet                       <-- one mainnet directory, but app specific sub directories
│   ├── chain
│   │   ├── full
|   |   |     └── db files
│   │   └── light
|   |         └── db files
│   ├── chain-beacon
│   │   ├── full
|   |   |     ├── beacon
│   │   │     |     └── db files
|   |   |     ├── shard-1
│   │   │     |     └── db files
|   |   |     └── shard-n
│   │   │           └── db files
│   │   └── light
|   |         ├── beacon
│   │         |     └── db files
|   |         ├── shard-1
│   │         |     └── db files
|   |         └── shard-n
│   │               └── db files
│   ├── logs
│   │   ├── trinity.log
│   │   ├── ...
│   │   ├── trinity.log.7
│   ├── logs-beacon
│   │   └── trinity.log
│   │   ├── ...
│   │   └── trinity.log.7
│   ├── ipc
│   │   ├── db.ipc
│   │   └── ...
│   ├── ipc-beacon
│   │   ├── db.ipc
│   │   └── ...
│   ├── pid
│   │   ├── database.pid
│   │   └── ...
│   ├── pid-beacon
│   │   ├── database.pid
│   │   └── ...
│   └── nodekey
|
└── ropsten
    ├── chain
    │   ├── full
    |   |     └── db files
    │   └── light
    |         └── db files
    ├── chain-beacon
    │   ├── full
    |   |     ├── beacon
    │   │     |     └── db files
    |   |     ├── shard-1
    │   │     |     └── db files
    |   |     └── shard-n
    │   │           └── db files
    │   └── light
    |         ├── beacon
    │         |     └── db files
    |         ├── shard-1
    │         |     └── db files
    |         └── shard-n
    │               └── db files
    ├── logs
    │   ├── trinity.log
    │   ├── ...
    │   ├── trinity.log.7
    ├── logs-beacon
    │   └── trinity.log
    │   ├── ...
    │   └── trinity.log.7
    ├── ipc
    │   ├── db.ipc
    │   └── ...
    ├── ipc-beacon
    │   ├── db.ipc
    │   └── ...
    ├── pid
    │   ├── database.pid
    │   └── ...
    ├── pid-beacon
    │   ├── database.pid
    │   └── ...
    └── nodekey
```


#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://i.chzbgr.com/full/7899870464/h1F921A54/)
