### PR TITLE
Run plugin discovery test only with --integration option

### DIFF
--- a/tests/trinity/integration/test_plugin_discovery.py
+++ b/tests/trinity/integration/test_plugin_discovery.py
@@ -1,12 +1,17 @@
+import pytest
 from trinity.plugins.registry import (
     discover_plugins
 )
-# This plugin is external to this code base and installed by tox
-# In order to install it locally run:
-# pip install -e trinity-external-plugins/examples/peer_count_reporter
-from peer_count_reporter_plugin import PeerCountReporterPlugin
 
 
 def test_plugin_discovery():
+    if not pytest.config.getoption("--integration"):
+        pytest.skip("Not asked to run integration tests")
+
+    # This plugin is external to this code base and installed by tox
+    # In order to install it locally run:
+    # pip install -e trinity-external-plugins/examples/peer_count_reporter
+    from peer_count_reporter_plugin import PeerCountReporterPlugin
+
     plugins = [type(plugin) for plugin in discover_plugins()]
     assert PeerCountReporterPlugin in plugins

--- a/tox.ini
+++ b/tox.ini
@@ -75,7 +75,7 @@ commands=
     pip install -e {toxinidir}/trinity-external-plugins/examples/peer_count_reporter
     # We don't want to run these tests concurrently to avoid running into errors
     # due to multiple Trinity instances competing for the same ports
-    pytest -n 1 {posargs:tests/trinity/integration/ -k 'not lightchain_integration'}
+    pytest --integration -n 1 {posargs:tests/trinity/integration/ -k 'not lightchain_integration'}
 
 [testenv:py36-trinity-integration]
 deps = {[common-trinity-integration]deps}


### PR DESCRIPTION
### What was wrong?

Our integration test that the installation of external plugins actually works is getting is often getting in the way for people new to the code base as seen in https://github.com/ethereum/py-evm/issues/1646, https://github.com/ethereum/py-evm/issues/1547 and https://github.com/ethereum/py-evm/issues/1539

The problem with this test is that nobody yet has found a way to do the plugin installation from right within pytest in a way that allows to dynamically import the plugin after the installation. That's why for that test, we rely on `tox` to install the plugin.

https://github.com/ethereum/py-evm/blob/48be6ca6bea5c6349ff3e00e477ce0db8305b43f/tox.ini#L75

But for people unaware of this, it means they try to run `pytest` after a fresh clone of the repo and the tests just breaks because of the missing import.

### How was it fixed?

Only run this test when the `--integration` parameter is given, so effectively only run it during CI.

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](http://i1.wp.com/www.funcage.com/blog/wp-content/uploads/2014/01/32-Cute-Pictures-That-Will-Make-Your-Day-018.jpg?resize=620%2C382)
