### PR TITLE
Add async variants for some iter tools

### DIFF
--- a/tests/core/task-queue-utils/test_async_iter.py
+++ b/tests/core/task-queue-utils/test_async_iter.py
@@ -1,0 +1,97 @@
+import itertools
+
+import pytest
+
+from eth_utils.toolz import (
+    cons,
+    take,
+)
+
+from trinity._utils.async_iter import (
+    async_chain,
+    async_cons,
+    async_iter_wrapper,
+    async_sliding_window,
+    async_take,
+)
+
+
+@pytest.mark.asyncio
+async def test_wrapping_async():
+    async def async_range():
+        for i in range(3):
+            yield i
+
+    wrapped = async_iter_wrapper(async_range())
+    result = [i async for i in wrapped]
+    assert result == [0, 1, 2]
+
+
+@pytest.mark.asyncio
+async def test_wrapping_sync():
+    wrapped = async_iter_wrapper(range(3))
+    result = [i async for i in wrapped]
+    assert result == [0, 1, 2]
+
+
+@pytest.mark.parametrize("iterables", [
+    (),
+    ([],),
+    ([1],),
+    ([1, 2], [3, 4]),
+    ([1, 2], [], [3, 4, 5]),
+])
+@pytest.mark.asyncio
+async def test_async_chain(iterables):
+    chained = async_chain(*iterables)
+    result = [i async for i in chained]
+    expected = list(itertools.chain(*iterables))
+    assert result == expected
+
+
+@pytest.mark.parametrize("num, iterable", [
+    (0, []),
+    (0, [1, 2]),
+    (1, [1]),
+    (1, [1, 2]),
+    (2, [1, 2, 3]),
+    (3, [1]),
+])
+@pytest.mark.asyncio
+async def test_async_take(num, iterable):
+    taken = async_take(num, iterable)
+    result = [i async for i in taken]
+    expected = list(take(num, iterable))
+    assert result == expected
+
+
+@pytest.mark.parametrize("item, iterable", [
+    (1, [1, 2, 3]),
+    (1, [])
+])
+@pytest.mark.asyncio
+async def test_async_cons(item, iterable):
+    consed = async_cons(item, iterable)
+    result = [i async for i in consed]
+    expected = list(cons(item, iterable))
+    assert result == expected
+
+
+@pytest.mark.parametrize("window_size, iterable, expected", [
+    (0, [], []),
+    (2, [], []),
+    (1, [1, 2, 3], [(1,), (2,), (3,)]),
+    (2, [1, 2, 3], [(1, 2), (2, 3)]),
+    (5, [1, 2, 3], []),
+])
+@pytest.mark.asyncio
+async def test_async_sliding_window(window_size, iterable, expected):
+    windowed = async_sliding_window(window_size, iterable)
+    result = [i async for i in windowed]
+    assert result == expected
+
+
+@pytest.mark.asyncio
+async def test_negative_sliding_window_size():
+    with pytest.raises(ValueError):
+        async_sliding_window(-1, [1, 2, 3])

--- a/trinity/_utils/async_iter.py
+++ b/trinity/_utils/async_iter.py
@@ -1,7 +1,18 @@
+import collections
 from typing import (
     AsyncIterable,
+    AsyncIterator,
+    Iterable,
     Set,
+    Tuple,
+    TypeVar,
+    Union,
 )
+
+
+T = TypeVar('T')
+
+AnyIterable = Union[Iterable[T], AsyncIterable[T]]
 
 
 async def contains_all(async_gen: AsyncIterable[str], keywords: Set[str]) -> bool:
@@ -19,3 +30,70 @@ async def contains_all(async_gen: AsyncIterable[str], keywords: Set[str]) -> boo
             return True
 
     return False
+
+
+async def async_iter_wrapper(iterable: AnyIterable[T]) -> AsyncIterator[T]:
+    if isinstance(iterable, Iterable):
+        for item in iterable:
+            yield item
+    elif isinstance(iterable, AsyncIterable):
+        async for item in iterable:
+            yield item
+
+
+async def async_chain(*iterables: AnyIterable[T]) -> AsyncIterator[T]:
+    for iterable in iterables:
+        async for item in async_iter_wrapper(iterable):
+            yield item
+
+
+def async_cons(first_item: T,
+               iterable: AnyIterable[T]) -> AsyncIterator[T]:
+    return async_chain([first_item], iterable)
+
+
+def async_take(n: int,
+               iterable: AnyIterable[T]) -> AsyncIterator[T]:
+    if n < 0:
+        raise ValueError("Number of elements to take must be non-negative")
+
+    async def async_generator() -> AsyncIterator[T]:
+        if n == 0:
+            return
+
+        yielded_items = 0
+        async for item in async_iter_wrapper(iterable):
+            yield item
+
+            yielded_items += 1
+            if yielded_items >= n:
+                break
+
+    return async_generator()
+
+
+def async_sliding_window(window_size: int,
+                         iterable: AnyIterable[T]) -> AsyncIterator[Tuple[T, ...]]:
+    if window_size < 0:
+        raise ValueError("size of sliding window must be non-negative")
+
+    async def async_generator() -> AsyncIterator[Tuple[T, ...]]:
+        if window_size == 0:
+            return
+
+        async_iterable = async_iter_wrapper(iterable)
+
+        d = collections.deque(
+            [item async for item in async_take(window_size, async_iterable)],
+            maxlen=window_size,
+        )
+
+        if len(d) < window_size:
+            return
+
+        yield tuple(d)
+        async for item in async_iterable:
+            d.append(item)
+            yield tuple(d)
+
+    return async_generator()

--- a/trinity/_utils/async_iter.py
+++ b/trinity/_utils/async_iter.py
@@ -1,4 +1,5 @@
 import collections
+import itertools
 from typing import (
     AsyncIterable,
     AsyncIterator,
@@ -48,21 +49,20 @@ def async_cons(first_item: T,
     )
 
 
-def async_take(n: int,
+def async_take(num_items: int,
                async_iterable: AsyncIterable[T]) -> AsyncIterator[T]:
-    if n < 0:
+    if num_items < 0:
         raise ValueError("Number of elements to take must be non-negative")
 
     async def async_generator() -> AsyncIterator[T]:
-        if n == 0:
+        if num_items == 0:
             return
 
-        yielded_items = 0
+        counter = itertools.count(1)
         async for item in async_iterable:
             yield item
 
-            yielded_items += 1
-            if yielded_items >= n:
+            if next(counter) >= num_items:
                 break
 
     return async_generator()


### PR DESCRIPTION
### What was wrong?

Working with asynchronous iterators can be painful without the utilities in `itertools` and `toolz`.

### How was it fixed?

Implemented async versions of

- `chain`
- `cons`
- `take`
- `sliding_window`

The functions work for both synchronous and asynchronous iterables, in particular to allow for mixing them (e.g. `chain`).

(Motivation: https://github.com/ethereum/py-evm/pull/1650#discussion_r243006657)

#### Cute Animal Picture
![put a cute animal picture link inside the parentheses](https://user-images.githubusercontent.com/29854669/50340653-2933e200-051c-11e9-816e-86e67ea4c840.jpeg)

![]()
