### PR TITLE
Handle errors on incoming connections

### DIFF
--- a/trinity/server.py
+++ b/trinity/server.py
@@ -232,7 +232,7 @@ class BaseServer(BaseService, Generic[TPeerPool]):
         try:
             ephem_pubkey, initiator_nonce, initiator_pubkey = decode_authentication(
                 msg, self.privkey)
-        except DecryptionError:
+        except DecryptionError as non_eip8_err:
             # Try to decode as EIP8
             got_eip8 = True
             msg_size = big_endian_to_int(msg[:2])
@@ -243,8 +243,11 @@ class BaseServer(BaseService, Generic[TPeerPool]):
             try:
                 ephem_pubkey, initiator_nonce, initiator_pubkey = decode_authentication(
                     msg, self.privkey)
-            except DecryptionError as err:
-                raise HandshakeFailure(f"Failed to decrypt handshake: {err}")
+            except DecryptionError as eip8_err:
+                raise HandshakeFailure(
+                    f"Failed to decrypt both EIP8 handshake: {eip8_err}  and "
+                    f"non-EIP8 handshake: {non_eip8_err}"
+                )
         else:
             got_eip8 = False
 

--- a/trinity/server.py
+++ b/trinity/server.py
@@ -193,14 +193,22 @@ class BaseServer(BaseService, Generic[TPeerPool]):
             HandshakeFailure,
             asyncio.IncompleteReadError,
         )
+
+        def cleanup_reader_and_writer() -> None:
+            if not reader.at_eof():
+                reader.feed_eof()
+            writer.close()
+
         try:
             await self._receive_handshake(reader, writer)
         except expected_exceptions as e:
             self.logger.debug("Could not complete handshake: %s", e)
+            cleanup_reader_and_writer()
         except OperationCancelled:
             pass
         except Exception as e:
             self.logger.exception("Unexpected error handling handshake")
+            cleanup_reader_and_writer()
 
     async def _receive_handshake(
             self, reader: asyncio.StreamReader, writer: asyncio.StreamWriter) -> None:
@@ -208,10 +216,19 @@ class BaseServer(BaseService, Generic[TPeerPool]):
             reader.read(ENCRYPTED_AUTH_MSG_LEN),
             timeout=REPLY_TIMEOUT)
 
-        ip, socket, *_ = writer.get_extra_info("peername")
+        peername = writer.get_extra_info("peername")
+        if peername is None:
+            socket = writer.get_extra_info("socket")
+            sockname = writer.get_extra_info("sockname")
+            raise HandshakeFailure(
+                "Received incoming connection with no remote information:"
+                f"socket={repr(socket)}  sockname={sockname}"
+            )
+
+        ip, socket, *_ = peername
         remote_address = Address(ip, socket)
         self.logger.debug("Receiving handshake from %s", remote_address)
-        got_eip8 = False
+
         try:
             ephem_pubkey, initiator_nonce, initiator_pubkey = decode_authentication(
                 msg, self.privkey)
@@ -226,9 +243,10 @@ class BaseServer(BaseService, Generic[TPeerPool]):
             try:
                 ephem_pubkey, initiator_nonce, initiator_pubkey = decode_authentication(
                     msg, self.privkey)
-            except DecryptionError as e:
-                self.logger.debug("Failed to decrypt handshake: %s", e)
-                return
+            except DecryptionError as err:
+                raise HandshakeFailure(f"Failed to decrypt handshake: {err}")
+        else:
+            got_eip8 = False
 
         initiator_remote = Node(initiator_pubkey, remote_address)
         responder = HandshakeResponder(initiator_remote, self.privkey, got_eip8, self.cancel_token)


### PR DESCRIPTION
migrated from: https://github.com/ethereum/py-evm/pull/1661

### What was wrong?

fixes: https://github.com/ethereum/py-evm/issues/1657

When an incoming connection's socket doesn't have address information an exception escapes the Trinity process.

Also, we end up leaving the TCP transports open.

### How was it fixed?

- Adds handling for the case where the incoming connection doesn't have the proper address info and log what data we can about the connection.
- Adds handling for the error cases while receiving the handshake to close the TCP transport.

#### Cute Animal Picture

![441ab30cbf83ea412ec0ebb34bec6fc0](https://user-images.githubusercontent.com/824194/50306302-6f247380-0452-11e9-880b-2a206255b9b3.jpg)

