### PR TITLE
Test package ci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -184,6 +184,12 @@ jobs:
       - image: circleci/python:3.6
         environment:
           TOXENV: py36-eth2
+  py36-wheel-cli:
+    <<: *common
+    docker:
+      - image: circleci/python:3.6
+        environment:
+          TOXENV: py36-wheel-cli
 
   py37-core:
     <<: *common
@@ -209,6 +215,12 @@ jobs:
       - image: circleci/python:3.7
         environment:
           TOXENV: py37-eth2
+  py37-wheel-cli:
+    <<: *common
+    docker:
+      - image: circleci/python:3.7
+        environment:
+          TOXENV: py37-wheel-cli
 
 workflows:
   version: 2
@@ -217,6 +229,7 @@ workflows:
       - py36-docs
 
       - py37-core
+      - py37-wheel-cli
       - py37-p2p
       - py37-eth2
 
@@ -230,6 +243,7 @@ workflows:
       - py36-rpc-blockchain
 
       - py36-core
+      - py36-wheel-cli
       - py36-p2p
       - py37-eth2
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -245,7 +245,7 @@ workflows:
       - py36-core
       - py36-wheel-cli
       - py36-p2p
-      - py37-eth2
+      - py36-eth2
 
       - py36-integration
       - py36-lightchain_integration

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,5 +1,5 @@
 [pytest]
-addopts= --showlocals
+addopts= --showlocals --durations 50 --maxfail 10
 python_paths= .
 xfail_strict=true
 log_format = %(levelname)8s  %(asctime)s  %(filename)20s  %(message)s

--- a/tox.ini
+++ b/tox.ini
@@ -15,21 +15,20 @@ ignore=
 [testenv]
 usedevelop=True
 passenv =
-    PYTEST_ADDOPTS
     TRAVIS_EVENT_TYPE
 commands=
-    core: pytest {posargs:tests/core/}
-    eth2: pytest {posargs:tests/eth2}
-    p2p: pytest {posargs:tests/p2p}
-    rpc-blockchain: pytest {posargs:tests/json-fixtures-over-rpc/test_rpc_fixtures.py -k 'not GeneralStateTests'}
-    rpc-state-frontier: pytest {posargs:tests/json-fixtures-over-rpc/test_rpc_fixtures.py -k 'GeneralStateTests and not stQuadraticComplexityTest and Frontier'}
-    rpc-state-homestead: pytest {posargs:tests/json-fixtures-over-rpc/test_rpc_fixtures.py -k 'GeneralStateTests and not stQuadraticComplexityTest and Homestead'}
-    rpc-state-tangerine_whistle: pytest {posargs:tests/json-fixtures-over-rpc/test_rpc_fixtures.py -k 'GeneralStateTests and not stQuadraticComplexityTest and EIP150'}
-    rpc-state-spurious_dragon: pytest {posargs:tests/json-fixtures-over-rpc/test_rpc_fixtures.py -k 'GeneralStateTests and not stQuadraticComplexityTest and EIP158'}
+    core: pytest -n 4 {posargs:tests/core/}
+    eth2: pytest -n 4 {posargs:tests/eth2}
+    p2p: pytest -n 4 {posargs:tests/p2p}
+    rpc-blockchain: pytest -n 4 {posargs:tests/json-fixtures-over-rpc/test_rpc_fixtures.py -k 'not GeneralStateTests'}
+    rpc-state-frontier: pytest -n 4 {posargs:tests/json-fixtures-over-rpc/test_rpc_fixtures.py -k 'GeneralStateTests and not stQuadraticComplexityTest and Frontier'}
+    rpc-state-homestead: pytest -n 4 {posargs:tests/json-fixtures-over-rpc/test_rpc_fixtures.py -k 'GeneralStateTests and not stQuadraticComplexityTest and Homestead'}
+    rpc-state-tangerine_whistle: pytest -n 4 {posargs:tests/json-fixtures-over-rpc/test_rpc_fixtures.py -k 'GeneralStateTests and not stQuadraticComplexityTest and EIP150'}
+    rpc-state-spurious_dragon: pytest -n 4 {posargs:tests/json-fixtures-over-rpc/test_rpc_fixtures.py -k 'GeneralStateTests and not stQuadraticComplexityTest and EIP158'}
     # The following test seems to consume a lot of memory. Restricting to 3 processes reduces crashes
-    rpc-state-byzantium: pytest -n3 {posargs:tests/json-fixtures-over-rpc/test_rpc_fixtures.py -k 'GeneralStateTests and not stQuadraticComplexityTest and Byzantium'}
-    rpc-state-constantinople: pytest -n3 {posargs:tests/json-fixtures-over-rpc/test_rpc_fixtures.py -k 'GeneralStateTests and not stQuadraticComplexityTest and Constantinople'}
-    rpc-state-quadratic: pytest {posargs:tests/json-fixtures-over-rpc/test_rpc_fixtures.py -k 'GeneralStateTests and stQuadraticComplexityTest'}
+    rpc-state-byzantium: pytest -n 3 {posargs:tests/json-fixtures-over-rpc/test_rpc_fixtures.py -k 'GeneralStateTests and not stQuadraticComplexityTest and Byzantium'}
+    rpc-state-constantinople: pytest -n 3 {posargs:tests/json-fixtures-over-rpc/test_rpc_fixtures.py -k 'GeneralStateTests and not stQuadraticComplexityTest and Constantinople'}
+    rpc-state-quadratic: pytest -n 4 {posargs:tests/json-fixtures-over-rpc/test_rpc_fixtures.py -k 'GeneralStateTests and stQuadraticComplexityTest'}
     lightchain_integration: pytest --integration {posargs:tests/integration/test_lightchain_integration.py}
 
 deps = .[p2p,trinity,test]
@@ -44,7 +43,6 @@ whitelist_externals=
     make
 deps = .[p2p, trinity, doc]
 passenv =
-    PYTEST_ADDOPTS
     TRAVIS_EVENT_TYPE
 commands=
     make validate-docs
@@ -82,7 +80,6 @@ use_develop=false
 [common-integration]
 deps = .[p2p,trinity,test]
 passenv =
-    PYTEST_ADDOPTS
     TRAVIS_EVENT_TYPE
 commands=
     pip install -e {toxinidir}/trinity-external-plugins/examples/peer_count_reporter

--- a/tox.ini
+++ b/tox.ini
@@ -4,6 +4,7 @@ envlist=
     py{36}-rpc-state-{frontier,homestead,tangerine_whistle,spurious_dragon,byzantium,constantinople,quadratic}
     py{36}-rpc-blockchain
     py{36,37}-lint
+    py{36,37}-wheel-cli
     py36-docs
 
 [flake8]
@@ -48,6 +49,35 @@ passenv =
 commands=
     make validate-docs
 
+[common-wheel-cli]
+deps=
+    pexpect
+    pytest
+    pytest-asyncio
+    wheel
+whitelist_externals=
+    /bin/rm
+    /bin/bash
+    /bin/cd
+commands=
+    /bin/rm -rf build dist
+    python setup.py sdist bdist_wheel
+    /bin/bash -c 'pip install --upgrade "$(ls dist/*.whl)""[p2p,trinity]"'
+    pytest {posargs:tests/integration/ -k 'trinity_cli'}
+
+[testenv:py36-wheel-cli]
+deps = {[common-wheel-cli]deps}
+whitelist_externals = {[common-wheel-cli]whitelist_externals}
+commands = {[common-wheel-cli]commands}
+skip_install=true
+use_develop=false
+
+[testenv:py37-wheel-cli]
+deps = {[common-wheel-cli]deps}
+whitelist_externals = {[common-wheel-cli]whitelist_externals}
+commands = {[common-wheel-cli]commands}
+skip_install=true
+use_develop=false
 
 [common-integration]
 deps = .[p2p,trinity,test]


### PR DESCRIPTION
### What was wrong?

Migrated from https://github.com/ethereum/py-evm/pull/1643

https://github.com/ethereum/trinity/issues/97 - no CI test of the packaged release

### How was it fixed?

Add a new tox and circle run against the packaged release.

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://i.pinimg.com/736x/f7/e0/2b/f7e02b16688218e0ec0730070bc73ff0--baby-sloth-cute-sloth.jpg)