### PR TITLE
Fix sync mode naming: change all of the SYNC_FULL to SYNC_FAST

### DIFF
--- a/scripts/db-shell.py
+++ b/scripts/db-shell.py
@@ -17,6 +17,7 @@ from trinity.constants import (
     MAINNET_NETWORK_ID,
     ROPSTEN_NETWORK_ID,
     SYNC_FULL,
+    SYNC_FAST,
     SYNC_LIGHT,
 )
 
@@ -30,9 +31,13 @@ if __name__ == '__main__':
     network_id = MAINNET_NETWORK_ID
     if args.ropsten:
         network_id = ROPSTEN_NETWORK_ID
-    sync_mode = SYNC_FULL
+
     if args.light:
         sync_mode = SYNC_LIGHT
+    elif args.full:
+        sync_mode = SYNC_FULL
+    else:
+        sync_mode = SYNC_FAST
 
     cfg = TrinityConfig(network_id, sync_mode=sync_mode)
     chaindb = ChainDB(LevelDB(cfg.database_dir))

--- a/tests/core/configuration/test_trinity_config_object.py
+++ b/tests/core/configuration/test_trinity_config_object.py
@@ -29,7 +29,7 @@ def test_trinity_config_computed_properties(xdg_trinity_root):
 
     assert trinity_config.network_id == 1
     assert trinity_config.data_dir == data_dir
-    assert trinity_config.database_dir == data_dir / DATABASE_DIR_NAME / "full"
+    assert trinity_config.database_dir == data_dir / DATABASE_DIR_NAME / "fast"
     assert trinity_config.nodekey_path == get_nodekey_path(data_dir)
 
 
@@ -42,7 +42,7 @@ def test_trinity_config_computed_properties_custom_xdg(tmpdir, xdg_trinity_root)
 
     assert trinity_config.network_id == 1
     assert trinity_config.data_dir == data_dir
-    assert trinity_config.database_dir == data_dir / DATABASE_DIR_NAME / "full"
+    assert trinity_config.database_dir == data_dir / DATABASE_DIR_NAME / "fast"
     assert trinity_config.nodekey_path == get_nodekey_path(data_dir)
 
 

--- a/trinity/cli_parser.py
+++ b/trinity/cli_parser.py
@@ -17,6 +17,7 @@ from trinity.constants import (
     MAINNET_NETWORK_ID,
     ROPSTEN_NETWORK_ID,
     SYNC_FULL,
+    SYNC_FAST,
     SYNC_LIGHT,
 )
 from trinity._utils.eip1085 import validate_raw_eip1085_genesis_config
@@ -244,8 +245,8 @@ network_parser.add_argument(
 mode_parser = syncing_parser.add_mutually_exclusive_group()
 mode_parser.add_argument(
     '--sync-mode',
-    choices={SYNC_LIGHT, SYNC_FULL},
-    default=SYNC_FULL,
+    choices={SYNC_LIGHT, SYNC_FAST, SYNC_FULL},
+    default=SYNC_FAST,
 )
 mode_parser.add_argument(
     '--light',  # TODO: consider --sync-mode like geth.

--- a/trinity/config.py
+++ b/trinity/config.py
@@ -40,6 +40,7 @@ from trinity.constants import (
     MAINNET_NETWORK_ID,
     ROPSTEN_NETWORK_ID,
     SYNC_FULL,
+    SYNC_FAST,
     SYNC_LIGHT,
 )
 from trinity._utils.chains import (
@@ -223,7 +224,7 @@ class TrinityConfig:
                  nodekey_path: str=None,
                  logfile_path: str=None,
                  nodekey: PrivateKey=None,
-                 sync_mode: str=SYNC_FULL,
+                 sync_mode: str=SYNC_FAST,
                  port: int=30303,
                  use_discv5: bool = False,
                  preferred_nodes: Tuple[KademliaNode, ...]=None,
@@ -293,7 +294,7 @@ class TrinityConfig:
 
     @sync_mode.setter
     def sync_mode(self, value: str) -> None:
-        if value not in {SYNC_FULL, SYNC_LIGHT}:
+        if value not in {SYNC_FULL, SYNC_FAST, SYNC_LIGHT}:
             raise ValueError(f"Unknown sync mode: {value}")
         self._sync_mode = value
 
@@ -381,6 +382,8 @@ class TrinityConfig:
         """
         if self.sync_mode == SYNC_FULL:
             return self.data_dir / DATABASE_DIR_NAME / "full"
+        elif self.sync_mode == SYNC_FAST:
+            return self.data_dir / DATABASE_DIR_NAME / "fast"
         elif self.sync_mode == SYNC_LIGHT:
             return self.data_dir / DATABASE_DIR_NAME / "light"
         else:
@@ -525,6 +528,10 @@ class Eth1AppConfig(BaseAppConfig):
         return self.trinity_config.sync_mode == SYNC_LIGHT
 
     @property
+    def is_fast_mode(self) -> bool:
+        return self.trinity_config.sync_mode == SYNC_FAST
+
+    @property
     def is_full_mode(self) -> bool:
         return self.trinity_config.sync_mode == SYNC_FULL
 
@@ -536,7 +543,7 @@ class Eth1AppConfig(BaseAppConfig):
         from trinity.nodes.full import FullNode
         from trinity.nodes.light import LightNode
 
-        if self.is_full_mode:
+        if self.is_full_mode or self.is_fast_mode:
             return FullNode
         elif self.is_light_mode:
             return LightNode

--- a/trinity/constants.py
+++ b/trinity/constants.py
@@ -22,6 +22,7 @@ ASSETS_DIR = Path(__file__).parent / "assets"
 
 # sync modes
 SYNC_FULL = 'full'
+SYNC_FAST = 'fast'
 SYNC_LIGHT = 'light'
 
 # lahja endpoint names

--- a/trinity/plugins/builtin/json_rpc/plugin.py
+++ b/trinity/plugins/builtin/json_rpc/plugin.py
@@ -57,6 +57,13 @@ class JsonRpcServerPlugin(BaseIsolatedPlugin):
             header_db = db_manager.get_headerdb()  # type: ignore
             event_bus_light_peer_chain = EventBusLightPeerChain(self.context.event_bus)
             chain = chain_config.light_chain_class(header_db, peer_chain=event_bus_light_peer_chain)
+
+        # Currently SYNC_FAST and SYNC_FULL are using the same implementation
+        #   We need to still work on the actual SYNC_FULL implementation:
+        #   - https://github.com/ethereum/trinity/issues/76
+        elif eth1_app_config.is_fast_mode:
+            db = db_manager.get_db()  # type: ignore
+            chain = chain_config.full_chain_class(db)
         elif eth1_app_config.is_full_mode:
             db = db_manager.get_db()  # type: ignore
             chain = chain_config.full_chain_class(db)


### PR DESCRIPTION
### What was wrong?

We need to fix an internal naming issue where we refer to our fast sync using `SYNC_FULL`. This should be renamed to `SYNC_FAST`, and use the fast terminology in place of full everywhere that is currently used.

Issue Reference: https://github.com/ethereum/trinity/issues/76

### How was it fixed?

Change the name from `SYNC_FULL` to `SYNC_FAST`

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://pbs.twimg.com/profile_images/962170088941019136/lgpCD8X4_400x400.jpg)
