### PR TITLE
Add Snappy Compression

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -50,6 +50,9 @@ geth_steps: &geth_steps
         keys:
           - cache-v1-{{ arch }}-{{ .Environment.CIRCLE_JOB }}-{{ checksum "setup.py" }}-{{ checksum "tox.ini" }}
     - run:
+        name: install libsnappy-dev
+        command: sudo apt install -y libsnappy-dev
+    - run:
         name: install dependencies
         command: pip install --user tox
     - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,6 +25,9 @@ common: &common
         keys:
           - cache-v1-{{ arch }}-{{ .Environment.CIRCLE_JOB }}-{{ checksum "setup.py" }}-{{ checksum "tox.ini" }}
     - run:
+        name: install libsnappy-dev
+        command: sudo apt install -y libsnappy-dev
+    - run:
         name: install dependencies
         command: pip install --user tox
     - run:

--- a/docs/guides/quickstart.rst
+++ b/docs/guides/quickstart.rst
@@ -29,6 +29,13 @@ we need to install the ``python3-pip`` package through the following command.
 .. note::
   .. include:: /fragments/virtualenv_explainer.rst
 
+Trinity uses Snappy Compression and hence needs the Snappy Library to be pre-installed on the system.
+It can be installed through the following command.
+
+.. code:: sh
+
+  apt-get install libsnappy-dev
+
 Finally, we can install the ``trinity`` package via pip.
 
 .. code:: sh
@@ -47,7 +54,13 @@ First, install LevelDB and the latest Python 3 with brew:
 .. note::
   .. include:: /fragments/virtualenv_explainer.rst
 
-Then, install the ``trinity`` package via pip:
+Now, install Snappy Library with brew as follows:
+
+.. code:: sh
+
+  brew install snappy
+
+Finally, install the ``trinity`` package via pip:
 
 .. code:: sh
 
@@ -116,13 +129,13 @@ to help us getting that bug fixed.
 
 .. code:: sh
 
-      INFO  05-29 01:57:02        main  
-    ______     _       _ __       
+      INFO  05-29 01:57:02        main
+    ______     _       _ __
   /_  __/____(_)___  (_) /___  __
     / / / ___/ / __ \/ / __/ / / /
-  / / / /  / / / / / / /_/ /_/ / 
-  /_/ /_/  /_/_/ /_/_/\__/\__, /  
-                        /____/   
+  / / / /  / / / / / / /_/ /_/ /
+  /_/ /_/  /_/_/ /_/_/\__/\__, /
+                        /____/
       INFO  05-29 01:57:02        main  Trinity/0.1.0a4/linux/cpython3.6.5
       INFO  05-29 01:57:02        main  network: 1
       INFO  05-29 01:57:02         ipc  IPC started at: /root/.local/share/trinity/mainnet/jsonrpc.ipc
@@ -146,7 +159,7 @@ Once Trinity successfully connected to other peers we should see it starting to 
 Running as a light client
 -------------------------
 
-.. warning:: 
+.. warning::
 
     It may take a **very** long time for Trinity to find an LES node with open
     slots.  This is not a bug with trinity, but rather a shortage of nodes
@@ -206,7 +219,7 @@ latest block by calling ``w3.eth.getBlock('latest')``.
 .. code:: sh
 
   In [9]: w3.eth.getBlock('latest')
-  Out[9]: 
+  Out[9]:
   AttributeDict({'difficulty': 743444339302,
   'extraData': HexBytes('0x476574682f4c5649562f76312e302e302f6c696e75782f676f312e342e32'),
   'gasLimit': 5000,
@@ -246,5 +259,3 @@ For a list of JSON-RPC endpoints which are expected to work, see this issue: htt
   - It is expected to have bugs and is not meant to be used in production
   - Things may be ridiculously slow or not work at all
   - Only a subset of JSON-RPC API calls are currently supported
-
-

--- a/p2p/constants.py
+++ b/p2p/constants.py
@@ -1,5 +1,8 @@
 SUPPORTED_RLPX_VERSION = 4
 
+# The p2p protocol version from which Snappy Compression is Enabled
+SNAPPY_PROTOCOL_VERSION = 5
+
 # Overhead added by ECIES encryption
 ENCRYPT_OVERHEAD_LENGTH = 113
 

--- a/p2p/p2p_proto.py
+++ b/p2p/p2p_proto.py
@@ -97,7 +97,8 @@ class P2PProtocol(Protocol):
 
     def __init__(self, peer: 'BasePeer') -> None:
         # For the base protocol the cmd_id_offset is always 0.
-        super().__init__(peer, cmd_id_offset=0)
+        # For the base protocol snappy compression should be disabled
+        super().__init__(peer, cmd_id_offset=0, snappy_support=False)
 
     def send_handshake(self) -> None:
         # TODO: move import out once this is in the trinity codebase
@@ -107,13 +108,16 @@ class P2PProtocol(Protocol):
                     capabilities=self.peer.capabilities,
                     listen_port=self.peer.listen_port,
                     remote_pubkey=self.peer.privkey.public_key.to_bytes())
-        header, body = Hello(self.cmd_id_offset).encode(data)
+        header, body = Hello(self.cmd_id_offset, self.snappy_support).encode(data)
         self.send(header, body)
 
     def send_disconnect(self, reason: DisconnectReason) -> None:
-        header, body = Disconnect(self.cmd_id_offset).encode(dict(reason=reason))
+        header, body = Disconnect(
+            self.cmd_id_offset,
+            self.snappy_support
+        ).encode(dict(reason=reason))
         self.send(header, body)
 
     def send_pong(self) -> None:
-        header, body = Pong(self.cmd_id_offset).encode({})
+        header, body = Pong(self.cmd_id_offset, self.snappy_support).encode({})
         self.send(header, body)

--- a/p2p/p2p_proto.py
+++ b/p2p/p2p_proto.py
@@ -83,7 +83,7 @@ class Pong(Command):
 
 class P2PProtocol(Protocol):
     name = 'p2p'
-    version = 4
+    version = 5
     _commands = [Hello, Ping, Pong, Disconnect]
     cmd_length = 16
 

--- a/p2p/p2p_proto.py
+++ b/p2p/p2p_proto.py
@@ -35,6 +35,14 @@ class Hello(Command):
         ('remote_pubkey', sedes.binary)
     ]
 
+    def decompress_payload(self, raw_payload: bytes) -> bytes:
+        # The `Hello` command doesn't support snappy compression
+        return raw_payload
+
+    def compress_payload(self, raw_payload: bytes) -> bytes:
+        # The `Hello` command doesn't support snappy compression
+        return raw_payload
+
 
 @enum.unique
 class DisconnectReason(enum.Enum):

--- a/p2p/peer.py
+++ b/p2p/peer.py
@@ -88,6 +88,7 @@ from .constants import (
     HEADER_LEN,
     MAC_LEN,
     REQUEST_PEER_CANDIDATE_TIMEOUT,
+    SNAPPY_PROTOCOL_VERSION,
 )
 
 from .events import (
@@ -496,6 +497,12 @@ class BasePeer(BaseService):
                 f"No matching capabilities between us ({self.capabilities}) and {self.remote} "
                 f"({remote_capabilities}), disconnecting"
             )
+
+        # Check whether to support Snappy Compression or not
+        # based on other peer's p2p protocol version
+        if msg['version'] >= SNAPPY_PROTOCOL_VERSION:
+            protocol.Command.snappy_support = True
+
         self.logger.debug(
             "Finished P2P handshake with %s, using sub-protocol %s",
             self.remote, self.sub_proto)

--- a/p2p/protocol.py
+++ b/p2p/protocol.py
@@ -50,7 +50,7 @@ class Command:
 
     _logger: logging.Logger = None
 
-    def __init__(self, cmd_id_offset: int, snappy_support: bool=False) -> None:
+    def __init__(self, cmd_id_offset: int, snappy_support: bool) -> None:
         self.cmd_id_offset = cmd_id_offset
         self.cmd_id = cmd_id_offset + self._cmd_id
         self.snappy_support = snappy_support
@@ -175,7 +175,7 @@ class Protocol:
 
     _logger: logging.Logger = None
 
-    def __init__(self, peer: 'BasePeer', cmd_id_offset: int, snappy_support: bool=False) -> None:
+    def __init__(self, peer: 'BasePeer', cmd_id_offset: int, snappy_support: bool) -> None:
         self.peer = peer
         self.cmd_id_offset = cmd_id_offset
         self.snappy_support = snappy_support

--- a/p2p/protocol.py
+++ b/p2p/protocol.py
@@ -48,13 +48,12 @@ class Command:
     decode_strict = True
     structure: List[Tuple[str, Any]] = []
 
-    snappy_support = False
-
     _logger: logging.Logger = None
 
-    def __init__(self, cmd_id_offset: int) -> None:
+    def __init__(self, cmd_id_offset: int, snappy_support: bool=False) -> None:
         self.cmd_id_offset = cmd_id_offset
         self.cmd_id = cmd_id_offset + self._cmd_id
+        self.snappy_support = snappy_support
 
     @property
     def logger(self) -> logging.Logger:
@@ -110,25 +109,31 @@ class Command:
         if packet_type != self.cmd_id:
             raise MalformedMessage(f"Wrong packet type: {packet_type}, expected {self.cmd_id}")
 
-        encoded_payload = data[1:]
-
-        # Do the Snappy Decompression only if the command is not a Hello Command (For Handshake)
-        # and only if Snappy Compression is supported by the protocol
-        if self.__class__.__name__ != 'Hello' and self.snappy_support:
-            encoded_payload = snappy.decompress(encoded_payload)
+        compressed_payload = data[1:]
+        encoded_payload = self.decompress_payload(compressed_payload)
 
         return self.decode_payload(encoded_payload)
 
-    def encode(self, data: PayloadType) -> Tuple[bytes, bytes]:
-        payload = self.encode_payload(data)
+    def decompress_payload(self, raw_payload: bytes) -> bytes:
+        # Do the Snappy Decompression only if Snappy Compression is supported by the protocol
+        if self.snappy_support:
+            return snappy.decompress(raw_payload)
+        else:
+            return raw_payload
 
-        # Do the Snappy Compression only if the command is not a Hello Command (For Handshake)
-        # and only if Snappy Compression is supported by the protocol
-        if self.__class__.__name__ != 'Hello' and self.snappy_support:
-            payload = snappy.compress(payload)
+    def compress_payload(self, raw_payload: bytes) -> bytes:
+        # Do the Snappy Compression only if Snappy Compression is supported by the protocol
+        if self.snappy_support:
+            return snappy.compress(raw_payload)
+        else:
+            return raw_payload
+
+    def encode(self, data: PayloadType) -> Tuple[bytes, bytes]:
+        encoded_payload = self.encode_payload(data)
+        compressed_payload = self.compress_payload(encoded_payload)
 
         enc_cmd_id = rlp.encode(self.cmd_id, sedes=rlp.sedes.big_endian_int)
-        frame_size = len(enc_cmd_id) + len(payload)
+        frame_size = len(enc_cmd_id) + len(compressed_payload)
         if frame_size.bit_length() > 24:
             raise ValueError("Frame size has to fit in a 3-byte integer")
 
@@ -141,7 +146,7 @@ class Command:
         header += zero_header
         header = _pad_to_16_byte_boundary(header)
 
-        body = _pad_to_16_byte_boundary(enc_cmd_id + payload)
+        body = _pad_to_16_byte_boundary(enc_cmd_id + compressed_payload)
         return header, body
 
 
@@ -170,12 +175,13 @@ class Protocol:
 
     _logger: logging.Logger = None
 
-    def __init__(self, peer: 'BasePeer', cmd_id_offset: int) -> None:
+    def __init__(self, peer: 'BasePeer', cmd_id_offset: int, snappy_support: bool=False) -> None:
         self.peer = peer
         self.cmd_id_offset = cmd_id_offset
-        self.commands = [cmd_class(cmd_id_offset) for cmd_class in self._commands]
-        self.cmd_by_type = {cmd_class: cmd_class(cmd_id_offset) for cmd_class in self._commands}
-        self.cmd_by_id = dict((cmd.cmd_id, cmd) for cmd in self.commands)
+        self.snappy_support = snappy_support
+        self.commands = [cmd_class(cmd_id_offset, snappy_support) for cmd_class in self._commands]
+        self.cmd_by_type = {type(cmd): cmd for cmd in self.commands}
+        self.cmd_by_id = {cmd.cmd_id: cmd for cmd in self.commands}
 
     @property
     def logger(self) -> logging.Logger:

--- a/p2p/tools/paragon/proto.py
+++ b/p2p/tools/paragon/proto.py
@@ -25,7 +25,7 @@ class ParagonProtocol(Protocol):
     # Broadcast
     #
     def send_broadcast_data(self, data: bytes) -> None:
-        cmd = BroadcastData(self.cmd_id_offset)
+        cmd = BroadcastData(self.cmd_id_offset, self.snappy_support)
         header, body = cmd.encode({'data': data})
         self.send(header, body)
 
@@ -33,11 +33,11 @@ class ParagonProtocol(Protocol):
     # Sum
     #
     def send_get_sum(self, value_a: int, value_b: int) -> None:
-        cmd = GetSum(self.cmd_id_offset)
+        cmd = GetSum(self.cmd_id_offset, self.snappy_support)
         header, body = cmd.encode({'a': value_a, 'b': value_b})
         self.send(header, body)
 
     def send_sum(self, result: int) -> None:
-        cmd = GetSum(self.cmd_id_offset)
+        cmd = GetSum(self.cmd_id_offset, self.snappy_support)
         header, body = cmd.encode({'result': result})
         self.send(header, body)

--- a/setup.py
+++ b/setup.py
@@ -11,6 +11,7 @@ deps = {
         "netifaces>=0.10.7<1",
         "pysha3>=1.0.0,<2.0.0",
         "upnpclient>=0.0.8,<1",
+        "python-snappy>=0.5.3",
     ],
     'trinity': [
         "async-generator==1.10",

--- a/tests/core/p2p-proto/test_peer.py
+++ b/tests/core/p2p-proto/test_peer.py
@@ -46,7 +46,14 @@ async def test_les_handshake():
     assert isinstance(peer2.sub_proto, LESProtocol)
 
 
-def test_sub_protocol_selection():
+@pytest.mark.parametrize(
+    'snappy_support',
+    (
+        True,
+        False,
+    )
+)
+def test_sub_protocol_selection(snappy_support):
     peer = ProtoMatchingPeer([LESProtocol, LESProtocolV2])
 
     proto = peer.select_sub_protocol([
@@ -54,13 +61,15 @@ def test_sub_protocol_selection():
         (LESProtocolV2.name, LESProtocolV2.version),
         (LESProtocolV3.name, LESProtocolV3.version),
         ('unknown', 1),
-    ])
+    ],
+        snappy_support=snappy_support
+    )
 
     assert isinstance(proto, LESProtocolV2)
     assert proto.cmd_id_offset == peer.base_protocol.cmd_length
 
     with pytest.raises(NoMatchingPeerCapabilities):
-        peer.select_sub_protocol([('unknown', 1)])
+        peer.select_sub_protocol([('unknown', 1)], snappy_support)
 
 
 @pytest.mark.asyncio

--- a/tests/core/p2p-proto/test_snappy_compression.py
+++ b/tests/core/p2p-proto/test_snappy_compression.py
@@ -1,0 +1,22 @@
+import pytest
+
+from tests.core.peer_helpers import (
+    get_directly_linked_peers,
+    get_directly_linked_v4_and_v5_peers,
+)
+
+
+@pytest.mark.asyncio
+async def test_snappy_compression_enabled_between_connected_v5_protocol_peers(request, event_loop):
+    alice, bob = await get_directly_linked_peers(request, event_loop)
+    assert alice.sub_proto.snappy_support is True
+    assert alice.sub_proto.snappy_support is True
+
+
+@pytest.mark.asyncio
+async def test_snappy_compression_enabled_between_connected_v4_and_v5_protocol_peers(
+        request,
+        event_loop):
+    alice, bob = await get_directly_linked_v4_and_v5_peers(request, event_loop)
+    assert alice.sub_proto.snappy_support is False
+    assert alice.sub_proto.snappy_support is False

--- a/tests/core/peer_helpers.py
+++ b/tests/core/peer_helpers.py
@@ -9,6 +9,7 @@ from p2p import ecies
 from p2p.tools.paragon.helpers import (
     get_directly_linked_peers_without_handshake as _get_directly_linked_peers_without_handshake,
     get_directly_linked_peers as _get_directly_linked_peers,
+    get_directly_linked_v4_and_v5_peers as _get_directly_linked_v4_and_v5_peers,
 )
 
 
@@ -118,6 +119,22 @@ async def get_directly_linked_peers(
     )
 
     return await _get_directly_linked_peers(
+        request, event_loop,
+        alice_factory=alice_factory,
+        bob_factory=bob_factory,
+    )
+
+
+async def get_directly_linked_v4_and_v5_peers(
+        request, event_loop,
+        alice_headerdb=None, bob_headerdb=None,
+        alice_peer_class=ETHPeer, bob_peer_class=None):
+    alice_factory, bob_factory = await _setup_alice_and_bob_factories(
+        alice_headerdb, bob_headerdb,
+        alice_peer_class, bob_peer_class,
+    )
+
+    return await _get_directly_linked_v4_and_v5_peers(
         request, event_loop,
         alice_factory=alice_factory,
         bob_factory=bob_factory,

--- a/tests/p2p/test_auth.py
+++ b/tests/p2p/test_auth.py
@@ -266,4 +266,4 @@ def test_eip8_hello():
         "f87137916b6e6574682f76302e39312f706c616e39cdc5836574683dc6846d6f726b1682270fb840"
         "fda1cff674c90c9a197539fe3dfb53086ace64f83ed7c6eabec741f7f381cc803e52ab2cd55d5569"
         "bce4347107a310dfd5f88a010cd2ffd1005ca406f1842877c883666f6f836261720304")
-    Hello(cmd_id_offset=0).decode_payload(payload)
+    Hello(cmd_id_offset=0, snappy_support=False).decode_payload(payload)

--- a/trinity/protocol/bcc/proto.py
+++ b/trinity/protocol/bcc/proto.py
@@ -42,14 +42,14 @@ class BCCProtocol(HasExtendedDebugLogger, Protocol):
             "genesis_hash": genesis_hash,
             "best_hash": best_hash,
         }
-        cmd = Status(self.cmd_id_offset)
+        cmd = Status(self.cmd_id_offset, self.snappy_support)
         self.logger.debug2("Sending BCC/Status msg: %s", resp)
         self.send(*cmd.encode(resp))
 
     def send_get_blocks(self,
                         block_slot_or_root: Union[BlockNumber, Hash32],
                         max_blocks: int) -> None:
-        cmd = GetBeaconBlocks(self.cmd_id_offset)
+        cmd = GetBeaconBlocks(self.cmd_id_offset, self.snappy_support)
         data = {
             'block_slot_or_root': block_slot_or_root,
             'max_blocks': max_blocks,
@@ -58,11 +58,11 @@ class BCCProtocol(HasExtendedDebugLogger, Protocol):
         self.send(header, body)
 
     def send_blocks(self, blocks: Tuple[BaseBeaconBlock, ...]) -> None:
-        cmd = BeaconBlocks(self.cmd_id_offset)
+        cmd = BeaconBlocks(self.cmd_id_offset, self.snappy_support)
         header, body = cmd.encode(blocks)
         self.send(header, body)
 
     def send_attestation_records(self, attestations: Tuple[Attestation, ...]) -> None:
-        cmd = AttestationRecords(self.cmd_id_offset)
+        cmd = AttestationRecords(self.cmd_id_offset, self.snappy_support)
         header, body = cmd.encode(attestations)
         self.send(header, body)

--- a/trinity/protocol/eth/proto.py
+++ b/trinity/protocol/eth/proto.py
@@ -62,7 +62,7 @@ class ETHProtocol(HasExtendedDebugLogger, Protocol):
             'best_hash': chain_info.block_hash,
             'genesis_hash': chain_info.genesis_hash,
         }
-        cmd = Status(self.cmd_id_offset)
+        cmd = Status(self.cmd_id_offset, self.snappy_support)
         self.logger.debug2("Sending ETH/Status msg: %s", resp)
         self.send(*cmd.encode(resp))
 
@@ -70,12 +70,12 @@ class ETHProtocol(HasExtendedDebugLogger, Protocol):
     # Node Data
     #
     def send_get_node_data(self, node_hashes: Tuple[Hash32, ...]) -> None:
-        cmd = GetNodeData(self.cmd_id_offset)
+        cmd = GetNodeData(self.cmd_id_offset, self.snappy_support)
         header, body = cmd.encode(node_hashes)
         self.send(header, body)
 
     def send_node_data(self, nodes: Tuple[bytes, ...]) -> None:
-        cmd = NodeData(self.cmd_id_offset)
+        cmd = NodeData(self.cmd_id_offset, self.snappy_support)
         header, body = cmd.encode(nodes)
         self.send(header, body)
 
@@ -94,7 +94,7 @@ class ETHProtocol(HasExtendedDebugLogger, Protocol):
         block_number_or_hash if reverse is False or ending at block_number_or_hash if reverse is
         True.
         """
-        cmd = GetBlockHeaders(self.cmd_id_offset)
+        cmd = GetBlockHeaders(self.cmd_id_offset, self.snappy_support)
         data = {
             'block_number_or_hash': block_number_or_hash,
             'max_headers': max_headers,
@@ -105,7 +105,7 @@ class ETHProtocol(HasExtendedDebugLogger, Protocol):
         self.send(header, body)
 
     def send_block_headers(self, headers: Tuple[BlockHeader, ...]) -> None:
-        cmd = BlockHeaders(self.cmd_id_offset)
+        cmd = BlockHeaders(self.cmd_id_offset, self.snappy_support)
         header, body = cmd.encode(headers)
         self.send(header, body)
 
@@ -113,12 +113,12 @@ class ETHProtocol(HasExtendedDebugLogger, Protocol):
     # Block Bodies
     #
     def send_get_block_bodies(self, block_hashes: Tuple[Hash32, ...]) -> None:
-        cmd = GetBlockBodies(self.cmd_id_offset)
+        cmd = GetBlockBodies(self.cmd_id_offset, self.snappy_support)
         header, body = cmd.encode(block_hashes)
         self.send(header, body)
 
     def send_block_bodies(self, blocks: List[BlockBody]) -> None:
-        cmd = BlockBodies(self.cmd_id_offset)
+        cmd = BlockBodies(self.cmd_id_offset, self.snappy_support)
         header, body = cmd.encode(blocks)
         self.send(header, body)
 
@@ -126,12 +126,12 @@ class ETHProtocol(HasExtendedDebugLogger, Protocol):
     # Receipts
     #
     def send_get_receipts(self, block_hashes: Tuple[Hash32, ...]) -> None:
-        cmd = GetReceipts(self.cmd_id_offset)
+        cmd = GetReceipts(self.cmd_id_offset, self.snappy_support)
         header, body = cmd.encode(block_hashes)
         self.send(header, body)
 
     def send_receipts(self, receipts: List[List[Receipt]]) -> None:
-        cmd = Receipts(self.cmd_id_offset)
+        cmd = Receipts(self.cmd_id_offset, self.snappy_support)
         header, body = cmd.encode(receipts)
         self.send(header, body)
 
@@ -139,6 +139,6 @@ class ETHProtocol(HasExtendedDebugLogger, Protocol):
     # Transactions
     #
     def send_transactions(self, transactions: List[BaseTransactionFields]) -> None:
-        cmd = Transactions(self.cmd_id_offset)
+        cmd = Transactions(self.cmd_id_offset, self.snappy_support)
         header, body = cmd.encode(transactions)
         self.send(header, body)

--- a/trinity/protocol/les/commands.py
+++ b/trinity/protocol/les/commands.py
@@ -233,7 +233,7 @@ class ContractCodes(Command):
 class StatusV2(Status):
     _cmd_id = 0
 
-    def __init__(self, cmd_id_offset: int, snappy_support: bool=False) -> None:
+    def __init__(self, cmd_id_offset: int, snappy_support: bool) -> None:
         super().__init__(cmd_id_offset, snappy_support)
         self.items_sedes['announceType'] = sedes.big_endian_int
 

--- a/trinity/protocol/les/commands.py
+++ b/trinity/protocol/les/commands.py
@@ -233,8 +233,8 @@ class ContractCodes(Command):
 class StatusV2(Status):
     _cmd_id = 0
 
-    def __init__(self, cmd_id_offset: int) -> None:
-        super().__init__(cmd_id_offset)
+    def __init__(self, cmd_id_offset: int, snappy_support: bool=False) -> None:
+        super().__init__(cmd_id_offset, snappy_support)
         self.items_sedes['announceType'] = sedes.big_endian_int
 
 

--- a/trinity/protocol/les/proto.py
+++ b/trinity/protocol/les/proto.py
@@ -66,7 +66,7 @@ class LESProtocol(Protocol):
             # TODO: Uncomment once we start relaying transactions.
             # 'txRelay': None,
         }
-        cmd = Status(self.cmd_id_offset)
+        cmd = Status(self.cmd_id_offset, self.snappy_support)
         self.send(*cmd.encode(resp))
         self.logger.debug("Sending LES/Status msg: %s", resp)
 
@@ -81,7 +81,7 @@ class LESProtocol(Protocol):
             'request_id': request_id,
             'block_hashes': block_hashes,
         }
-        header, body = GetBlockBodies(self.cmd_id_offset).encode(data)
+        header, body = GetBlockBodies(self.cmd_id_offset, self.snappy_support).encode(data)
         self.send(header, body)
 
         return request_id
@@ -101,7 +101,7 @@ class LESProtocol(Protocol):
         """
         if request_id is None:
             request_id = gen_request_id()
-        cmd = GetBlockHeaders(self.cmd_id_offset)
+        cmd = GetBlockHeaders(self.cmd_id_offset, self.snappy_support)
         data = {
             'request_id': request_id,
             'query': GetBlockHeadersQuery(
@@ -125,7 +125,7 @@ class LESProtocol(Protocol):
             'headers': headers,
             'buffer_value': buffer_value,
         }
-        header, body = BlockHeaders(self.cmd_id_offset).encode(data)
+        header, body = BlockHeaders(self.cmd_id_offset, self.snappy_support).encode(data)
         self.send(header, body)
 
         return request_id
@@ -137,7 +137,7 @@ class LESProtocol(Protocol):
             'request_id': request_id,
             'block_hashes': [block_hash],
         }
-        header, body = GetReceipts(self.cmd_id_offset).encode(data)
+        header, body = GetReceipts(self.cmd_id_offset, self.snappy_support).encode(data)
         self.send(header, body)
 
         return request_id
@@ -150,7 +150,7 @@ class LESProtocol(Protocol):
             'request_id': request_id,
             'proof_requests': [ProofRequest(block_hash, account_key, key, from_level)],
         }
-        header, body = GetProofs(self.cmd_id_offset).encode(data)
+        header, body = GetProofs(self.cmd_id_offset, self.snappy_support).encode(data)
         self.send(header, body)
 
         return request_id
@@ -162,7 +162,7 @@ class LESProtocol(Protocol):
             'request_id': request_id,
             'code_requests': [ContractCodeRequest(block_hash, key)],
         }
-        header, body = GetContractCodes(self.cmd_id_offset).encode(data)
+        header, body = GetContractCodes(self.cmd_id_offset, self.snappy_support).encode(data)
         self.send(header, body)
 
         return request_id
@@ -187,7 +187,7 @@ class LESProtocolV2(LESProtocol):
             'serveChainSince': 0,
             'txRelay': None,
         }
-        cmd = StatusV2(self.cmd_id_offset)
+        cmd = StatusV2(self.cmd_id_offset, self.snappy_support)
         self.logger.debug("Sending LES/Status msg: %s", resp)
         self.send(*cmd.encode(resp))
 
@@ -203,7 +203,7 @@ class LESProtocolV2(LESProtocol):
             'request_id': request_id,
             'proof_requests': [ProofRequest(block_hash, account_key, key, from_level)],
         }
-        header, body = GetProofsV2(self.cmd_id_offset).encode(data)
+        header, body = GetProofsV2(self.cmd_id_offset, self.snappy_support).encode(data)
         self.send(header, body)
 
         return request_id


### PR DESCRIPTION
### What was wrong?
Fixes Issue #57


### How was it fixed?
* As of now, the Snappy Compression is made default for the transfer of messages in the Clients. In other words at this stage, this would work only if the following assumption holds, 
`All the clients in the Ethereum Network support Snappy Compression`.
* The Next step of this would be to check if the `other Node` which we are communicating with, supports `Snappy Compression` or not. And we should get this information in the `Handshake` itself. Only if it is supported, then we should send `Snappy Compressed Messages`. Else we shouldn't `Compress` the messages.
* Also `try/catch` exceptions should be added wherever we are using 
`Snappy compression/decompression`.

### References
* Mainly Referred [this](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-706.md) `EIP`
* Heavily Inspired by `geth` mainly from the functionalities `ReadMsg` and `WriteMsg` of 
`go-ethereum/p2p/rlpx.go`


#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://www.rd.com/wp-content/uploads/2017/10/203_The-Dogist-Puppies-760x506.jpg)
