### PR TITLE
Make Peer LESProtocol Methods generate own Request ID's

### DIFF
--- a/scripts/peer.py
+++ b/scripts/peer.py
@@ -95,9 +95,8 @@ def _main() -> None:
             peer.sub_proto.send_get_receipts(hashes)
         else:
             peer = cast(LESPeer, peer)
-            request_id = 1
-            peer.sub_proto.send_get_block_bodies(list(hashes), request_id + 1)
-            peer.sub_proto.send_get_receipts(hashes[0], request_id + 2)
+            peer.sub_proto.send_get_block_bodies(list(hashes))
+            peer.sub_proto.send_get_receipts(hashes[0])
 
     sigint_received = asyncio.Event()
     for sig in [signal.SIGINT, signal.SIGTERM]:

--- a/tests/core/p2p-proto/test_les_protocol_commands.py
+++ b/tests/core/p2p-proto/test_les_protocol_commands.py
@@ -1,0 +1,63 @@
+import asyncio
+import pytest
+
+from trinity.protocol.les.peer import (
+    LESPeer,
+)
+from trinity.protocol.les.proto import (
+    LESProtocol,
+)
+
+from tests.core.peer_helpers import (
+    get_directly_linked_peers,
+)
+
+
+@pytest.fixture
+async def les_peer_and_remote(request, event_loop):
+    peer, remote = await get_directly_linked_peers(
+        request,
+        event_loop,
+        alice_peer_class=LESPeer,
+    )
+    return peer, remote
+
+
+@pytest.mark.parametrize(
+    'request_id, is_request_id_provided',
+    (
+        (1, True),
+        (5, True),
+        (1000, True),
+        (None, False),
+    )
+)
+@pytest.mark.asyncio
+async def test_les_protocol_methods_request_id(
+        les_peer_and_remote, request_id, is_request_id_provided):
+    # Test ensuring the correctness of the LES Protocol commands
+    # irrespective of whether request_id is provided or not.
+
+    # Setting up the peers which are just connected by streams
+    peer, remote = les_peer_and_remote
+    assert isinstance(peer.sub_proto, LESProtocol)
+    assert isinstance(remote.sub_proto, LESProtocol)
+
+    # Test for get_block_headers
+    with remote.collect_sub_proto_messages() as buffer:
+        generated_request_id = peer.sub_proto.send_get_block_headers(
+            b'1234', 1, 0, False, request_id=request_id
+        )
+        await asyncio.sleep(0.1)
+
+    messages = buffer.get_messages()
+    assert len(messages) == 1
+    peer, cmd, msg = messages[0]
+
+    # Asserted that the reply message has the request_id as that which was generated
+    assert generated_request_id == msg['request_id']
+    # Assert the generated request_id is same as that which was provided
+    if is_request_id_provided:
+        assert msg['request_id'] == request_id
+    else:
+        assert msg['request_id'] != request_id

--- a/trinity/sync/light/service.py
+++ b/trinity/sync/light/service.py
@@ -69,7 +69,6 @@ from p2p.service import (
 from trinity.db.header import BaseAsyncHeaderDB
 from trinity.protocol.les.peer import LESPeer, LESPeerPool
 from trinity.rlp.block_body import BlockBody
-from trinity._utils.les import gen_request_id
 
 
 class BaseLightPeerChain(ABC):
@@ -167,8 +166,7 @@ class LightPeerChain(PeerSubscriber, BaseService, BaseLightPeerChain):
     async def coro_get_block_body_by_hash(self, block_hash: Hash32) -> BlockBody:
         peer = cast(LESPeer, self.peer_pool.highest_td_peer)
         self.logger.debug("Fetching block %s from %s", encode_hex(block_hash), peer)
-        request_id = gen_request_id()
-        peer.sub_proto.send_get_block_bodies([block_hash], request_id)
+        request_id = peer.sub_proto.send_get_block_bodies([block_hash])
         reply = await self._wait_for_reply(request_id)
         if not reply['bodies']:
             raise BlockNotFound(f"Peer {peer} has no block with hash {block_hash}")
@@ -181,8 +179,7 @@ class LightPeerChain(PeerSubscriber, BaseService, BaseLightPeerChain):
     async def coro_get_receipts(self, block_hash: Hash32) -> List[Receipt]:
         peer = cast(LESPeer, self.peer_pool.highest_td_peer)
         self.logger.debug("Fetching %s receipts from %s", encode_hex(block_hash), peer)
-        request_id = gen_request_id()
-        peer.sub_proto.send_get_receipts(block_hash, request_id)
+        request_id = peer.sub_proto.send_get_receipts(block_hash)
         reply = await self._wait_for_reply(request_id)
         if not reply['receipts']:
             raise BlockNotFound(f"No block with hash {block_hash} found")
@@ -254,8 +251,7 @@ class LightPeerChain(PeerSubscriber, BaseService, BaseLightPeerChain):
             account's code hash
         """
         # request contract code
-        request_id = gen_request_id()
-        peer.sub_proto.send_get_contract_code(block_hash, keccak(address), request_id)
+        request_id = peer.sub_proto.send_get_contract_code(block_hash, keccak(address))
         reply = await self._wait_for_reply(request_id)
 
         if not reply['codes']:
@@ -370,8 +366,7 @@ class LightPeerChain(PeerSubscriber, BaseService, BaseLightPeerChain):
                          account_key: bytes,
                          key: bytes,
                          from_level: int = 0) -> List[bytes]:
-        request_id = gen_request_id()
-        peer.sub_proto.send_get_proof(block_hash, account_key, key, from_level, request_id)
+        request_id = peer.sub_proto.send_get_proof(block_hash, account_key, key, from_level)
         reply = await self._wait_for_reply(request_id)
         return reply['proof']
 


### PR DESCRIPTION
### What was wrong?
Fixes #27


### How was it fixed?
The argument of `request_id` was made by default `None` in all the `LESProtocol Function Signatures` which use this argument. The main idea here is that the `Peers` don't pass in the `request_id` and the `request_id` would be automatically generated and returned by the `request calls(LESProtocol Methods)` made by them. 

On the other hand the `Server` which accepts these `requests` has to pass the `request_id` which it receives, so that it can create a `reply` with the same `request_id`. Hence the `Server` or `Remote Peer` passes the argument `request_id` to the `LESProtocol Functions` (unlike the peers which generate their own). This functionality of maintaining the `request_id` in the `server` side is needed because it has to send a `reply` with the same `request_id` as the `request` which it receives, so that the `client` or `peer` which receives a `reply`, knows to which `request` it has got a `reply` to.


#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcSqtKVVaJ1na9IfqfQK8XX5jdy2ict5YhJJxKftE5xXt9pev3yt)
