### PR TITLE
Don't run plugin discovery tests by default

### DIFF
--- a/tests/integration/test_plugin_discovery.py
+++ b/tests/integration/test_plugin_discovery.py
@@ -1,12 +1,16 @@
+import pytest
 from trinity.plugins.registry import (
     discover_plugins
 )
-# This plugin is external to this code base and installed by tox
-# In order to install it locally run:
-# pip install -e trinity-external-plugins/examples/peer_count_reporter
-from peer_count_reporter_plugin import PeerCountReporterPlugin
-
 
 def test_plugin_discovery():
+    if not pytest.config.getoption("--integration"):
+        pytest.skip("Not asked to run integration tests")
+
+    # This plugin is external to this code base and installed by tox
+    # In order to install it locally run:
+    # pip install -e trinity-external-plugins/examples/peer_count_reporter
+    from peer_count_reporter_plugin import PeerCountReporterPlugin
+
     plugins = [type(plugin) for plugin in discover_plugins()]
     assert PeerCountReporterPlugin in plugins

--- a/tests/integration/test_plugin_discovery.py
+++ b/tests/integration/test_plugin_discovery.py
@@ -3,6 +3,7 @@ from trinity.plugins.registry import (
     discover_plugins
 )
 
+
 def test_plugin_discovery():
     if not pytest.config.getoption("--integration"):
         pytest.skip("Not asked to run integration tests")

--- a/tox.ini
+++ b/tox.ini
@@ -57,7 +57,7 @@ commands=
     pip install -e {toxinidir}/trinity-external-plugins/examples/peer_count_reporter
     # We don't want to run these tests concurrently to avoid running into errors
     # due to multiple Trinity instances competing for the same ports
-    pytest -n 1 {posargs:tests/integration/ -k 'not lightchain_integration'}
+    pytest --integration -n 1 {posargs:tests/integration/ -k 'not lightchain_integration'}
 
 [testenv:py36-integration]
 deps = {[common-integration]deps}


### PR DESCRIPTION
Trinity also suffers from ethereum/py-evm#1646, which was solved by https://github.com/ethereum/py-evm/pull/1649/commits/713de38d4bf542344aaebb130eeae9623f88aa05 but the solution didn't survive the migration to this repo.

#### Cute Animal Picture

![migrating-turtles](https://user-images.githubusercontent.com/466333/50666468-b68a2400-0f69-11e9-863d-fc4c7c63dd84.jpg)

