### PR TITLE
Add default returns for eth_coinbase, eth_hashrate, eth_gasPrice JSON RPC calls

### DIFF
--- a/tests/core/json-rpc/test_ipc.py
+++ b/tests/core/json-rpc/test_ipc.py
@@ -176,6 +176,14 @@ def mock_network_id(network_id):
             {'result': False, 'id': 3, 'jsonrpc': '2.0'},
         ),
         (
+            build_request('eth_coinbase'),
+            {'result': '0x0000000000000000000000000000000000000000', 'id': 3, 'jsonrpc': '2.0'},
+        ),
+        (
+            build_request('eth_hashrate'),
+            {'result': '0x0', 'id': 3, 'jsonrpc': '2.0'},
+        ),
+        (
             build_request('web3_clientVersion'),
             {'result': construct_trinity_client_identifier(), 'id': 3, 'jsonrpc': '2.0'},
         ),

--- a/trinity/rpc/modules/eth.py
+++ b/trinity/rpc/modules/eth.py
@@ -156,8 +156,10 @@ class Eth(RPCModule):
         result = self._chain.get_transaction_result(transaction, header)
         return encode_hex(result)
 
-    async def coinbase(self) -> Hash32:
-        raise NotImplementedError()
+    async def coinbase(self) -> str:
+        # Trinity doesn't support mining yet and hence coinbase_address is default (ZERO_ADDRESS)
+        coinbase_address = ZERO_ADDRESS
+        return encode_hex(coinbase_address)
 
     @format_params(identity, to_int_if_hex)
     async def estimateGas(self, txn_dict: Dict[str, Any], at_block: Union[str, int]) -> str:
@@ -263,7 +265,9 @@ class Eth(RPCModule):
         return header_to_dict(uncle)
 
     async def hashrate(self) -> str:
-        raise NotImplementedError()
+        # Trinity doesn't support mining yet and hence hashrate is default (0)
+        hashrate = 0
+        return hex(hashrate)
 
     async def mining(self) -> bool:
         return False

--- a/trinity/rpc/modules/eth.py
+++ b/trinity/rpc/modules/eth.py
@@ -1,3 +1,5 @@
+import os
+
 from cytoolz import (
     identity,
 )
@@ -22,6 +24,7 @@ from eth_utils import (
     encode_hex,
     int_to_big_endian,
     is_integer,
+    to_wei,
 )
 
 from eth.constants import (
@@ -169,8 +172,8 @@ class Eth(RPCModule):
         gas = self._chain.estimate_gas(transaction, header)
         return hex(gas)
 
-    async def gasPrice(self) -> int:
-        raise NotImplementedError()
+    async def gasPrice(self) -> str:
+        return hex(int(os.environ.get('TRINITY_GAS_PRICE', to_wei(1, 'gwei'))))
 
     @format_params(decode_hex, to_int_if_hex)
     async def getBalance(self, address: Address, at_block: Union[str, int]) -> str:


### PR DESCRIPTION
### What was wrong?

Link to Old PR: https://github.com/ethereum/py-evm/pull/1651

As part of Issue #20 .
Implements `eth_coinbase` and `eth_hashrate` functions. The return values are the default values as mining isn't supported by trinity as of now.
`eth_gasPrice` currently returns the average of the `gasprices` of all the transactions in a block.


### How was it fixed?

The functions were `modified/added` to `trinity/rpc/eth.py`


#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://camo.githubusercontent.com/b26633c78be9e8c390fc5896033cec837f01d185/68747470733a2f2f636f736d6f732d696d61676573322e696d6769782e6e65742f66696c652f7370696e612f70686f746f2f31343737322f4765747479496d616765732d3639313132303937392e6a70673f69786c69623d7261696c732d322e312e34266175746f3d666f726d61742663683d5769647468253243445052266669743d6d617826773d383335)
