### PR TITLE
CI: rename EIP15{0,8} tox jobs to their long-form fork names.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -128,18 +128,18 @@ jobs:
       - image: circleci/python:3.6
         environment:
           TOXENV: py36-rpc-state-homestead
-  py36-rpc-state-eip150:
+  py36-rpc-state-tangerine_whistle:
     <<: *common
     docker:
       - image: circleci/python:3.6
         environment:
-          TOXENV: py36-rpc-state-eip150
-  py36-rpc-state-eip158:
+          TOXENV: py36-rpc-state-tangerine_whistle
+  py36-rpc-state-spurious_dragon:
     <<: *common
     docker:
       - image: circleci/python:3.6
         environment:
-          TOXENV: py36-rpc-state-eip158
+          TOXENV: py36-rpc-state-spurious_dragon
   py36-rpc-blockchain:
     <<: *common
     docker:
@@ -211,8 +211,8 @@ workflows:
       - py36-rpc-state-constantinople
       - py36-rpc-state-frontier
       - py36-rpc-state-homestead
-      - py36-rpc-state-eip150
-      - py36-rpc-state-eip158
+      - py36-rpc-state-tangerine_whistle
+      - py36-rpc-state-spurious_dragon
       - py36-rpc-state-quadratic
       - py36-rpc-blockchain
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 envlist=
     py{36,37}-{core,p2p,integration,lightchain_integration}
-    py{36}-rpc-state-{frontier,homestead,eip150,eip158,byzantium,constantinople,quadratic}
+    py{36}-rpc-state-{frontier,homestead,tangerine_whistle,spurious_dragon,byzantium,constantinople,quadratic}
     py{36}-rpc-blockchain
     py{36,37}-lint
     py36-docs
@@ -22,8 +22,8 @@ commands=
     rpc-blockchain: pytest {posargs:tests/json-fixtures-over-rpc/test_rpc_fixtures.py -k 'not GeneralStateTests'}
     rpc-state-frontier: pytest {posargs:tests/json-fixtures-over-rpc/test_rpc_fixtures.py -k 'GeneralStateTests and not stQuadraticComplexityTest and Frontier'}
     rpc-state-homestead: pytest {posargs:tests/json-fixtures-over-rpc/test_rpc_fixtures.py -k 'GeneralStateTests and not stQuadraticComplexityTest and Homestead'}
-    rpc-state-eip150: pytest {posargs:tests/json-fixtures-over-rpc/test_rpc_fixtures.py -k 'GeneralStateTests and not stQuadraticComplexityTest and EIP150'}
-    rpc-state-eip158: pytest {posargs:tests/json-fixtures-over-rpc/test_rpc_fixtures.py -k 'GeneralStateTests and not stQuadraticComplexityTest and EIP158'}
+    rpc-state-tangerine_whistle: pytest {posargs:tests/json-fixtures-over-rpc/test_rpc_fixtures.py -k 'GeneralStateTests and not stQuadraticComplexityTest and EIP150'}
+    rpc-state-spurious_dragon: pytest {posargs:tests/json-fixtures-over-rpc/test_rpc_fixtures.py -k 'GeneralStateTests and not stQuadraticComplexityTest and EIP158'}
     # The following test seems to consume a lot of memory. Restricting to 3 processes reduces crashes
     rpc-state-byzantium: pytest -n3 {posargs:tests/json-fixtures-over-rpc/test_rpc_fixtures.py -k 'GeneralStateTests and not stQuadraticComplexityTest and Byzantium'}
     rpc-state-constantinople: pytest -n3 {posargs:tests/json-fixtures-over-rpc/test_rpc_fixtures.py -k 'GeneralStateTests and not stQuadraticComplexityTest and Constantinople'}


### PR DESCRIPTION
### What was wrong?

Fallout from PR https://github.com/ethereum/py-evm/pull/1577#discussion_r241148668.

Closes #102.

CI jobs have `eip150`, `eip158` in their names.

One has to know the numbers refer to hard-forks to understand jobs don't check for kitty support, or the like.

### How was it fixed?

Renamed CI job name (label only).

(Or was the original request to rename it throughout the codebase?..)

### Cute Animal Picture

![put a cute animal picture link inside the parentheses](http://muc1.framepool.com/shotimg/270153560-whisker-floreana-island-upside-down-sea-lion.jpg)

Source: thumbnail of a [video on framepool](http://muc1.framepool.com/en/shot/270153560-whisker-floreana-island-upside-down-sea-lion)