### PR TITLE
Christoph/feat/rpc beacon modules

### DIFF
--- a/trinity/plugins/builtin/json_rpc/plugin.py
+++ b/trinity/plugins/builtin/json_rpc/plugin.py
@@ -27,9 +27,10 @@ from trinity.rpc.main import (
 )
 from trinity.rpc.modules import (
     BEACON_RPC_MODULES,
+    BeaconRPCModule,
     ETH1_RPC_MODULES,
     initialize_modules,
-    RPCModule,
+    Eth1RPCModule,
 )
 from trinity.rpc.ipc import (
     IPCServer,
@@ -56,7 +57,7 @@ class JsonRpcServerPlugin(BaseIsolatedPlugin):
             help="Disables the JSON-RPC Server",
         )
 
-    def setup_eth1_modules(self, trinity_config: TrinityConfig) -> Tuple[RPCModule, ...]:
+    def setup_eth1_modules(self, trinity_config: TrinityConfig) -> Tuple[Eth1RPCModule, ...]:
         db_manager = create_db_manager(trinity_config.database_ipc_path)
         db_manager.connect()
 
@@ -77,7 +78,7 @@ class JsonRpcServerPlugin(BaseIsolatedPlugin):
 
         return initialize_modules(ETH1_RPC_MODULES, chain, self.event_bus)
 
-    def setup_beacon_modules(self, trinity_config: TrinityConfig) -> Tuple[RPCModule, ...]:
+    def setup_beacon_modules(self, trinity_config: TrinityConfig) -> Tuple[BeaconRPCModule, ...]:
 
         return initialize_modules(BEACON_RPC_MODULES, None, self.event_bus)
 

--- a/trinity/rpc/modules/__init__.py
+++ b/trinity/rpc/modules/__init__.py
@@ -1,6 +1,10 @@
 from .main import (  # noqa: F401
+    BaseRPCModule,
+    BeaconRPCModule,
+    ChainReplacementEvent,
+    Eth1RPCModule,
     initialize_modules,
-    RPCModule
+    RPCModule,
 )
 
 from .beacon import Beacon  # noqa: F401

--- a/trinity/rpc/modules/beacon.py
+++ b/trinity/rpc/modules/beacon.py
@@ -1,7 +1,7 @@
-from trinity.rpc.modules import RPCModule
+from trinity.rpc.modules import BeaconRPCModule
 
 
-class Beacon(RPCModule):
+class Beacon(BeaconRPCModule):
 
     @property
     def name(self) -> str:

--- a/trinity/rpc/modules/eth.py
+++ b/trinity/rpc/modules/eth.py
@@ -152,15 +152,15 @@ class Eth(Eth1RPCModule):
         return []
 
     async def blockNumber(self) -> str:
-        num = self._chain.get_canonical_head().block_number
+        num = self.chain.get_canonical_head().block_number
         return hex(num)
 
     @format_params(identity, to_int_if_hex)
     async def call(self, txn_dict: Dict[str, Any], at_block: Union[str, int]) -> str:
-        header = await get_header(self._chain, at_block)
-        validate_transaction_call_dict(txn_dict, self._chain.get_vm(header))
-        transaction = dict_to_spoof_transaction(self._chain, header, txn_dict)
-        result = self._chain.get_transaction_result(transaction, header)
+        header = await get_header(self.chain, at_block)
+        validate_transaction_call_dict(txn_dict, self.chain.get_vm(header))
+        transaction = dict_to_spoof_transaction(self.chain, header, txn_dict)
+        result = self.chain.get_transaction_result(transaction, header)
         return encode_hex(result)
 
     async def coinbase(self) -> str:
@@ -170,10 +170,10 @@ class Eth(Eth1RPCModule):
 
     @format_params(identity, to_int_if_hex)
     async def estimateGas(self, txn_dict: Dict[str, Any], at_block: Union[str, int]) -> str:
-        header = await get_header(self._chain, at_block)
-        validate_transaction_gas_estimation_dict(txn_dict, self._chain.get_vm(header))
-        transaction = dict_to_spoof_transaction(self._chain, header, txn_dict)
-        gas = self._chain.estimate_gas(transaction, header)
+        header = await get_header(self.chain, at_block)
+        validate_transaction_gas_estimation_dict(txn_dict, self.chain.get_vm(header))
+        transaction = dict_to_spoof_transaction(self.chain, header, txn_dict)
+        gas = self.chain.estimate_gas(transaction, header)
         return hex(gas)
 
     async def gasPrice(self) -> str:
@@ -181,7 +181,7 @@ class Eth(Eth1RPCModule):
 
     @format_params(decode_hex, to_int_if_hex)
     async def getBalance(self, address: Address, at_block: Union[str, int]) -> str:
-        account_db = await account_db_at_block(self._chain, at_block)
+        account_db = await account_db_at_block(self.chain, at_block)
         balance = account_db.get_balance(address)
 
         return hex(balance)
@@ -190,29 +190,29 @@ class Eth(Eth1RPCModule):
     async def getBlockByHash(self,
                              block_hash: Hash32,
                              include_transactions: bool) -> Dict[str, Union[str, List[str]]]:
-        block = await self._chain.coro_get_block_by_hash(block_hash)
-        return block_to_dict(block, self._chain, include_transactions)
+        block = await self.chain.coro_get_block_by_hash(block_hash)
+        return block_to_dict(block, self.chain, include_transactions)
 
     @format_params(to_int_if_hex, identity)
     async def getBlockByNumber(self,
                                at_block: Union[str, int],
                                include_transactions: bool) -> Dict[str, Union[str, List[str]]]:
-        block = await get_block_at_number(self._chain, at_block)
-        return block_to_dict(block, self._chain, include_transactions)
+        block = await get_block_at_number(self.chain, at_block)
+        return block_to_dict(block, self.chain, include_transactions)
 
     @format_params(decode_hex)
     async def getBlockTransactionCountByHash(self, block_hash: Hash32) -> str:
-        block = await self._chain.coro_get_block_by_hash(block_hash)
+        block = await self.chain.coro_get_block_by_hash(block_hash)
         return hex(len(block.transactions))
 
     @format_params(to_int_if_hex)
     async def getBlockTransactionCountByNumber(self, at_block: Union[str, int]) -> str:
-        block = await get_block_at_number(self._chain, at_block)
+        block = await get_block_at_number(self.chain, at_block)
         return hex(len(block.transactions))
 
     @format_params(decode_hex, to_int_if_hex)
     async def getCode(self, address: Address, at_block: Union[str, int]) -> str:
-        account_db = await account_db_at_block(self._chain, at_block)
+        account_db = await account_db_at_block(self.chain, at_block)
         code = account_db.get_code(address)
         return encode_hex(code)
 
@@ -221,7 +221,7 @@ class Eth(Eth1RPCModule):
         if not is_integer(position) or position < 0:
             raise TypeError("Position of storage must be a whole number, but was: %r" % position)
 
-        account_db = await account_db_at_block(self._chain, at_block)
+        account_db = await account_db_at_block(self.chain, at_block)
         stored_val = account_db.get_storage(address, position)
         return encode_hex(int_to_big_endian(stored_val))
 
@@ -229,7 +229,7 @@ class Eth(Eth1RPCModule):
     async def getTransactionByBlockHashAndIndex(self,
                                                 block_hash: Hash32,
                                                 index: int) -> Dict[str, str]:
-        block = await self._chain.coro_get_block_by_hash(block_hash)
+        block = await self.chain.coro_get_block_by_hash(block_hash)
         transaction = block.transactions[index]
         return transaction_to_dict(transaction)
 
@@ -237,29 +237,29 @@ class Eth(Eth1RPCModule):
     async def getTransactionByBlockNumberAndIndex(self,
                                                   at_block: Union[str, int],
                                                   index: int) -> Dict[str, str]:
-        block = await get_block_at_number(self._chain, at_block)
+        block = await get_block_at_number(self.chain, at_block)
         transaction = block.transactions[index]
         return transaction_to_dict(transaction)
 
     @format_params(decode_hex, to_int_if_hex)
     async def getTransactionCount(self, address: Address, at_block: Union[str, int]) -> str:
-        account_db = await account_db_at_block(self._chain, at_block)
+        account_db = await account_db_at_block(self.chain, at_block)
         nonce = account_db.get_nonce(address)
         return hex(nonce)
 
     @format_params(decode_hex)
     async def getUncleCountByBlockHash(self, block_hash: Hash32) -> str:
-        block = await self._chain.coro_get_block_by_hash(block_hash)
+        block = await self.chain.coro_get_block_by_hash(block_hash)
         return hex(len(block.uncles))
 
     @format_params(to_int_if_hex)
     async def getUncleCountByBlockNumber(self, at_block: Union[str, int]) -> str:
-        block = await get_block_at_number(self._chain, at_block)
+        block = await get_block_at_number(self.chain, at_block)
         return hex(len(block.uncles))
 
     @format_params(decode_hex, to_int_if_hex)
     async def getUncleByBlockHashAndIndex(self, block_hash: Hash32, index: int) -> Dict[str, str]:
-        block = await self._chain.coro_get_block_by_hash(block_hash)
+        block = await self.chain.coro_get_block_by_hash(block_hash)
         uncle = block.uncles[index]
         return header_to_dict(uncle)
 
@@ -267,7 +267,7 @@ class Eth(Eth1RPCModule):
     async def getUncleByBlockNumberAndIndex(self,
                                             at_block: Union[str, int],
                                             index: int) -> Dict[str, str]:
-        block = await get_block_at_number(self._chain, at_block)
+        block = await get_block_at_number(self.chain, at_block)
         uncle = block.uncles[index]
         return header_to_dict(uncle)
 
@@ -288,7 +288,7 @@ class Eth(Eth1RPCModule):
         highestBlock: BlockNumber
 
     async def syncing(self) -> Union[bool, SyncProgress]:
-        res = await self._event_bus.request(SyncingRequest(), TO_NETWORKING_BROADCAST_CONFIG)
+        res = await self.event_bus.request(SyncingRequest(), TO_NETWORKING_BROADCAST_CONFIG)
         if res.is_syncing:
             return {
                 "startingBlock": res.progress.starting_block,

--- a/trinity/rpc/modules/eth.py
+++ b/trinity/rpc/modules/eth.py
@@ -56,7 +56,7 @@ from trinity.rpc.format import (
     transaction_to_dict,
 )
 from trinity.rpc.modules import (
-    RPCModule,
+    Eth1RPCModule,
 )
 from trinity.sync.common.events import (
     SyncingRequest,
@@ -136,7 +136,7 @@ def dict_to_spoof_transaction(
     return SpoofTransaction(unsigned, from_=sender)
 
 
-class Eth(RPCModule):
+class Eth(Eth1RPCModule):
     '''
     All the methods defined by JSON-RPC API, starting with "eth_"...
 

--- a/trinity/rpc/modules/evm.py
+++ b/trinity/rpc/modules/evm.py
@@ -1,8 +1,12 @@
 from typing import (
     Any
 )
+
 from eth_utils import (
     encode_hex,
+)
+from lahja import (
+    BroadcastConfig,
 )
 
 from eth.chains.base import (
@@ -21,11 +25,12 @@ from trinity.rpc.format import (
     format_params,
 )
 from trinity.rpc.modules import (
-    RPCModule,
+    ChainReplacementEvent,
+    Eth1RPCModule,
 )
 
 
-class EVM(RPCModule):
+class EVM(Eth1RPCModule):
 
     @property
     def name(self) -> str:
@@ -38,7 +43,14 @@ class EVM(RPCModule):
         which is then replaced inside :class:`~trinity.rpc.main.RPCServer`
         for all future calls.
         '''
-        return new_chain_from_fixture(chain_info, type(self._chain))
+        chain = new_chain_from_fixture(chain_info, type(self._chain))
+
+        self._event_bus.broadcast(
+            ChainReplacementEvent(chain),
+            BroadcastConfig(internal=True)
+        )
+
+        return chain
 
     @format_params(normalize_block)
     async def applyBlockFixture(self, block_info: Any) -> str:

--- a/trinity/rpc/modules/evm.py
+++ b/trinity/rpc/modules/evm.py
@@ -43,9 +43,9 @@ class EVM(Eth1RPCModule):
         which is then replaced inside :class:`~trinity.rpc.main.RPCServer`
         for all future calls.
         '''
-        chain = new_chain_from_fixture(chain_info, type(self._chain))
+        chain = new_chain_from_fixture(chain_info, type(self.chain))
 
-        self._event_bus.broadcast(
+        self.event_bus.broadcast(
             ChainReplacementEvent(chain),
             BroadcastConfig(internal=True)
         )
@@ -59,5 +59,5 @@ class EVM(Eth1RPCModule):
         which is then replaced inside :class:`~trinity.rpc.main.RPCServer`
         for all future calls.
         '''
-        _, _, rlp_encoded = apply_fixture_block_to_chain(block_info, self._chain)
+        _, _, rlp_encoded = apply_fixture_block_to_chain(block_info, self.chain)
         return encode_hex(rlp_encoded)

--- a/trinity/rpc/modules/main.py
+++ b/trinity/rpc/modules/main.py
@@ -43,16 +43,16 @@ class BaseRPCModule(ABC):
 class RPCModule(BaseRPCModule, Generic[TChain]):
 
     def __init__(self, chain: TChain, event_bus: Endpoint) -> None:
-        self._chain = chain
-        self._event_bus = event_bus
+        self.chain = chain
+        self.event_bus = event_bus
 
-        self._event_bus.subscribe(
+        self.event_bus.subscribe(
             ChainReplacementEvent,
             lambda ev: self.set_chain(ev.chain)
         )
 
     def set_chain(self, chain: TChain) -> None:
-        self._chain = chain
+        self.chain = chain
 
 
 Eth1RPCModule = RPCModule['BaseAsyncChain']

--- a/trinity/rpc/modules/net.py
+++ b/trinity/rpc/modules/net.py
@@ -1,10 +1,10 @@
 from p2p.events import PeerCountRequest
 from trinity.constants import TO_NETWORKING_BROADCAST_CONFIG
 from trinity.nodes.events import NetworkIdRequest
-from trinity.rpc.modules import RPCModule
+from trinity.rpc.modules import Eth1RPCModule
 
 
-class Net(RPCModule):
+class Net(Eth1RPCModule):
 
     @property
     def name(self) -> str:

--- a/trinity/rpc/modules/net.py
+++ b/trinity/rpc/modules/net.py
@@ -14,7 +14,7 @@ class Net(Eth1RPCModule):
         """
         Returns the current network ID.
         """
-        response = await self._event_bus.request(
+        response = await self.event_bus.request(
             NetworkIdRequest(),
             TO_NETWORKING_BROADCAST_CONFIG
         )
@@ -24,7 +24,7 @@ class Net(Eth1RPCModule):
         """
         Return the number of peers that are currently connected to the node
         """
-        response = await self._event_bus.request(
+        response = await self.event_bus.request(
             PeerCountRequest(),
             TO_NETWORKING_BROADCAST_CONFIG
         )

--- a/trinity/rpc/modules/web3.py
+++ b/trinity/rpc/modules/web3.py
@@ -4,11 +4,11 @@ from eth_utils import decode_hex, encode_hex
 from trinity._utils.version import construct_trinity_client_identifier
 
 from trinity.rpc.modules import (
-    RPCModule,
+    Eth1RPCModule
 )
 
 
-class Web3(RPCModule):
+class Web3(Eth1RPCModule):
 
     @property
     def name(self) -> str:


### PR DESCRIPTION
### What was wrong?

RPC Modules were locked to depend on `BaseAsyncChain` .

### How was it fixed?

1. `RPCModule` is genreic over `TChain`
2. RPCServer dropped dependency on the chain so that all it cares about is the `name` which means it is satisfied by the new non-generic `BaseRPCModule`.
3. The chain reset mechanism is now event bus based (making it possible to drop the `chain` dependency on the `RPCServer`

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses]()
