### PR TITLE
Add undeclared eth-utils dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,6 +17,7 @@ deps = {
         "bloom-filter==1.3",
         "cachetools>=2.1.0,<3.0.0",
         "coincurve>=10.0.0,<11.0.0",
+        "eth-utils>=1.3.0,<2",
         "ipython>=6.2.1,<7.0.0",
         "plyvel==1.0.5",
         "py-evm==0.2.0a38",


### PR DESCRIPTION
### What was wrong?

The `eth-utils` dependency was not explicitly declared.

### How was it fixed?

Added it to the main application dependencies.

#### Cute Animal Picture

![23-hilarious-photos-of-surprised-animals-6](https://user-images.githubusercontent.com/824194/50927670-b11f5480-1415-11e9-8c8c-c98a011b0d2c.jpg)

