### PR TITLE
Stop --disable-discovery from emitting WARNINGs

### DIFF
--- a/p2p/discovery.py
+++ b/p2p/discovery.py
@@ -955,6 +955,38 @@ class DiscoveryByTopicProtocol(DiscoveryProtocol):
         return tuple(seen_nodes)
 
 
+class NoopDiscoveryService(BaseService):
+    'A stub "discovery service" which does nothing'
+
+    def __init__(self, event_bus: Endpoint, token: CancelToken = None) -> None:
+        super().__init__(token)
+        self._event_bus = event_bus
+
+    async def handle_get_peer_candidates_requests(self) -> None:
+        async for event in self._event_bus.stream(PeerCandidatesRequest):
+            self.logger.debug("Servicing request for more peer candidates")
+
+            self._event_bus.broadcast(
+                event.expected_response_type()(tuple()),
+                event.broadcast_config()
+            )
+
+    async def handle_get_random_bootnode_requests(self) -> None:
+        async for event in self._event_bus.stream(RandomBootnodeRequest):
+            self.logger.debug("Servicing request for boot nodes")
+
+            self._event_bus.broadcast(
+                event.expected_response_type()(tuple()),
+                event.broadcast_config()
+            )
+
+    async def _run(self) -> None:
+        self.run_daemon_task(self.handle_get_peer_candidates_requests())
+        self.run_daemon_task(self.handle_get_random_bootnode_requests())
+
+        await self.cancel_token.wait()
+
+
 class DiscoveryService(BaseService):
     _last_lookup: float = 0
     _lookup_interval: int = 30
@@ -969,9 +1001,6 @@ class DiscoveryService(BaseService):
         self.port = port
         self._event_bus = event_bus
         self._lookup_running = asyncio.Lock()
-
-        self.run_daemon_task(self.handle_get_peer_candidates_requests())
-        self.run_daemon_task(self.handle_get_random_bootnode_requests())
 
     async def handle_get_peer_candidates_requests(self) -> None:
         async for event in self._event_bus.stream(PeerCandidatesRequest):
@@ -998,6 +1027,9 @@ class DiscoveryService(BaseService):
             )
 
     async def _run(self) -> None:
+        self.run_daemon_task(self.handle_get_peer_candidates_requests())
+        self.run_daemon_task(self.handle_get_random_bootnode_requests())
+
         await self._start_udp_listener()
         self.run_task(self.proto.bootstrap())
         await self.cancel_token.wait()


### PR DESCRIPTION
Part of #127

TODO:
- [ ] Add some kind of test that this works?

When --disable-discovery was set it turn the discovery
plugin completely turned itself off. However, PeerPool still expected
something to respond to `PeerCandidatesRequest` and `RandomBootnodeRequest`
messages, so the log was full of WARNINGS complaining about unanswered
messages.

This commit adds `NoopDiscoveryService` which is used when the
--disable-discovery flag is passed. It answers every message with the
empty set.

![frozen-whiskers](https://user-images.githubusercontent.com/466333/50933886-f8a8df00-141b-11e9-86da-a59e2c68e22e.jpeg)
