### PR TITLE
Fix some minor parser bugs

### DIFF
--- a/trinity/cli_parser.py
+++ b/trinity/cli_parser.py
@@ -328,11 +328,3 @@ debug_parser.add_argument(
         "Enables profiling via cProfile."
     ),
 )
-
-#
-# Add `fix-unclean-shutdown` sub-command to trinity CLI
-#
-fix_unclean_shutdown_parser = subparser.add_parser(
-    'fix-unclean-shutdown',
-    help='close any dangling processes from a previous unclean shutdown',
-)

--- a/trinity/cli_parser.py
+++ b/trinity/cli_parser.py
@@ -138,7 +138,7 @@ subparser = parser.add_subparsers(dest='subcommand')
 #
 # Argument Groups
 #
-trinity_parser = parser.add_argument_group('sync mode')
+trinity_parser = parser.add_argument_group('core')
 logging_parser = parser.add_argument_group('logging')
 network_parser = parser.add_argument_group('network')
 syncing_parser = parser.add_argument_group('sync mode')


### PR DESCRIPTION
### What was wrong?

- The trinity core parser was falsely captioned with `sync mode`
- There was some leftover code for the `fix-unclean-shutdown` command that is actually provided by the plugin

### How was it fixed?

- renamed parser
- removed dead code

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://pbs.twimg.com/media/DfLOp8yWsAAy3fI.jpg)
