### PR TITLE
[WIP] Use NamedTuple instead of Dict for Messages throughout

### DIFF
--- a/p2p/peer.py
+++ b/p2p/peer.py
@@ -306,7 +306,7 @@ class BasePeer(BaseService):
             msg = cast(Dict[str, Any], msg)
             # Peers sometimes send a disconnect msg before they send the sub-proto handshake.
             raise HandshakeFailure(
-                f"{self} disconnected before completing sub-proto handshake: {msg['reason_name']}"
+                f"{self} disconnected before completing sub-proto handshake: {msg.reason_name}"
             )
         await self.process_sub_proto_handshake(cmd, msg)
         self.logger.debug("Finished %s handshake with %s", self.sub_proto, self.remote)
@@ -329,7 +329,7 @@ class BasePeer(BaseService):
             msg = cast(Dict[str, Any], msg)
             # Peers sometimes send a disconnect msg before they send the initial P2P handshake.
             raise HandshakeFailure(
-                f"{self} disconnected before completing sub-proto handshake: {msg['reason_name']}"
+                f"{self} disconnected before completing sub-proto handshake: {msg.reason_name}"
             )
         await self.process_p2p_handshake(cmd, msg)
 
@@ -447,7 +447,7 @@ class BasePeer(BaseService):
         """Handle the base protocol (P2P) messages."""
         if isinstance(cmd, Disconnect):
             msg = cast(Dict[str, Any], msg)
-            raise RemoteDisconnected(msg['reason_name'])
+            raise RemoteDisconnected(msg.reason_name)
         elif isinstance(cmd, Ping):
             self.base_protocol.send_pong()
         elif isinstance(cmd, Pong):
@@ -487,7 +487,7 @@ class BasePeer(BaseService):
         if not isinstance(cmd, Hello):
             await self.disconnect(DisconnectReason.bad_protocol)
             raise HandshakeFailure(f"Expected a Hello msg, got {cmd}, disconnecting")
-        remote_capabilities = msg['capabilities']
+        remote_capabilities = msg.capabilities
         try:
             self.sub_proto = self.select_sub_protocol(remote_capabilities)
         except NoMatchingPeerCapabilities:

--- a/p2p/tools/paragon/commands.py
+++ b/p2p/tools/paragon/commands.py
@@ -1,3 +1,7 @@
+from typing import (
+    NamedTuple,
+)
+
 from rlp import sedes
 
 from p2p.protocol import (
@@ -5,23 +9,39 @@ from p2p.protocol import (
 )
 
 
+class BroadcastDataMessage(NamedTuple):
+    data: bytes
+
+
 class BroadcastData(Command):
     _cmd_id = 0
+    message_class = BroadcastDataMessage
     structure = [
         ('data', sedes.binary),
     ]
 
 
+class GetSumMessage(NamedTuple):
+    a: int
+    b: int
+
+
 class GetSum(Command):
     _cmd_id = 2
+    message_class = GetSumMessage
     structure = [
         ('a', sedes.big_endian_int),
         ('b', sedes.big_endian_int),
     ]
 
 
+class SumMessage(NamedTuple):
+    result: int
+
+
 class Sum(Command):
     _cmd_id = 3
+    message_class = SumMessage
     structure = [
         ('result', sedes.big_endian_int),
     ]

--- a/tests/core/p2p-proto/bcc/test_commands.py
+++ b/tests/core/p2p-proto/bcc/test_commands.py
@@ -14,9 +14,10 @@ from p2p.peer import (
 )
 
 from trinity.protocol.bcc.commands import (
+    AttestationRecords,
     BeaconBlocks,
     GetBeaconBlocks,
-    AttestationRecords,
+    GetBeaconBlocksMessage,
 )
 
 from .helpers import (
@@ -95,10 +96,10 @@ async def test_send_get_blocks_by_slot(request, event_loop):
 
     message = await msg_buffer.msg_queue.get()
     assert isinstance(message.command, GetBeaconBlocks)
-    assert message.payload == {
-        "block_slot_or_root": 123,
-        "max_blocks": 10,
-    }
+    assert message.payload == GetBeaconBlocksMessage(
+        block_slot_or_root=123,
+        max_blocks=10,
+    )
 
 
 @pytest.mark.asyncio
@@ -111,10 +112,10 @@ async def test_send_get_blocks_by_hash(request, event_loop):
 
     message = await msg_buffer.msg_queue.get()
     assert isinstance(message.command, GetBeaconBlocks)
-    assert message.payload == {
-        "block_slot_or_root": b"\x33" * 32,
-        "max_blocks": 15,
-    }
+    assert message.payload == GetBeaconBlocksMessage(
+        block_slot_or_root=b"\x33" * 32,
+        max_blocks=15,
+    )
 
 
 @pytest.mark.asyncio

--- a/tests/core/p2p-proto/bcc/test_handshake.py
+++ b/tests/core/p2p-proto/bcc/test_handshake.py
@@ -50,10 +50,10 @@ async def test_unidirectional_handshake(request, event_loop):
 
     assert isinstance(cmd, Status)
 
-    assert msg["protocol_version"] == BCCProtocol.version
-    assert msg["network_id"] == alice.context.network_id
-    assert msg["genesis_hash"] == alice_head_hash
-    assert msg["best_hash"] == alice_genesis_hash
+    assert msg.protocol_version == BCCProtocol.version
+    assert msg.network_id == alice.context.network_id
+    assert msg.genesis_hash == alice_head_hash
+    assert msg.best_hash == alice_genesis_hash
 
     await bob.process_sub_proto_handshake(cmd, msg)
 

--- a/tests/core/p2p-proto/test_les_protocol_commands.py
+++ b/tests/core/p2p-proto/test_les_protocol_commands.py
@@ -55,9 +55,9 @@ async def test_les_protocol_methods_request_id(
     peer, cmd, msg = messages[0]
 
     # Asserted that the reply message has the request_id as that which was generated
-    assert generated_request_id == msg['request_id']
+    assert generated_request_id == msg.request_id
     # Assert the generated request_id is same as that which was provided
     if is_request_id_provided:
-        assert msg['request_id'] == request_id
+        assert msg.request_id == request_id
     else:
-        assert msg['request_id'] != request_id
+        assert msg.request_id != request_id

--- a/tests/core/p2p-proto/test_peer_block_header_validator_api.py
+++ b/tests/core/p2p-proto/test_peer_block_header_validator_api.py
@@ -21,7 +21,7 @@ class RequestIDMonitor(PeerSubscriber):
 
     async def next_request_id(self):
         msg = await self.msg_queue.get()
-        return msg.payload['request_id']
+        return msg.payload.request_id
 
 
 @to_tuple

--- a/tests/core/p2p-proto/test_stats.py
+++ b/tests/core/p2p-proto/test_stats.py
@@ -21,7 +21,7 @@ class RequestIDMonitor(PeerSubscriber):
 
     async def next_request_id(self):
         msg = await self.msg_queue.get()
-        return msg.payload['request_id']
+        return msg.payload.request_id
 
 
 @to_tuple

--- a/trinity/protocol/bcc/commands.py
+++ b/trinity/protocol/bcc/commands.py
@@ -1,4 +1,6 @@
 from typing import (
+    Any,
+    NamedTuple,
     Union,
 )
 
@@ -24,8 +26,16 @@ from eth2.beacon.types.blocks import BeaconBlock
 from eth2.beacon.types.attestations import Attestation
 
 
+class StatusMessage(NamedTuple):
+    protocol_version: int
+    network_id: int
+    genesis_hash: bytes
+    best_hash: bytes
+
+
 class Status(Command):
     _cmd_id = 0
+    message_class = StatusMessage
     structure = [
         ('protocol_version', sedes.big_endian_int),
         ('network_id', sedes.big_endian_int),
@@ -40,8 +50,15 @@ GetBeaconBlocksMessage = TypedDict("GetBeaconBlocksMessage", {
 })
 
 
+class GetBeaconBlocksMessage(NamedTuple):
+    # TODO: Replace below Type Hint Appropriately
+    block_slot_or_root: Any
+    max_blocks: int
+
+
 class GetBeaconBlocks(Command):
     _cmd_id = 1
+    message_class = GetBeaconBlocksMessage
     structure = [
         ('block_slot_or_root', HashOrNumber()),
         ('max_blocks', sedes.big_endian_int),

--- a/trinity/protocol/bcc/peer.py
+++ b/trinity/protocol/bcc/peer.py
@@ -59,22 +59,22 @@ class BCCPeer(BasePeer):
             raise HandshakeFailure(f"Expected a BCC Status msg, got {cmd}, disconnecting")
 
         msg = cast(Dict[str, Any], msg)
-        if msg['network_id'] != self.network_id:
+        if msg.network_id != self.network_id:
             await self.disconnect(DisconnectReason.useless_peer)
             raise HandshakeFailure(
-                f"{self} network ({msg['network_id']}) does not match ours "
+                f"{self} network ({msg.network_id}) does not match ours "
                 f"({self.network_id}), disconnecting"
             )
         # TODO: pass accurate `block_class: Type[BaseBeaconBlock]` under per BeaconStateMachine fork
         genesis_block = self.chain_db.get_canonical_block_by_slot(0, BeaconBlock)
-        if msg['genesis_hash'] != genesis_block.hash:
+        if msg.genesis_hash != genesis_block.hash:
             await self.disconnect(DisconnectReason.useless_peer)
             raise HandshakeFailure(
-                f"{self} genesis ({encode_hex(msg['genesis_hash'])}) does not "
+                f"{self} genesis ({encode_hex(msg.genesis_hash)}) does not "
                 f"match ours ({encode_hex(genesis_block.hash)}), disconnecting"
             )
 
-        self.head_hash = msg['best_hash']
+        self.head_hash = msg.best_hash
 
     @property
     def network_id(self) -> int:

--- a/trinity/protocol/bcc/servers.py
+++ b/trinity/protocol/bcc/servers.py
@@ -69,8 +69,8 @@ class BCCRequestServer(BaseRequestServer):
         if not peer.is_operational:
             return
 
-        max_blocks = msg["max_blocks"]
-        block_slot_or_root = msg["block_slot_or_root"]
+        max_blocks = msg.max_blocks
+        block_slot_or_root = msg.block_slot_or_root
 
         try:
             if isinstance(block_slot_or_root, int):

--- a/trinity/protocol/eth/commands.py
+++ b/trinity/protocol/eth/commands.py
@@ -1,6 +1,9 @@
 from typing import (
     cast,
+    List,
+    NamedTuple,
     Tuple,
+    Union,
 )
 
 from rlp import sedes
@@ -19,8 +22,17 @@ from trinity.rlp.block_body import BlockBody
 from trinity.rlp.sedes import HashOrNumber
 
 
+class StatusMessage(NamedTuple):
+    protocol_version: int
+    network_id: int
+    td: int
+    best_hash: bytes
+    genesis_hash: bytes
+
+
 class Status(Command):
     _cmd_id = 0
+    message_class = StatusMessage
     structure = [
         ('protocol_version', sedes.big_endian_int),
         ('network_id', sedes.big_endian_int),
@@ -40,8 +52,16 @@ class Transactions(Command):
     structure = sedes.CountableList(BaseTransactionFields)
 
 
+class GetBlockHeadersMessage(NamedTuple):
+    block_number_or_hash: int
+    max_headers: int
+    skip: int
+    reverse: bool
+
+
 class GetBlockHeaders(Command):
     _cmd_id = 3
+    message_class = GetBlockHeadersMessage
     structure = [
         ('block_number_or_hash', HashOrNumber()),
         ('max_headers', sedes.big_endian_int),
@@ -68,8 +88,14 @@ class BlockBodies(Command):
     structure = sedes.CountableList(BlockBody)
 
 
+class NewBlockMessage(NamedTuple):
+    block: List[Union[BlockHeader, List[BaseTransactionFields], List[BlockHeader]]]
+    total_difficulty: int
+
+
 class NewBlock(Command):
     _cmd_id = 7
+    message_class = NewBlockMessage
     structure = [
         ('block', sedes.List([BlockHeader,
                               sedes.CountableList(BaseTransactionFields),

--- a/trinity/protocol/eth/peer.py
+++ b/trinity/protocol/eth/peer.py
@@ -50,9 +50,9 @@ class ETHPeer(BaseChainPeer):
     def handle_sub_proto_msg(self, cmd: Command, msg: _DecodedMsgType) -> None:
         if isinstance(cmd, NewBlock):
             msg = cast(Dict[str, Any], msg)
-            header, _, _ = msg['block']
+            header, _, _ = msg.block
             actual_head = header.parent_hash
-            actual_td = msg['total_difficulty'] - header.difficulty
+            actual_td = msg.total_difficulty - header.difficulty
             if actual_td > self.head_td:
                 self.head_hash = actual_head
                 self.head_td = actual_td
@@ -68,21 +68,21 @@ class ETHPeer(BaseChainPeer):
             await self.disconnect(DisconnectReason.subprotocol_error)
             raise HandshakeFailure(f"Expected a ETH Status msg, got {cmd}, disconnecting")
         msg = cast(Dict[str, Any], msg)
-        if msg['network_id'] != self.network_id:
+        if msg.network_id != self.network_id:
             await self.disconnect(DisconnectReason.useless_peer)
             raise HandshakeFailure(
-                f"{self} network ({msg['network_id']}) does not match ours "
+                f"{self} network ({msg.network_id}) does not match ours "
                 f"({self.network_id}), disconnecting"
             )
         genesis = await self.genesis
-        if msg['genesis_hash'] != genesis.hash:
+        if msg.genesis_hash != genesis.hash:
             await self.disconnect(DisconnectReason.useless_peer)
             raise HandshakeFailure(
-                f"{self} genesis ({encode_hex(msg['genesis_hash'])}) does not "
+                f"{self} genesis ({encode_hex(msg.genesis_hash)}) does not "
                 f"match ours ({genesis.hex_hash}), disconnecting"
             )
-        self.head_td = msg['td']
-        self.head_hash = msg['best_hash']
+        self.head_td = msg.td
+        self.head_hash = msg.best_hash
 
 
 class ETHPeerFactory(BaseChainPeerFactory):

--- a/trinity/protocol/eth/servers.py
+++ b/trinity/protocol/eth/servers.py
@@ -59,10 +59,10 @@ class ETHPeerRequestHandler(BasePeerRequestHandler):
         query = cast(Dict[Any, Union[bool, int]], msg)
         self.logger.debug("%s requested headers: %s", peer, query)
         request = ETHHeaderRequest(
-            cast(BlockIdentifier, query['block_number_or_hash']),
-            query['max_headers'],
-            query['skip'],
-            cast(bool, query['reverse']),
+            cast(BlockIdentifier, query.block_number_or_hash),
+            query.max_headers,
+            query.skip,
+            cast(bool, query.reverse),
         )
 
         headers = await self.lookup_headers(request)

--- a/trinity/protocol/les/commands.py
+++ b/trinity/protocol/les/commands.py
@@ -4,12 +4,9 @@ from typing import (
     Dict,
     Iterator,
     List,
+    NamedTuple,
     Tuple,
     Union,
-)
-
-from eth_utils import (
-    to_dict,
 )
 
 import rlp
@@ -28,12 +25,29 @@ from trinity.rlp.block_body import BlockBody
 from trinity.rlp.sedes import HashOrNumber
 
 
+class StatusMessage(NamedTuple):
+    protocolVersion: int
+    networkId: int
+    headTd: int
+    headHash: bytes
+    headNum: int
+    genesisHash: bytes
+    serveHeaders: Any
+    serveChainSince: int
+    serveStateSince: int
+    txRelay: Any
+    flowControl_BL: int = None
+    flowControl_MRC: List[List[int]] = None
+    flowControl_MRR: int = None
+
+
 class Status(Command):
     _cmd_id = 0
     decode_strict = False
     # A list of (key, value) pairs is all a Status msg contains, but since the values can be of
     # any type, we need to use the raw sedes here and do the actual deserialization in
     # decode_payload().
+    message_class = StatusMessage
     structure = sedes.CountableList(sedes.List([sedes.text, sedes.raw]))
     # The sedes used for each key in the list above. Keys that use None as their sedes are
     # optional and have no value -- IOW, they just need to be present in the msg when appropriate.
@@ -48,23 +62,40 @@ class Status(Command):
         'serveChainSince': sedes.big_endian_int,
         'serveStateSince': sedes.big_endian_int,
         'txRelay': None,
-        'flowControl/BL': sedes.big_endian_int,
-        'flowControl/MRC': sedes.CountableList(
+        'flowControl_BL': sedes.big_endian_int,
+        'flowControl_MRC': sedes.CountableList(
             sedes.List([sedes.big_endian_int, sedes.big_endian_int, sedes.big_endian_int])),
-        'flowControl/MRR': sedes.big_endian_int,
+        'flowControl_MRR': sedes.big_endian_int,
     }
 
-    @to_dict
+    # T = TypeVar("T")
+    #
+    # def to_NamedTuple(
+    #     tupleType: NamedTuple,
+    # ) -> Callable[..., Callable[..., T]]:
+    #     def outer(fn):
+    #         @functools.wraps(fn)
+    #         def inner(*args, **kwargs) -> "T":  # type: ignore
+    #             return tupleType(*fn(*args, **kwargs))
+    #
+    #         return inner
+    #
+    #     return outer
+
+    # @to_NamedTuple(StatusMessage)
     def decode_payload(self, rlp_data: bytes) -> Iterator[Tuple[str, Any]]:
         data = cast(List[Tuple[str, bytes]], super().decode_payload(rlp_data))
         # The LES/Status msg contains an arbitrary list of (key, value) pairs, where values can
         # have different types and unknown keys should be ignored for forward compatibility
         # reasons, so here we need an extra pass to deserialize each of the key/value pairs we
         # know about.
+        message_dict = {}
         for key, value in data:
             if key not in self.items_sedes:
                 continue
-            yield key, self._deserialize_item(key, value)
+            message_dict[key] = self._deserialize_item(key, value)
+
+        return self.get_message_class()(**message_dict)
 
     def encode_payload(self, data: Union[_DecodedMsgType, sedes.CountableList]) -> bytes:
         response = [
@@ -91,8 +122,18 @@ class Status(Command):
             return b''
 
 
+class AnnounceMessage(NamedTuple):
+    head_hash: bytes
+    head_number: int
+    head_td: int
+    reorg_depth: int
+    # TODO: Need to change below
+    params: List[List[Union[str, Any]]]
+
+
 class Announce(Command):
     _cmd_id = 1
+    message_class = AnnounceMessage
     structure = [
         ('head_hash', sedes.binary),
         ('head_number', sedes.big_endian_int),
@@ -113,16 +154,29 @@ class GetBlockHeadersQuery(rlp.Serializable):
     ]
 
 
+class GetBlockHeadersMessage(NamedTuple):
+    request_id: int
+    query: GetBlockHeadersQuery
+
+
 class GetBlockHeaders(Command):
     _cmd_id = 2
+    message_class = GetBlockHeadersMessage
     structure = [
         ('request_id', sedes.big_endian_int),
         ('query', GetBlockHeadersQuery),
     ]
 
 
+class BlockHeadersMessage(NamedTuple):
+    request_id: int
+    buffer_value: int
+    headers: List[BlockHeader]
+
+
 class BlockHeaders(BaseBlockHeaders):
     _cmd_id = 3
+    message_class = BlockHeadersMessage
     structure = [
         ('request_id', sedes.big_endian_int),
         ('buffer_value', sedes.big_endian_int),
@@ -131,19 +185,32 @@ class BlockHeaders(BaseBlockHeaders):
 
     def extract_headers(self, msg: _DecodedMsgType) -> Tuple[BlockHeader, ...]:
         msg = cast(Dict[str, Any], msg)
-        return cast(Tuple[BlockHeader, ...], tuple(msg['headers']))
+        return cast(Tuple[BlockHeader, ...], tuple(msg.headers))
+
+
+class GetBlockBodiesMessage(NamedTuple):
+    request_id: int
+    block_hashes: List[bytes]
 
 
 class GetBlockBodies(Command):
     _cmd_id = 4
+    message_class = GetBlockBodiesMessage
     structure = [
         ('request_id', sedes.big_endian_int),
         ('block_hashes', sedes.CountableList(sedes.binary)),
     ]
 
 
+class BlockBodiesMessage(NamedTuple):
+    request_id: int
+    buffer_value: int
+    bodies: List[BlockBody]
+
+
 class BlockBodies(Command):
     _cmd_id = 5
+    message_class = BlockBodiesMessage
     structure = [
         ('request_id', sedes.big_endian_int),
         ('buffer_value', sedes.big_endian_int),
@@ -151,16 +218,29 @@ class BlockBodies(Command):
     ]
 
 
+class GetReceiptsMessage(NamedTuple):
+    request_id: int
+    block_hashes: List[bytes]
+
+
 class GetReceipts(Command):
     _cmd_id = 6
+    message_class = GetReceiptsMessage
     structure = [
         ('request_id', sedes.big_endian_int),
         ('block_hashes', sedes.CountableList(sedes.binary)),
     ]
 
 
+class ReceiptsMessage(NamedTuple):
+    request_id: int
+    buffer_value: int
+    receipts: List[List[Receipt]]
+
+
 class Receipts(Command):
     _cmd_id = 7
+    message_class = ReceiptsMessage
     structure = [
         ('request_id', sedes.big_endian_int),
         ('buffer_value', sedes.big_endian_int),
@@ -177,16 +257,32 @@ class ProofRequest(rlp.Serializable):
     ]
 
 
+class GetProofsMessage(NamedTuple):
+    request_id: int
+    proof_requests: List[ProofRequest]
+
+
 class GetProofs(Command):
     _cmd_id = 8
+    message_class = GetProofsMessage
     structure = [
         ('request_id', sedes.big_endian_int),
         ('proof_requests', sedes.CountableList(ProofRequest)),
     ]
 
 
+class GetProofsMessage(NamedTuple):
+    request_id: int
+    buffer_value: int
+    # TODO: Need to change below Any
+    proofs: List[List[Any]]
+    # TODO: Need to tighten below type
+    proof: List[Any] = None
+
+
 class Proofs(Command):
     _cmd_id = 9
+    message_class = GetProofsMessage
     structure = [
         ('request_id', sedes.big_endian_int),
         ('buffer_value', sedes.big_endian_int),
@@ -199,11 +295,16 @@ class Proofs(Command):
         # This is just to make Proofs messages compatible with ProofsV2, so that LightPeerChain
         # doesn't have to special-case them. Soon we should be able to drop support for LES/1
         # anyway, and then all this code will go away.
-        if not decoded['proofs']:
-            decoded['proof'] = []
+        if not decoded.proofs:
+            proof = []
         else:
-            decoded['proof'] = decoded['proofs'][0]
-        return decoded
+            proof = decoded.proofs[0]
+        return self.get_message_class()(
+            request_id=decoded.request_id,
+            buffer_value=decoded.buffer_value,
+            proofs=decoded.proofs,
+            proof=proof,
+        )
 
 
 class ContractCodeRequest(rlp.Serializable):
@@ -213,16 +314,29 @@ class ContractCodeRequest(rlp.Serializable):
     ]
 
 
+class GetContractCodesMessage(NamedTuple):
+    request_id: int
+    code_requests: List[ContractCodeRequest]
+
+
 class GetContractCodes(Command):
     _cmd_id = 10
+    message_class = GetContractCodesMessage
     structure = [
         ('request_id', sedes.big_endian_int),
         ('code_requests', sedes.CountableList(ContractCodeRequest)),
     ]
 
 
+class ContractCodesMessage(NamedTuple):
+    request_id: int
+    buffer_value: int
+    codes: List[bytes]
+
+
 class ContractCodes(Command):
     _cmd_id = 11
+    message_class = ContractCodesMessage
     structure = [
         ('request_id', sedes.big_endian_int),
         ('buffer_value', sedes.big_endian_int),
@@ -230,8 +344,26 @@ class ContractCodes(Command):
     ]
 
 
+class StatusV2Message(NamedTuple):
+    protocolVersion: int
+    networkId: int
+    headTd: int
+    headHash: bytes
+    headNum: int
+    genesisHash: bytes
+    serveHeaders: Any
+    serveChainSince: int
+    serveStateSince: int = None
+    txRelay: Any = None
+    flowControl_BL: int = None
+    flowControl_MRC: List[List[int]] = None
+    flowControl_MRR: int = None
+    announceType: int = None
+
+
 class StatusV2(Status):
     _cmd_id = 0
+    message_class = StatusV2Message
 
     def __init__(self, cmd_id_offset: int) -> None:
         super().__init__(cmd_id_offset)
@@ -242,8 +374,16 @@ class GetProofsV2(GetProofs):
     _cmd_id = 15
 
 
+class ProofsV2Message(NamedTuple):
+    request_id: int
+    buffer_value: int
+    # TODO: Change below from Any to Type[Sedes.raw]
+    proof: List[Any]
+
+
 class ProofsV2(Command):
     _cmd_id = 16
+    message_class = ProofsV2Message
     structure = [
         ('request_id', sedes.big_endian_int),
         ('buffer_value', sedes.big_endian_int),

--- a/trinity/protocol/les/normalizers.py
+++ b/trinity/protocol/les/normalizers.py
@@ -16,5 +16,5 @@ LESNormalizer = BaseNormalizer[Dict[str, Any], TResult]
 class BlockHeadersNormalizer(LESNormalizer[Tuple[BlockHeader, ...]]):
     @staticmethod
     def normalize_result(message: Dict[str, Any]) -> Tuple[BlockHeader, ...]:
-        result = message['headers']
+        result = message.headers
         return result

--- a/trinity/protocol/les/peer.py
+++ b/trinity/protocol/les/peer.py
@@ -79,28 +79,28 @@ class LESPeer(BaseChainPeer):
             await self.disconnect(DisconnectReason.subprotocol_error)
             raise HandshakeFailure(f"Expected a LES Status msg, got {cmd}, disconnecting")
         msg = cast(Dict[str, Any], msg)
-        if msg['networkId'] != self.network_id:
+        if msg.networkId != self.network_id:
             await self.disconnect(DisconnectReason.useless_peer)
             raise HandshakeFailure(
-                f"{self} network ({msg['networkId']}) does not match ours "
+                f"{self} network ({msg.networkId}) does not match ours "
                 f"({self.network_id}), disconnecting"
             )
         genesis = await self.genesis
-        if msg['genesisHash'] != genesis.hash:
+        if msg.genesisHash != genesis.hash:
             await self.disconnect(DisconnectReason.useless_peer)
             raise HandshakeFailure(
-                f"{self} genesis ({encode_hex(msg['genesisHash'])}) does not "
+                f"{self} genesis ({encode_hex(msg.genesisHash)}) does not "
                 f"match ours ({genesis.hex_hash}), disconnecting"
             )
         # Eventually we might want to keep connections to peers where we are the only side serving
         # data, but right now both our chain syncer and the Peer.boot() method expect the remote
         # to reply to header requests, so if they don't we simply disconnect here.
-        if 'serveHeaders' not in msg:
+        if msg.serveHeaders is None:
             await self.disconnect(DisconnectReason.useless_peer)
             raise HandshakeFailure(f"{self} doesn't serve headers, disconnecting")
-        self.head_td = msg['headTd']
-        self.head_hash = msg['headHash']
-        self.head_number = msg['headNum']
+        self.head_td = msg.headTd
+        self.head_hash = msg.headHash
+        self.head_number = msg.headNum
 
 
 class LESPeerFactory(BaseChainPeerFactory):

--- a/trinity/protocol/les/servers.py
+++ b/trinity/protocol/les/servers.py
@@ -28,11 +28,11 @@ class LESPeerRequestHandler(BasePeerRequestHandler):
             return
         self.logger.debug("Peer %s made header request: %s", peer, msg)
         request = LightHeaderRequest(
-            msg['query'].block_number_or_hash,
-            msg['query'].max_headers,
-            msg['query'].skip,
-            msg['query'].reverse,
-            msg['request_id'],
+            msg.query.block_number_or_hash,
+            msg.query.max_headers,
+            msg.query.skip,
+            msg.query.reverse,
+            msg.request_id,
         )
         headers = await self.lookup_headers(request)
         self.logger.debug2("Replying to %s with %d headers", peer, len(headers))

--- a/trinity/protocol/les/validators.py
+++ b/trinity/protocol/les/validators.py
@@ -18,5 +18,8 @@ class GetBlockHeadersValidator(BaseBlockHeadersValidator):
 
 
 def match_payload_request_id(request: Dict[str, Any], response: Dict[str, Any]) -> None:
-    if request['request_id'] != response['request_id']:
+    # The request here would be a dict which would be processed to
+    # make a NamedTuple message at the time of sending on wire.
+    # But the response would be a NamedTuple message
+    if request['request_id'] != response.request_id:
         raise ValidationError("Request `id` does not match")


### PR DESCRIPTION
### What was wrong?
Fixes Issue: #28 


### How was it fixed?
`NamedTuple` classes were created for each `Command` as suggested by @carver [here](https://github.com/ethereum/trinity/issues/28#issuecomment-445086738). Likewise the 
whole (hopefully) codebase has been wiped out of the usage of  `dict` and has been replaced with `NamedTuple` classes.


#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcSjQet_UBKmxN9RGYVoSR8k219gQjNz3cjL8Y82Rx4eFYjS6_FC)
