### PR TITLE
`eth2` module is coming

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -178,6 +178,12 @@ jobs:
       - image: circleci/python:3.6
         environment:
           TOXENV: py36-rpc-state-quadratic
+  py36-eth2:
+    <<: *common
+    docker:
+      - image: circleci/python:3.6
+        environment:
+          TOXENV: py36-eth2
 
   py37-core:
     <<: *common
@@ -197,6 +203,12 @@ jobs:
       - image: circleci/python:3.7
         environment:
           TOXENV: py37-p2p
+  py37-eth2:
+    <<: *common
+    docker:
+      - image: circleci/python:3.7
+        environment:
+          TOXENV: py37-eth2
 
 workflows:
   version: 2
@@ -206,6 +218,7 @@ workflows:
 
       - py37-core
       - py37-p2p
+      - py37-eth2
 
       - py36-rpc-state-byzantium
       - py36-rpc-state-constantinople
@@ -218,6 +231,7 @@ workflows:
 
       - py36-core
       - py36-p2p
+      - py37-eth2
 
       - py36-integration
       - py36-lightchain_integration

--- a/eth2/__init__.py
+++ b/eth2/__init__.py
@@ -1,0 +1,2 @@
+# This is to ensure we call setup_extended_logging() before anything else.
+import eth as _eth_module  # noqa: F401

--- a/eth2/_utils/bitfield.py
+++ b/eth2/_utils/bitfield.py
@@ -1,0 +1,55 @@
+import operator
+
+from typing import (
+    List,
+)
+from cytoolz import (
+    curry,
+)
+from cytoolz.curried import reduce
+from itertools import (
+    zip_longest,
+)
+from eth2.beacon.typing import Bitfield
+
+
+@curry
+def has_voted(bitfield: Bitfield, index: int) -> bool:
+    return bool(bitfield[index // 8] & (128 >> (index % 8)))
+
+
+@curry
+def set_voted(bitfield: Bitfield, index: int) -> Bitfield:
+    byte_index = index // 8
+    bit_index = index % 8
+    new_byte_value = bitfield[byte_index] | (128 >> bit_index)
+    new_bitfield = bitfield[:byte_index] + bytes([new_byte_value]) + bitfield[byte_index + 1:]
+    return Bitfield(new_bitfield)
+
+
+def get_bitfield_length(bit_count: int) -> int:
+    """Return the length of the bitfield for a given number of attesters in bytes."""
+    return (bit_count + 7) // 8
+
+
+def get_empty_bitfield(bit_count: int) -> Bitfield:
+    return Bitfield(b"\x00" * get_bitfield_length(bit_count))
+
+
+def get_vote_count(bitfield: Bitfield) -> int:
+    return len(
+        tuple(
+            index
+            for index in range(len(bitfield) * 8)
+            if has_voted(bitfield, index)
+        )
+    )
+
+
+def or_bitfields(bitfields: List[Bitfield]) -> Bitfield:
+    byte_slices = zip_longest(*bitfields)
+
+    if len(set((len(b) for b in bitfields))) != 1:
+        raise ValueError("The bitfield sizes are different")
+
+    return Bitfield(bytes(map(reduce(operator.or_), byte_slices)))

--- a/eth2/_utils/blobs.py
+++ b/eth2/_utils/blobs.py
@@ -16,7 +16,7 @@ from eth_utils import (
 from eth._utils.padding import (
     zpad_right,
 )
-from eth._utils.merkle import (
+from eth2._utils.merkle import (
     get_merkle_root_from_items,
 )
 

--- a/eth2/_utils/blobs.py
+++ b/eth2/_utils/blobs.py
@@ -1,0 +1,116 @@
+from io import (
+    BytesIO,
+)
+
+from typing import (
+    Iterable,
+    Iterator,
+)
+
+from eth_utils import (
+    apply_to_return_value,
+    int_to_big_endian,
+    ValidationError,
+)
+
+from eth._utils.padding import (
+    zpad_right,
+)
+from eth._utils.merkle import (
+    get_merkle_root_from_items,
+)
+
+from typing import (
+    cast,
+)
+from eth_typing import (
+    Hash32,
+)
+
+
+#
+# Blobs and Chunks constants
+#
+CHUNK_SIZE = 32
+CHUNK_DATA_SIZE = CHUNK_SIZE - 1  # size of chunk excluding the indicator byte
+COLLATION_SIZE = 2**17
+assert COLLATION_SIZE % CHUNK_SIZE == 0
+# size of a blob filling a full collation
+MAX_BLOB_SIZE = COLLATION_SIZE // CHUNK_SIZE * CHUNK_DATA_SIZE
+
+
+def iterate_chunks(collation_body: bytes) -> Iterator[Hash32]:
+    check_body_size(collation_body)
+    for chunk_start in range(0, len(collation_body), CHUNK_SIZE):
+        yield cast(Hash32, collation_body[chunk_start:chunk_start + CHUNK_SIZE])
+
+
+def calc_chunk_root(collation_body: bytes) -> Hash32:
+    check_body_size(collation_body)
+    chunks = list(iterate_chunks(collation_body))
+    return get_merkle_root_from_items(chunks)
+
+
+def check_body_size(body: bytes) -> bytes:
+    if len(body) != COLLATION_SIZE:
+        raise ValidationError("{} byte collation body exceeds maximum allowed size".format(
+            len(body)
+        ))
+    return body
+
+
+@apply_to_return_value(check_body_size)
+@apply_to_return_value(lambda v: zpad_right(v, COLLATION_SIZE))
+@apply_to_return_value(b"".join)
+def serialize_blobs(blobs: Iterable[bytes]) -> Iterator[bytes]:
+    """Serialize a sequence of blobs and return a collation body."""
+    for i, blob in enumerate(blobs):
+        if len(blob) == 0:
+            raise ValidationError("Cannot serialize blob {} of length 0".format(i))
+        if len(blob) > MAX_BLOB_SIZE:
+            raise ValidationError("Cannot serialize blob {} of size {}".format(i, len(blob)))
+
+        for blob_index in range(0, len(blob), CHUNK_DATA_SIZE):
+            remaining_blob_bytes = len(blob) - blob_index
+
+            if remaining_blob_bytes <= CHUNK_DATA_SIZE:
+                length_bits = remaining_blob_bytes
+            else:
+                length_bits = 0
+
+            flag_bits = 0  # TODO: second parameter? blobs as tuple `(flag, blob)`?
+            indicator_byte = int_to_big_endian(length_bits | (flag_bits << 5))
+            if len(indicator_byte) != 1:
+                raise Exception("Invariant: indicator is not a single byte")
+
+            yield indicator_byte
+            yield blob[blob_index:blob_index + CHUNK_DATA_SIZE]
+
+        # end of range(0, N, k) is given by the largest multiple of k smaller than N, i.e.,
+        # (ceil(N / k) - 1) * k where ceil(N / k) == -(-N // k)
+        last_blob_index = (-(-len(blob) // CHUNK_DATA_SIZE) - 1) * CHUNK_DATA_SIZE
+        if last_blob_index != blob_index:
+            raise Exception("Invariant: last blob index calculation failed")
+        chunk_filler = b"\x00" * (CHUNK_DATA_SIZE - (len(blob) - last_blob_index))
+        yield chunk_filler
+
+
+def deserialize_blobs(body: bytes) -> Iterator[bytes]:
+    """Deserialize the blobs encoded in a body, returning an iterator."""
+    blob = BytesIO()
+    for chunk in iterate_chunks(body):
+        indicator_byte = chunk[0]
+        flag_bits = indicator_byte & 0b11100000  # TODO: yield, filter, ...?  # noqa: F841
+        length_bits = indicator_byte & 0b00011111
+
+        if length_bits == 0:
+            length = CHUNK_DATA_SIZE
+            terminal = False
+        else:
+            length = length_bits
+            terminal = True
+
+        blob.write(chunk[1:length + 1])
+        if terminal:
+            yield blob.getvalue()
+            blob = BytesIO()

--- a/eth2/_utils/bls.py
+++ b/eth2/_utils/bls.py
@@ -1,0 +1,238 @@
+from typing import (  # noqa: F401
+    Dict,
+    Sequence,
+    Tuple,
+    Union,
+)
+
+from eth_utils import (
+    big_endian_to_int,
+    ValidationError,
+)
+
+from py_ecc.optimized_bls12_381 import (  # NOQA
+    G1,
+    G2,
+    Z1,
+    Z2,
+    neg,
+    add,
+    multiply,
+    FQ,
+    FQ2,
+    FQ12,
+    FQP,
+    pairing,
+    normalize,
+    field_modulus as q,
+    b,
+    b2,
+    is_on_curve,
+    curve_order,
+    final_exponentiate
+)
+from eth2.beacon._utils.hash import hash_eth2
+
+from eth2.beacon.typing import (
+    BLSPubkey,
+    BLSSignature,
+)
+
+G2_cofactor = 305502333931268344200999753193121504214466019254188142667664032982267604182971884026507427359259977847832272839041616661285803823378372096355777062779109  # noqa: E501
+FQ2_order = q ** 2 - 1
+eighth_roots_of_unity = [
+    FQ2([1, 1]) ** ((FQ2_order * k) // 8)
+    for k in range(8)
+]
+
+
+#
+# Helpers
+#
+def FQP_point_to_FQ2_point(pt: Tuple[FQP, FQP, FQP]) -> Tuple[FQ2, FQ2, FQ2]:
+    """
+    Transform FQP to FQ2 for type hinting.
+    """
+    return (
+        FQ2(pt[0].coeffs),
+        FQ2(pt[1].coeffs),
+        FQ2(pt[2].coeffs),
+    )
+
+
+def modular_squareroot(value: int) -> FQP:
+    """
+    ``modular_squareroot(x)`` returns the value ``y`` such that ``y**2 % q == x``,
+    and None if this is not possible. In cases where there are two solutions,
+    the value with higher imaginary component is favored;
+    if both solutions have equal imaginary component the value with higher real
+    component is favored.
+    """
+    candidate_squareroot = value ** ((FQ2_order + 8) // 16)
+    check = candidate_squareroot ** 2 / value
+    if check in eighth_roots_of_unity[::2]:
+        x1 = candidate_squareroot / eighth_roots_of_unity[eighth_roots_of_unity.index(check) // 2]
+        x2 = FQ2([-x1.coeffs[0], -x1.coeffs[1]])  # x2 = -x1
+        return x1 if (x1.coeffs[1], x1.coeffs[0]) > (x2.coeffs[1], x2.coeffs[0]) else x2
+    return None
+
+
+def hash_to_G2(message: bytes, domain: int) -> Tuple[FQ2, FQ2, FQ2]:
+    domain_in_bytes = domain.to_bytes(8, 'big')
+
+    # Initial candidate x coordinate
+    x_re = big_endian_to_int(hash_eth2(domain_in_bytes + b'\x01' + message))
+    x_im = big_endian_to_int(hash_eth2(domain_in_bytes + b'\x02' + message))
+    x_coordinate = FQ2([x_re, x_im])  # x_re + x_im * i
+
+    # Test candidate y coordinates until a one is found
+    while 1:
+        y_coordinate_squared = x_coordinate ** 3 + FQ2([4, 4])  # The curve is y^2 = x^3 + 4(i + 1)
+        y_coordinate = modular_squareroot(y_coordinate_squared)
+        if y_coordinate is not None:  # Check if quadratic residue found
+            break
+        x_coordinate += FQ2([1, 0])  # Add 1 and try again
+
+    return multiply(
+        (x_coordinate, y_coordinate, FQ2([1, 0])),
+        G2_cofactor
+    )
+
+
+#
+# G1
+#
+def compress_G1(pt: Tuple[FQ, FQ, FQ]) -> int:
+    x, y = normalize(pt)
+    return x.n + 2**383 * (y.n % 2)
+
+
+def decompress_G1(pt: int) -> Tuple[FQ, FQ, FQ]:
+    if pt == 0:
+        return (FQ(1), FQ(1), FQ(0))
+    x = pt % 2**383
+    y_mod_2 = pt // 2**383
+    y = pow((x**3 + b.n) % q, (q + 1) // 4, q)
+
+    if pow(y, 2, q) != (x**3 + b.n) % q:
+        raise ValueError(
+            "he given point is not on G1: y**2 = x**3 + b"
+        )
+    if y % 2 != y_mod_2:
+        y = q - y
+    return (FQ(x), FQ(y), FQ(1))
+
+
+#
+# G2
+#
+def compress_G2(pt: Tuple[FQP, FQP, FQP]) -> Tuple[int, int]:
+    if not is_on_curve(pt, b2):
+        raise ValueError(
+            "The given point is not on the twisted curve over FQ**2"
+        )
+    x, y = normalize(pt)
+    return (
+        int(x.coeffs[0] + 2**383 * (y.coeffs[0] % 2)),
+        int(x.coeffs[1])
+    )
+
+
+def decompress_G2(p: Tuple[int, int]) -> Tuple[FQP, FQP, FQP]:
+    x1 = p[0] % 2**383
+    y1_mod_2 = p[0] // 2**383
+    x2 = p[1]
+    x = FQ2([x1, x2])
+    if x == FQ2([0, 0]):
+        return FQ2([1, 0]), FQ2([1, 0]), FQ2([0, 0])
+    y = modular_squareroot(x**3 + b2)
+    if y.coeffs[0] % 2 != y1_mod_2:
+        y = FQ2((y * -1).coeffs)
+    if not is_on_curve((x, y, FQ2([1, 0])), b2):
+        raise ValueError(
+            "The given point is not on the twisted curve over FQ**2"
+        )
+    return x, y, FQ2([1, 0])
+
+
+#
+# APIs
+#
+def sign(message: bytes,
+         privkey: int,
+         domain: int) -> BLSSignature:
+    return BLSSignature(
+        compress_G2(
+            multiply(
+                hash_to_G2(message, domain),
+                privkey
+            )
+        ))
+
+
+def privtopub(k: int) -> BLSPubkey:
+    return BLSPubkey(compress_G1(multiply(G1, k)))
+
+
+def verify(message: bytes, pubkey: BLSPubkey, signature: BLSSignature, domain: int) -> bool:
+    try:
+        final_exponentiation = final_exponentiate(
+            pairing(
+                FQP_point_to_FQ2_point(decompress_G2(signature)),
+                G1,
+                final_exponentiate=False,
+            ) *
+            pairing(
+                FQP_point_to_FQ2_point(hash_to_G2(message, domain)),
+                neg(decompress_G1(pubkey)),
+                final_exponentiate=False,
+            )
+        )
+        return final_exponentiation == FQ12.one()
+    except (ValidationError, ValueError, AssertionError):
+        return False
+
+
+def aggregate_signatures(signatures: Sequence[BLSSignature]) -> BLSSignature:
+    o = Z2
+    for s in signatures:
+        o = FQP_point_to_FQ2_point(add(o, decompress_G2(s)))
+    return BLSSignature(compress_G2(o))
+
+
+def aggregate_pubkeys(pubkeys: Sequence[BLSPubkey]) -> BLSPubkey:
+    o = Z1
+    for p in pubkeys:
+        o = add(o, decompress_G1(p))
+    return BLSPubkey(compress_G1(o))
+
+
+def verify_multiple(pubkeys: Sequence[BLSPubkey],
+                    messages: Sequence[bytes],
+                    signature: BLSSignature,
+                    domain: int) -> bool:
+    len_msgs = len(messages)
+
+    if len(pubkeys) != len_msgs:
+        raise ValidationError(
+            "len(pubkeys) (%s) should be equal to len(messages) (%s)" % (
+                len(pubkeys), len_msgs
+            )
+        )
+
+    try:
+        o = FQ12([1] + [0] * 11)
+        for m_pubs in set(messages):
+            # aggregate the pubs
+            group_pub = Z1
+            for i in range(len_msgs):
+                if messages[i] == m_pubs:
+                    group_pub = add(group_pub, decompress_G1(pubkeys[i]))
+
+            o *= pairing(hash_to_G2(m_pubs, domain), group_pub, final_exponentiate=False)
+        o *= pairing(decompress_G2(signature), neg(G1), final_exponentiate=False)
+
+        final_exponentiation = final_exponentiate(o)
+        return final_exponentiation == FQ12.one()
+    except (ValidationError, ValueError, AssertionError):
+        return False

--- a/eth2/_utils/merkle.py
+++ b/eth2/_utils/merkle.py
@@ -1,0 +1,147 @@
+"""Utilities for binary merkle trees.
+
+Merkle trees are represented as sequences of layers, from root to leaves. The root layer contains
+only a single element, the leaves as many as there are data items in the tree. The data itself is
+not considered to be part of the tree.
+"""
+
+import math
+from typing import (
+    Iterable,
+    NewType,
+    Sequence,
+    Union,
+)
+
+from cytoolz import (
+    identity,
+    iterate,
+    partition,
+    reduce,
+    take,
+)
+from eth2.beacon._utils.hash import (
+    hash_eth2,
+)
+from eth_typing import (
+    Hash32,
+)
+from eth_utils import (
+    ValidationError,
+)
+
+
+MerkleTree = NewType("MerkleTree", Sequence[Sequence[Hash32]])
+MerkleProof = NewType("MerkleProof", Sequence[Hash32])
+
+
+def get_root(tree: MerkleTree) -> Hash32:
+    """
+    Get the root hash of a Merkle tree.
+    """
+    return tree[0][0]
+
+
+def get_branch_indices(node_index: int, depth: int) -> Iterable[int]:
+    """
+    Get the indices of all ancestors up until the root for a node with a given depth.
+    """
+    return tuple(take(depth, iterate(lambda index: index // 2, node_index)))
+
+
+def get_merkle_proof(tree: MerkleTree, item_index: int) -> Iterable[Hash32]:
+    """
+    Read off the Merkle proof for an item from a Merkle tree.
+    """
+    if item_index < 0 or item_index >= len(tree[-1]):
+        raise ValidationError("Item index out of range")
+
+    # special case of tree consisting of only root
+    if len(tree) == 1:
+        return ()
+
+    branch_indices = get_branch_indices(item_index, len(tree))
+    proof_indices = [i ^ 1 for i in branch_indices][:-1]  # get sibling by flipping rightmost bit
+    return tuple(
+        layer[proof_index]
+        for layer, proof_index
+        in zip(reversed(tree), proof_indices)
+    )
+
+
+def _calc_parent_hash(left_node: Hash32, right_node: Hash32) -> Hash32:
+    """
+    Calculate the parent hash of a node and its sibling.
+    """
+    return hash_eth2(left_node + right_node)
+
+
+def verify_merkle_proof(root: Hash32,
+                        item: Union[bytes, bytearray],
+                        item_index: int,
+                        proof: MerkleProof) -> bool:
+    """
+    Verify a Merkle proof against a root hash.
+    """
+    leaf = hash_eth2(item)
+    branch_indices = get_branch_indices(item_index, len(proof))
+    node_orderers = [
+        identity if branch_index % 2 == 0 else reversed
+        for branch_index in branch_indices
+    ]
+    proof_root = reduce(
+        lambda n1, n2_and_order: _calc_parent_hash(*n2_and_order[1]([n1, n2_and_order[0]])),
+        zip(proof, node_orderers),
+        leaf,
+    )
+    return proof_root == root
+
+
+def _hash_layer(layer: Sequence[Hash32]) -> Iterable[Hash32]:
+    """
+    Calculate the layer on top of another one.
+    """
+    return tuple(
+        _calc_parent_hash(left, right)
+        for left, right in partition(2, layer)
+    )
+
+
+def calc_merkle_tree(items: Sequence[Union[bytes, bytearray]]) -> MerkleTree:
+    """
+    Calculate the Merkle tree corresponding to a list of items.
+    """
+    leaves = tuple(hash_eth2(item) for item in items)
+    return calc_merkle_tree_from_leaves(leaves)
+
+
+def get_merkle_root_from_items(items: Sequence[Union[bytes, bytearray]]) -> Hash32:
+    """
+    Calculate the Merkle root corresponding to a list of items.
+    """
+    return get_root(calc_merkle_tree(items))
+
+
+def calc_merkle_tree_from_leaves(leaves: Sequence[Hash32]) -> MerkleTree:
+    if len(leaves) == 0:
+        raise ValueError("No leaves given")
+    n_layers = math.log2(len(leaves)) + 1
+    if not n_layers.is_integer():
+        raise ValueError("Number of leaves is not a power of two")
+    n_layers = int(n_layers)
+
+    reversed_tree = tuple(take(n_layers, iterate(_hash_layer, leaves)))
+    tree = MerkleTree(tuple(reversed(reversed_tree)))
+
+    if len(tree[0]) != 1:
+        raise Exception("Invariant: There must only be one root")
+
+    return tree
+
+
+def get_merkle_root(leaves: Sequence[Hash32]) -> Hash32:
+    """
+    Return the Merkle root of the given 32-byte hashes.
+    Note: it has to be a full tree, i.e., `len(values)` is an exact power of 2.
+    """
+    return get_root(calc_merkle_tree_from_leaves(leaves))

--- a/eth2/beacon/_utils/hash.py
+++ b/eth2/beacon/_utils/hash.py
@@ -1,0 +1,15 @@
+from typing import (
+    Union,
+)
+
+from eth_typing import Hash32
+from eth_hash.auto import keccak
+
+
+def hash_eth2(data: Union[bytes, bytearray]) -> Hash32:
+    """
+    Return Keccak-256 hashed result.
+    Note: it's a placeholder and we aim to migrate to a S[T/N]ARK-friendly hash function in
+    a future Ethereum 2.0 deployment phase.
+    """
+    return Hash32(keccak(data))

--- a/eth2/beacon/_utils/random.py
+++ b/eth2/beacon/_utils/random.py
@@ -1,0 +1,98 @@
+
+from typing import (
+    Any,
+    Iterable,
+    Sequence,
+    Tuple,
+    TypeVar,
+)
+
+from eth_typing import (
+    Hash32,
+)
+from eth_utils import (
+    to_tuple,
+)
+
+from eth2.beacon._utils.hash import (
+    hash_eth2,
+)
+from eth2.beacon.constants import (
+    RAND_BYTES,
+    RAND_MAX,
+)
+
+
+TItem = TypeVar('TItem')
+
+
+@to_tuple
+def shuffle(values: Sequence[Any],
+            seed: Hash32) -> Iterable[Any]:
+    """
+    Returns the shuffled ``values`` with seed as entropy.
+    Mainly for shuffling active validators in-protocol.
+
+    Spec: https://github.com/ethereum/eth2.0-specs/blob/70cef14a08de70e7bd0455d75cf380eb69694bfb/specs/core/0_beacon-chain.md#helper-functions  # noqa: E501
+    """
+    values_count = len(values)
+
+    # The range of the RNG places an upper-bound on the size of the list that
+    # may be shuffled. It is a logic error to supply an oversized list.
+    if values_count >= RAND_MAX:
+        raise ValueError(
+            "values_count (%s) should less than RAND_MAX (%s)." %
+            (values_count, RAND_MAX)
+        )
+
+    output = [x for x in values]
+    source = seed
+    index = 0
+    while index < values_count - 1:
+        # Re-hash the `source` to obtain a new pattern of bytes.
+        source = hash_eth2(source)
+
+        # Iterate through the `source` bytes in 3-byte chunks.
+        for position in range(0, 32 - (32 % RAND_BYTES), RAND_BYTES):
+            # Determine the number of indices remaining in `values` and exit
+            # once the last index is reached.
+            remaining = values_count - index
+            if remaining == 1:
+                break
+
+            # Read 3-bytes of `source` as a 24-bit big-endian integer.
+            sample_from_source = int.from_bytes(
+                source[position:position + RAND_BYTES], 'big'
+            )
+
+            # Sample values greater than or equal to `sample_max` will cause
+            # modulo bias when mapped into the `remaining` range.
+            sample_max = RAND_MAX - RAND_MAX % remaining
+
+            # Perform a swap if the consumed entropy will not cause modulo bias.
+            if sample_from_source < sample_max:
+                # Select a replacement index for the current index.
+                replacement_position = (sample_from_source % remaining) + index
+                # Swap the current index with the replacement index.
+                (output[index], output[replacement_position]) = (
+                    output[replacement_position],
+                    output[index]
+                )
+                index += 1
+            else:
+                # The sample causes modulo bias. A new sample should be read.
+                pass
+
+    return output
+
+
+def split(values: Sequence[TItem], split_count: int) -> Tuple[Any, ...]:
+    """
+    Returns the split ``values`` in ``split_count`` pieces in protocol.
+    Spec: https://github.com/ethereum/eth2.0-specs/blob/70cef14a08de70e7bd0455d75cf380eb69694bfb/specs/core/0_beacon-chain.md#helper-functions  # noqa: E501
+    """
+    list_length = len(values)
+    return tuple(
+        values[(list_length * i // split_count): (list_length * (i + 1) // split_count)]
+        for i in range(split_count)
+    )

--- a/eth2/beacon/aggregation.py
+++ b/eth2/beacon/aggregation.py
@@ -1,0 +1,66 @@
+from typing import (
+    Iterable,
+    Tuple,
+)
+from cytoolz import (
+    pipe
+)
+
+from eth2._utils import bls
+from eth2._utils.bitfield import (
+    set_voted,
+)
+from eth2.beacon.enums import SignatureDomain
+from eth2.beacon.typing import (
+    BLSPubkey,
+    BLSSignature,
+    Bitfield,
+    CommitteeIndex,
+)
+
+
+def verify_votes(
+    message: bytes,
+    votes: Iterable[Tuple[CommitteeIndex, BLSSignature, BLSPubkey]],
+    domain: SignatureDomain
+) -> Tuple[Tuple[BLSSignature, ...], Tuple[CommitteeIndex, ...]]:
+    """
+    Verify the given votes.
+
+    vote: (committee_index, sig, public_key)
+    """
+    sigs_with_committe_info = tuple(
+        (sig, committee_index)
+        for (committee_index, sig, public_key)
+        in votes
+        if bls.verify(message, public_key, sig, domain)
+    )
+    try:
+        sigs, committee_indices = zip(*sigs_with_committe_info)
+    except ValueError:
+        sigs = tuple()
+        committee_indices = tuple()
+
+    return sigs, committee_indices
+
+
+def aggregate_votes(
+    bitfield: Bitfield,
+    sigs: Iterable[BLSSignature],
+    voting_sigs: Iterable[BLSSignature],
+    voting_committee_indices: Iterable[CommitteeIndex]
+) -> Tuple[Bitfield, BLSSignature]:
+    """
+    Aggregate the votes.
+    """
+    # Update the bitfield and append the signatures
+    sigs = tuple(sigs) + tuple(voting_sigs)
+    bitfield = pipe(
+        bitfield,
+        *(
+            set_voted(index=committee_index)
+            for committee_index in voting_committee_indices
+        )
+    )
+
+    return bitfield, bls.aggregate_signatures(sigs)

--- a/eth2/beacon/block_committees_info.py
+++ b/eth2/beacon/block_committees_info.py
@@ -1,0 +1,19 @@
+from typing import (
+    NamedTuple,
+    Tuple,
+    TYPE_CHECKING,
+)
+
+if TYPE_CHECKING:
+    from eth2.beacon.types.shard_committees import ShardCommittee  # noqa: F401
+
+
+BlockCommitteesInfo = NamedTuple(
+    'BlockCommitteesInfo',
+    (
+        ('proposer_index', int),
+        ('proposer_shard', int),
+        ('proposer_committee_size', int),
+        ('shards_committees', Tuple['ShardCommittee'])
+    )
+)

--- a/eth2/beacon/constants.py
+++ b/eth2/beacon/constants.py
@@ -1,0 +1,22 @@
+from eth2.beacon.typing import (
+    BLSSignature,
+    SlotNumber,
+)
+
+
+#
+# shuffle function
+#
+
+# The size of 3 bytes in integer
+# sample_range = 2 ** (3 * 8) = 2 ** 24 = 16777216
+# sample_range = 16777216
+
+# Entropy is consumed from the seed in 3-byte (24 bit) chunks.
+RAND_BYTES = 3
+# The highest possible result of the RNG.
+RAND_MAX = 2 ** (RAND_BYTES * 8) - 1
+
+EMPTY_SIGNATURE = BLSSignature((0, 0))
+GWEI_PER_ETH = 10**9
+FAR_FUTURE_SLOT = SlotNumber(2**64 - 1)

--- a/eth2/beacon/db/chain.py
+++ b/eth2/beacon/db/chain.py
@@ -302,7 +302,7 @@ class BeaconChainDB(BaseBeaconChainDB):
             cls,
             db: BaseDB,
             block: BaseBeaconBlock
-    ) -> None:
+    ) -> int:
         # TODO: It's a stub before we implement fork choice rule
         score = block.slot
 
@@ -310,6 +310,7 @@ class BeaconChainDB(BaseBeaconChainDB):
             SchemaV1.make_block_root_to_score_lookup_key(block.root),
             rlp.encode(score, sedes=rlp.sedes.big_endian_int),
         )
+        return score
 
     @classmethod
     def _persist_block_chain(
@@ -360,7 +361,7 @@ class BeaconChainDB(BaseBeaconChainDB):
                 curr_block_head.root,
                 rlp.encode(curr_block_head),
             )
-            cls._set_block_scores_to_db(db, curr_block_head)
+            score = cls._set_block_scores_to_db(db, curr_block_head)
 
         try:
             previous_canonical_head = cls._get_canonical_head(db, block_class).root

--- a/eth2/beacon/db/chain.py
+++ b/eth2/beacon/db/chain.py
@@ -1,0 +1,533 @@
+from abc import ABC, abstractmethod
+import functools
+
+from typing import (
+    Iterable,
+    Tuple,
+    Type,
+)
+from cytoolz import (
+    concat,
+    first,
+    sliding_window,
+)
+
+import rlp
+from eth_typing import (
+    Hash32,
+)
+from eth_utils import (
+    encode_hex,
+    to_tuple,
+    ValidationError,
+)
+
+from eth.db.backends.base import (
+    BaseAtomicDB,
+    BaseDB,
+)
+from eth.constants import (
+    GENESIS_PARENT_HASH,
+)
+from eth.exceptions import (
+    BlockNotFound,
+    CanonicalHeadNotFound,
+    ParentNotFound,
+    StateRootNotFound,
+)
+from eth.validation import (
+    validate_word,
+)
+
+from eth2.beacon.types.states import BeaconState  # noqa: F401
+from eth2.beacon.types.blocks import (  # noqa: F401
+    BaseBeaconBlock,
+    BeaconBlock,
+)
+from eth2.beacon.validation import (
+    validate_slot,
+)
+
+from eth2.beacon.db.schema import SchemaV1
+
+
+class BaseBeaconChainDB(ABC):
+    db = None  # type: BaseAtomicDB
+
+    #
+    # Block API
+    #
+    @abstractmethod
+    def persist_block(
+            self,
+            block: BaseBeaconBlock,
+            block_class: Type[BaseBeaconBlock]
+    ) -> Tuple[Tuple[bytes, ...], Tuple[bytes, ...]]:
+        pass
+
+    @abstractmethod
+    def get_canonical_block_root(self, slot: int) -> Hash32:
+        pass
+
+    @abstractmethod
+    def get_canonical_block_by_slot(self,
+                                    slot: int,
+                                    block_class: Type[BaseBeaconBlock]) -> BaseBeaconBlock:
+        pass
+
+    @abstractmethod
+    def get_canonical_block_root_by_slot(self, slot: int) -> Hash32:
+        pass
+
+    @abstractmethod
+    def get_canonical_head(self, block_class: Type[BaseBeaconBlock]) -> BaseBeaconBlock:
+        pass
+
+    @abstractmethod
+    def get_block_by_root(self,
+                          block_root: Hash32,
+                          block_class: Type[BaseBeaconBlock]) -> BaseBeaconBlock:
+        pass
+
+    @abstractmethod
+    def get_score(self, block_root: Hash32) -> int:
+        pass
+
+    @abstractmethod
+    def block_exists(self, block_root: Hash32) -> bool:
+        pass
+
+    @abstractmethod
+    def persist_block_chain(
+            self,
+            blocks: Iterable[BaseBeaconBlock],
+            block_class: Type[BaseBeaconBlock]
+    ) -> Tuple[Tuple[BaseBeaconBlock, ...], Tuple[BaseBeaconBlock, ...]]:
+        pass
+
+    #
+    # Beacon State
+    #
+    @abstractmethod
+    def get_state_by_root(self, state_root: Hash32) -> BeaconState:
+        pass
+
+    @abstractmethod
+    def persist_state(self,
+                      state: BeaconState) -> None:
+        pass
+
+    #
+    # Raw Database API
+    #
+    @abstractmethod
+    def exists(self, key: bytes) -> bool:
+        pass
+
+    @abstractmethod
+    def get(self, key: bytes) -> bytes:
+        pass
+
+
+class BeaconChainDB(BaseBeaconChainDB):
+    def __init__(self, db: BaseAtomicDB) -> None:
+        self.db = db
+
+    def persist_block(
+            self,
+            block: BaseBeaconBlock,
+            block_class: Type[BaseBeaconBlock]
+    ) -> Tuple[Tuple[bytes, ...], Tuple[bytes, ...]]:
+        """
+        Persist the given block.
+        """
+        with self.db.atomic_batch() as db:
+            return self._persist_block(db, block, block_class)
+
+    @classmethod
+    def _persist_block(
+            cls,
+            db: 'BaseDB',
+            block: BaseBeaconBlock,
+            block_class: Type[BaseBeaconBlock]) -> Tuple[Tuple[bytes, ...], Tuple[bytes, ...]]:
+        block_chain = (block, )
+        new_canonical_blocks, old_canonical_blocks = cls._persist_block_chain(
+            db,
+            block_chain,
+            block_class,
+        )
+
+        return new_canonical_blocks, old_canonical_blocks
+
+    #
+    #
+    # Copied from HeaderDB
+    #
+    #
+
+    #
+    # Canonical Chain API
+    #
+    def get_canonical_block_root(self, slot: int) -> Hash32:
+        """
+        Return the block root for the canonical block at the given number.
+
+        Raise BlockNotFound if there's no block with the given number in the
+        canonical chain.
+        """
+        return self._get_canonical_block_root(self.db, slot)
+
+    @staticmethod
+    def _get_canonical_block_root(db: BaseDB, slot: int) -> Hash32:
+        validate_slot(slot)
+        slot_to_root_key = SchemaV1.make_block_slot_to_root_lookup_key(slot)
+        try:
+            encoded_key = db[slot_to_root_key]
+        except KeyError:
+            raise BlockNotFound(
+                "No canonical block for block slot #{0}".format(slot)
+            )
+        else:
+            return rlp.decode(encoded_key, sedes=rlp.sedes.binary)
+
+    def get_canonical_block_by_slot(self,
+                                    slot: int,
+                                    block_class: Type[BaseBeaconBlock]) -> BaseBeaconBlock:
+        """
+        Return the block with the given slot in the canonical chain.
+
+        Raise BlockNotFound if there's no block with the given slot in the
+        canonical chain.
+        """
+        return self._get_canonical_block_by_slot(self.db, slot, block_class)
+
+    @classmethod
+    def _get_canonical_block_by_slot(
+            cls,
+            db: BaseDB,
+            slot: int,
+            block_class: Type[BaseBeaconBlock]) -> BaseBeaconBlock:
+        canonical_block_root = cls._get_canonical_block_root_by_slot(db, slot)
+        return cls._get_block_by_root(db, canonical_block_root, block_class)
+
+    def get_canonical_block_root_by_slot(self, slot: int) -> Hash32:
+        """
+        Return the block root with the given slot in the canonical chain.
+
+        Raise BlockNotFound if there's no block with the given slot in the
+        canonical chain.
+        """
+        return self._get_canonical_block_root_by_slot(self.db, slot)
+
+    @classmethod
+    def _get_canonical_block_root_by_slot(
+            cls,
+            db: BaseDB,
+            slot: int) -> Hash32:
+        validate_slot(slot)
+        return cls._get_canonical_block_root(db, slot)
+
+    def get_canonical_head(self, block_class: Type[BaseBeaconBlock]) -> BaseBeaconBlock:
+        """
+        Return the current block at the head of the chain.
+        """
+        return self._get_canonical_head(self.db, block_class)
+
+    @classmethod
+    def _get_canonical_head(cls,
+                            db: BaseDB,
+                            block_class: Type[BaseBeaconBlock]) -> BaseBeaconBlock:
+        try:
+            canonical_head_root = db[SchemaV1.make_canonical_head_root_lookup_key()]
+        except KeyError:
+            raise CanonicalHeadNotFound("No canonical head set for this chain")
+        return cls._get_block_by_root(db, Hash32(canonical_head_root), block_class)
+
+    def get_block_by_root(self,
+                          block_root: Hash32,
+                          block_class: Type[BaseBeaconBlock]) -> BaseBeaconBlock:
+        return self._get_block_by_root(self.db, block_root, block_class)
+
+    @staticmethod
+    def _get_block_by_root(db: BaseDB,
+                           block_root: Hash32,
+                           block_class: Type[BaseBeaconBlock]) -> BaseBeaconBlock:
+        """
+        Return the requested block header as specified by block root.
+
+        Raise BlockNotFound if it is not present in the db.
+        """
+        validate_word(block_root, title="block root")
+        try:
+            block_rlp = db[block_root]
+        except KeyError:
+            raise BlockNotFound("No block with root {0} found".format(
+                encode_hex(block_root)))
+        return _decode_block(block_rlp, block_class)
+
+    def get_score(self, block_root: Hash32) -> int:
+        return self._get_score(self.db, block_root)
+
+    @staticmethod
+    def _get_score(db: BaseDB, block_root: Hash32) -> int:
+        try:
+            encoded_score = db[SchemaV1.make_block_root_to_score_lookup_key(block_root)]
+        except KeyError:
+            raise BlockNotFound("No block with hash {0} found".format(
+                encode_hex(block_root)))
+        return rlp.decode(encoded_score, sedes=rlp.sedes.big_endian_int)
+
+    def block_exists(self, block_root: Hash32) -> bool:
+        return self._block_exists(self.db, block_root)
+
+    @staticmethod
+    def _block_exists(db: BaseDB, block_root: Hash32) -> bool:
+        validate_word(block_root, title="block root")
+        return block_root in db
+
+    def persist_block_chain(
+            self,
+            blocks: Iterable[BaseBeaconBlock],
+            block_class: Type[BaseBeaconBlock]
+    ) -> Tuple[Tuple[BaseBeaconBlock, ...], Tuple[BaseBeaconBlock, ...]]:
+        """
+        Return two iterable of blocks, the first containing the new canonical blocks,
+        the second containing the old canonical headers
+        """
+        with self.db.atomic_batch() as db:
+            return self._persist_block_chain(db, blocks, block_class)
+
+    @classmethod
+    def _set_block_scores_to_db(
+            cls,
+            db: BaseDB,
+            block: BaseBeaconBlock
+    ) -> None:
+        # TODO: It's a stub before we implement fork choice rule
+        score = block.slot
+
+        db.set(
+            SchemaV1.make_block_root_to_score_lookup_key(block.root),
+            rlp.encode(score, sedes=rlp.sedes.big_endian_int),
+        )
+
+    @classmethod
+    def _persist_block_chain(
+            cls,
+            db: BaseDB,
+            blocks: Iterable[BaseBeaconBlock],
+            block_class: Type[BaseBeaconBlock]
+    ) -> Tuple[Tuple[BaseBeaconBlock, ...], Tuple[BaseBeaconBlock, ...]]:
+        blocks_iterator = iter(blocks)
+
+        try:
+            first_block = first(blocks_iterator)
+        except StopIteration:
+            return tuple(), tuple()
+
+        is_genesis = first_block.parent_root == GENESIS_PARENT_HASH
+        if not is_genesis and not cls._block_exists(db, first_block.parent_root):
+            raise ParentNotFound(
+                "Cannot persist block ({}) with unknown parent ({})".format(
+                    encode_hex(first_block.root), encode_hex(first_block.parent_root)))
+
+        if is_genesis:
+            score = 0
+        else:
+            score = cls._get_score(db, first_block.parent_root)
+
+        curr_block_head = first_block
+        db.set(
+            curr_block_head.root,
+            rlp.encode(curr_block_head),
+        )
+        cls._set_block_scores_to_db(db, curr_block_head)
+
+        orig_blocks_seq = concat([(first_block,), blocks_iterator])
+
+        for parent, child in sliding_window(2, orig_blocks_seq):
+            if parent.root != child.parent_root:
+                raise ValidationError(
+                    "Non-contiguous chain. Expected {} to have {} as parent but was {}".format(
+                        encode_hex(child.root),
+                        encode_hex(parent.root),
+                        encode_hex(child.parent_root),
+                    )
+                )
+
+            curr_block_head = child
+            db.set(
+                curr_block_head.root,
+                rlp.encode(curr_block_head),
+            )
+            cls._set_block_scores_to_db(db, curr_block_head)
+
+        try:
+            previous_canonical_head = cls._get_canonical_head(db, block_class).root
+            head_score = cls._get_score(db, previous_canonical_head)
+        except CanonicalHeadNotFound:
+            return cls._set_as_canonical_chain_head(db, curr_block_head.root, block_class)
+
+        if score > head_score:
+            return cls._set_as_canonical_chain_head(db, curr_block_head.root, block_class)
+        else:
+            return tuple(), tuple()
+
+    @classmethod
+    def _set_as_canonical_chain_head(
+            cls,
+            db: BaseDB,
+            block_root: Hash32,
+            block_class: Type[BaseBeaconBlock]
+    ) -> Tuple[Tuple[BaseBeaconBlock, ...], Tuple[BaseBeaconBlock, ...]]:
+        """
+        Set the canonical chain HEAD to the block as specified by the
+        given block root.
+
+        :return: a tuple of the blocks that are newly in the canonical chain, and the blocks that
+            are no longer in the canonical chain
+        """
+        try:
+            block = cls._get_block_by_root(db, block_root, block_class)
+        except BlockNotFound:
+            raise ValueError(
+                "Cannot use unknown block root as canonical head: {}".format(block_root)
+            )
+
+        new_canonical_blocks = tuple(reversed(cls._find_new_ancestors(db, block, block_class)))
+        old_canonical_blocks = []
+
+        for block in new_canonical_blocks:
+            try:
+                old_canonical_root = cls._get_canonical_block_root(db, block.slot)
+            except BlockNotFound:
+                # no old_canonical block, and no more possible
+                break
+            else:
+                old_canonical_block = cls._get_block_by_root(db, old_canonical_root, block_class)
+                old_canonical_blocks.append(old_canonical_block)
+
+        for block in new_canonical_blocks:
+            cls._add_block_slot_to_root_lookup(db, block)
+
+        db.set(SchemaV1.make_canonical_head_root_lookup_key(), block.root)
+
+        return new_canonical_blocks, tuple(old_canonical_blocks)
+
+    @classmethod
+    @to_tuple
+    def _find_new_ancestors(
+            cls,
+            db: BaseDB,
+            block: BaseBeaconBlock,
+            block_class: Type[BaseBeaconBlock]) -> Iterable[BaseBeaconBlock]:
+        """
+        Return the chain leading up from the given block until (but not including)
+        the first ancestor it has in common with our canonical chain.
+
+        If D is the canonical head in the following chain, and F is the new block,
+        then this function returns (F, E).
+
+        A - B - C - D
+               \
+                E - F
+        """
+        while True:
+            try:
+                orig = cls._get_canonical_block_by_slot(db, block.slot, block_class)
+            except BlockNotFound:
+                # This just means the block is not on the canonical chain.
+                pass
+            else:
+                if orig.root == block.root:
+                    # Found the common ancestor, stop.
+                    break
+
+            # Found a new ancestor
+            yield block
+
+            if block.parent_root == GENESIS_PARENT_HASH:
+                break
+            else:
+                block = cls._get_block_by_root(db, block.parent_root, block_class)
+
+    @staticmethod
+    def _add_block_slot_to_root_lookup(db: BaseDB, block: BaseBeaconBlock) -> None:
+        """
+        Set a record in the database to allow looking up this block by its
+        block slot.
+        """
+        block_slot_to_root_key = SchemaV1.make_block_slot_to_root_lookup_key(
+            block.slot
+        )
+        db.set(
+            block_slot_to_root_key,
+            rlp.encode(block.root, sedes=rlp.sedes.binary),
+        )
+
+    #
+    # Beacon State API
+    #
+    def get_state_by_root(self, state_root: Hash32) -> BeaconState:
+        return self._get_state_by_root(self.db, state_root)
+
+    @staticmethod
+    def _get_state_by_root(db: BaseDB, state_root: Hash32) -> BeaconState:
+        """
+        Return the requested beacon state as specified by state hash.
+
+        Raises StateRootNotFound if it is not present in the db.
+        """
+        # TODO: validate_state_root
+        try:
+            state_rlp = db[state_root]
+        except KeyError:
+            raise StateRootNotFound("No state with root {0} found".format(
+                encode_hex(state_rlp)))
+        return _decode_state(state_rlp)
+
+    def persist_state(self,
+                      state: BeaconState) -> None:
+        """
+        Persist the given BeaconState.
+        """
+        return self._persist_state(self.db, state)
+
+    @classmethod
+    def _persist_state(cls,
+                       db: BaseDB,
+                       state: BeaconState) -> None:
+        db.set(
+            state.root,
+            rlp.encode(state),
+        )
+
+    #
+    # Raw Database API
+    #
+    def exists(self, key: bytes) -> bool:
+        """
+        Return True if the given key exists in the database.
+        """
+        return self.db.exists(key)
+
+    def get(self, key: bytes) -> bytes:
+        """
+        Return the value for the given key or a KeyError if it doesn't exist in the database.
+        """
+        return self.db[key]
+
+
+# When performing a chain sync (either fast or regular modes), we'll very often need to look
+# up recent blocks to validate the chain, and decoding their RLP representation is
+# relatively expensive so we cache that here, but use a small cache because we *should* only
+# be looking up recent blocks.
+@functools.lru_cache(128)
+def _decode_block(block_rlp: bytes, sedes: Type[BaseBeaconBlock]) -> BaseBeaconBlock:
+    return rlp.decode(block_rlp, sedes=sedes)
+
+
+@functools.lru_cache(128)
+def _decode_state(state_rlp: bytes) -> BeaconState:
+    # TODO: forkable BeaconState fields?
+    return rlp.decode(state_rlp, sedes=BeaconState)

--- a/eth2/beacon/db/schema.py
+++ b/eth2/beacon/db/schema.py
@@ -1,0 +1,43 @@
+from abc import ABC, abstractmethod
+
+from eth_typing import (
+    Hash32,
+)
+
+
+class BaseSchema(ABC):
+    #
+    # Block
+    #
+    @staticmethod
+    @abstractmethod
+    def make_canonical_head_root_lookup_key() -> bytes:
+        pass
+
+    @staticmethod
+    @abstractmethod
+    def make_block_slot_to_root_lookup_key(slot: int) -> bytes:
+        pass
+
+    @staticmethod
+    @abstractmethod
+    def make_block_root_to_score_lookup_key(block_root: Hash32) -> bytes:
+        pass
+
+
+class SchemaV1(BaseSchema):
+    #
+    # Block
+    #
+    @staticmethod
+    def make_canonical_head_root_lookup_key() -> bytes:
+        return b'v1:beacon:canonical-head-root'
+
+    @staticmethod
+    def make_block_slot_to_root_lookup_key(slot: int) -> bytes:
+        slot_to_root_key = b'v1:beacon:block-slot-to-root:%d' % slot
+        return slot_to_root_key
+
+    @staticmethod
+    def make_block_root_to_score_lookup_key(block_root: Hash32) -> bytes:
+        return b'v1:beacon:block-root-to-score:%s' % block_root

--- a/eth2/beacon/deposit_helpers.py
+++ b/eth2/beacon/deposit_helpers.py
@@ -1,0 +1,132 @@
+from eth_typing import (
+    Hash32,
+)
+from eth_utils import (
+    ValidationError,
+)
+
+from eth2._utils import bls
+
+from eth2.beacon.constants import (
+    EMPTY_SIGNATURE,
+)
+from eth2.beacon.enums import (
+    SignatureDomain,
+)
+from eth2.beacon.types.deposit_input import DepositInput
+from eth2.beacon.types.states import BeaconState
+from eth2.beacon.types.validator_records import ValidatorRecord
+from eth2.beacon.helpers import (
+    get_domain,
+)
+from eth2.beacon.typing import (
+    BLSPubkey,
+    BLSSignature,
+    ValidatorIndex,
+    Gwei,
+)
+
+
+def validate_proof_of_possession(state: BeaconState,
+                                 pubkey: BLSPubkey,
+                                 proof_of_possession: BLSSignature,
+                                 withdrawal_credentials: Hash32,
+                                 randao_commitment: Hash32,
+                                 custody_commitment: Hash32) -> None:
+    deposit_input = DepositInput(
+        pubkey=pubkey,
+        withdrawal_credentials=withdrawal_credentials,
+        randao_commitment=randao_commitment,
+        custody_commitment=custody_commitment,
+        proof_of_possession=EMPTY_SIGNATURE,
+    )
+
+    is_valid_signature = bls.verify(
+        pubkey=pubkey,
+        # TODO: change to hash_tree_root(deposit_input) when we have SSZ tree hashing
+        message=deposit_input.root,
+        signature=proof_of_possession,
+        domain=get_domain(
+            state.fork_data,
+            state.slot,
+            SignatureDomain.DOMAIN_DEPOSIT,
+        ),
+    )
+
+    if not is_valid_signature:
+        raise ValidationError(
+            "BLS signature verification error"
+        )
+
+
+def add_pending_validator(state: BeaconState,
+                          validator: ValidatorRecord,
+                          amount: Gwei) -> BeaconState:
+    """
+    Add a validator to ``state``.
+    """
+    state = state.copy(
+        validator_registry=state.validator_registry + (validator,),
+        validator_balances=state.validator_balances + (amount, ),
+    )
+
+    return state
+
+
+def process_deposit(*,
+                    state: BeaconState,
+                    pubkey: BLSPubkey,
+                    amount: Gwei,
+                    proof_of_possession: BLSSignature,
+                    withdrawal_credentials: Hash32,
+                    randao_commitment: Hash32,
+                    custody_commitment: Hash32) -> BeaconState:
+    """
+    Process a deposit from Ethereum 1.0.
+    """
+    validate_proof_of_possession(
+        state=state,
+        pubkey=pubkey,
+        proof_of_possession=proof_of_possession,
+        withdrawal_credentials=withdrawal_credentials,
+        randao_commitment=randao_commitment,
+        custody_commitment=custody_commitment,
+    )
+
+    validator_pubkeys = tuple(v.pubkey for v in state.validator_registry)
+    if pubkey not in validator_pubkeys:
+        validator = ValidatorRecord.create_pending_validator(
+            pubkey=pubkey,
+            withdrawal_credentials=withdrawal_credentials,
+            randao_commitment=randao_commitment,
+            custody_commitment=custody_commitment,
+        )
+
+        # Note: In phase 2 registry indices that has been withdrawn for a long time
+        # will be recycled.
+        state = add_pending_validator(
+            state,
+            validator,
+            amount,
+        )
+    else:
+        # Top-up - increase balance by deposit
+        index = ValidatorIndex(validator_pubkeys.index(pubkey))
+        validator = state.validator_registry[index]
+
+        if validator.withdrawal_credentials != withdrawal_credentials:
+            raise ValidationError(
+                "`withdrawal_credentials` are incorrect:\n"
+                "\texpected: %s, found: %s" % (
+                    validator.withdrawal_credentials,
+                    validator.withdrawal_credentials,
+                )
+            )
+
+        # Update validator's balance and state
+        state = state.update_validator_balance(
+            validator_index=index,
+            balance=state.validator_balances[index] + amount,
+        )
+
+    return state

--- a/eth2/beacon/enums.py
+++ b/eth2/beacon/enums.py
@@ -1,0 +1,18 @@
+from enum import IntEnum
+
+
+class ValidatorStatusFlags(IntEnum):
+    INITIATED_EXIT = 1
+    WITHDRAWABLE = 2
+
+
+class ValidatorRegistryDeltaFlag(IntEnum):
+    ACTIVATION = 0
+    EXIT = 1
+
+
+class SignatureDomain(IntEnum):
+    DOMAIN_DEPOSIT = 0
+    DOMAIN_ATTESTATION = 1
+    DOMAIN_PROPOSAL = 2
+    DOMAIN_EXIT = 3

--- a/eth2/beacon/helpers.py
+++ b/eth2/beacon/helpers.py
@@ -1,0 +1,510 @@
+from typing import (
+    Iterable,
+    Sequence,
+    Tuple,
+    TYPE_CHECKING,
+)
+
+import functools
+
+from eth_utils import (
+    to_tuple,
+    ValidationError,
+)
+from eth_typing import (
+    Hash32,
+)
+
+from eth2._utils.bitfield import (
+    get_bitfield_length,
+    has_voted,
+)
+import eth2._utils.bls as bls
+from eth._utils.numeric import (
+    clamp,
+)
+from eth2.beacon._utils.random import (
+    shuffle,
+    split,
+)
+
+from eth2.beacon.block_committees_info import (
+    BlockCommitteesInfo,
+)
+from eth2.beacon.constants import (
+    GWEI_PER_ETH,
+)
+from eth2.beacon.enums import (
+    SignatureDomain,
+)
+from eth2.beacon.types.shard_committees import (
+    ShardCommittee,
+)
+from eth2.beacon.typing import (
+    Bitfield,
+    BLSPubkey,
+    Ether,
+    Gwei,
+    ShardNumber,
+    SlotNumber,
+    ValidatorIndex,
+)
+
+if TYPE_CHECKING:
+    from eth2.beacon.types.attestation_data import AttestationData  # noqa: F401
+    from eth2.beacon.types.blocks import BaseBeaconBlock  # noqa: F401
+    from eth2.beacon.types.states import BeaconState  # noqa: F401
+    from eth2.beacon.types.fork_data import ForkData  # noqa: F401
+    from eth2.beacon.types.slashable_vote_data import SlashableVoteData  # noqa: F401
+    from eth2.beacon.types.validator_records import ValidatorRecord  # noqa: F401
+
+
+#
+# Get block root
+#
+def _get_block_root(
+        latest_block_roots: Sequence[Hash32],
+        state_slot: SlotNumber,
+        slot: SlotNumber,
+        latest_block_roots_length: int) -> Hash32:
+    """
+    Return the block root at a recent ``slot``.
+    """
+    if state_slot > slot + latest_block_roots_length:
+        raise ValidationError(
+            "state.slot ({}) should be less than or equal to "
+            "(slot + latest_block_roots_length) ({}), "
+            "where slot={}, latest_block_roots_length={}".format(
+                state_slot,
+                slot + latest_block_roots_length,
+                slot,
+                latest_block_roots_length,
+            )
+        )
+    if slot >= state_slot:
+        raise ValidationError(
+            "slot ({}) should be less than state.slot ({})".format(
+                slot,
+                state_slot,
+            )
+        )
+    return latest_block_roots[slot % latest_block_roots_length]
+
+
+def get_block_root(
+        state: 'BeaconState',
+        slot: SlotNumber,
+        latest_block_roots_length: int) -> Hash32:
+    """
+    Return the block root at a recent ``slot``.
+    """
+    return _get_block_root(
+        state.latest_block_roots,
+        state.slot,
+        slot,
+        latest_block_roots_length,
+    )
+
+
+#
+# Get shards_committees or indices
+#
+@to_tuple
+def _get_shard_committees_at_slot(
+        state_slot: SlotNumber,
+        shard_committees_at_slots: Sequence[Sequence[ShardCommittee]],
+        slot: SlotNumber,
+        epoch_length: int) -> Iterable[ShardCommittee]:
+
+    earliest_slot_in_array = state_slot - (state_slot % epoch_length) - epoch_length
+
+    if earliest_slot_in_array > slot:
+        raise ValidationError(
+            "earliest_slot_in_array ({}) should be less than or equal to slot ({})".format(
+                earliest_slot_in_array,
+                slot,
+            )
+        )
+    if slot >= earliest_slot_in_array + epoch_length * 2:
+        raise ValidationError(
+            "slot ({}) should be less than "
+            "(earliest_slot_in_array + epoch_length * 2) ({}), "
+            "where earliest_slot_in_array={}, epoch_length={}".format(
+                slot,
+                earliest_slot_in_array + epoch_length * 2,
+                earliest_slot_in_array,
+                epoch_length,
+            )
+        )
+
+    return shard_committees_at_slots[slot - earliest_slot_in_array]
+
+
+def get_shard_committees_at_slot(state: 'BeaconState',
+                                 slot: SlotNumber,
+                                 epoch_length: int) -> Tuple[ShardCommittee]:
+    """
+    Return the ``ShardCommittee`` for the ``slot``.
+    """
+    return _get_shard_committees_at_slot(
+        state_slot=state.slot,
+        shard_committees_at_slots=state.shard_committees_at_slots,
+        slot=slot,
+        epoch_length=epoch_length,
+    )
+
+
+def get_active_validator_indices(validators: Sequence['ValidatorRecord'],
+                                 slot: SlotNumber) -> Tuple[ValidatorIndex, ...]:
+    """
+    Get indices of active validators from ``validators``.
+    """
+    return tuple(
+        ValidatorIndex(index) for index, validator in enumerate(validators)
+        if validator.is_active(slot)
+    )
+
+
+#
+# Shuffling
+#
+@to_tuple
+def _get_shards_committees_for_shard_indices(
+        shard_indices: Sequence[Sequence[ValidatorIndex]],
+        start_shard: ShardNumber,
+        total_validator_count: int,
+        shard_count: int) -> Iterable[ShardCommittee]:
+    """
+    Return filled [ShardCommittee] tuple.
+    """
+    for index, indices in enumerate(shard_indices):
+        yield ShardCommittee(
+            shard=ShardNumber((start_shard + index) % shard_count),
+            committee=indices,
+            total_validator_count=total_validator_count,
+        )
+
+
+@to_tuple
+def get_shuffling(*,
+                  seed: Hash32,
+                  validators: Sequence['ValidatorRecord'],
+                  crosslinking_start_shard: ShardNumber,
+                  slot: SlotNumber,
+                  epoch_length: int,
+                  target_committee_size: int,
+                  shard_count: int) -> Iterable[Tuple[ShardCommittee]]:
+    """
+    Return shuffled ``shard_committee_for_slots`` (``[[ShardCommittee]]``) of
+    the given active ``validators`` using ``seed`` as entropy.
+
+    Two-dimensional:
+    The first layer is ``slot`` number
+        ``shard_committee_for_slots[slot] -> [ShardCommittee]``
+    The second layer is ``shard_indices`` number
+        ``shard_committee_for_slots[slot][shard_indices] -> ShardCommittee``
+
+    Example:
+        validators:
+            [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]
+        After shuffling:
+            [6, 0, 2, 12, 14, 8, 10, 4, 9, 1, 5, 13, 15, 7, 3, 11]
+        Split by slot:
+            [
+                [6, 0, 2, 12, 14], [8, 10, 4, 9, 1], [5, 13, 15, 7, 3, 11]
+            ]
+        Split by shard:
+            [
+                [6, 0], [2, 12, 14], [8, 10], [4, 9, 1], [5, 13, 15] ,[7, 3, 11]
+            ]
+        Fill to output:
+            [
+                # slot 0
+                [
+                    ShardCommittee(shard_id=0, committee=[6, 0]),
+                    ShardCommittee(shard_id=1, committee=[2, 12, 14]),
+                ],
+                # slot 1
+                [
+                    ShardCommittee(shard_id=2, committee=[8, 10]),
+                    ShardCommittee(shard_id=3, committee=[4, 9, 1]),
+                ],
+                # slot 2
+                [
+                    ShardCommittee(shard_id=4, committee=[5, 13, 15]),
+                    ShardCommittee(shard_id=5, committee=[7, 3, 11]),
+                ],
+            ]
+    """
+    active_validators = get_active_validator_indices(validators, slot)
+    active_validators_size = len(active_validators)
+    committees_per_slot = clamp(
+        1,
+        shard_count // epoch_length,
+        active_validators_size // epoch_length // target_committee_size,
+    )
+    # Shuffle with seed
+    shuffled_active_validator_indices = shuffle(active_validators, seed)
+
+    # Split the shuffled list into epoch_length pieces
+    validators_per_slot = split(shuffled_active_validator_indices, epoch_length)
+    for index, slot_indices in enumerate(validators_per_slot):
+        # Split the shuffled list into committees_per_slot pieces
+        shard_indices = split(slot_indices, committees_per_slot)
+        start_shard = crosslinking_start_shard + index * committees_per_slot
+        yield _get_shards_committees_for_shard_indices(
+            shard_indices,
+            start_shard,
+            active_validators_size,
+            shard_count,
+        )
+
+
+#
+# Get proposer position
+#
+def get_block_committees_info(parent_block: 'BaseBeaconBlock',
+                              state: 'BeaconState',
+                              epoch_length: int) -> BlockCommitteesInfo:
+    shards_committees = get_shard_committees_at_slot(
+        state,
+        parent_block.slot,
+        epoch_length,
+    )
+    """
+    Return the block committees and proposer info with BlockCommitteesInfo pack.
+    """
+    # `proposer_index_in_committee` th attester in `shard_committee`
+    # is the proposer of the parent block.
+    try:
+        shard_committee = shards_committees[0]
+    except IndexError:
+        raise ValidationError("shards_committees should not be empty.")
+
+    proposer_committee_size = len(shard_committee.committee)
+    if proposer_committee_size <= 0:
+        raise ValidationError(
+            "The first committee should not be empty"
+        )
+
+    proposer_index_in_committee = (
+        parent_block.slot %
+        proposer_committee_size
+    )
+
+    proposer_index = shard_committee.committee[proposer_index_in_committee]
+
+    return BlockCommitteesInfo(
+        proposer_index=proposer_index,
+        proposer_shard=shard_committee.shard,
+        proposer_committee_size=proposer_committee_size,
+        shards_committees=shards_committees,
+    )
+
+
+def get_beacon_proposer_index(state: 'BeaconState',
+                              slot: SlotNumber,
+                              epoch_length: int) -> ValidatorIndex:
+    """
+    Return the beacon proposer index for the ``slot``.
+    """
+    shard_committees = get_shard_committees_at_slot(
+        state,
+        slot,
+        epoch_length,
+    )
+    try:
+        first_shard_committee = shard_committees[0]
+    except IndexError:
+        raise ValidationError("shard_committees should not be empty.")
+
+    proposer_committee_size = len(first_shard_committee.committee)
+
+    if proposer_committee_size <= 0:
+        raise ValidationError(
+            "The first committee should not be empty"
+        )
+
+    return first_shard_committee.committee[slot % len(first_shard_committee.committee)]
+
+
+#
+# Bitfields
+#
+@to_tuple
+def get_attestation_participants(state: 'BeaconState',
+                                 slot: SlotNumber,
+                                 shard: ShardNumber,
+                                 participation_bitfield: Bitfield,
+                                 epoch_length: int) -> Iterable[ValidatorIndex]:
+    """
+    Return the participants' indices at the ``slot`` of shard ``shard``
+    from ``participation_bitfield``.
+    """
+    # Find the relevant committee
+    # Filter by slot
+    shard_committees_at_slot = get_shard_committees_at_slot(
+        state,
+        slot,
+        epoch_length,
+    )
+    # Filter by shard
+    shard_committees = tuple(
+        [
+            shard_committee
+            for shard_committee in shard_committees_at_slot
+            if shard_committee.shard == shard
+        ]
+    )
+
+    try:
+        shard_committee = shard_committees[0]
+    except IndexError:
+        raise ValidationError("shard_committees should not be empty.")
+
+    if len(participation_bitfield) != get_bitfield_length(len(shard_committee.committee)):
+        raise ValidationError(
+            'Invalid bitfield length,'
+            "\texpected: %s, found: %s" % (
+                get_bitfield_length(len(shard_committee.committee)),
+                len(participation_bitfield),
+            )
+        )
+
+    # Find the participating attesters in the committee
+    for bitfield_index, validator_index in enumerate(shard_committee.committee):
+        if has_voted(participation_bitfield, bitfield_index):
+            yield validator_index
+
+
+#
+# Misc
+#
+def get_effective_balance(
+        validator_balances: Sequence[Gwei],
+        index: ValidatorIndex,
+        max_deposit: Ether) -> Gwei:
+    """
+    Return the effective balance (also known as "balance at stake") for a
+    ``validator`` with the given ``index``.
+    """
+    return min(validator_balances[index], Gwei(max_deposit * GWEI_PER_ETH))
+
+
+def get_fork_version(fork_data: 'ForkData',
+                     slot: SlotNumber) -> int:
+    """
+    Return the current ``fork_version`` from the given ``fork_data`` and ``slot``.
+    """
+    if slot < fork_data.fork_slot:
+        return fork_data.pre_fork_version
+    else:
+        return fork_data.post_fork_version
+
+
+def get_domain(fork_data: 'ForkData',
+               slot: SlotNumber,
+               domain_type: SignatureDomain) -> int:
+    """
+    Return the domain number of the current fork and ``domain_type``.
+    """
+    # 2 ** 32 = 4294967296
+    return get_fork_version(
+        fork_data,
+        slot,
+    ) * 4294967296 + domain_type
+
+
+@to_tuple
+def get_pubkey_for_indices(validators: Sequence['ValidatorRecord'],
+                           indices: Sequence[ValidatorIndex]) -> Iterable[BLSPubkey]:
+    for index in indices:
+        yield validators[index].pubkey
+
+
+@to_tuple
+def generate_aggregate_pubkeys(validators: Sequence['ValidatorRecord'],
+                               vote_data: 'SlashableVoteData') -> Iterable[BLSPubkey]:
+    """
+    Compute the aggregate pubkey we expect based on
+    the proof-of-custody indices found in the ``vote_data``.
+    """
+    custody_bit_0_indices = vote_data.custody_bit_0_indices
+    custody_bit_1_indices = vote_data.custody_bit_1_indices
+    all_indices = (custody_bit_0_indices, custody_bit_1_indices)
+    get_pubkeys = functools.partial(get_pubkey_for_indices, validators)
+    return map(
+        bls.aggregate_pubkeys,
+        map(get_pubkeys, all_indices),
+    )
+
+
+def verify_vote_count(vote_data: 'SlashableVoteData', max_casper_votes: int) -> bool:
+    """
+    Ensure we have no more than ``max_casper_votes`` in the ``vote_data``.
+    """
+    return vote_data.vote_count <= max_casper_votes
+
+
+def verify_slashable_vote_data_signature(state: 'BeaconState',
+                                         vote_data: 'SlashableVoteData') -> bool:
+    """
+    Ensure we have a valid aggregate signature for the ``vote_data``.
+    """
+    pubkeys = generate_aggregate_pubkeys(state.validator_registry, vote_data)
+
+    messages = vote_data.messages
+
+    signature = vote_data.aggregate_signature
+
+    domain = get_domain(state.fork_data, state.slot, SignatureDomain.DOMAIN_ATTESTATION)
+
+    return bls.verify_multiple(
+        pubkeys=pubkeys,
+        messages=messages,
+        signature=signature,
+        domain=domain,
+    )
+
+
+def verify_slashable_vote_data(state: 'BeaconState',
+                               vote_data: 'SlashableVoteData',
+                               max_casper_votes: int) -> bool:
+    """
+    Ensure that the ``vote_data`` is properly assembled and contains the signature
+    we expect from the validators we expect. Otherwise, return False as
+    the ``vote_data`` is invalid.
+    """
+    return (
+        verify_vote_count(vote_data, max_casper_votes) and
+        verify_slashable_vote_data_signature(state, vote_data)
+    )
+
+
+def is_double_vote(attestation_data_1: 'AttestationData',
+                   attestation_data_2: 'AttestationData') -> bool:
+    """
+    Assumes ``attestation_data_1`` is distinct from ``attestation_data_2``.
+
+    Returns True if the provided ``AttestationData`` are slashable
+    due to a 'double vote'.
+    """
+    return attestation_data_1.slot == attestation_data_2.slot
+
+
+def is_surround_vote(attestation_data_1: 'AttestationData',
+                     attestation_data_2: 'AttestationData') -> bool:
+    """
+    Assumes ``attestation_data_1`` is distinct from ``attestation_data_2``.
+
+    Returns True if the provided ``AttestationData`` are slashable
+    due to a 'surround vote'.
+
+    Note: parameter order matters as this function only checks
+    that ``attestation_data_1`` surrounds ``attestation_data_2``.
+    """
+    return (
+        (attestation_data_1.justified_slot < attestation_data_2.justified_slot) and
+        (attestation_data_2.justified_slot + 1 == attestation_data_2.slot) and
+        (attestation_data_2.slot < attestation_data_1.slot)
+    )

--- a/eth2/beacon/sedes.py
+++ b/eth2/beacon/sedes.py
@@ -1,0 +1,10 @@
+from rlp.sedes import (
+    BigEndianInt,
+    Binary,
+)
+
+
+hash32 = Binary.fixed_length(32)
+uint24 = BigEndianInt(24)
+uint64 = BigEndianInt(64)
+uint384 = BigEndianInt(384)

--- a/eth2/beacon/state_machines/base.py
+++ b/eth2/beacon/state_machines/base.py
@@ -1,0 +1,133 @@
+from abc import (
+    ABC,
+    abstractmethod,
+)
+from typing import (
+    Tuple,
+    Type,
+)
+
+from eth_typing import (
+    Hash32,
+)
+
+from eth._utils.datatypes import (
+    Configurable,
+)
+
+from eth2.beacon.db.chain import BaseBeaconChainDB
+from eth2.beacon.types.blocks import BaseBeaconBlock
+from eth2.beacon.types.states import BeaconState
+
+
+from .state_transitions import (
+    BaseStateTransition,
+)
+from .configs import (  # noqa: F401
+    BeaconConfig,
+)
+
+
+class BaseBeaconStateMachine(Configurable, ABC):
+    fork = None  # type: str
+    chaindb = None  # type: BaseBeaconChainDB
+    config = None  # type: BeaconConfig
+
+    block = None  # type: BaseBeaconBlock
+    _state = None  # type: BeaconState
+
+    block_class = None  # type: Type[BaseBeaconBlock]
+    state_class = None  # type: Type[BeaconState]
+    state_transition_class = None  # type: Type[BaseStateTransition]
+
+    @classmethod
+    @abstractmethod
+    def get_block_class(cls) -> Type[BaseBeaconBlock]:
+        pass
+
+    @classmethod
+    @abstractmethod
+    def get_state_class(cls) -> Type[BeaconState]:
+        pass
+
+    @classmethod
+    @abstractmethod
+    def get_state_transiton_class(cls) -> Type[BaseStateTransition]:
+        pass
+
+    @property
+    @abstractmethod
+    def state_transition(self) -> BaseStateTransition:
+        pass
+
+    #
+    # Import block API
+    #
+    @abstractmethod
+    def import_block(self, block: BaseBeaconBlock) -> Tuple[BeaconState, BaseBeaconBlock]:
+        pass
+
+
+class BeaconStateMachine(BaseBeaconStateMachine):
+    def __init__(self,
+                 chaindb: BaseBeaconChainDB,
+                 block_root: Hash32,
+                 block_class: Type[BaseBeaconBlock]) -> None:
+        self.chaindb = chaindb
+        self.block = self.chaindb.get_block_by_root(block_root, block_class)
+
+    @property
+    def state(self) -> BeaconState:
+        if self._state is None:
+            self._state = self.chaindb.get_state_by_root(self.block.state_root)
+        return self._state
+
+    @classmethod
+    def get_block_class(cls) -> Type[BaseBeaconBlock]:
+        """
+        Return the :class:`~eth2.beacon.types.blocks.BeaconBlock` class that this
+        StateMachine uses for blocks.
+        """
+        if cls.block_class is None:
+            raise AttributeError("No `block_class` has been set for this StateMachine")
+        else:
+            return cls.block_class
+
+    @classmethod
+    def get_state_class(cls) -> Type[BeaconState]:
+        """
+        Return the :class:`~eth2.beacon.types.states.BeaconState` class that this
+        StateMachine uses for BeaconState.
+        """
+        if cls.state_class is None:
+            raise AttributeError("No `state_class` has been set for this StateMachine")
+        else:
+            return cls.state_class
+
+    @classmethod
+    def get_state_transiton_class(cls) -> Type[BaseStateTransition]:
+        """
+        Return the :class:`~eth2.beacon.state_machines.state_transitions.BaseStateTransition`
+        class that this StateTransition uses for StateTransition.
+        """
+        if cls.state_transition_class is None:
+            raise AttributeError("No `state_transition_class` has been set for this StateMachine")
+        else:
+            return cls.state_transition_class
+
+    @property
+    def state_transition(self) -> BaseStateTransition:
+        return self.get_state_transiton_class()(self.config)
+
+    #
+    # Import block API
+    #
+    def import_block(self, block: BaseBeaconBlock) -> Tuple[BeaconState, BaseBeaconBlock]:
+        state = self.state_transition.apply_state_transition(
+            self.state,
+            block,
+        )
+        # TODO: Validate state roots
+        # TODO: Update self.state
+        # TODO: persist states in BeaconChain
+        return state, block

--- a/eth2/beacon/state_machines/configs.py
+++ b/eth2/beacon/state_machines/configs.py
@@ -1,0 +1,60 @@
+from typing import (
+    NamedTuple,
+)
+
+from eth.typing import (
+    Address,
+)
+from eth2.beacon.typing import (
+    SlotNumber,
+    ShardNumber,
+    Ether,
+    Second,
+)
+
+
+BeaconConfig = NamedTuple(
+    'BeaconConfig',
+    (
+        # Misc
+        ('SHARD_COUNT', int),
+        ('TARGET_COMMITTEE_SIZE', int),
+        ('EJECTION_BALANCE', Ether),
+        ('MAX_BALANCE_CHURN_QUOTIENT', int),
+        ('BEACON_CHAIN_SHARD_NUMBER', ShardNumber),
+        ('MAX_CASPER_VOTES', int),
+        ('LATEST_BLOCK_ROOTS_LENGTH', int),
+        ('LATEST_RANDAO_MIXES_LENGTH', int),
+        ('LATEST_PENALIZED_EXIT_LENGTH', int),
+        # EMPTY_SIGNATURE is defined in constants.py
+        # Deposit contract
+        ('DEPOSIT_CONTRACT_ADDRESS', Address),
+        ('DEPOSIT_CONTRACT_TREE_DEPTH', int),
+        ('MIN_DEPOSIT', Ether),
+        ('MAX_DEPOSIT', Ether),
+        # ZERO_HASH (ZERO_HASH32) is defined in constants.py
+        # Initial values
+        ('GENESIS_FORK_VERSION', int),
+        ('GENESIS_SLOT', SlotNumber),
+        ('BLS_WITHDRAWAL_PREFIX_BYTE', bytes),
+        # Time parameters
+        ('SLOT_DURATION', Second),
+        ('MIN_ATTESTATION_INCLUSION_DELAY', int),
+        ('EPOCH_LENGTH', int),
+        ('SEED_LOOKAHEAD', int),
+        ('ENTRY_EXIT_DELAY', int),
+        ('POW_RECEIPT_ROOT_VOTING_PERIOD', int),
+        ('MIN_VALIDATOR_WITHDRAWAL_TIME', int),
+        # Reward and penalty quotients
+        ('BASE_REWARD_QUOTIENT', int),
+        ('WHISTLEBLOWER_REWARD_QUOTIENT', int),
+        ('INCLUDER_REWARD_QUOTIENT', int),
+        ('INACTIVITY_PENALTY_QUOTIENT', int),
+        # Max operations per block
+        ('MAX_PROPOSER_SLASHINGS', int),
+        ('MAX_CASPER_SLASHINGS', int),
+        ('MAX_ATTESTATIONS', int),
+        ('MAX_DEPOSITS', int),
+        ('MAX_EXITS', int),
+    )
+)

--- a/eth2/beacon/state_machines/forks/serenity/__init__.py
+++ b/eth2/beacon/state_machines/forks/serenity/__init__.py
@@ -1,0 +1,23 @@
+from typing import Type  # noqa: F401
+
+from eth2.beacon.types.blocks import BaseBeaconBlock  # noqa: F401
+from eth2.beacon.types.states import BeaconState  # noqa: F401
+
+from eth2.beacon.state_machines.base import BeaconStateMachine
+from eth2.beacon.state_machines.state_transitions import BaseStateTransition  # noqa: F401
+
+from .configs import SERENITY_CONFIG
+from .blocks import SerenityBeaconBlock
+from .states import SerenityBeaconState
+from .state_transitions import SerenityStateTransition
+
+
+class SerenityStateMachine(BeaconStateMachine):
+    # fork name
+    fork = 'serenity'  # type: str
+
+    # classes
+    block_class = SerenityBeaconBlock  # type: Type[BaseBeaconBlock]
+    state_class = SerenityBeaconState  # type: Type[BeaconState]
+    state_transition_class = SerenityStateTransition  # type: Type[BaseStateTransition]
+    config = SERENITY_CONFIG

--- a/eth2/beacon/state_machines/forks/serenity/blocks.py
+++ b/eth2/beacon/state_machines/forks/serenity/blocks.py
@@ -1,0 +1,12 @@
+from eth2.beacon.types.blocks import (
+    BeaconBlock,
+    BeaconBlockBody,
+)
+
+
+class SerenityBeaconBlockBody(BeaconBlockBody):
+    pass
+
+
+class SerenityBeaconBlock(BeaconBlock):
+    pass

--- a/eth2/beacon/state_machines/forks/serenity/configs.py
+++ b/eth2/beacon/state_machines/forks/serenity/configs.py
@@ -1,0 +1,52 @@
+from eth.constants import (
+    ZERO_ADDRESS,
+)
+from eth2.beacon.state_machines.configs import BeaconConfig
+from eth2.beacon.typing import (
+    SlotNumber,
+    ShardNumber,
+    Ether,
+    Second,
+)
+
+
+SERENITY_CONFIG = BeaconConfig(
+    # Misc
+    SHARD_COUNT=2**10,  # (= 1,024) shards
+    TARGET_COMMITTEE_SIZE=2**7,  # (= 128) validators
+    EJECTION_BALANCE=Ether(2**4),  # (= 16) ETH
+    MAX_BALANCE_CHURN_QUOTIENT=2**5,  # (= 32)
+    BEACON_CHAIN_SHARD_NUMBER=ShardNumber(2**64 - 1),
+    MAX_CASPER_VOTES=2**10,  # (= 1,024) votes
+    LATEST_BLOCK_ROOTS_LENGTH=2**13,  # (= 8,192) block roots
+    LATEST_RANDAO_MIXES_LENGTH=2**13,  # (= 8,192) randao mixes
+    LATEST_PENALIZED_EXIT_LENGTH=2**13,  # (= 8,192) randao mixes
+    # Deposit contract
+    DEPOSIT_CONTRACT_ADDRESS=ZERO_ADDRESS,  # TBD
+    DEPOSIT_CONTRACT_TREE_DEPTH=2**5,  # (= 32)
+    MIN_DEPOSIT=Ether(2**0),  # (= 1) ETH
+    MAX_DEPOSIT=Ether(2**5),  # (= 32) ETH
+    # Initial values
+    GENESIS_FORK_VERSION=0,
+    GENESIS_SLOT=SlotNumber(0),
+    BLS_WITHDRAWAL_PREFIX_BYTE=b'\x00',
+    # Time parameters
+    SLOT_DURATION=Second(6),  # seconds
+    MIN_ATTESTATION_INCLUSION_DELAY=2**2,  # (= 4) slots
+    EPOCH_LENGTH=2**6,  # (= 64) slots
+    SEED_LOOKAHEAD=2**6,  # (= 64) slots
+    ENTRY_EXIT_DELAY=2**8,  # (= 256) slots
+    POW_RECEIPT_ROOT_VOTING_PERIOD=2**10,  # (= 1,024) slots
+    MIN_VALIDATOR_WITHDRAWAL_TIME=2**14,  # (= 16,384) slots
+    # Reward and penalty quotients
+    BASE_REWARD_QUOTIENT=2**10,  # (= 1,024)
+    WHISTLEBLOWER_REWARD_QUOTIENT=2**9,  # (= 512)
+    INCLUDER_REWARD_QUOTIENT=2**3,  # (= 8)
+    INACTIVITY_PENALTY_QUOTIENT=2**24,  # (= 16,777,216)
+    # Max operations per block
+    MAX_PROPOSER_SLASHINGS=2**4,  # (= 16)
+    MAX_CASPER_SLASHINGS=2**4,  # (= 16)
+    MAX_ATTESTATIONS=2**7,  # (= 128)
+    MAX_DEPOSITS=2**4,  # (= 16)
+    MAX_EXITS=2**4,  # (= 16)
+)

--- a/eth2/beacon/state_machines/forks/serenity/operations.py
+++ b/eth2/beacon/state_machines/forks/serenity/operations.py
@@ -1,0 +1,45 @@
+from eth2.beacon.types.blocks import BaseBeaconBlock
+from eth2.beacon.types.pending_attestation_records import PendingAttestationRecord
+from eth2.beacon.types.states import BeaconState
+from eth2.beacon.state_machines.configs import BeaconConfig
+
+from .validation import (
+    validate_serenity_attestation,
+)
+
+
+def process_attestations(state: BeaconState,
+                         block: BaseBeaconBlock,
+                         config: BeaconConfig) -> BeaconState:
+    """
+    Implements 'per-block-processing.operations.attestations' portion of Phase 0 spec:
+    https://github.com/ethereum/eth2.0-specs/blob/master/specs/core/0_beacon-chain.md#attestations-1
+
+    Validate the ``attestations`` contained within the ``block`` in the context of ``state``.
+    If any invalid, throw ``ValidationError``.
+    Otherwise, append an ``PendingAttestationRecords`` for each to ``latest_attestations``.
+    Return resulting ``state``.
+    """
+    for attestation in block.body.attestations:
+        validate_serenity_attestation(
+            state,
+            attestation,
+            config.EPOCH_LENGTH,
+            config.MIN_ATTESTATION_INCLUSION_DELAY,
+            config.LATEST_BLOCK_ROOTS_LENGTH,
+        )
+
+    # update_latest_attestations
+    additional_pending_attestations = tuple(
+        PendingAttestationRecord(
+            data=attestation.data,
+            participation_bitfield=attestation.participation_bitfield,
+            custody_bitfield=attestation.custody_bitfield,
+            slot_included=state.slot,
+        )
+        for attestation in block.body.attestations
+    )
+    state = state.copy(
+        latest_attestations=state.latest_attestations + additional_pending_attestations,
+    )
+    return state

--- a/eth2/beacon/state_machines/forks/serenity/state_transitions.py
+++ b/eth2/beacon/state_machines/forks/serenity/state_transitions.py
@@ -1,0 +1,59 @@
+from eth_typing import (
+    Hash32,
+)
+
+from eth2.beacon.types.blocks import BaseBeaconBlock
+from eth2.beacon.types.states import BeaconState
+
+from eth2.beacon.state_machines.configs import BeaconConfig
+from eth2.beacon.state_machines.state_transitions import BaseStateTransition
+
+from .operations import (
+    process_attestations,
+)
+from .validation import (
+    validate_serenity_proposer_signature,
+)
+
+
+class SerenityStateTransition(BaseStateTransition):
+    config = None
+
+    def __init__(self, config: BeaconConfig):
+        self.config = config
+
+    def apply_state_transition(self, state: BeaconState, block: BaseBeaconBlock) -> BeaconState:
+        while state.slot != block.slot:
+            state = self.per_slot_transition(state, block.parent_root)
+            if state.slot == block.slot:
+                state = self.per_block_transition(state, block)
+            if state.slot % self.config.EPOCH_LENGTH == 0:
+                state = self.per_epoch_transition(state)
+
+        return state
+
+    def per_slot_transition(self,
+                            state: BeaconState,
+                            previous_block_root: Hash32) -> BeaconState:
+        # TODO
+        state = state.copy(
+            slot=state.slot + 1
+        )
+        return state
+
+    def per_block_transition(self, state: BeaconState, block: BaseBeaconBlock) -> BeaconState:
+        # TODO
+        validate_serenity_proposer_signature(
+            state,
+            block,
+            beacon_chain_shard_number=self.config.BEACON_CHAIN_SHARD_NUMBER,
+            epoch_length=self.config.EPOCH_LENGTH,
+        )
+
+        state = process_attestations(state, block, self.config)
+
+        return state
+
+    def per_epoch_transition(self, state: BeaconState) -> BeaconState:
+        # TODO
+        return state

--- a/eth2/beacon/state_machines/forks/serenity/states.py
+++ b/eth2/beacon/state_machines/forks/serenity/states.py
@@ -1,0 +1,5 @@
+from eth2.beacon.types.states import BeaconState
+
+
+class SerenityBeaconState(BeaconState):
+    pass

--- a/eth2/beacon/state_machines/forks/serenity/validation.py
+++ b/eth2/beacon/state_machines/forks/serenity/validation.py
@@ -1,0 +1,286 @@
+from eth_typing import (
+    Hash32
+)
+from eth_utils import (
+    ValidationError,
+)
+import rlp
+
+from eth.constants import (
+    ZERO_HASH32,
+)
+
+from eth2._utils import bls as bls
+from eth2.beacon._utils.hash import (
+    hash_eth2,
+)
+
+from eth2.beacon.enums import (
+    SignatureDomain,
+)
+from eth2.beacon.helpers import (
+    get_attestation_participants,
+    get_beacon_proposer_index,
+    get_block_root,
+    get_domain,
+)
+from eth2.beacon.types.blocks import BaseBeaconBlock  # noqa: F401
+from eth2.beacon.types.states import BeaconState  # noqa: F401
+from eth2.beacon.types.attestations import Attestation  # noqa: F401
+from eth2.beacon.types.attestation_data import AttestationData  # noqa: F401
+from eth2.beacon.types.proposal_signed_data import ProposalSignedData
+from eth2.beacon.typing import (
+    ShardNumber,
+)
+
+
+#
+# Proposer signature validation
+#
+def validate_serenity_proposer_signature(state: BeaconState,
+                                         block: BaseBeaconBlock,
+                                         beacon_chain_shard_number: ShardNumber,
+                                         epoch_length: int) -> None:
+    block_without_signature_root = block.block_without_signature_root
+
+    # TODO: Replace this root with tree hash root
+    proposal_root = ProposalSignedData(
+        state.slot,
+        beacon_chain_shard_number,
+        block_without_signature_root,
+    ).root
+
+    # Get the public key of proposer
+    beacon_proposer_index = get_beacon_proposer_index(state, state.slot, epoch_length)
+    proposer_pubkey = state.validator_registry[beacon_proposer_index].pubkey
+
+    is_valid_signature = bls.verify(
+        pubkey=proposer_pubkey,
+        message=proposal_root,
+        signature=block.signature,
+        domain=get_domain(state.fork_data, state.slot, SignatureDomain.DOMAIN_PROPOSAL),
+    )
+
+    if not is_valid_signature:
+        raise ValidationError("Invalid Proposer Signature on block")
+
+
+#
+# Attestation validation
+#
+def validate_serenity_attestation(state: BeaconState,
+                                  attestation: Attestation,
+                                  epoch_length: int,
+                                  min_attestation_inclusion_delay: int,
+                                  latest_block_roots_length: int) -> None:
+    """
+    Validate the given ``attestation``.
+    Raise ``ValidationError`` if it's invalid.
+    """
+
+    validate_serenity_attestation_slot(
+        attestation.data,
+        state.slot,
+        epoch_length,
+        min_attestation_inclusion_delay,
+    )
+
+    validate_serenity_attestation_justified_slot(
+        attestation.data,
+        state.slot,
+        state.previous_justified_slot,
+        state.justified_slot,
+        epoch_length,
+    )
+
+    validate_serenity_attestation_justified_block_root(
+        attestation.data,
+        justified_block_root=get_block_root(
+            state=state,
+            slot=attestation.data.justified_slot,
+            latest_block_roots_length=latest_block_roots_length,
+        ),
+    )
+
+    validate_serenity_attestation_latest_crosslink_root(
+        attestation.data,
+        latest_crosslink_root=state.latest_crosslinks[attestation.data.shard].shard_block_root,
+    )
+
+    validate_serenity_attestation_shard_block_root(attestation.data)
+
+    validate_serenity_attestation_aggregate_signature(
+        state,
+        attestation,
+        epoch_length,
+    )
+
+
+def validate_serenity_attestation_slot(attestation_data: AttestationData,
+                                       current_slot: int,
+                                       epoch_length: int,
+                                       min_attestation_inclusion_delay: int) -> None:
+    """
+    Validate ``slot`` field of ``attestation_data``.
+    Raise ``ValidationError`` if it's invalid.
+    """
+    if attestation_data.slot + min_attestation_inclusion_delay > current_slot:
+        raise ValidationError(
+            "Attestation slot plus min inclusion delay is too high:\n"
+            "\tFound: %s (%s + %s), Needed less than or equal to %s" %
+            (
+                attestation_data.slot + min_attestation_inclusion_delay,
+                attestation_data.slot,
+                min_attestation_inclusion_delay,
+                current_slot,
+            )
+        )
+    if attestation_data.slot + epoch_length < current_slot:
+        raise ValidationError(
+            "Attestation slot plus epoch length is too low:\n"
+            "\tFound: %s (%s + %s), Needed greater than or equal to: %s" %
+            (
+                attestation_data.slot + epoch_length,
+                attestation_data.slot,
+                epoch_length,
+                current_slot,
+            )
+        )
+
+
+def validate_serenity_attestation_justified_slot(attestation_data: AttestationData,
+                                                 current_slot: int,
+                                                 previous_justified_slot: int,
+                                                 justified_slot: int,
+                                                 epoch_length: int) -> None:
+    """
+    Validate ``justified_slot`` field of ``attestation_data``.
+    Raise ``ValidationError`` if it's invalid.
+    """
+    if attestation_data.slot >= current_slot - (current_slot % epoch_length):
+        if attestation_data.justified_slot != justified_slot:
+            raise ValidationError(
+                "Attestation ``slot`` is after recent epoch transition but attestation"
+                "``justified_slot`` is not targeting the ``justified_slot``:\n"
+                "\tFound: %s, Expected %s" %
+                (attestation_data.justified_slot, justified_slot)
+            )
+    else:
+        if attestation_data.justified_slot != previous_justified_slot:
+            raise ValidationError(
+                "Attestation ``slot`` is before recent epoch transition but attestation"
+                "``justified_slot`` is not targeting the ``previous_justified_slot:\n"
+                "\tFound: %s, Expected %s" %
+                (attestation_data.justified_slot, previous_justified_slot)
+            )
+
+
+def validate_serenity_attestation_justified_block_root(attestation_data: AttestationData,
+                                                       justified_block_root: Hash32) -> None:
+    """
+    Validate ``justified_block_root`` field of ``attestation_data``.
+    Raise ``ValidationError`` if it's invalid.
+    """
+    if attestation_data.justified_block_root != justified_block_root:
+        raise ValidationError(
+            "Attestation ``justified_block_root`` is not equal to the "
+            "``justified_block_root`` at the ``justified_slot``:\n"
+            "\tFound: %s, Expected %s at slot %s" %
+            (
+                attestation_data.justified_block_root,
+                justified_block_root,
+                attestation_data.justified_slot,
+            )
+        )
+
+
+def validate_serenity_attestation_latest_crosslink_root(attestation_data: AttestationData,
+                                                        latest_crosslink_root: Hash32) -> None:
+    """
+    Validate that either the attestation ``latest_crosslink_root`` or ``shard_block_root``
+    field of ``attestation_data`` is the provided ``latest_crosslink_root``.
+    Raise ``ValidationError`` if it's invalid.
+    """
+    acceptable_shard_block_roots = {
+        attestation_data.latest_crosslink_root,
+        attestation_data.shard_block_root,
+    }
+    if latest_crosslink_root not in acceptable_shard_block_roots:
+        raise ValidationError(
+            "Neither the attestation ``latest_crosslink_root`` nor the attestation "
+            "``shard_block_root`` are equal to the ``latest_crosslink_root``.\n"
+            "\tFound: %s and %s, Expected %s" %
+            (
+                attestation_data.latest_crosslink_root,
+                attestation_data.shard_block_root,
+                latest_crosslink_root,
+            )
+        )
+
+
+def validate_serenity_attestation_shard_block_root(attestation_data: AttestationData) -> None:
+    """
+    Validate ``shard_block_root`` field of `attestation_data`.
+    Raise ``ValidationError`` if it's invalid.
+
+    Note: This is the Phase 0 version of ``shard_block_root`` validation.
+    This is a built-in stub and will be changed in phase 1.
+    """
+    if attestation_data.shard_block_root != ZERO_HASH32:
+        raise ValidationError(
+            "Attestation ``shard_block_root`` is not ZERO_HASH32.\n"
+            "\tFound: %s, Expected %s" %
+            (
+                attestation_data.shard_block_root,
+                ZERO_HASH32,
+            )
+        )
+
+
+def validate_serenity_attestation_aggregate_signature(state: BeaconState,
+                                                      attestation: Attestation,
+                                                      epoch_length: int) -> None:
+    """
+    Validate ``aggregate_signature`` field of ``attestation``.
+    Raise ``ValidationError`` if it's invalid.
+
+    Note: This is the phase 0 version of `aggregate_signature`` validation.
+    All proof of custody bits are assumed to be 0 within the signed data.
+    This will change to reflect real proof of custody bits in the Phase 1.
+    """
+    participant_indices = get_attestation_participants(
+        state=state,
+        slot=attestation.data.slot,
+        shard=attestation.data.shard,
+        participation_bitfield=attestation.participation_bitfield,
+        epoch_length=epoch_length,
+    )
+
+    pubkeys = tuple(
+        state.validator_registry[validator_index].pubkey
+        for validator_index in participant_indices
+    )
+    group_public_key = bls.aggregate_pubkeys(pubkeys)
+
+    # TODO: change to tree hashing when we have SSZ
+    # TODO: Replace with AttestationAndCustodyBit data structure
+    message = hash_eth2(
+        rlp.encode(attestation.data) +
+        (0).to_bytes(1, "big")
+    )
+
+    is_valid_signature = bls.verify(
+        message=message,
+        pubkey=group_public_key,
+        signature=attestation.aggregate_signature,
+        domain=get_domain(
+            fork_data=state.fork_data,
+            slot=attestation.data.slot,
+            domain_type=SignatureDomain.DOMAIN_ATTESTATION,
+        ),
+
+    )
+    if not is_valid_signature:
+        raise ValidationError(
+            "Attestation ``aggregate_signature`` is invalid."
+        )

--- a/eth2/beacon/state_machines/state_transitions.py
+++ b/eth2/beacon/state_machines/state_transitions.py
@@ -1,0 +1,41 @@
+from abc import (
+    ABC,
+    abstractmethod,
+)
+
+from eth_typing import (
+    Hash32,
+)
+from eth._utils.datatypes import (
+    Configurable,
+)
+
+from eth2.beacon.types.blocks import BaseBeaconBlock
+from eth2.beacon.types.states import BeaconState
+
+from eth2.beacon.state_machines.configs import BeaconConfig
+
+
+class BaseStateTransition(Configurable, ABC):
+    config = None
+
+    def __init__(self, config: BeaconConfig):
+        self.config = config
+
+    @abstractmethod
+    def apply_state_transition(self, state: BeaconState, block: BaseBeaconBlock) -> BeaconState:
+        pass
+
+    @abstractmethod
+    def per_slot_transition(self,
+                            state: BeaconState,
+                            previous_block_root: Hash32) -> BeaconState:
+        pass
+
+    @abstractmethod
+    def per_block_transition(self, state: BeaconState, block: BaseBeaconBlock) -> BeaconState:
+        pass
+
+    @abstractmethod
+    def per_epoch_transition(self, state: BeaconState) -> BeaconState:
+        pass

--- a/eth2/beacon/types/attestation_data.py
+++ b/eth2/beacon/types/attestation_data.py
@@ -1,0 +1,58 @@
+from eth_typing import (
+    Hash32,
+)
+import rlp
+
+from eth2.beacon.sedes import (
+    uint64,
+    hash32,
+)
+
+from eth2.beacon.typing import (
+    SlotNumber,
+    ShardNumber,
+)
+
+
+class AttestationData(rlp.Serializable):
+    """
+    Note: using RLP until we have standardized serialization format.
+    """
+    fields = [
+        # Slot number
+        ('slot', uint64),
+        # Shard number
+        ('shard', uint64),
+        # Hash of the signed beacon block
+        ('beacon_block_root', hash32),
+        # Hash of the ancestor at the epoch boundary
+        ('epoch_boundary_root', hash32),
+        # Shard block root being attested to
+        ('shard_block_root', hash32),
+        # Last crosslink hash
+        ('latest_crosslink_root', hash32),
+        # Slot of the last justified beacon block
+        ('justified_slot', uint64),
+        # Hash of the last justified beacon block
+        ('justified_block_root', hash32),
+    ]
+
+    def __init__(self,
+                 slot: SlotNumber,
+                 shard: ShardNumber,
+                 beacon_block_root: Hash32,
+                 epoch_boundary_root: Hash32,
+                 shard_block_root: Hash32,
+                 latest_crosslink_root: Hash32,
+                 justified_slot: SlotNumber,
+                 justified_block_root: Hash32) -> None:
+        super().__init__(
+            slot,
+            shard,
+            beacon_block_root,
+            epoch_boundary_root,
+            shard_block_root,
+            latest_crosslink_root,
+            justified_slot,
+            justified_block_root,
+        )

--- a/eth2/beacon/types/attestation_data_and_custody_bits.py
+++ b/eth2/beacon/types/attestation_data_and_custody_bits.py
@@ -1,0 +1,50 @@
+import rlp
+from rlp.sedes import (
+    Boolean,
+)
+from eth_typing import (
+    Hash32,
+)
+
+from eth2.beacon._utils.hash import (
+    hash_eth2,
+)
+
+from .attestation_data import (
+    AttestationData,
+)
+
+
+class AttestationDataAndCustodyBit(rlp.Serializable):
+    """
+    Note: using RLP until we have standardized serialization format.
+    """
+    fields = [
+        # Attestation data
+        ('data', AttestationData),
+        # Custody bit
+        ('custody_bit', Boolean),
+    ]
+
+    def __init__(self,
+                 data: AttestationData,
+                 custody_bit: bool)-> None:
+
+        super().__init__(
+            data=data,
+            custody_bit=custody_bit,
+        )
+
+    _hash = None
+
+    @property
+    def hash(self) -> Hash32:
+        if self._hash is None:
+            self._hash = hash_eth2(rlp.encode(self.data))
+        return self._hash
+
+    @property
+    def root(self) -> Hash32:
+        # Alias of `hash`.
+        # Using flat hash, will likely use SSZ tree hash.
+        return self.hash

--- a/eth2/beacon/types/attestations.py
+++ b/eth2/beacon/types/attestations.py
@@ -1,0 +1,47 @@
+import rlp
+from rlp.sedes import (
+    binary,
+    CountableList,
+)
+
+from eth2.beacon.sedes import (
+    uint384,
+)
+
+
+from .attestation_data import (
+    AttestationData,
+)
+
+from eth2.beacon.typing import (
+    Bitfield,
+    BLSSignature,
+)
+from eth2.beacon.constants import EMPTY_SIGNATURE
+
+
+class Attestation(rlp.Serializable):
+    """
+    Note: using RLP until we have standardized serialization format.
+    """
+    fields = [
+        ('data', AttestationData),
+        # Attester participation bitfield
+        ('participation_bitfield', binary),
+        # Proof of custody bitfield
+        ('custody_bitfield', binary),
+        # BLS aggregate signature
+        ('aggregate_signature', CountableList(uint384)),
+    ]
+
+    def __init__(self,
+                 data: AttestationData,
+                 participation_bitfield: Bitfield,
+                 custody_bitfield: Bitfield,
+                 aggregate_signature: BLSSignature=EMPTY_SIGNATURE) -> None:
+        super().__init__(
+            data,
+            participation_bitfield,
+            custody_bitfield,
+            aggregate_signature,
+        )

--- a/eth2/beacon/types/blocks.py
+++ b/eth2/beacon/types/blocks.py
@@ -1,0 +1,196 @@
+from abc import (
+    ABC,
+    abstractmethod,
+)
+
+from typing import (
+    Sequence,
+    TYPE_CHECKING,
+)
+
+from eth_typing import (
+    Hash32,
+)
+from eth_utils import (
+    encode_hex,
+)
+
+import rlp
+from rlp.sedes import (
+    CountableList,
+)
+
+
+from eth._utils.datatypes import (
+    Configurable,
+)
+from eth2.beacon.sedes import (
+    hash32,
+    uint64,
+    uint384,
+)
+
+from eth2.beacon.constants import EMPTY_SIGNATURE
+from eth2.beacon._utils.hash import hash_eth2
+from eth2.beacon.typing import (
+    SlotNumber,
+    BLSSignature,
+)
+
+
+from .attestations import Attestation
+from .custody_challenges import CustodyChallenge
+from .custody_reseeds import CustodyReseed
+from .custody_responses import CustodyResponse
+from .casper_slashings import CasperSlashing
+from .deposits import Deposit
+from .exits import Exit
+from .proposer_slashings import ProposerSlashing
+
+if TYPE_CHECKING:
+    from eth2.beacon.db.chain import BaseBeaconChainDB  # noqa: F401
+
+
+class BaseBeaconBlockBody(rlp.Serializable):
+    fields = [
+        ('proposer_slashings', CountableList(ProposerSlashing)),
+        ('casper_slashings', CountableList(CasperSlashing)),
+        ('attestations', CountableList(Attestation)),
+        ('custody_reseeds', CountableList(CustodyReseed)),
+        ('custody_challenges', CountableList(CustodyChallenge)),
+        ('custody_responses', CountableList(CustodyResponse)),
+        ('deposits', CountableList(Deposit)),
+        ('exits', CountableList(Exit)),
+    ]
+
+    def __init__(self,
+                 proposer_slashings: Sequence[ProposerSlashing],
+                 casper_slashings: Sequence[CasperSlashing],
+                 attestations: Sequence[Attestation],
+                 custody_reseeds: Sequence[CustodyReseed],
+                 custody_challenges: Sequence[CustodyResponse],
+                 custody_responses: Sequence[CustodyResponse],
+                 deposits: Sequence[Deposit],
+                 exits: Sequence[Exit])-> None:
+        super().__init__(
+            proposer_slashings=proposer_slashings,
+            casper_slashings=casper_slashings,
+            attestations=attestations,
+            custody_reseeds=custody_reseeds,
+            custody_challenges=custody_challenges,
+            custody_responses=custody_responses,
+            deposits=deposits,
+            exits=exits,
+        )
+
+
+class BaseBeaconBlock(rlp.Serializable, Configurable, ABC):
+    block_body_class = BaseBeaconBlockBody
+
+    fields = [
+        #
+        # Header
+        #
+        ('slot', uint64),
+        ('parent_root', hash32),
+        ('state_root', hash32),
+        ('randao_reveal', hash32),
+        ('candidate_pow_receipt_root', hash32),
+        ('signature', CountableList(uint384)),
+
+        #
+        # Body
+        #
+        ('body', block_body_class),
+    ]
+
+    def __init__(self,
+                 slot: SlotNumber,
+                 parent_root: Hash32,
+                 state_root: Hash32,
+                 randao_reveal: Hash32,
+                 candidate_pow_receipt_root: Hash32,
+                 body: BaseBeaconBlockBody,
+                 signature: BLSSignature=EMPTY_SIGNATURE) -> None:
+        super().__init__(
+            slot=slot,
+            parent_root=parent_root,
+            state_root=state_root,
+            randao_reveal=randao_reveal,
+            candidate_pow_receipt_root=candidate_pow_receipt_root,
+            signature=signature,
+            body=body,
+        )
+
+    def __repr__(self) -> str:
+        return '<Block #{0} {1}>'.format(
+            self.slot,
+            encode_hex(self.root)[2:10],
+        )
+
+    _hash = None
+
+    @property
+    def hash(self) -> Hash32:
+        if self._hash is None:
+            self._hash = hash_eth2(rlp.encode(self))
+        return self._hash
+
+    @property
+    def root(self) -> Hash32:
+        # Alias of `hash`.
+        # Using flat hash, might change to SSZ tree hash.
+        return self.hash
+
+    @property
+    def num_attestations(self) -> int:
+        return len(self.body.attestations)
+
+    @property
+    def block_without_signature_root(self) -> Hash32:
+        return self.copy(
+            signature=EMPTY_SIGNATURE
+        ).root
+
+    @classmethod
+    @abstractmethod
+    def from_root(cls, root: Hash32, chaindb: 'BaseBeaconChainDB') -> 'BaseBeaconBlock':
+        """
+        Return the block denoted by the given block root.
+        """
+        raise NotImplementedError("Must be implemented by subclasses")
+
+
+class BeaconBlockBody(BaseBeaconBlockBody):
+    pass
+
+
+class BeaconBlock(BaseBeaconBlock):
+    block_body_class = BeaconBlockBody
+
+    @classmethod
+    def from_root(cls, root: Hash32, chaindb: 'BaseBeaconChainDB') -> 'BeaconBlock':
+        """
+        Returns the block denoted by the given block header.
+        """
+        block = chaindb.get_block_by_root(root, cls)
+        body = cls.block_body_class(
+            proposer_slashings=block.body.proposer_slashings,
+            casper_slashings=block.body.casper_slashings,
+            attestations=block.body.attestations,
+            custody_reseeds=block.body.custody_reseeds,
+            custody_challenges=block.body.custody_challenges,
+            custody_responses=block.body.custody_responses,
+            deposits=block.body.deposits,
+            exits=block.body.exits,
+        )
+
+        return cls(
+            slot=block.slot,
+            parent_root=block.parent_root,
+            state_root=block.state_root,
+            randao_reveal=block.randao_reveal,
+            candidate_pow_receipt_root=block.candidate_pow_receipt_root,
+            signature=block.signature,
+            body=body,
+        )

--- a/eth2/beacon/types/candidate_pow_receipt_root_records.py
+++ b/eth2/beacon/types/candidate_pow_receipt_root_records.py
@@ -1,0 +1,29 @@
+from eth_typing import (
+    Hash32,
+)
+import rlp
+
+from eth2.beacon.sedes import (
+    uint64,
+    hash32,
+)
+
+
+class CandidatePoWReceiptRootRecord(rlp.Serializable):
+    """
+    Note: using RLP until we have standardized serialization format.
+    """
+    fields = [
+        # Candidate PoW receipt root
+        ('candidate_pow_receipt_root', hash32),
+        # Vote count
+        ('votes', uint64),
+    ]
+
+    def __init__(self,
+                 candidate_pow_receipt_root: Hash32,
+                 votes: int) -> None:
+        super().__init__(
+            candidate_pow_receipt_root=candidate_pow_receipt_root,
+            votes=votes,
+        )

--- a/eth2/beacon/types/casper_slashings.py
+++ b/eth2/beacon/types/casper_slashings.py
@@ -1,0 +1,22 @@
+import rlp
+from .slashable_vote_data import SlashableVoteData
+
+
+class CasperSlashing(rlp.Serializable):
+    """
+    Note: using RLP until we have standardized serialization format.
+    """
+    fields = [
+        # First batch of votes
+        ('slashable_vote_data_1', SlashableVoteData),
+        # Second batch of votes
+        ('slashable_vote_data_2', SlashableVoteData),
+    ]
+
+    def __init__(self,
+                 slashable_vote_data_1: SlashableVoteData,
+                 slashable_vote_data_2: SlashableVoteData)-> None:
+        super().__init__(
+            slashable_vote_data_1,
+            slashable_vote_data_2,
+        )

--- a/eth2/beacon/types/crosslink_records.py
+++ b/eth2/beacon/types/crosslink_records.py
@@ -1,0 +1,32 @@
+from eth_typing import (
+    Hash32,
+)
+import rlp
+
+from eth2.beacon.sedes import (
+    uint64,
+    hash32,
+)
+
+from eth2.beacon.typing import SlotNumber
+
+
+class CrosslinkRecord(rlp.Serializable):
+    """
+    Note: using RLP until we have standardized serialization format.
+    """
+    fields = [
+        # Slot during which crosslink was added
+        ('slot', uint64),
+        # Shard chain block root
+        ('shard_block_root', hash32),
+    ]
+
+    def __init__(self,
+                 slot: SlotNumber,
+                 shard_block_root: Hash32) -> None:
+
+        super().__init__(
+            slot=slot,
+            shard_block_root=shard_block_root,
+        )

--- a/eth2/beacon/types/custody_challenges.py
+++ b/eth2/beacon/types/custody_challenges.py
@@ -1,0 +1,5 @@
+import rlp
+
+
+class CustodyChallenge(rlp.Serializable):
+    pass

--- a/eth2/beacon/types/custody_reseeds.py
+++ b/eth2/beacon/types/custody_reseeds.py
@@ -1,0 +1,5 @@
+import rlp
+
+
+class CustodyReseed(rlp.Serializable):
+    pass

--- a/eth2/beacon/types/custody_responses.py
+++ b/eth2/beacon/types/custody_responses.py
@@ -1,0 +1,5 @@
+import rlp
+
+
+class CustodyResponse(rlp.Serializable):
+    pass

--- a/eth2/beacon/types/deposit_data.py
+++ b/eth2/beacon/types/deposit_data.py
@@ -1,0 +1,32 @@
+
+import rlp
+from eth2.beacon.sedes import uint64
+from .deposit_input import DepositInput
+from eth2.beacon.typing import (
+    Timestamp,
+    Gwei,
+)
+
+
+class DepositData(rlp.Serializable):
+    """
+    Not in spec, this is for fields in Deposit
+    """
+    fields = [
+        ('deposit_input', DepositInput),
+        # Amount in Gwei
+        ('amount', uint64),
+        # Timestamp from deposit contract
+        ('timestamp', uint64),
+    ]
+
+    def __init__(self,
+                 deposit_input: DepositInput,
+                 amount: Gwei,
+                 timestamp: Timestamp) -> None:
+
+        super().__init__(
+            deposit_input,
+            amount,
+            timestamp,
+        )

--- a/eth2/beacon/types/deposit_input.py
+++ b/eth2/beacon/types/deposit_input.py
@@ -1,0 +1,58 @@
+from eth_typing import (
+    Hash32,
+)
+import rlp
+from rlp.sedes import (
+    CountableList,
+)
+
+from eth2.beacon.sedes import (
+    hash32,
+    uint384,
+)
+from eth2.beacon._utils.hash import hash_eth2
+from eth2.beacon.typing import (
+    BLSPubkey,
+    BLSSignature,
+)
+from eth2.beacon.constants import EMPTY_SIGNATURE
+
+
+class DepositInput(rlp.Serializable):
+    """
+    Note: using RLP until we have standardized serialization format.
+    """
+    fields = [
+        # BLS pubkey
+        ('pubkey', uint384),
+        # Withdrawal credentials
+        ('withdrawal_credentials', hash32),
+        # Initial RANDAO commitment
+        ('randao_commitment', hash32),
+        # Initial proof of custody commitment
+        ('custody_commitment', hash32),
+        # BLS proof of possession (a BLS signature)
+        ('proof_of_possession', CountableList(uint384)),
+    ]
+
+    def __init__(self,
+                 pubkey: BLSPubkey,
+                 withdrawal_credentials: Hash32,
+                 randao_commitment: Hash32,
+                 custody_commitment: Hash32,
+                 proof_of_possession: BLSSignature=EMPTY_SIGNATURE) -> None:
+        super().__init__(
+            pubkey=pubkey,
+            withdrawal_credentials=withdrawal_credentials,
+            randao_commitment=randao_commitment,
+            custody_commitment=custody_commitment,
+            proof_of_possession=proof_of_possession,
+        )
+
+    _root = None
+
+    @property
+    def root(self) -> Hash32:
+        if self._root is None:
+            self._root = hash_eth2(rlp.encode(self))
+        return self._root

--- a/eth2/beacon/types/deposits.py
+++ b/eth2/beacon/types/deposits.py
@@ -1,0 +1,43 @@
+from typing import (
+    Sequence,
+)
+
+from eth_typing import (
+    Hash32,
+)
+import rlp
+from rlp.sedes import (
+    CountableList,
+)
+
+from eth2.beacon.sedes import (
+    hash32,
+    uint64,
+)
+
+from .deposit_data import DepositData
+
+
+class Deposit(rlp.Serializable):
+    """
+    Note: using RLP until we have standardized serialization format.
+    """
+
+    fields = [
+        # Receipt Merkle branch
+        ('merkle_branch', CountableList(hash32)),
+        # Merkle tree index
+        ('merkle_tree_index', uint64),
+        # Deposit data
+        ('deposit_data', DepositData),
+    ]
+
+    def __init__(self,
+                 merkle_branch: Sequence[Hash32],
+                 merkle_tree_index: int,
+                 deposit_data: DepositData)-> None:
+        super().__init__(
+            merkle_branch,
+            merkle_tree_index,
+            deposit_data,
+        )

--- a/eth2/beacon/types/exits.py
+++ b/eth2/beacon/types/exits.py
@@ -1,0 +1,39 @@
+import rlp
+from rlp.sedes import (
+    CountableList,
+)
+from eth2.beacon.sedes import (
+    uint24,
+    uint64,
+    uint384,
+)
+from eth2.beacon.typing import (
+    BLSSignature,
+    SlotNumber,
+    ValidatorIndex,
+)
+from eth2.beacon.constants import EMPTY_SIGNATURE
+
+
+class Exit(rlp.Serializable):
+    """
+    Note: using RLP until we have standardized serialization format.
+    """
+    fields = [
+        # Minimum slot for processing exit
+        ('slot', uint64),
+        # Index of the exiting validator
+        ('validator_index', uint24),
+        # Validator signature
+        ('signature', CountableList(uint384)),
+    ]
+
+    def __init__(self,
+                 slot: SlotNumber,
+                 validator_index: ValidatorIndex,
+                 signature: BLSSignature=EMPTY_SIGNATURE) -> None:
+        super().__init__(
+            slot,
+            validator_index,
+            signature,
+        )

--- a/eth2/beacon/types/fork_data.py
+++ b/eth2/beacon/types/fork_data.py
@@ -1,0 +1,33 @@
+import rlp
+
+from eth2.beacon.sedes import (
+    uint64,
+)
+
+from eth2.beacon.typing import (
+    SlotNumber,
+)
+
+
+class ForkData(rlp.Serializable):
+    """
+    Note: using RLP until we have standardized serialization format.
+    """
+    fields = [
+        # Previous fork version
+        ('pre_fork_version', uint64),
+        # Post fork version
+        ('post_fork_version', uint64),
+        # Fork slot number
+        ('fork_slot', uint64)
+    ]
+
+    def __init__(self,
+                 pre_fork_version: int,
+                 post_fork_version: int,
+                 fork_slot: SlotNumber) -> None:
+        super().__init__(
+            pre_fork_version=pre_fork_version,
+            post_fork_version=post_fork_version,
+            fork_slot=fork_slot,
+        )

--- a/eth2/beacon/types/pending_attestation_records.py
+++ b/eth2/beacon/types/pending_attestation_records.py
@@ -1,0 +1,44 @@
+import rlp
+from rlp.sedes import (
+    binary,
+)
+
+from eth2.beacon.sedes import (
+    uint64,
+)
+from eth2.beacon.typing import (
+    SlotNumber,
+    Bitfield,
+)
+
+from .attestation_data import (
+    AttestationData,
+)
+
+
+class PendingAttestationRecord(rlp.Serializable):
+    """
+    Note: using RLP until we have standardized serialization format.
+    """
+    fields = [
+        # Signed data
+        ('data', AttestationData),
+        # Attester participation bitfield
+        ('participation_bitfield', binary),
+        # Custody bitfield
+        ('custody_bitfield', binary),
+        # Slot the attestation was included
+        ('slot_included', uint64),
+    ]
+
+    def __init__(self,
+                 data: AttestationData,
+                 participation_bitfield: Bitfield,
+                 custody_bitfield: Bitfield,
+                 slot_included: SlotNumber) -> None:
+        super().__init__(
+            data=data,
+            participation_bitfield=participation_bitfield,
+            custody_bitfield=custody_bitfield,
+            slot_included=slot_included,
+        )

--- a/eth2/beacon/types/proposal_signed_data.py
+++ b/eth2/beacon/types/proposal_signed_data.py
@@ -1,0 +1,53 @@
+from eth_typing import (
+    Hash32,
+)
+import rlp
+
+from eth2.beacon._utils.hash import hash_eth2
+
+from eth2.beacon.sedes import (
+    uint64,
+    hash32,
+)
+from eth2.beacon.typing import (
+    SlotNumber,
+    ShardNumber,
+)
+
+
+class ProposalSignedData(rlp.Serializable):
+    """
+    Note: using RLP until we have standardized serialization format.
+    """
+    fields = [
+        # Slot number
+        ('slot', uint64),
+        # Shard number (or `2**64 - 1` for beacon chain)
+        ('shard', uint64),
+        # block root
+        ('block_root', hash32),
+    ]
+
+    def __init__(self,
+                 slot: SlotNumber,
+                 shard: ShardNumber,
+                 block_root: Hash32) -> None:
+        super().__init__(
+            slot,
+            shard,
+            block_root,
+        )
+
+    _hash = None
+
+    @property
+    def hash(self) -> Hash32:
+        if self._hash is None:
+            self._hash = hash_eth2(rlp.encode(self))
+        return self._hash
+
+    @property
+    def root(self) -> Hash32:
+        # Alias of `hash`.
+        # Using flat hash, might change to SSZ tree hash.
+        return self.hash

--- a/eth2/beacon/types/proposer_slashings.py
+++ b/eth2/beacon/types/proposer_slashings.py
@@ -1,0 +1,44 @@
+import rlp
+from rlp.sedes import (
+    CountableList,
+)
+from eth2.beacon.sedes import (
+    uint24,
+    uint384,
+)
+from .proposal_signed_data import ProposalSignedData
+from eth2.beacon.typing import (
+    BLSSignature,
+    ValidatorIndex,
+)
+from eth2.beacon.constants import EMPTY_SIGNATURE
+
+
+class ProposerSlashing(rlp.Serializable):
+    fields = [
+        # Proposer index
+        ('proposer_index', uint24),
+        # First proposal data
+        ('proposal_data_1', ProposalSignedData),
+        # First proposal signature
+        ('proposal_signature_1', CountableList(uint384)),
+        # Second proposal data
+        ('proposal_data_2', ProposalSignedData),
+        # Second proposal signature
+        ('proposal_signature_2', CountableList(uint384)),
+    ]
+
+    def __init__(self,
+                 proposer_index: ValidatorIndex,
+                 proposal_data_1: ProposalSignedData,
+                 proposal_data_2: ProposalSignedData,
+                 # default arguments follow non-default arguments
+                 proposal_signature_1: BLSSignature = EMPTY_SIGNATURE,
+                 proposal_signature_2: BLSSignature = EMPTY_SIGNATURE) -> None:
+        super().__init__(
+            proposer_index=proposer_index,
+            proposal_data_1=proposal_data_1,
+            proposal_data_2=proposal_data_2,
+            proposal_signature_1=proposal_signature_1,
+            proposal_signature_2=proposal_signature_2,
+        )

--- a/eth2/beacon/types/shard_committees.py
+++ b/eth2/beacon/types/shard_committees.py
@@ -1,0 +1,42 @@
+from typing import (
+    Sequence,
+)
+
+import rlp
+from rlp.sedes import (
+    CountableList,
+)
+
+from eth2.beacon.sedes import (
+    uint24,
+    uint64,
+)
+from eth2.beacon.typing import (
+    ShardNumber,
+    ValidatorIndex,
+)
+
+
+class ShardCommittee(rlp.Serializable):
+    """
+    Note: using RLP until we have standardized serialization format.
+    """
+    fields = [
+        # Shard number
+        ('shard', uint64),
+        # Validator indices
+        ('committee', CountableList(uint24)),
+        # Total validator count (for proofs of custody)
+        ('total_validator_count', uint64),
+    ]
+
+    def __init__(self,
+                 shard: ShardNumber,
+                 committee: Sequence[ValidatorIndex],
+                 total_validator_count: int)-> None:
+
+        super().__init__(
+            shard=shard,
+            committee=committee,
+            total_validator_count=total_validator_count,
+        )

--- a/eth2/beacon/types/shard_reassignment_records.py
+++ b/eth2/beacon/types/shard_reassignment_records.py
@@ -1,0 +1,35 @@
+import rlp
+
+from eth2.beacon.sedes import (
+    uint24,
+    uint64,
+)
+from eth2.beacon.typing import (
+    SlotNumber,
+    ShardNumber,
+    ValidatorIndex,
+)
+
+
+class ShardReassignmentRecord(rlp.Serializable):
+    """
+    Note: using RLP until we have standardized serialization format.
+    """
+    fields = [
+        # Which validator to reassign
+        ('validator_index', uint24),
+        # To which shard
+        ('shard', uint64),
+        # When
+        ('slot', uint64),
+    ]
+
+    def __init__(self,
+                 validator_index: ValidatorIndex,
+                 shard: ShardNumber,
+                 slot: SlotNumber)-> None:
+        super().__init__(
+            validator_index=validator_index,
+            shard=shard,
+            slot=slot,
+        )

--- a/eth2/beacon/types/slashable_vote_data.py
+++ b/eth2/beacon/types/slashable_vote_data.py
@@ -1,0 +1,87 @@
+import rlp
+from rlp.sedes import (
+    CountableList,
+)
+from typing import (
+    Sequence,
+    Tuple,
+)
+from eth_typing import (
+    Hash32,
+)
+from eth2.beacon._utils.hash import hash_eth2
+from eth2.beacon.sedes import (
+    uint24,
+    uint384,
+)
+from eth2.beacon.typing import (
+    BLSSignature,
+    ValidatorIndex,
+)
+from eth2.beacon.constants import EMPTY_SIGNATURE
+
+from .attestation_data import AttestationData
+from .attestation_data_and_custody_bits import AttestationDataAndCustodyBit
+
+
+class SlashableVoteData(rlp.Serializable):
+    """
+    Note: using RLP until we have standardized serialization format.
+    """
+    fields = [
+        # Validator indices with custody bit equal to 0
+        ('custody_bit_0_indices', CountableList(uint24)),
+        # Validator indices with custody bit equal to 1
+        ('custody_bit_1_indices', CountableList(uint24)),
+        # Attestation data
+        ('data', AttestationData),
+        # Aggregate signature
+        ('aggregate_signature', CountableList(uint384)),
+    ]
+
+    def __init__(self,
+                 custody_bit_0_indices: Sequence[ValidatorIndex],
+                 custody_bit_1_indices: Sequence[ValidatorIndex],
+                 data: AttestationData,
+                 aggregate_signature: BLSSignature = EMPTY_SIGNATURE) -> None:
+        super().__init__(
+            custody_bit_0_indices,
+            custody_bit_1_indices,
+            data,
+            aggregate_signature,
+        )
+
+    _hash = None
+
+    @property
+    def hash(self) -> Hash32:
+        if self._hash is None:
+            self._hash = hash_eth2(rlp.encode(self.data))
+        return self._hash
+
+    @property
+    def root(self) -> Hash32:
+        # Alias of `hash`.
+        # Using flat hash, will likely use SSZ tree hash.
+        return self.hash
+
+    _vote_count = None
+
+    @property
+    def vote_count(self) -> int:
+        if self._vote_count is None:
+            count_zero_indices = len(self.custody_bit_0_indices)
+            count_one_indices = len(self.custody_bit_1_indices)
+            self._vote_count = count_zero_indices + count_one_indices
+        return self._vote_count
+
+    @property
+    def messages(self) -> Tuple[Hash32, Hash32]:
+        """
+        Build the messages that validators are expected to sign for a ``CasperSlashing`` operation.
+        """
+        # TODO: change to hash_tree_root when we have SSZ tree hashing
+        return (
+            AttestationDataAndCustodyBit(self.data, False).root,
+            AttestationDataAndCustodyBit(self.data, True).root,
+        )

--- a/eth2/beacon/types/states.py
+++ b/eth2/beacon/types/states.py
@@ -1,0 +1,227 @@
+from typing import (
+    Sequence,
+)
+
+from eth_typing import (
+    Hash32,
+)
+from eth_utils import (
+    encode_hex,
+)
+
+import rlp
+from rlp.sedes import (
+    binary,
+    CountableList,
+)
+
+from eth2.beacon.sedes import (
+    uint24,
+    uint64,
+    hash32,
+)
+from eth2.beacon._utils.hash import (
+    hash_eth2,
+)
+from eth2.beacon.typing import (
+    SlotNumber,
+    Bitfield,
+    Timestamp,
+    Gwei,
+    ValidatorIndex,
+)
+
+from .pending_attestation_records import PendingAttestationRecord
+from .candidate_pow_receipt_root_records import CandidatePoWReceiptRootRecord
+from .custody_challenges import CustodyChallenge
+from .crosslink_records import CrosslinkRecord
+from .fork_data import ForkData
+from .shard_committees import ShardCommittee
+from .shard_reassignment_records import ShardReassignmentRecord
+from .validator_records import ValidatorRecord
+
+
+class BeaconState(rlp.Serializable):
+    """
+    Note: using RLP until we have standardized serialization format.
+    """
+    fields = [
+        # Misc
+        ('slot', uint64),
+        ('genesis_time', uint64),
+        ('fork_data', ForkData),  # For versioning hard forks
+
+        # Validator registry
+        ('validator_registry', CountableList(ValidatorRecord)),
+        ('validator_balances', CountableList(uint64)),
+        ('validator_registry_latest_change_slot', uint64),
+        ('validator_registry_exit_count', uint64),
+        ('validator_registry_delta_chain_tip', hash32),  # For light clients to easily track delta
+
+        # Randomness and committees
+        ('latest_randao_mixes', CountableList(hash32)),
+        ('latest_vdf_outputs', CountableList(hash32)),
+        ('shard_committees_at_slots', CountableList(CountableList((ShardCommittee)))),
+        ('persistent_committees', CountableList(CountableList(uint24))),
+        ('persistent_committee_reassignments', CountableList(ShardReassignmentRecord)),
+
+        # Custody challenges
+        ('custody_challenges', CountableList(CustodyChallenge)),
+
+        # Finality
+        ('previous_justified_slot', uint64),
+        ('justified_slot', uint64),
+        # TODO: check if justification_bitfield is bytes or int
+        ('justification_bitfield', binary),
+        ('finalized_slot', uint64),
+
+        # Recent state
+        ('latest_crosslinks', CountableList(CrosslinkRecord)),
+        ('latest_block_roots', CountableList(hash32)),  # Needed to process attestations, older to newer  # noqa: E501
+        ('latest_penalized_exit_balances', CountableList(uint64)),  # Balances penalized at every withdrawal period  # noqa: E501
+        ('latest_attestations', CountableList(PendingAttestationRecord)),
+        ('batched_block_roots', CountableList(Hash32)),  # allow for a log-sized Merkle proof from any block to any historical block root"  # noqa: E501
+
+        # PoW receipt root
+        ('processed_pow_receipt_root', hash32),
+        ('candidate_pow_receipt_roots', CountableList(CandidatePoWReceiptRootRecord)),
+    ]
+
+    def __init__(
+            self,
+            slot: SlotNumber,
+            genesis_time: Timestamp,
+            fork_data: ForkData,
+            validator_registry_latest_change_slot: SlotNumber,
+            validator_registry_exit_count: int,
+            validator_registry_delta_chain_tip: Hash32,
+            previous_justified_slot: SlotNumber,
+            justified_slot: SlotNumber,
+            justification_bitfield: Bitfield,
+            finalized_slot: SlotNumber,
+            processed_pow_receipt_root: Hash32,
+            validator_registry: Sequence[ValidatorRecord]=(),
+            validator_balances: Sequence[Gwei]=(),
+            latest_randao_mixes: Sequence[Hash32]=(),
+            latest_vdf_outputs: Sequence[Hash32]=(),
+            shard_committees_at_slots: Sequence[Sequence[ShardCommittee]]=(),
+            persistent_committees: Sequence[Sequence[ValidatorIndex]]=(),
+            persistent_committee_reassignments: Sequence[ShardReassignmentRecord]=(),
+            custody_challenges: Sequence[CustodyChallenge]=(),
+            latest_crosslinks: Sequence[CrosslinkRecord]=(),
+            latest_block_roots: Sequence[Hash32]=(),
+            latest_penalized_exit_balances: Sequence[Gwei]=(),
+            batched_block_roots: Sequence[Hash32]=(),
+            latest_attestations: Sequence[PendingAttestationRecord]=(),
+            candidate_pow_receipt_roots: Sequence[CandidatePoWReceiptRootRecord]=()
+    ) -> None:
+        if len(validator_registry) != len(validator_balances):
+            raise ValueError(
+                "The length of validator_registry and validator_balances should be the same."
+            )
+        super().__init__(
+            # Misc
+            slot=slot,
+            genesis_time=genesis_time,
+            fork_data=fork_data,
+            # Validator registry
+            validator_registry=validator_registry,
+            validator_balances=validator_balances,
+            validator_registry_latest_change_slot=validator_registry_latest_change_slot,
+            validator_registry_exit_count=validator_registry_exit_count,
+            validator_registry_delta_chain_tip=validator_registry_delta_chain_tip,
+            # Randomness and committees
+            latest_randao_mixes=latest_randao_mixes,
+            latest_vdf_outputs=latest_vdf_outputs,
+            shard_committees_at_slots=shard_committees_at_slots,
+            persistent_committees=persistent_committees,
+            persistent_committee_reassignments=persistent_committee_reassignments,
+            # Proof of Custody
+            custody_challenges=custody_challenges,
+            # Finality
+            previous_justified_slot=previous_justified_slot,
+            justified_slot=justified_slot,
+            justification_bitfield=justification_bitfield,
+            finalized_slot=finalized_slot,
+            # Recent state
+            latest_crosslinks=latest_crosslinks,
+            latest_block_roots=latest_block_roots,
+            latest_penalized_exit_balances=latest_penalized_exit_balances,
+            latest_attestations=latest_attestations,
+            batched_block_roots=batched_block_roots,
+            # PoW receipt root
+            processed_pow_receipt_root=processed_pow_receipt_root,
+            candidate_pow_receipt_roots=candidate_pow_receipt_roots,
+        )
+
+    def __repr__(self) -> str:
+        return 'BeaconState #{0}>'.format(
+            encode_hex(self.root)[2:10],
+        )
+
+    _hash = None
+
+    @property
+    def hash(self) -> Hash32:
+        if self._hash is None:
+            self._hash = hash_eth2(rlp.encode(self))
+        return self._hash
+
+    @property
+    def root(self) -> Hash32:
+        # Alias of `hash`.
+        # Using flat hash, might change to SSZ tree hash.
+        return self.hash
+
+    @property
+    def num_validators(self) -> int:
+        return len(self.validator_registry)
+
+    @property
+    def num_crosslinks(self) -> int:
+        return len(self.latest_crosslinks)
+
+    def update_validator_registry(self,
+                                  validator_index: ValidatorIndex,
+                                  validator: ValidatorRecord) -> 'BeaconState':
+        """
+        Replace ``self.validator_registry[validator_index]`` with ``validator``.
+        """
+        if validator_index >= self.num_validators or validator_index < 0:
+            raise IndexError("Incorrect validator index")
+
+        validator_registry = list(self.validator_registry)
+        validator_registry[validator_index] = validator
+
+        updated_state = self.copy(
+            validator_registry=tuple(validator_registry),
+        )
+        return updated_state
+
+    def update_validator_balance(self,
+                                 validator_index: ValidatorIndex,
+                                 balance: Gwei) -> 'BeaconState':
+        """
+        Update the balance of validator of the given ``validator_index``.
+        """
+        if validator_index >= self.num_validators or validator_index < 0:
+            raise IndexError("Incorrect validator index")
+
+        validator_balances = list(self.validator_balances)
+        validator_balances[validator_index] = balance
+
+        updated_state = self.copy(
+            validator_balances=tuple(validator_balances),
+        )
+        return updated_state
+
+    def update_validator(self,
+                         validator_index: ValidatorIndex,
+                         validator: ValidatorRecord,
+                         balance: Gwei) -> 'BeaconState':
+        """
+        Update the ``ValidatorRecord`` and balance of validator of the given ``validator_index``.
+        """
+        state = self.update_validator_registry(validator_index, validator)
+        state = state.update_validator_balance(validator_index, balance)
+        return state

--- a/eth2/beacon/types/validator_records.py
+++ b/eth2/beacon/types/validator_records.py
@@ -1,0 +1,112 @@
+from eth_typing import (
+    Hash32,
+)
+import rlp
+
+from eth2.beacon.sedes import (
+    uint64,
+    uint384,
+    hash32,
+)
+from eth2.beacon.constants import (
+    FAR_FUTURE_SLOT,
+)
+from eth2.beacon.typing import (
+    SlotNumber,
+    BLSPubkey,
+)
+
+
+class ValidatorRecord(rlp.Serializable):
+    """
+    Note: using RLP until we have standardized serialization format.
+    """
+    fields = [
+        # BLS public key
+        ('pubkey', uint384),
+        # Withdrawal credentials
+        ('withdrawal_credentials', hash32),
+        # RANDAO commitment
+        ('randao_commitment', hash32),
+        # Slot the proposer has skipped (ie. layers of RANDAO expected)
+        ('randao_layers', uint64),
+        # Slot when validator activated
+        ('activation_slot', uint64),
+        # Slot when validator exited
+        ('exit_slot', uint64),
+        # Slot when validator withdrew
+        ('withdrawal_slot', uint64),
+        # Slot when validator was penalized
+        ('penalized_slot', uint64),
+        # Exit counter when validator exited
+        ('exit_count', uint64),
+        # Status flags
+        ('status_flags', uint64),
+        # Proof of custody commitment
+        ('custody_commitment', hash32),
+        # Slot of latest custody reseed
+        ('latest_custody_reseed_slot', uint64),
+        # Slot of second-latest custody reseed
+        ('penultimate_custody_reseed_slot', uint64),
+    ]
+
+    def __init__(self,
+                 pubkey: BLSPubkey,
+                 withdrawal_credentials: Hash32,
+                 randao_commitment: Hash32,
+                 randao_layers: int,
+                 activation_slot: SlotNumber,
+                 exit_slot: SlotNumber,
+                 withdrawal_slot: SlotNumber,
+                 penalized_slot: SlotNumber,
+                 exit_count: int,
+                 status_flags: int,
+                 custody_commitment: Hash32,
+                 latest_custody_reseed_slot: SlotNumber,
+                 penultimate_custody_reseed_slot: SlotNumber) -> None:
+        super().__init__(
+            pubkey=pubkey,
+            withdrawal_credentials=withdrawal_credentials,
+            randao_commitment=randao_commitment,
+            randao_layers=randao_layers,
+            activation_slot=activation_slot,
+            exit_slot=exit_slot,
+            withdrawal_slot=withdrawal_slot,
+            penalized_slot=penalized_slot,
+            exit_count=exit_count,
+            status_flags=status_flags,
+            custody_commitment=custody_commitment,
+            latest_custody_reseed_slot=latest_custody_reseed_slot,
+            penultimate_custody_reseed_slot=penultimate_custody_reseed_slot,
+        )
+
+    def is_active(self, slot: int) -> bool:
+        """
+        Return ``True`` if the validator is active during the slot, ``slot``.
+        """
+        return self.activation_slot <= slot < self.exit_slot
+
+    @classmethod
+    def create_pending_validator(cls,
+                                 pubkey: BLSPubkey,
+                                 withdrawal_credentials: Hash32,
+                                 randao_commitment: Hash32,
+                                 custody_commitment: Hash32) -> 'ValidatorRecord':
+        """
+        Return a new pending ``ValidatorRecord`` with the given fields.
+        """
+        return cls(
+            pubkey=pubkey,
+            withdrawal_credentials=withdrawal_credentials,
+            randao_commitment=randao_commitment,
+            randao_layers=0,
+            activation_slot=FAR_FUTURE_SLOT,
+            exit_slot=FAR_FUTURE_SLOT,
+            withdrawal_slot=FAR_FUTURE_SLOT,
+            penalized_slot=FAR_FUTURE_SLOT,
+            exit_count=0,
+            status_flags=0,
+            custody_commitment=custody_commitment,
+            latest_custody_reseed_slot=SlotNumber(0),
+            penultimate_custody_reseed_slot=SlotNumber(0),
+        )

--- a/eth2/beacon/types/validator_registry_delta_block.py
+++ b/eth2/beacon/types/validator_registry_delta_block.py
@@ -1,0 +1,65 @@
+from eth_typing import (
+    Hash32,
+)
+import rlp
+
+from eth2.beacon._utils.hash import (
+    hash_eth2,
+)
+from eth2.beacon.typing import (
+    BLSPubkey,
+    SlotNumber,
+    ValidatorIndex,
+)
+
+from eth2.beacon.enums import (
+    ValidatorRegistryDeltaFlag,
+)
+
+from eth2.beacon.sedes import (
+    hash32,
+    uint24,
+    uint64,
+    uint384,
+)
+
+
+class ValidatorRegistryDeltaBlock(rlp.Serializable):
+    """
+    Note: using RLP until we have standardized serialization format.
+    """
+    fields = [
+        ('latest_registry_delta_root', hash32),
+        ('validator_index', uint24),
+        ('pubkey', uint384),
+        ('slot', uint64),
+        ('flag', uint64),
+    ]
+
+    def __init__(self,
+                 latest_registry_delta_root: Hash32,
+                 validator_index: ValidatorIndex,
+                 pubkey: BLSPubkey,
+                 slot: SlotNumber,
+                 flag: ValidatorRegistryDeltaFlag) -> None:
+        super().__init__(
+            latest_registry_delta_root=latest_registry_delta_root,
+            validator_index=validator_index,
+            pubkey=pubkey,
+            slot=slot,
+            flag=flag,
+        )
+
+    _hash = None
+
+    @property
+    def hash(self) -> Hash32:
+        if self._hash is None:
+            self._hash = hash_eth2(rlp.encode(self))
+        return self._hash
+
+    @property
+    def root(self) -> Hash32:
+        # Alias of `hash`.
+        # Using flat hash, might change to SSZ tree hash.
+        return self.hash

--- a/eth2/beacon/typing.py
+++ b/eth2/beacon/typing.py
@@ -1,0 +1,19 @@
+from typing import NewType, Tuple
+
+SlotNumber = NewType('SlotNumber', int)  # uint64
+ShardNumber = NewType('ShardNumber', int)  # uint64
+BLSPubkey = NewType('BLSPubkey', int)  # uint384
+BLSSignature = NewType('BLSSignature', Tuple[int, int])  # Tuple[uint384, uint384]
+
+Bitfield = NewType('Bitfield', bytes)  # uint64
+
+
+ValidatorIndex = NewType('ValidatorIndex', int)  # uint24
+CommitteeIndex = NewType('CommitteeIndex', int)
+
+
+Ether = NewType('Ether', int)  # uint64
+Gwei = NewType('Gwei', int)  # uint64
+
+Timestamp = NewType('Timestamp', int)
+Second = NewType('Second', int)

--- a/eth2/beacon/validation.py
+++ b/eth2/beacon/validation.py
@@ -1,0 +1,15 @@
+from typing import (
+    Any,
+)
+
+from eth.validation import (
+    validate_gte,
+    validate_lte,
+    validate_is_integer,
+)
+
+
+def validate_slot(slot: Any, title: str="Slot") -> None:
+    validate_is_integer(slot, title)
+    validate_gte(slot, 0, title)
+    validate_lte(slot, 2**64 - 1, title)

--- a/setup.py
+++ b/setup.py
@@ -64,6 +64,15 @@ deps = {
         "tox==2.7.0",
         "twine",
     ],
+    'eth2': [
+        "cytoolz>=0.9.0,<1.0.0",
+        "eth-typing>=2.0.0,<3.0.0",
+        "eth-utils>=1.3.0b0,<2.0.0",
+        "lru-dict>=1.1.6",
+        "mypy_extensions>=0.4.1,<1.0.0",
+        "py-ecc>=1.4.7,<2.0.0",
+        "rlp==1.0.3",
+    ],
 }
 
 
@@ -73,7 +82,8 @@ deps['dev'] = (
     deps['trinity'] +
     deps['test'] +
     deps['doc'] +
-    deps['lint']
+    deps['lint'] +
+    deps['eth2']
 )
 
 
@@ -89,7 +99,7 @@ setup(
     author_email='piper@pipermerriam.com',
     url='https://github.com/ethereum/trinity',
     include_package_data=True,
-    py_modules=['trinity', 'p2p'],
+    py_modules=['trinity', 'p2p', 'eth2'],
     python_requires=">=3.6,<4",
     install_requires=install_requires,
     extras_require=deps,

--- a/tests/core/p2p-proto/bcc/helpers.py
+++ b/tests/core/p2p-proto/bcc/helpers.py
@@ -10,9 +10,9 @@ from eth_utils.toolz import (
 )
 
 from eth.db.atomic import AtomicDB
-from eth.beacon.db.chain import BeaconChainDB
-from eth.beacon.types.blocks import (
-    BaseBeaconBlock,
+from eth2.beacon.db.chain import BeaconChainDB
+from eth2.beacon.types.blocks import (
+    BeaconBlock,
     BeaconBlockBody,
 )
 from eth.constants import (
@@ -37,6 +37,9 @@ def empty_body():
         proposer_slashings=(),
         casper_slashings=(),
         attestations=(),
+        custody_reseeds=(),
+        custody_challenges=(),
+        custody_responses=(),
         deposits=(),
         exits=(),
     )
@@ -57,7 +60,7 @@ def create_test_block(parent=None, **kwargs):
         kwargs["parent_root"] = parent.root
         kwargs["slot"] = parent.slot + 1
 
-    return BaseBeaconBlock(**merge(defaults, kwargs))
+    return BeaconBlock(**merge(defaults, kwargs))
 
 
 @to_tuple
@@ -79,7 +82,7 @@ def get_fresh_chain_db():
     genesis_block = create_test_block(slot=0)
 
     chain_db = BeaconChainDB(db)
-    chain_db.persist_block(genesis_block)
+    chain_db.persist_block(genesis_block, BeaconBlock)
 
     return chain_db
 

--- a/tests/core/p2p-proto/bcc/test_commands.py
+++ b/tests/core/p2p-proto/bcc/test_commands.py
@@ -1,9 +1,9 @@
 import pytest
 
 
-from eth.beacon.types.attestations import Attestation
-from eth.beacon.types.attestation_data import AttestationData
-from eth.beacon.types.blocks import BaseBeaconBlock
+from eth2.beacon.types.attestations import Attestation
+from eth2.beacon.types.attestation_data import AttestationData
+from eth2.beacon.types.blocks import BeaconBlock
 
 from eth.constants import (
     ZERO_HASH32,
@@ -44,7 +44,7 @@ async def test_send_single_block(request, event_loop):
     msg_buffer = MsgBuffer()
     bob.add_subscriber(msg_buffer)
 
-    block = BaseBeaconBlock(
+    block = BeaconBlock(
         slot=1,
         parent_root=ZERO_HASH32,
         state_root=ZERO_HASH32,
@@ -67,7 +67,7 @@ async def test_send_multiple_blocks(request, event_loop):
     bob.add_subscriber(msg_buffer)
 
     blocks = tuple(
-        BaseBeaconBlock(
+        BeaconBlock(
             slot=slot,
             parent_root=ZERO_HASH32,
             state_root=ZERO_HASH32,

--- a/tests/core/p2p-proto/bcc/test_handshake.py
+++ b/tests/core/p2p-proto/bcc/test_handshake.py
@@ -4,6 +4,10 @@ import asyncio
 
 from p2p.exceptions import HandshakeFailure
 
+from eth2.beacon.types.blocks import (
+    BeaconBlock,
+)
+
 from trinity.protocol.bcc.proto import BCCProtocol
 from trinity.protocol.bcc.commands import (
     Status,
@@ -28,16 +32,16 @@ async def test_directly_linked_peers(request, event_loop):
     assert isinstance(alice.sub_proto, BCCProtocol)
     assert isinstance(bob.sub_proto, BCCProtocol)
 
-    assert alice.head_hash == bob.context.chain_db.get_canonical_head().hash
-    assert bob.head_hash == alice.context.chain_db.get_canonical_head().hash
+    assert alice.head_hash == bob.context.chain_db.get_canonical_head(BeaconBlock).hash
+    assert bob.head_hash == alice.context.chain_db.get_canonical_head(BeaconBlock).hash
 
 
 @pytest.mark.asyncio
 async def test_unidirectional_handshake(request, event_loop):
     alice, bob = await get_directly_linked_peers_without_handshake()
     alice_chain_db = alice.context.chain_db
-    alice_genesis_hash = alice_chain_db.get_canonical_block_by_slot(0).hash
-    alice_head_hash = alice_chain_db.get_canonical_head().hash
+    alice_genesis_hash = alice_chain_db.get_canonical_block_by_slot(0, BeaconBlock).hash
+    alice_head_hash = alice_chain_db.get_canonical_head(BeaconBlock).hash
 
     await asyncio.gather(alice.do_p2p_handshake(), bob.do_p2p_handshake())
 

--- a/tests/core/p2p-proto/bcc/test_requests.py
+++ b/tests/core/p2p-proto/bcc/test_requests.py
@@ -5,6 +5,11 @@ import asyncio
 from p2p.peer import (
     MsgBuffer,
 )
+
+from eth2.beacon.types.blocks import (
+    BeaconBlock,
+)
+
 from trinity.protocol.bcc.servers import BCCRequestServer
 from trinity.protocol.bcc.commands import (
     BeaconBlocks,
@@ -48,7 +53,7 @@ async def test_get_single_block_by_slot(request, event_loop):
     response = await response_buffer.msg_queue.get()
 
     assert isinstance(response.command, BeaconBlocks)
-    assert response.payload == (chain_db.get_block_by_root(block_root),)
+    assert response.payload == (chain_db.get_block_by_root(block_root, BeaconBlock),)
 
 
 @pytest.mark.asyncio
@@ -60,7 +65,7 @@ async def test_get_single_block_by_root(request, event_loop):
     response = await response_buffer.msg_queue.get()
 
     assert isinstance(response.command, BeaconBlocks)
-    assert response.payload == (chain_db.get_canonical_block_by_slot(0),)
+    assert response.payload == (chain_db.get_canonical_block_by_slot(0, BeaconBlock),)
 
 
 @pytest.mark.asyncio
@@ -102,11 +107,14 @@ async def test_get_unknown_block_by_root(request, event_loop):
 @pytest.mark.asyncio
 async def test_get_canonical_block_range_by_slot(request, event_loop):
     chain_db = get_fresh_chain_db()
-    base_branch = create_branch(3, root=chain_db.get_canonical_block_by_slot(0))
+    base_branch = create_branch(3, root=chain_db.get_canonical_block_by_slot(0, BeaconBlock))
+    print('base_branch', base_branch)
+
     non_canonical_branch = create_branch(3, root=base_branch[-1], state_root=b"\x00" * 32)
+
     canonical_branch = create_branch(4, root=base_branch[-1], state_root=b"\x11" * 32)
     for branch in [base_branch, non_canonical_branch, canonical_branch]:
-        chain_db.persist_block_chain(branch)
+        chain_db.persist_block_chain(branch, BeaconBlock)
 
     alice, response_buffer = await get_request_server_setup(request, event_loop, chain_db)
 
@@ -122,11 +130,11 @@ async def test_get_canonical_block_range_by_slot(request, event_loop):
 @pytest.mark.asyncio
 async def test_get_canonical_block_range_by_root(request, event_loop):
     chain_db = get_fresh_chain_db()
-    base_branch = create_branch(3, root=chain_db.get_canonical_block_by_slot(0))
+    base_branch = create_branch(3, root=chain_db.get_canonical_block_by_slot(0, BeaconBlock))
     non_canonical_branch = create_branch(3, root=base_branch[-1], state_root=b"\x00" * 32)
     canonical_branch = create_branch(4, root=base_branch[-1], state_root=b"\x11" * 32)
     for branch in [base_branch, non_canonical_branch, canonical_branch]:
-        chain_db.persist_block_chain(branch)
+        chain_db.persist_block_chain(branch, BeaconBlock)
 
     alice, response_buffer = await get_request_server_setup(request, event_loop, chain_db)
 
@@ -142,11 +150,11 @@ async def test_get_canonical_block_range_by_root(request, event_loop):
 @pytest.mark.asyncio
 async def test_get_incomplete_canonical_block_range(request, event_loop):
     chain_db = get_fresh_chain_db()
-    base_branch = create_branch(3, root=chain_db.get_canonical_block_by_slot(0))
+    base_branch = create_branch(3, root=chain_db.get_canonical_block_by_slot(0, BeaconBlock))
     non_canonical_branch = create_branch(3, root=base_branch[-1], state_root=b"\x00" * 32)
     canonical_branch = create_branch(4, root=base_branch[-1], state_root=b"\x11" * 32)
     for branch in [base_branch, non_canonical_branch, canonical_branch]:
-        chain_db.persist_block_chain(branch)
+        chain_db.persist_block_chain(branch, BeaconBlock)
 
     alice, response_buffer = await get_request_server_setup(request, event_loop, chain_db)
 
@@ -162,11 +170,11 @@ async def test_get_incomplete_canonical_block_range(request, event_loop):
 @pytest.mark.asyncio
 async def test_get_non_canonical_branch(request, event_loop):
     chain_db = get_fresh_chain_db()
-    base_branch = create_branch(3, root=chain_db.get_canonical_block_by_slot(0))
+    base_branch = create_branch(3, root=chain_db.get_canonical_block_by_slot(0, BeaconBlock))
     non_canonical_branch = create_branch(3, root=base_branch[-1], state_root=b"\x00" * 32)
     canonical_branch = create_branch(4, root=base_branch[-1], state_root=b"\x11" * 32)
     for branch in [base_branch, non_canonical_branch, canonical_branch]:
-        chain_db.persist_block_chain(branch)
+        chain_db.persist_block_chain(branch, BeaconBlock)
 
     alice, response_buffer = await get_request_server_setup(request, event_loop, chain_db)
 

--- a/tests/eth2/beacon/_utils/test_hash.py
+++ b/tests/eth2/beacon/_utils/test_hash.py
@@ -1,0 +1,11 @@
+from eth2.beacon._utils.hash import hash_eth2
+from eth_hash.auto import keccak
+
+
+def test_hash():
+    output = hash_eth2(b'helloworld')
+    assert len(output) == 32
+
+
+def test_hash_is_keccak256():
+    assert hash_eth2(b'foo') == keccak(b'foo')

--- a/tests/eth2/beacon/_utils/test_random.py
+++ b/tests/eth2/beacon/_utils/test_random.py
@@ -1,0 +1,43 @@
+import pytest
+
+from eth2.beacon._utils.random import (
+    shuffle,
+)
+
+
+@pytest.mark.parametrize(
+    (
+        'values,seed,expect'
+    ),
+    [
+        (
+            tuple(range(100)),
+            b'\x32' * 32,
+            (
+                92, 18, 80, 86, 39, 56, 81, 74, 68, 64,
+                52, 82, 26, 25, 45, 2, 66, 38, 35, 15,
+                46, 9, 65, 55, 85, 51, 53, 95, 57, 88,
+                43, 70, 22, 5, 31, 63, 90, 61, 89, 24,
+                6, 94, 12, 29, 84, 72, 42, 73, 40, 48,
+                16, 77, 69, 4, 14, 75, 21, 17, 54, 37,
+                98, 3, 60, 36, 76, 1, 97, 0, 44, 19,
+                83, 28, 41, 47, 13, 91, 93, 7, 71, 58,
+                11, 20, 50, 30, 34, 49, 33, 59, 79, 62,
+                67, 96, 78, 8, 10, 99, 87, 27, 32, 23,
+            ),
+        ),
+        (
+            tuple(range(12)),
+            b'\x23' * 32,
+            (11, 4, 9, 5, 7, 10, 2, 8, 0, 6, 3, 1),
+        ),
+    ],
+)
+def test_shuffle_consistent(values, seed, expect):
+    assert shuffle(values, seed) == expect
+
+
+def test_shuffle_out_of_bound():
+    values = [i for i in range(2**24 + 1)]
+    with pytest.raises(ValueError):
+        shuffle(values, b'hello')

--- a/tests/eth2/beacon/conftest.py
+++ b/tests/eth2/beacon/conftest.py
@@ -1,0 +1,696 @@
+import pytest
+import rlp
+
+from eth.constants import (
+    ZERO_HASH32,
+)
+from eth_utils import (
+    to_tuple,
+)
+
+import eth2._utils.bls as bls
+from eth2.beacon._utils.hash import hash_eth2
+from eth2._utils.bitfield import (
+    get_empty_bitfield,
+)
+from eth2.beacon.aggregation import (
+    aggregate_votes,
+)
+from eth2.beacon.constants import (
+    FAR_FUTURE_SLOT,
+    GWEI_PER_ETH,
+)
+from eth2.beacon.enums import (
+    SignatureDomain,
+)
+from eth2.beacon.helpers import (
+    get_domain,
+)
+
+from eth2.beacon.helpers import (
+    get_shuffling,
+)
+from eth2.beacon.types.attestation_data import AttestationData
+from eth2.beacon.types.attestations import Attestation
+from eth2.beacon.types.states import BeaconState
+from eth2.beacon.types.crosslink_records import CrosslinkRecord
+from eth2.beacon.types.deposit_data import DepositData
+from eth2.beacon.types.deposit_input import DepositInput
+from eth2.beacon.types.proposal_signed_data import ProposalSignedData
+from eth2.beacon.types.slashable_vote_data import SlashableVoteData
+
+from eth2.beacon.types.blocks import (
+    BeaconBlockBody,
+)
+from eth2.beacon.state_machines.forks.serenity.configs import SERENITY_CONFIG
+from eth2.beacon.types.fork_data import (
+    ForkData,
+)
+
+from tests.eth2.beacon.helpers import (
+    mock_validator_record,
+)
+
+DEFAULT_SHUFFLING_SEED = b'\00' * 32
+DEFAULT_RANDAO = b'\45' * 32
+DEFAULT_NUM_VALIDATORS = 40
+
+
+@pytest.fixture(scope="session")
+def privkeys():
+    return [int.from_bytes(hash_eth2(str(i).encode('utf-8'))[:4], 'big') for i in range(100)]
+
+
+@pytest.fixture(scope="session")
+def keymap(privkeys):
+    keymap = {}
+    for i, k in enumerate(privkeys):
+        keymap[bls.privtopub(k)] = k
+        if i % 50 == 0:
+            print("Generated %d keys" % i)
+    return keymap
+
+
+@pytest.fixture(scope="session")
+def pubkeys(keymap):
+    return list(keymap)
+
+
+@pytest.fixture
+def sample_proposer_slashing_params(sample_proposal_signed_data_params):
+    proposal_data = ProposalSignedData(**sample_proposal_signed_data_params)
+    return {
+        'proposer_index': 1,
+        'proposal_data_1': proposal_data,
+        'proposal_signature_1': (1, 2, 3),
+        'proposal_data_2': proposal_data,
+        'proposal_signature_2': (4, 5, 6),
+    }
+
+
+@pytest.fixture
+def sample_attestation_params(sample_attestation_data_params):
+    return {
+        'data': AttestationData(**sample_attestation_data_params),
+        'participation_bitfield': b'\12' * 16,
+        'custody_bitfield': b'\34' * 16,
+        'aggregate_signature': [0, 0],
+    }
+
+
+@pytest.fixture
+def sample_attestation_data_params():
+    return {
+        'slot': 10,
+        'shard': 12,
+        'beacon_block_root': b'\x11' * 32,
+        'epoch_boundary_root': b'\x22' * 32,
+        'shard_block_root': b'\x33' * 32,
+        'latest_crosslink_root': b'\x44' * 32,
+        'justified_slot': 5,
+        'justified_block_root': b'\x55' * 32,
+    }
+
+
+@pytest.fixture
+def sample_attestation_data_and_custody_bit_params(sample_attestation_data_params):
+    return {
+        'data': AttestationData(**sample_attestation_data_params),
+        'custody_bit': False,
+    }
+
+
+@pytest.fixture
+def sample_beacon_block_body_params():
+    return {
+        'proposer_slashings': (),
+        'casper_slashings': (),
+        'attestations': (),
+        'custody_reseeds': (),
+        'custody_challenges': (),
+        'custody_responses': (),
+        'deposits': (),
+        'exits': (),
+    }
+
+
+@pytest.fixture
+def sample_beacon_block_params(sample_beacon_block_body_params):
+    return {
+        'slot': 10,
+        'parent_root': ZERO_HASH32,
+        'state_root': b'\x55' * 32,
+        'randao_reveal': b'\x55' * 32,
+        'candidate_pow_receipt_root': b'\x55' * 32,
+        'signature': (0, 0),
+        'body': BeaconBlockBody(**sample_beacon_block_body_params)
+    }
+
+
+@pytest.fixture
+def sample_beacon_state_params(sample_fork_data_params):
+    return {
+        'slot': 0,
+        'genesis_time': 0,
+        'fork_data': ForkData(**sample_fork_data_params),
+        'validator_registry': (),
+        'validator_balances': (),
+        'validator_registry_latest_change_slot': 10,
+        'validator_registry_exit_count': 10,
+        'validator_registry_delta_chain_tip': b'\x55' * 32,
+        'latest_randao_mixes': (),
+        'latest_vdf_outputs': (),
+        'shard_committees_at_slots': (),
+        'persistent_committees': (),
+        'persistent_committee_reassignments': (),
+        'custody_challenges': (),
+        'previous_justified_slot': 0,
+        'justified_slot': 0,
+        'justification_bitfield': b'\x00',
+        'finalized_slot': 0,
+        'latest_crosslinks': (),
+        'latest_block_roots': (),
+        'latest_penalized_exit_balances': (),
+        'latest_attestations': (),
+        'batched_block_roots': (),
+        'processed_pow_receipt_root': b'\x55' * 32,
+        'candidate_pow_receipt_roots': (),
+    }
+
+
+@pytest.fixture
+def sample_candidate_pow_receipt_root_record_params():
+    return {
+        'candidate_pow_receipt_root': b'\x43' * 32,
+        'votes': 10,
+    }
+
+
+@pytest.fixture
+def sample_crosslink_record_params():
+    return {
+        'slot': 0,
+        'shard_block_root': b'\x43' * 32,
+    }
+
+
+@pytest.fixture
+def sample_deposit_input_params():
+    return {
+        'pubkey': 123,
+        'withdrawal_credentials': b'\11' * 32,
+        'randao_commitment': b'\11' * 32,
+        'custody_commitment': ZERO_HASH32,
+        'proof_of_possession': (0, 0),
+    }
+
+
+@pytest.fixture
+def sample_deposit_data_params(sample_deposit_input_params):
+    return {
+        'deposit_input': DepositInput(**sample_deposit_input_params),
+        'amount': 56,
+        'timestamp': 1501851927,
+    }
+
+
+@pytest.fixture
+def sample_deposit_params(sample_deposit_data_params):
+    return {
+        'merkle_branch': (),
+        'merkle_tree_index': 5,
+        'deposit_data': DepositData(**sample_deposit_data_params)
+    }
+
+
+@pytest.fixture
+def sample_exit_params():
+    return {
+        'slot': 123,
+        'validator_index': 15,
+        'signature': (0, 0),
+    }
+
+
+@pytest.fixture
+def sample_fork_data_params():
+    return {
+        'pre_fork_version': 0,
+        'post_fork_version': 0,
+        'fork_slot': 2**64 - 1,
+    }
+
+
+@pytest.fixture
+def sample_pending_attestation_record_params(sample_attestation_data_params):
+    return {
+        'data': AttestationData(**sample_attestation_data_params),
+        'participation_bitfield': b'\12' * 16,
+        'custody_bitfield': b'\34' * 16,
+        'slot_included': 0,
+    }
+
+
+@pytest.fixture
+def sample_proposal_signed_data_params():
+    return {
+        'slot': 10,
+        'shard': 12,
+        'block_root': b'\x43' * 32,
+    }
+
+
+@pytest.fixture
+def sample_recent_proposer_record_params():
+    return {
+        'index': 10,
+        'randao_commitment': b'\x43' * 32,
+        'balance_delta': 3
+    }
+
+
+@pytest.fixture
+def sample_shard_committee_params():
+    return {
+        'shard': 10,
+        'committee': (1, 3, 5),
+        'total_validator_count': 100
+    }
+
+
+@pytest.fixture
+def sample_shard_reassignment_record():
+    return {
+        'validator_index': 10,
+        'shard': 11,
+        'slot': 12,
+    }
+
+
+@pytest.fixture
+def sample_slashable_vote_data_params(sample_attestation_data_params):
+    return {
+        'custody_bit_0_indices': (10, 11, 12, 15, 28),
+        'custody_bit_1_indices': (7, 8, 100, 131, 249),
+        'data': AttestationData(**sample_attestation_data_params),
+        'aggregate_signature': (1, 2, 3, 4, 5),
+    }
+
+
+@pytest.fixture
+def sample_casper_slashing_params(sample_slashable_vote_data_params):
+    vote_data = SlashableVoteData(**sample_slashable_vote_data_params)
+    return {
+        'slashable_vote_data_1': vote_data,
+        'slashable_vote_data_2': vote_data,
+    }
+
+
+@pytest.fixture
+def sample_validator_record_params():
+    return {
+        'pubkey': 123,
+        'withdrawal_credentials': b'\x01' * 32,
+        'randao_commitment': b'\x01' * 32,
+        'randao_layers': 1,
+        'activation_slot': FAR_FUTURE_SLOT,
+        'exit_slot': FAR_FUTURE_SLOT,
+        'withdrawal_slot': FAR_FUTURE_SLOT,
+        'penalized_slot': FAR_FUTURE_SLOT,
+        'exit_count': 0,
+        'status_flags': 0,
+        'custody_commitment': ZERO_HASH32,
+        'latest_custody_reseed_slot': 0,
+        'penultimate_custody_reseed_slot': 0,
+    }
+
+
+@pytest.fixture
+def sample_validator_registry_delta_block_params():
+    return {
+        'latest_registry_delta_root': b'\x01' * 32,
+        'validator_index': 1,
+        'pubkey': 123,
+        'slot': 0,
+        'flag': 1,
+    }
+
+
+@pytest.fixture
+def empty_beacon_state(latest_block_roots_length,
+                       latest_penalized_exit_length):
+    return BeaconState(
+        slot=0,
+        genesis_time=0,
+        fork_data=ForkData(
+            pre_fork_version=0,
+            post_fork_version=0,
+            fork_slot=0,
+        ),
+        validator_registry=(),
+        validator_balances=(),
+        validator_registry_latest_change_slot=10,
+        validator_registry_exit_count=10,
+        validator_registry_delta_chain_tip=b'\x55' * 32,
+        latest_randao_mixes=(),
+        latest_vdf_outputs=(),
+        shard_committees_at_slots=(),
+        persistent_committees=(),
+        persistent_committee_reassignments=(),
+        previous_justified_slot=0,
+        justified_slot=0,
+        justification_bitfield=0,
+        finalized_slot=0,
+        latest_crosslinks=(),
+        latest_block_roots=(ZERO_HASH32,) * latest_block_roots_length,
+        latest_penalized_exit_balances=(0,) * latest_penalized_exit_length,
+        latest_attestations=(),
+        batched_block_roots=(),
+        processed_pow_receipt_root=b'\x55' * 32,
+        candidate_pow_receipt_roots=(),
+    )
+
+
+@pytest.fixture()
+def ten_validators_state(empty_beacon_state, max_deposit):
+    validator_count = 10
+    return empty_beacon_state.copy(
+        validator_registry=tuple(
+            mock_validator_record(
+                pubkey=pubkey,
+                is_active=True,
+            )
+            for pubkey in range(validator_count)
+        ),
+        validator_balances=(max_deposit * GWEI_PER_ETH,) * validator_count,
+    )
+
+
+#
+# Temporary default values
+#
+@pytest.fixture
+def init_shuffling_seed():
+    return DEFAULT_SHUFFLING_SEED
+
+
+@pytest.fixture
+def init_randao():
+    return DEFAULT_RANDAO
+
+
+@pytest.fixture
+def num_validators():
+    return DEFAULT_NUM_VALIDATORS
+
+
+@pytest.fixture
+def init_validator_privkeys(privkeys, num_validators):
+    return privkeys[:num_validators]
+
+
+@pytest.fixture
+def init_validator_pubkeys(pubkeys, num_validators):
+    return pubkeys[:num_validators]
+
+
+#
+# config
+#
+@pytest.fixture
+def shard_count():
+    return SERENITY_CONFIG.SHARD_COUNT
+
+
+@pytest.fixture
+def target_committee_size():
+    return SERENITY_CONFIG.TARGET_COMMITTEE_SIZE
+
+
+@pytest.fixture
+def ejection_balance():
+    return SERENITY_CONFIG.EJECTION_BALANCE
+
+
+@pytest.fixture
+def max_balance_churn_quotient():
+    return SERENITY_CONFIG.MAX_BALANCE_CHURN_QUOTIENT
+
+
+@pytest.fixture
+def beacon_chain_shard_number():
+    return SERENITY_CONFIG.BEACON_CHAIN_SHARD_NUMBER
+
+
+@pytest.fixture
+def max_casper_votes():
+    return SERENITY_CONFIG.MAX_CASPER_VOTES
+
+
+@pytest.fixture
+def latest_block_roots_length():
+    return SERENITY_CONFIG.LATEST_BLOCK_ROOTS_LENGTH
+
+
+@pytest.fixture
+def latest_randao_mixes_length():
+    return SERENITY_CONFIG.LATEST_RANDAO_MIXES_LENGTH
+
+
+@pytest.fixture
+def latest_penalized_exit_length():
+    return SERENITY_CONFIG.LATEST_PENALIZED_EXIT_LENGTH
+
+
+@pytest.fixture
+def deposit_contract_address():
+    return SERENITY_CONFIG.DEPOSIT_CONTRACT_ADDRESS
+
+
+@pytest.fixture
+def deposit_contract_tree_depth():
+    return SERENITY_CONFIG.DEPOSIT_CONTRACT_TREE_DEPTH
+
+
+@pytest.fixture
+def min_deposit():
+    return SERENITY_CONFIG.MIN_DEPOSIT
+
+
+@pytest.fixture
+def max_deposit():
+    return SERENITY_CONFIG.MAX_DEPOSIT
+
+
+@pytest.fixture
+def genesis_fork_version():
+    return SERENITY_CONFIG.GENESIS_FORK_VERSION
+
+
+@pytest.fixture
+def genesis_slot():
+    return SERENITY_CONFIG.GENESIS_SLOT
+
+
+@pytest.fixture
+def bls_withdrawal_prefix_byte():
+    return SERENITY_CONFIG.BLS_WITHDRAWAL_PREFIX_BYTE
+
+
+@pytest.fixture
+def slot_duration():
+    return SERENITY_CONFIG.SLOT_DURATION
+
+
+@pytest.fixture
+def min_attestation_inclusion_delay():
+    return SERENITY_CONFIG.MIN_ATTESTATION_INCLUSION_DELAY
+
+
+@pytest.fixture
+def epoch_length():
+    return SERENITY_CONFIG.EPOCH_LENGTH
+
+
+@pytest.fixture
+def seed_lookahead():
+    return SERENITY_CONFIG.SEED_LOOKAHEAD
+
+
+@pytest.fixture
+def entry_exit_delay():
+    return SERENITY_CONFIG.ENTRY_EXIT_DELAY
+
+
+@pytest.fixture
+def pow_receipt_root_voting_period():
+    return SERENITY_CONFIG.POW_RECEIPT_ROOT_VOTING_PERIOD
+
+
+@pytest.fixture
+def min_validator_withdrawal_time():
+    return SERENITY_CONFIG.MIN_VALIDATOR_WITHDRAWAL_TIME
+
+
+@pytest.fixture
+def base_reward_quotient():
+    return SERENITY_CONFIG.BASE_REWARD_QUOTIENT
+
+
+@pytest.fixture
+def whistleblower_reward_quotient():
+    return SERENITY_CONFIG.WHISTLEBLOWER_REWARD_QUOTIENT
+
+
+@pytest.fixture
+def includer_reward_quotient():
+    return SERENITY_CONFIG.INCLUDER_REWARD_QUOTIENT
+
+
+@pytest.fixture
+def inactivity_penalty_quotient():
+    return SERENITY_CONFIG.INACTIVITY_PENALTY_QUOTIENT
+
+
+@pytest.fixture
+def max_proposer_slashings():
+    return SERENITY_CONFIG.MAX_PROPOSER_SLASHINGS
+
+
+@pytest.fixture
+def max_casper_slashings():
+    return SERENITY_CONFIG.MAX_CASPER_SLASHINGS
+
+
+@pytest.fixture
+def max_attestations():
+    return SERENITY_CONFIG.MAX_ATTESTATIONS
+
+
+@pytest.fixture
+def max_deposits():
+    return SERENITY_CONFIG.MAX_DEPOSITS
+
+
+@pytest.fixture
+def max_exits():
+    return SERENITY_CONFIG.MAX_EXITS
+
+
+#
+# genesis
+#
+@pytest.fixture
+def genesis_state(sample_beacon_state_params,
+                  activated_genesis_validators,
+                  genesis_balances,
+                  epoch_length,
+                  target_committee_size,
+                  genesis_slot,
+                  shard_count,
+                  latest_block_roots_length):
+    initial_shuffling = get_shuffling(
+        seed=ZERO_HASH32,
+        validators=activated_genesis_validators,
+        crosslinking_start_shard=0,
+        slot=genesis_slot,
+        epoch_length=epoch_length,
+        target_committee_size=target_committee_size,
+        shard_count=shard_count
+    )
+    return BeaconState(**sample_beacon_state_params).copy(
+        validator_registry=activated_genesis_validators,
+        validator_balances=genesis_balances,
+        shard_committees_at_slots=initial_shuffling + initial_shuffling,
+        latest_block_roots=tuple(ZERO_HASH32 for _ in range(latest_block_roots_length)),
+        latest_crosslinks=tuple(
+            CrosslinkRecord(
+                slot=genesis_slot,
+                shard_block_root=ZERO_HASH32,
+            )
+            for _ in range(shard_count)
+        )
+    )
+
+
+@pytest.fixture
+def initial_validators(init_validator_pubkeys,
+                       init_randao,
+                       max_deposit):
+    """
+    Inactive
+    """
+    return tuple(
+        mock_validator_record(
+            pubkey=pubkey,
+            withdrawal_credentials=ZERO_HASH32,
+            randao_commitment=init_randao,
+            status_flags=0,
+            is_active=False,
+        )
+        for pubkey in init_validator_pubkeys
+    )
+
+
+@to_tuple
+@pytest.fixture
+def activated_genesis_validators(initial_validators, genesis_slot):
+    """
+    Active
+    """
+    for validator in initial_validators:
+        yield validator.copy(activation_slot=genesis_slot)
+
+
+@pytest.fixture
+def genesis_balances(init_validator_pubkeys, max_deposit):
+    return tuple(
+        max_deposit * GWEI_PER_ETH
+        for _ in init_validator_pubkeys
+    )
+
+
+#
+# Create mock consensus objects
+#
+@pytest.fixture
+def create_mock_signed_attestation(privkeys):
+    def create_mock_signed_attestation(state,
+                                       shard_committee,
+                                       voting_committee_indices,
+                                       attestation_data):
+        message = hash_eth2(
+            rlp.encode(attestation_data) +
+            (0).to_bytes(1, "big")
+        )
+        # participants sign message
+        signatures = [
+            bls.sign(
+                message,
+                privkeys[shard_committee.committee[committee_index]],
+                domain=get_domain(
+                    fork_data=state.fork_data,
+                    slot=attestation_data.slot,
+                    domain_type=SignatureDomain.DOMAIN_ATTESTATION,
+                )
+            )
+            for committee_index in voting_committee_indices
+        ]
+
+        # aggregate signatures and construct participant bitfield
+        participation_bitfield, aggregate_signature = aggregate_votes(
+            bitfield=get_empty_bitfield(len(shard_committee.committee)),
+            sigs=(),
+            voting_sigs=signatures,
+            voting_committee_indices=voting_committee_indices,
+        )
+
+        # create attestation from attestation_data, particpipant_bitfield, and signature
+        return Attestation(
+            data=attestation_data,
+            participation_bitfield=participation_bitfield,
+            custody_bitfield=b'',
+            aggregate_signature=aggregate_signature,
+        )
+
+    return create_mock_signed_attestation

--- a/tests/eth2/beacon/db/test_beacon_chaindb.py
+++ b/tests/eth2/beacon/db/test_beacon_chaindb.py
@@ -1,0 +1,125 @@
+import pytest
+
+from hypothesis import (
+    given,
+    strategies as st,
+)
+
+import rlp
+
+from eth.constants import (
+    GENESIS_PARENT_HASH,
+)
+from eth.exceptions import (
+    BlockNotFound,
+    ParentNotFound,
+)
+from eth2.beacon._utils.hash import (
+    hash_eth2,
+)
+from eth._utils.rlp import (
+    validate_rlp_equal,
+)
+
+from eth2.beacon.db.chain import (
+    BeaconChainDB,
+)
+from eth2.beacon.db.schema import SchemaV1
+from eth2.beacon.state_machines.forks.serenity.blocks import (
+    BeaconBlock,
+)
+from eth2.beacon.types.states import BeaconState
+
+
+@pytest.fixture
+def chaindb(base_db):
+    return BeaconChainDB(base_db)
+
+
+@pytest.fixture(params=[0, 10, 999])
+def block(request, sample_beacon_block_params):
+    return BeaconBlock(**sample_beacon_block_params).copy(
+        parent_root=GENESIS_PARENT_HASH,
+        slot=request.param,
+    )
+
+
+@pytest.fixture()
+def state(sample_beacon_state_params):
+    return BeaconState(**sample_beacon_state_params)
+
+
+def test_chaindb_add_block_number_to_root_lookup(chaindb, block):
+    block_slot_to_root_key = SchemaV1.make_block_slot_to_root_lookup_key(block.slot)
+    assert not chaindb.exists(block_slot_to_root_key)
+    chaindb.persist_block(block, block.__class__)
+    assert chaindb.exists(block_slot_to_root_key)
+
+
+def test_chaindb_persist_block_and_slot_to_root(chaindb, block):
+    with pytest.raises(BlockNotFound):
+        chaindb.get_block_by_root(block.root, block.__class__)
+    slot_to_root_key = SchemaV1.make_block_root_to_score_lookup_key(block.root)
+    assert not chaindb.exists(slot_to_root_key)
+
+    chaindb.persist_block(block, block.__class__)
+
+    assert chaindb.get_block_by_root(block.root, block.__class__) == block
+    assert chaindb.exists(slot_to_root_key)
+
+
+@given(seed=st.binary(min_size=32, max_size=32))
+def test_chaindb_persist_block_and_unknown_parent(chaindb, block, seed):
+    n_block = block.copy(parent_root=hash_eth2(seed))
+    with pytest.raises(ParentNotFound):
+        chaindb.persist_block(n_block, n_block.__class__)
+
+
+def test_chaindb_persist_block_and_block_to_root(chaindb, block):
+    block_to_root_key = SchemaV1.make_block_root_to_score_lookup_key(block.root)
+    assert not chaindb.exists(block_to_root_key)
+    chaindb.persist_block(block, block.__class__)
+    assert chaindb.exists(block_to_root_key)
+
+
+def test_chaindb_get_score(chaindb, sample_beacon_block_params):
+    genesis = BeaconBlock(**sample_beacon_block_params).copy(
+        parent_root=GENESIS_PARENT_HASH,
+        slot=0,
+    )
+    chaindb.persist_block(genesis, genesis.__class__)
+
+    genesis_score_key = SchemaV1.make_block_root_to_score_lookup_key(genesis.root)
+    genesis_score = rlp.decode(chaindb.db.get(genesis_score_key), sedes=rlp.sedes.big_endian_int)
+    assert genesis_score == 0
+    assert chaindb.get_score(genesis.root) == 0
+
+    block1 = BeaconBlock(**sample_beacon_block_params).copy(
+        parent_root=genesis.root,
+        slot=1,
+    )
+    chaindb.persist_block(block1, block1.__class__)
+
+    block1_score_key = SchemaV1.make_block_root_to_score_lookup_key(block1.root)
+    block1_score = rlp.decode(chaindb.db.get(block1_score_key), sedes=rlp.sedes.big_endian_int)
+    assert block1_score == 1
+    assert chaindb.get_score(block1.root) == 1
+
+
+def test_chaindb_get_block_by_root(chaindb, block):
+    chaindb.persist_block(block, block.__class__)
+    result_block = chaindb.get_block_by_root(block.root, block.__class__)
+    validate_rlp_equal(result_block, block)
+
+
+def test_chaindb_get_canonical_block_root(chaindb, block):
+    chaindb.persist_block(block, block.__class__)
+    block_root = chaindb.get_canonical_block_root(block.slot)
+    assert block_root == block.root
+
+
+def test_chaindb_state(chaindb, state):
+    chaindb.persist_state(state)
+
+    result_state = chaindb.get_state_by_root(state.root)
+    assert result_state.root == state.root

--- a/tests/eth2/beacon/helpers.py
+++ b/tests/eth2/beacon/helpers.py
@@ -1,0 +1,77 @@
+from eth_utils import to_tuple
+
+from eth2._utils import bls
+
+from eth.constants import (
+    ZERO_HASH32,
+)
+from eth2.beacon.constants import (
+    EMPTY_SIGNATURE,
+    FAR_FUTURE_SLOT,
+)
+from eth2.beacon.enums import (
+    SignatureDomain,
+)
+from eth2.beacon.helpers import (
+    get_domain,
+)
+from eth2.beacon.types.deposit_input import DepositInput
+from eth2.beacon.types.validator_records import (
+    ValidatorRecord,
+)
+
+
+def mock_validator_record(pubkey,
+                          withdrawal_credentials=ZERO_HASH32,
+                          randao_commitment=ZERO_HASH32,
+                          status_flags=0,
+                          is_active=True):
+    return ValidatorRecord(
+        pubkey=pubkey,
+        withdrawal_credentials=withdrawal_credentials,
+        randao_commitment=randao_commitment,
+        randao_layers=0,
+        activation_slot=0 if is_active else FAR_FUTURE_SLOT,
+        exit_slot=FAR_FUTURE_SLOT,
+        withdrawal_slot=FAR_FUTURE_SLOT,
+        penalized_slot=FAR_FUTURE_SLOT,
+        exit_count=0,
+        status_flags=status_flags,
+        custody_commitment=b'\x55' * 32,
+        latest_custody_reseed_slot=0,
+        penultimate_custody_reseed_slot=0,
+    )
+
+
+@to_tuple
+def get_pseudo_chain(length, genesis_block):
+    """
+    Get a pseudo chain, only slot and parent_root are valid.
+    """
+    block = genesis_block.copy()
+    yield block
+    for slot in range(1, length * 3):
+        block = genesis_block.copy(
+            slot=slot,
+            parent_root=block.root
+        )
+        yield block
+
+
+def sign_proof_of_possession(deposit_input, privkey, fork_data, slot):
+    domain = get_domain(
+        fork_data,
+        slot,
+        SignatureDomain.DOMAIN_DEPOSIT,
+    )
+    return bls.sign(deposit_input.root, privkey, domain)
+
+
+def make_deposit_input(pubkey, withdrawal_credentials, randao_commitment, custody_commitment):
+    return DepositInput(
+        pubkey=pubkey,
+        withdrawal_credentials=withdrawal_credentials,
+        randao_commitment=randao_commitment,
+        custody_commitment=custody_commitment,
+        proof_of_possession=EMPTY_SIGNATURE,
+    )

--- a/tests/eth2/beacon/state_machines/conftest.py
+++ b/tests/eth2/beacon/state_machines/conftest.py
@@ -1,0 +1,88 @@
+import pytest
+
+from eth2.beacon.state_machines.configs import BeaconConfig
+from eth2.beacon.state_machines.forks.serenity import (
+    SerenityStateMachine,
+)
+
+
+@pytest.fixture
+def config(
+        shard_count,
+        target_committee_size,
+        ejection_balance,
+        max_balance_churn_quotient,
+        beacon_chain_shard_number,
+        max_casper_votes,
+        latest_block_roots_length,
+        latest_randao_mixes_length,
+        latest_penalized_exit_length,
+        deposit_contract_address,
+        deposit_contract_tree_depth,
+        min_deposit,
+        max_deposit,
+        genesis_fork_version,
+        genesis_slot,
+        bls_withdrawal_prefix_byte,
+        slot_duration,
+        min_attestation_inclusion_delay,
+        epoch_length,
+        seed_lookahead,
+        entry_exit_delay,
+        pow_receipt_root_voting_period,
+        min_validator_withdrawal_time,
+        base_reward_quotient,
+        whistleblower_reward_quotient,
+        includer_reward_quotient,
+        inactivity_penalty_quotient,
+        max_proposer_slashings,
+        max_casper_slashings,
+        max_attestations,
+        max_deposits,
+        max_exits
+):
+    return BeaconConfig(
+        SHARD_COUNT=shard_count,
+        TARGET_COMMITTEE_SIZE=target_committee_size,
+        EJECTION_BALANCE=ejection_balance,
+        MAX_BALANCE_CHURN_QUOTIENT=max_balance_churn_quotient,
+        BEACON_CHAIN_SHARD_NUMBER=beacon_chain_shard_number,
+        MAX_CASPER_VOTES=max_casper_votes,
+        LATEST_BLOCK_ROOTS_LENGTH=latest_block_roots_length,
+        LATEST_RANDAO_MIXES_LENGTH=latest_randao_mixes_length,
+        LATEST_PENALIZED_EXIT_LENGTH=latest_penalized_exit_length,
+        DEPOSIT_CONTRACT_ADDRESS=deposit_contract_address,
+        DEPOSIT_CONTRACT_TREE_DEPTH=deposit_contract_tree_depth,
+        MIN_DEPOSIT=min_deposit,
+        MAX_DEPOSIT=max_deposit,
+        GENESIS_FORK_VERSION=genesis_fork_version,
+        GENESIS_SLOT=genesis_slot,
+        BLS_WITHDRAWAL_PREFIX_BYTE=bls_withdrawal_prefix_byte,
+        SLOT_DURATION=slot_duration,
+        MIN_ATTESTATION_INCLUSION_DELAY=min_attestation_inclusion_delay,
+        EPOCH_LENGTH=epoch_length,
+        SEED_LOOKAHEAD=seed_lookahead,
+        ENTRY_EXIT_DELAY=entry_exit_delay,
+        POW_RECEIPT_ROOT_VOTING_PERIOD=pow_receipt_root_voting_period,
+        MIN_VALIDATOR_WITHDRAWAL_TIME=min_validator_withdrawal_time,
+        BASE_REWARD_QUOTIENT=base_reward_quotient,
+        WHISTLEBLOWER_REWARD_QUOTIENT=whistleblower_reward_quotient,
+        INCLUDER_REWARD_QUOTIENT=includer_reward_quotient,
+        INACTIVITY_PENALTY_QUOTIENT=inactivity_penalty_quotient,
+        MAX_PROPOSER_SLASHINGS=max_proposer_slashings,
+        MAX_CASPER_SLASHINGS=max_casper_slashings,
+        MAX_ATTESTATIONS=max_attestations,
+        MAX_DEPOSITS=max_deposits,
+        MAX_EXITS=max_exits,
+    )
+
+
+#
+# State machine
+#
+@pytest.fixture
+def fixture_sm_class(config):
+    return SerenityStateMachine.configure(
+        __name__='SerenityStateMachineForTesting',
+        config=config,
+    )

--- a/tests/eth2/beacon/state_machines/forks/test_serenity_operations.py
+++ b/tests/eth2/beacon/state_machines/forks/test_serenity_operations.py
@@ -1,0 +1,137 @@
+import pytest
+
+from eth_utils import (
+    ValidationError,
+)
+
+from eth.constants import (
+    ZERO_HASH32,
+)
+
+from eth2.beacon.helpers import (
+    get_block_root,
+    get_shard_committees_at_slot,
+)
+
+from eth2.beacon.types.attestation_data import AttestationData
+from eth2.beacon.state_machines.forks.serenity.blocks import (
+    SerenityBeaconBlock,
+    SerenityBeaconBlockBody,
+)
+from eth2.beacon.state_machines.forks.serenity.operations import (
+    process_attestations,
+)
+
+
+@pytest.fixture
+def create_mock_signed_attestations_at_slot(config,
+                                            sample_attestation_data_params,
+                                            create_mock_signed_attestation):
+    def create_mock_signed_attestations_at_slot(state,
+                                                attestation_slot):
+        attestations = []
+        shard_and_committees_at_slot = get_shard_committees_at_slot(
+            state,
+            slot=attestation_slot,
+            epoch_length=config.EPOCH_LENGTH,
+        )
+        for shard_committee in shard_and_committees_at_slot:
+            # have 0th committee member sign
+            voting_committee_indices = [0]
+            latest_crosslink_root = state.latest_crosslinks[shard_committee.shard].shard_block_root
+
+            assert len(shard_committee.committee) > 0
+            attestation_data = AttestationData(**sample_attestation_data_params).copy(
+                slot=attestation_slot,
+                shard=shard_committee.shard,
+                justified_slot=state.previous_justified_slot,
+                justified_block_root=get_block_root(
+                    state,
+                    state.previous_justified_slot,
+                    config.LATEST_BLOCK_ROOTS_LENGTH,
+                ),
+                latest_crosslink_root=latest_crosslink_root,
+                shard_block_root=ZERO_HASH32,
+            )
+
+            attestations.append(
+                create_mock_signed_attestation(
+                    state,
+                    shard_committee,
+                    voting_committee_indices,
+                    attestation_data,
+                )
+            )
+        return tuple(attestations)
+    return create_mock_signed_attestations_at_slot
+
+
+@pytest.mark.parametrize(
+    (
+        'num_validators,'
+        'epoch_length,'
+        'min_attestation_inclusion_delay,'
+        'target_committee_size,'
+        'shard_count,'
+        'success,'
+    ),
+    [
+        (10, 2, 1, 2, 2, True),
+        (10, 2, 1, 2, 2, False),
+        (40, 4, 2, 3, 5, True),
+    ]
+)
+def test_process_attestations(genesis_state,
+                              sample_attestation_data_params,
+                              sample_beacon_block_params,
+                              sample_beacon_block_body_params,
+                              config,
+                              create_mock_signed_attestations_at_slot,
+                              success):
+
+    attestation_slot = 0
+    current_slot = attestation_slot + config.MIN_ATTESTATION_INCLUSION_DELAY
+    state = genesis_state.copy(
+        slot=current_slot,
+    )
+
+    attestations = create_mock_signed_attestations_at_slot(
+        state,
+        attestation_slot,
+    )
+
+    assert len(attestations) > 0
+
+    if not success:
+        # create invalid attestation in the future
+        invalid_attestation_data = attestations[-1].data.copy(
+            slot=state.slot + 10,
+        )
+        invalid_attestation = attestations[-1].copy(
+            data=invalid_attestation_data,
+        )
+        attestations = attestations[:-1] + (invalid_attestation,)
+
+    block_body = SerenityBeaconBlockBody(**sample_beacon_block_body_params).copy(
+        attestations=attestations,
+    )
+    block = SerenityBeaconBlock(**sample_beacon_block_params).copy(
+        slot=current_slot,
+        body=block_body,
+    )
+
+    if success:
+        new_state = process_attestations(
+            state,
+            block,
+            config,
+        )
+
+        assert len(new_state.latest_attestations) == len(attestations)
+    else:
+        with pytest.raises(ValidationError):
+            process_attestations(
+                state,
+                block,
+                config,
+            )

--- a/tests/eth2/beacon/state_machines/test_attestation_validation.py
+++ b/tests/eth2/beacon/state_machines/test_attestation_validation.py
@@ -1,0 +1,290 @@
+import pytest
+from hypothesis import (
+    given,
+    settings,
+    strategies as st,
+)
+
+from eth_utils import (
+    ValidationError,
+)
+
+from eth.constants import (
+    ZERO_HASH32,
+)
+
+from eth2.beacon.state_machines.forks.serenity.validation import (
+    validate_serenity_attestation_aggregate_signature,
+    validate_serenity_attestation_latest_crosslink_root,
+    validate_serenity_attestation_justified_block_root,
+    validate_serenity_attestation_justified_slot,
+    validate_serenity_attestation_shard_block_root,
+    validate_serenity_attestation_slot,
+)
+from eth2.beacon.types.attestation_data import AttestationData
+
+
+@pytest.mark.parametrize(
+    (
+        'attestation_slot,'
+        'current_slot,'
+        'epoch_length,'
+        'min_attestation_inclusion_delay,'
+        'is_valid,'
+    ),
+    [
+        (0, 5, 5, 1, True),
+        (0, 5, 5, 5, True),
+        (0, 5, 5, 6, False),  # attestation_slot + in_attestation_inclusion_delay > current_slot
+        (7, 5, 10, 1, False),  # attestation_slot > current_slot
+        (10, 20, 10, 2, True),
+        (9, 20, 10, 2, False),  # attestation_slot + EPOCH_LENGTH < current_slot
+    ]
+)
+def test_validate_serenity_attestation_slot(sample_attestation_data_params,
+                                            attestation_slot,
+                                            current_slot,
+                                            epoch_length,
+                                            min_attestation_inclusion_delay,
+                                            is_valid):
+    attestation_data = AttestationData(**sample_attestation_data_params).copy(
+        slot=attestation_slot,
+    )
+
+    if is_valid:
+        validate_serenity_attestation_slot(
+            attestation_data,
+            current_slot,
+            epoch_length,
+            min_attestation_inclusion_delay,
+        )
+    else:
+        with pytest.raises(ValidationError):
+            validate_serenity_attestation_slot(
+                attestation_data,
+                current_slot,
+                epoch_length,
+                min_attestation_inclusion_delay,
+            )
+
+
+@pytest.mark.parametrize(
+    (
+        'attestation_slot,'
+        'attestation_justified_slot,'
+        'current_slot,'
+        'previous_justified_slot,'
+        'justified_slot,'
+        'epoch_length,'
+        'is_valid,'
+    ),
+    [
+        (13, 5, 14, 0, 5, 5, True),
+        (13, 0, 14, 0, 5, 5, False),  # targeting previous_justified_slot, should be targeting justified_slot # noqa: E501
+        (13, 20, 14, 0, 5, 5, False),  # targeting future slot, should be targeting justified_slot
+        (29, 10, 30, 10, 20, 10, True),
+        (29, 20, 30, 10, 20, 10, False),  # targeting justified_slot, should be targeting previous_justified_slot # noqa: E501
+        (29, 36, 30, 10, 20, 10, False),  # targeting future slot,  should be targeting previous_justified_slot # noqa: E501
+        (10, 10, 10, 10, 10, 10, True),
+    ]
+)
+def test_validate_serenity_attestation_justified_slot(sample_attestation_data_params,
+                                                      attestation_slot,
+                                                      attestation_justified_slot,
+                                                      current_slot,
+                                                      previous_justified_slot,
+                                                      justified_slot,
+                                                      epoch_length,
+                                                      is_valid):
+    attestation_data = AttestationData(**sample_attestation_data_params).copy(
+        slot=attestation_slot,
+        justified_slot=attestation_justified_slot,
+    )
+
+    if is_valid:
+        validate_serenity_attestation_justified_slot(
+            attestation_data,
+            current_slot,
+            previous_justified_slot,
+            justified_slot,
+            epoch_length,
+        )
+    else:
+        with pytest.raises(ValidationError):
+            validate_serenity_attestation_justified_slot(
+                attestation_data,
+                current_slot,
+                previous_justified_slot,
+                justified_slot,
+                epoch_length,
+            )
+
+
+@pytest.mark.parametrize(
+    (
+        'attestation_justified_block_root,'
+        'justified_block_root,'
+        'is_valid,'
+    ),
+    [
+        (b'\x42' * 32, b'\x35' * 32, False),  # attestation.justified_block_root != justified_block_root # noqa: E501
+        (b'\x42' * 32, b'\x42' * 32, True),
+    ]
+)
+def test_validate_serenity_attestation_justified_block_root(sample_attestation_data_params,
+                                                            attestation_justified_block_root,
+                                                            justified_block_root,
+                                                            is_valid):
+    attestation_data = AttestationData(**sample_attestation_data_params).copy(
+        justified_block_root=attestation_justified_block_root,
+    )
+
+    if is_valid:
+        validate_serenity_attestation_justified_block_root(
+            attestation_data,
+            justified_block_root
+        )
+    else:
+        with pytest.raises(ValidationError):
+            validate_serenity_attestation_justified_block_root(
+                attestation_data,
+                justified_block_root
+            )
+
+
+@pytest.mark.parametrize(
+    (
+        'attestation_latest_crosslink_root,'
+        'attestation_shard_block_root,'
+        'latest_crosslink_root,'
+        'is_valid,'
+    ),
+    [
+        (b'\x66' * 32, b'\x42' * 32, b'\x35' * 32, False),
+        (b'\x42' * 32, b'\x42' * 32, b'\x66' * 32, False),
+        (b'\x66' * 32, b'\x42' * 32, b'\x42' * 32, True),
+        (b'\x42' * 32, b'\x35' * 32, b'\x42' * 32, True),
+        (b'\x42' * 32, b'\x42' * 32, b'\x42' * 32, True),
+    ]
+)
+def test_validate_serenity_attestation_latest_crosslink_root(sample_attestation_data_params,
+                                                             attestation_latest_crosslink_root,
+                                                             attestation_shard_block_root,
+                                                             latest_crosslink_root,
+                                                             is_valid):
+    sample_attestation_data_params['latest_crosslink_root'] = attestation_latest_crosslink_root
+    sample_attestation_data_params['shard_block_root'] = attestation_shard_block_root
+    attestation_data = AttestationData(**sample_attestation_data_params).copy(
+        latest_crosslink_root=attestation_latest_crosslink_root,
+        shard_block_root=attestation_shard_block_root,
+    )
+
+    if is_valid:
+        validate_serenity_attestation_latest_crosslink_root(
+            attestation_data,
+            latest_crosslink_root,
+        )
+    else:
+        with pytest.raises(ValidationError):
+            validate_serenity_attestation_latest_crosslink_root(
+                attestation_data,
+                latest_crosslink_root,
+            )
+
+
+@pytest.mark.parametrize(
+    (
+        'attestation_shard_block_root,'
+        'is_valid,'
+    ),
+    [
+        (ZERO_HASH32, True),
+        (b'\x35' * 32, False),
+        (b'\x66' * 32, False),
+    ]
+)
+def test_validate_serenity_attestation_shard_block_root(sample_attestation_data_params,
+                                                        attestation_shard_block_root,
+                                                        is_valid):
+    attestation_data = AttestationData(**sample_attestation_data_params).copy(
+        shard_block_root=attestation_shard_block_root,
+    )
+
+    if is_valid:
+        validate_serenity_attestation_shard_block_root(
+            attestation_data,
+        )
+    else:
+        with pytest.raises(ValidationError):
+            validate_serenity_attestation_shard_block_root(
+                attestation_data,
+            )
+
+
+@settings(max_examples=1)
+@given(random=st.randoms())
+@pytest.mark.parametrize(
+    (
+        'num_validators,'
+        'epoch_length,'
+        'target_committee_size,'
+        'shard_count,'
+        'is_valid,'
+    ),
+    [
+        (10, 2, 2, 2, True),
+        (40, 4, 3, 5, True),
+        (20, 5, 3, 2, True),
+        (20, 5, 3, 2, False),
+    ],
+)
+def test_validate_serenity_attestation_aggregate_signature(genesis_state,
+                                                           epoch_length,
+                                                           random,
+                                                           sample_attestation_data_params,
+                                                           create_mock_signed_attestation,
+                                                           is_valid):
+    state = genesis_state
+
+    # choose committee
+    slot = 0
+    shard_committee = state.shard_committees_at_slots[slot][0]
+    committee_size = len(shard_committee.committee)
+
+    # randomly select 3/4 participants from committee
+    votes_count = len(shard_committee.committee) * 3 // 4
+    voting_committee_indices = random.sample(range(committee_size), votes_count)
+    assert len(voting_committee_indices) > 0
+
+    attestation_data = AttestationData(**sample_attestation_data_params).copy(
+        slot=slot,
+        shard=shard_committee.shard,
+    )
+
+    attestation = create_mock_signed_attestation(
+        state,
+        shard_committee,
+        voting_committee_indices,
+        attestation_data,
+    )
+
+    if is_valid:
+        validate_serenity_attestation_aggregate_signature(
+            state,
+            attestation,
+            epoch_length,
+        )
+    else:
+        # mess up signature
+        attestation = attestation.copy(
+            aggregate_signature=(
+                attestation.aggregate_signature[0] + 10,
+                attestation.aggregate_signature[1] - 1
+            )
+        )
+        with pytest.raises(ValidationError):
+            validate_serenity_attestation_aggregate_signature(
+                state,
+                attestation,
+                epoch_length,
+            )

--- a/tests/eth2/beacon/state_machines/test_demo.py
+++ b/tests/eth2/beacon/state_machines/test_demo.py
@@ -1,0 +1,80 @@
+import pytest
+
+
+from eth2._utils import bls as bls
+from eth2.beacon.db.chain import BeaconChainDB
+from eth2.beacon.enums import (
+    SignatureDomain,
+)
+from eth2.beacon.helpers import (
+    get_beacon_proposer_index,
+)
+from eth2.beacon.state_machines.forks.serenity.blocks import (
+    SerenityBeaconBlock,
+)
+
+
+from eth2.beacon.types.proposal_signed_data import ProposalSignedData
+
+
+@pytest.mark.parametrize(
+    (
+        'num_validators,'
+        'epoch_length,'
+        'min_attestation_inclusion_delay,'
+        'target_committee_size,'
+        'shard_count'
+    ),
+    [
+        (10, 10, 1, 2, 2)
+    ]
+)
+def test_demo(base_db,
+              sample_beacon_block_params,
+              genesis_state,
+              fixture_sm_class,
+              config,
+              privkeys,
+              pubkeys):
+    chaindb = BeaconChainDB(base_db)
+    state = genesis_state
+    block = SerenityBeaconBlock(**sample_beacon_block_params).copy(
+        slot=state.slot + 2,
+        state_root=state.root,
+    )
+
+    # Sign block
+    beacon_proposer_index = get_beacon_proposer_index(
+        state,
+        block.slot,
+        config.EPOCH_LENGTH,
+    )
+    index_in_privkeys = pubkeys.index(
+        state.validator_registry[beacon_proposer_index].pubkey
+    )
+    beacon_proposer_privkey = privkeys[index_in_privkeys]
+    empty_signature_block_root = block.block_without_signature_root
+    proposal_root = ProposalSignedData(
+        block.slot,
+        config.BEACON_CHAIN_SHARD_NUMBER,
+        empty_signature_block_root,
+    ).root
+    block = block.copy(
+        signature=bls.sign(
+            message=proposal_root,
+            privkey=beacon_proposer_privkey,
+            domain=SignatureDomain.DOMAIN_PROPOSAL,
+        ),
+    )
+
+    # Store in chaindb
+    chaindb.persist_block(block, SerenityBeaconBlock)
+    chaindb.persist_state(state)
+
+    # Get state machine instance
+    sm = fixture_sm_class(chaindb, block.root, SerenityBeaconBlock)
+    result_state, _ = sm.import_block(block)
+
+    assert state.slot == 0
+    assert result_state.slot == block.slot
+    assert isinstance(sm.block, SerenityBeaconBlock)

--- a/tests/eth2/beacon/state_machines/test_proposer_signature_validation.py
+++ b/tests/eth2/beacon/state_machines/test_proposer_signature_validation.py
@@ -1,0 +1,98 @@
+import pytest
+
+from eth_utils import (
+    ValidationError,
+)
+
+from eth2._utils import bls
+
+from eth2.beacon.constants import (
+    GWEI_PER_ETH,
+)
+from eth2.beacon.enums import (
+    SignatureDomain,
+)
+from eth2.beacon.types.blocks import BeaconBlock
+from eth2.beacon.types.proposal_signed_data import (
+    ProposalSignedData,
+)
+from eth2.beacon.types.states import BeaconState
+
+from eth2.beacon.state_machines.forks.serenity.validation import (
+    validate_serenity_proposer_signature,
+)
+
+from tests.eth2.beacon.helpers import mock_validator_record
+from tests.eth2.beacon.test_helpers import (
+    get_sample_shard_committees_at_slots,
+)
+
+
+@pytest.mark.parametrize(
+    'proposer_privkey, proposer_pubkey, is_valid_signature',
+    (
+        (0, bls.privtopub(0), True),
+        (0, bls.privtopub(0) + 1, False),
+        (0, 123, False),
+
+        (123, bls.privtopub(123), True),
+        (123, bls.privtopub(123) + 1, False),
+        (123, 123, False),
+    )
+)
+def test_validate_serenity_proposer_signature(
+        proposer_privkey,
+        proposer_pubkey,
+        is_valid_signature,
+        sample_beacon_block_params,
+        sample_beacon_state_params,
+        sample_shard_committee_params,
+        beacon_chain_shard_number,
+        epoch_length,
+        max_deposit):
+
+    state = BeaconState(**sample_beacon_state_params).copy(
+        validator_registry=tuple(
+            mock_validator_record(proposer_pubkey)
+            for _ in range(10)
+        ),
+        validator_balances=(max_deposit * GWEI_PER_ETH,) * 10,
+        shard_committees_at_slots=get_sample_shard_committees_at_slots(
+            num_slot=128,
+            num_shard_committee_per_slot=10,
+            sample_shard_committee_params=sample_shard_committee_params,
+        ),
+    )
+
+    default_block = BeaconBlock(**sample_beacon_block_params)
+    empty_signature_block_root = default_block.block_without_signature_root
+
+    proposal_root = ProposalSignedData(
+        state.slot,
+        beacon_chain_shard_number,
+        empty_signature_block_root,
+    ).root
+
+    proposed_block = BeaconBlock(**sample_beacon_block_params).copy(
+        signature=bls.sign(
+            message=proposal_root,
+            privkey=proposer_privkey,
+            domain=SignatureDomain.DOMAIN_PROPOSAL,
+        ),
+    )
+
+    if is_valid_signature:
+        validate_serenity_proposer_signature(
+            state,
+            proposed_block,
+            beacon_chain_shard_number,
+            epoch_length,
+        )
+    else:
+        with pytest.raises(ValidationError):
+            validate_serenity_proposer_signature(
+                state,
+                proposed_block,
+                beacon_chain_shard_number,
+                epoch_length,
+            )

--- a/tests/eth2/beacon/test_aggregation.py
+++ b/tests/eth2/beacon/test_aggregation.py
@@ -1,0 +1,73 @@
+import pytest
+from hypothesis import (
+    given,
+    settings,
+    strategies as st,
+)
+
+from eth2._utils import bls
+from eth2._utils.bitfield import (
+    get_empty_bitfield,
+    has_voted,
+)
+from eth2.beacon.aggregation import (
+    aggregate_votes,
+    verify_votes,
+)
+
+
+@settings(max_examples=1)
+@given(random=st.randoms())
+@pytest.mark.parametrize(
+    (
+        'votes_count'
+    ),
+    [
+        (0),
+        (9),
+    ],
+)
+def test_aggregate_votes(votes_count, random, privkeys, pubkeys):
+    bit_count = 10
+    pre_bitfield = get_empty_bitfield(bit_count)
+    pre_sigs = ()
+    domain = 0
+
+    random_votes = random.sample(range(bit_count), votes_count)
+    message = b'hello'
+
+    # Get votes: (committee_index, sig, public_key)
+    votes = [
+        (
+            committee_index,
+            bls.sign(message, privkeys[committee_index], domain),
+            pubkeys[committee_index],
+        )
+        for committee_index in random_votes
+    ]
+
+    # Verify
+    sigs, committee_indices = verify_votes(message, votes, domain)
+
+    # Aggregate the votes
+    bitfield, sigs = aggregate_votes(
+        bitfield=pre_bitfield,
+        sigs=pre_sigs,
+        voting_sigs=sigs,
+        voting_committee_indices=committee_indices
+    )
+
+    try:
+        _, _, pubs = zip(*votes)
+    except ValueError:
+        pubs = ()
+
+    voted_index = [
+        committee_index
+        for committee_index in random_votes
+        if has_voted(bitfield, committee_index)
+    ]
+    assert len(voted_index) == len(votes)
+
+    aggregated_pubs = bls.aggregate_pubkeys(pubs)
+    assert bls.verify(message, aggregated_pubs, sigs, domain)

--- a/tests/eth2/beacon/test_beacon_validation.py
+++ b/tests/eth2/beacon/test_beacon_validation.py
@@ -1,0 +1,32 @@
+import pytest
+
+from eth_utils import (
+    ValidationError,
+)
+
+from eth2.beacon.validation import (
+    validate_slot,
+)
+
+
+@pytest.mark.parametrize(
+    "slot,is_valid",
+    (
+        (tuple(), False),
+        ([], False),
+        ({}, False),
+        (set(), False),
+        ('abc', False),
+        (1234, True),
+        (-1, False),
+        (0, True),
+        (100, True),
+        (2 ** 64, False),
+    ),
+)
+def test_validate_slot(slot, is_valid):
+    if is_valid:
+        validate_slot(slot)
+    else:
+        with pytest.raises(ValidationError):
+            validate_slot(slot)

--- a/tests/eth2/beacon/test_deposit_helpers.py
+++ b/tests/eth2/beacon/test_deposit_helpers.py
@@ -1,0 +1,171 @@
+import pytest
+
+from eth_utils import (
+    ValidationError,
+)
+
+from eth2.beacon.constants import (
+    GWEI_PER_ETH,
+)
+from eth2.beacon.deposit_helpers import (
+    add_pending_validator,
+    process_deposit,
+    validate_proof_of_possession,
+)
+from eth2.beacon.types.states import BeaconState
+from eth2.beacon.types.validator_records import ValidatorRecord
+
+from tests.eth2.beacon.helpers import (
+    make_deposit_input,
+    sign_proof_of_possession,
+)
+
+
+def test_add_pending_validator(sample_beacon_state_params,
+                               sample_validator_record_params):
+
+    validator_registry_len = 2
+    state = BeaconState(**sample_beacon_state_params).copy(
+        validator_registry=[
+            ValidatorRecord(**sample_validator_record_params)
+            for _ in range(validator_registry_len)
+        ],
+        validator_balances=(100,) * validator_registry_len,
+    )
+    validator = ValidatorRecord(**sample_validator_record_params)
+    amount = 5566
+    state = add_pending_validator(
+        state,
+        validator,
+        amount,
+    )
+
+    assert state.validator_registry[-1] == validator
+
+
+@pytest.mark.parametrize(
+    "expected",
+    (
+        (True),
+        (ValidationError),
+    ),
+)
+def test_validate_proof_of_possession(sample_beacon_state_params, pubkeys, privkeys, expected):
+    state = BeaconState(**sample_beacon_state_params)
+
+    privkey = privkeys[0]
+    pubkey = pubkeys[0]
+    withdrawal_credentials = b'\x34' * 32
+    custody_commitment = b'\x12' * 32
+    randao_commitment = b'\x56' * 32
+
+    deposit_input = make_deposit_input(
+        pubkey=pubkey,
+        withdrawal_credentials=withdrawal_credentials,
+        randao_commitment=randao_commitment,
+        custody_commitment=custody_commitment,
+    )
+    if expected is True:
+        proof_of_possession = sign_proof_of_possession(
+            deposit_input,
+            privkey,
+            state.fork_data,
+            state.slot,
+        )
+
+        validate_proof_of_possession(
+            state=state,
+            pubkey=pubkey,
+            proof_of_possession=proof_of_possession,
+            withdrawal_credentials=withdrawal_credentials,
+            randao_commitment=randao_commitment,
+            custody_commitment=custody_commitment,
+        )
+    else:
+        proof_of_possession = b'\x11' * 32
+        with pytest.raises(ValidationError):
+            validate_proof_of_possession(
+                state=state,
+                pubkey=pubkey,
+                proof_of_possession=proof_of_possession,
+                withdrawal_credentials=withdrawal_credentials,
+                randao_commitment=randao_commitment,
+                custody_commitment=custody_commitment,
+            )
+
+
+def test_process_deposit(sample_beacon_state_params,
+                         privkeys,
+                         pubkeys,
+                         max_deposit):
+    state = BeaconState(**sample_beacon_state_params).copy(
+        slot=1,
+        validator_registry=(),
+    )
+
+    privkey_1 = privkeys[0]
+    pubkey_1 = pubkeys[0]
+    amount = max_deposit * GWEI_PER_ETH
+    withdrawal_credentials = b'\x34' * 32
+    custody_commitment = b'\x11' * 32
+    randao_commitment = b'\x56' * 32
+
+    deposit_input = make_deposit_input(
+        pubkey=pubkey_1,
+        withdrawal_credentials=withdrawal_credentials,
+        randao_commitment=randao_commitment,
+        custody_commitment=custody_commitment,
+    )
+    proof_of_possession = sign_proof_of_possession(
+        deposit_input,
+        privkey_1,
+        state.fork_data,
+        state.slot,
+    )
+
+    # Add the first validator
+    result_state = process_deposit(
+        state=state,
+        pubkey=pubkey_1,
+        amount=amount,
+        proof_of_possession=proof_of_possession,
+        withdrawal_credentials=withdrawal_credentials,
+        randao_commitment=randao_commitment,
+        custody_commitment=custody_commitment,
+    )
+
+    assert len(result_state.validator_registry) == 1
+    index = 0
+    assert result_state.validator_registry[0].pubkey == pubkey_1
+    assert result_state.validator_registry[index].withdrawal_credentials == withdrawal_credentials
+    assert result_state.validator_registry[index].randao_commitment == randao_commitment
+    assert result_state.validator_balances[index] == amount
+    # test immutable
+    assert len(state.validator_registry) == 0
+
+    # Add the second validator
+    privkey_2 = privkeys[1]
+    pubkey_2 = pubkeys[1]
+    deposit_input = make_deposit_input(
+        pubkey=pubkey_2,
+        withdrawal_credentials=withdrawal_credentials,
+        randao_commitment=randao_commitment,
+        custody_commitment=custody_commitment,
+    )
+    proof_of_possession = sign_proof_of_possession(
+        deposit_input,
+        privkey_2,
+        state.fork_data,
+        state.slot,
+    )
+    result_state = process_deposit(
+        state=result_state,
+        pubkey=pubkey_2,
+        amount=amount,
+        proof_of_possession=proof_of_possession,
+        withdrawal_credentials=withdrawal_credentials,
+        randao_commitment=randao_commitment,
+        custody_commitment=custody_commitment,
+    )
+    assert len(result_state.validator_registry) == 2
+    assert result_state.validator_registry[1].pubkey == pubkey_2

--- a/tests/eth2/beacon/test_helpers.py
+++ b/tests/eth2/beacon/test_helpers.py
@@ -1,0 +1,1008 @@
+import copy
+import random
+
+import itertools
+import pytest
+
+from hypothesis import (
+    given,
+    strategies as st,
+)
+
+from eth_utils import (
+    ValidationError,
+)
+from eth_utils.toolz import assoc
+
+from eth.constants import (
+    ZERO_HASH32,
+)
+from eth2.beacon.constants import (
+    GWEI_PER_ETH,
+    FAR_FUTURE_SLOT,
+)
+from eth2.beacon.enums import (
+    SignatureDomain,
+)
+from eth2.beacon.state_machines.forks.serenity.blocks import (
+    SerenityBeaconBlock,
+)
+from eth2.beacon.types.attestation_data import (
+    AttestationData,
+)
+from eth2.beacon.types.fork_data import ForkData
+from eth2.beacon.types.shard_committees import ShardCommittee
+from eth2.beacon.types.slashable_vote_data import SlashableVoteData
+from eth2.beacon.types.states import BeaconState
+from eth2.beacon.types.validator_records import ValidatorRecord
+from eth2.beacon.helpers import (
+    _get_block_root,
+    _get_shard_committees_at_slot,
+    get_active_validator_indices,
+    get_attestation_participants,
+    get_beacon_proposer_index,
+    get_effective_balance,
+    get_domain,
+    get_fork_version,
+    get_shuffling,
+    get_block_committees_info,
+    get_pubkey_for_indices,
+    generate_aggregate_pubkeys,
+    verify_vote_count,
+    verify_slashable_vote_data_signature,
+    verify_slashable_vote_data,
+    is_double_vote,
+    is_surround_vote,
+)
+import eth2._utils.bls as bls
+
+from tests.eth2.beacon.helpers import (
+    get_pseudo_chain,
+)
+
+
+@pytest.fixture()
+def sample_block(sample_beacon_block_params):
+    return SerenityBeaconBlock(**sample_beacon_block_params)
+
+
+@pytest.fixture()
+def sample_state(sample_beacon_state_params):
+    return BeaconState(**sample_beacon_state_params)
+
+
+def get_sample_shard_committees_at_slots(num_slot,
+                                         num_shard_committee_per_slot,
+                                         sample_shard_committee_params):
+
+    return tuple(
+        [
+            [
+                ShardCommittee(**sample_shard_committee_params)
+                for _ in range(num_shard_committee_per_slot)
+            ]
+            for _ in range(num_slot)
+        ]
+    )
+
+
+def generate_mock_latest_block_roots(
+        genesis_block,
+        current_slot,
+        epoch_length,
+        latest_block_roots_length):
+    assert current_slot < latest_block_roots_length
+
+    chain_length = (current_slot // epoch_length + 1) * epoch_length
+    blocks = get_pseudo_chain(chain_length, genesis_block)
+    latest_block_roots = [
+        block.hash
+        for block in blocks[:current_slot]
+    ] + [
+        ZERO_HASH32
+        for _ in range(latest_block_roots_length - current_slot)
+    ]
+    return blocks, latest_block_roots
+
+
+#
+# Get block rootes
+#
+@pytest.mark.parametrize(
+    (
+        'current_slot,target_slot,success'
+    ),
+    [
+        (10, 0, True),
+        (10, 9, True),
+        (10, 10, False),
+        (128, 0, True),
+        (128, 127, True),
+        (128, 128, False),
+    ],
+)
+def test_get_block_root(current_slot,
+                        target_slot,
+                        success,
+                        epoch_length,
+                        latest_block_roots_length,
+                        sample_block):
+    blocks, latest_block_roots = generate_mock_latest_block_roots(
+        sample_block,
+        current_slot,
+        epoch_length,
+        latest_block_roots_length,
+    )
+
+    if success:
+        block_root = _get_block_root(
+            latest_block_roots,
+            current_slot,
+            target_slot,
+            latest_block_roots_length,
+        )
+        assert block_root == blocks[target_slot].root
+    else:
+        with pytest.raises(ValidationError):
+            _get_block_root(
+                latest_block_roots,
+                current_slot,
+                target_slot,
+                latest_block_roots_length,
+            )
+
+
+#
+# Get shards_committees or indices
+#
+@pytest.mark.parametrize(
+    (
+        'num_validators,'
+        'epoch_length,'
+        'state_slot,'
+        'num_slot,'
+        'num_shard_committee_per_slot,'
+        'slot,'
+        'success'
+    ),
+    [
+        (
+            100,
+            64,
+            0,
+            128,
+            10,
+            0,
+            True,
+        ),
+        (
+            100,
+            64,
+            64,
+            128,
+            10,
+            64,
+            True,
+        ),
+        (
+            100,
+            64,
+            1,
+            128,
+            10,
+            1,
+            True,
+        ),
+        # slot is too small
+        (
+            100,
+            64,
+            128,
+            128,
+            10,
+            0,
+            False,
+        ),
+        # slot is too large
+        (
+            100,
+            64,
+            0,
+            128,
+            10,
+            64,
+            False,
+        ),
+    ],
+)
+def test_get_shard_committees_at_slot(
+        num_validators,
+        epoch_length,
+        state_slot,
+        num_slot,
+        num_shard_committee_per_slot,
+        slot,
+        success,
+        sample_shard_committee_params):
+
+    shard_committees_at_slots = get_sample_shard_committees_at_slots(
+        num_slot,
+        num_shard_committee_per_slot,
+        sample_shard_committee_params
+    )
+
+    if success:
+        shard_committees = _get_shard_committees_at_slot(
+            state_slot=state_slot,
+            shard_committees_at_slots=shard_committees_at_slots,
+            slot=slot,
+            epoch_length=epoch_length,
+        )
+        assert len(shard_committees) > 0
+        assert len(shard_committees[0].committee) > 0
+    else:
+        with pytest.raises(ValidationError):
+            _get_shard_committees_at_slot(
+                state_slot=state_slot,
+                shard_committees_at_slots=shard_committees_at_slots,
+                slot=slot,
+                epoch_length=epoch_length,
+            )
+
+
+#
+# Shuffling
+#
+@pytest.mark.parametrize(
+    (
+        'num_validators,'
+        'epoch_length,'
+        'target_committee_size,'
+        'shard_count,'
+        'slot'
+    ),
+    [
+        (1000, 20, 10, 100, 0),
+        (1000, 20, 10, 100, 5),
+        (1000, 20, 10, 100, 30),
+        (20, 10, 3, 10, 0),  # active_validators_size < epoch_length * target_committee_size
+        (20, 10, 3, 10, 5),
+        (20, 10, 3, 10, 30),
+    ],
+)
+def test_get_shuffling_is_complete(activated_genesis_validators,
+                                   epoch_length,
+                                   target_committee_size,
+                                   shard_count,
+                                   slot):
+    shuffling = get_shuffling(
+        seed=b'\x35' * 32,
+        validators=activated_genesis_validators,
+        crosslinking_start_shard=0,
+        slot=slot,
+        epoch_length=epoch_length,
+        target_committee_size=target_committee_size,
+        shard_count=shard_count,
+    )
+
+    assert len(shuffling) == epoch_length
+    validators = set()
+    shards = set()
+    for slot_indices in shuffling:
+        for shard_committee in slot_indices:
+            shards.add(shard_committee.shard)
+            for validator_index in shard_committee.committee:
+                validators.add(validator_index)
+
+    assert len(activated_genesis_validators) > 0
+    assert len(validators) == len(activated_genesis_validators)
+
+
+@pytest.mark.parametrize(
+    (
+        'num_validators,'
+        'epoch_length,'
+        'target_committee_size,'
+        'shard_count'
+    ),
+    [
+        (1000, 20, 10, 100),
+        (100, 50, 10, 10),
+        (20, 10, 3, 10),
+    ],
+)
+def test_get_shuffling_handles_shard_wrap(activated_genesis_validators,
+                                          epoch_length,
+                                          target_committee_size,
+                                          shard_count):
+    shuffling = get_shuffling(
+        seed=b'\x35' * 32,
+        validators=activated_genesis_validators,
+        crosslinking_start_shard=shard_count - 1,
+        slot=0,
+        epoch_length=epoch_length,
+        target_committee_size=target_committee_size,
+        shard_count=shard_count,
+    )
+
+    # shard assignments should wrap around to 0 rather than continuing to SHARD_COUNT
+    for slot_indices in shuffling:
+        for shard_committee in slot_indices:
+            assert shard_committee.shard < shard_count
+
+
+#
+# Get proposer postition
+#
+@pytest.mark.parametrize(
+    (
+        'num_validators,committee,parent_block_number,result_proposer_index'
+    ),
+    [
+        (100, [4, 5, 6, 7], 0, 4),
+        (100, [4, 5, 6, 7], 2, 6),
+        (100, [4, 5, 6, 7], 11, 7),
+        (100, [], 1, ValidationError()),
+    ],
+)
+def test_get_block_committees_info(monkeypatch,
+                                   sample_block,
+                                   sample_state,
+                                   num_validators,
+                                   committee,
+                                   parent_block_number,
+                                   result_proposer_index,
+                                   epoch_length):
+    from eth2.beacon import helpers
+
+    def mock_get_shard_committees_at_slot(state,
+                                          slot,
+                                          epoch_length):
+        return (
+            ShardCommittee(
+                shard=1,
+                committee=committee,
+                total_validator_count=num_validators,
+            ),
+        )
+
+    monkeypatch.setattr(
+        helpers,
+        'get_shard_committees_at_slot',
+        mock_get_shard_committees_at_slot
+    )
+
+    parent_block = sample_block
+    parent_block = sample_block.copy(
+        slot=parent_block_number,
+    )
+
+    if isinstance(result_proposer_index, Exception):
+        with pytest.raises(ValidationError):
+            get_block_committees_info(
+                parent_block,
+                sample_state,
+                epoch_length,
+            )
+    else:
+        block_committees_info = get_block_committees_info(
+            parent_block,
+            sample_state,
+            epoch_length,
+        )
+        assert (
+            block_committees_info.proposer_index ==
+            result_proposer_index
+        )
+
+
+@pytest.mark.parametrize(
+    (
+        'num_validators,'
+        'epoch_length,'
+        'committee,'
+        'slot,'
+        'success,'
+    ),
+    [
+        (
+            100,
+            64,
+            (10, 11, 12),
+            0,
+            True,
+        ),
+        (
+            100,
+            64,
+            (),
+            0,
+            False,
+        ),
+    ]
+)
+def test_get_beacon_proposer_index(
+        monkeypatch,
+        num_validators,
+        epoch_length,
+        committee,
+        slot,
+        success,
+        sample_state):
+
+    from eth2.beacon import helpers
+
+    def mock_get_shard_committees_at_slot(state,
+                                          slot,
+                                          epoch_length):
+        return (
+            ShardCommittee(
+                shard=1,
+                committee=committee,
+                total_validator_count=num_validators,
+            ),
+        )
+
+    monkeypatch.setattr(
+        helpers,
+        'get_shard_committees_at_slot',
+        mock_get_shard_committees_at_slot
+    )
+    if success:
+        proposer_index = get_beacon_proposer_index(
+            sample_state,
+            slot,
+            epoch_length
+        )
+        assert proposer_index == committee[slot % len(committee)]
+    else:
+        with pytest.raises(ValidationError):
+            get_beacon_proposer_index(
+                sample_state,
+                slot,
+                epoch_length
+            )
+
+
+def test_get_active_validator_indices(sample_validator_record_params):
+    current_slot = 1
+    # 3 validators are ACTIVE
+    validators = [
+        ValidatorRecord(
+            **sample_validator_record_params,
+        ).copy(
+            activation_slot=0,
+            exit_slot=FAR_FUTURE_SLOT,
+        )
+        for i in range(3)
+    ]
+    active_validator_indices = get_active_validator_indices(validators, current_slot)
+    assert len(active_validator_indices) == 3
+
+    validators[0] = validators[0].copy(
+        activation_slot=current_slot + 1,  # activation_slot > current_slot
+    )
+    active_validator_indices = get_active_validator_indices(validators, current_slot)
+    assert len(active_validator_indices) == 2
+
+
+@pytest.mark.parametrize(
+    (
+        'num_validators,'
+        'epoch_length,'
+        'committee,'
+        'participation_bitfield,'
+        'expected'
+    ),
+    [
+        (
+            100,
+            64,
+            (10, 11, 12),
+            b'\00',
+            (),
+        ),
+        (
+            100,
+            64,
+            (10, 11, 12),
+            b'\x80',
+            (10,),
+        ),
+        (
+            100,
+            64,
+            (10, 11, 12),
+            b'\xc0',
+            (10, 11),
+        ),
+        (
+            100,
+            64,
+            (10, 11, 12),
+            b'\x00\x00',
+            ValueError(),
+        ),
+    ]
+)
+def test_get_attestation_participants(
+        monkeypatch,
+        num_validators,
+        epoch_length,
+        committee,
+        participation_bitfield,
+        expected,
+        sample_state):
+    from eth2.beacon import helpers
+
+    def mock_get_shard_committees_at_slot(state,
+                                          slot,
+                                          epoch_length):
+        return (
+            ShardCommittee(
+                shard=0,
+                committee=committee,
+                total_validator_count=num_validators,
+            ),
+        )
+
+    monkeypatch.setattr(
+        helpers,
+        'get_shard_committees_at_slot',
+        mock_get_shard_committees_at_slot
+    )
+
+    if isinstance(expected, Exception):
+        with pytest.raises(ValidationError):
+            get_attestation_participants(
+                state=sample_state,
+                slot=0,
+                shard=0,
+                participation_bitfield=participation_bitfield,
+                epoch_length=epoch_length,
+            )
+    else:
+        result = get_attestation_participants(
+            state=sample_state,
+            slot=0,
+            shard=0,
+            participation_bitfield=participation_bitfield,
+            epoch_length=epoch_length,
+        )
+
+        assert result == expected
+
+
+@pytest.mark.parametrize(
+    (
+        'balance,'
+        'max_deposit,'
+        'expected'
+    ),
+    [
+        (
+            1 * GWEI_PER_ETH,
+            32,
+            1 * GWEI_PER_ETH,
+        ),
+        (
+            32 * GWEI_PER_ETH,
+            32,
+            32 * GWEI_PER_ETH,
+        ),
+        (
+            33 * GWEI_PER_ETH,
+            32,
+            32 * GWEI_PER_ETH,
+        )
+    ]
+)
+def test_get_effective_balance(balance, max_deposit, expected, sample_validator_record_params):
+    balances = (balance,)
+    result = get_effective_balance(balances, 0, max_deposit)
+    assert result == expected
+
+
+@pytest.mark.parametrize(
+    (
+        'pre_fork_version,'
+        'post_fork_version,'
+        'fork_slot,'
+        'current_slot,'
+        'expected'
+    ),
+    [
+        (0, 0, 0, 0, 0),
+        (0, 0, 0, 1, 0),
+        (0, 1, 20, 10, 0),
+        (0, 1, 20, 20, 1),
+        (0, 1, 10, 20, 1),
+    ]
+)
+def test_get_fork_version(pre_fork_version,
+                          post_fork_version,
+                          fork_slot,
+                          current_slot,
+                          expected):
+    fork_data = ForkData(
+        pre_fork_version=pre_fork_version,
+        post_fork_version=post_fork_version,
+        fork_slot=fork_slot,
+    )
+    assert expected == get_fork_version(
+        fork_data,
+        current_slot,
+    )
+
+
+@pytest.mark.parametrize(
+    (
+        'pre_fork_version,'
+        'post_fork_version,'
+        'fork_slot,'
+        'current_slot,'
+        'domain_type,'
+        'expected'
+    ),
+    [
+        (1, 2, 20, 10, 10, 1 * 2 ** 32 + 10),
+        (1, 2, 20, 20, 11, 2 * 2 ** 32 + 11),
+        (1, 2, 10, 20, 12, 2 * 2 ** 32 + 12),
+    ]
+)
+def test_get_domain(pre_fork_version,
+                    post_fork_version,
+                    fork_slot,
+                    current_slot,
+                    domain_type,
+                    expected):
+    fork_data = ForkData(
+        pre_fork_version=pre_fork_version,
+        post_fork_version=post_fork_version,
+        fork_slot=fork_slot,
+    )
+    assert expected == get_domain(
+        fork_data=fork_data,
+        slot=current_slot,
+        domain_type=domain_type,
+    )
+
+
+def _generate_some_indices(data, max_value_for_list):
+    """
+    Hypothesis helper that generates a list of some integers [0, `max_value_for_list`].
+    The usage is to randomly sample some elements from a sequence of some element.
+    """
+    return data.draw(
+        st.lists(
+            st.integers(
+                min_value=0,
+                max_value=max_value_for_list,
+            ),
+        )
+    )
+
+
+@given(st.data())
+def test_get_pubkey_for_indices(activated_genesis_validators, data):
+    max_value_for_list = len(activated_genesis_validators) - 1
+    indices = _generate_some_indices(data, max_value_for_list)
+    pubkeys = get_pubkey_for_indices(activated_genesis_validators, indices)
+
+    assert len(indices) == len(pubkeys)
+
+    for index, pubkey in enumerate(pubkeys):
+        validator_index = indices[index]
+        assert activated_genesis_validators[validator_index].pubkey == pubkey
+
+
+def _list_and_index(data, max_size=None, elements=st.integers()):
+    '''
+    Hypothesis helper function cribbed from their docs on @composite
+    '''
+    xs = data.draw(st.lists(elements, max_size=max_size))
+    i = data.draw(st.integers(min_value=0, max_value=max(len(xs) - 1, 0)))
+    return (xs, i)
+
+
+@given(st.data())
+def test_generate_aggregate_pubkeys(activated_genesis_validators,
+                                    sample_slashable_vote_data_params,
+                                    data):
+    max_value_for_list = len(activated_genesis_validators) - 1
+    (indices, some_index) = _list_and_index(
+        data,
+        elements=st.integers(
+            min_value=0,
+            max_value=max_value_for_list,
+        )
+    )
+    custody_bit_0_indices = indices[:some_index]
+    custody_bit_1_indices = indices[some_index:]
+
+    key = "custody_bit_0_indices"
+    sample_slashable_vote_data_params[key] = custody_bit_0_indices
+    key = "custody_bit_1_indices"
+    sample_slashable_vote_data_params[key] = custody_bit_1_indices
+
+    votes = SlashableVoteData(**sample_slashable_vote_data_params)
+
+    keys = generate_aggregate_pubkeys(activated_genesis_validators, votes)
+    assert len(keys) == 2
+
+    (poc_0_key, poc_1_key) = keys
+
+    poc_0_keys = get_pubkey_for_indices(activated_genesis_validators, custody_bit_0_indices)
+    poc_1_keys = get_pubkey_for_indices(activated_genesis_validators, custody_bit_1_indices)
+
+    assert bls.aggregate_pubkeys(poc_0_keys) == poc_0_key
+    assert bls.aggregate_pubkeys(poc_1_keys) == poc_1_key
+
+
+@given(st.data())
+def test_verify_vote_count(max_casper_votes, sample_slashable_vote_data_params, data):
+    (indices, some_index) = _list_and_index(data, max_size=max_casper_votes)
+    custody_bit_0_indices = indices[:some_index]
+    custody_bit_1_indices = indices[some_index:]
+
+    key = "custody_bit_0_indices"
+    sample_slashable_vote_data_params[key] = custody_bit_0_indices
+    key = "custody_bit_1_indices"
+    sample_slashable_vote_data_params[key] = custody_bit_1_indices
+
+    votes = SlashableVoteData(**sample_slashable_vote_data_params)
+
+    assert verify_vote_count(votes, max_casper_votes)
+
+
+def _get_indices_and_signatures(num_validators, message, privkeys, fork_data, slot):
+    num_indices = 5
+    assert num_validators >= num_indices
+    indices = random.sample(range(num_validators), num_indices)
+    privkeys = [privkeys[i] for i in indices]
+    domain_type = SignatureDomain.DOMAIN_ATTESTATION
+    domain = get_domain(
+        fork_data=fork_data,
+        slot=slot,
+        domain_type=domain_type,
+    )
+    signatures = tuple(
+        map(lambda key: bls.sign(message, key, domain), privkeys)
+    )
+    return (indices, signatures)
+
+
+def _correct_slashable_vote_data_params(num_validators, params, messages, privkeys, fork_data):
+    valid_params = copy.deepcopy(params)
+
+    key = "custody_bit_0_indices"
+    (poc_0_indices, poc_0_signatures) = _get_indices_and_signatures(
+        num_validators,
+        messages[0],
+        privkeys,
+        fork_data,
+        params["data"].slot,
+    )
+    valid_params[key] = poc_0_indices
+
+    key = "custody_bit_1_indices"
+    # NOTE: does not guarantee non-empty intersection
+    (poc_1_indices, poc_1_signatures) = _get_indices_and_signatures(
+        num_validators,
+        messages[1],
+        privkeys,
+        fork_data,
+        params["data"].slot,
+    )
+    valid_params[key] = poc_1_indices
+
+    signatures = poc_0_signatures + poc_1_signatures
+    aggregate_signature = bls.aggregate_signatures(signatures)
+
+    valid_params["aggregate_signature"] = aggregate_signature
+
+    return valid_params
+
+
+def _corrupt_signature(params, fork_data):
+    message = bytes.fromhex("deadbeefcafe")
+    privkey = 42
+    domain_type = SignatureDomain.DOMAIN_ATTESTATION
+    domain = get_domain(
+        fork_data=fork_data,
+        slot=params["data"].slot,
+        domain_type=domain_type,
+    )
+    corrupt_signature = bls.sign(message, privkey, domain)
+
+    return assoc(params, "aggregate_signature", corrupt_signature)
+
+
+def _corrupt_vote_count(params):
+    key = "custody_bit_0_indices"
+    for i in itertools.count():
+        if i not in params[key]:
+            new_vote_count = params[key] + [i]
+            return assoc(
+                params,
+                key,
+                new_vote_count,
+            )
+    else:
+        raise Exception("Unreachable code path")
+
+
+def _create_slashable_vote_data_messages(params):
+    # TODO update when we move to `ssz` tree hash
+    votes = SlashableVoteData(**params)
+    return votes.messages
+
+
+@pytest.mark.parametrize(
+    (
+        'num_validators',
+    ),
+    [
+        (40,),
+    ]
+)
+def test_verify_slashable_vote_data_signature(num_validators,
+                                              privkeys,
+                                              sample_beacon_state_params,
+                                              activated_genesis_validators,
+                                              genesis_balances,
+                                              sample_slashable_vote_data_params,
+                                              sample_fork_data_params):
+    state = BeaconState(**sample_beacon_state_params).copy(
+        validator_registry=activated_genesis_validators,
+        validator_balances=genesis_balances,
+        fork_data=ForkData(**sample_fork_data_params),
+    )
+
+    # NOTE: we can do this before "correcting" the params as they
+    # touch disjoint subsets of the provided params
+    messages = _create_slashable_vote_data_messages(sample_slashable_vote_data_params)
+
+    valid_params = _correct_slashable_vote_data_params(
+        num_validators,
+        sample_slashable_vote_data_params,
+        messages,
+        privkeys,
+        state.fork_data,
+    )
+    valid_votes = SlashableVoteData(**valid_params)
+    assert verify_slashable_vote_data_signature(state, valid_votes)
+
+    invalid_params = _corrupt_signature(valid_params, state.fork_data)
+    invalid_votes = SlashableVoteData(**invalid_params)
+    assert not verify_slashable_vote_data_signature(state, invalid_votes)
+
+
+def _run_verify_slashable_vote(params, state, max_casper_votes, should_succeed):
+    votes = SlashableVoteData(**params)
+    result = verify_slashable_vote_data(state, votes, max_casper_votes)
+    if should_succeed:
+        assert result
+    else:
+        assert not result
+
+
+@pytest.mark.parametrize(
+    (
+        'num_validators',
+    ),
+    [
+        (40,),
+    ]
+)
+@pytest.mark.parametrize(
+    (
+        'param_mapper',
+        'should_succeed',
+        'needs_fork_data',
+    ),
+    [
+        (lambda params: params, True, False),
+        (_corrupt_vote_count, False, False),
+        (_corrupt_signature, False, True),
+        (lambda params, fork_data: _corrupt_vote_count(
+            _corrupt_signature(params, fork_data)
+        ), False, True),
+    ],
+)
+def test_verify_slashable_vote_data(num_validators,
+                                    param_mapper,
+                                    should_succeed,
+                                    needs_fork_data,
+                                    privkeys,
+                                    sample_beacon_state_params,
+                                    activated_genesis_validators,
+                                    genesis_balances,
+                                    sample_slashable_vote_data_params,
+                                    sample_fork_data_params,
+                                    max_casper_votes):
+    state = BeaconState(**sample_beacon_state_params).copy(
+        validator_registry=activated_genesis_validators,
+        validator_balances=genesis_balances,
+        fork_data=ForkData(**sample_fork_data_params),
+    )
+
+    # NOTE: we can do this before "correcting" the params as they
+    # touch disjoint subsets of the provided params
+    messages = _create_slashable_vote_data_messages(sample_slashable_vote_data_params)
+
+    params = _correct_slashable_vote_data_params(
+        num_validators,
+        sample_slashable_vote_data_params,
+        messages,
+        privkeys,
+        state.fork_data,
+    )
+    if needs_fork_data:
+        params = param_mapper(params, state.fork_data)
+    else:
+        params = param_mapper(params)
+    _run_verify_slashable_vote(params, state, max_casper_votes, should_succeed)
+
+
+def test_is_double_vote(sample_attestation_data_params):
+    attestation_data_1_params = {
+        **sample_attestation_data_params,
+        'slot': 12345,
+    }
+    attestation_data_1 = AttestationData(**attestation_data_1_params)
+
+    attestation_data_2_params = {
+        **sample_attestation_data_params,
+        'slot': 12345,
+    }
+    attestation_data_2 = AttestationData(**attestation_data_2_params)
+
+    assert is_double_vote(attestation_data_1, attestation_data_2)
+
+    attestation_data_3_params = {
+        **sample_attestation_data_params,
+        'slot': 54321,
+    }
+    attestation_data_3 = AttestationData(**attestation_data_3_params)
+
+    assert not is_double_vote(attestation_data_1, attestation_data_3)
+
+
+@pytest.mark.parametrize(
+    (
+        'attestation_1_slot,'
+        'attestation_1_justified_slot,'
+        'attestation_2_slot,'
+        'attestation_2_justified_slot,'
+        'expected'
+    ),
+    [
+        (0, 0, 0, 0, False),
+        (4, 3, 3, 2, False),  # not (attestation_1_justified_slot < attestation_2_justified_slot
+        (4, 0, 3, 1, False),  # not (attestation_2_justified_slot + 1 == attestation_2_slot)
+        (4, 0, 4, 3, False),  # not (attestation_2_slot < attestation_1_slot)
+        (4, 0, 3, 2, True),
+    ],
+)
+def test_is_surround_vote(sample_attestation_data_params,
+                          attestation_1_slot,
+                          attestation_1_justified_slot,
+                          attestation_2_slot,
+                          attestation_2_justified_slot,
+                          expected):
+    attestation_data_1_params = {
+        **sample_attestation_data_params,
+        'slot': attestation_1_slot,
+        'justified_slot': attestation_1_justified_slot,
+    }
+    attestation_data_1 = AttestationData(**attestation_data_1_params)
+
+    attestation_data_2_params = {
+        **sample_attestation_data_params,
+        'slot': attestation_2_slot,
+        'justified_slot': attestation_2_justified_slot,
+    }
+    attestation_data_2 = AttestationData(**attestation_data_2_params)
+
+    assert is_surround_vote(attestation_data_1, attestation_data_2) == expected

--- a/tests/eth2/beacon/types/test_attestation.py
+++ b/tests/eth2/beacon/types/test_attestation.py
@@ -1,0 +1,18 @@
+import pytest
+
+from eth2.beacon.types.attestations import (
+    Attestation,
+)
+
+
+@pytest.mark.parametrize(
+    'param,default_value',
+    [
+        ('aggregate_signature', (0, 0)),
+    ]
+)
+def test_defaults(param, default_value, sample_attestation_params):
+    del sample_attestation_params[param]
+    attestation = Attestation(**sample_attestation_params)
+
+    assert getattr(attestation, param) == default_value

--- a/tests/eth2/beacon/types/test_attestation_data.py
+++ b/tests/eth2/beacon/types/test_attestation_data.py
@@ -1,0 +1,9 @@
+from eth2.beacon.types.attestation_data import (
+    AttestationData,
+)
+
+
+def test_defaults(sample_attestation_data_params):
+    attestation_data = AttestationData(**sample_attestation_data_params)
+
+    assert attestation_data.slot == sample_attestation_data_params['slot']

--- a/tests/eth2/beacon/types/test_attestation_data_and_custody_bit.py
+++ b/tests/eth2/beacon/types/test_attestation_data_and_custody_bit.py
@@ -1,0 +1,11 @@
+from eth2.beacon.types.attestation_data_and_custody_bits import (
+    AttestationDataAndCustodyBit,
+)
+
+
+def test_defaults(sample_attestation_data_and_custody_bit_params):
+    params = sample_attestation_data_and_custody_bit_params
+    attestation_data_and_custody_bit = AttestationDataAndCustodyBit(**params)
+
+    assert attestation_data_and_custody_bit.data == params['data']
+    assert attestation_data_and_custody_bit.custody_bit == params['custody_bit']

--- a/tests/eth2/beacon/types/test_block.py
+++ b/tests/eth2/beacon/types/test_block.py
@@ -1,0 +1,26 @@
+from eth2.beacon.state_machines.forks.serenity.blocks import (
+    SerenityBeaconBlock,
+)
+from eth2.beacon.types.attestations import (
+    Attestation,
+)
+
+
+def test_defaults(sample_beacon_block_params):
+    block = SerenityBeaconBlock(**sample_beacon_block_params)
+    assert block.slot == sample_beacon_block_params['slot']
+    assert len(block.body.custody_challenges) == 0
+
+
+def test_update_attestations(sample_attestation_params, sample_beacon_block_params):
+    block = SerenityBeaconBlock(**sample_beacon_block_params)
+    attestations = block.body.attestations
+    attestations = list(attestations)
+    attestations.append(Attestation(**sample_attestation_params))
+    body2 = block.body.copy(
+        attestations=attestations
+    )
+    block2 = block.copy(
+        body=body2
+    )
+    assert block2.num_attestations == 1

--- a/tests/eth2/beacon/types/test_candidate_pow_receipt_root_record.py
+++ b/tests/eth2/beacon/types/test_candidate_pow_receipt_root_record.py
@@ -1,0 +1,11 @@
+from eth2.beacon.types.candidate_pow_receipt_root_records import (
+    CandidatePoWReceiptRootRecord,
+)
+
+
+def test_defaults(sample_candidate_pow_receipt_root_record_params):
+    candidate_pow_receipt_roots = CandidatePoWReceiptRootRecord(
+        **sample_candidate_pow_receipt_root_record_params
+    )
+    assert candidate_pow_receipt_roots.candidate_pow_receipt_root == sample_candidate_pow_receipt_root_record_params['candidate_pow_receipt_root']  # noqa: E501
+    assert candidate_pow_receipt_roots.votes == sample_candidate_pow_receipt_root_record_params['votes']  # noqa: E501

--- a/tests/eth2/beacon/types/test_casper_slashings.py
+++ b/tests/eth2/beacon/types/test_casper_slashings.py
@@ -1,0 +1,16 @@
+from eth2.beacon.types.casper_slashings import CasperSlashing
+
+
+def test_defaults(sample_casper_slashing_params):
+    slashing = CasperSlashing(**sample_casper_slashing_params)
+
+    assert (slashing.slashable_vote_data_1
+            .custody_bit_0_indices ==
+            sample_casper_slashing_params['slashable_vote_data_1']
+            .custody_bit_0_indices
+            )
+    assert (slashing.slashable_vote_data_2
+            .custody_bit_1_indices ==
+            sample_casper_slashing_params['slashable_vote_data_2']
+            .custody_bit_1_indices
+            )

--- a/tests/eth2/beacon/types/test_crosslink_record.py
+++ b/tests/eth2/beacon/types/test_crosslink_record.py
@@ -1,0 +1,9 @@
+from eth2.beacon.types.crosslink_records import (
+    CrosslinkRecord,
+)
+
+
+def test_defaults(sample_crosslink_record_params):
+    crosslink = CrosslinkRecord(**sample_crosslink_record_params)
+    assert crosslink.slot == sample_crosslink_record_params['slot']
+    assert crosslink.shard_block_root == sample_crosslink_record_params['shard_block_root']

--- a/tests/eth2/beacon/types/test_deposit_data.py
+++ b/tests/eth2/beacon/types/test_deposit_data.py
@@ -1,0 +1,9 @@
+from eth2.beacon.types.deposit_data import DepositData
+
+
+def test_defaults(sample_deposit_data_params):
+    deposit_data = DepositData(**sample_deposit_data_params)
+
+    assert deposit_data.deposit_input.pubkey == sample_deposit_data_params['deposit_input'].pubkey
+    assert deposit_data.amount == sample_deposit_data_params['amount']
+    assert deposit_data.timestamp == sample_deposit_data_params['timestamp']

--- a/tests/eth2/beacon/types/test_deposit_input.py
+++ b/tests/eth2/beacon/types/test_deposit_input.py
@@ -1,0 +1,7 @@
+from eth2.beacon.types.deposit_input import DepositInput
+
+
+def test_defaults(sample_deposit_input_params):
+    deposit_input = DepositInput(**sample_deposit_input_params)
+
+    assert deposit_input.pubkey == sample_deposit_input_params['pubkey']

--- a/tests/eth2/beacon/types/test_deposits.py
+++ b/tests/eth2/beacon/types/test_deposits.py
@@ -1,0 +1,7 @@
+from eth2.beacon.types.deposits import Deposit
+
+
+def test_defaults(sample_deposit_params):
+    deposit = Deposit(**sample_deposit_params)
+
+    assert deposit.deposit_data.timestamp == sample_deposit_params['deposit_data'].timestamp

--- a/tests/eth2/beacon/types/test_exits.py
+++ b/tests/eth2/beacon/types/test_exits.py
@@ -1,0 +1,10 @@
+
+from eth2.beacon.types.exits import (
+    Exit,
+)
+
+
+def test_defaults(sample_exit_params):
+    exit = Exit(**sample_exit_params)
+
+    assert exit.signature[0] == sample_exit_params['signature'][0]

--- a/tests/eth2/beacon/types/test_fork_data.py
+++ b/tests/eth2/beacon/types/test_fork_data.py
@@ -1,0 +1,10 @@
+from eth2.beacon.types.fork_data import (
+    ForkData,
+)
+
+
+def test_defaults(sample_fork_data_params):
+    fork_data = ForkData(**sample_fork_data_params)
+    assert fork_data.pre_fork_version == sample_fork_data_params['pre_fork_version']
+    assert fork_data.post_fork_version == sample_fork_data_params['post_fork_version']
+    assert fork_data.fork_slot == sample_fork_data_params['fork_slot']

--- a/tests/eth2/beacon/types/test_pending_attestation_record.py
+++ b/tests/eth2/beacon/types/test_pending_attestation_record.py
@@ -1,0 +1,12 @@
+from eth2.beacon.types.pending_attestation_records import (
+    PendingAttestationRecord,
+)
+
+
+def test_defaults(sample_pending_attestation_record_params):
+    pending_attestation = PendingAttestationRecord(**sample_pending_attestation_record_params)
+
+    assert pending_attestation.data == sample_pending_attestation_record_params['data']
+    assert pending_attestation.participation_bitfield == sample_pending_attestation_record_params['participation_bitfield']  # noqa: E501
+    assert pending_attestation.custody_bitfield == sample_pending_attestation_record_params['custody_bitfield']  # noqa: E501
+    assert pending_attestation.slot_included == sample_pending_attestation_record_params['slot_included']  # noqa: E501

--- a/tests/eth2/beacon/types/test_proposal_signed_data.py
+++ b/tests/eth2/beacon/types/test_proposal_signed_data.py
@@ -1,0 +1,10 @@
+from eth2.beacon.types.proposal_signed_data import (
+    ProposalSignedData,
+)
+
+
+def test_defaults(sample_proposal_signed_data_params):
+    proposal_signed_data = ProposalSignedData(**sample_proposal_signed_data_params)
+    assert proposal_signed_data.slot == sample_proposal_signed_data_params['slot']
+    assert proposal_signed_data.shard == sample_proposal_signed_data_params['shard']
+    assert proposal_signed_data.block_root == sample_proposal_signed_data_params['block_root']

--- a/tests/eth2/beacon/types/test_proposer_slashings.py
+++ b/tests/eth2/beacon/types/test_proposer_slashings.py
@@ -1,0 +1,13 @@
+
+from eth2.beacon.types.proposer_slashings import (
+    ProposerSlashing,
+)
+
+
+def test_defaults(sample_proposer_slashing_params):
+    slashing = ProposerSlashing(**sample_proposer_slashing_params)
+    assert slashing.proposer_index == sample_proposer_slashing_params['proposer_index']
+    assert slashing.proposal_data_1 == sample_proposer_slashing_params['proposal_data_1']
+    assert slashing.proposal_signature_1 == sample_proposer_slashing_params['proposal_signature_1']
+    assert slashing.proposal_data_2 == sample_proposer_slashing_params['proposal_data_2']
+    assert slashing.proposal_signature_2 == sample_proposer_slashing_params['proposal_signature_2']

--- a/tests/eth2/beacon/types/test_shard_committee.py
+++ b/tests/eth2/beacon/types/test_shard_committee.py
@@ -1,0 +1,10 @@
+from eth2.beacon.types.shard_committees import (
+    ShardCommittee,
+)
+
+
+def test_defaults(sample_shard_committee_params):
+    shard_committee = ShardCommittee(**sample_shard_committee_params)
+    assert shard_committee.shard == sample_shard_committee_params['shard']
+    assert shard_committee.committee == sample_shard_committee_params['committee']
+    assert shard_committee.total_validator_count == sample_shard_committee_params['total_validator_count']  # noqa: E501

--- a/tests/eth2/beacon/types/test_shard_reassignment_record.py
+++ b/tests/eth2/beacon/types/test_shard_reassignment_record.py
@@ -1,0 +1,10 @@
+from eth2.beacon.types.shard_reassignment_records import (
+    ShardReassignmentRecord,
+)
+
+
+def test_defaults(sample_shard_reassignment_record):
+    shard_reassignment = ShardReassignmentRecord(**sample_shard_reassignment_record)
+    assert shard_reassignment.validator_index == sample_shard_reassignment_record['validator_index']
+    assert shard_reassignment.shard == sample_shard_reassignment_record['shard']
+    assert shard_reassignment.slot == sample_shard_reassignment_record['slot']

--- a/tests/eth2/beacon/types/test_slashable_vote_data.py
+++ b/tests/eth2/beacon/types/test_slashable_vote_data.py
@@ -1,0 +1,59 @@
+from eth2.beacon.types.attestation_data_and_custody_bits import (
+    AttestationDataAndCustodyBit,
+)
+from eth2.beacon.types.slashable_vote_data import (
+    SlashableVoteData,
+)
+
+
+def test_defaults(sample_slashable_vote_data_params):
+    vote_data = SlashableVoteData(**sample_slashable_vote_data_params)
+
+    assert (vote_data.custody_bit_0_indices ==
+            sample_slashable_vote_data_params['custody_bit_0_indices'])
+    assert (vote_data.custody_bit_1_indices ==
+            sample_slashable_vote_data_params['custody_bit_1_indices'])
+    assert vote_data.data == sample_slashable_vote_data_params['data']
+    assert vote_data.aggregate_signature == sample_slashable_vote_data_params['aggregate_signature']
+
+
+def test_hash(sample_slashable_vote_data_params):
+    vote_data = SlashableVoteData(**sample_slashable_vote_data_params)
+
+    # NOTE: this hash was simply copied from the existing implementation
+    # which should be the keccak-256 of the rlp serialization of `votes`.
+    # Given that this value will change soon (cf. ssz tree hash), we just
+    # do this to get the test passing for now and will need to update later
+    # if we expect the hash computation is not working correctly
+    hash_hex = "7e4b4cf3ac47988865d693a29b6aa5a825f27e065cf21a80af5e077ea102e297"
+
+    assert vote_data.hash == bytes.fromhex(hash_hex)
+
+
+def test_root(sample_slashable_vote_data_params):
+    vote_data = SlashableVoteData(**sample_slashable_vote_data_params)
+
+    # NOTE: see note in `test_hash`, this test will need to be updated
+    # once ssz tree hash lands...
+
+    assert vote_data.root == vote_data.hash
+
+
+def test_vote_count(sample_slashable_vote_data_params):
+    vote_data = SlashableVoteData(**sample_slashable_vote_data_params)
+
+    key = "custody_bit_0_indices"
+    custody_bit_0_indices = sample_slashable_vote_data_params[key]
+    key = "custody_bit_1_indices"
+    custody_bit_1_indices = sample_slashable_vote_data_params[key]
+
+    assert vote_data.vote_count == len(custody_bit_0_indices) + len(custody_bit_1_indices)
+
+
+def test_messages(sample_slashable_vote_data_params):
+    vote_data = SlashableVoteData(**sample_slashable_vote_data_params)
+
+    assert vote_data.messages == (
+        AttestationDataAndCustodyBit(vote_data.data, False).root,
+        AttestationDataAndCustodyBit(vote_data.data, True).root,
+    )

--- a/tests/eth2/beacon/types/test_states.py
+++ b/tests/eth2/beacon/types/test_states.py
@@ -1,0 +1,110 @@
+import pytest
+
+import rlp
+
+from eth2.beacon.constants import (
+    GWEI_PER_ETH,
+)
+from eth2.beacon.types.states import (
+    BeaconState,
+)
+from eth2.beacon.types.crosslink_records import (
+    CrosslinkRecord,
+)
+from eth2.beacon._utils.hash import (
+    hash_eth2,
+)
+
+from tests.eth2.beacon.helpers import (
+    mock_validator_record,
+)
+
+
+def test_defaults(sample_beacon_state_params):
+    state = BeaconState(**sample_beacon_state_params)
+    assert state.validator_registry == sample_beacon_state_params['validator_registry']
+    assert state.validator_registry_latest_change_slot == sample_beacon_state_params['validator_registry_latest_change_slot']  # noqa: E501
+
+
+def test_validator_registry_and_balances_length(sample_beacon_state_params):
+    # When len(BeaconState.validator_registry) != len(BeaconState.validtor_balances)
+    with pytest.raises(ValueError):
+        BeaconState(**sample_beacon_state_params).copy(
+            validator_registry=tuple(
+                mock_validator_record(pubkey)
+                for pubkey in range(10)
+            ),
+        )
+
+
+@pytest.mark.parametrize(
+    'expected', [(0), (1)]
+)
+def test_num_validators(expected,
+                        max_deposit,
+                        empty_beacon_state):
+    state = empty_beacon_state.copy(
+        validator_registry=tuple(
+            mock_validator_record(
+                pubkey,
+            )
+            for pubkey in range(expected)
+        ),
+        validator_balances=(max_deposit * GWEI_PER_ETH,) * expected,
+    )
+
+    assert state.num_validators == expected
+
+
+@pytest.mark.parametrize(
+    'expected', [(0), (1), (5)]
+)
+def test_num_crosslink_records(expected,
+                               sample_crosslink_record_params,
+                               empty_beacon_state):
+    crosslink_records = [
+        CrosslinkRecord(**sample_crosslink_record_params)
+        for i in range(expected)
+    ]
+    state = empty_beacon_state.copy(
+        latest_crosslinks=crosslink_records,
+    )
+
+    assert state.num_crosslinks == expected
+
+
+def test_hash(sample_beacon_state_params):
+    state = BeaconState(**sample_beacon_state_params)
+    assert state.root == hash_eth2(rlp.encode(state))
+
+
+@pytest.mark.parametrize(
+    'validator_index, new_pubkey, new_balance',
+    [
+        (0, 5566, 100),
+        (100, 5566, 100),
+    ]
+)
+def test_update_validator(ten_validators_state,
+                          validator_index,
+                          new_pubkey,
+                          new_balance):
+    state = ten_validators_state
+    validator = mock_validator_record(new_pubkey)
+
+    if validator_index < state.num_validators:
+        result_state = state.update_validator(
+            validator_index=validator_index,
+            validator=validator,
+            balance=new_balance,
+        )
+        assert result_state.validator_balances[validator_index] == new_balance
+        assert result_state.validator_registry[validator_index].pubkey == new_pubkey
+        assert state.validator_registry[validator_index].pubkey != new_pubkey
+    else:
+        with pytest.raises(IndexError):
+            state.update_validator(
+                validator_index=validator_index,
+                validator=validator,
+                balance=new_balance,
+            )

--- a/tests/eth2/beacon/types/test_validator_record.py
+++ b/tests/eth2/beacon/types/test_validator_record.py
@@ -1,0 +1,61 @@
+import pytest
+
+from eth2.beacon.constants import (
+    FAR_FUTURE_SLOT,
+)
+from eth2.beacon.types.validator_records import (
+    ValidatorRecord,
+)
+
+
+def test_defaults(sample_validator_record_params):
+    validator = ValidatorRecord(**sample_validator_record_params)
+    assert validator.pubkey == sample_validator_record_params['pubkey']
+    assert validator.withdrawal_credentials == sample_validator_record_params['withdrawal_credentials']  # noqa: E501
+
+
+@pytest.mark.parametrize(
+    'activation_slot,exit_slot,slot,expected',
+    [
+        (0, 1, 0, True),
+        (1, 1, 1, False),
+        (0, 1, 1, False),
+        (0, 1, 2, False),
+    ],
+)
+def test_is_active(sample_validator_record_params,
+                   activation_slot,
+                   exit_slot,
+                   slot,
+                   expected):
+    validator_record_params = {
+        **sample_validator_record_params,
+        'activation_slot': activation_slot,
+        'exit_slot': exit_slot,
+    }
+    validator = ValidatorRecord(**validator_record_params)
+    assert validator.is_active(slot) == expected
+
+
+def test_create_pending_validator():
+    pubkey = 123
+    withdrawal_credentials = b'\x11' * 32
+    randao_commitment = b'\x22' * 32
+    custody_commitment = b'\x33' * 32
+
+    validator = ValidatorRecord.create_pending_validator(
+        pubkey=pubkey,
+        withdrawal_credentials=withdrawal_credentials,
+        randao_commitment=randao_commitment,
+        custody_commitment=custody_commitment,
+    )
+
+    assert validator.pubkey == pubkey
+    assert validator.withdrawal_credentials == withdrawal_credentials
+    assert validator.randao_commitment == randao_commitment
+    assert validator.randao_layers == 0
+    assert validator.activation_slot == FAR_FUTURE_SLOT
+    assert validator.exit_slot == FAR_FUTURE_SLOT
+    assert validator.withdrawal_slot == FAR_FUTURE_SLOT
+    assert validator.penalized_slot == FAR_FUTURE_SLOT
+    assert validator.exit_count == 0

--- a/tests/eth2/beacon/types/test_validator_registry_delta_block.py
+++ b/tests/eth2/beacon/types/test_validator_registry_delta_block.py
@@ -1,0 +1,14 @@
+from eth2.beacon.types.validator_registry_delta_block import (
+    ValidatorRegistryDeltaBlock,
+)
+
+
+def test_defaults(sample_validator_registry_delta_block_params):
+    validator_registry_delta_block = ValidatorRegistryDeltaBlock(
+        **sample_validator_registry_delta_block_params
+    )
+    assert validator_registry_delta_block.latest_registry_delta_root == sample_validator_registry_delta_block_params['latest_registry_delta_root']  # noqa: E501
+    assert validator_registry_delta_block.validator_index == sample_validator_registry_delta_block_params['validator_index']  # noqa: E501
+    assert validator_registry_delta_block.pubkey == sample_validator_registry_delta_block_params['pubkey']  # noqa: E501
+    assert validator_registry_delta_block.slot == sample_validator_registry_delta_block_params['slot']  # noqa: E501
+    assert validator_registry_delta_block.flag == sample_validator_registry_delta_block_params['flag']  # noqa: E501

--- a/tests/eth2/bitfield-utils/test_bitfields.py
+++ b/tests/eth2/bitfield-utils/test_bitfields.py
@@ -1,0 +1,173 @@
+import random
+
+from hypothesis import (
+    given,
+    strategies as st,
+)
+import pytest
+
+from eth2._utils.bitfield import (
+    has_voted,
+    set_voted,
+    get_bitfield_length,
+    get_empty_bitfield,
+    get_vote_count,
+    or_bitfields,
+)
+
+
+@pytest.mark.parametrize(
+    'attester_count, bitfield_length',
+    [
+        (0, 0),
+        (1, 1),
+        (8, 1),
+        (9, 2),
+        (16, 2),
+        (17, 3),
+    ]
+)
+def test_bitfield_length(attester_count, bitfield_length):
+    assert get_bitfield_length(attester_count) == bitfield_length
+
+
+def test_empty_bitfield():
+    attesters = list(range(10))
+    bitfield = get_empty_bitfield(len(attesters))
+
+    for attester in attesters:
+        assert not has_voted(bitfield, attester)
+
+
+def test_bitfield_single_votes():
+    attesters = list(range(10))
+    bitfield = get_empty_bitfield(len(attesters))
+
+    assert set_voted(bitfield, 0) == b'\x80\x00'
+    assert set_voted(bitfield, 1) == b'\x40\x00'
+    assert set_voted(bitfield, 2) == b'\x20\x00'
+    assert set_voted(bitfield, 7) == b'\x01\x00'
+    assert set_voted(bitfield, 8) == b'\x00\x80'
+    assert set_voted(bitfield, 9) == b'\x00\x40'
+
+    for voter in attesters:
+        bitfield = set_voted(b'\x00\x00', voter)
+        for attester in attesters:
+            if attester == voter:
+                assert has_voted(bitfield, attester)
+            else:
+                assert not has_voted(bitfield, attester)
+
+
+def test_bitfield_all_votes():
+    attesters = list(range(10))
+
+    bitfield = get_empty_bitfield(len(attesters))
+    for attester in attesters:
+        bitfield = set_voted(bitfield, attester)
+
+    for attester in attesters:
+        assert has_voted(bitfield, attester)
+    assert bitfield == b'\xff\xc0'
+
+
+def test_bitfield_some_votes():
+    attesters = list(range(10))
+    voters = [0, 4, 5, 9]
+
+    bitfield = get_empty_bitfield(len(attesters))
+    for voter in voters:
+        bitfield = set_voted(bitfield, voter)
+
+    assert bitfield == b'\x8c\x40'
+
+    for attester in attesters:
+        if attester in voters:
+            assert has_voted(bitfield, attester)
+        else:
+            assert not has_voted(bitfield, attester)
+
+
+def test_bitfield_multiple_votes():
+    bitfield = get_empty_bitfield(1)
+    bitfield = set_voted(bitfield, 0)
+    bitfield = set_voted(bitfield, 0)
+    assert has_voted(bitfield, 0)
+
+
+def test_get_vote_count():
+    bitfield = get_empty_bitfield(5)
+    bitfield = set_voted(bitfield, 0)
+    bitfield = set_voted(bitfield, 3)
+    assert get_vote_count(bitfield) == 2
+
+
+def test_or_bitfields():
+    bitfield_1 = get_empty_bitfield(2)
+    bitfield_1 = set_voted(bitfield_1, 0)
+    assert get_vote_count(bitfield_1) == 1
+
+    # same size as bitfield_1
+    bitfield_2 = get_empty_bitfield(2)
+    bitfield_2 = set_voted(bitfield_2, 1)
+    assert get_vote_count(bitfield_2) == 1
+
+    bitfield = or_bitfields([bitfield_1, bitfield_2])
+    assert get_vote_count(bitfield) == 2
+
+    # different size from bitfield_1
+    bitfield_3 = get_empty_bitfield(100)
+    bitfield_3 = set_voted(bitfield_3, 99)
+    assert get_vote_count(bitfield_3) == 1
+
+    with pytest.raises(ValueError):
+        or_bitfields([bitfield_1, bitfield_3])
+
+
+@given(st.integers(1, 1000))
+def test_set_vote_and_has_vote(bit_count):
+    bitfield = get_empty_bitfield(bit_count)
+    index = random.choice(range(bit_count))
+    bitfield = set_voted(bitfield, index)
+    assert has_voted(bitfield, index)
+
+
+@given(st.integers(1, 999))
+def test_has_voted_random(votes_count):
+    bit_count = 1000
+    bitfield = get_empty_bitfield(bit_count)
+    random_votes = random.sample(range(bit_count), votes_count)
+
+    for index in random_votes:
+        bitfield = set_voted(bitfield, index)
+    assert get_vote_count(bitfield) == votes_count
+
+    for index in range(bit_count):
+        if index in random_votes:
+            assert has_voted(bitfield, index)
+        else:
+            assert not has_voted(bitfield, index)
+
+
+@given(
+    st.lists(
+        st.lists(elements=st.integers(0, 99), min_size=5, max_size=100, unique=True),
+        min_size=1,
+        max_size=100,
+    )
+)
+def test_or_bitfields_random(votes):
+    bitfields = []
+    bit_count = 100
+
+    for vote in votes:
+        bitfield = get_empty_bitfield(bit_count)
+        for index in vote:
+            bitfield = set_voted(bitfield, index)
+        bitfields.append(bitfield)
+
+    bitfield = or_bitfields(bitfields)
+
+    for index in range(bit_count):
+        if has_voted(bitfield, index):
+            assert any(has_voted(b, index) for b in bitfields)

--- a/tests/eth2/bls-utils/test_bls.py
+++ b/tests/eth2/bls-utils/test_bls.py
@@ -1,0 +1,95 @@
+import pytest
+
+from eth2._utils.bls import (
+    G1,
+    G2,
+    hash_to_G2,
+    compress_G1,
+    compress_G2,
+    decompress_G1,
+    decompress_G2,
+    normalize,
+    multiply,
+    sign,
+    privtopub,
+    aggregate_signatures,
+    aggregate_pubkeys,
+    verify,
+    verify_multiple,
+)
+
+
+@pytest.mark.parametrize(
+    'privkey',
+    [
+        (1),
+        (5),
+        (124),
+        (735),
+        (127409812145),
+        (90768492698215092512159),
+        (0),
+    ]
+)
+def test_bls_core(privkey):
+    domain = 0
+    p1 = multiply(G1, privkey)
+    p2 = multiply(G2, privkey)
+    msg = str(privkey).encode('utf-8')
+    msghash = hash_to_G2(msg, domain=domain)
+
+    assert normalize(decompress_G1(compress_G1(p1))) == normalize(p1)
+    assert normalize(decompress_G2(compress_G2(p2))) == normalize(p2)
+    assert normalize(decompress_G2(compress_G2(msghash))) == normalize(msghash)
+    sig = sign(msg, privkey, domain=domain)
+    pub = privtopub(privkey)
+    assert verify(msg, pub, sig, domain=domain)
+
+
+@pytest.mark.parametrize(
+    'msg, privkeys',
+    [
+        (b'cow', [1, 5, 124, 735, 127409812145, 90768492698215092512159, 0]),
+        (b'dog', [42, 666, 1274099945, 4389392949595]),
+    ]
+)
+def test_signature_aggregation(msg, privkeys):
+    domain = 0
+    sigs = [sign(msg, k, domain=domain) for k in privkeys]
+    pubs = [privtopub(k) for k in privkeys]
+    aggsig = aggregate_signatures(sigs)
+    aggpub = aggregate_pubkeys(pubs)
+    assert verify(msg, aggpub, aggsig, domain=domain)
+
+
+@pytest.mark.parametrize(
+    'msg_1, msg_2, privkeys_1, privkeys_2',
+    [
+        (b'cow', b'wow', tuple(range(10)), tuple(range(10))),
+        (b'cow', b'wow', (0, 1, 2, 3), (4, 5, 6, 7)),
+        (b'cow', b'wow', (0, 1, 2, 3), (2, 3, 4, 5)),
+    ]
+)
+def test_multi_aggregation(msg_1, msg_2, privkeys_1, privkeys_2):
+    domain = 0
+
+    sigs_1 = [sign(msg_1, k, domain=domain) for k in privkeys_1]
+    pubs_1 = [privtopub(k) for k in privkeys_1]
+    aggsig_1 = aggregate_signatures(sigs_1)
+    aggpub_1 = aggregate_pubkeys(pubs_1)
+
+    sigs_2 = [sign(msg_2, k, domain=domain) for k in privkeys_2]
+    pubs_2 = [privtopub(k) for k in privkeys_2]
+    aggsig_2 = aggregate_signatures(sigs_2)
+    aggpub_2 = aggregate_pubkeys(pubs_2)
+
+    msgs = [msg_1, msg_2]
+    pubs = [aggpub_1, aggpub_2]
+    aggsig = aggregate_signatures([aggsig_1, aggsig_2])
+
+    assert verify_multiple(
+        pubkeys=pubs,
+        messages=msgs,
+        signature=aggsig,
+        domain=domain,
+    )

--- a/tests/eth2/merkle-utils/test_merkle_trees.py
+++ b/tests/eth2/merkle-utils/test_merkle_trees.py
@@ -1,0 +1,157 @@
+import pytest
+
+from eth_utils import (
+    ValidationError,
+)
+
+from eth2.beacon._utils.hash import (
+    hash_eth2,
+)
+
+from eth2._utils.merkle import (
+    get_merkle_root_from_items,
+    calc_merkle_tree,
+    get_root,
+    get_merkle_proof,
+    get_merkle_root,
+    verify_merkle_proof,
+)
+
+
+@pytest.mark.parametrize("leaves,tree", [
+    (
+        (b"single leaf",),
+        (
+            (hash_eth2(b"single leaf"),),
+        ),
+    ),
+    (
+        (b"left", b"right"),
+        (
+            (hash_eth2(hash_eth2(b"left") + hash_eth2(b"right")),),
+            (hash_eth2(b"left"), hash_eth2(b"right")),
+        ),
+    ),
+    (
+        (b"1", b"2", b"3", b"4"),
+        (
+            (
+                hash_eth2(
+                    hash_eth2(
+                        hash_eth2(b"1") + hash_eth2(b"2")
+                    ) + hash_eth2(
+                        hash_eth2(b"3") + hash_eth2(b"4")
+                    )
+                ),
+            ),
+            (
+                hash_eth2(
+                    hash_eth2(b"1") + hash_eth2(b"2")
+                ),
+                hash_eth2(
+                    hash_eth2(b"3") + hash_eth2(b"4")
+                ),
+            ),
+            (
+                hash_eth2(b"1"),
+                hash_eth2(b"2"),
+                hash_eth2(b"3"),
+                hash_eth2(b"4"),
+            ),
+        ),
+    ),
+])
+def test_merkle_tree_calculation(leaves, tree):
+    calculated_tree = calc_merkle_tree(leaves)
+    assert calculated_tree == tree
+    assert get_root(tree) == tree[0][0]
+    assert get_merkle_root_from_items(leaves) == get_root(tree)
+
+
+@pytest.mark.parametrize("leave_number", [0, 3, 5, 6, 7, 9])
+def test_invalid_merkle_root_calculation(leave_number):
+    with pytest.raises(ValueError):
+        get_merkle_root_from_items((b"",) * leave_number)
+
+
+@pytest.mark.parametrize("leaves,index,proof", [
+    (
+        (b"1", b"2"),
+        0,
+        (hash_eth2(b"2"),),
+    ),
+    (
+        (b"1", b"2"),
+        1,
+        (hash_eth2(b"1"),),
+    ),
+    (
+        (b"1", b"2", b"3", b"4"),
+        0,
+        (hash_eth2(b"2"), hash_eth2(hash_eth2(b"3") + hash_eth2(b"4"))),
+    ),
+    (
+        (b"1", b"2", b"3", b"4"),
+        1,
+        (hash_eth2(b"1"), hash_eth2(hash_eth2(b"3") + hash_eth2(b"4"))),
+    ),
+    (
+        (b"1", b"2", b"3", b"4"),
+        2,
+        (hash_eth2(b"4"), hash_eth2(hash_eth2(b"1") + hash_eth2(b"2"))),
+    ),
+    (
+        (b"1", b"2", b"3", b"4"),
+        3,
+        (hash_eth2(b"3"), hash_eth2(hash_eth2(b"1") + hash_eth2(b"2"))),
+    ),
+])
+def test_merkle_proofs(leaves, index, proof):
+    tree = calc_merkle_tree(leaves)
+    root = get_root(tree)
+    item = leaves[index]
+    calculated_proof = get_merkle_proof(tree, index)
+    assert calculated_proof == proof
+    assert verify_merkle_proof(root, item, index, calculated_proof)
+
+    assert not verify_merkle_proof(b"\x00" * 32, item, index, proof)
+    assert not verify_merkle_proof(root, b"\x00" * 32, index, proof)
+    assert not verify_merkle_proof(root, item, (index + 1) % len(leaves), proof)
+    for replaced_index in range(len(proof)):
+        altered_proof = proof[:replaced_index] + (b"\x00" * 32,) + proof[replaced_index + 1:]
+        assert not verify_merkle_proof(root, item, index, altered_proof)
+
+
+def test_single_element_merkle_proof():
+    leaves = (b"1",)
+    tree = calc_merkle_tree(leaves)
+    root = get_root(tree)
+    assert get_merkle_proof(tree, 0) == ()
+    assert verify_merkle_proof(root, b"1", 0, ())
+    assert not verify_merkle_proof(b"\x00" * 32, b"1", 0, ())
+    assert not verify_merkle_proof(root, b"2", 0, ())
+    assert not verify_merkle_proof(root, b"1", 0, (b"\x00" * 32,))
+
+
+@pytest.mark.parametrize("leaves", [
+    (b"1",),
+    (b"1", b"2"),
+    (b"1", b"2", b"3", b"4"),
+])
+def test_proof_generation_index_validation(leaves):
+    tree = calc_merkle_tree(leaves)
+    for invalid_index in [-1, len(leaves)]:
+        with pytest.raises(ValidationError):
+            get_merkle_proof(tree, invalid_index)
+
+
+def test_get_merkle_root():
+    hash_0 = b"0" * 32
+    leaves = (hash_0,)
+    root = get_merkle_root(leaves)
+    assert root == hash_0
+
+    hash_1 = b"1" * 32
+    leaves = (hash_0, hash_1)
+    root = get_merkle_root(leaves)
+    assert root == hash_eth2(hash_0 + hash_1)

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist=
-    py{36,37}-{core,p2p,integration,lightchain_integration}
+    py{36,37}-{core,p2p,integration,lightchain_integration,eth2}
     py{36}-rpc-state-{frontier,homestead,tangerine_whistle,spurious_dragon,byzantium,constantinople,quadratic}
     py{36}-rpc-blockchain
     py{36,37}-lint
@@ -18,6 +18,7 @@ passenv =
     TRAVIS_EVENT_TYPE
 commands=
     core: pytest {posargs:tests/core/}
+    eth2: pytest {posargs:tests/eth2}
     p2p: pytest {posargs:tests/p2p}
     rpc-blockchain: pytest {posargs:tests/json-fixtures-over-rpc/test_rpc_fixtures.py -k 'not GeneralStateTests'}
     rpc-state-frontier: pytest {posargs:tests/json-fixtures-over-rpc/test_rpc_fixtures.py -k 'GeneralStateTests and not stQuadraticComplexityTest and Frontier'}
@@ -71,15 +72,16 @@ commands = {[common-integration]commands}
 
 
 [common-lint]
-deps = .[p2p,trinity,lint]
+deps = .[p2p,trinity,lint,eth2]
 setenv=MYPYPATH={toxinidir}:{toxinidir}/stubs
 commands=
     flake8 {toxinidir}/p2p
     flake8 {toxinidir}/tests
     flake8 {toxinidir}/trinity
     flake8 {toxinidir}/scripts
+    flake8 {toxinidir}/eth2
     # TODO: Drop --ignore-missing-imports once we have type annotations for eth_utils, coincurve and cytoolz
-    mypy --follow-imports=silent --warn-unused-ignores --ignore-missing-imports --no-strict-optional --check-untyped-defs --disallow-incomplete-defs --disallow-untyped-defs --disallow-any-generics -p p2p -p trinity
+    mypy --follow-imports=silent --warn-unused-ignores --ignore-missing-imports --no-strict-optional --check-untyped-defs --disallow-incomplete-defs --disallow-untyped-defs --disallow-any-generics -p p2p -p trinity -p eth2
 
 
 [testenv:py36-lint]

--- a/trinity/protocol/bcc/commands.py
+++ b/trinity/protocol/bcc/commands.py
@@ -20,8 +20,8 @@ from trinity.rlp.sedes import (
     HashOrNumber,
 )
 
-from eth.beacon.types.blocks import BaseBeaconBlock
-from eth.beacon.types.attestations import Attestation
+from eth2.beacon.types.blocks import BeaconBlock
+from eth2.beacon.types.attestations import Attestation
 
 
 class Status(Command):
@@ -50,7 +50,7 @@ class GetBeaconBlocks(Command):
 
 class BeaconBlocks(Command):
     _cmd_id = 2
-    structure = sedes.CountableList(BaseBeaconBlock)
+    structure = sedes.CountableList(BeaconBlock)
 
 
 class AttestationRecords(Command):

--- a/trinity/protocol/bcc/context.py
+++ b/trinity/protocol/bcc/context.py
@@ -1,6 +1,6 @@
 from p2p.peer import BasePeerContext
 
-from eth.beacon.db.chain import BaseBeaconChainDB
+from eth2.beacon.db.chain import BaseBeaconChainDB
 
 
 class BeaconContext(BasePeerContext):

--- a/trinity/protocol/bcc/proto.py
+++ b/trinity/protocol/bcc/proto.py
@@ -1,7 +1,7 @@
 from p2p.protocol import Protocol
 
-from eth.beacon.types.blocks import BaseBeaconBlock
-from eth.beacon.types.attestations import Attestation
+from eth2.beacon.types.blocks import BaseBeaconBlock
+from eth2.beacon.types.attestations import Attestation
 
 from trinity.protocol.bcc.commands import (
     Status,


### PR DESCRIPTION
### What was wrong?

https://github.com/ethereum/py-evm/issues/1659 part 2: move `eth2` module from `Py-EVM` to Trinity repo

part 1 is here: https://github.com/ethereum/py-evm/pull/1713

### How was it fixed?
1. Move `eth2` module from `Py-EVM` to Trinity repo (see part 1: https://github.com/ethereum/py-evm/pull/1713)
2. Fix `eth2._utils.blobs`: use `eth2._utils.merkle`
3. Fix `BeaconChainDB`:
    1. `_set_block_scores_to_db` returns `score`
    2. Update local variable `score` in `_persist_block_chain`
4. Update BCCProtocol: use latest `eth2` module

**Note**: after https://github.com/ethereum/py-evm/pull/1708, we need to pass `block_class` to some `BeaconChainDB` APIs. Will open another issue for it, right now I hardcoded `BeaconBlock` and left **#TODO** comment.

#### Cute Animal Picture

![63bbbcd2fabb117116f6e69a2345f5be](https://user-images.githubusercontent.com/9263930/50970076-5cfe9800-151b-11e9-9841-f83a887165c4.jpg)
