### PR TITLE
Add support for w3.admin.addPeer()

### DIFF
--- a/p2p/events.py
+++ b/p2p/events.py
@@ -50,3 +50,9 @@ class PeerCountRequest(BaseRequestResponseEvent[PeerCountResponse]):
     @staticmethod
     def expected_response_type() -> Type[PeerCountResponse]:
         return PeerCountResponse
+
+
+class ConnectToNodeCommand(BaseEvent):
+
+    def __init__(self, node: str) -> None:
+        self.node = node

--- a/p2p/kademlia.py
+++ b/p2p/kademlia.py
@@ -29,6 +29,8 @@ from eth_keys import (
 
 from eth_hash.auto import keccak
 
+from trinity._utils.validation import validate_enode_uri
+
 k_b = 8  # 8 bits per hop
 
 k_bucket_size = 16
@@ -101,6 +103,7 @@ class Node:
 
     @classmethod
     def from_uri(cls, uri: str) -> 'Node':
+        validate_enode_uri(uri)  # Be no more permissive than the validation
         parsed = urlparse.urlparse(uri)
         pubkey = keys.PublicKey(decode_hex(parsed.username))
         return cls(pubkey, Address(parsed.hostname, parsed.port))

--- a/p2p/kademlia.py
+++ b/p2p/kademlia.py
@@ -20,6 +20,7 @@ from urllib import parse as urlparse
 from eth_utils import (
     big_endian_to_int,
     decode_hex,
+    remove_0x_prefix,
 )
 
 from eth_keys import (
@@ -110,8 +111,7 @@ class Node:
 
     def uri(self) -> str:
         hexstring = self.pubkey.to_hex()
-        if hexstring.startswith('0x'):
-            hexstring = hexstring[2:]
+        hexstring = remove_0x_prefix(hexstring)
         return f'enode://{hexstring}@{self.address.ip}:{self.address.tcp_port}'
 
     def __str__(self) -> str:

--- a/p2p/kademlia.py
+++ b/p2p/kademlia.py
@@ -109,7 +109,10 @@ class Node:
         return cls(pubkey, Address(parsed.hostname, parsed.port))
 
     def uri(self) -> str:
-        return f'enode://{self.pubkey.to_hex()}@{self.address.ip}:{self.address.tcp_port}'
+        hexstring = self.pubkey.to_hex()
+        if hexstring.startswith('0x'):
+            hexstring = hexstring[2:]
+        return f'enode://{hexstring}@{self.address.ip}:{self.address.tcp_port}'
 
     def __str__(self) -> str:
         return '<Node(%s@%s)>' % (self.pubkey.to_hex()[:6], self.address.ip)

--- a/p2p/peer.py
+++ b/p2p/peer.py
@@ -801,9 +801,8 @@ class BasePeerPool(BaseService, AsyncIterable[BasePeer]):
 
     async def accept_connect_commands(self) -> None:
         async for command in self.event_bus.stream(ConnectToNodeCommand):
-            # TODO: This adds nodes in series, it won't handle a high rate of commands
             self.logger.debug('Received request to connect to %s', command.node)
-            await self.connect_to_nodes(from_uris([command.node]))
+            self.run_task(self.connect_to_nodes(from_uris([command.node])))
 
     async def handle_peer_count_requests(self) -> None:
         async for req in self.event_bus.stream(PeerCountRequest):

--- a/tests/core/_utils/test_validation.py
+++ b/tests/core/_utils/test_validation.py
@@ -24,6 +24,9 @@ GOOD_KEY = (
         ('enode://public_key:[::]:30303', MALFORMED_URI),
         ('enode://nonhex@add', 'public key must be a 128-character hex string'),
         ('enode://00@[::]:30303', 'public key must be a 128-character hex string'),
+
+        # The following tests check for validations which are done by functions internal
+        # to validate_enode_uri
         (f'enode://{GOOD_KEY}@10:30303', "'10' does not appear to be an IPv4 or IPv6 address"),
         (f'enode://{GOOD_KEY}@[::]:3000000', "Port out of range 0-65535"),
         (f'enode://{GOOD_KEY}@[::/24]:30303', "Invalid IPv6 URL"),

--- a/tests/core/_utils/test_validation.py
+++ b/tests/core/_utils/test_validation.py
@@ -1,0 +1,67 @@
+import pytest
+
+from trinity._utils.validation import (
+    validate_enode_uri
+)
+
+
+MALFORMED_URI = 'enode string must be of the form "enode://public-key@ip:port"'
+GOOD_KEY = (
+    '717ad99b1e67a93cd77806c9273d9195807da1db38ecfc535aa207598a4bd599'
+    '645599a0d11f72c1107ba4fb44ab133b0188a2f0b47ff16ba12b0a5ec0350202'
+)
+
+
+@pytest.mark.parametrize(
+    'uri,message',
+    (
+        ('/:hi', MALFORMED_URI),
+        ('wrongscheme://public_key:[::]:30303', MALFORMED_URI),
+        ('enode://public_key:[::]:30303', MALFORMED_URI),
+        ('enode://nonhex@add', 'public key must be a 128-character hex string'),
+        ('enode://00@[::]:30303', 'public key must be a 128-character hex string'),
+        (f'enode://{GOOD_KEY}@10:30303', "'10' does not appear to be an IPv4 or IPv6 address"),
+        (f'enode://{GOOD_KEY}@[::]:3000000', "Port out of range 0-65535"),
+        (f'enode://{GOOD_KEY}@[::/24]:30303', "Invalid IPv6 URL"),
+    ),
+)
+def test_validate_enode_failures(uri, message):
+    try:
+        validate_enode_uri(uri)
+    except ValueError as e:
+        assert message == str(e)
+    else:
+        assert False, 'an exception should have been thrown'
+
+
+@pytest.mark.parametrize(
+    'uri',
+    (
+        (f'enode://{GOOD_KEY}@[::]:30303'),
+        (f'enode://{GOOD_KEY}@[::]'),
+        (f'enode://{GOOD_KEY}@10.0.1.2'),
+        (f'enode://{GOOD_KEY}@10.0.1.2:5000'),
+    ),
+)
+def test_validate_enode_success(uri):
+    validate_enode_uri(uri)
+
+
+@pytest.mark.parametrize(
+    'uri,should_fail',
+    (
+        (f'enode://{GOOD_KEY}@[::]:30303', True),
+        (f'enode://{GOOD_KEY}@[::]', True),
+        (f'enode://{GOOD_KEY}@10.0.1.2', False),
+        (f'enode://{GOOD_KEY}@10.0.1.2:5000', False),
+    ),
+)
+def test_validate_enode_require_ip(uri, should_fail):
+    try:
+        validate_enode_uri(uri, require_ip=True)
+    except ValueError as e:
+        if not should_fail:
+            raise
+        assert 'A concrete IP address must be specified' == str(e)
+    else:
+        assert not should_fail

--- a/tests/core/_utils/test_validation.py
+++ b/tests/core/_utils/test_validation.py
@@ -1,5 +1,9 @@
 import pytest
 
+from eth_utils import (
+    ValidationError,
+)
+
 from trinity._utils.validation import (
     validate_enode_uri
 )
@@ -26,12 +30,8 @@ GOOD_KEY = (
     ),
 )
 def test_validate_enode_failures(uri, message):
-    try:
+    with pytest.raises(ValidationError, match=message):
         validate_enode_uri(uri)
-    except ValueError as e:
-        assert message == str(e)
-    else:
-        assert False, 'an exception should have been thrown'
 
 
 @pytest.mark.parametrize(
@@ -59,7 +59,7 @@ def test_validate_enode_success(uri):
 def test_validate_enode_require_ip(uri, should_fail):
     try:
         validate_enode_uri(uri, require_ip=True)
-    except ValueError as e:
+    except ValidationError as e:
         if not should_fail:
             raise
         assert 'A concrete IP address must be specified' == str(e)

--- a/tests/core/_utils/test_validation.py
+++ b/tests/core/_utils/test_validation.py
@@ -60,11 +60,9 @@ def test_validate_enode_success(uri):
     ),
 )
 def test_validate_enode_require_ip(uri, should_fail):
-    try:
-        validate_enode_uri(uri, require_ip=True)
-    except ValidationError as e:
-        if not should_fail:
-            raise
-        assert 'A concrete IP address must be specified' == str(e)
+    if should_fail:
+        message = "A concrete IP address must be specified"
+        with pytest.raises(ValidationError, match=message):
+            validate_enode_uri(uri, require_ip=True)
     else:
-        assert not should_fail
+        validate_enode_uri(uri, require_ip=True)

--- a/tests/core/json-rpc/test_ipc.py
+++ b/tests/core/json-rpc/test_ipc.py
@@ -537,10 +537,9 @@ GOOD_KEY = (
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
-    'description, request_msg, expected',
+    'request_msg, expected',
     (
         (
-            'Validation occurs',
             build_request('admin_addPeer', ['enode://none@[::]:30303']),
             {
                 'jsonrpc': '2.0',
@@ -549,7 +548,6 @@ GOOD_KEY = (
             },
         ),
         (
-            'Validation checks for ip address',
             build_request('admin_addPeer', [f'enode://{GOOD_KEY}@[::]:30303']),
             {
                 'jsonrpc': '2.0',
@@ -557,10 +555,10 @@ GOOD_KEY = (
                 'A concrete IP address must be specified'
             },
         ),
-    )
+    ),
+    ids=["Validation occurs", "Validation checks for ip address"],
 )
 async def test_admin_addPeer_error_messages(
-        description,
         jsonrpc_ipc_pipe_path,
         request_msg,
         event_loop,

--- a/tests/core/json-rpc/test_ipc.py
+++ b/tests/core/json-rpc/test_ipc.py
@@ -17,6 +17,7 @@ from eth_utils import (
 from p2p.events import (
     PeerCountRequest,
     PeerCountResponse,
+    ConnectToNodeCommand,
 )
 from trinity.nodes.events import (
     NetworkIdRequest,
@@ -526,3 +527,74 @@ async def test_eth_over_ipc(
         event_loop
     )
     assert result == expected
+
+
+GOOD_KEY = (
+    '717ad99b1e67a93cd77806c9273d9195807da1db38ecfc535aa207598a4bd599'
+    '645599a0d11f72c1107ba4fb44ab133b0188a2f0b47ff16ba12b0a5ec0350202'
+)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    'description, request_msg, expected',
+    (
+        (
+            'Validation occurs',
+            build_request('admin_addPeer', ['enode://none@[::]:30303']),
+            {
+                'jsonrpc': '2.0',
+                'id': 3, 'error':
+                'public key must be a 128-character hex string'
+            },
+        ),
+        (
+            'Validation checks for ip address',
+            build_request('admin_addPeer', [f'enode://{GOOD_KEY}@[::]:30303']),
+            {
+                'jsonrpc': '2.0',
+                'id': 3, 'error':
+                'A concrete IP address must be specified'
+            },
+        ),
+    )
+)
+async def test_admin_addPeer_error_messages(
+        description,
+        jsonrpc_ipc_pipe_path,
+        request_msg,
+        event_loop,
+        expected,
+        ipc_server):
+
+    result = await get_ipc_response(
+        jsonrpc_ipc_pipe_path,
+        request_msg,
+        event_loop
+    )
+    assert result == expected
+
+
+@pytest.mark.asyncio
+async def test_admin_addPeer_fires_message(
+        jsonrpc_ipc_pipe_path,
+        event_loop,
+        event_bus,
+        ipc_server):
+
+    future = asyncio.ensure_future(
+        event_bus.wait_for(ConnectToNodeCommand), loop=event_loop
+    )
+
+    enode = f'enode://{GOOD_KEY}@10.0.0.1:30303'
+    request = build_request('admin_addPeer', [enode])
+
+    result = await get_ipc_response(
+        jsonrpc_ipc_pipe_path,
+        request,
+        event_loop
+    )
+    assert result == {'id': 3, 'jsonrpc': '2.0', 'result': None}
+
+    event = await asyncio.wait_for(future, timeout=0.1, loop=event_loop)
+    assert event.node == enode

--- a/trinity/cli_parser.py
+++ b/trinity/cli_parser.py
@@ -20,6 +20,7 @@ from trinity.constants import (
     SYNC_LIGHT,
 )
 from trinity._utils.eip1085 import validate_raw_eip1085_genesis_config
+from trinity._utils.validation import validate_enode_uri
 
 
 class ValidateAndStoreEnodes(argparse.Action):
@@ -30,6 +31,8 @@ class ValidateAndStoreEnodes(argparse.Action):
                  option_string: str=None) -> None:
         if value is None:
             return
+
+        validate_enode_uri(value)
 
         enode = Node.from_uri(value)
 

--- a/trinity/rpc/modules/__init__.py
+++ b/trinity/rpc/modules/__init__.py
@@ -22,6 +22,7 @@ from .main import (  # noqa: F401
     ChainBasedRPCModule,
 )
 
+from .admin import Admin
 from .beacon import Beacon  # noqa: F401
 from .eth import Eth  # noqa: F401
 from .evm import EVM  # noqa: F401
@@ -35,6 +36,7 @@ def initialize_eth1_modules(chain: BaseAsyncChain, event_bus: Endpoint) -> Itera
     yield EVM(chain, event_bus)
     yield Net(event_bus)
     yield Web3()
+    yield Admin(event_bus)
 
 
 @to_tuple

--- a/trinity/rpc/modules/admin.py
+++ b/trinity/rpc/modules/admin.py
@@ -1,0 +1,26 @@
+from lahja import Endpoint
+
+from p2p.events import ConnectToNodeCommand
+from p2p.kademlia import Node
+from trinity.constants import TO_NETWORKING_BROADCAST_CONFIG
+from trinity.rpc.modules import BaseRPCModule
+
+
+class Admin(BaseRPCModule):
+
+    def __init__(self, event_bus: Endpoint) -> None:
+        self.event_bus = event_bus
+
+    @property
+    def name(self) -> str:
+        return 'admin'
+
+    async def addPeer(self, node: str) -> None:
+
+        # Throw an exception to show the user if {node} has the wrong format
+        enode = Node.from_uri(node)  # noqa: F841
+
+        self.event_bus.broadcast(
+            ConnectToNodeCommand(node),
+            TO_NETWORKING_BROADCAST_CONFIG
+        )

--- a/trinity/rpc/modules/admin.py
+++ b/trinity/rpc/modules/admin.py
@@ -1,9 +1,9 @@
 from lahja import Endpoint
 
 from p2p.events import ConnectToNodeCommand
-from p2p.kademlia import Node
 from trinity.constants import TO_NETWORKING_BROADCAST_CONFIG
 from trinity.rpc.modules import BaseRPCModule
+from trinity._utils.validation import validate_enode_uri
 
 
 class Admin(BaseRPCModule):
@@ -16,9 +16,7 @@ class Admin(BaseRPCModule):
         return 'admin'
 
     async def addPeer(self, node: str) -> None:
-
-        # Throw an exception to show the user if {node} has the wrong format
-        enode = Node.from_uri(node)  # noqa: F841
+        validate_enode_uri(node, require_ip=True)
 
         self.event_bus.broadcast(
             ConnectToNodeCommand(node),


### PR DESCRIPTION
You can now inject peers into the pool by calling the `w3.admin.addPeer()` endpoint.

Some future work?
- If you try to add a peer when the pool is full your request [will be silently dropped](https://github.com/ethereum/trinity/blob/master/p2p/peer.py#L985). That's not very user friendly.
- If you add a peer with the format `enode://the-key:[::]:30303` the RPC will be accepted, even though this is the wrong format, we don't know how to connect to `[::]`! It will then fail with a `DEBUG` rather than a more user friendly `INFO`.

I think fixing these requires turning this into an AddPeerRequest/Response pair. That might be the right thing to do eventually but I think this is good enough for now?

#### Cute Animal Picture

![sheep](https://user-images.githubusercontent.com/466333/51007090-04b79e00-14fb-11e9-90e7-856fca4537d9.jpeg)

