### PR TITLE
Slashing conditions

### DIFF
--- a/eth2/beacon/helpers.py
+++ b/eth2/beacon/helpers.py
@@ -168,7 +168,7 @@ def get_active_validator_indices(validators: Sequence['ValidatorRecord'],
 #
 # Get the epoch that a slot is in
 #
-def epoch_from_slot(slot, epoch_length):
+def epoch_from_slot(slot: int, epoch_length: int) -> int:
     return slot // epoch_length
 
 

--- a/eth2/beacon/helpers.py
+++ b/eth2/beacon/helpers.py
@@ -166,6 +166,13 @@ def get_active_validator_indices(validators: Sequence['ValidatorRecord'],
 
 
 #
+# Get the epoch that a slot is in
+#
+def epoch_from_slot(slot, epoch_length):
+    return slot // epoch_length
+
+
+#
 # Shuffling
 #
 @to_tuple
@@ -490,8 +497,8 @@ def is_double_vote(attestation_data_1: 'AttestationData',
     Returns True if the provided ``AttestationData`` are slashable
     due to a 'double vote'.
     """
-    target_epoch_1 = attestation_data_1.slot // epoch_length
-    target_epoch_2 = attestation_data_2.slot // epoch_length
+    target_epoch_1 = epoch_from_slot(attestation_data_1.slot, epoch_length)
+    target_epoch_2 = epoch_from_slot(attestation_data_2.slot, epoch_length)
     return target_epoch_1 == target_epoch_2
 
 
@@ -507,10 +514,10 @@ def is_surround_vote(attestation_data_1: 'AttestationData',
     Note: parameter order matters as this function only checks
     that ``attestation_data_1`` surrounds ``attestation_data_2``.
     """
-    source_epoch_1 = attestation_data_1.justified_slot // epoch_length
-    source_epoch_2 = attestation_data_2.justified_slot // epoch_length
-    target_epoch_1 = attestation_data_1.slot // epoch_length
-    target_epoch_2 = attestation_data_2.slot // epoch_length
+    source_epoch_1 = epoch_from_slot(attestation_data_1.justified_slot, epoch_length)
+    source_epoch_2 = epoch_from_slot(attestation_data_2.justified_slot, epoch_length)
+    target_epoch_1 = epoch_from_slot(attestation_data_1.slot, epoch_length)
+    target_epoch_2 = epoch_from_slot(attestation_data_2.slot, epoch_length)
     return (
         (source_epoch_1 < source_epoch_2) and
         (source_epoch_2 + 1 == target_epoch_2) and

--- a/eth2/beacon/helpers.py
+++ b/eth2/beacon/helpers.py
@@ -482,18 +482,22 @@ def verify_slashable_vote_data(state: 'BeaconState',
 
 
 def is_double_vote(attestation_data_1: 'AttestationData',
-                   attestation_data_2: 'AttestationData') -> bool:
+                   attestation_data_2: 'AttestationData',
+                   epoch_length: int) -> bool:
     """
     Assumes ``attestation_data_1`` is distinct from ``attestation_data_2``.
 
     Returns True if the provided ``AttestationData`` are slashable
     due to a 'double vote'.
     """
-    return attestation_data_1.slot == attestation_data_2.slot
+    target_epoch_1 = attestation_data_1.slot // epoch_length
+    target_epoch_2 = attestation_data_2.slot // epoch_length
+    return target_epoch_1 == target_epoch_2
 
 
 def is_surround_vote(attestation_data_1: 'AttestationData',
-                     attestation_data_2: 'AttestationData') -> bool:
+                     attestation_data_2: 'AttestationData',
+                     epoch_length: int) -> bool:
     """
     Assumes ``attestation_data_1`` is distinct from ``attestation_data_2``.
 
@@ -503,8 +507,12 @@ def is_surround_vote(attestation_data_1: 'AttestationData',
     Note: parameter order matters as this function only checks
     that ``attestation_data_1`` surrounds ``attestation_data_2``.
     """
+    source_epoch_1 = attestation_data_1.justified_slot // epoch_length
+    source_epoch_2 = attestation_data_2.justified_slot // epoch_length
+    target_epoch_1 = attestation_data_1.slot // epoch_length
+    target_epoch_2 = attestation_data_2.slot // epoch_length
     return (
-        (attestation_data_1.justified_slot < attestation_data_2.justified_slot) and
-        (attestation_data_2.justified_slot + 1 == attestation_data_2.slot) and
-        (attestation_data_2.slot < attestation_data_1.slot)
+        (source_epoch_1 < source_epoch_2) and
+        (source_epoch_2 + 1 == target_epoch_2) and
+        (target_epoch_2 < target_epoch_1)
     )

--- a/tests/eth2/beacon/test_helpers.py
+++ b/tests/eth2/beacon/test_helpers.py
@@ -945,45 +945,38 @@ def test_verify_slashable_vote_data(num_validators,
     _run_verify_slashable_vote(params, state, max_casper_votes, should_succeed)
 
 
-def test_is_double_vote(sample_attestation_data_params):
-    epoch_length = 64
+@pytest.mark.parametrize(
+    (
+        'attestation_1_slot,'
+        'attestation_2_slot,'
+        'expected,'
+        'epoch_length'
+    ),
+    [
+        ((64 * 15) + 5, (64 * 15) + 5, True, 64),
+        ((64 * 15) + 5, 64 * 25, False, 64),
+        ((64 * 15) + 5, (64 * 16) - 1, True, 64),
+        ((64 * 15) + 5, 64 * 16, False, 64),
+    ],
+)
+def test_is_double_vote(sample_attestation_data_params,
+                        attestation_1_slot,
+                        attestation_2_slot,
+                        expected,
+                        epoch_length):
     attestation_data_1_params = {
         **sample_attestation_data_params,
-        'slot': (epoch_length * 15) + 5,
+        'slot': attestation_1_slot,
     }
     attestation_data_1 = AttestationData(**attestation_data_1_params)
 
     attestation_data_2_params = {
         **sample_attestation_data_params,
-        'slot': (epoch_length * 15) + 5,
+        'slot': attestation_2_slot,
     }
     attestation_data_2 = AttestationData(**attestation_data_2_params)
 
-    assert is_double_vote(attestation_data_1, attestation_data_2, epoch_length)
-
-    attestation_data_3_params = {
-        **sample_attestation_data_params,
-        'slot': epoch_length * 25,
-    }
-    attestation_data_3 = AttestationData(**attestation_data_3_params)
-
-    assert not is_double_vote(attestation_data_1, attestation_data_3, epoch_length)
-
-    attestation_data_4_params = {
-        **sample_attestation_data_params,
-        'slot': (epoch_length * 16) - 1,
-    }
-    attestation_data_4 = AttestationData(**attestation_data_4_params)
-
-    assert is_double_vote(attestation_data_1, attestation_data_4, epoch_length)
-
-    attestation_data_5_params = {
-        **sample_attestation_data_params,
-        'slot': epoch_length * 16,
-    }
-    attestation_data_5 = AttestationData(**attestation_data_5_params)
-
-    assert not is_double_vote(attestation_data_1, attestation_data_5, epoch_length)
+    assert is_double_vote(attestation_data_1, attestation_data_2, epoch_length) == expected
 
 
 @pytest.mark.parametrize(
@@ -992,14 +985,15 @@ def test_is_double_vote(sample_attestation_data_params):
         'attestation_1_justified_slot,'
         'attestation_2_slot,'
         'attestation_2_justified_slot,'
-        'expected'
+        'expected,'
+        'epoch_length'
     ),
     [
-        (64, 0, 64 * 2, 64, False),
-        (64, 64, 64 * 2, 64 * 2, False),  # not (source_epoch_1 < source_epoch_2)
-        (4, 0, 64 * 6, 64 * 5, False),  # not (source_epoch_2 + 1 == target_epoch_2)
-        (64, 0, 0, 0, False),  # not (target_epoch_2 < target_epoch_1)
-        (64 * 4, 0, 64 * 3, 64 * 2, True),
+        (64, 0, 64 * 2, 64, False, 64),
+        (64, 64, 64 * 2, 64 * 2, False, 64),  # not (source_epoch_1 < source_epoch_2)
+        (4, 0, 64 * 6, 64 * 5, False, 64),  # not (source_epoch_2 + 1 == target_epoch_2)
+        (64, 0, 0, 0, False, 64),  # not (target_epoch_2 < target_epoch_1)
+        (64 * 4, 0, 64 * 3, 64 * 2, True, 64),
     ],
 )
 def test_is_surround_vote(sample_attestation_data_params,
@@ -1007,8 +1001,8 @@ def test_is_surround_vote(sample_attestation_data_params,
                           attestation_1_justified_slot,
                           attestation_2_slot,
                           attestation_2_justified_slot,
-                          expected):
-    epoch_length = 64
+                          expected,
+                          epoch_length):
     attestation_data_1_params = {
         **sample_attestation_data_params,
         'slot': attestation_1_slot,

--- a/tests/eth2/beacon/test_helpers.py
+++ b/tests/eth2/beacon/test_helpers.py
@@ -983,7 +983,7 @@ def test_is_double_vote(sample_attestation_data_params):
     }
     attestation_data_5 = AttestationData(**attestation_data_5_params)
 
-    assert not is_double_vote(attestation_data_1, attestation_data_5, epoch_length) 
+    assert not is_double_vote(attestation_data_1, attestation_data_5, epoch_length)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
### What was wrong?

Resolves #144. 

### How was it fixed?

Original pull request: [from py-evm](https://github.com/ethereum/py-evm/pull/1694)

Fixed eth.beacon.helpers.is_double_vote and eth.beacon.helpers.is_surround_vote as ethereum/eth2.0-specs#373. Also added tests to `tests/beacon/test_helpers.py` to test epoch boundaries. 

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://i.pinimg.com/originals/a3/5c/d2/a35cd25590aadd546d4552611e25ca40.jpg)
