### PR TITLE
Sync fix: simultaneously handle fork & duplicates

### DIFF
--- a/trinity/sync/full/chain.py
+++ b/trinity/sync/full/chain.py
@@ -60,7 +60,6 @@ from trinity.sync.common.constants import (
 from trinity.sync.common.headers import HeaderSyncerAPI
 from trinity.sync.common.peers import WaitingPeers
 from trinity._utils.datastructures import (
-    DuplicateTasks,
     MissingDependency,
     OrderedTaskPreparation,
     TaskQueue,
@@ -443,13 +442,10 @@ class FastChainBodySyncer(BaseBodyChainSyncer):
         """
         async for headers in self.wait_iter(self._header_syncer.new_sync_headers()):
             try:
-                self._block_persist_tracker.register_tasks(headers)
-            except DuplicateTasks as exc:
+                # We might end up with duplicates that can be safely ignored.
                 # Likely scenario: switched which peer downloads headers, and the new peer isn't
                 # aware of some of the in-progress headers
-                self.logger.debug("Duplicate headers during fast sync %r, skipping", exc.duplicates)
-                non_duplicates = tuple(header for header in headers if header not in exc.duplicates)
-                self._block_persist_tracker.register_tasks(non_duplicates)
+                self._block_persist_tracker.register_tasks(headers, ignore_duplicates=True)
             except MissingDependency:
                 # The parent of this header is not registered as a dependency yet.
                 # Some reasons this might happen, in rough descending order of likelihood:


### PR DESCRIPTION
### What was wrong?

fixes #119 - simultaneous duplicates and missing dependency

### How was it fixed?

Handle duplicates without an exception, for simpler handling of missing dependencies.

Also (intend to) handle some notable secondary effects that @lithp pointed out:

- ~~a crashed chain syncer should crash the node~~ -- _woah, this was bigger than I expected, pulling into another PR_
- [x] limit the duplicate task message -- *actually, this message was removed entirely*

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://i.pinimg.com/474x/c1/7f/76/c17f769872c75cc8fe1b530737a004c0--cute-puppies-cute-dogs.jpg)
