### PR TITLE
Resolve some service shutdown hangups

### DIFF
--- a/p2p/discovery.py
+++ b/p2p/discovery.py
@@ -1003,7 +1003,7 @@ class DiscoveryService(BaseService):
         self._lookup_running = asyncio.Lock()
 
     async def handle_get_peer_candidates_requests(self) -> None:
-        async for event in self._event_bus.stream(PeerCandidatesRequest):
+        async for event in self.wait_iter(self._event_bus.stream(PeerCandidatesRequest)):
 
             self.run_task(self.maybe_lookup_random_node())
 
@@ -1016,7 +1016,7 @@ class DiscoveryService(BaseService):
             )
 
     async def handle_get_random_bootnode_requests(self) -> None:
-        async for event in self._event_bus.stream(RandomBootnodeRequest):
+        async for event in self.wait_iter(self._event_bus.stream(RandomBootnodeRequest)):
 
             nodes = tuple(to_uris(self.proto.get_random_bootnode()))
 

--- a/p2p/peer.py
+++ b/p2p/peer.py
@@ -821,7 +821,7 @@ class BasePeerPool(BaseService, AsyncIterable[BasePeer]):
             self.run_task(self.connect_to_nodes(from_uris([command.node])))
 
     async def handle_peer_count_requests(self) -> None:
-        async for req in self.event_bus.stream(PeerCountRequest):
+        async for req in self.wait_iter(self.event_bus.stream(PeerCountRequest)):
                 # We are listening for all `PeerCountRequest` events but we ensure to only send a
                 # `PeerCountResponse` to the callsite that made the request.  We do that by
                 # retrieving a `BroadcastConfig` from the request via the

--- a/p2p/peer.py
+++ b/p2p/peer.py
@@ -1005,7 +1005,7 @@ class BasePeerPool(BaseService, AsyncIterable[BasePeer]):
 
     async def connect_to_nodes(self, nodes: Iterator[Node]) -> None:
         for node in nodes:
-            if self.is_full:
+            if self.is_full or not self.is_operational:
                 return
 
             # TODO: Consider changing connect() to raise an exception instead of returning None,

--- a/p2p/service.py
+++ b/p2p/service.py
@@ -305,6 +305,12 @@ class BaseService(ABC, CancellableMixin):
     def is_running(self) -> bool:
         return self._run_lock.locked()
 
+    async def cancellation(self) -> None:
+        """
+        Pause until this service is cancelled
+        """
+        await self.wait(self.events.cancelled.wait())
+
     async def threadsafe_cancel(self) -> None:
         """
         Cancel service in another thread. Block until service is cleaned up.

--- a/p2p/service.py
+++ b/p2p/service.py
@@ -165,7 +165,7 @@ class BaseService(ABC, CancellableMixin):
                         awaitable,
                         self,
                     )
-                    self.cancel_token.trigger()
+                    self.cancel_nowait()
         self.run_task(_run_daemon_task_wrapper())
 
     def run_child_service(self, child_service: 'BaseService') -> None:
@@ -217,7 +217,7 @@ class BaseService(ABC, CancellableMixin):
                         service,
                         self,
                     )
-                    self.cancel_token.trigger()
+                    self.cancel_nowait()
 
         self.run_task(_run_daemon_wrapper())
 
@@ -327,7 +327,7 @@ class BaseService(ABC, CancellableMixin):
 
         Should return or raise OperationCancelled when the CancelToken is triggered.
         """
-        raise NotImplementedError()
+        pass
 
     async def _cleanup(self) -> None:
         """Clean up any resources held by this service.

--- a/tests/core/p2p-proto/test_server.py
+++ b/tests/core/p2p-proto/test_server.py
@@ -154,6 +154,8 @@ async def test_peer_pool_connect(monkeypatch, event_loop, server):
         context=ParagonContext(),
     )
     nodes = [RECEIVER_REMOTE]
+    asyncio.ensure_future(initiator_peer_pool.run(), loop=event_loop)
+    await initiator_peer_pool.events.started.wait()
     await initiator_peer_pool.connect_to_nodes(nodes)
     # Give the receiver_server a chance to ack the handshake.
     await asyncio.sleep(0.2)
@@ -163,6 +165,7 @@ async def test_peer_pool_connect(monkeypatch, event_loop, server):
 
     # Stop our peer to make sure its pending asyncio tasks are cancelled.
     await list(initiator_peer_pool.connected_nodes.values())[0].cancel()
+    await initiator_peer_pool.cancel()
 
 
 @pytest.mark.asyncio
@@ -186,5 +189,4 @@ async def test_peer_pool_answers_connect_commands(event_loop, event_bus, server)
     await asyncio.sleep(0.5)
 
     assert len(server.peer_pool.connected_nodes) == 1
-
     await initiator_peer_pool.cancel()

--- a/trinity/nodes/base.py
+++ b/trinity/nodes/base.py
@@ -140,4 +140,5 @@ class Node(BaseService):
         await self.event_bus.wait_for_connection()
         self.notify_resource_available()
         self.run_daemon_task(self.handle_network_id_requests())
-        await self.get_p2p_server().run()
+        self.run_daemon(self.get_p2p_server())
+        await self.cancellation()

--- a/trinity/nodes/base.py
+++ b/trinity/nodes/base.py
@@ -56,7 +56,7 @@ class Node(BaseService):
         self.event_bus = event_bus
 
     async def handle_network_id_requests(self) -> None:
-        async for req in self.event_bus.stream(NetworkIdRequest):
+        async for req in self.wait_iter(self.event_bus.stream(NetworkIdRequest)):
             # We are listening for all `NetworkIdRequest` events but we ensure to only send a
             # `NetworkIdResponse` to the callsite that made the request.  We do that by
             # retrieving a `BroadcastConfig` from the request via the

--- a/trinity/protocol/common/servers.py
+++ b/trinity/protocol/common/servers.py
@@ -50,7 +50,7 @@ class BaseRequestServer(BaseService, PeerSubscriber):
     async def _run(self) -> None:
         self.run_daemon_task(self._handle_msg_loop())
         with self.subscribe(self._peer_pool):
-            await self.events.cancelled.wait()
+            await self.cancellation()
 
     async def _handle_msg_loop(self) -> None:
         while self.is_operational:

--- a/trinity/sync/full/service.py
+++ b/trinity/sync/full/service.py
@@ -56,6 +56,12 @@ class FullNodeSyncer(BaseService):
             self.logger.info(
                 "Finished fast fast-sync; previous head: %s, current head: %s", previous_head, head
             )
+
+            if not fast_syncer.is_complete:
+                self.logger.warning("Fast syncer completed abnormally. Exiting...")
+                self.cancel_nowait()
+                return
+
             # remove the reference so the memory can be reclaimed
             del fast_syncer
 


### PR DESCRIPTION
### What was wrong?

Lots of services were failing to shut down cleanly. They would permanently hang on one of their child tasks or services. One noted side effect is that when the syncer crashes, the node keeps running. See #119 

Out of scope for this PR: even after the `FullNode` shuts down, the processes continue running, so there's still an awkward ending where you have to `Ctrl-C` out.

@cburgdorf would you mind figuring out how to make all the processes shut down when the `FullNode` exits? The bootstrapping code changed a lot, and is heavily entangled with the event bus, so the "right" way to do this isn't obvious to me anymore. I'll open an issue, but I would appreciate your review here anyway (which is also good background for the issue).

### How was it fixed?

Hunt down the places that were preventing the node services from shutting down. Some general classes of things found:

- tasks that were hanging waiting for an event bus event
- tasks that were waiting for a cancellation event, but the `cancel_token` trigger was never generating a cancellation event
- perhaps the most tangential (I'm happy to pull this into another PR if anyone asks): when fast sync exits abnormally, regular sync was starting. now it just exits immediately.

Note that there are some more asyncio warnings on shutdown now, but I still think it's forward progress.

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://i.pinimg.com/474x/98/44/2f/98442f0d906ec9577145c7b12d4ec13f.jpg)