### PR TITLE
Shutdown all plugins when node finishs

### DIFF
--- a/trinity/events.py
+++ b/trinity/events.py
@@ -1,6 +1,19 @@
 from lahja import (
-    BaseEvent
+    BaseEvent,
+    BroadcastConfig,
+    Endpoint
 )
+
+from trinity.constants import (
+    MAIN_EVENTBUS_ENDPOINT,
+)
+
+
+def request_shutdown(event_bus: Endpoint, reason: str) -> None:
+    event_bus.broadcast(
+        ShutdownRequest(reason),
+        BroadcastConfig(filter_endpoint=MAIN_EVENTBUS_ENDPOINT)
+    )
 
 
 class ShutdownRequest(BaseEvent):

--- a/trinity/extensibility/plugin.py
+++ b/trinity/extensibility/plugin.py
@@ -23,18 +23,14 @@ from typing import (
 )
 
 from lahja import (
-    BroadcastConfig,
     Endpoint,
 )
 
 from trinity.config import (
     TrinityConfig
 )
-from trinity.constants import (
-    MAIN_EVENTBUS_ENDPOINT
-)
 from trinity.events import (
-    ShutdownRequest,
+    request_shutdown,
 )
 from trinity.extensibility.events import (
     BaseEvent,
@@ -96,10 +92,7 @@ class PluginContext:
         :class:`~lahja.eventbus.EventBus`. The actual shutdown routine is executed and coordinated
         by the main application process who listens for this event.
         """
-        self.event_bus.broadcast(
-            ShutdownRequest(reason),
-            BroadcastConfig(filter_endpoint=MAIN_EVENTBUS_ENDPOINT)
-        )
+        request_shutdown(self.event_bus, reason)
 
     @property
     def args(self) -> Namespace:

--- a/trinity/nodes/base.py
+++ b/trinity/nodes/base.py
@@ -27,6 +27,9 @@ from trinity.config import (
     ChainConfig,
     TrinityConfig,
 )
+from trinity.events import (
+    request_shutdown,
+)
 from trinity.extensibility.events import (
     ResourceAvailableEvent
 )
@@ -142,3 +145,6 @@ class Node(BaseService):
         self.run_daemon_task(self.handle_network_id_requests())
         self.run_daemon(self.get_p2p_server())
         await self.cancellation()
+
+    async def _cleanup(self) -> None:
+        request_shutdown(self.event_bus, "Node finished unexpectedly")


### PR DESCRIPTION
### What was wrong?

Triggered by #166.

Currently, if the `Node` (aka the current `networking` process)  finishes, all external processes continue running unaffected. This PR changes this so that when the `Node` finishes (for whatever reason), all other running processes are instructed to shut down.

### How was it fixed?

Send a `ShutdownRequest` at the last thing in `Node.run(...)`.
As we move more and more responsibilities into plugins (e.g. #155 moves the sync into a plugin) this responsibility would shift so that essential plugins would trigger this. 

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://i.pinimg.com/originals/ac/c3/a8/acc3a87b68e2340b4edb4568e3e2d768.jpg)
