### PR TITLE
Allow Ping, Pong, Disconnect Messages snappy compressible

### DIFF
--- a/p2p/p2p_proto.py
+++ b/p2p/p2p_proto.py
@@ -95,10 +95,10 @@ class P2PProtocol(Protocol):
     _commands = [Hello, Ping, Pong, Disconnect]
     cmd_length = 16
 
-    def __init__(self, peer: 'BasePeer') -> None:
+    def __init__(self, peer: 'BasePeer', snappy_support: bool) -> None:
         # For the base protocol the cmd_id_offset is always 0.
         # For the base protocol snappy compression should be disabled
-        super().__init__(peer, cmd_id_offset=0, snappy_support=False)
+        super().__init__(peer, cmd_id_offset=0, snappy_support=snappy_support)
 
     def send_handshake(self) -> None:
         # TODO: move import out once this is in the trinity codebase

--- a/p2p/peer.py
+++ b/p2p/peer.py
@@ -211,7 +211,9 @@ class BasePeer(BaseService):
         # Networking reader and writer objects for communication
         self.reader = connection.reader
         self.writer = connection.writer
-        self.base_protocol = P2PProtocol(self)
+        # Initially while doing the handshake, the base protocol shouldn't support
+        # snappy compression
+        self.base_protocol = P2PProtocol(self, snappy_support=False)
 
         # Flag indicating whether the connection this peer represents was
         # established from a dial-out or dial-in (True: dial-in, False:
@@ -492,6 +494,12 @@ class BasePeer(BaseService):
         # Check whether to support Snappy Compression or not
         # based on other peer's p2p protocol version
         snappy_support = msg['version'] >= SNAPPY_PROTOCOL_VERSION
+
+        if snappy_support:
+            # Now update the base protocol to support snappy compression
+            # This is needed so that Trinity is compatible with parity since
+            # parity sends Ping even after Handshake
+            self.base_protocol = P2PProtocol(self, snappy_support=snappy_support)
 
         remote_capabilities = msg['capabilities']
         try:

--- a/p2p/peer.py
+++ b/p2p/peer.py
@@ -498,7 +498,7 @@ class BasePeer(BaseService):
         if snappy_support:
             # Now update the base protocol to support snappy compression
             # This is needed so that Trinity is compatible with parity since
-            # parity sends Ping even after Handshake
+            # parity sends Ping immediately after Handshake
             self.base_protocol = P2PProtocol(self, snappy_support=snappy_support)
 
         remote_capabilities = msg['capabilities']

--- a/tests/core/p2p-proto/test_peer.py
+++ b/tests/core/p2p-proto/test_peer.py
@@ -54,7 +54,7 @@ async def test_les_handshake():
     )
 )
 def test_sub_protocol_selection(snappy_support):
-    peer = ProtoMatchingPeer([LESProtocol, LESProtocolV2])
+    peer = ProtoMatchingPeer([LESProtocol, LESProtocolV2], snappy_support)
 
     proto = peer.select_sub_protocol([
         (LESProtocol.name, LESProtocol.version),
@@ -102,6 +102,6 @@ class LESProtocolV3(LESProtocol):
 
 class ProtoMatchingPeer(LESPeer):
 
-    def __init__(self, supported_sub_protocols):
+    def __init__(self, supported_sub_protocols, snappy_support):
         self._supported_sub_protocols = supported_sub_protocols
-        self.base_protocol = P2PProtocol(self)
+        self.base_protocol = P2PProtocol(self, snappy_support)


### PR DESCRIPTION
### What was wrong?
Previously `Ping, Pong, Disconnect messages` weren't `snappy compressible/decompressible` by Trinity. But the other clients have `compressed` the messages coming out of those commands (If both our client and the other one have agreed on snappy compression).

Fixes #169 


### How was it fixed?
The `base_protocol` of the peer is initially created with `snappy_support` set to false. But after the handshake, when both of the clients agree on using `snappy compression`, then the `base_protocol` variable of the peer is recreated by setting the `snappy_support` variable to `True`. Further details can be seen in the code.


#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://i.pinimg.com/originals/53/3c/77/533c77e23442fddef187c79a412913cf.jpg)
