### PR TITLE
[WIP] Rework snappy_support into property

### DIFF
--- a/p2p/p2p_proto.py
+++ b/p2p/p2p_proto.py
@@ -95,10 +95,10 @@ class P2PProtocol(Protocol):
     _commands = [Hello, Ping, Pong, Disconnect]
     cmd_length = 16
 
-    def __init__(self, peer: 'BasePeer', snappy_support: bool) -> None:
-        # For the base protocol the cmd_id_offset is always 0.
-        # For the base protocol snappy compression should be disabled
-        super().__init__(peer, cmd_id_offset=0, snappy_support=snappy_support)
+    def __init__(self, peer: 'BasePeer') -> None:
+        # DEVp2p command ID offset is always 0, since it's the lowest-level protocol.
+        # DEVp2p sessions always start with compression disabled, upgrading if remote supports it.
+        super().__init__(peer, cmd_id_offset=0, snappy_support=False)
 
     def send_handshake(self) -> None:
         # TODO: move import out once this is in the trinity codebase

--- a/p2p/peer.py
+++ b/p2p/peer.py
@@ -212,9 +212,7 @@ class BasePeer(BaseService):
         # Networking reader and writer objects for communication
         self.reader = connection.reader
         self.writer = connection.writer
-        # Initially while doing the handshake, the base protocol shouldn't support
-        # snappy compression
-        self.base_protocol = P2PProtocol(self, snappy_support=False)
+        self.base_protocol = P2PProtocol(self)
 
         # Flag indicating whether the connection this peer represents was
         # established from a dial-out or dial-in (True: dial-in, False:
@@ -496,11 +494,8 @@ class BasePeer(BaseService):
         # based on other peer's p2p protocol version
         snappy_support = msg['version'] >= SNAPPY_PROTOCOL_VERSION
 
-        if snappy_support:
-            # Now update the base protocol to support snappy compression
-            # This is needed so that Trinity is compatible with parity since
-            # parity sends Ping immediately after Handshake
-            self.base_protocol = P2PProtocol(self, snappy_support=snappy_support)
+        # Now update the base protocol to support snappy compression
+        self.base_protocol.snappy_support = snappy_support
 
         remote_capabilities = msg['capabilities']
         try:

--- a/p2p/protocol.py
+++ b/p2p/protocol.py
@@ -178,16 +178,29 @@ class Protocol:
     def __init__(self, peer: 'BasePeer', cmd_id_offset: int, snappy_support: bool) -> None:
         self.peer = peer
         self.cmd_id_offset = cmd_id_offset
-        self.snappy_support = snappy_support
-        self.commands = [cmd_class(cmd_id_offset, snappy_support) for cmd_class in self._commands]
-        self.cmd_by_type = {type(cmd): cmd for cmd in self.commands}
-        self.cmd_by_id = {cmd.cmd_id: cmd for cmd in self.commands}
+        self._snappy_support = snappy_support
+        self.snappy_support = self._snappy_support
 
     @property
     def logger(self) -> logging.Logger:
         if self._logger is None:
             self._logger = logging.getLogger(f"p2p.protocol.{type(self).__name__}")
         return self._logger
+
+    @property
+    def snappy_support(self) -> bool:
+        '''TODO'''
+        return self._snappy_support
+
+    @snappy_support.setter
+    def snappy_support(self, enabled: bool) -> None:
+        '''TODO'''
+        self._snappy_support = enabled
+        # update available commands, including their parameters
+        self.commands = [cmd_class(self.cmd_id_offset, self._snappy_support)
+                         for cmd_class in self._commands]
+        self.cmd_by_type = {type(cmd): cmd for cmd in self.commands}
+        self.cmd_by_id = {cmd.cmd_id: cmd for cmd in self.commands}
 
     def send(self, header: bytes, body: bytes) -> None:
         self.peer.send(header, body)

--- a/tests/core/p2p-proto/test_peer.py
+++ b/tests/core/p2p-proto/test_peer.py
@@ -46,30 +46,21 @@ async def test_les_handshake():
     assert isinstance(peer2.sub_proto, LESProtocol)
 
 
-@pytest.mark.parametrize(
-    'snappy_support',
-    (
-        True,
-        False,
-    )
-)
-def test_sub_protocol_selection(snappy_support):
-    peer = ProtoMatchingPeer([LESProtocol, LESProtocolV2], snappy_support)
+def test_sub_protocol_selection():
+    peer = ProtoMatchingPeer([LESProtocol, LESProtocolV2])
 
     proto = peer.select_sub_protocol([
         (LESProtocol.name, LESProtocol.version),
         (LESProtocolV2.name, LESProtocolV2.version),
         (LESProtocolV3.name, LESProtocolV3.version),
-        ('unknown', 1),
-    ],
-        snappy_support=snappy_support
-    )
+        ('unknown', 1)
+    ])
 
     assert isinstance(proto, LESProtocolV2)
     assert proto.cmd_id_offset == peer.base_protocol.cmd_length
 
     with pytest.raises(NoMatchingPeerCapabilities):
-        peer.select_sub_protocol([('unknown', 1)], snappy_support)
+        peer.select_sub_protocol([('unknown', 1)])
 
 
 @pytest.mark.asyncio
@@ -102,6 +93,6 @@ class LESProtocolV3(LESProtocol):
 
 class ProtoMatchingPeer(LESPeer):
 
-    def __init__(self, supported_sub_protocols, snappy_support):
+    def __init__(self, supported_sub_protocols):
         self._supported_sub_protocols = supported_sub_protocols
-        self.base_protocol = P2PProtocol(self, snappy_support)
+        self.base_protocol = P2PProtocol(self)

--- a/tests/core/p2p-proto/test_snappy_compression.py
+++ b/tests/core/p2p-proto/test_snappy_compression.py
@@ -14,7 +14,7 @@ async def test_snappy_compression_enabled_between_connected_v5_protocol_peers(re
 
 
 @pytest.mark.asyncio
-async def test_snappy_compression_enabled_between_connected_v4_and_v5_protocol_peers(
+async def test_snappy_compression_disabled_between_connected_v4_and_v5_protocol_peers(
         request,
         event_loop):
     alice, bob = await get_directly_linked_v4_and_v5_peers(request, event_loop)

--- a/trinity/protocol/eth/proto.py
+++ b/trinity/protocol/eth/proto.py
@@ -63,7 +63,8 @@ class ETHProtocol(HasExtendedDebugLogger, Protocol):
             'genesis_hash': chain_info.genesis_hash,
         }
         cmd = Status(self.cmd_id_offset, self.snappy_support)
-        self.logger.debug2("Sending ETH/Status msg: %s", resp)
+        self.logger.debug2("Sending ETH/Status msg: %s; with cmd id_offset %s and compression %s",
+                           resp, cmd.cmd_id_offset, cmd.snappy_support)
         self.send(*cmd.encode(resp))
 
     #


### PR DESCRIPTION
### What was wrong?

When upgrading from no-compression to with-compression, the whole [P2P]Protocol was re-initialised, churning objects on every connection, even if the remote only wants to say "too many peers, bye".

Also, `snappy_support` is passed around as an argument (a lot!) - and it should not be: it's a property estabilished by the lowest-level interchange (handshake, `Hello`) of the DEVp2p protocol, and should
be "inherited" from then on until the end of session.

In PR #108, this was done to avoid mutating global `Command` class (fair enough); however, this:

* increases boilerplate;
* suggests there are occasions on which `cmd_id_offset` or `snappy_support` might change for a given command during a particular session; and
* won't scale to high numbers of sub-...-sub-protocol parameters (not an argument until it happens, I know ^_^).

### How was it fixed?

Only partially.

- [x] Don't replace the entire `base_protocol` instance of a `BasePeer`; instead, set its existing `base_protocol`'s `snappy_support` (which is reworked as a `@property`).
- [x] Don't pass `snappy_support` to `select_sub_protocol()`; instead, acquire it the same way as `cmd_id_offset` is.
- [ ] All `Command`s still pass the two variables around. :(

### Cute Animal Picture

![put a cute animal picture link inside the parentheses](http://images2.fanpop.com/image/photos/9700000/Chihuahua-puppies-puppies-9726091-1600-1200.jpg)

Via: [teddybear64 @ fanpop](http://www.fanpop.com/clubs/puppies/images/9726091/title/chihuahua-puppies-wallpaper)