### PR TITLE
Append cached replacement node when a node is removed in KBucket.

### DIFF
--- a/p2p/kademlia.py
+++ b/p2p/kademlia.py
@@ -193,6 +193,9 @@ class KBucket(Sized):
         if node not in self:
             return
         self.nodes.remove(node)
+        if self.replacement_cache:
+            replacement_node = self.replacement_cache.pop()
+            self.nodes.append(replacement_node)
 
     def in_range(self, node: Node) -> bool:
         return self.start <= node.id <= self.end

--- a/tests/p2p/test_kademlia.py
+++ b/tests/p2p/test_kademlia.py
@@ -123,21 +123,25 @@ def test_kbucket_remove():
     nodes = [random_node() for _ in range(bucket.k)]
     for node in nodes:
         bucket.add(node)
-    assert len(bucket) == bucket.k
+    assert bucket.nodes == nodes
+    assert bucket.replacement_cache == []
 
     replacement_count = 10
     replacement_nodes = [random_node() for _ in range(replacement_count)]
     for replacement_node in replacement_nodes:
         bucket.add(replacement_node)
-    assert len(bucket) == bucket.k
+    assert bucket.nodes == nodes
+    assert bucket.replacement_cache == replacement_nodes
 
     for node in nodes:
         bucket.remove_node(node)
-    assert len(bucket) == replacement_count
+    assert bucket.nodes == list(reversed(replacement_nodes))
+    assert bucket.replacement_cache == []
 
     for replacement_node in replacement_nodes:
         bucket.remove_node(replacement_node)
-    assert len(bucket) == 0
+    assert bucket.nodes == []
+    assert bucket.replacement_cache == []
 
 
 def test_kbucket_split():

--- a/tests/p2p/test_kademlia.py
+++ b/tests/p2p/test_kademlia.py
@@ -116,6 +116,30 @@ def test_kbucket_add():
     assert bucket.head == node2
 
 
+def test_kbucket_remove():
+    bucket = kademlia.KBucket(0, 100)
+    bucket.k = 25
+
+    nodes = [random_node() for _ in range(bucket.k)]
+    for node in nodes:
+        bucket.add(node)
+    assert len(bucket) == bucket.k
+
+    replacement_count = 10
+    replacement_nodes = [random_node() for _ in range(replacement_count)]
+    for replacement_node in replacement_nodes:
+        bucket.add(replacement_node)
+    assert len(bucket) == bucket.k
+
+    for node in nodes:
+        bucket.remove_node(node)
+    assert len(bucket) == replacement_count
+
+    for replacement_node in replacement_nodes:
+        bucket.remove_node(replacement_node)
+    assert len(bucket) == 0
+
+
 def test_kbucket_split():
     bucket = kademlia.KBucket(0, 100)
     for i in range(1, bucket.k + 1):


### PR DESCRIPTION
### What was wrong?
I found Replacement nodes are not used in KBucket.


### How was it fixed?
When the number of nodes in KBucket decreases, one of the replacement nodes is added.

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://pbs.twimg.com/media/C4TmngHVYAAY83v.jpg)
