### PR TITLE
Make usage of proxy classes more robust

### DIFF
--- a/tests/core/database/test_database_over_ipc_manager.py
+++ b/tests/core/database/test_database_over_ipc_manager.py
@@ -26,7 +26,7 @@ from trinity.initialization import (
 )
 from trinity.constants import ROPSTEN_NETWORK_ID
 from trinity.db.chain import AsyncChainDBProxy
-from trinity.db.base import DBProxy
+from trinity.db.base import AsyncDBProxy
 from trinity._utils.ipc import (
     wait_for_ipc,
     kill_process_gracefully,
@@ -74,7 +74,7 @@ def manager(database_server_ipc_path):
     class DBManager(BaseManager):
         pass
 
-    DBManager.register('get_db', proxytype=DBProxy)
+    DBManager.register('get_db', proxytype=AsyncDBProxy)
     DBManager.register('get_chaindb', proxytype=AsyncChainDBProxy)
 
     _manager = DBManager(address=str(database_server_ipc_path))

--- a/tests/core/database/test_database_over_ipc_manager.py
+++ b/tests/core/database/test_database_over_ipc_manager.py
@@ -25,7 +25,7 @@ from trinity.initialization import (
     initialize_data_dir,
 )
 from trinity.constants import ROPSTEN_NETWORK_ID
-from trinity.db.chain import ChainDBProxy
+from trinity.db.chain import AsyncChainDBProxy
 from trinity.db.base import DBProxy
 from trinity._utils.ipc import (
     wait_for_ipc,
@@ -75,7 +75,7 @@ def manager(database_server_ipc_path):
         pass
 
     DBManager.register('get_db', proxytype=DBProxy)
-    DBManager.register('get_chaindb', proxytype=ChainDBProxy)
+    DBManager.register('get_chaindb', proxytype=AsyncChainDBProxy)
 
     _manager = DBManager(address=str(database_server_ipc_path))
     _manager.connect()

--- a/tests/core/integration_test_helpers.py
+++ b/tests/core/integration_test_helpers.py
@@ -25,7 +25,7 @@ from eth.tools.builder.chain import (
 from eth.db.header import HeaderDB
 from eth.vm.forks.byzantium import ByzantiumVM
 
-from trinity.db.base import AsyncBaseDB
+from trinity.db.base import BaseAsyncDB
 from trinity.db.chain import BaseAsyncChainDB
 from trinity.db.header import BaseAsyncHeaderDB
 
@@ -52,17 +52,17 @@ def async_passthrough(base_name):
     return passthrough_method
 
 
-class FakeAsyncAtomicDB(AtomicDB, AsyncBaseDB):
+class FakeAsyncAtomicDB(AtomicDB, BaseAsyncDB):
     coro_set = async_passthrough('set')
     coro_exists = async_passthrough('exists')
 
 
-class FakeAsyncMemoryDB(MemoryDB, AsyncBaseDB):
+class FakeAsyncMemoryDB(MemoryDB, BaseAsyncDB):
     coro_set = async_passthrough('set')
     coro_exists = async_passthrough('exists')
 
 
-class FakeAsyncLevelDB(LevelDB, AsyncBaseDB):
+class FakeAsyncLevelDB(LevelDB, BaseAsyncDB):
     coro_set = async_passthrough('set')
     coro_exists = async_passthrough('exists')
 

--- a/tests/core/integration_test_helpers.py
+++ b/tests/core/integration_test_helpers.py
@@ -21,11 +21,12 @@ from eth.tools.builder.chain import (
     enable_pow_mining,
     genesis,
 )
+from eth.db.header import HeaderDB
 from eth.vm.forks.byzantium import ByzantiumVM
 
 from trinity.db.base import AsyncBaseDB
 from trinity.db.chain import AsyncChainDB
-from trinity.db.header import AsyncHeaderDB
+from trinity.db.header import BaseAsyncHeaderDB
 
 ZIPPED_FIXTURES_PATH = Path(__file__).parent.parent / 'integration' / 'fixtures'
 
@@ -65,7 +66,7 @@ class FakeAsyncLevelDB(LevelDB, AsyncBaseDB):
     coro_exists = async_passthrough('exists')
 
 
-class FakeAsyncHeaderDB(AsyncHeaderDB):
+class FakeAsyncHeaderDB(BaseAsyncHeaderDB, HeaderDB):
     coro_get_canonical_block_hash = async_passthrough('get_canonical_block_hash')
     coro_get_canonical_block_header_by_number = async_passthrough('get_canonical_block_header_by_number')  # noqa: E501
     coro_get_canonical_head = async_passthrough('get_canonical_head')

--- a/tests/core/integration_test_helpers.py
+++ b/tests/core/integration_test_helpers.py
@@ -15,6 +15,7 @@ from eth.chains.base import (
 from eth.db.backends.level import LevelDB
 from eth.db.backends.memory import MemoryDB
 from eth.db.atomic import AtomicDB
+from eth.db.chain import ChainDB
 from eth.tools.builder.chain import (
     build,
     byzantium_at,
@@ -25,7 +26,7 @@ from eth.db.header import HeaderDB
 from eth.vm.forks.byzantium import ByzantiumVM
 
 from trinity.db.base import AsyncBaseDB
-from trinity.db.chain import AsyncChainDB
+from trinity.db.chain import BaseAsyncChainDB
 from trinity.db.header import BaseAsyncHeaderDB
 
 ZIPPED_FIXTURES_PATH = Path(__file__).parent.parent / 'integration' / 'fixtures'
@@ -77,7 +78,7 @@ class FakeAsyncHeaderDB(BaseAsyncHeaderDB, HeaderDB):
     coro_persist_header_chain = async_passthrough('persist_header_chain')
 
 
-class FakeAsyncChainDB(FakeAsyncHeaderDB, AsyncChainDB):
+class FakeAsyncChainDB(BaseAsyncChainDB, FakeAsyncHeaderDB, ChainDB):
     coro_persist_block = async_passthrough('persist_block')
     coro_persist_uncles = async_passthrough('persist_uncles')
     coro_persist_trie_data_dict = async_passthrough('persist_trie_data_dict')

--- a/tests/core/proxies/test_proxy_implementation.py
+++ b/tests/core/proxies/test_proxy_implementation.py
@@ -1,3 +1,6 @@
+from trinity.db.chain import (
+    AsyncChainDBPreProxy
+)
 from trinity.db.header import (
     AsyncHeaderDBPreProxy,
 )
@@ -7,3 +10,4 @@ def test_can_instantiate_proxy():
     # The test fails if we forget to implement any of the abstract methods
     # that the proxy derives from it's abstract base classes
     assert AsyncHeaderDBPreProxy(None) is not None
+    assert AsyncChainDBPreProxy(None) is not None

--- a/tests/core/proxies/test_proxy_implementation.py
+++ b/tests/core/proxies/test_proxy_implementation.py
@@ -1,5 +1,8 @@
+from trinity.db.base import (
+    AsyncDBPreProxy,
+)
 from trinity.db.chain import (
-    AsyncChainDBPreProxy
+    AsyncChainDBPreProxy,
 )
 from trinity.db.header import (
     AsyncHeaderDBPreProxy,
@@ -11,3 +14,4 @@ def test_can_instantiate_proxy():
     # that the proxy derives from it's abstract base classes
     assert AsyncHeaderDBPreProxy(None) is not None
     assert AsyncChainDBPreProxy(None) is not None
+    assert AsyncDBPreProxy() is not None

--- a/tests/core/proxies/test_proxy_implementation.py
+++ b/tests/core/proxies/test_proxy_implementation.py
@@ -1,0 +1,9 @@
+from trinity.db.header import (
+    AsyncHeaderDBPreProxy,
+)
+
+
+def test_can_instantiate_proxy():
+    # The test fails if we forget to implement any of the abstract methods
+    # that the proxy derives from it's abstract base classes
+    assert AsyncHeaderDBPreProxy(None) is not None

--- a/trinity/chains/header.py
+++ b/trinity/chains/header.py
@@ -1,16 +1,11 @@
 from abc import abstractmethod
-from typing import Tuple, Type
+from typing import Tuple
 
 from eth.chains.header import (
     BaseHeaderChain,
     HeaderChain,
 )
 from eth.rlp.headers import BlockHeader
-
-from trinity.db.header import (
-    AsyncHeaderDB,
-    BaseAsyncHeaderDB,
-)
 
 
 class BaseAsyncHeaderChain(BaseHeaderChain):
@@ -24,7 +19,6 @@ class BaseAsyncHeaderChain(BaseHeaderChain):
 
 
 class AsyncHeaderChain(HeaderChain, BaseAsyncHeaderChain):
-    _headerdb_class: Type[BaseAsyncHeaderDB] = AsyncHeaderDB
 
     async def coro_get_canonical_head(self) -> BlockHeader:
         raise NotImplementedError("Chain classes must implement this method")

--- a/trinity/db/chain.py
+++ b/trinity/db/chain.py
@@ -14,19 +14,19 @@ from typing import (
 from eth_typing import Hash32
 
 from eth.db.chain import ChainDB
+from eth.db.header import HeaderDB
 from eth.rlp.blocks import BaseBlock
 from eth.rlp.headers import BlockHeader
 from eth.rlp.receipts import Receipt
 from eth.rlp.transactions import BaseTransaction
 
-from trinity.db.header import AsyncHeaderDB
 from trinity._utils.mp import (
     async_method,
     sync_method,
 )
 
 
-class AsyncChainDB(ChainDB, AsyncHeaderDB):
+class AsyncChainDB(ChainDB, HeaderDB):
     async def coro_get(self, key: bytes) -> bytes:
         raise NotImplementedError()
 

--- a/trinity/db/chain.py
+++ b/trinity/db/chain.py
@@ -1,3 +1,4 @@
+from abc import abstractmethod
 # Typeshed definitions for multiprocessing.managers is incomplete, so ignore them for now:
 # https://github.com/python/typeshed/blob/85a788dbcaa5e9e9a62e55f15d44530cd28ba830/stdlib/3/multiprocessing/managers.pyi#L3
 from multiprocessing.managers import (  # type: ignore
@@ -13,8 +14,8 @@ from typing import (
 
 from eth_typing import Hash32
 
-from eth.db.chain import ChainDB
-from eth.db.header import HeaderDB
+from eth.db.backends.base import BaseAtomicDB
+from eth.db.chain import BaseChainDB
 from eth.rlp.blocks import BaseBlock
 from eth.rlp.headers import BlockHeader
 from eth.rlp.receipts import Receipt
@@ -26,34 +27,53 @@ from trinity._utils.mp import (
 )
 
 
-class AsyncChainDB(ChainDB, HeaderDB):
+class BaseAsyncChainDB(BaseChainDB):
+    """
+    Abstract base class extends the abstract ``BaseChainDB`` with async APIs.
+    """
+
+    @abstractmethod
     async def coro_get(self, key: bytes) -> bytes:
-        raise NotImplementedError()
+        pass
 
+    @abstractmethod
     async def coro_persist_block(self, block: BaseBlock) -> None:
-        raise NotImplementedError()
+        pass
 
+    @abstractmethod
     async def coro_persist_uncles(self, uncles: Tuple[BlockHeader]) -> Hash32:
-        raise NotImplementedError()
+        pass
 
+    @abstractmethod
     async def coro_persist_trie_data_dict(self, trie_data_dict: Dict[Hash32, bytes]) -> None:
-        raise NotImplementedError()
+        pass
 
+    @abstractmethod
     async def coro_get_block_transactions(
             self,
             header: BlockHeader,
             transaction_class: Type[BaseTransaction]) -> Iterable[BaseTransaction]:
-        raise NotImplementedError()
+        pass
 
+    @abstractmethod
     async def coro_get_block_uncles(self, uncles_hash: Hash32) -> List[BlockHeader]:
-        raise NotImplementedError()
+        pass
 
+    @abstractmethod
     async def coro_get_receipts(
             self, header: BlockHeader, receipt_class: Type[Receipt]) -> List[Receipt]:
-        raise NotImplementedError()
+        pass
 
 
-class ChainDBProxy(BaseProxy):
+class AsyncChainDBPreProxy(BaseAsyncChainDB):
+    """
+    Proxy implementation of ``BaseAsyncChainDB`` that does not derive from
+    ``BaseProxy`` for the purpose of improved testability.
+    """
+
+    def __init__(self, db: BaseAtomicDB) -> None:
+        pass
+
     coro_get = async_method('get')
     coro_get_block_header_by_hash = async_method('get_block_header_by_hash')
     coro_get_canonical_head = async_method('get_canonical_head')
@@ -69,12 +89,31 @@ class ChainDBProxy(BaseProxy):
     coro_get_block_uncles = async_method('get_block_uncles')
     coro_get_receipts = async_method('get_receipts')
 
+    add_receipt = sync_method('add_receipt')
+    add_transaction = sync_method('add_transaction')
+    exists = sync_method('exists')
     get = sync_method('get')
     get_block_header_by_hash = sync_method('get_block_header_by_hash')
+    get_block_transactions = sync_method('get_block_transactions')
+    get_block_transaction_hashes = sync_method('get_block_transaction_hashes')
+    get_block_uncles = sync_method('get_block_uncles')
     get_canonical_head = sync_method('get_canonical_head')
+    get_receipts = sync_method('get_receipts')
     get_score = sync_method('get_score')
+    get_transaction_by_index = sync_method('get_transaction_by_index')
+    get_transaction_index = sync_method('get_transaction_index')
     header_exists = sync_method('header_exists')
+    get_canonical_block_header_by_number = sync_method('get_canonical_block_header_by_number')
     get_canonical_block_hash = sync_method('get_canonical_block_hash')
+    persist_block = sync_method('persist_block')
     persist_header = sync_method('persist_header')
+    persist_header_chain = sync_method('persist_header_chain')
     persist_uncles = sync_method('persist_uncles')
     persist_trie_data_dict = sync_method('persist_trie_data_dict')
+
+
+class AsyncChainDBProxy(BaseProxy, AsyncChainDBPreProxy):
+    """
+    Turn ``AsyncChainDBPreProxy`` into an actual proxy by deriving from ``BaseProxy``
+    """
+    pass

--- a/trinity/db/manager.py
+++ b/trinity/db/manager.py
@@ -8,7 +8,7 @@ from eth.db.backends.base import BaseAtomicDB
 from eth.db.header import HeaderDB
 
 from trinity.config import TrinityConfig
-from trinity.db.base import DBProxy
+from trinity.db.base import AsyncDBProxy
 from trinity.db.chain import AsyncChainDBProxy
 from trinity.db.header import (
     AsyncHeaderDBProxy
@@ -33,7 +33,7 @@ def get_chaindb_manager(trinity_config: TrinityConfig, base_db: BaseAtomicDB) ->
         pass
 
     DBManager.register(
-        'get_db', callable=lambda: TracebackRecorder(base_db), proxytype=DBProxy)
+        'get_db', callable=lambda: TracebackRecorder(base_db), proxytype=AsyncDBProxy)
 
     DBManager.register(
         'get_chaindb',
@@ -59,7 +59,7 @@ def create_db_manager(ipc_path: pathlib.Path) -> BaseManager:
     class DBManager(BaseManager):
         pass
 
-    DBManager.register('get_db', proxytype=DBProxy)
+    DBManager.register('get_db', proxytype=AsyncDBProxy)
     DBManager.register('get_chaindb', proxytype=AsyncChainDBProxy)
     DBManager.register('get_headerdb', proxytype=AsyncHeaderDBProxy)
 

--- a/trinity/db/manager.py
+++ b/trinity/db/manager.py
@@ -4,13 +4,13 @@ from multiprocessing.managers import (
 import pathlib
 
 from eth.db.backends.base import BaseAtomicDB
+from eth.db.header import HeaderDB
 
 from trinity.config import TrinityConfig
 from trinity.db.base import DBProxy
 from trinity.db.chain import AsyncChainDB, ChainDBProxy
 from trinity.db.header import (
-    AsyncHeaderDB,
-    AsyncHeaderDBProxy,
+    AsyncHeaderDBProxy
 )
 from trinity.initialization import (
     is_database_initialized,
@@ -26,7 +26,7 @@ def get_chaindb_manager(trinity_config: TrinityConfig, base_db: BaseAtomicDB) ->
     if not is_database_initialized(chaindb):
         initialize_database(chain_config, chaindb, base_db)
 
-    headerdb = AsyncHeaderDB(base_db)
+    headerdb = HeaderDB(base_db)
 
     class DBManager(BaseManager):
         pass

--- a/trinity/initialization.py
+++ b/trinity/initialization.py
@@ -10,7 +10,7 @@ from trinity.config import (
     ChainConfig,
     TrinityConfig,
 )
-from trinity.db.chain import AsyncChainDB
+from trinity.db.chain import BaseAsyncChainDB
 from trinity.exceptions import (
     MissingPath,
 )
@@ -50,7 +50,7 @@ def is_data_dir_initialized(trinity_config: TrinityConfig) -> bool:
     return True
 
 
-def is_database_initialized(chaindb: AsyncChainDB) -> bool:
+def is_database_initialized(chaindb: BaseAsyncChainDB) -> bool:
     try:
         chaindb.get_canonical_head()
     except CanonicalHeadNotFound:
@@ -103,7 +103,7 @@ def initialize_data_dir(trinity_config: TrinityConfig) -> None:
 
 
 def initialize_database(chain_config: ChainConfig,
-                        chaindb: AsyncChainDB,
+                        chaindb: BaseAsyncChainDB,
                         base_db: BaseAtomicDB) -> None:
     try:
         chaindb.get_canonical_head()

--- a/trinity/nodes/base.py
+++ b/trinity/nodes/base.py
@@ -18,7 +18,7 @@ from p2p.service import (
 
 from trinity.chains.full import FullChain
 from trinity.db.header import (
-    AsyncHeaderDB,
+    BaseAsyncHeaderDB,
 )
 from trinity.db.manager import (
     create_db_manager
@@ -108,7 +108,7 @@ class Node(BaseService):
         return self._db_manager
 
     @property
-    def headerdb(self) -> AsyncHeaderDB:
+    def headerdb(self) -> BaseAsyncHeaderDB:
         return self._headerdb
 
     def notify_resource_available(self) -> None:

--- a/trinity/protocol/common/servers.py
+++ b/trinity/protocol/common/servers.py
@@ -24,7 +24,7 @@ from p2p.protocol import (
 )
 from p2p.service import BaseService
 
-from trinity.db.header import AsyncHeaderDB
+from trinity.db.header import BaseAsyncHeaderDB
 from trinity.protocol.common.peer import BasePeerPool
 from trinity.protocol.common.requests import BaseHeaderRequest
 from trinity._utils.logging import HasExtendedDebugLogger
@@ -80,7 +80,7 @@ class BaseRequestServer(BaseService, PeerSubscriber):
 
 
 class BasePeerRequestHandler(CancellableMixin, HasExtendedDebugLogger):
-    def __init__(self, db: AsyncHeaderDB, token: CancelToken) -> None:
+    def __init__(self, db: BaseAsyncHeaderDB, token: CancelToken) -> None:
         self.db = db
         self.cancel_token = token
 

--- a/trinity/protocol/eth/servers.py
+++ b/trinity/protocol/eth/servers.py
@@ -28,7 +28,7 @@ from p2p.protocol import (
     Command,
 )
 
-from trinity.db.chain import AsyncChainDB
+from trinity.db.chain import BaseAsyncChainDB
 from trinity.protocol.common.servers import BaseRequestServer, BasePeerRequestHandler
 from trinity.protocol.eth import commands
 from trinity.protocol.eth.peer import ETHPeer, ETHPeerPool
@@ -46,9 +46,9 @@ from trinity.rlp.block_body import BlockBody
 
 
 class ETHPeerRequestHandler(BasePeerRequestHandler):
-    def __init__(self, db: AsyncChainDB, token: CancelToken) -> None:
+    def __init__(self, db: BaseAsyncChainDB, token: CancelToken) -> None:
         super().__init__(db, token)
-        self.db: AsyncChainDB = db
+        self.db: BaseAsyncChainDB = db
 
     async def handle_get_block_headers(
             self,
@@ -146,7 +146,7 @@ class ETHRequestServer(BaseRequestServer):
 
     def __init__(
             self,
-            db: AsyncChainDB,
+            db: BaseAsyncChainDB,
             peer_pool: ETHPeerPool,
             token: CancelToken = None) -> None:
         super().__init__(peer_pool, token)

--- a/trinity/protocol/les/servers.py
+++ b/trinity/protocol/les/servers.py
@@ -14,7 +14,7 @@ from p2p.protocol import (
     _DecodedMsgType,
 )
 
-from trinity.db.header import AsyncHeaderDB
+from trinity.db.header import BaseAsyncHeaderDB
 from trinity.protocol.common.servers import BaseRequestServer, BasePeerRequestHandler
 from trinity.protocol.les import commands
 from trinity.protocol.les.peer import LESPeer, LESPeerPool
@@ -50,7 +50,7 @@ class LightRequestServer(BaseRequestServer):
 
     def __init__(
             self,
-            db: AsyncHeaderDB,
+            db: BaseAsyncHeaderDB,
             peer_pool: LESPeerPool,
             token: CancelToken = None) -> None:
         super().__init__(peer_pool, token)

--- a/trinity/server.py
+++ b/trinity/server.py
@@ -52,7 +52,7 @@ from p2p.service import BaseService
 
 from trinity.chains.base import BaseAsyncChain
 from trinity.constants import DEFAULT_PREFERRED_NODES
-from trinity.db.base import AsyncBaseDB
+from trinity.db.base import BaseAsyncDB
 from trinity.db.chain import BaseAsyncChainDB
 from trinity.db.header import BaseAsyncHeaderDB
 from trinity.protocol.common.context import ChainContext
@@ -82,7 +82,7 @@ class BaseServer(BaseService, Generic[TPeerPool]):
                  chain: BaseAsyncChain,
                  chaindb: BaseAsyncChainDB,
                  headerdb: BaseAsyncHeaderDB,
-                 base_db: AsyncBaseDB,
+                 base_db: BaseAsyncDB,
                  network_id: int,
                  max_peers: int = DEFAULT_MAX_PEERS,
                  bootstrap_nodes: Tuple[Node, ...] = None,

--- a/trinity/server.py
+++ b/trinity/server.py
@@ -54,7 +54,7 @@ from trinity.chains.base import BaseAsyncChain
 from trinity.constants import DEFAULT_PREFERRED_NODES
 from trinity.db.base import AsyncBaseDB
 from trinity.db.chain import AsyncChainDB
-from trinity.db.header import AsyncHeaderDB
+from trinity.db.header import BaseAsyncHeaderDB
 from trinity.protocol.common.context import ChainContext
 from trinity.protocol.common.peer import BaseChainPeerPool
 from trinity.protocol.common.servers import BaseRequestServer
@@ -81,7 +81,7 @@ class BaseServer(BaseService, Generic[TPeerPool]):
                  port: int,
                  chain: BaseAsyncChain,
                  chaindb: AsyncChainDB,
-                 headerdb: AsyncHeaderDB,
+                 headerdb: BaseAsyncHeaderDB,
                  base_db: AsyncBaseDB,
                  network_id: int,
                  max_peers: int = DEFAULT_MAX_PEERS,

--- a/trinity/server.py
+++ b/trinity/server.py
@@ -53,7 +53,7 @@ from p2p.service import BaseService
 from trinity.chains.base import BaseAsyncChain
 from trinity.constants import DEFAULT_PREFERRED_NODES
 from trinity.db.base import AsyncBaseDB
-from trinity.db.chain import AsyncChainDB
+from trinity.db.chain import BaseAsyncChainDB
 from trinity.db.header import BaseAsyncHeaderDB
 from trinity.protocol.common.context import ChainContext
 from trinity.protocol.common.peer import BaseChainPeerPool
@@ -80,7 +80,7 @@ class BaseServer(BaseService, Generic[TPeerPool]):
                  privkey: datatypes.PrivateKey,
                  port: int,
                  chain: BaseAsyncChain,
-                 chaindb: AsyncChainDB,
+                 chaindb: BaseAsyncChainDB,
                  headerdb: BaseAsyncHeaderDB,
                  base_db: AsyncBaseDB,
                  network_id: int,

--- a/trinity/sync/common/chain.py
+++ b/trinity/sync/common/chain.py
@@ -36,7 +36,7 @@ from p2p.service import (
 )
 
 from trinity.chains.base import BaseAsyncChain
-from trinity.db.header import AsyncHeaderDB
+from trinity.db.header import BaseAsyncHeaderDB
 from trinity.protocol.common.peer import (
     BaseChainPeer,
 )
@@ -55,7 +55,7 @@ class PeerHeaderSyncer(BaseService):
 
     def __init__(self,
                  chain: BaseAsyncChain,
-                 db: AsyncHeaderDB,
+                 db: BaseAsyncHeaderDB,
                  peer: BaseChainPeer,
                  token: CancelToken = None) -> None:
         super().__init__(token)

--- a/trinity/sync/common/headers.py
+++ b/trinity/sync/common/headers.py
@@ -43,7 +43,7 @@ from p2p.protocol import Command
 from p2p.service import BaseService
 
 from trinity.chains.base import BaseAsyncChain
-from trinity.db.header import AsyncHeaderDB
+from trinity.db.header import BaseAsyncHeaderDB
 from trinity.protocol.common.commands import (
     BaseBlockHeaders,
 )
@@ -77,7 +77,7 @@ class SkeletonSyncer(BaseService, Generic[TChainPeer]):
 
     def __init__(self,
                  chain: BaseAsyncChain,
-                 db: AsyncHeaderDB,
+                 db: BaseAsyncHeaderDB,
                  peer: TChainPeer,
                  token: CancelToken) -> None:
         super().__init__(token=token)
@@ -708,7 +708,7 @@ class BaseHeaderChainSyncer(BaseService, HeaderSyncerAPI, Generic[TChainPeer]):
 
     def __init__(self,
                  chain: BaseAsyncChain,
-                 db: AsyncHeaderDB,
+                 db: BaseAsyncHeaderDB,
                  peer_pool: BaseChainPeerPool,
                  token: CancelToken = None) -> None:
         super().__init__(token)

--- a/trinity/sync/full/chain.py
+++ b/trinity/sync/full/chain.py
@@ -44,7 +44,7 @@ from p2p.protocol import Command
 from p2p.service import BaseService
 
 from trinity.chains.base import BaseAsyncChain
-from trinity.db.chain import AsyncChainDB
+from trinity.db.chain import BaseAsyncChainDB
 from trinity.protocol.eth.monitors import ETHChainTipMonitor
 from trinity.protocol.eth import commands
 from trinity.protocol.eth.constants import (
@@ -101,7 +101,7 @@ class BaseBodyChainSyncer(BaseService, PeerSubscriber):
 
     def __init__(self,
                  chain: BaseAsyncChain,
-                 db: AsyncChainDB,
+                 db: BaseAsyncChainDB,
                  peer_pool: ETHPeerPool,
                  token: CancelToken = None) -> None:
         super().__init__(token=token)
@@ -292,7 +292,7 @@ class BaseBodyChainSyncer(BaseService, PeerSubscriber):
 class FastChainSyncer(BaseService):
     def __init__(self,
                  chain: BaseAsyncChain,
-                 db: AsyncChainDB,
+                 db: BaseAsyncChainDB,
                  peer_pool: ETHPeerPool,
                  token: CancelToken = None) -> None:
         super().__init__(token=token)
@@ -392,7 +392,7 @@ class FastChainBodySyncer(BaseBodyChainSyncer):
     """
     def __init__(self,
                  chain: BaseAsyncChain,
-                 db: AsyncChainDB,
+                 db: BaseAsyncChainDB,
                  peer_pool: ETHPeerPool,
                  header_syncer: HeaderSyncerAPI,
                  token: CancelToken = None) -> None:
@@ -771,7 +771,7 @@ class FastChainBodySyncer(BaseBodyChainSyncer):
 class RegularChainSyncer(BaseService):
     def __init__(self,
                  chain: BaseAsyncChain,
-                 db: AsyncChainDB,
+                 db: BaseAsyncChainDB,
                  peer_pool: ETHPeerPool,
                  token: CancelToken = None) -> None:
         super().__init__(token=token)
@@ -803,7 +803,7 @@ class RegularChainBodySyncer(BaseBodyChainSyncer):
     """
     def __init__(self,
                  chain: BaseAsyncChain,
-                 db: AsyncChainDB,
+                 db: BaseAsyncChainDB,
                  peer_pool: ETHPeerPool,
                  header_syncer: HeaderSyncerAPI,
                  token: CancelToken = None) -> None:

--- a/trinity/sync/full/hexary_trie.py
+++ b/trinity/sync/full/hexary_trie.py
@@ -30,7 +30,7 @@ from trie.utils.nodes import (
     is_blank_node,
 )
 
-from trinity.db.base import AsyncBaseDB
+from trinity.db.base import BaseAsyncDB
 from trinity.exceptions import SyncRequestAlreadyProcessed
 
 
@@ -115,7 +115,7 @@ class HexaryTrieSync:
 
     def __init__(self,
                  root_hash: Hash32,
-                 db: AsyncBaseDB,
+                 db: BaseAsyncDB,
                  nodes_cache: BaseDB,
                  logger: ExtendedDebugLogger) -> None:
         # Nodes that haven't been requested yet.

--- a/trinity/sync/full/service.py
+++ b/trinity/sync/full/service.py
@@ -9,7 +9,7 @@ from p2p.service import BaseService
 
 from trinity.chains.base import BaseAsyncChain
 from trinity.db.base import AsyncBaseDB
-from trinity.db.chain import AsyncChainDB
+from trinity.db.chain import BaseAsyncChainDB
 from trinity.protocol.eth.peer import ETHPeerPool
 
 from .chain import FastChainSyncer, RegularChainSyncer
@@ -19,13 +19,13 @@ from .state import StateDownloader
 
 class FullNodeSyncer(BaseService):
     chain: BaseAsyncChain = None
-    chaindb: AsyncChainDB = None
+    chaindb: BaseAsyncChainDB = None
     base_db: AsyncBaseDB = None
     peer_pool: ETHPeerPool = None
 
     def __init__(self,
                  chain: BaseAsyncChain,
-                 chaindb: AsyncChainDB,
+                 chaindb: BaseAsyncChainDB,
                  base_db: AsyncBaseDB,
                  peer_pool: ETHPeerPool,
                  token: CancelToken = None) -> None:

--- a/trinity/sync/full/service.py
+++ b/trinity/sync/full/service.py
@@ -8,7 +8,7 @@ from eth.constants import BLANK_ROOT_HASH
 from p2p.service import BaseService
 
 from trinity.chains.base import BaseAsyncChain
-from trinity.db.base import AsyncBaseDB
+from trinity.db.base import BaseAsyncDB
 from trinity.db.chain import BaseAsyncChainDB
 from trinity.protocol.eth.peer import ETHPeerPool
 
@@ -20,13 +20,13 @@ from .state import StateDownloader
 class FullNodeSyncer(BaseService):
     chain: BaseAsyncChain = None
     chaindb: BaseAsyncChainDB = None
-    base_db: AsyncBaseDB = None
+    base_db: BaseAsyncDB = None
     peer_pool: ETHPeerPool = None
 
     def __init__(self,
                  chain: BaseAsyncChain,
                  chaindb: BaseAsyncChainDB,
-                 base_db: AsyncBaseDB,
+                 base_db: BaseAsyncDB,
                  peer_pool: ETHPeerPool,
                  token: CancelToken = None) -> None:
         super().__init__(token)

--- a/trinity/sync/full/state.py
+++ b/trinity/sync/full/state.py
@@ -49,7 +49,7 @@ from p2p.exceptions import (
 )
 from p2p.peer import BasePeer, PeerSubscriber
 
-from trinity.db.base import AsyncBaseDB
+from trinity.db.base import BaseAsyncDB
 from trinity.db.chain import BaseAsyncChainDB
 from trinity.exceptions import (
     AlreadyWaiting,
@@ -76,7 +76,7 @@ class StateDownloader(BaseService, PeerSubscriber):
 
     def __init__(self,
                  chaindb: BaseAsyncChainDB,
-                 account_db: AsyncBaseDB,
+                 account_db: BaseAsyncDB,
                  root_hash: Hash32,
                  peer_pool: ETHPeerPool,
                  token: CancelToken = None) -> None:

--- a/trinity/sync/full/state.py
+++ b/trinity/sync/full/state.py
@@ -50,7 +50,7 @@ from p2p.exceptions import (
 from p2p.peer import BasePeer, PeerSubscriber
 
 from trinity.db.base import AsyncBaseDB
-from trinity.db.chain import AsyncChainDB
+from trinity.db.chain import BaseAsyncChainDB
 from trinity.exceptions import (
     AlreadyWaiting,
     SyncRequestAlreadyProcessed,
@@ -75,7 +75,7 @@ class StateDownloader(BaseService, PeerSubscriber):
     _total_timeouts = 0
 
     def __init__(self,
-                 chaindb: AsyncChainDB,
+                 chaindb: BaseAsyncChainDB,
                  account_db: AsyncBaseDB,
                  root_hash: Hash32,
                  peer_pool: ETHPeerPool,

--- a/trinity/sync/light/chain.py
+++ b/trinity/sync/light/chain.py
@@ -4,7 +4,7 @@ from cancel_token import CancelToken
 from p2p.service import BaseService
 
 from trinity.chains.base import BaseAsyncChain
-from trinity.db.header import AsyncHeaderDB
+from trinity.db.header import BaseAsyncHeaderDB
 from trinity.protocol.les.peer import LESPeerPool
 from trinity.protocol.les.sync import LightHeaderChainSyncer
 from trinity._utils.timer import Timer
@@ -13,7 +13,7 @@ from trinity._utils.timer import Timer
 class LightChainSyncer(BaseService):
     def __init__(self,
                  chain: BaseAsyncChain,
-                 db: AsyncHeaderDB,
+                 db: BaseAsyncHeaderDB,
                  peer_pool: LESPeerPool,
                  token: CancelToken = None) -> None:
         super().__init__(token=token)


### PR DESCRIPTION
### What was wrong?

1. Our current proxy classes are a known source of fatal bugs. The reason for that is because they only derive from `BaseProxy` (e.g. `ChainDBProxy(BaseProxy)`) and then implement whatever they want. So, there is *zero* guarantee that a `ChainDBProxy` will actually have the methods of a `BaseChainDB` which has lead to many run time crashes in Trinity over time.

2. The complexity of classes involved is higher than it needs to be. E.g. taking a look at `AsyncHeaderDB` it may seem that the purpose of this class is to be an *abstract* definition.

https://github.com/ethereum/trinity/blob/0d76f212ac71ba8567533c813d549f640403e953/trinity/db/header.py#L70-L94

But that is not the case, the abstract definition is the `BaseAsyncHeaderDB`  as shown below:

https://github.com/ethereum/trinity/blob/0d76f212ac71ba8567533c813d549f640403e953/trinity/db/header.py#L29-L67

So, what is the purpose of `AsyncHeaderDB` if all it does is to derive from `HeaderDB` and throw in the async methods? 

The answer is that the manager instantiates an `AsyncHeaderDB` (which derives from `HeaderDB`) to use that as the backend for the `AsyncHeaderDBProxy`.

https://github.com/ethereum/trinity/blob/0d76f212ac71ba8567533c813d549f640403e953/trinity/db/manager.py#L29-L47

But there's no reason for that added complexity because the `AsyncHeaderDBProxy` just calls methods of the `HeaderDB` and so a `HeaderDB` serves just fine as a backend for that proxy.

In other words, there is no reason why we should write an implementation without implementation. That's what the *abstract*  base class is for. And since we use three different DB types + the beacon chain does the same, the complexity adds up (6 superfluous classes basically) .

### How was it fixed?

1. This removes all the extra classes that **were not abstract classes** yet did not provide an implementation.

2. This introduces a pattern of implementing a `*PreProxy` that **does** implement an abstract base class and hence throws if an abstract method is not implemented. It also adds a very simple test that just instantiates each `PreProxy`. **This eliminates a common source of Trinity bugs**. In fact, this PR already adds method implementations that the new tests revealed that were missing.


3. This fixes naming inconsistency issues. All abstract base classes begin with `Base*` to be more in line with the rest of the code base.

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](http://all4desktop.com/data_images/original/4243145-animals.jpg)
