### PR TITLE
[conceptual] move compression to base peer

### DIFF
--- a/trinity/protocol/eth/proto.py
+++ b/trinity/protocol/eth/proto.py
@@ -75,9 +75,8 @@ class ETHProtocol(HasExtendedDebugLogger, Protocol):
         self.send(header, body)
 
     def send_node_data(self, nodes: Tuple[bytes, ...]) -> None:
-        cmd = NodeData(self.cmd_id_offset, self.snappy_support)
-        header, body = cmd.encode(nodes)
-        self.send(header, body)
+        cmd = NodeData(self.cmd_id_offset)
+        self.request(cmd, cmd.encode_payload(nodes))
 
     #
     # Block Headers


### PR DESCRIPTION
### What was wrong?

Something still feels wrong about passing around the snappy boolean everywhere. Inspired by #175

### How was it fixed?

Move compression (like encryption) to the base peer.

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses]()
