### PR TITLE
Use Python 3.6 syntax for TypedDict

### DIFF
--- a/trinity/protocol/bcc/commands.py
+++ b/trinity/protocol/bcc/commands.py
@@ -34,10 +34,9 @@ class Status(Command):
     ]
 
 
-GetBeaconBlocksMessage = TypedDict("GetBeaconBlocksMessage", {
-    "block_slot_or_root": Union[int, Hash32],
-    "max_blocks": int,
-})
+class GetBeaconBlocksMessage(TypedDict):
+    block_slot_or_root: Union[int, Hash32]
+    max_blocks: int
 
 
 class GetBeaconBlocks(Command):


### PR DESCRIPTION
### What was wrong?

Found a place where we used the Python 3.5 syntax for TypedDict.

### How was it fixed?

Use the class based syntax.

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://i.pinimg.com/originals/c6/30/96/c63096ea9f25cbb23b5476fbefbc6c83.jpg)
