### PR TITLE
Fix KBucket.add for a duplicate node of replacement_cache.

### DIFF
--- a/p2p/kademlia.py
+++ b/p2p/kademlia.py
@@ -229,6 +229,8 @@ class KBucket(Sized):
         elif len(self) < self.k:
             self.nodes.append(node)
         else:
+            if node in self.replacement_cache:
+                self.replacement_cache.remove(node)
             self.replacement_cache.append(node)
             return self.head
         return None

--- a/tests/p2p/test_kademlia.py
+++ b/tests/p2p/test_kademlia.py
@@ -114,6 +114,18 @@ def test_kbucket_add():
     assert bucket.add(node3) == node2
     assert bucket.nodes == [node2, node]
     assert bucket.head == node2
+    assert bucket.replacement_cache == [node3]
+
+    node4 = random_node()
+    assert bucket.add(node4) == node2
+    assert bucket.nodes == [node2, node]
+    assert bucket.head == node2
+    assert bucket.replacement_cache == [node3, node4]
+
+    assert bucket.add(node3) == node2
+    assert bucket.nodes == [node2, node]
+    assert bucket.head == node2
+    assert bucket.replacement_cache == [node4, node3]
 
 
 def test_kbucket_remove():


### PR DESCRIPTION
### What was wrong?
- `KBucket.add` does not handle a duplicate node of `KBucket.replacement_cache`.


### How was it fixed?
- Add codes similar to handling duplicate nodes in `KBucket.nodes`


#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](http://rgo4.com/files/attach/images/2681740/730/638/016/dbb8817d02a0ad60025e6b1e272fd3cc.jpg)
