### PR TITLE
Fix some broken imports

### DIFF
--- a/eth2/README.md
+++ b/eth2/README.md
@@ -104,7 +104,7 @@ Py-EVM abstracts EVM with `BaseVM` that defines the interfaces, and implements s
 ![](https://storage.googleapis.com/ethereum-hackmd/upload_14a701ef308508cd7f837eeca56ed251.png)
 
 
-The in-protocol data structures are defined in `eth.beacon.types`. If the data fields might be different from the future forks, we can implement a new subclass in the future.
+The in-protocol data structures are defined in `eth2.beacon.types`. If the data fields might be different from the future forks, we can implement a new subclass in the future.
 
 ![](https://storage.googleapis.com/ethereum-hackmd/upload_be262ea6aac671174463882ed3f11420.png)
 

--- a/trinity/protocol/bcc/normalizers.py
+++ b/trinity/protocol/bcc/normalizers.py
@@ -2,7 +2,7 @@ from typing import (
     Tuple,
 )
 
-from eth.beacon.types.blocks import BaseBeaconBlock
+from eth2.beacon.types.blocks import BaseBeaconBlock
 
 from trinity.protocol.common.normalizers import BaseNormalizer
 

--- a/trinity/protocol/bcc/trackers.py
+++ b/trinity/protocol/bcc/trackers.py
@@ -2,7 +2,7 @@ from typing import (
     Tuple,
 )
 
-from eth.beacon.types.blocks import BaseBeaconBlock
+from eth2.beacon.types.blocks import BaseBeaconBlock
 
 from trinity.protocol.common.trackers import BasePerformanceTracker
 from trinity.protocol.bcc.requests import (


### PR DESCRIPTION
### What was wrong?

Looks like #188 broke some imports.

### How was it fixed?

Replaced `eth.beacon` with `eth2.beacon`.

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://i.pinimg.com/originals/a1/6c/cf/a16ccfdca8f1975b416119b63730e152.jpg)
