### PR TITLE
[WIP] Make `Command` class "stateless"

### DIFF
--- a/p2p/p2p_proto.py
+++ b/p2p/p2p_proto.py
@@ -109,7 +109,7 @@ class P2PProtocol(Protocol):
                     capabilities=self.peer.capabilities,
                     listen_port=self.peer.listen_port,
                     remote_pubkey=self.peer.privkey.public_key.to_bytes())
-        header, body = Hello(self.cmd_id_offset, self.snappy_support).encode(data)
+        header, body = Hello(self._cmd_id_offset, self._snappy_support).encode(data)
         self.send(header, body)
 
     def send_disconnect(self, reason: DisconnectReason) -> None:
@@ -121,5 +121,5 @@ class P2PProtocol(Protocol):
         self.send(header, body)
 
     def send_pong(self) -> None:
-        header, body = Pong(self.cmd_id_offset, self.snappy_support).encode({})
+        header, body = Pong(self._cmd_id_offset, self._snappy_support).encode({})
         self.send(header, body)

--- a/p2p/p2p_proto.py
+++ b/p2p/p2p_proto.py
@@ -96,10 +96,10 @@ class P2PProtocol(Protocol):
     _commands = [Hello, Ping, Pong, Disconnect]
     cmd_length = 16
 
-    def __init__(self, peer: 'BasePeer', snappy_support: bool) -> None:
-        # For the base protocol the cmd_id_offset is always 0.
-        # For the base protocol snappy compression should be disabled
-        super().__init__(peer, cmd_id_offset=0, snappy_support=snappy_support)
+    def __init__(self, peer: 'BasePeer') -> None:
+        # DEVp2p command ID offset is always 0, since it's the lowest-level protocol.
+        # DEVp2p sessions always start with compression disabled, upgrading if remote supports it.
+        super().__init__(peer, cmd_id_offset=0, snappy_support=False)
 
     def send_handshake(self) -> None:
         # TODO: move import out once this is in the trinity codebase

--- a/p2p/p2p_proto.py
+++ b/p2p/p2p_proto.py
@@ -81,7 +81,7 @@ class Disconnect(Command):
         try:
             raw_decoded = cast(Dict[str, int], super().decode(data))
         except rlp.exceptions.ListDeserializationError:
-            self.logger.warning("Malformed Disconnect message: %s", data)
+            cls.logger.warning("Malformed Disconnect message: %s", data)
             raise MalformedMessage(f"Malformed Disconnect message: {data}")
         return assoc(raw_decoded, 'reason_name', cls.get_reason_name(raw_decoded['reason']))
 

--- a/p2p/peer.py
+++ b/p2p/peer.py
@@ -196,9 +196,7 @@ class BasePeer(BaseService):
         # Networking reader and writer objects for communication
         self.reader = connection.reader
         self.writer = connection.writer
-        # Initially while doing the handshake, the base protocol shouldn't support
-        # snappy compression
-        self.base_protocol = P2PProtocol(self, snappy_support=False)
+        self.base_protocol = P2PProtocol(self)
 
         # Flag indicating whether the connection this peer represents was
         # established from a dial-out or dial-in (True: dial-in, False:
@@ -480,11 +478,8 @@ class BasePeer(BaseService):
         # based on other peer's p2p protocol version
         snappy_support = msg['version'] >= SNAPPY_PROTOCOL_VERSION
 
-        if snappy_support:
-            # Now update the base protocol to support snappy compression
-            # This is needed so that Trinity is compatible with parity since
-            # parity sends Ping immediately after Handshake
-            self.base_protocol = P2PProtocol(self, snappy_support=snappy_support)
+        # Now update the base protocol to support snappy compression
+        self.base_protocol.snappy_support = snappy_support
 
         remote_capabilities = msg['capabilities']
         try:

--- a/p2p/peer.py
+++ b/p2p/peer.py
@@ -483,7 +483,7 @@ class BasePeer(BaseService):
 
         remote_capabilities = msg['capabilities']
         try:
-            self.sub_proto = self.select_sub_protocol(remote_capabilities, snappy_support)
+            self.sub_proto = self.select_sub_protocol(remote_capabilities)
         except NoMatchingPeerCapabilities:
             await self.disconnect(DisconnectReason.useless_peer)
             raise HandshakeFailure(
@@ -596,9 +596,8 @@ class BasePeer(BaseService):
         if self.is_operational:
             self.cancel_nowait()
 
-    def select_sub_protocol(self,
-                            remote_capabilities: List[Tuple[bytes, int]],
-                            snappy_support: bool) -> protocol.Protocol:
+    def select_sub_protocol(
+            self, remote_capabilities: List[Tuple[bytes, int]]) -> protocol.Protocol:
         """Select the sub-protocol to use when talking to the remote.
 
         Find the highest version of our supported sub-protocols that is also supported by the
@@ -612,7 +611,9 @@ class BasePeer(BaseService):
         if not matching_capabilities:
             raise NoMatchingPeerCapabilities()
         _, highest_matching_version = max(matching_capabilities, key=operator.itemgetter(1))
+        # inherit protocol properties from base protocol (e.g. ETH or LES - from DEVp2p)
         offset = self.base_protocol.cmd_length
+        snappy_support = self.base_protocol.snappy_support
         for proto_class in self._supported_sub_protocols:
             if proto_class.version == highest_matching_version:
                 return proto_class(self, offset, snappy_support)

--- a/p2p/protocol.py
+++ b/p2p/protocol.py
@@ -188,16 +188,29 @@ class Protocol:
     def __init__(self, peer: 'BasePeer', cmd_id_offset: int, snappy_support: bool) -> None:
         self.peer = peer
         self.cmd_id_offset = cmd_id_offset
-        self.snappy_support = snappy_support
-        self.commands = [cmd_class(cmd_id_offset, snappy_support) for cmd_class in self._commands]
-        self.cmd_by_type = {type(cmd): cmd for cmd in self.commands}
-        self.cmd_by_id = {cmd.cmd_id: cmd for cmd in self.commands}
+        self._snappy_support = snappy_support
+        self.snappy_support = self._snappy_support
 
     @property
     def logger(self) -> logging.Logger:
         if self._logger is None:
             self._logger = logging.getLogger(f"p2p.protocol.{type(self).__name__}")
         return self._logger
+
+    @property
+    def snappy_support(self) -> bool:
+        '''TODO'''
+        return self._snappy_support
+
+    @snappy_support.setter
+    def snappy_support(self, enabled: bool) -> None:
+        '''TODO'''
+        self._snappy_support = enabled
+        # update available commands, including their parameters
+        self.commands = [cmd_class(self.cmd_id_offset, self._snappy_support)
+                         for cmd_class in self._commands]
+        self.cmd_by_type = {type(cmd): cmd for cmd in self.commands}
+        self.cmd_by_id = {cmd.cmd_id: cmd for cmd in self.commands}
 
     def send(self, header: bytes, body: bytes) -> None:
         self.peer.send(header, body)

--- a/p2p/protocol.py
+++ b/p2p/protocol.py
@@ -71,10 +71,7 @@ class Command:
             cls._logger = logging.getLogger(f"p2p.protocol.{type(cls).__name__}")
         return cls._logger
 
-    # FIXME: make @classmethod
-    @property
-    def is_base_protocol(cls) -> bool:
-        return cls._cmd_id_offset == 0
+    # TODO: add abstract methods for is_base_protocol
 
     # FIXME: reference to `self`
     # def __str__(self) -> str:
@@ -184,6 +181,7 @@ def get_command_class(cmd_class, cmd_id_offset, snappy_support):
         _snappy_support = snappy_support
 
         cmd_id = _cmd_id_offset + cmd_class._cmd_id
+        is_base_protocol = _cmd_id_offset == 0
         cmd_type = cmd_class
 
         # FIXME: `self`

--- a/p2p/protocol.py
+++ b/p2p/protocol.py
@@ -189,7 +189,13 @@ class Protocol:
         self.peer = peer
         self.cmd_id_offset = cmd_id_offset
         self._snappy_support = snappy_support
-        self.snappy_support = self._snappy_support
+        self._update_protocol_commands()
+
+    def _update_protocol_commands(self) -> None:
+        self.commands = [cmd_class(self.cmd_id_offset, self._snappy_support)
+                         for cmd_class in self._commands]
+        self.cmd_by_type = {type(cmd): cmd for cmd in self.commands}
+        self.cmd_by_id = {cmd.cmd_id: cmd for cmd in self.commands}
 
     @property
     def logger(self) -> logging.Logger:
@@ -206,11 +212,7 @@ class Protocol:
     def snappy_support(self, enabled: bool) -> None:
         '''TODO'''
         self._snappy_support = enabled
-        # update available commands, including their parameters
-        self.commands = [cmd_class(self.cmd_id_offset, self._snappy_support)
-                         for cmd_class in self._commands]
-        self.cmd_by_type = {type(cmd): cmd for cmd in self.commands}
-        self.cmd_by_id = {cmd.cmd_id: cmd for cmd in self.commands}
+        self._update_protocol_commands()
 
     def send(self, header: bytes, body: bytes) -> None:
         self.peer.send(header, body)

--- a/p2p/protocol.py
+++ b/p2p/protocol.py
@@ -1,4 +1,4 @@
-from abc import ABC
+from abc import ABC, abstractmethod
 import logging
 import struct
 from typing import (
@@ -53,18 +53,28 @@ TRequestPayload = TypeVar('TRequestPayload', bound=PayloadType, covariant=True)
 _DecodedMsgType = PayloadType
 
 
-class Command:
+class Command(ABC):
     _cmd_id: int = None
     _cmd_id_offset: int = None
-    cmd_id = None
     _snappy_support = None
+
+    cmd_id = None
+    is_base_protocol = None
 
     decode_strict = True
     structure: List[Tuple[str, Any]] = []
 
     logger = None
 
-    # TODO: add abstract methods for is_base_protocol
+    @classmethod
+    @abstractmethod
+    def __repr__(cls) -> str:
+        raise NotImplementedError("Commands not bound to a protocol must not exist.")
+
+    @classmethod
+    @abstractmethod
+    def __str__(cls) -> str:
+        raise NotImplementedError("Commands not bound to a protocol must not exist.")
 
     @classmethod
     def encode_payload(cls, data: Union[PayloadType, sedes.CountableList]) -> bytes:
@@ -189,8 +199,8 @@ def get_command_class(cmd_base_class: Type[Command],
         _snappy_support = snappy_support
 
         cmd_id = _cmd_id_offset + cmd_base_class._cmd_id
-
         is_base_protocol = _cmd_id_offset == 0
+
         cmd_type = cmd_base_class
 
         logger = logging.getLogger(f"p2p.protocol.{cmd_base_class.__name__}")

--- a/p2p/protocol.py
+++ b/p2p/protocol.py
@@ -176,7 +176,8 @@ def get_command_class(cmd_class, cmd_id_offset, snappy_support):
     if specifier in command_classes.keys():
         return command_classes[specifier]
 
-    class CommandClassInstance(cmd_class):
+    class CommandWithSettings(cmd_class):
+        '''TODO'''
         _cmd_id_offset = cmd_id_offset
         _snappy_support = snappy_support
 
@@ -184,14 +185,14 @@ def get_command_class(cmd_class, cmd_id_offset, snappy_support):
         is_base_protocol = _cmd_id_offset == 0
         cmd_type = cmd_class
 
-        # FIXME: `self`
-        def __repr__(self):
-            # FIXME: not, strictly speaking, correct (it's not a tuple!)
-            return f'{specifier}'
-        # def __type__(self):
-        #     return cmd_class
+        @classmethod
+        def __repr__(cls):
+            return (
+                f"{cmd_class}<cmd_id_offset={cmd_id_offset}, "
+                f"snappy_support={snappy_support})>"
+            )
 
-    c = CommandClassInstance()
+    c = CommandWithSettings()
     command_classes[specifier] = c
     return c
 

--- a/tests/core/p2p-proto/test_peer.py
+++ b/tests/core/p2p-proto/test_peer.py
@@ -46,30 +46,21 @@ async def test_les_handshake():
     assert isinstance(peer2.sub_proto, LESProtocol)
 
 
-@pytest.mark.parametrize(
-    'snappy_support',
-    (
-        True,
-        False,
-    )
-)
-def test_sub_protocol_selection(snappy_support):
-    peer = ProtoMatchingPeer([LESProtocol, LESProtocolV2], snappy_support)
+def test_sub_protocol_selection():
+    peer = ProtoMatchingPeer([LESProtocol, LESProtocolV2])
 
     proto = peer.select_sub_protocol([
         (LESProtocol.name, LESProtocol.version),
         (LESProtocolV2.name, LESProtocolV2.version),
         (LESProtocolV3.name, LESProtocolV3.version),
-        ('unknown', 1),
-    ],
-        snappy_support=snappy_support
-    )
+        ('unknown', 1)
+    ])
 
     assert isinstance(proto, LESProtocolV2)
     assert proto.cmd_id_offset == peer.base_protocol.cmd_length
 
     with pytest.raises(NoMatchingPeerCapabilities):
-        peer.select_sub_protocol([('unknown', 1)], snappy_support)
+        peer.select_sub_protocol([('unknown', 1)])
 
 
 @pytest.mark.asyncio
@@ -102,6 +93,6 @@ class LESProtocolV3(LESProtocol):
 
 class ProtoMatchingPeer(LESPeer):
 
-    def __init__(self, supported_sub_protocols, snappy_support):
+    def __init__(self, supported_sub_protocols):
         self._supported_sub_protocols = supported_sub_protocols
-        self.base_protocol = P2PProtocol(self, snappy_support)
+        self.base_protocol = P2PProtocol(self)

--- a/tests/core/p2p-proto/test_snappy_compression.py
+++ b/tests/core/p2p-proto/test_snappy_compression.py
@@ -14,7 +14,7 @@ async def test_snappy_compression_enabled_between_connected_v5_protocol_peers(re
 
 
 @pytest.mark.asyncio
-async def test_snappy_compression_enabled_between_connected_v4_and_v5_protocol_peers(
+async def test_snappy_compression_disabled_between_connected_v4_and_v5_protocol_peers(
         request,
         event_loop):
     alice, bob = await get_directly_linked_v4_and_v5_peers(request, event_loop)

--- a/trinity/protocol/common/commands.py
+++ b/trinity/protocol/common/commands.py
@@ -9,7 +9,8 @@ from p2p.protocol import (
 )
 
 
-class BaseBlockHeaders(ABC, Command):
+# `Command` must come before `ABC`, since `Command` is derived from `ABC`
+class BaseBlockHeaders(Command, ABC):
 
     @abstractmethod
     def extract_headers(self, msg: _DecodedMsgType) -> Tuple[BlockHeader, ...]:

--- a/trinity/protocol/common/managers.py
+++ b/trinity/protocol/common/managers.py
@@ -143,7 +143,7 @@ class ResponseCandidateStream(
                 if peer != self._peer:
                     self.logger.error("Unexpected peer: %s  expected: %s", peer, self._peer)
                     continue
-                elif isinstance(cmd, self.response_msg_type):
+                elif cmd.cmd_type == self.response_msg_type:
                     await self._handle_msg(cast(TResponsePayload, msg))
                 else:
                     self.logger.warning("Unexpected payload type: %s", cmd.__class__.__name__)

--- a/trinity/protocol/common/monitors.py
+++ b/trinity/protocol/common/monitors.py
@@ -68,7 +68,7 @@ class BaseChainTipMonitor(BaseService, PeerSubscriber):
         new_tip_types = tuple(self.subscription_msg_types)
         while self.is_operational:
             peer, cmd, msg = await self.wait(self.msg_queue.get())
-            if isinstance(cmd, new_tip_types):
+            if cmd.cmd_type in new_tip_types:
                 self._notify_tip()
 
     def _notify_tip(self) -> None:

--- a/trinity/protocol/eth/peer.py
+++ b/trinity/protocol/eth/peer.py
@@ -48,7 +48,7 @@ class ETHPeer(BaseChainPeer):
         return self._requests
 
     def handle_sub_proto_msg(self, cmd: Command, msg: _DecodedMsgType) -> None:
-        if isinstance(cmd, NewBlock):
+        if cmd.cmd_type == NewBlock:
             msg = cast(Dict[str, Any], msg)
             header, _, _ = msg['block']
             actual_head = header.parent_hash
@@ -64,7 +64,7 @@ class ETHPeer(BaseChainPeer):
 
     async def process_sub_proto_handshake(
             self, cmd: Command, msg: _DecodedMsgType) -> None:
-        if not isinstance(cmd, Status):
+        if not cmd.cmd_type == Status:
             await self.disconnect(DisconnectReason.subprotocol_error)
             raise HandshakeFailure(f"Expected a ETH Status msg, got {cmd}, disconnecting")
         msg = cast(Dict[str, Any], msg)

--- a/trinity/protocol/eth/proto.py
+++ b/trinity/protocol/eth/proto.py
@@ -62,21 +62,20 @@ class ETHProtocol(HasExtendedDebugLogger, Protocol):
             'best_hash': chain_info.block_hash,
             'genesis_hash': chain_info.genesis_hash,
         }
-        cmd = Status(self.cmd_id_offset, self.snappy_support)
-        self.logger.debug2("Sending ETH/Status msg: %s; with cmd id_offset %s and compression %s",
-                           resp, cmd.cmd_id_offset, cmd.snappy_support)
+        cmd = self.cmd_by_type[Status]
+        self.logger.debug2("Sending ETH/Status msg: %s; using cmd %r", resp, cmd)
         self.send(*cmd.encode(resp))
 
     #
     # Node Data
     #
     def send_get_node_data(self, node_hashes: Tuple[Hash32, ...]) -> None:
-        cmd = GetNodeData(self.cmd_id_offset, self.snappy_support)
+        cmd = self.cmd_by_type[GetNodeData]
         header, body = cmd.encode(node_hashes)
         self.send(header, body)
 
     def send_node_data(self, nodes: Tuple[bytes, ...]) -> None:
-        cmd = NodeData(self.cmd_id_offset, self.snappy_support)
+        cmd = self.cmd_by_type[NodeData]
         header, body = cmd.encode(nodes)
         self.send(header, body)
 
@@ -95,7 +94,7 @@ class ETHProtocol(HasExtendedDebugLogger, Protocol):
         block_number_or_hash if reverse is False or ending at block_number_or_hash if reverse is
         True.
         """
-        cmd = GetBlockHeaders(self.cmd_id_offset, self.snappy_support)
+        cmd = self.cmd_by_type[GetBlockHeaders]
         data = {
             'block_number_or_hash': block_number_or_hash,
             'max_headers': max_headers,
@@ -106,7 +105,7 @@ class ETHProtocol(HasExtendedDebugLogger, Protocol):
         self.send(header, body)
 
     def send_block_headers(self, headers: Tuple[BlockHeader, ...]) -> None:
-        cmd = BlockHeaders(self.cmd_id_offset, self.snappy_support)
+        cmd = self.cmd_by_type[BlockHeaders]
         header, body = cmd.encode(headers)
         self.send(header, body)
 
@@ -114,12 +113,12 @@ class ETHProtocol(HasExtendedDebugLogger, Protocol):
     # Block Bodies
     #
     def send_get_block_bodies(self, block_hashes: Tuple[Hash32, ...]) -> None:
-        cmd = GetBlockBodies(self.cmd_id_offset, self.snappy_support)
+        cmd = self.cmd_by_type[GetBlockBodies]
         header, body = cmd.encode(block_hashes)
         self.send(header, body)
 
     def send_block_bodies(self, blocks: List[BlockBody]) -> None:
-        cmd = BlockBodies(self.cmd_id_offset, self.snappy_support)
+        cmd = self.cmd_by_type[BlockBodies]
         header, body = cmd.encode(blocks)
         self.send(header, body)
 
@@ -127,12 +126,12 @@ class ETHProtocol(HasExtendedDebugLogger, Protocol):
     # Receipts
     #
     def send_get_receipts(self, block_hashes: Tuple[Hash32, ...]) -> None:
-        cmd = GetReceipts(self.cmd_id_offset, self.snappy_support)
+        cmd = self.cmd_by_type[GetReceipts]
         header, body = cmd.encode(block_hashes)
         self.send(header, body)
 
     def send_receipts(self, receipts: List[List[Receipt]]) -> None:
-        cmd = Receipts(self.cmd_id_offset, self.snappy_support)
+        cmd = self.cmd_by_type[Receipts]
         header, body = cmd.encode(receipts)
         self.send(header, body)
 
@@ -140,6 +139,6 @@ class ETHProtocol(HasExtendedDebugLogger, Protocol):
     # Transactions
     #
     def send_transactions(self, transactions: List[BaseTransactionFields]) -> None:
-        cmd = Transactions(self.cmd_id_offset, self.snappy_support)
+        cmd = self.cmd_by_type[Transactions]
         header, body = cmd.encode(transactions)
         self.send(header, body)

--- a/trinity/protocol/eth/proto.py
+++ b/trinity/protocol/eth/proto.py
@@ -63,7 +63,8 @@ class ETHProtocol(HasExtendedDebugLogger, Protocol):
             'genesis_hash': chain_info.genesis_hash,
         }
         cmd = Status(self.cmd_id_offset, self.snappy_support)
-        self.logger.debug2("Sending ETH/Status msg: %s", resp)
+        self.logger.debug2("Sending ETH/Status msg: %s; with cmd id_offset %s and compression %s",
+                           resp, cmd.cmd_id_offset, cmd.snappy_support)
         self.send(*cmd.encode(resp))
 
     #

--- a/trinity/protocol/eth/servers.py
+++ b/trinity/protocol/eth/servers.py
@@ -161,17 +161,20 @@ class ETHRequestServer(BaseRequestServer):
             commands.NewBlockHashes,
         )
 
-        if isinstance(cmd, ignored_commands):
+        cmd_type = cmd.cmd_type
+
+        if cmd_type in ignored_commands:
+            self.logger.debug2("cmd %s in ignored_commands, doing nothing.", cmd)
             pass
-        elif isinstance(cmd, commands.GetBlockHeaders):
+        elif cmd_type == commands.GetBlockHeaders:
             await self._handler.handle_get_block_headers(peer, cast(Dict[str, Any], msg))
-        elif isinstance(cmd, commands.GetBlockBodies):
+        elif cmd_type == commands.GetBlockBodies:
             block_hashes = cast(Sequence[Hash32], msg)
             await self._handler.handle_get_block_bodies(peer, block_hashes)
-        elif isinstance(cmd, commands.GetReceipts):
+        elif cmd_type == commands.GetReceipts:
             block_hashes = cast(Sequence[Hash32], msg)
             await self._handler.handle_get_receipts(peer, block_hashes)
-        elif isinstance(cmd, commands.GetNodeData):
+        elif cmd_type == commands.GetNodeData:
             node_hashes = cast(Sequence[Hash32], msg)
             await self._handler.handle_get_node_data(peer, node_hashes)
         else:


### PR DESCRIPTION
WIP, demo.

Closes #175 (is part of this PR).
Closes #193 (different solution).

See linked PRs for earlier discussion, and some of my arguments.

### What was wrong?

* Every peer's got a `Protocol` (or sub-class) instance, and every instance of that holds (identical) instances of `Command`s in the protocol.
* `cmd_offset` and `snappy_support` - protocol implementation detail and per-connection protocol feature, respectively - are passed around needlessly, requiring every sub-protocol developer to know of their existence.

### How was it fixed?

Only dirty so far.

* A module-level "look-up table" for `Command`s and a function to operate it are introduced.
* `Command`s are referenced by class.
* Each `Protocol` instance maintains a list of command-plus-feature classes they support, plus `dict` mappings (similarly to how it was done previously).
* `Protocol`s are still per-peer objects. This can be addressed later.

TODO:

- [ ] `BCC` and `LES` need to be updated, too!
- [ ] Run tests locally and fix failures.
- [ ] Address TODOs and FIXMEs in code.

### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://i2.wp.com/cuteandkids.com/wp-content/uploads/2017/04/PUMPKIN-THE-RACCOON-INSTAGRAM-BOOK-CUTEANDKIDS-BLOG.png?resize=599%2C598&ssl=1)

Source: [Pumpkin the raccoon](https://cuteandkids.com/inspire/pumpkin-the-raccoon/), by Laura Young