### PR TITLE
[proof of concept] State Sync Rebasing

### DIFF
--- a/p2p/kademlia.py
+++ b/p2p/kademlia.py
@@ -30,7 +30,6 @@ from eth_keys import (
 
 from eth_hash.auto import keccak
 
-from trinity._utils.validation import validate_enode_uri
 
 k_b = 8  # 8 bits per hop
 
@@ -104,7 +103,6 @@ class Node:
 
     @classmethod
     def from_uri(cls, uri: str) -> 'Node':
-        validate_enode_uri(uri)  # Be no more permissive than the validation
         parsed = urlparse.urlparse(uri)
         pubkey = keys.PublicKey(decode_hex(parsed.username))
         return cls(pubkey, Address(parsed.hostname, parsed.port))

--- a/tests/core/integration_test_helpers.py
+++ b/tests/core/integration_test_helpers.py
@@ -34,8 +34,9 @@ async def connect_to_peers_loop(peer_pool, nodes):
     """Loop forever trying to connect to one of the given nodes if the pool is not yet full."""
     while peer_pool.is_operational:
         try:
-            if not peer_pool.is_full:
-                await peer_pool.connect_to_nodes(nodes)
+            await peer_pool.connect_to_nodes(
+                [node for node in nodes if node not in peer_pool.connected_nodes]
+            )
             await peer_pool.wait(asyncio.sleep(2))
         except OperationCancelled:
             break

--- a/trinity/protocol/eth/monitors.py
+++ b/trinity/protocol/eth/monitors.py
@@ -1,6 +1,137 @@
+from typing import (
+    Any,
+    AsyncIterator,
+    cast,
+    Dict,
+    Tuple,
+)
+
+from cancel_token import CancelToken
+from eth_utils import ValidationError
+
+from eth.rlp.headers import (
+    BlockHeader
+)
+
+from p2p.exceptions import PeerConnectionLost
+from p2p.peer import BasePeer, PeerSubscriber
+from p2p.service import BaseService
+
 from trinity.protocol.common.monitors import BaseChainTipMonitor
+from trinity.protocol.common.peer import BaseChainPeer, BaseChainPeerPool
 from trinity.protocol.eth import commands
 
 
 class ETHChainTipMonitor(BaseChainTipMonitor):
     subscription_msg_types = frozenset({commands.NewBlock})
+
+
+class ETHVerifiedTipMonitor(BaseService, PeerSubscriber):
+    """
+    Monitor for potential changes to the tip of the chain: a new peer or a new block
+
+    Fetches and verifies and yields the new highest header
+
+    Subclass must specify :attr:`subscription_msg_types`
+    """
+    # This is a rather arbitrary value, but when the sync is operating normally we never see
+    # the msg queue grow past a few hundred items, so this should be a reasonable limit for
+    # now.
+    msg_queue_maxsize = 2000
+    subscription_msg_types = frozenset({commands.NewBlock})
+
+    def __init__(
+            self,
+            peer_pool: BaseChainPeerPool,
+            token: CancelToken = None) -> None:
+        super().__init__(token)
+        self._peer_pool = peer_pool
+        self._subscriber_notice = self.get_event_loop().create_future()
+
+    async def wait_tip_info(self) -> AsyncIterator[Tuple[BaseChainPeer, BlockHeader]]:
+        """
+        This iterator waits until there is potentially new tip information.
+        New tip information means a new peer connected or a new block arrived.
+        Then it yields the peer with the highest total difficulty.
+        It continues indefinitely, until this service is cancelled.
+        """
+        if self.is_cancelled:
+            raise ValidationError("%s is cancelled, new tip info is impossible", self)
+        elif not self.is_running:
+            await self.events.started.wait()
+
+        while self.is_operational:
+            peer, header = await self.wait(self._subscriber_notice)
+            yield (peer, header)
+
+    def register_peer(self, peer: BasePeer) -> None:
+        # don't block the caller
+        self.run_task(self._handle_new_peer(peer))
+
+    async def _handle_new_peer(self, peer: BasePeer) -> None:
+        if peer != self._peer_pool.highest_td_peer:
+            self.logger.debug("%s connected but it doesn't have the latest block")
+            return
+
+        self.logger.debug("Connected to %s, asking for highest block", peer)
+        block_hash = peer.head_hash
+
+        # TODO: Maybe this header is already in the database, it's worth checking
+
+        try:
+            TWO_SECONDS = 2
+            # using self.wait because even though peer will probably use the same cancel
+            # token as this monitor was given it probably shouldn't rely on that
+            headers = await self.wait(peer.requests.get_block_headers(
+                block_hash, max_headers=1, reverse=False, timeout=TWO_SECONDS
+            ))
+        except (TimeoutError, PeerConnectionLost) as err:
+            # TODO: maybe we should either retry or disconnect?
+            self.logger.debug("Unable to fetch the latest block from %s, quitting", peer)
+            return
+        except ValidationError as err:
+            self.logger.debug("Invalid header response from %s. Quitting", peer)
+            return
+
+        if peer != self._peer_pool.highest_td_peer:
+            # another peer with a higher td likely connected while we were await'ing
+            self.logger.debug("%s is no longer our highest peer, cancelling fetch", peer)
+            return
+
+        if len(headers) != 1:
+            self.logger.debug(
+                "Didn't expect to receive %s headers from peer. Quitting", len(headers)
+            )
+        else:
+            header = headers[0]
+
+        # TODO: validate the header and check the seal
+
+        self.logger.info('notifying of new tip from %s, %s', peer, header)
+        self._notify_tip(peer, header)
+
+    def _handle_new_block(self, peer: BasePeer, msg: Dict[str, Any]) -> None:
+        if peer != self._peer_pool.highest_td_peer:
+            self.logger.debug("received new block from %s but it is not our highest peer", peer)
+            return
+
+        header, _, _ = msg['block']
+        self.logger.info('new header %s from %s', header, peer)
+        self._notify_tip(peer, header)
+
+    async def _handle_msg_loop(self) -> None:
+        while self.is_operational:
+            peer, cmd, msg = await self.wait(self.msg_queue.get())
+            if isinstance(cmd, commands.NewBlock):
+                self._handle_new_block(peer, cast(Dict[str, Any], msg))
+            else:
+                assert False, 'unexpected message!'
+
+    def _notify_tip(self, peer: BasePeer, header: BlockHeader) -> None:
+        self._subscriber_notice.set_result((peer, header))
+        self._subscriber_notice = self.get_event_loop().create_future()
+
+    async def _run(self) -> None:
+        self.run_daemon_task(self._handle_msg_loop())
+        with self.subscribe(self._peer_pool):
+            await self.wait(self.events.cancelled.wait())

--- a/trinity/sync/full/hexary_trie.py
+++ b/trinity/sync/full/hexary_trie.py
@@ -148,6 +148,9 @@ class HexaryTrieSync:
     def has_pending_requests(self) -> bool:
         return len(self.requests) > 0
 
+    def new_root_hash(self, root_hash: Hash32):
+        self.logger.info('accepted new root hash command')
+
     def next_batch(self, n: int = 1) -> List[SyncRequest]:
         """Return the next requests that should be dispatched."""
         if len(self.queue) == 0:

--- a/trinity/sync/full/service.py
+++ b/trinity/sync/full/service.py
@@ -12,9 +12,9 @@ from trinity.db.base import AsyncBaseDB
 from trinity.db.chain import AsyncChainDB
 from trinity.protocol.eth.peer import ETHPeerPool
 
-from .chain import FastChainSyncer, RegularChainSyncer
-from .constants import FAST_SYNC_CUTOFF
-from .state import StateDownloader
+from trinity.sync.full.chain import FastChainSyncer, RegularChainSyncer
+from trinity.sync.full.constants import FAST_SYNC_CUTOFF
+from trinity.sync.full.state import StateDownloader
 
 
 class FullNodeSyncer(BaseService):


### PR DESCRIPTION
This is a not-quite-functional slightly-embarrassing spike of a solution to #55, getting state syncing and chain syncing to happen concurrently.

- `StateDownloader` no longer accepts a `root_hash` argument. Instead, it spawns a `ETHVerifiedTipMonitor` and changes it's sync target whenever the monitor says that a new highest block has appeared.
- `ETHVerifiedTipMonitor` is like a `ChainTipMonitor` except instead of firing whenever a possibly-relevant message is received it does a little work to extract the block header and return that to its listeners. (This is related to https://github.com/ethereum/trinity/issues/54) It fetches the tip from every peer that connects, it also listens for `NewBlock` messages, and it yields the new highest-known header every time a new one is discovered.

Because `ETHVerifiedTipMonitor` does a fair amount of work (and a proper implementation will do even more) there should only ever be one instance. Maybe it can be started early by the `FullServer` and broadcast `NewHead` events over lajha for any interested parties. This might be the wrong factoring, because the header syncer should probably have some control over this process, while header sync is running it'll collect information which could out the tip we're using as malicious.

Remaining work:
- `ETHVerifiedTipMonitor` doesn't verify the headers yet.
- `HexarySync` accepts a `new_root_hash` command but does nothing with it, so the state sync never actually rebases.
- Some tests. I've just been running this manually against a parity node I'm running.

#### Cute Animal Picture

![turtle-lead](https://user-images.githubusercontent.com/466333/51521884-c5cbf700-1ddc-11e9-8061-8f5d66cca40f.jpg)

