### PR TITLE
Goal: Make it possible to move PeerPool into an isolated plugin

### DIFF
--- a/docs/release_notes/trinity.rst
+++ b/docs/release_notes/trinity.rst
@@ -4,7 +4,8 @@ Trinity
 Unreleased (latest source)
 --------------------------
 
-None
+- `#291 <https://github.com/ethereum/trinity/pull/291>`_: Performance: Move the Request server into its own isolated plugin process
+- `#291 <https://github.com/ethereum/trinity/pull/291>`_: Extensibility: Relay all peer pool message on the event bus
 
 0.1.0-alpha.23
 --------------------------

--- a/p2p/events.py
+++ b/p2p/events.py
@@ -37,22 +37,3 @@ class RandomBootnodeRequest(BaseRequestResponseEvent[PeerCandidatesResponse]):
     @staticmethod
     def expected_response_type() -> Type[PeerCandidatesResponse]:
         return PeerCandidatesResponse
-
-
-class PeerCountResponse(BaseEvent):
-
-    def __init__(self, peer_count: int) -> None:
-        self.peer_count = peer_count
-
-
-class PeerCountRequest(BaseRequestResponseEvent[PeerCountResponse]):
-
-    @staticmethod
-    def expected_response_type() -> Type[PeerCountResponse]:
-        return PeerCountResponse
-
-
-class ConnectToNodeCommand(BaseEvent):
-
-    def __init__(self, node: str) -> None:
-        self.node = node

--- a/p2p/peer_pool.py
+++ b/p2p/peer_pool.py
@@ -35,10 +35,7 @@ from p2p.constants import (
     REQUEST_PEER_CANDIDATE_TIMEOUT,
 )
 from p2p.events import (
-    ConnectToNodeCommand,
     PeerCandidatesRequest,
-    PeerCountRequest,
-    PeerCountResponse,
     RandomBootnodeRequest,
 )
 from p2p.exceptions import (
@@ -85,7 +82,7 @@ class BasePeerPool(BaseService, AsyncIterable[BasePeer]):
                  max_peers: int = DEFAULT_MAX_PEERS,
                  peer_info: BasePeerInfo = NoopPeerInfo(),
                  token: CancelToken = None,
-                 event_bus: Endpoint = None
+                 event_bus: Endpoint = None,
                  ) -> None:
         super().__init__(token)
 
@@ -98,19 +95,6 @@ class BasePeerPool(BaseService, AsyncIterable[BasePeer]):
         self.connected_nodes: Dict[Node, BasePeer] = {}
         self._subscribers: List[PeerSubscriber] = []
         self.event_bus = event_bus
-
-    async def accept_connect_commands(self) -> None:
-        async for command in self.wait_iter(self.event_bus.stream(ConnectToNodeCommand)):
-            self.logger.debug('Received request to connect to %s', command.node)
-            self.run_task(self.connect_to_nodes(from_uris([command.node])))
-
-    async def handle_peer_count_requests(self) -> None:
-        async for req in self.wait_iter(self.event_bus.stream(PeerCountRequest)):
-                # We are listening for all `PeerCountRequest` events but we ensure to only send a
-                # `PeerCountResponse` to the callsite that made the request.  We do that by
-                # retrieving a `BroadcastConfig` from the request via the
-                # `event.broadcast_config()` API.
-                self.event_bus.broadcast(PeerCountResponse(len(self)), req.broadcast_config())
 
     async def maybe_connect_more_peers(self) -> None:
         while self.is_operational:
@@ -229,9 +213,8 @@ class BasePeerPool(BaseService, AsyncIterable[BasePeer]):
         # FIXME: PeerPool should probably no longer be a BaseService, but for now we're keeping it
         # so in order to ensure we cancel all peers when we terminate.
         if self.event_bus is not None:
-            self.run_daemon_task(self.handle_peer_count_requests())
             self.run_daemon_task(self.maybe_connect_more_peers())
-            self.run_daemon_task(self.accept_connect_commands())
+
         self.run_daemon_task(self._periodically_report_stats())
         await self.cancel_token.wait()
 

--- a/p2p/peer_pool.py
+++ b/p2p/peer_pool.py
@@ -92,7 +92,7 @@ class BasePeerPool(BaseService, AsyncIterable[BasePeer]):
         self.max_peers = max_peers
         self.context = context
 
-        self.connected_nodes: Dict[Node, BasePeer] = {}
+        self.connected_nodes: Dict[str, BasePeer] = {}
         self._subscribers: List[PeerSubscriber] = []
         self.event_bus = event_bus
 
@@ -201,7 +201,7 @@ class BasePeerPool(BaseService, AsyncIterable[BasePeer]):
         to the peer, we also add the given messages to our subscriber's queues.
         """
         self.logger.info('Adding %s to pool', peer)
-        self.connected_nodes[peer.remote] = peer
+        self.connected_nodes[peer.remote.uri()] = peer
         peer.add_finished_callback(self._peer_finished)
         for subscriber in self._subscribers:
             subscriber.register_peer(peer)
@@ -291,9 +291,9 @@ class BasePeerPool(BaseService, AsyncIterable[BasePeer]):
         This is passed as a callback to be called when a peer finishes.
         """
         peer = cast(BasePeer, peer)
-        if peer.remote in self.connected_nodes:
+        if peer.remote.uri() in self.connected_nodes:
             self.logger.info("%s finished, removing from pool", peer)
-            self.connected_nodes.pop(peer.remote)
+            self.connected_nodes.pop(peer.remote.uri())
         else:
             self.logger.warning(
                 "%s finished but was not found in connected_nodes (%s)", peer, self.connected_nodes)

--- a/p2p/tools/paragon/__init__.py
+++ b/p2p/tools/paragon/__init__.py
@@ -3,6 +3,9 @@ from .commands import (  # noqa: F401
     GetSum,
     Sum,
 )
+from .events import (  # noqa: F401
+    GetSumRequest,
+)
 from .proto import (  # noqa: F401
     ParagonProtocol,
 )
@@ -11,6 +14,9 @@ from .peer import (  # noqa: F401
     ParagonPeer,
     ParagonPeerFactory,
     ParagonPeerPool,
+    ParagonPeerPoolEventBusRequestHandler,
+    ParagonMockPeerPoolWithConnectedPeers,
+    ParagonProxyPeer,
 )
 from .helpers import (  # noqa: F401
     get_directly_connected_streams,

--- a/p2p/tools/paragon/events.py
+++ b/p2p/tools/paragon/events.py
@@ -1,0 +1,14 @@
+from lahja import (
+    BaseEvent,
+)
+from p2p.peer import (
+    IdentifiablePeer,
+)
+
+
+class GetSumRequest(BaseEvent):
+
+    def __init__(self, dto_peer: IdentifiablePeer, a: int, b: int) -> None:
+        self.dto_peer = dto_peer
+        self.a = a
+        self.b = b

--- a/p2p/tools/paragon/peer.py
+++ b/p2p/tools/paragon/peer.py
@@ -1,7 +1,15 @@
+from typing import (
+    Iterable,
+)
+from lahja import (
+    BroadcastConfig,
+    Endpoint,
+)
 from p2p.peer import (
     BasePeer,
     BasePeerContext,
     BasePeerFactory,
+    IdentifiablePeer,
 )
 from p2p.peer_pool import (
     BasePeerPool,
@@ -11,7 +19,33 @@ from p2p.protocol import (
     _DecodedMsgType,
 )
 
-from .proto import ParagonProtocol
+from trinity.protocol.common.peer_pool_event_bus import (
+    BasePeerPoolEventBusRequestHandler,
+)
+
+from .events import GetSumRequest
+from .proto import (
+    ParagonProtocol,
+    ProxyParagonProtocol,
+)
+
+
+class ParagonProxyPeer:
+    """
+    A ``ParagonPeer`` that can be used from any process as a drop-in replacement for the actual
+    peer that sits in the peer pool. Any action performed on the ``ParagonProxyPeer`` is delegated
+    to the actual peer in the pool.
+    """
+
+    def __init__(self, sub_proto: ProxyParagonProtocol):
+        self.sub_proto = sub_proto
+
+    @classmethod
+    def from_dto_peer(cls,
+                      dto_peer: IdentifiablePeer,
+                      event_bus: Endpoint,
+                      broadcast_config: BroadcastConfig) -> 'ParagonProxyPeer':
+            return cls(ProxyParagonProtocol(dto_peer, event_bus, broadcast_config))
 
 
 class ParagonPeer(BasePeer):
@@ -40,6 +74,35 @@ class ParagonPeerFactory(BasePeerFactory):
     context: ParagonContext
 
 
+class ParagonPeerPoolEventBusRequestHandler(BasePeerPoolEventBusRequestHandler[ParagonPeer]):
+    """
+    A request handler to handle paragon specific requests to the peer pool.
+    """
+
+    async def _run(self) -> None:
+        self.logger.info("Running ParagonPeerPoolEventBusRequestHandler")
+        self.run_daemon_task(self.handle_get_sum_requests())
+        await super()._run()
+
+    async def handle_get_sum_requests(self) -> None:
+        async for req in self.wait_iter(self._event_bus.stream(GetSumRequest)):
+            peer = self.maybe_return_peer(req.dto_peer)
+            if peer is None:
+                continue
+
+            peer.sub_proto.send_get_sum(req.a, req.b)
+
+
 class ParagonPeerPool(BasePeerPool):
     peer_factory_class = ParagonPeerFactory
     context: ParagonContext
+
+
+class ParagonMockPeerPoolWithConnectedPeers(ParagonPeerPool):
+    def __init__(self, peers: Iterable[ParagonPeer]) -> None:
+        super().__init__(privkey=None, context=None)
+        for peer in peers:
+            self.connected_nodes[peer.remote.uri()] = peer
+
+    async def _run(self) -> None:
+        raise NotImplementedError("This is a mock PeerPool implementation, you must not _run() it")

--- a/p2p/tools/paragon/proto.py
+++ b/p2p/tools/paragon/proto.py
@@ -5,6 +5,13 @@ from typing import (
     Dict,
 )
 
+from lahja import (
+    BroadcastConfig,
+    Endpoint,
+)
+from p2p.peer import (
+    IdentifiablePeer,
+)
 from p2p.protocol import (
     Protocol,
 )
@@ -13,6 +20,9 @@ from .commands import (
     BroadcastData,
     GetSum,
     Sum,
+)
+from .events import (
+    GetSumRequest,
 )
 
 
@@ -49,3 +59,30 @@ class ParagonProtocol(Protocol):
         msg: Dict[str, Any] = {'result': result}
         header, body = cmd.encode(msg)
         self.send(header, body)
+
+
+class ProxyParagonProtocol:
+    """
+    A ``PargonProtocol`` that can be used outside of the process that runs the peer pool. Any
+    action performed on this class is delegated to the process that runs the peer pool.
+    """
+
+    def __init__(self,
+                 dto_peer: IdentifiablePeer,
+                 event_bus: Endpoint,
+                 broadcast_config: BroadcastConfig):
+        self._dto_peer = dto_peer
+        self._event_bus = event_bus
+        self._broadcast_config = broadcast_config
+
+    def send_broadcast_data(self, data: bytes) -> None:
+        raise NotImplementedError("Not yet implemented")
+
+    def send_get_sum(self, value_a: int, value_b: int) -> None:
+        self._event_bus.broadcast(
+            GetSumRequest(self._dto_peer, value_a, value_b),
+            self._broadcast_config,
+        )
+
+    def send_sum(self, result: int) -> None:
+        raise NotImplementedError("Not yet implemented")

--- a/setup.py
+++ b/setup.py
@@ -29,6 +29,7 @@ deps = {
         "websockets==5.0.1",
         "jsonschema==2.6.0",
         "mypy_extensions>=0.4.1,<1.0.0",
+        "typing_extensions>=3.7.2,<4.0.0",
     ],
     'test': [
         "hypothesis==3.69.5",

--- a/tests/core/json-rpc/test_ipc.py
+++ b/tests/core/json-rpc/test_ipc.py
@@ -14,14 +14,14 @@ from eth_utils import (
     to_hex,
 )
 
-from p2p.events import (
-    PeerCountRequest,
-    PeerCountResponse,
-    ConnectToNodeCommand,
-)
 from trinity.nodes.events import (
     NetworkIdRequest,
     NetworkIdResponse,
+)
+from trinity.protocol.common.events import (
+    ConnectToNodeCommand,
+    PeerCountRequest,
+    PeerCountResponse,
 )
 from trinity.sync.common.events import (
     SyncingRequest,

--- a/tests/core/p2p-proto/conftest.py
+++ b/tests/core/p2p-proto/conftest.py
@@ -1,0 +1,39 @@
+import pytest
+
+from tests.core.integration_test_helpers import (
+    FakeAsyncAtomicDB,
+    load_fixture_db,
+    load_mining_chain,
+    DBFixture,
+)
+
+
+@pytest.fixture
+def leveldb_20():
+    yield from load_fixture_db(DBFixture.twenty_pow_headers)
+
+
+@pytest.fixture
+def leveldb_1000():
+    yield from load_fixture_db(DBFixture.thousand_pow_headers)
+
+
+@pytest.fixture
+def chaindb_1000(leveldb_1000):
+    chain = load_mining_chain(FakeAsyncAtomicDB(leveldb_1000))
+    assert chain.chaindb.get_canonical_head().block_number == 1000
+    return chain.chaindb
+
+
+@pytest.fixture
+def chaindb_20(leveldb_20):
+    chain = load_mining_chain(FakeAsyncAtomicDB(leveldb_20))
+    assert chain.chaindb.get_canonical_head().block_number == 20
+    return chain.chaindb
+
+
+@pytest.fixture
+def chaindb_fresh():
+    chain = load_mining_chain(FakeAsyncAtomicDB())
+    assert chain.chaindb.get_canonical_head().block_number == 0
+    return chain.chaindb

--- a/tests/core/p2p-proto/test_requests.py
+++ b/tests/core/p2p-proto/test_requests.py
@@ -1,0 +1,138 @@
+import asyncio
+
+import pytest
+
+from trinity.constants import TO_NETWORKING_BROADCAST_CONFIG
+from trinity.protocol.common.peer_pool_event_bus import (
+    BasePeerPoolMessageRelayer
+)
+from trinity.protocol.eth.peer import (
+    ETHProxyPeer,
+    ETHPeerPoolEventBusRequestHandler,
+)
+from trinity.protocol.eth.servers import (
+    ETHIsolatedRequestServer,
+)
+from tests.core.integration_test_helpers import (
+    FakeAsyncChainDB,
+    FakeAsyncHeaderDB,
+)
+from tests.core.peer_helpers import (
+    get_directly_linked_peers,
+    MockPeerPoolWithConnectedPeers,
+)
+
+
+async def make_peer_pool_answer_event_bus_requests(event_bus, peer_pool):
+    peer_pool_event_bus_request_handler = ETHPeerPoolEventBusRequestHandler(
+        event_bus,
+        peer_pool,
+        peer_pool.cancel_token
+    )
+    asyncio.ensure_future(peer_pool_event_bus_request_handler.run())
+    await peer_pool_event_bus_request_handler.events.started.wait()
+
+
+async def make_peer_pool_relay_messages_on_event_bus(event_bus, peer_pool):
+    peer_pool_message_relayer = BasePeerPoolMessageRelayer(peer_pool, event_bus)
+    asyncio.ensure_future(peer_pool_message_relayer.run())
+    await peer_pool_message_relayer.events.started.wait()
+
+
+async def run_isolated_request_server(event_bus, chaindb):
+    request_server = ETHIsolatedRequestServer(
+        event_bus,
+        TO_NETWORKING_BROADCAST_CONFIG,
+        FakeAsyncChainDB(chaindb)
+    )
+    asyncio.ensure_future(request_server.run())
+    await request_server.events.started.wait()
+
+
+@pytest.mark.asyncio
+async def test_proxy_peer_requests(request,
+                                   event_bus,
+                                   other_event_bus,
+                                   event_loop,
+                                   chaindb_fresh,
+                                   chaindb_20):
+
+    client_peer, server_peer = await get_directly_linked_peers(
+        request,
+        event_loop,
+        alice_headerdb=FakeAsyncHeaderDB(chaindb_fresh.db),
+        bob_headerdb=FakeAsyncHeaderDB(chaindb_20.db),
+    )
+
+    client_peer_pool = MockPeerPoolWithConnectedPeers([client_peer], event_bus=other_event_bus)
+    await make_peer_pool_answer_event_bus_requests(other_event_bus, client_peer_pool)
+    await make_peer_pool_relay_messages_on_event_bus(other_event_bus, client_peer_pool)
+
+    server_peer_pool = MockPeerPoolWithConnectedPeers([server_peer], event_bus=event_bus)
+    await make_peer_pool_answer_event_bus_requests(event_bus, server_peer_pool)
+    await make_peer_pool_relay_messages_on_event_bus(event_bus, server_peer_pool)
+    await run_isolated_request_server(event_bus, chaindb_20.db)
+
+    proxy_peer = ETHProxyPeer.from_dto_peer(
+        client_peer.to_dto(),
+        other_event_bus,
+        TO_NETWORKING_BROADCAST_CONFIG,
+    )
+
+    headers = await proxy_peer.requests.get_block_headers(0, 1, 0, False)
+    assert len(headers) == 1
+    block_header = headers[0]
+    assert block_header.block_number == 0
+
+    receipts = await proxy_peer.requests.get_receipts(headers)
+    assert len(receipts) == 1
+    receipt = receipts[0]
+    assert receipt[1][0] == block_header.receipt_root
+
+    block_bundles = await proxy_peer.requests.get_block_bodies(headers)
+    assert len(block_bundles) == 1
+    first_bundle = block_bundles[0]
+    assert first_bundle[1][0] == block_header.transaction_root
+
+    node_data = await proxy_peer.requests.get_node_data((block_header.state_root,))
+    assert node_data[0][0] == block_header.state_root
+
+
+@pytest.mark.asyncio
+async def test_proxy_peer_requests_with_timeouts(request,
+                                                 event_bus,
+                                                 other_event_bus,
+                                                 event_loop,
+                                                 chaindb_fresh,
+                                                 chaindb_20):
+
+    client_peer, server_peer = await get_directly_linked_peers(
+        request,
+        event_loop,
+        alice_headerdb=FakeAsyncHeaderDB(chaindb_fresh.db),
+        bob_headerdb=FakeAsyncHeaderDB(chaindb_20.db),
+    )
+
+    client_peer_pool = MockPeerPoolWithConnectedPeers([client_peer], event_bus=other_event_bus)
+    await make_peer_pool_answer_event_bus_requests(other_event_bus, client_peer_pool)
+    await make_peer_pool_relay_messages_on_event_bus(other_event_bus, client_peer_pool)
+
+    # There is no server in this tests so that requests naturally time out
+
+    proxy_peer = ETHProxyPeer.from_dto_peer(
+        client_peer.to_dto(),
+        other_event_bus,
+        TO_NETWORKING_BROADCAST_CONFIG,
+    )
+
+    with pytest.raises(TimeoutError):
+        await proxy_peer.requests.get_block_headers(0, 1, 0, False, timeout=0.01)
+
+    with pytest.raises(TimeoutError):
+        await proxy_peer.requests.get_receipts((), timeout=0.01)
+
+    with pytest.raises(TimeoutError):
+        await proxy_peer.requests.get_block_bodies((), timeout=0.01)
+
+    with pytest.raises(TimeoutError):
+        await proxy_peer.requests.get_node_data((), timeout=0.01)

--- a/tests/core/p2p-proto/test_server.py
+++ b/tests/core/p2p-proto/test_server.py
@@ -11,7 +11,6 @@ from eth.db.atomic import AtomicDB
 from eth.db.chain import ChainDB
 
 from p2p.auth import HandshakeInitiator, _handshake
-from p2p.events import ConnectToNodeCommand
 from p2p.kademlia import (
     Node,
     Address,
@@ -21,13 +20,18 @@ from p2p.tools.paragon import (
     ParagonContext,
     ParagonPeer,
     ParagonPeerPool,
+    ParagonPeerPoolEventBusRequestHandler,
 )
 
 from trinity.constants import TO_NETWORKING_BROADCAST_CONFIG
+from trinity.protocol.common.events import ConnectToNodeCommand
 from trinity.server import BaseServer
 
 from tests.p2p.auth_constants import eip8_values
-from tests.core.integration_test_helpers import FakeAsyncHeaderDB
+from tests.core.integration_test_helpers import (
+    FakeAsyncHeaderDB,
+    make_peer_pool_answer_event_bus_requests,
+)
 
 
 def get_open_port():
@@ -58,13 +62,11 @@ class ParagonServer(BaseServer):
             privkey=self.privkey,
             context=ParagonContext(),
             token=self.cancel_token,
+            event_bus=self.event_bus,
         )
 
-    def _make_request_server(self):
-        return
 
-
-def get_server(privkey, address):
+def get_server(privkey, address, event_bus):
     base_db = AtomicDB()
     headerdb = FakeAsyncHeaderDB(base_db)
     chaindb = ChainDB(base_db)
@@ -78,13 +80,14 @@ def get_server(privkey, address):
         headerdb=headerdb,
         base_db=base_db,
         network_id=NETWORK_ID,
+        event_bus=event_bus,
     )
     return server
 
 
 @pytest.fixture
-async def server():
-    server = get_server(RECEIVER_PRIVKEY, SERVER_ADDRESS)
+async def server(event_bus):
+    server = get_server(RECEIVER_PRIVKEY, SERVER_ADDRESS, event_bus)
     await asyncio.wait_for(server._start_tcp_listener(), timeout=1)
     try:
         yield server
@@ -175,6 +178,11 @@ async def test_peer_pool_answers_connect_commands(event_loop, event_bus, server)
     )
     asyncio.ensure_future(initiator_peer_pool.run(), loop=event_loop)
     await initiator_peer_pool.events.started.wait()
+    await make_peer_pool_answer_event_bus_requests(
+        event_bus,
+        initiator_peer_pool,
+        handler_type=ParagonPeerPoolEventBusRequestHandler
+    )
 
     assert len(server.peer_pool.connected_nodes) == 0
 
@@ -186,4 +194,5 @@ async def test_peer_pool_answers_connect_commands(event_loop, event_bus, server)
     await asyncio.sleep(0.5)
 
     assert len(server.peer_pool.connected_nodes) == 1
+
     await initiator_peer_pool.cancel()

--- a/tests/core/p2p-proto/test_sync.py
+++ b/tests/core/p2p-proto/test_sync.py
@@ -50,8 +50,8 @@ async def test_fast_syncer_with_isolated_server(request,
                                                 other_event_bus,
                                                 event_loop,
                                                 chaindb_fresh,
-                                                chaindb_20):
-
+                                                chaindb_1000):
+    chaindb_20 = chaindb_1000
     server_event_bus = event_bus
     client_event_bus = other_event_bus
     client_peer, server_peer = await get_directly_linked_peers(
@@ -76,7 +76,7 @@ async def test_fast_syncer_with_isolated_server(request,
         client_event_bus,
     )
     # FastChainSyncer.run() will return as soon as it's caught up with the peer.
-    await asyncio.wait_for(client.run(), timeout=2)
+    await asyncio.wait_for(client.run(), timeout=20)
 
     head = chaindb_fresh.get_canonical_head()
     assert head == chaindb_20.get_canonical_head()
@@ -84,7 +84,7 @@ async def test_fast_syncer_with_isolated_server(request,
     # # Now download the state for the chain's head.
     state_downloader = StateDownloader(
         chaindb_fresh, chaindb_fresh.db, head.state_root, client_peer_pool)
-    await asyncio.wait_for(state_downloader.run(), timeout=2)
+    await asyncio.wait_for(state_downloader.run(), timeout=20)
 
     assert head.state_root in chaindb_fresh.db
 

--- a/tests/core/p2p-proto/test_sync.py
+++ b/tests/core/p2p-proto/test_sync.py
@@ -89,32 +89,34 @@ async def test_fast_syncer_with_isolated_server(request,
     assert head.state_root in chaindb_fresh.db
 
 
-@pytest.mark.asyncio
-async def test_fast_syncer(request, event_loop, chaindb_fresh, chaindb_20):
-    client_peer, server_peer = await get_directly_linked_peers(
-        request, event_loop,
-        alice_headerdb=FakeAsyncHeaderDB(chaindb_fresh.db),
-        bob_headerdb=FakeAsyncHeaderDB(chaindb_20.db))
-    client_peer_pool = MockPeerPoolWithConnectedPeers([client_peer])
-    client = FastChainSyncer(ByzantiumTestChain(chaindb_fresh.db), chaindb_fresh, client_peer_pool)
-    server_peer_pool = MockPeerPoolWithConnectedPeers([server_peer])
-    server_request_handler = ETHRequestServer(FakeAsyncChainDB(chaindb_20.db), server_peer_pool)
-    asyncio.ensure_future(server_request_handler.run())
-    server_peer.logger.info("%s is serving 20 blocks", server_peer)
-    client_peer.logger.info("%s is syncing up 20", client_peer)
+# @pytest.mark.asyncio
+# async def test_fast_syncer(request, event_loop, event_bus, chaindb_fresh, chaindb_20):
+#     client_peer, server_peer = await get_directly_linked_peers(
+#         request, event_loop,
+#         alice_headerdb=FakeAsyncHeaderDB(chaindb_fresh.db),
+#         bob_headerdb=FakeAsyncHeaderDB(chaindb_20.db))
+#     client_peer_pool = MockPeerPoolWithConnectedPeers([client_peer], event_bus=event_bus)
+#     client = FastChainSyncer(ByzantiumTestChain(chaindb_fresh.db), chaindb_fresh, event_bus)
+#     await make_peer_pool_answer_event_bus_requests(event_bus, client_peer_pool)
+#     await make_peer_pool_relay_messages_on_event_bus(event_bus, client_peer_pool)
+#     server_peer_pool = MockPeerPoolWithConnectedPeers([server_peer])
+#     server_request_handler = ETHRequestServer(FakeAsyncChainDB(chaindb_20.db), server_peer_pool)
+#     asyncio.ensure_future(server_request_handler.run())
+#     server_peer.logger.info("%s is serving 20 blocks", server_peer)
+#     client_peer.logger.info("%s is syncing up 20", client_peer)
 
-    # FastChainSyncer.run() will return as soon as it's caught up with the peer.
-    await asyncio.wait_for(client.run(), timeout=2)
+#     # FastChainSyncer.run() will return as soon as it's caught up with the peer.
+#     await asyncio.wait_for(client.run(), timeout=2)
 
-    head = chaindb_fresh.get_canonical_head()
-    assert head == chaindb_20.get_canonical_head()
+#     head = chaindb_fresh.get_canonical_head()
+#     assert head == chaindb_20.get_canonical_head()
 
-    # Now download the state for the chain's head.
-    state_downloader = StateDownloader(
-        chaindb_fresh, chaindb_fresh.db, head.state_root, client_peer_pool)
-    await asyncio.wait_for(state_downloader.run(), timeout=2)
+#     # Now download the state for the chain's head.
+#     state_downloader = StateDownloader(
+#         chaindb_fresh, chaindb_fresh.db, head.state_root, client_peer_pool)
+#     await asyncio.wait_for(state_downloader.run(), timeout=2)
 
-    assert head.state_root in chaindb_fresh.db
+#     assert head.state_root in chaindb_fresh.db
 
 
 @pytest.mark.asyncio

--- a/tests/core/p2p-proto/test_sync.py
+++ b/tests/core/p2p-proto/test_sync.py
@@ -24,13 +24,9 @@ from tests.core.integration_test_helpers import (
     ByzantiumTestChain,
     FakeAsyncChainDB,
     FakeAsyncHeaderDB,
-    FakeAsyncAtomicDB,
-    load_fixture_db,
-    load_mining_chain,
     make_peer_pool_answer_event_bus_requests,
     make_peer_pool_relay_messages_on_event_bus,
     run_isolated_request_server,
-    DBFixture,
 )
 from tests.core.peer_helpers import (
     get_directly_linked_peers,
@@ -236,37 +232,6 @@ async def test_light_syncer(request, event_loop, chaindb_fresh, chaindb_20):
     asyncio.ensure_future(client.run())
 
     await wait_for_head(chaindb_fresh, chaindb_20.get_canonical_head())
-
-
-@pytest.fixture
-def leveldb_20():
-    yield from load_fixture_db(DBFixture.twenty_pow_headers)
-
-
-@pytest.fixture
-def leveldb_1000():
-    yield from load_fixture_db(DBFixture.thousand_pow_headers)
-
-
-@pytest.fixture
-def chaindb_1000(leveldb_1000):
-    chain = load_mining_chain(FakeAsyncAtomicDB(leveldb_1000))
-    assert chain.chaindb.get_canonical_head().block_number == 1000
-    return chain.chaindb
-
-
-@pytest.fixture
-def chaindb_20(leveldb_20):
-    chain = load_mining_chain(FakeAsyncAtomicDB(leveldb_20))
-    assert chain.chaindb.get_canonical_head().block_number == 20
-    return chain.chaindb
-
-
-@pytest.fixture
-def chaindb_fresh():
-    chain = load_mining_chain(FakeAsyncAtomicDB())
-    assert chain.chaindb.get_canonical_head().block_number == 0
-    return chain.chaindb
 
 
 async def wait_for_head(headerdb, header):

--- a/tests/core/p2p-proto/test_sync.py
+++ b/tests/core/p2p-proto/test_sync.py
@@ -2,10 +2,21 @@ import asyncio
 
 import pytest
 
-from trinity.protocol.eth.servers import ETHRequestServer
-from trinity.protocol.les.peer import LESPeer
-from trinity.protocol.les.servers import LightRequestServer
-from trinity.sync.full.chain import FastChainSyncer, RegularChainSyncer
+from trinity.protocol.eth.servers import (
+    ETHRequestServer,
+)
+from trinity.protocol.les.peer import (
+    LESPeer,
+    LESPeerPoolEventBusRequestHandler,
+)
+from trinity.protocol.les.servers import (
+    LightRequestServer,
+    LightIsolatedRequestServer,
+)
+from trinity.sync.full.chain import (
+    FastChainSyncer,
+    RegularChainSyncer,
+)
 from trinity.sync.full.state import StateDownloader
 from trinity.sync.light.chain import LightChainSyncer
 
@@ -16,6 +27,9 @@ from tests.core.integration_test_helpers import (
     FakeAsyncAtomicDB,
     load_fixture_db,
     load_mining_chain,
+    make_peer_pool_answer_event_bus_requests,
+    make_peer_pool_relay_messages_on_event_bus,
+    run_isolated_request_server,
     DBFixture,
 )
 from tests.core.peer_helpers import (
@@ -32,6 +46,41 @@ def small_header_batches(monkeypatch):
     from trinity.protocol.eth import constants
     monkeypatch.setattr(constants, 'MAX_HEADERS_FETCH', 10)
     monkeypatch.setattr(constants, 'MAX_BODIES_FETCH', 5)
+
+
+@pytest.mark.asyncio
+async def test_fast_syncer_with_isolated_server(request,
+                                                event_bus,
+                                                event_loop,
+                                                chaindb_fresh,
+                                                chaindb_20):
+    client_peer, server_peer = await get_directly_linked_peers(
+        request, event_loop,
+        alice_headerdb=FakeAsyncHeaderDB(chaindb_fresh.db),
+        bob_headerdb=FakeAsyncHeaderDB(chaindb_20.db))
+    client_peer_pool = MockPeerPoolWithConnectedPeers([client_peer])
+    client = FastChainSyncer(ByzantiumTestChain(chaindb_fresh.db), chaindb_fresh, client_peer_pool)
+    server_peer_pool = MockPeerPoolWithConnectedPeers([server_peer], event_bus=event_bus)
+
+    await make_peer_pool_answer_event_bus_requests(event_bus, server_peer_pool)
+    await make_peer_pool_relay_messages_on_event_bus(event_bus, server_peer_pool)
+    await run_isolated_request_server(event_bus, chaindb_20.db)
+
+    server_peer.logger.info("%s is serving 20 blocks", server_peer)
+    client_peer.logger.info("%s is syncing up 20", client_peer)
+
+    # FastChainSyncer.run() will return as soon as it's caught up with the peer.
+    await asyncio.wait_for(client.run(), timeout=2)
+
+    head = chaindb_fresh.get_canonical_head()
+    assert head == chaindb_20.get_canonical_head()
+
+    # # Now download the state for the chain's head.
+    state_downloader = StateDownloader(
+        chaindb_fresh, chaindb_fresh.db, head.state_root, client_peer_pool)
+    await asyncio.wait_for(state_downloader.run(), timeout=2)
+
+    assert head.state_root in chaindb_fresh.db
 
 
 @pytest.mark.asyncio
@@ -118,6 +167,46 @@ async def test_regular_syncer(request, event_loop, chaindb_fresh, chaindb_20):
     await wait_for_head(chaindb_fresh, chaindb_20.get_canonical_head())
     head = chaindb_fresh.get_canonical_head()
     assert head.state_root in chaindb_fresh.db
+
+
+@pytest.mark.asyncio
+async def test_light_syncer_with_isolated_server(request,
+                                                 event_loop,
+                                                 event_bus,
+                                                 chaindb_fresh,
+                                                 chaindb_20):
+    client_peer, server_peer = await get_directly_linked_peers(
+        request, event_loop,
+        alice_peer_class=LESPeer,
+        alice_headerdb=FakeAsyncHeaderDB(chaindb_fresh.db),
+        bob_headerdb=FakeAsyncHeaderDB(chaindb_20.db))
+    client = LightChainSyncer(
+        ByzantiumTestChain(chaindb_fresh.db),
+        chaindb_fresh,
+        MockPeerPoolWithConnectedPeers([client_peer]))
+    server_peer_pool = MockPeerPoolWithConnectedPeers([server_peer], event_bus=event_bus)
+
+    await make_peer_pool_answer_event_bus_requests(
+        event_bus,
+        server_peer_pool,
+        handler_type=LESPeerPoolEventBusRequestHandler
+    )
+    await make_peer_pool_relay_messages_on_event_bus(event_bus, server_peer_pool)
+    await run_isolated_request_server(
+        event_bus, chaindb_20.db, server_type=LightIsolatedRequestServer)
+
+    server_peer.logger.info("%s is serving 20 blocks", server_peer)
+    client_peer.logger.info("%s is syncing up 20", client_peer)
+
+    def finalizer():
+        event_loop.run_until_complete(client.cancel())
+        # Yield control so that client/server.run() returns, otherwise asyncio will complain.
+        event_loop.run_until_complete(asyncio.sleep(0.1))
+    request.addfinalizer(finalizer)
+
+    asyncio.ensure_future(client.run())
+
+    await wait_for_head(chaindb_fresh, chaindb_20.get_canonical_head())
 
 
 @pytest.mark.asyncio

--- a/tests/core/peer_helpers.py
+++ b/tests/core/peer_helpers.py
@@ -142,10 +142,10 @@ async def get_directly_linked_v4_and_v5_peers(
 
 
 class MockPeerPoolWithConnectedPeers(ETHPeerPool):
-    def __init__(self, peers) -> None:
-        super().__init__(privkey=None, context=None)
+    def __init__(self, peers, event_bus=None) -> None:
+        super().__init__(privkey=None, context=None, event_bus=event_bus)
         for peer in peers:
-            self.connected_nodes[peer.remote] = peer
+            self.connected_nodes[peer.remote.uri()] = peer
 
     async def _run(self) -> None:
         raise NotImplementedError("This is a mock PeerPool implementation, you must not _run() it")

--- a/tests/integration/test_trinity_cli.py
+++ b/tests/integration/test_trinity_cli.py
@@ -122,6 +122,9 @@ async def test_web3(command, async_process_runner):
         "Started DB server process",
         "Started networking process",
         "IPC started at",
+        # Ensure we do not start making requests that depend on the networking
+        # process, before it is connected to the JSON-RPC-API
+        "EventBus Endpoint networking connecting to other Endpoint bjson-rpc-api",
     })
 
     attached_trinity = pexpect.spawn('trinity', ['attach'], logfile=sys.stdout)

--- a/tests/p2p/test_peerpool_relayer.py
+++ b/tests/p2p/test_peerpool_relayer.py
@@ -1,0 +1,49 @@
+import asyncio
+
+import pytest
+
+from trinity.protocol.common.events import PeerPoolMessageEvent
+from trinity.protocol.common.peer_pool_event_bus import BasePeerPoolMessageRelayer
+
+from p2p.tools.paragon import (
+    get_directly_linked_peers,
+    GetSum,
+    ParagonMockPeerPoolWithConnectedPeers,
+)
+
+
+@pytest.mark.asyncio
+async def test_relays_pool_events(request, event_loop, event_bus):
+
+    received_events = []
+    event_bus.subscribe(PeerPoolMessageEvent, lambda ev: received_events.append(ev))
+
+    alice, bob = await get_directly_linked_peers(
+        request,
+        event_loop,
+    )
+
+    peer_pool = ParagonMockPeerPoolWithConnectedPeers([alice, bob])
+
+    relayer = BasePeerPoolMessageRelayer(peer_pool, event_bus)
+    asyncio.ensure_future(relayer.run())
+
+    def finalizer():
+        event_loop.run_until_complete(relayer.cancel())
+    request.addfinalizer(finalizer)
+
+    alice.sub_proto.send_get_sum(10, 20)
+    bob.sub_proto.send_get_sum(30, 40)
+
+    await asyncio.sleep(0.01)
+    assert len(received_events) == 2
+
+    alice_event = received_events[0]
+    assert isinstance(alice_event.cmd, GetSum)
+    assert alice_event.msg == {'a': 10, 'b': 20}
+    assert alice_event.peer.uri == bob.to_dto().uri
+
+    bob_event = received_events[1]
+    assert isinstance(bob_event.cmd, GetSum)
+    assert bob_event.msg == {'a': 30, 'b': 40}
+    assert bob_event.peer.uri == alice.to_dto().uri

--- a/trinity-external-plugins/examples/peer_count_reporter/peer_count_reporter_plugin/plugin.py
+++ b/trinity-external-plugins/examples/peer_count_reporter/peer_count_reporter_plugin/plugin.py
@@ -4,11 +4,11 @@
 from argparse import ArgumentParser, _SubParsersAction
 import asyncio
 
-from p2p.events import PeerCountRequest
 from p2p.service import BaseService
 from lahja import Endpoint
 from trinity.endpoint import TrinityEventBusEndpoint
 from trinity.extensibility import BaseIsolatedPlugin
+from trinity.protocol.common.events import PeerCountRequest
 from trinity._utils.shutdown import exit_with_service_and_endpoint
 
 

--- a/trinity/plugins/builtin/ethstats/ethstats_service.py
+++ b/trinity/plugins/builtin/ethstats/ethstats_service.py
@@ -5,9 +5,6 @@ import websockets
 from eth.chains.base import (
     BaseChain,
 )
-from p2p.events import (
-    PeerCountRequest,
-)
 from p2p.service import (
     BaseService,
 )
@@ -36,6 +33,9 @@ from trinity.plugins.builtin.ethstats.ethstats_client import (
     EthstatsMessage,
     EthstatsData,
     timestamp_ms,
+)
+from trinity.protocol.common.events import (
+    PeerCountRequest,
 )
 
 

--- a/trinity/plugins/builtin/request_server/plugin.py
+++ b/trinity/plugins/builtin/request_server/plugin.py
@@ -1,0 +1,84 @@
+from argparse import (
+    ArgumentParser,
+    _SubParsersAction,
+)
+import asyncio
+
+from lahja import (
+    Endpoint,
+)
+from p2p.service import (
+    BaseService,
+)
+
+from trinity.config import (
+    Eth1AppConfig,
+    Eth1DbMode,
+)
+from trinity.constants import (
+    TO_NETWORKING_BROADCAST_CONFIG,
+)
+from trinity.db.eth1.manager import (
+    create_db_consumer_manager
+)
+from trinity.extensibility import (
+    BaseIsolatedPlugin,
+)
+from trinity.protocol.eth.servers import (
+    ETHIsolatedRequestServer
+)
+from trinity.protocol.les.servers import (
+    LightIsolatedRequestServer,
+)
+from trinity._utils.shutdown import (
+    exit_with_service_and_endpoint,
+)
+
+
+class RequestServerPlugin(BaseIsolatedPlugin):
+
+    @property
+    def name(self) -> str:
+        return "Request Server"
+
+    def on_ready(self, manager_eventbus: Endpoint) -> None:
+        if not self.context.args.disable_request_server:
+            self.start()
+
+    def configure_parser(self, arg_parser: ArgumentParser, subparser: _SubParsersAction) -> None:
+        arg_parser.add_argument(
+            "--disable-request-server",
+            action="store_true",
+            help="Disables the Request Server",
+        )
+
+    def do_start(self) -> None:
+
+        trinity_config = self.context.trinity_config
+
+        db_manager = create_db_consumer_manager(trinity_config.database_ipc_path)
+
+        eth1_app_config = trinity_config.get_app_config(Eth1AppConfig)
+
+        if eth1_app_config.database_mode is Eth1DbMode.LIGHT:
+            header_db = db_manager.get_headerdb()  # type: ignore
+            server: BaseService = LightIsolatedRequestServer(
+                self.event_bus,
+                TO_NETWORKING_BROADCAST_CONFIG,
+                header_db
+            )
+        elif eth1_app_config.database_mode is Eth1DbMode.FULL:
+            chain_db = db_manager.get_chaindb()  # type: ignore
+            server = ETHIsolatedRequestServer(
+                self.event_bus,
+                TO_NETWORKING_BROADCAST_CONFIG,
+                chain_db
+            )
+        else:
+            raise Exception(f"Unsupported Database Mode: {eth1_app_config.database_mode}")
+
+        loop = asyncio.get_event_loop()
+        asyncio.ensure_future(exit_with_service_and_endpoint(server, self.event_bus))
+        asyncio.ensure_future(server.run())
+        loop.run_forever()
+        loop.close()

--- a/trinity/plugins/builtin/tmp_sync/plugin.py
+++ b/trinity/plugins/builtin/tmp_sync/plugin.py
@@ -1,0 +1,89 @@
+from argparse import (
+    ArgumentParser,
+    _SubParsersAction,
+)
+import asyncio
+
+from lahja import (
+    Endpoint,
+)
+from p2p.service import (
+    BaseService,
+)
+
+from trinity.config import (
+    Eth1AppConfig,
+    Eth1DbMode,
+)
+from trinity.constants import (
+    TO_NETWORKING_BROADCAST_CONFIG,
+)
+from trinity.db.eth1.manager import (
+    create_db_consumer_manager
+)
+from trinity.extensibility import (
+    BaseIsolatedPlugin,
+)
+from trinity.protocol.eth.servers import (
+    ETHIsolatedRequestServer
+)
+from trinity.protocol.les.servers import (
+    LightIsolatedRequestServer,
+)
+from trinity.sync.full.chain import (
+    FastChainSyncer,
+)
+from trinity._utils.shutdown import (
+    exit_with_service_and_endpoint,
+)
+
+
+# Temp plugin for easier development
+class TmpSyncPlugin(BaseIsolatedPlugin):
+
+    @property
+    def name(self) -> str:
+        return "TmpSync"
+
+    def on_ready(self, manager_eventbus: Endpoint) -> None:
+        if not self.context.args.disable_request_server:
+            self.start()
+
+    def configure_parser(self, arg_parser: ArgumentParser, subparser: _SubParsersAction) -> None:
+        arg_parser.add_argument(
+            "--tmp-sync",
+            action="store_true",
+            help="Enable futuristic isolated process sync",
+        )
+
+    def do_start(self) -> None:
+
+        trinity_config = self.context.trinity_config
+
+        db_manager = create_db_consumer_manager(trinity_config.database_ipc_path)
+
+        eth1_app_config = trinity_config.get_app_config(Eth1AppConfig)
+        chain_config = trinity_config.get_chain_config()
+
+
+        if eth1_app_config.database_mode is Eth1DbMode.LIGHT:
+            header_db = db_manager.get_headerdb()  # type: ignore
+            server: BaseService = LightIsolatedRequestServer(
+                self.event_bus,
+                TO_NETWORKING_BROADCAST_CONFIG,
+                header_db
+            )
+        elif eth1_app_config.database_mode is Eth1DbMode.FULL:
+            chain_db = db_manager.get_chaindb()  # type: ignore
+            db = db_manager.get_db()
+            chain_db = db_manager.get_chaindb()
+            chain = chain_config.full_chain_class(db)
+            syncer = FastChainSyncer(chain, chain_db, self.event_bus)
+        else:
+            raise Exception(f"Unsupported Database Mode: {eth1_app_config.database_mode}")
+
+        loop = asyncio.get_event_loop()
+        asyncio.ensure_future(exit_with_service_and_endpoint(syncer, self.event_bus))
+        asyncio.ensure_future(syncer.run())
+        loop.run_forever()
+        loop.close()

--- a/trinity/plugins/registry.py
+++ b/trinity/plugins/registry.py
@@ -22,6 +22,9 @@ from trinity.plugins.builtin.json_rpc.plugin import (
 from trinity.plugins.builtin.peer_discovery.plugin import (
     PeerDiscoveryPlugin,
 )
+from trinity.plugins.builtin.request_server.plugin import (
+    RequestServerPlugin,
+)
 from trinity.plugins.builtin.syncer.plugin import (
     FastThenFullSyncStrategy,
     FullSyncStrategy,
@@ -58,6 +61,7 @@ ETH1_NODE_PLUGINS: Tuple[BasePlugin, ...] = (
     DbShellPlugin(use_ipython=is_ipython_available()),
     EthstatsPlugin(),
     LightPeerChainBridgePlugin(),
+    RequestServerPlugin(),
     SyncerPlugin((
         FastThenFullSyncStrategy(),
         FullSyncStrategy(),

--- a/trinity/plugins/registry.py
+++ b/trinity/plugins/registry.py
@@ -38,6 +38,9 @@ from trinity.plugins.builtin.tx_pool.plugin import (
 from trinity.plugins.builtin.light_peer_chain_bridge.plugin import (
     LightPeerChainBridgePlugin
 )
+from trinity.plugins.builtin.tmp_sync.plugin import (
+    TmpSyncPlugin,
+)
 
 
 def is_ipython_available() -> bool:
@@ -67,7 +70,8 @@ ETH1_NODE_PLUGINS: Tuple[BasePlugin, ...] = (
         FullSyncStrategy(),
         LightSyncStrategy(),
         NoopSyncStrategy(),
-    ), FastThenFullSyncStrategy),
+    ), NoopSyncStrategy),
+    TmpSyncPlugin(),
     TxPlugin(),
 )
 

--- a/trinity/protocol/bcc/peer.py
+++ b/trinity/protocol/bcc/peer.py
@@ -1,5 +1,6 @@
 from typing import (
     cast,
+    NamedTuple,
 )
 
 from eth_utils import (
@@ -18,6 +19,7 @@ from eth2.beacon.typing import (
 from p2p.peer import (
     BasePeer,
     BasePeerFactory,
+    IdentifiablePeer,
 )
 from p2p.peer_pool import (
     BasePeerPool,
@@ -39,6 +41,12 @@ from trinity.protocol.bcc.commands import (
 from trinity.protocol.bcc.context import (
     BeaconContext,
 )
+
+
+class BCCPeerDTO(NamedTuple):
+    head_slot: Slot
+    network_id: int
+    uri: str
 
 
 class BCCPeer(BasePeer):
@@ -94,6 +102,13 @@ class BCCPeer(BasePeer):
         if self._requests is None:
             self._requests = BCCExchangeHandler(self)
         return self._requests
+
+    def to_dto(self) -> IdentifiablePeer:
+        return BCCPeerDTO(
+            head_slot=self.head_slot,
+            network_id=self.network_id,
+            uri=self.remote.uri(),
+        )
 
 
 class BCCPeerFactory(BasePeerFactory):

--- a/trinity/protocol/common/events.py
+++ b/trinity/protocol/common/events.py
@@ -7,21 +7,49 @@ from lahja import (
     BaseRequestResponseEvent,
 )
 
+from p2p.peer import (
+    IdentifiablePeer,
+)
+from p2p.protocol import (
+    Command,
+    PayloadType,
+)
+
 
 class ConnectToNodeCommand(BaseEvent):
+    """
+    Event that wraps a node URI that the pool should connect to.
+    """
 
     def __init__(self, node: str) -> None:
         self.node = node
 
 
 class PeerCountResponse(BaseEvent):
+    """
+    Response event that wraps the count of peers connected to the pool.
+    """
 
     def __init__(self, peer_count: int) -> None:
         self.peer_count = peer_count
 
 
 class PeerCountRequest(BaseRequestResponseEvent[PeerCountResponse]):
+    """
+    Request event to get the count of peers connected to the pool.
+    """
 
     @staticmethod
     def expected_response_type() -> Type[PeerCountResponse]:
         return PeerCountResponse
+
+
+class PeerPoolMessageEvent(BaseEvent):
+    """
+    Event broadcasted when a peer sends a command.
+    """
+
+    def __init__(self, peer: IdentifiablePeer, cmd: Command, msg: PayloadType) -> None:
+        self.peer = peer
+        self.cmd = cmd
+        self.msg = msg

--- a/trinity/protocol/common/events.py
+++ b/trinity/protocol/common/events.py
@@ -1,0 +1,27 @@
+from typing import (
+    Type,
+)
+
+from lahja import (
+    BaseEvent,
+    BaseRequestResponseEvent,
+)
+
+
+class ConnectToNodeCommand(BaseEvent):
+
+    def __init__(self, node: str) -> None:
+        self.node = node
+
+
+class PeerCountResponse(BaseEvent):
+
+    def __init__(self, peer_count: int) -> None:
+        self.peer_count = peer_count
+
+
+class PeerCountRequest(BaseRequestResponseEvent[PeerCountResponse]):
+
+    @staticmethod
+    def expected_response_type() -> Type[PeerCountResponse]:
+        return PeerCountResponse

--- a/trinity/protocol/common/events.py
+++ b/trinity/protocol/common/events.py
@@ -10,6 +10,9 @@ from lahja import (
 from p2p.peer import (
     IdentifiablePeer,
 )
+from p2p.p2p_proto import (
+    DisconnectReason,
+)
 from p2p.protocol import (
     Command,
     PayloadType,
@@ -71,3 +74,13 @@ class PeerLeftEvent(BaseEvent):
 
     def __init__(self, peer: IdentifiablePeer) -> None:
         self.peer = peer
+
+
+class DisconnectPeerEvent(BaseEvent):
+    """
+    Event broadcasted when we want to disconnect from a peer
+    """
+
+    def __init__(self, peer: IdentifiablePeer, reason: DisconnectReason) -> None:
+        self.peer = peer
+        self.reason = reason

--- a/trinity/protocol/common/events.py
+++ b/trinity/protocol/common/events.py
@@ -53,3 +53,21 @@ class PeerPoolMessageEvent(BaseEvent):
         self.peer = peer
         self.cmd = cmd
         self.msg = msg
+
+
+class PeerJoinedEvent(BaseEvent):
+    """
+    Event broadcasted when a new peer joined the pool.
+    """
+
+    def __init__(self, peer: IdentifiablePeer) -> None:
+        self.peer = peer
+
+
+class PeerLeftEvent(BaseEvent):
+    """
+    Event broadcasted when a peer left the pool.
+    """
+
+    def __init__(self, peer: IdentifiablePeer) -> None:
+        self.peer = peer

--- a/trinity/protocol/common/handlers.py
+++ b/trinity/protocol/common/handlers.py
@@ -63,7 +63,8 @@ if TYPE_CHECKING:
             BlockIdentifier,
             int,
             DefaultArg(int, 'skip'),
-            DefaultArg(int, 'reverse')
+            DefaultArg(int, 'reverse'),
+            DefaultArg(float, 'timeout')
         ],
         Awaitable[Tuple[BlockHeader, ...]]
     ]

--- a/trinity/protocol/common/peer.py
+++ b/trinity/protocol/common/peer.py
@@ -25,6 +25,7 @@ from p2p.kademlia import Node
 from p2p.peer import (
     BasePeer,
     BasePeerFactory,
+    IdentifiablePeer,
 )
 from p2p.peer_pool import (
     BasePeerPool,
@@ -42,6 +43,16 @@ class ChainInfo(NamedTuple):
     block_hash: Hash32
     total_difficulty: int
     genesis_hash: Hash32
+
+
+class BaseChainDTOPeer(NamedTuple):
+    # TODO: Calling code might worker under the assumption these values are live
+    # which they aren't for the DTO. Potential footgun?
+    uri: str
+    head_td: int
+    head_hash: Hash32
+    head_number: BlockNumber
+    max_headers_fetch: int
 
 
 class BaseChainPeer(BasePeer):
@@ -90,6 +101,15 @@ class BaseChainPeer(BasePeer):
             block_hash=head.hash,
             total_difficulty=total_difficulty,
             genesis_hash=genesis.hash,
+        )
+
+    def to_dto(self) -> IdentifiablePeer:
+        return BaseChainDTOPeer(
+            self.remote.uri(),
+            self.head_td,
+            self.head_hash,
+            self.head_number,
+            self.max_headers_fetch,
         )
 
 

--- a/trinity/protocol/common/peer_pool_event_bus.py
+++ b/trinity/protocol/common/peer_pool_event_bus.py
@@ -1,0 +1,57 @@
+from cancel_token import (
+    CancelToken,
+)
+from lahja import (
+    Endpoint,
+)
+
+from p2p.kademlia import (
+    from_uris,
+)
+from p2p.peer_pool import (
+    BasePeerPool,
+)
+from p2p.service import (
+    BaseService,
+)
+
+from .events import (
+    ConnectToNodeCommand,
+    PeerCountRequest,
+    PeerCountResponse,
+)
+
+
+class BasePeerPoolEventBusRequestHandler(BaseService):
+    """
+    Base class that handles requests that are coming through the event bus and are meant to be
+    handled by the peer pool. Subclasses should extend this class with custom event handlers.
+    """
+
+    def __init__(self,
+                 event_bus: Endpoint,
+                 peer_pool: BasePeerPool,
+                 token: CancelToken = None) -> None:
+        super().__init__(token)
+        self._peer_pool = peer_pool
+        self._event_bus = event_bus
+
+    async def accept_connect_commands(self) -> None:
+        async for command in self.wait_iter(self._event_bus.stream(ConnectToNodeCommand)):
+            self.logger.debug('Received request to connect to %s', command.node)
+            self.run_task(self._peer_pool.connect_to_nodes(from_uris([command.node])))
+
+    async def handle_peer_count_requests(self) -> None:
+        async for req in self.wait_iter(self._event_bus.stream(PeerCountRequest)):
+            self._event_bus.broadcast(
+                PeerCountResponse(len(self._peer_pool)),
+                req.broadcast_config()
+            )
+
+    async def _run(self) -> None:
+        self.logger.info("Running BasePeerPoolEventBusRequestHandler")
+
+        self.run_daemon_task(self.handle_peer_count_requests())
+        self.run_daemon_task(self.accept_connect_commands())
+
+        await self.cancel_token.wait()

--- a/trinity/protocol/common/peer_pool_event_bus.py
+++ b/trinity/protocol/common/peer_pool_event_bus.py
@@ -33,6 +33,8 @@ from .events import (
     PeerCountRequest,
     PeerCountResponse,
     PeerPoolMessageEvent,
+    PeerJoinedEvent,
+    PeerLeftEvent,
 )
 
 
@@ -50,6 +52,7 @@ class BasePeerPoolEventBusRequestHandler(BaseService, Generic[TPeer]):
                  peer_pool: BasePeerPool,
                  token: CancelToken = None) -> None:
         super().__init__(token)
+        # TODO: Make both plublic (intended to use in derived classes)
         self._peer_pool = peer_pool
         self._event_bus = event_bus
 
@@ -118,3 +121,9 @@ class BasePeerPoolMessageRelayer(BaseService, PeerSubscriber):
             while self.is_operational:
                 peer, cmd, msg = await self.wait(self.msg_queue.get())
                 self._event_bus.broadcast(PeerPoolMessageEvent(peer.to_dto(), cmd, msg))
+
+    def register_peer(self, peer: BasePeer) -> None:
+        self._event_bus.broadcast(PeerJoinedEvent(peer.to_dto()))
+
+    def deregister_peer(self, peer: BasePeer) -> None:
+        self._event_bus.broadcast(PeerLeftEvent(peer.to_dto()))

--- a/trinity/protocol/eth/events.py
+++ b/trinity/protocol/eth/events.py
@@ -1,0 +1,54 @@
+from typing import (
+    List,
+    Tuple,
+)
+
+from eth.rlp.blocks import BaseBlock
+from eth.rlp.headers import BlockHeader
+from eth.rlp.receipts import Receipt
+from lahja import (
+    BaseEvent,
+)
+from p2p.peer import (
+    IdentifiablePeer,
+)
+
+
+class SendBlockHeadersEvent(BaseEvent):
+    """
+    An event to carry a *send block header* action from the proxy peer to the actual peer
+    in the peer pool.
+    """
+    def __init__(self, dto_peer: IdentifiablePeer, headers: Tuple[BlockHeader, ...]) -> None:
+        self.dto_peer = dto_peer
+        self.headers = headers
+
+
+class SendBlockBodiesEvent(BaseEvent):
+    """
+    An event to carry a *send block bodies* action from the proxy peer to the actual peer
+    in the peer pool.
+    """
+    def __init__(self, dto_peer: IdentifiablePeer, blocks: List[BaseBlock]) -> None:
+        self.dto_peer = dto_peer
+        self.blocks = blocks
+
+
+class SendNodeDataEvent(BaseEvent):
+    """
+    An event to carry a *send node data* action from the proxy peer to the actual peer
+    in the peer pool.
+    """
+    def __init__(self, dto_peer: IdentifiablePeer, nodes: Tuple[bytes, ...]) -> None:
+        self.dto_peer = dto_peer
+        self.nodes = nodes
+
+
+class SendReceiptsEvent(BaseEvent):
+    """
+    An event to carry a *send receipts* action from the proxy peer to the actual peer
+    in the peer pool.
+    """
+    def __init__(self, dto_peer: IdentifiablePeer, receipts: List[List[Receipt]]) -> None:
+        self.dto_peer = dto_peer
+        self.receipts = receipts

--- a/trinity/protocol/eth/events.py
+++ b/trinity/protocol/eth/events.py
@@ -162,3 +162,40 @@ class GetReceiptsRequest(BaseRequestResponseEvent[GetReceiptsResponse]):
     @staticmethod
     def expected_response_type() -> Type[GetReceiptsResponse]:
         return GetReceiptsResponse
+
+# Other PeerPool events
+
+
+class GetHighestTDPeerResponse(BaseEvent):
+
+    def __init__(self,
+                 dto_peer: IdentifiablePeer) -> None:
+        self.dto_peer = dto_peer
+
+
+class GetHighestTDPeerRequest(BaseRequestResponseEvent[GetHighestTDPeerResponse]):
+
+    def __init__(self,
+                 timeout: float) -> None:
+        self.timeout = timeout
+
+    @staticmethod
+    def expected_response_type() -> Type[GetHighestTDPeerResponse]:
+        return GetHighestTDPeerResponse
+
+
+class GetConnectedPeersResponse(BaseEvent):
+
+    def __init__(self,
+                 dto_peers: Tuple[IdentifiablePeer, ...]) -> None:
+        self.dto_peers = dto_peers
+
+
+class GetConnectedPeersRequest(BaseRequestResponseEvent[GetConnectedPeersResponse]):
+
+    def __init__(self, min_td: int = 0) -> None:
+        self.min_td = min_td
+
+    @staticmethod
+    def expected_response_type() -> Type[GetConnectedPeersResponse]:
+        return GetConnectedPeersResponse

--- a/trinity/protocol/eth/events.py
+++ b/trinity/protocol/eth/events.py
@@ -1,18 +1,32 @@
 from typing import (
     List,
     Tuple,
+    Type,
 )
 
 from eth.rlp.blocks import BaseBlock
 from eth.rlp.headers import BlockHeader
 from eth.rlp.receipts import Receipt
+from eth_typing import (
+    BlockIdentifier,
+    Hash32,
+)
 from lahja import (
     BaseEvent,
+    BaseRequestResponseEvent,
 )
 from p2p.peer import (
     IdentifiablePeer,
 )
 
+from trinity.protocol.common.types import (
+    BlockBodyBundles,
+    NodeDataBundles,
+    ReceiptsBundles,
+)
+
+
+# RAW PROTOCOL EVENTS
 
 class SendBlockHeadersEvent(BaseEvent):
     """
@@ -52,3 +66,99 @@ class SendReceiptsEvent(BaseEvent):
     def __init__(self, dto_peer: IdentifiablePeer, receipts: List[List[Receipt]]) -> None:
         self.dto_peer = dto_peer
         self.receipts = receipts
+
+
+# EXCHANGE HANDLER REQUEST / RESPONSE PAIRS
+
+class GetBlockHeadersResponse(BaseEvent):
+
+    def __init__(self,
+                 headers: Tuple[BlockHeader, ...]) -> None:
+        self.headers = headers
+
+
+class GetBlockHeadersRequest(BaseRequestResponseEvent[GetBlockHeadersResponse]):
+
+    def __init__(self,
+                 dto_peer: IdentifiablePeer,
+                 block_number_or_hash: BlockIdentifier,
+                 max_headers: int,
+                 skip: int,
+                 reverse: bool,
+                 timeout: float) -> None:
+        self.dto_peer = dto_peer
+        self.block_number_or_hash = block_number_or_hash
+        self.max_headers = max_headers
+        self.skip = skip
+        self.reverse = reverse
+        self.timeout = timeout
+
+    @staticmethod
+    def expected_response_type() -> Type[GetBlockHeadersResponse]:
+        return GetBlockHeadersResponse
+
+
+class GetBlockBodiesResponse(BaseEvent):
+
+    def __init__(self,
+                 bundles: BlockBodyBundles) -> None:
+        self.bundles = bundles
+
+
+class GetBlockBodiesRequest(BaseRequestResponseEvent[GetBlockBodiesResponse]):
+
+    def __init__(self,
+                 dto_peer: IdentifiablePeer,
+                 headers: Tuple[BlockHeader, ...],
+                 timeout: float) -> None:
+        self.dto_peer = dto_peer
+        self.headers = headers
+        self.timeout = timeout
+
+    @staticmethod
+    def expected_response_type() -> Type[GetBlockBodiesResponse]:
+        return GetBlockBodiesResponse
+
+
+class GetNodeDataResponse(BaseEvent):
+
+    def __init__(self,
+                 bundles: NodeDataBundles) -> None:
+        self.bundles = bundles
+
+
+class GetNodeDataRequest(BaseRequestResponseEvent[GetNodeDataResponse]):
+
+    def __init__(self,
+                 dto_peer: IdentifiablePeer,
+                 node_hashes: Tuple[Hash32, ...],
+                 timeout: float) -> None:
+        self.dto_peer = dto_peer
+        self.node_hashes = node_hashes
+        self.timeout = timeout
+
+    @staticmethod
+    def expected_response_type() -> Type[GetNodeDataResponse]:
+        return GetNodeDataResponse
+
+
+class GetReceiptsResponse(BaseEvent):
+
+    def __init__(self,
+                 bundles: ReceiptsBundles) -> None:
+        self.bundles = bundles
+
+
+class GetReceiptsRequest(BaseRequestResponseEvent[GetReceiptsResponse]):
+
+    def __init__(self,
+                 dto_peer: IdentifiablePeer,
+                 headers: Tuple[BlockHeader, ...],
+                 timeout: float) -> None:
+        self.dto_peer = dto_peer
+        self.headers = headers
+        self.timeout = timeout
+
+    @staticmethod
+    def expected_response_type() -> Type[GetReceiptsResponse]:
+        return GetReceiptsResponse

--- a/trinity/protocol/eth/handlers.py
+++ b/trinity/protocol/eth/handlers.py
@@ -1,5 +1,44 @@
+import asyncio
+from abc import (
+    abstractmethod,
+)
+import concurrent
+from typing import (
+    Awaitable,
+    Tuple,
+    TypeVar,
+)
+import typing_extensions
+
+from lahja import (
+    BroadcastConfig,
+    Endpoint,
+)
+from p2p.peer import (
+    IdentifiablePeer,
+)
+from eth.rlp.headers import (
+    BlockHeader,
+)
+from eth_typing import (
+    BlockIdentifier,
+    Hash32,
+)
+
+
 from trinity.protocol.common.handlers import (
     BaseChainExchangeHandler,
+)
+from trinity.protocol.common.types import (
+    BlockBodyBundles,
+    NodeDataBundles,
+    ReceiptsBundles,
+)
+from trinity.protocol.eth.events import (
+    GetBlockHeadersRequest,
+    GetBlockBodiesRequest,
+    GetNodeDataRequest,
+    GetReceiptsRequest,
 )
 
 from .exchanges import (
@@ -8,6 +47,40 @@ from .exchanges import (
     GetNodeDataExchange,
     GetReceiptsExchange,
 )
+
+
+class ETHExchangeHandlerLike(typing_extensions.Protocol):
+    """
+    Define the ETHExchangeHandler protocol that streamlines peer communication
+    into request/response pairs
+    """
+
+    @abstractmethod
+    async def get_block_headers(self,
+                                block_number_or_hash: BlockIdentifier,
+                                max_headers: int = None,
+                                skip: int = 0,
+                                reverse: bool = True,
+                                timeout: float = None) -> Tuple[BlockHeader, ...]:
+        pass
+
+    @abstractmethod
+    async def get_block_bodies(self,
+                               headers: Tuple[BlockHeader, ...],
+                               timeout: float = None) -> BlockBodyBundles:
+        pass
+
+    @abstractmethod
+    async def get_node_data(self,
+                            node_hashes: Tuple[Hash32, ...],
+                            timeout: float = None) -> NodeDataBundles:
+        pass
+
+    @abstractmethod
+    async def get_receipts(self,
+                           headers: Tuple[BlockHeader, ...],
+                           timeout: float = None) -> ReceiptsBundles:
+        pass
 
 
 class ETHExchangeHandler(BaseChainExchangeHandler):
@@ -22,3 +95,93 @@ class ETHExchangeHandler(BaseChainExchangeHandler):
     get_block_bodies: GetBlockBodiesExchange
     get_node_data: GetNodeDataExchange
     get_receipts: GetReceiptsExchange
+
+
+class ProxyETHExchangeHandler:
+    """
+    An ``ETHExchangeHandler`` that can be used outside of the process that runs the peer pool. Any
+    action performed on this class is delegated to the process that runs the peer pool.
+    """
+
+    def __init__(self,
+                 dto_peer: IdentifiablePeer,
+                 event_bus: Endpoint,
+                 broadcast_config: BroadcastConfig):
+        self._dto_peer = dto_peer
+        self._event_bus = event_bus
+        self._broadcast_config = broadcast_config
+
+    T = TypeVar('T')
+
+    async def wait_for(self, awaitable: Awaitable[T], timeout: float) -> T:
+        # FIXME: Just a crutch to make it work for now
+        try:
+            return await asyncio.wait_for(awaitable, timeout=timeout)
+        except concurrent.futures.TimeoutError as e:
+            raise TimeoutError(e) from e
+
+    async def get_block_headers(self,
+                                block_number_or_hash: BlockIdentifier,
+                                max_headers: int = None,
+                                skip: int = 0,
+                                reverse: bool = True,
+                                timeout: float = None) -> Tuple[BlockHeader, ...]:
+
+        response = await self.wait_for(self._event_bus.request(
+            GetBlockHeadersRequest(
+                self._dto_peer,
+                block_number_or_hash,
+                max_headers,
+                skip,
+                reverse,
+                timeout,
+            ),
+            self._broadcast_config
+        ), timeout=timeout)
+
+        return response.headers
+
+    async def get_block_bodies(self,
+                               headers: Tuple[BlockHeader, ...],
+                               timeout: float = None) -> BlockBodyBundles:
+
+        response = await self.wait_for(self._event_bus.request(
+            GetBlockBodiesRequest(
+                self._dto_peer,
+                headers,
+                timeout,
+            ),
+            self._broadcast_config
+        ), timeout=timeout)
+
+        return response.bundles
+
+    async def get_node_data(self,
+                            node_hashes: Tuple[Hash32, ...],
+                            timeout: float = None) -> NodeDataBundles:
+
+        response = await self.wait_for(self._event_bus.request(
+            GetNodeDataRequest(
+                self._dto_peer,
+                node_hashes,
+                timeout,
+            ),
+            self._broadcast_config
+        ), timeout=timeout)
+
+        return response.bundles
+
+    async def get_receipts(self,
+                           headers: Tuple[BlockHeader, ...],
+                           timeout: float = None) -> ReceiptsBundles:
+
+        response = await self.wait_for(self._event_bus.request(
+            GetReceiptsRequest(
+                self._dto_peer,
+                headers,
+                timeout,
+            ),
+            self._broadcast_config
+        ), timeout=timeout)
+
+        return response.bundles

--- a/trinity/protocol/eth/peer.py
+++ b/trinity/protocol/eth/peer.py
@@ -280,6 +280,7 @@ class ETHPeerPoolEventBusRequestHandler(BasePeerPoolEventBusRequestHandler[ETHPe
             except TimeoutError:
                 self.logger.debug("Timed out waiting on %s from %s", GetBlockHeadersRequest, peer)
             else:
+                self.logger.warning("Responding from %s from %s", GetBlockHeadersRequest, peer)
                 self._event_bus.broadcast(GetBlockHeadersResponse(headers), ev.broadcast_config())
 
     async def handle_get_block_bodies_requests(self) -> None:
@@ -297,6 +298,7 @@ class ETHPeerPoolEventBusRequestHandler(BasePeerPoolEventBusRequestHandler[ETHPe
             except TimeoutError:
                 self.logger.debug("Timed out waiting on %s from %s", GetBlockBodiesRequest, peer)
             else:
+                self.logger.warning("Responding from %s from %s", GetBlockBodiesRequest, peer)
                 self._event_bus.broadcast(GetBlockBodiesResponse(bundles), ev.broadcast_config())
 
     async def handle_get_node_data_requests(self) -> None:
@@ -309,8 +311,9 @@ class ETHPeerPoolEventBusRequestHandler(BasePeerPoolEventBusRequestHandler[ETHPe
             try:
                 bundles = await peer.requests.get_node_data(ev.node_hashes, ev.timeout)
             except TimeoutError:
-                self.logger.debug("Timed out waiting on %s from %s", GetBlockBodiesRequest, peer)
+                self.logger.debug("Timed out waiting on %s from %s", GetNodeDataRequest, peer)
             else:
+                self.logger.warning("Responding from %s from %s", GetNodeDataRequest, peer)
                 self._event_bus.broadcast(GetNodeDataResponse(bundles), ev.broadcast_config())
 
     async def handle_get_receipts_requests(self) -> None:
@@ -325,6 +328,7 @@ class ETHPeerPoolEventBusRequestHandler(BasePeerPoolEventBusRequestHandler[ETHPe
             except TimeoutError:
                 self.logger.debug("Timed out waiting on %s from %s", GetReceiptsRequest, peer)
             else:
+                self.logger.warning("Responding from %s from %s", GetReceiptsRequest, peer)
                 self._event_bus.broadcast(GetReceiptsResponse(bundles), ev.broadcast_config())
 
     async def handle_get_highest_td_peer_requests(self) -> None:
@@ -336,6 +340,7 @@ class ETHPeerPoolEventBusRequestHandler(BasePeerPoolEventBusRequestHandler[ETHPe
                 # no peers are available right now
                 highest_td_peer = None
 
+            self.logger.warning("Responding from %s from %s", GetHighestTDPeerRequest, highest_td_peer)
             self._event_bus.broadcast(
                 GetHighestTDPeerResponse(highest_td_peer),
                 ev.broadcast_config()
@@ -346,6 +351,8 @@ class ETHPeerPoolEventBusRequestHandler(BasePeerPoolEventBusRequestHandler[ETHPe
 
             peers = self._peer_pool.get_peers(ev.min_td)
             dto_peers = tuple(peer.to_dto() for peer in peers)
+
+            self.logger.warning("Responding from %s from %s", GetHighestTDPeerRequest, dto_peers)
             self._event_bus.broadcast(
                 GetConnectedPeersResponse(dto_peers),
                 ev.broadcast_config()

--- a/trinity/protocol/eth/peer.py
+++ b/trinity/protocol/eth/peer.py
@@ -366,6 +366,9 @@ class ETHProxyPeerPool:
     # TODO: Broadcast config, timeout
     async def get_hightest_td_peer(self) -> ETHProxyPeer:
         response = await self.event_bus.request(GetHighestTDPeerRequest(2))
+        if response.dto_peer is None:
+            return None
+
         return ETHProxyPeer.from_dto_peer(response.dto_peer, self.event_bus, self.broadcast_config)
 
     async def get_connected_peers(self, min_td: int = 0) -> ETHProxyPeer:

--- a/trinity/protocol/eth/peer.py
+++ b/trinity/protocol/eth/peer.py
@@ -214,10 +214,14 @@ class ETHProxyPeer:
         return not self._disconnected
 
     async def disconnect(self, reason: DisconnectReason) -> None:
+        self._disconnected = True
         self.event_bus.broadcast(
             DisconnectPeerEvent(self.dto_peer, reason),
             TO_NETWORKING_BROADCAST_CONFIG,
         )
+
+    def __str__(self) -> str:
+        return f"{self.__class__.__name__} {self.dto_peer.uri}"
 
     @classmethod
     def from_dto_peer(cls,

--- a/trinity/protocol/eth/servers.py
+++ b/trinity/protocol/eth/servers.py
@@ -21,17 +21,32 @@ from eth_typing import (
 from eth_utils import (
     to_hex,
 )
+from lahja import (
+    BroadcastConfig,
+    Endpoint,
+)
 
 from p2p import protocol
-from p2p.peer import BasePeer
+from p2p.peer import (
+    BasePeer,
+    IdentifiablePeer,
+)
 from p2p.protocol import (
     Command,
 )
 
 from trinity.db.eth1.chain import BaseAsyncChainDB
-from trinity.protocol.common.servers import BaseRequestServer, BasePeerRequestHandler
+from trinity.protocol.common.servers import (
+    BaseIsolatedRequestServer,
+    BaseRequestServer,
+    BasePeerRequestHandler,
+)
 from trinity.protocol.eth import commands
-from trinity.protocol.eth.peer import ETHPeer, ETHPeerPool
+from trinity.protocol.eth.peer import (
+    ETHPeerLike,
+    ETHPeerPool,
+    ETHProxyPeer,
+)
 
 from eth.rlp.receipts import Receipt
 from eth.rlp.transactions import BaseTransactionFields
@@ -52,7 +67,7 @@ class ETHPeerRequestHandler(BasePeerRequestHandler):
 
     async def handle_get_block_headers(
             self,
-            peer: ETHPeer,
+            peer: ETHPeerLike,
             msg: Dict[str, Any]) -> None:
         if not peer.is_operational:
             return
@@ -69,7 +84,9 @@ class ETHPeerRequestHandler(BasePeerRequestHandler):
         self.logger.debug2("Replying to %s with %d headers", peer, len(headers))
         peer.sub_proto.send_block_headers(headers)
 
-    async def handle_get_block_bodies(self, peer: ETHPeer, block_hashes: Sequence[Hash32]) -> None:
+    async def handle_get_block_bodies(self,
+                                      peer: ETHPeerLike,
+                                      block_hashes: Sequence[Hash32]) -> None:
         if not peer.is_operational:
             return
         self.logger.debug2("%s requested bodies for %d blocks", peer, len(block_hashes))
@@ -90,7 +107,7 @@ class ETHPeerRequestHandler(BasePeerRequestHandler):
         self.logger.debug2("Replying to %s with %d block bodies", peer, len(bodies))
         peer.sub_proto.send_block_bodies(bodies)
 
-    async def handle_get_receipts(self, peer: ETHPeer, block_hashes: Sequence[Hash32]) -> None:
+    async def handle_get_receipts(self, peer: ETHPeerLike, block_hashes: Sequence[Hash32]) -> None:
         if not peer.is_operational:
             return
         self.logger.debug2("%s requested receipts for %d blocks", peer, len(block_hashes))
@@ -109,7 +126,7 @@ class ETHPeerRequestHandler(BasePeerRequestHandler):
         self.logger.debug2("Replying to %s with receipts for %d blocks", peer, len(receipts))
         peer.sub_proto.send_receipts(receipts)
 
-    async def handle_get_node_data(self, peer: ETHPeer, node_hashes: Sequence[Hash32]) -> None:
+    async def handle_get_node_data(self, peer: ETHPeerLike, node_hashes: Sequence[Hash32]) -> None:
         if not peer.is_operational:
             return
         self.logger.debug2("%s requested %d trie nodes", peer, len(node_hashes))
@@ -154,7 +171,7 @@ class ETHRequestServer(BaseRequestServer):
 
     async def _handle_msg(self, base_peer: BasePeer, cmd: Command,
                           msg: protocol._DecodedMsgType) -> None:
-        peer = cast(ETHPeer, base_peer)
+        peer = cast(ETHPeerLike, base_peer)
 
         ignored_commands = (
             commands.Transactions,
@@ -164,6 +181,53 @@ class ETHRequestServer(BaseRequestServer):
         if isinstance(cmd, ignored_commands):
             pass
         elif isinstance(cmd, commands.GetBlockHeaders):
+            await self._handler.handle_get_block_headers(peer, cast(Dict[str, Any], msg))
+        elif isinstance(cmd, commands.GetBlockBodies):
+            block_hashes = cast(Sequence[Hash32], msg)
+            await self._handler.handle_get_block_bodies(peer, block_hashes)
+        elif isinstance(cmd, commands.GetReceipts):
+            block_hashes = cast(Sequence[Hash32], msg)
+            await self._handler.handle_get_receipts(peer, block_hashes)
+        elif isinstance(cmd, commands.GetNodeData):
+            node_hashes = cast(Sequence[Hash32], msg)
+            await self._handler.handle_get_node_data(peer, node_hashes)
+        else:
+            self.logger.debug("%s msg not handled yet, need to be implemented", cmd)
+
+
+class ETHIsolatedRequestServer(BaseIsolatedRequestServer):
+    """
+    Like :class:`~trinity.protocol.eth.servers.ETHRequestServer` but can be run outside of the
+    process that hosts the :class:`~p2p.peer_pool.BasePeerPool`.
+    """
+
+    _handled_commands = (
+        commands.GetBlockHeaders,
+        commands.GetBlockBodies,
+        commands.GetReceipts,
+        commands.GetNodeData,
+    )
+
+    def __init__(
+            self,
+            event_bus: Endpoint,
+            broadcast_config: BroadcastConfig,
+            db: BaseAsyncChainDB,
+            token: CancelToken = None) -> None:
+        super().__init__(event_bus, broadcast_config, token)
+        self._handler = ETHPeerRequestHandler(db, self.cancel_token)
+
+    async def _handle_msg(self,
+                          dto_peer: IdentifiablePeer,
+                          cmd: Command,
+                          msg: protocol._DecodedMsgType) -> None:
+
+        if type(cmd) not in self._handled_commands:
+            return
+
+        self.logger.debug("Peer %s requested %s", dto_peer.uri, cmd)
+        peer = ETHProxyPeer.from_dto_peer(dto_peer, self.event_bus, self.broadcast_config)
+        if isinstance(cmd, commands.GetBlockHeaders):
             await self._handler.handle_get_block_headers(peer, cast(Dict[str, Any], msg))
         elif isinstance(cmd, commands.GetBlockBodies):
             block_hashes = cast(Sequence[Hash32], msg)

--- a/trinity/protocol/les/events.py
+++ b/trinity/protocol/les/events.py
@@ -1,0 +1,27 @@
+from typing import (
+    Tuple,
+)
+
+from eth.rlp.headers import BlockHeader
+from lahja import (
+    BaseEvent,
+)
+from p2p.peer import (
+    IdentifiablePeer,
+)
+
+
+class SendBlockHeadersEvent(BaseEvent):
+    """
+    An event to carry a *send block headers* action from the proxy peer to the actual peer
+    in the peer pool.
+    """
+    def __init__(self,
+                 dto_peer: IdentifiablePeer,
+                 headers: Tuple[BlockHeader, ...],
+                 buffer_value: int,
+                 request_id: int=None) -> None:
+        self.dto_peer = dto_peer
+        self.headers = headers
+        self.buffer_value = buffer_value
+        self.request_id = request_id

--- a/trinity/protocol/les/servers.py
+++ b/trinity/protocol/les/servers.py
@@ -7,23 +7,39 @@ from typing import (
 )
 
 from cancel_token import CancelToken
+from lahja import (
+    BroadcastConfig,
+    Endpoint,
+)
 
-from p2p.peer import BasePeer
+from p2p.peer import (
+    BasePeer,
+    IdentifiablePeer,
+)
 from p2p.protocol import (
     Command,
     _DecodedMsgType,
 )
 
 from trinity.db.eth1.header import BaseAsyncHeaderDB
-from trinity.protocol.common.servers import BaseRequestServer, BasePeerRequestHandler
+from trinity.protocol.common.servers import (
+    BaseRequestServer,
+    BaseIsolatedRequestServer,
+    BasePeerRequestHandler,
+)
 from trinity.protocol.les import commands
-from trinity.protocol.les.peer import LESPeer, LESPeerPool
+from trinity.protocol.les.peer import (
+    LESPeer,
+    LESPeerLike,
+    LESPeerPool,
+    LESProxyPeer,
+)
 
 from trinity.protocol.les.requests import HeaderRequest as LightHeaderRequest
 
 
 class LESPeerRequestHandler(BasePeerRequestHandler):
-    async def handle_get_block_headers(self, peer: LESPeer, msg: Dict[str, Any]) -> None:
+    async def handle_get_block_headers(self, peer: LESPeerLike, msg: Dict[str, Any]) -> None:
         if not peer.is_operational:
             return
         self.logger.debug("Peer %s made header request: %s", peer, msg)
@@ -64,3 +80,38 @@ class LightRequestServer(BaseRequestServer):
             await self._handler.handle_get_block_headers(peer, block_request_kwargs)
         else:
             self.logger.debug("%s msg from %s not implemented", cmd, peer)
+
+
+class LightIsolatedRequestServer(BaseIsolatedRequestServer):
+    """
+    Like :class:`~trinity.protocol.les.servers.LightRequestServer` but can be run outside of the
+    process that hosts the :class:`~p2p.peer_pool.BasePeerPool`.
+    """
+
+    _handled_commands = (
+        commands.GetBlockHeaders,
+    )
+
+    def __init__(
+            self,
+            event_bus: Endpoint,
+            broadcast_config: BroadcastConfig,
+            db: BaseAsyncHeaderDB,
+            token: CancelToken = None) -> None:
+        super().__init__(event_bus, broadcast_config, token)
+        self._handler = LESPeerRequestHandler(db, self.cancel_token)
+
+    async def _handle_msg(self,
+                          dto_peer: IdentifiablePeer,
+                          cmd: Command,
+                          msg: _DecodedMsgType) -> None:
+
+        if type(cmd) not in self._handled_commands:
+            return
+
+        self.logger.debug("Peer %s requested %s", dto_peer.uri, cmd)
+        peer = LESProxyPeer.from_dto_peer(dto_peer, self.event_bus, self.broadcast_config)
+        if isinstance(cmd, commands.GetBlockHeaders):
+            await self._handler.handle_get_block_headers(peer, cast(Dict[str, Any], msg))
+        else:
+            self.logger.debug("%s msg not handled yet, need to be implemented", cmd)

--- a/trinity/rpc/modules/admin.py
+++ b/trinity/rpc/modules/admin.py
@@ -1,8 +1,6 @@
-
-from p2p.events import ConnectToNodeCommand
-
 from trinity.constants import TO_NETWORKING_BROADCAST_CONFIG
 from trinity.endpoint import TrinityEventBusEndpoint
+from trinity.protocol.common.events import ConnectToNodeCommand
 from trinity.rpc.modules import BaseRPCModule
 from trinity._utils.validation import validate_enode_uri
 

--- a/trinity/rpc/modules/net.py
+++ b/trinity/rpc/modules/net.py
@@ -1,7 +1,8 @@
-from p2p.events import PeerCountRequest
+
 from trinity.constants import TO_NETWORKING_BROADCAST_CONFIG
 from trinity.endpoint import TrinityEventBusEndpoint
 from trinity.nodes.events import NetworkIdRequest
+from trinity.protocol.common.events import PeerCountRequest
 from trinity.rpc.modules import BaseRPCModule
 
 

--- a/trinity/server.py
+++ b/trinity/server.py
@@ -55,6 +55,7 @@ from trinity.protocol.common.peer_pool_event_bus import (
     BasePeerPoolMessageRelayer,
 )
 from trinity.protocol.eth.peer import ETHPeerPool
+from trinity.protocol.eth.peer import ETHPeerPoolEventBusRequestHandler
 from trinity.protocol.les.peer import LESPeerPool
 
 
@@ -298,6 +299,14 @@ class FullServer(BaseServer[ETHPeerPool]):
             event_bus=self.event_bus
         )
 
+    def _make_peer_pool_request_handler(
+            self,
+            peer_pool: TPeerPool) -> ETHPeerPoolEventBusRequestHandler:
+        return ETHPeerPoolEventBusRequestHandler(
+            self.event_bus,
+            peer_pool,
+            self.cancel_token
+        )
 
 class LightServer(BaseServer[LESPeerPool]):
     def _make_peer_pool(self) -> LESPeerPool:

--- a/trinity/server.py
+++ b/trinity/server.py
@@ -308,6 +308,7 @@ class FullServer(BaseServer[ETHPeerPool]):
             self.cancel_token
         )
 
+
 class LightServer(BaseServer[LESPeerPool]):
     def _make_peer_pool(self) -> LESPeerPool:
         context = ChainContext(

--- a/trinity/server.py
+++ b/trinity/server.py
@@ -50,6 +50,7 @@ from trinity.db.eth1.header import BaseAsyncHeaderDB
 from trinity.endpoint import TrinityEventBusEndpoint
 from trinity.protocol.common.context import ChainContext
 from trinity.protocol.common.peer import BaseChainPeerPool
+from trinity.protocol.common.peer_pool_event_bus import BasePeerPoolEventBusRequestHandler
 from trinity.protocol.common.servers import BaseRequestServer
 from trinity.protocol.eth.peer import ETHPeerPool
 from trinity.protocol.eth.servers import ETHRequestServer
@@ -106,6 +107,7 @@ class BaseServer(BaseService, Generic[TPeerPool]):
         # child services
         self.upnp_service = UPnPService(port, token=self.cancel_token)
         self.peer_pool = self._make_peer_pool()
+        self._peer_pool_request_handler = self._make_peer_pool_request_handler(self.peer_pool)
         self.request_server = self._make_request_server()
 
         if not bootstrap_nodes:
@@ -114,6 +116,14 @@ class BaseServer(BaseService, Generic[TPeerPool]):
     @abstractmethod
     def _make_peer_pool(self) -> TPeerPool:
         pass
+
+    def _make_peer_pool_request_handler(self,
+                                        peer_pool: TPeerPool) -> BasePeerPoolEventBusRequestHandler:
+        return BasePeerPoolEventBusRequestHandler(
+            self.event_bus,
+            peer_pool,
+            self.cancel_token
+        )
 
     @abstractmethod
     def _make_request_server(self) -> BaseRequestServer:
@@ -150,6 +160,7 @@ class BaseServer(BaseService, Generic[TPeerPool]):
         self.logger.info('peers: max_peers=%s', self.max_peers)
 
         self.run_daemon(self.peer_pool)
+        self.run_daemon(self._peer_pool_request_handler)
         self.run_daemon(self.request_server)
 
         # UPNP service is still experimental and not essential, so we don't use run_daemon() for

--- a/trinity/sync/beacon/chain.py
+++ b/trinity/sync/beacon/chain.py
@@ -143,7 +143,7 @@ class BeaconChainSyncer(BaseService):
                               ) -> AsyncGenerator[Tuple[BaseBeaconBlock, ...], None]:
         slot = start_slot
         while True:
-            self.logger.debug(
+            self.logger.warning(
                 "Requesting blocks from %s starting at #%d",
                 self.sync_peer,
                 slot,

--- a/trinity/sync/common/chain.py
+++ b/trinity/sync/common/chain.py
@@ -90,7 +90,7 @@ class PeerHeaderSyncer(BaseService):
                 peer.head_td, peer, head_td)
             return
         else:
-            self.logger.debug(
+            self.logger.warning(
                 "%s announced Head TD %d, which is higher than ours (%d), starting sync",
                 peer, peer.head_td, head_td)
         self.sync_progress = SyncProgress(head.block_number, head.block_number, peer.head_number)
@@ -122,7 +122,7 @@ class PeerHeaderSyncer(BaseService):
                             all_headers[-1].block_number + 1,
                             head.block_number - MAX_REORG_DEPTH
                         )
-                        self.logger.debug(
+                        self.logger.warning(
                             "All %d headers redundant, head at %s, fetching from #%d",
                             len(all_headers),
                             head,
@@ -131,7 +131,7 @@ class PeerHeaderSyncer(BaseService):
                         continue
                 else:
                     headers = all_headers
-                self.logger.debug2('sync received new headers: %s', headers)
+                self.logger.warning('sync received new headers: %s', headers)
             except OperationCancelled:
                 self.logger.info("Sync with %s completed", peer)
                 break
@@ -191,7 +191,7 @@ class PeerHeaderSyncer(BaseService):
                 )
                 break
 
-            self.logger.debug(
+            self.logger.warning(
                 "Got new header chain from %s: %s..%s",
                 peer,
                 first,
@@ -224,7 +224,7 @@ class PeerHeaderSyncer(BaseService):
     async def _request_headers(
             self, peer: BaseChainPeer, start_at: BlockNumber) -> Tuple[BlockHeader, ...]:
         """Fetch a batch of headers starting at start_at and return the ones we're missing."""
-        self.logger.debug("Requsting chain of headers from %s starting at #%d", peer, start_at)
+        self.logger.warning("Requsting chain of headers from %s starting at #%d", peer, start_at)
 
         return await peer.requests.get_block_headers(
             start_at,
@@ -245,7 +245,7 @@ class PeerHeaderSyncer(BaseService):
         for header in iter_headers:
             is_present = await self.wait(self.db.coro_header_exists(header.hash))
             if is_present:
-                self.logger.debug("Discarding header that we already have: %s", header)
+                self.logger.warning("Discarding header that we already have: %s", header)
             else:
                 yield header
                 break

--- a/trinity/sync/common/headers.py
+++ b/trinity/sync/common/headers.py
@@ -108,6 +108,7 @@ class SkeletonSyncer(BaseService, Generic[TChainPeer]):
                 self._fetched_headers.task_done()
 
     async def _run(self) -> None:
+        self.logger.info("Running Skeleton Sync with %s", self.peer)
         self.run_daemon_task(self._display_stats())
         await self.wait(self._quietly_fetch_full_skeleton())
         self.logger.info("Skeleton %s stopped responding, waiting for sync to complete", self.peer)
@@ -118,7 +119,7 @@ class SkeletonSyncer(BaseService, Generic[TChainPeer]):
         queue = self._fetched_headers
         while self.is_operational:
             await self.sleep(5)
-            self.logger.warning("Skeleton header queue is %d/%d full", queue.qsize(), queue.maxsize)
+            self.logger.warning("Skeleton header queue is %d/%d full (peer %s)", queue.qsize(), queue.maxsize, self.peer)
 
     async def _quietly_fetch_full_skeleton(self) -> None:
         try:
@@ -142,6 +143,8 @@ class SkeletonSyncer(BaseService, Generic[TChainPeer]):
         There are some exceptions where more than two headers are returned consecutively.
         """
         peer = self.peer
+
+        self.logging.warning("Starting skeleton sync with %s", peer)
 
         # launch the skeleton sync by finding a segment that has a parent header in the DB
         launch_headers = await self.wait(self._find_launch_headers(peer))

--- a/trinity/sync/common/headers.py
+++ b/trinity/sync/common/headers.py
@@ -562,7 +562,7 @@ class HeaderMeatSyncer(BaseService, Generic[TChainPeer]):
     async def _watch_new_peers(self) -> None:
         async for ev in self.wait_iter(self._event_bus.stream(PeerJoinedEvent)):
             proxy_peer = ETHProxyPeer.from_dto_peer(
-                ev.dto_peer,
+                ev.peer,
                 self._event_bus,
                 TO_NETWORKING_BROADCAST_CONFIG
             )
@@ -611,7 +611,7 @@ class HeaderMeatSyncer(BaseService, Generic[TChainPeer]):
             complete_task_fn: Callable[[], None],
             fail_task_fn: Callable[[], None]) -> None:
         try:
-            completed_headers = await peer.wait(self._fetch_segment(peer, parent_header, length))
+            completed_headers = await self.wait(self._fetch_segment(peer, parent_header, length))
         except BaseP2PError as exc:
             self.logger.info("Unexpected p2p err while downloading headers from %s: %s", peer, exc)
             self.logger.debug("Problem downloading headers from peer, dropping...", exc_info=True)

--- a/trinity/sync/common/headers.py
+++ b/trinity/sync/common/headers.py
@@ -144,7 +144,7 @@ class SkeletonSyncer(BaseService, Generic[TChainPeer]):
         """
         peer = self.peer
 
-        self.logging.warning("Starting skeleton sync with %s", peer)
+        self.logger.warning("Starting skeleton sync with %s", peer)
 
         # launch the skeleton sync by finding a segment that has a parent header in the DB
         launch_headers = await self.wait(self._find_launch_headers(peer))

--- a/trinity/sync/common/peers.py
+++ b/trinity/sync/common/peers.py
@@ -34,22 +34,24 @@ class WaitingPeers(Generic[TChainPeer]):
         self._peer_wrapper = SortableTask.orderable_by_func(self._get_peer_rank)
 
     def _get_peer_rank(self, peer: TChainPeer) -> float:
-        relevant_throughputs = [
-            exchange.tracker.items_per_second_ema.value
-            for exchange in peer.requests
-            if issubclass(exchange.response_cmd_type, self._response_command_type)
-        ]
+        return 1.0
+    # def _get_peer_rank(self, peer: TChainPeer) -> float:
+    #     relevant_throughputs = [
+    #         exchange.tracker.items_per_second_ema.value
+    #         for exchange in peer.requests
+    #         if issubclass(exchange.response_cmd_type, self._response_command_type)
+    #     ]
 
-        if len(relevant_throughputs) == 0:
-            raise ValidationError(
-                f"Could not find any exchanges on {peer} "
-                f"with response {self._response_command_type!r}"
-            )
+    #     if len(relevant_throughputs) == 0:
+    #         raise ValidationError(
+    #             f"Could not find any exchanges on {peer} "
+    #             f"with response {self._response_command_type!r}"
+    #         )
 
-        avg_throughput = sum(relevant_throughputs) / len(relevant_throughputs)
+    #     avg_throughput = sum(relevant_throughputs) / len(relevant_throughputs)
 
-        # high throughput peers should pop out of the queue first, so ranked as negative
-        return -1 * avg_throughput
+    #     # high throughput peers should pop out of the queue first, so ranked as negative
+    #     return -1 * avg_throughput
 
     def put_nowait(self, peer: TChainPeer) -> None:
         self._waiting_peers.put_nowait(self._peer_wrapper(peer))

--- a/trinity/sync/full/chain.py
+++ b/trinity/sync/full/chain.py
@@ -153,7 +153,7 @@ class BaseBodyChainSyncer(BaseService, ABC):
             # schedule the body download and move on
             # TODO: Maybe another reason to make ETHProxyPeer a BaseService?
             self.run_task(self._run_body_download_batch(peer, batch_id, headers))
-            #peer.run_task(self._run_body_download_batch(peer, batch_id, headers))
+            # peer.run_task(self._run_body_download_batch(peer, batch_id, headers))
 
     async def _block_body_bundle_processing(self, bundles: Tuple[BlockBodyBundle, ...]) -> None:
         """
@@ -298,7 +298,9 @@ class BaseBodyChainSyncer(BaseService, ABC):
             self.logger.warning("Pending block bodies call to %r operation cancelled", peer)
             return tuple()
         except PeerConnectionLost:
-            self.logger.warning("Peer went away, cancelling the block body request and moving on...")
+            self.logger.warning(
+                "Peer went away, cancelling the block body request and moving on..."
+            )
             return tuple()
         except Exception:
             self.logger.exception("Unknown error when getting block bodies")
@@ -678,7 +680,6 @@ class FastChainBodySyncer(BaseBodyChainSyncer):
 
             # schedule the receipt download and move on
             self.run_task(self._run_receipt_download_batch(peer, batch_id, headers))
-            #peer.run_task(self._run_receipt_download_batch(peer, batch_id, headers))
 
     def _mark_body_download_complete(
             self,

--- a/trinity/sync/full/chain.py
+++ b/trinity/sync/full/chain.py
@@ -133,7 +133,7 @@ class BaseBodyChainSyncer(BaseService, ABC):
 
     async def _watch_new_peers(self):
         async for ev in self.wait_iter(self.event_bus.stream(PeerJoinedEvent)):
-            self.register_peer(ev.dto_peer)
+            self.register_peer(ev.peer)
 
     @abstractmethod
     def register_peer(self, peer: IdentifiablePeer) -> None:

--- a/trinity/sync/full/hexary_trie.py
+++ b/trinity/sync/full/hexary_trie.py
@@ -161,11 +161,11 @@ class HexaryTrieSync:
                        is_raw: bool = False) -> None:
         """Schedule a request for the node with the given key."""
         if node_key in self.nodes_cache:
-            self.logger.debug2("Node %s already exists in db", encode_hex(node_key))
+            self.logger.warning("Node %s already exists in db", encode_hex(node_key))
             return
         if await self.db.coro_exists(node_key):
             self.nodes_cache[node_key] = b''
-            self.logger.debug2("Node %s already exists in db", encode_hex(node_key))
+            self.logger.warning("Node %s already exists in db", encode_hex(node_key))
             return
         self._schedule(node_key, parent, depth, leaf_callback, is_raw)
 
@@ -177,7 +177,7 @@ class HexaryTrieSync:
 
         existing = self.requests.get(node_key)
         if existing is not None:
-            self.logger.debug2(
+            self.logger.warning(
                 "Already requesting %s, will just update parents list", node_key)
             existing.parents.append(parent)
             return
@@ -186,7 +186,7 @@ class HexaryTrieSync:
         # Requests get added to both self.queue and self.requests; the former is used to keep
         # track which requests should be sent next, and the latter is used to avoid scheduling a
         # request for a given node multiple times.
-        self.logger.debug2("Scheduling retrieval of %s", encode_hex(request.node_key))
+        self.logger.warning("Scheduling retrieval of %s", encode_hex(request.node_key))
         self.requests[request.node_key] = request
         bisect.insort(self.queue, request)
 
@@ -200,7 +200,7 @@ class HexaryTrieSync:
             if request is None:
                 # This may happen if we resend a request for a node after waiting too long,
                 # and then eventually get two responses with it.
-                self.logger.debug2(
+                self.logger.warning(
                     "No SyncRequest found for %s, maybe we got more than one response for it",
                     encode_hex(node_key))
                 return

--- a/trinity/sync/light/service.py
+++ b/trinity/sync/light/service.py
@@ -165,7 +165,7 @@ class LightPeerChain(PeerSubscriber, BaseService, BaseLightPeerChain):
     @service_timeout(COMPLETION_TIMEOUT)
     async def coro_get_block_body_by_hash(self, block_hash: Hash32) -> BlockBody:
         peer = cast(LESPeer, self.peer_pool.highest_td_peer)
-        self.logger.debug("Fetching block %s from %s", encode_hex(block_hash), peer)
+        self.logger.warning("Fetching block %s from %s", encode_hex(block_hash), peer)
         request_id = peer.sub_proto.send_get_block_bodies([block_hash])
         reply = await self._wait_for_reply(request_id)
         if not reply['bodies']:
@@ -178,7 +178,7 @@ class LightPeerChain(PeerSubscriber, BaseService, BaseLightPeerChain):
     @service_timeout(COMPLETION_TIMEOUT)
     async def coro_get_receipts(self, block_hash: Hash32) -> List[Receipt]:
         peer = cast(LESPeer, self.peer_pool.highest_td_peer)
-        self.logger.debug("Fetching %s receipts from %s", encode_hex(block_hash), peer)
+        self.logger.warning("Fetching %s receipts from %s", encode_hex(block_hash), peer)
         request_id = peer.sub_proto.send_get_receipts(block_hash)
         reply = await self._wait_for_reply(request_id)
         if not reply['receipts']:
@@ -340,7 +340,7 @@ class LightPeerChain(PeerSubscriber, BaseService, BaseLightPeerChain):
 
         :raise BadLESResponse: if the peer replies with a header that has a different hash
         """
-        self.logger.debug("Fetching header %s from %s", encode_hex(block_hash), peer)
+        self.logger.warning("Fetching header %s from %s", encode_hex(block_hash), peer)
         max_headers = 1
 
         # TODO: Figure out why mypy thinks the first parameter to `get_block_headers`

--- a/trinity/tools/async_process_runner.py
+++ b/trinity/tools/async_process_runner.py
@@ -1,4 +1,5 @@
 import asyncio
+import logging
 import os
 import signal
 from typing import (
@@ -13,6 +14,7 @@ class AsyncProcessRunner():
 
     def __init__(self, debug_fn: Callable[[bytes], None] = None) -> None:
         self.debug_fn = debug_fn
+        self.logger = logging.getLogger("trinity.tools.async_process_runner.AsyncProcessRunner")
 
     @classmethod
     async def create_and_run(cls,
@@ -64,4 +66,7 @@ class AsyncProcessRunner():
         raise TimeoutError(f'Killed process after {timeout_sec} seconds')
 
     def kill(self) -> None:
-        os.killpg(os.getpgid(self.proc.pid), signal.SIGKILL)
+        try:
+            os.killpg(os.getpgid(self.proc.pid), signal.SIGKILL)
+        except ProcessLookupError:
+            self.logger.info("Process %s has already disappeared", self.proc.pid)


### PR DESCRIPTION
### What was wrong?

I think we are more or less aligned in our vision that we need to push forward the multiprocessing architecture that we've started. Similar to how modern browsers work (or many other applications), Trinity needs to run many processes in parallel to be able to handle the workload it is forced to deal with. This is especially true in a language such as Python that does not handle threading efficiently.

Today, we already have the [JSON-RPC Server](https://github.com/ethereum/trinity/blob/fa370299106b6391e203e8945f44f09f2c9d8703/trinity/plugins/builtin/json_rpc/plugin.py#L43), the [Peer Discovery](https://github.com/ethereum/trinity/blob/fa370299106b6391e203e8945f44f09f2c9d8703/trinity/plugins/builtin/peer_discovery/plugin.py#L144) and the [ETH Stats Reporting](https://github.com/ethereum/trinity/blob/fa370299106b6391e203e8945f44f09f2c9d8703/trinity/plugins/builtin/ethstats/plugin.py#L31) running as isolated processes (by deriving from `BaseIsolatedPlugin` which handles the heavy lifting).

Often these processes need to talk to other parts of Trinity. E.g. the `PeerPool` needs to talk to the discovery, the ETH Stats Reporting needs to ask the `PeerPool` for the number of connected nodes etc.

We leverage a central `EventBus` to handle such inter-process communication.

However, most of the networking is still running rather tightly coupled in one hardcoded (read: not managed through a plugin) process known as the `networking` process.

To be able to move core stuff such as *syncing*, *tx pool* etc into its own isolated processes, we need to get rid of the fact that most interactions with the `PeerPool` still rely on the code being run in the same process as the `PeerPool`.

In other words, what I believe, the best way forward would look like, is to have the `PeerPool` itself run as an isolated process and have all interactions be made through the `EventBus` (related: [event-bus-all-the-things](https://github.com/ethereum/trinity/issues/79), [write-an-eventbus-friendly-peerpool](https://github.com/ethereum/trinity/issues/89))

This PR is an attempt to experiment with that idea.

### How was it fixed?

Not yet. Just getting started.

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses]()
