### PR TITLE
Ensure PeerPool does not hang on ConnectToNodeCommand

### DIFF
--- a/p2p/peer_pool.py
+++ b/p2p/peer_pool.py
@@ -93,7 +93,7 @@ class BasePeerPool(BaseService, AsyncIterable[BasePeer]):
         self.event_bus = event_bus
 
     async def accept_connect_commands(self) -> None:
-        async for command in self.event_bus.stream(ConnectToNodeCommand):
+        async for command in self.wait_iter(self.event_bus.stream(ConnectToNodeCommand)):
             self.logger.debug('Received request to connect to %s', command.node)
             self.run_task(self.connect_to_nodes(from_uris([command.node])))
 


### PR DESCRIPTION
### What was wrong?

PeerPool hangs on cancel, waiting for `ConnectToNodeCommand` to finish.

### How was it fixed?

Wrapped with `wait_iter(...)`.
There are probably other parts of the code base where the same fix applies but this one I came across while working on #213 so it is verified that this is indeed needed.

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](http://pixdaus.com/files/items/pics/4/74/500474_ccce83134683e52605fe822065a8579b_large.jpg)
