### PR TITLE
Fix MissingDependencyError during regular sync

### DIFF
--- a/trinity/sync/full/chain.py
+++ b/trinity/sync/full/chain.py
@@ -848,7 +848,7 @@ class RegularChainBodySyncer(BaseBodyChainSyncer):
         tasks (downloading block bodies) as they become available.
         """
         async for headers in self.wait_iter(self._header_syncer.new_sync_headers()):
-            self._block_import_tracker.register_tasks(headers)
+            self._block_import_tracker.register_tasks(headers, ignore_duplicates=True)
 
             new_headers = tuple(h for h in headers if h not in self._block_body_tasks)
 


### PR DESCRIPTION

### What was wrong?

Node crashes during regular sync #219

### How was it fixed?

This is a blind shot in the hope to resolve #219 which seems related to #119 (isn't it beautiful both bugs are exactly 100 issues apart) but for the `RegularChainBodySyncer` instead of the `FastChainBodySyncer`. It applies #165 but at another place.

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://static.boredpanda.com/blog/wp-content/uploads/2014/04/happy-animal-facts-29.jpg)
