### PR TITLE
Tune EthStats interval and expose it to CLI

### DIFF
--- a/trinity/plugins/builtin/ethstats/ethstats_service.py
+++ b/trinity/plugins/builtin/ethstats/ethstats_service.py
@@ -47,6 +47,7 @@ class EthstatsService(BaseService):
         server_secret: str,
         node_id: str,
         node_contact: str,
+        stats_interval: int,
     ) -> None:
         super().__init__()
 
@@ -56,6 +57,7 @@ class EthstatsService(BaseService):
         self.server_secret = server_secret
         self.node_id = node_id
         self.node_contact = node_contact
+        self.stats_interval = stats_interval
 
         self.chain = self.get_chain()
 
@@ -104,7 +106,7 @@ class EthstatsService(BaseService):
             await client.send_stats(await self.get_node_stats())
             await client.send_block(self.get_node_block())
 
-            await self.sleep(5)
+            await self.sleep(self.stats_interval)
 
     def get_node_info(self) -> EthstatsData:
         '''Getter for data that should be sent once, on start-up.'''
@@ -141,7 +143,7 @@ class EthstatsService(BaseService):
                     PeerCountRequest(),
                     TO_NETWORKING_BROADCAST_CONFIG,
                 ),
-                timeout=0.5
+                timeout=1
             )).peer_count
         except TimeoutError:
             self.logger.warning("Timeout: PeerPool did not answer PeerCountRequest")

--- a/trinity/plugins/builtin/ethstats/plugin.py
+++ b/trinity/plugins/builtin/ethstats/plugin.py
@@ -31,6 +31,7 @@ DEFAULT_SERVERS_URLS = {
 class EthstatsPlugin(BaseIsolatedPlugin):
     server_url: str
     server_secret: str
+    stats_interval: int
     node_id: str
     node_contact: str
 
@@ -70,6 +71,11 @@ class EthstatsPlugin(BaseIsolatedPlugin):
             help='Node contact information for stats server',
             default=os.environ.get('ETHSTATS_NODE_CONTACT', ''),
         )
+        ethstats_parser.add_argument(
+            '--ethstats-interval',
+            help='The interval at which data is reported back',
+            default=10,
+        )
 
     def on_ready(self) -> None:
         args = self.context.args
@@ -100,6 +106,7 @@ class EthstatsPlugin(BaseIsolatedPlugin):
 
         self.node_id = args.ethstats_node_id
         self.node_contact = args.ethstats_node_contact
+        self.stats_interval = args.ethstats_interval
 
         self.start()
 
@@ -110,6 +117,7 @@ class EthstatsPlugin(BaseIsolatedPlugin):
             self.server_secret,
             self.node_id,
             self.node_contact,
+            self.stats_interval,
         )
 
         loop: asyncio.AbstractEventLoop = asyncio.get_event_loop()


### PR DESCRIPTION
### What was wrong?

The EthStats reporting could use a bit of tuning to reduce pressure on the `networking` process and report peer count more reliable. 

### How was it fixed?

1. Report stats less often
2. Wait a little longer on peer count response
3. Expose interval via --ethstats-interval option

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://i.ytimg.com/vi/nt_363yXkfA/maxresdefault.jpg)
