### PR TITLE
tests/integration: address some intermittent failures of `py3*-wheel-cli` CI jobs

### DIFF
--- a/tests/integration/test_trinity_cli.py
+++ b/tests/integration/test_trinity_cli.py
@@ -129,6 +129,7 @@ async def test_web3(command, async_process_runner):
     attached_trinity = pexpect.spawn('trinity', ['attach'], logfile=sys.stdout)
     try:
         attached_trinity.expect("An instance of Web3 connected to the running chain")
+        attached_trinity.expect(r"In \[.*\]:")  # ipython console ready to accept commands
         attached_trinity.sendline("w3.net.version")
         attached_trinity.expect("'1'")
         attached_trinity.sendline("w3")

--- a/tests/integration/test_trinity_cli.py
+++ b/tests/integration/test_trinity_cli.py
@@ -114,11 +114,12 @@ async def test_light_boot(async_process_runner, command):
 @pytest.mark.parametrize(
     'command',
     (
-        ('trinity', ),
+        # no network sync -> less resources used -> no kill in CI run
+        ('trinity', '--disable-discovery', '--max-peers=0',),
     )
 )
 @pytest.mark.asyncio
-async def test_web3(command, async_process_runner):
+async def test_web3(async_process_runner, command):
     await async_process_runner.run(command, timeout_sec=30)
     assert await contains_all(async_process_runner.stderr, {
         "Started DB server process",

--- a/tox.ini
+++ b/tox.ini
@@ -68,14 +68,12 @@ deps = {[common-wheel-cli]deps}
 whitelist_externals = {[common-wheel-cli]whitelist_externals}
 commands = {[common-wheel-cli]commands}
 skip_install=true
-use_develop=false
 
 [testenv:py37-wheel-cli]
 deps = {[common-wheel-cli]deps}
 whitelist_externals = {[common-wheel-cli]whitelist_externals}
 commands = {[common-wheel-cli]commands}
 skip_install=true
-use_develop=false
 
 [common-integration]
 deps = .[p2p,trinity,test]


### PR DESCRIPTION
### What was wrong?

Many PRs failing `py3*-wheel-cli` jobs, e.g.: https://github.com/ethereum/trinity/pull/173#issuecomment-457366460, for two reasons:

* In the failing test, `w3.net.version` in the console of `trinity attach` is (sometimes) sent before the console is done attaching; the test then waits forever to read an answer for a question no one heard.
* For some reason, some process gets a `kill -9` from the OS (likely the initial one, with DB connection and IPC socket and whatnot); the test then waits forever for an answer from a process that's no longer there. Described in more detail in PR https://github.com/ethereum/trinity/pull/227#issuecomment-457908353.

### How was it fixed?

- [x] Wait for `In [1]:` of IPython console output. It seems this is enough to stop `py37-wheel-cli` from failing.
- [x] Test for `trinity attach` starts background `trinity` with no discovery and 0 max peers, since it's not strictly required in this test. That should limit resource consumption, and prevent unexpected failures due to networking exceptions bubbling up to the chain syncer, which now (since PR ???) has the power to shut down the node on unexpected exception.

The following was debugged, but left for PR https://github.com/ethereum/trinity/pull/227#issuecomment-457908353 to address more gracefully:

- [ ] Lower the number of CPUs used so CI machine's file handle / process number limits are not hit, and the OS doesn't intervene by `kill -9`.

### Cute Animal Picture

Waiting for tests to go green.

![put a cute animal picture link inside the parentheses](https://i.pinimg.com/736x/73/60/d5/7360d53e1224015ff771353edf7b3d19--like-a-boss-like-a-man.jpg)

Via [Pinterest](https://www.pinterest.com/pin/325948091754940630/) (source unknown)