### PR TITLE
Trinity long run Job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,6 @@
 version: 2.0
 
-# heavily inspired by: 
+# heavily inspired by:
 # https://raw.githubusercontent.com/pinax/pinax-wiki/6bd2a99ab6f702e300d708532a6d1d9aa638b9f8/.circleci/config.yml
 
 common: &common
@@ -172,6 +172,12 @@ jobs:
         environment:
           TOXENV: py36-lightchain_integration
           GETH_VERSION: v1.8.1
+  py36-long_run_integration:
+    <<: *common
+    docker:
+      - image: circleci/python:3.6
+        environment:
+          TOXENV: py36-long_run_integration
   py36-p2p:
     <<: *common
     docker:
@@ -255,6 +261,7 @@ workflows:
 
       - py36-integration
       - py36-lightchain_integration
+      - py36-long_run_integration
 
       - py36-lint
       - py37-lint

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -50,6 +50,9 @@ from trinity.rpc.modules import (
 from trinity.rpc.ipc import (
     IPCServer,
 )
+from trinity.tools.async_process_runner import (
+    AsyncProcessRunner,
+)
 from trinity._utils.xdg import (
     get_xdg_trinity_root,
 )
@@ -103,6 +106,21 @@ def event_loop():
         yield loop
     finally:
         loop.close()
+
+
+# This fixture provides a tear down to run after each test that uses it.
+# This ensures the AsyncProcessRunner will never leave a process behind
+@pytest.fixture(scope="function")
+def async_process_runner(event_loop):
+    runner = AsyncProcessRunner(
+        # This allows running pytest with -s and observing the output
+        debug_fn=lambda line: print(line)
+    )
+    yield runner
+    try:
+        runner.kill()
+    except ProcessLookupError:
+        pass
 
 
 @pytest.fixture(scope='module')

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -1,0 +1,22 @@
+async def run_command_and_detect_errors(async_process_runner, command, time):
+    """
+    Run the given ``command`` on the given ``async_process_runner`` for ``time`` seconds and
+    throw an Exception in case any unresolved Exceptions are detected in the output of the command.
+    """
+    lines_since_error = 0
+    await async_process_runner.run(command, timeout_sec=time)
+    async for line in async_process_runner.stderr:
+
+        # We detect errors by some string at the beginning of the Traceback and keep
+        # counting lines from there to be able to read and report more valuable info
+        if "Traceback (most recent call last)" in line and lines_since_error == 0:
+            lines_since_error = 1
+        elif lines_since_error > 0:
+            lines_since_error += 1
+
+        # Keep on listening for output for a maxmimum of 100 lines after the error
+        if lines_since_error >= 100:
+            break
+
+    if lines_since_error > 0:
+        raise Exception("Exception during Trinity boot detected")

--- a/tests/integration/test_trinity_cli.py
+++ b/tests/integration/test_trinity_cli.py
@@ -10,7 +10,10 @@ from eth.constants import (
     GENESIS_PARENT_HASH,
 )
 
-from trinity.tools.async_process_runner import AsyncProcessRunner
+from tests.integration.helpers import (
+    run_command_and_detect_errors,
+)
+
 from trinity._utils.async_iter import (
     contains_all
 )
@@ -24,25 +27,12 @@ from trinity._utils.async_iter import (
 # However, UNIX IPC paths can only be 100 chars which means long paths
 # *WILL* break these tests. See: https://unix.stackexchange.com/q/367008
 
-# This fixture provides a tear down to run after each test that uses it.
-# This ensures the AsyncProcessRunner will never leave a process behind
-@pytest.fixture(scope="function")
-def async_process_runner(event_loop):
-    runner = AsyncProcessRunner(
-        # This allows running pytest with -s and observing the output
-        debug_fn=lambda line: print(line)
-    )
-    yield runner
-    try:
-        runner.kill()
-    except ProcessLookupError:
-        pass
 
 # Great for debugging the AsyncProcessRunner
 # @pytest.mark.asyncio
 # async def test_ping(async_process_runner):
 #     await async_process_runner.run(['ping', 'www.google.de'])
-#     assert await contains_all(async_process_runner.iterate_stdout(), ['byytes from'])
+#     assert await contains_all(async_process_runner.stdout, {'bytes from'})
 
 
 @pytest.mark.parametrize(
@@ -168,20 +158,4 @@ async def test_web3(command, async_process_runner):
 async def test_does_not_throw(async_process_runner, command):
     # This is our last line of defence. This test basically observes the first
     # 20 seconds of the Trinity boot process and fails if Trinity logs any exceptions
-    lines_since_error = 0
-    await async_process_runner.run(command, timeout_sec=20)
-    async for line in async_process_runner.stderr:
-
-        # We detect errors by some string at the beginning of the Traceback and keep
-        # counting lines from there to be able to read and report more valuable info
-        if "Traceback (most recent call last)" in line and lines_since_error == 0:
-            lines_since_error = 1
-        elif lines_since_error > 0:
-            lines_since_error += 1
-
-        # Keep on listening for output for a maxmimum of 100 lines after the error
-        if lines_since_error >= 100:
-            break
-
-    if lines_since_error > 0:
-        raise Exception("Exception during Trinity boot detected")
+    await run_command_and_detect_errors(async_process_runner, command, 20)

--- a/tests/trinity_long_run/test_trinity_long_run.py
+++ b/tests/trinity_long_run/test_trinity_long_run.py
@@ -1,0 +1,18 @@
+import pytest
+
+from tests.integration.helpers import (
+    run_command_and_detect_errors,
+)
+
+
+@pytest.mark.parametrize(
+    'command',
+    (
+        # ropsten
+        ('trinity', '--ropsten',),
+    )
+)
+@pytest.mark.asyncio
+async def test_does_not_throw_long_run(async_process_runner, command):
+    # Ensure that no errors are thrown when trinity is run for 90 seconds
+    await run_command_and_detect_errors(async_process_runner, command, 90)

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,7 @@
 [tox]
 envlist=
     py{36,37}-{core,p2p,integration,lightchain_integration,eth2}
+    py{36}-long_run_integration
     py{36}-rpc-state-{frontier,homestead,tangerine_whistle,spurious_dragon,byzantium,constantinople,quadratic}
     py{36}-rpc-blockchain
     py{36,37}-lint
@@ -96,6 +97,12 @@ commands = {[common-integration]commands}
 deps = {[common-integration]deps}
 passenv = {[common-integration]passenv}
 commands = {[common-integration]commands}
+
+[testenv:py36-long_run_integration]
+deps = {[common-integration]deps}
+passenv = {[common-integration]passenv}
+commands =
+    pytest -n 1 {posargs:tests/trinity_long_run/}
 
 
 [common-lint]


### PR DESCRIPTION
### What was wrong?
Fixes #170 


### How was it fixed?
Now a new Circle CI job is created to run `trinity --ropsten` for 90 seconds.

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://www.millionfeed.com/wp-content/uploads/2017/09/incredibly-cute-baby-animal-pictures-around-the-world-15065608488gn4k.jpg)
