### PR TITLE
Faster task pruning

### DIFF
--- a/docs/release_notes/trinity.rst
+++ b/docs/release_notes/trinity.rst
@@ -12,6 +12,8 @@ Unreleased (latest source)
 - `#155 <https://github.com/ethereum/trinity/pull/155>`_: Feature: Disable syncing entirely with `--sync-mode none`
 - `#155 <https://github.com/ethereum/trinity/pull/155>`_: Feature: Allow running `--sync-mode full` directly
 - `#155 <https://github.com/ethereum/trinity/pull/155>`_: Feature: Allow plugins to extend `--sync-mode` with different strategies
+- `#236 <https://github.com/ethereum/trinity/pull/236>`_: Performance: Quicker pruning of in-memory headers, was a leading asyncio bottleneck
+- `#236 <https://github.com/ethereum/trinity/pull/236>`_: Bugfix: Several reliability improvements during sync
 
 0.1.0-alpha.20
 --------------

--- a/tests/core/task-queue-utils/test_ordered_task_preparation.py
+++ b/tests/core/task-queue-utils/test_ordered_task_preparation.py
@@ -15,7 +15,7 @@ from trinity._utils.datastructures import (
     OrderedTaskPreparation,
 )
 
-DEFAULT_TIMEOUT = 0.05
+DEFAULT_TIMEOUT = 0.01
 
 
 async def wait(coro, timeout=DEFAULT_TIMEOUT):
@@ -33,6 +33,15 @@ class OnePrereq(Enum):
 class TwoPrereqs(Enum):
     Prereq1 = auto()
     Prereq2 = auto()
+
+
+async def assert_nothing_ready(otp):
+    try:
+        finished = await wait(otp.ready_tasks())
+    except asyncio.TimeoutError:
+        pass
+    else:
+        assert False, f"No tasks should be ready, but got {finished!r}"
 
 
 @pytest.mark.asyncio
@@ -71,8 +80,16 @@ async def test_pruning():
     # make a number task depend on the mod10, so 4 and 14 both depend on task 3
     ti = OrderedTaskPreparation(OnePrereq, identity, lambda x: (x % 10) - 1, max_depth=2)
     ti.set_finished_dependency(3)
-    ti.register_tasks((4, 5, 6))
+    ti.register_tasks((4, 5, 6, 7, 8))
     ti.finish_prereq(OnePrereq.one, (4, 5, 6))
+
+    # trigger pruning by requesting the ready tasks through 6, then "finishing" them
+    # by requesting the next batch of ready tasks (7)
+    completed = await wait(ti.ready_tasks())
+    assert completed == (4, 5, 6)
+    ti.finish_prereq(OnePrereq.one, (7, ))
+    completed = await wait(ti.ready_tasks())
+    assert completed == (7, )
 
     # it's fine to prepare a task that depends up to two back in history
     # this depends on 5
@@ -85,9 +102,11 @@ async def test_pruning():
         # this depends on 3
         ti.register_tasks((14, ))
 
-    # test the same concept, but after pruning more than just the starting task...
-    ti.register_tasks((7, ))
-    ti.finish_prereq(OnePrereq.one, (7, ))
+    # test the same concept, but after pruning tasks that weren't the starting tasks
+    # trigger pruning from the head at 7 by completing the one *after* 7
+    ti.finish_prereq(OnePrereq.one, (8, ))
+    completed = await wait(ti.ready_tasks())
+    assert completed == (8, )
 
     ti.register_tasks((26, ))
     ti.register_tasks((27, ))
@@ -98,12 +117,7 @@ async def test_pruning():
 @pytest.mark.asyncio
 async def test_wait_forever():
     ti = OrderedTaskPreparation(OnePrereq, identity, lambda x: x - 1)
-    try:
-        finished = await wait(ti.ready_tasks())
-    except asyncio.TimeoutError:
-        pass
-    else:
-        assert False, f"No steps should complete, but got {finished!r}"
+    await assert_nothing_ready(ti)
 
 
 def test_finish_same_task_twice():
@@ -226,12 +240,7 @@ async def test_register_out_of_order():
     ti.register_tasks((4, 5))
     ti.finish_prereq(OnePrereq.one, (4, 5))
 
-    try:
-        finished = await wait(ti.ready_tasks())
-    except asyncio.TimeoutError:
-        pass
-    else:
-        assert False, f"No steps should be ready, but got {finished!r}"
+    await assert_nothing_ready(ti)
 
     ti.register_tasks((2, 3))
     ti.finish_prereq(OnePrereq.one, (2, 3))
@@ -250,12 +259,7 @@ async def test_no_prereq_tasks_out_of_order():
     ti.set_finished_dependency(1)
     ti.register_tasks((4, 5))
 
-    try:
-        finished = await wait(ti.ready_tasks())
-    except asyncio.TimeoutError:
-        pass
-    else:
-        assert False, f"No steps should be ready, but got {finished!r}"
+    await assert_nothing_ready(ti)
 
     ti.register_tasks((2, 3))
 
@@ -289,7 +293,8 @@ async def test_finished_dependency_midstream():
     assert ready == (6, )
 
 
-def test_dangled_pruning():
+@pytest.mark.asyncio
+async def test_dangled_pruning():
     # make a number task depend on the mod10, so 4 and 14 both depend on task 3
     ti = OrderedTaskPreparation(
         NoPrerequisites,
@@ -299,20 +304,31 @@ def test_dangled_pruning():
         accept_dangling_tasks=True,
     )
     ti.set_finished_dependency(3)
-    ti.register_tasks((5, 6))
+    ti.register_tasks((4, 5, 6))
+    finished = await ti.ready_tasks()
+    assert finished == (4, 5, 6)
 
     # No obvious way to check which tasks are pruned when accepting dangling tasks,
     # so use an internal API until a better option is found:
-    # Nothing should be pruned yet
+    # Nothing should be pruned yet, because caller is still "acting" on (4, 5, 6)
     assert 3 in ti._tasks
 
-    ti.register_tasks((4, ))
+    # caller indicates that she is done working on (4, 5, 6) by calling ready_tasks() again
+    await assert_nothing_ready(ti)
 
     # 3 should be pruned now
     assert 3 not in ti._tasks
     assert 4 in ti._tasks
 
     ti.register_tasks((7, ))
+    finished = await ti.ready_tasks()
+    assert finished == (7, )
+
+    # 4 still shouldn't be pruned, because caller is "acting" on 7
+    assert 4 in ti._tasks
+
+    # caller indicates that she is done working on (7, ) by calling ready_tasks() again
+    await assert_nothing_ready(ti)
 
     # 4 should be pruned now
     assert 4 not in ti._tasks
@@ -338,7 +354,8 @@ def fork_prereq(task):
     return TaskID(task.idx - 1, task.parent_fork)
 
 
-def test_forked_pruning():
+@pytest.mark.asyncio
+async def test_forked_pruning():
     ti = OrderedTaskPreparation(
         NoPrerequisites,
         task_id,
@@ -371,6 +388,15 @@ def test_forked_pruning():
         Task(5, 1, 1),
     ))
 
+    finished = await ti.ready_tasks()
+    assert len(finished) == 14
+
+    # nothing should be pruned, because caller is still "acting" on all tasks
+    assert TaskID(1, 0) in ti._tasks
+
+    # caller indicates that she is done working on tasks by calling ready_tasks() again
+    await assert_nothing_ready(ti)
+
     assert TaskID(1, 0) not in ti._tasks
     assert TaskID(2, 0) not in ti._tasks
     assert TaskID(3, 0) not in ti._tasks
@@ -380,7 +406,8 @@ def test_forked_pruning():
     assert TaskID(10, 0) in ti._tasks
 
 
-def test_forked_pruning_dangling():
+@pytest.mark.asyncio
+async def test_forked_pruning_dangling():
     ti = OrderedTaskPreparation(
         OnePrereq,
         task_id,
@@ -443,6 +470,10 @@ def test_forked_pruning_dangling():
     ti.register_tasks((
         Task(1, 0, 0),
     ))
+
+    # nothing is ready, because the prereq on the first task is incomplete
+    await assert_nothing_ready(ti)
+
     ti.finish_prereq(OnePrereq.one, (
         Task(1, 0, 0),
     ))
@@ -480,6 +511,16 @@ def test_forked_pruning_dangling():
         Task(9, 1, 1),
     ))
 
+    finished = await ti.ready_tasks()
+    assert len(finished) == 28
+
+    # nothing should be pruned, because caller is still "acting" on all tasks
+    assert TaskID(1, 0) in ti._tasks
+
+    # caller indicates that she is done working on tasks by calling ready_tasks() again
+    await assert_nothing_ready(ti)
+
+    # find the tips of the chains that have and have not been pruned
     assert TaskID(6, 1) not in ti._tasks
     assert TaskID(7, 1) in ti._tasks
     assert TaskID(17, 0) not in ti._tasks
@@ -536,7 +577,8 @@ def test_re_fork_at_prune_boundary():
     ))
 
 
-def test_pruning_speed():
+@pytest.mark.asyncio
+async def test_pruning_speed():
     length = 10000
     ti = OrderedTaskPreparation(
         NoPrerequisites,
@@ -546,9 +588,58 @@ def test_pruning_speed():
     )
     ti.set_finished_dependency(-1)
     ti.register_tasks(range(length))
+
+    finished = await ti.ready_tasks()
+    assert len(finished) == length
+
+    await assert_nothing_ready(ti)
+    # nothing should be pruned, because the max depth hasn't been reached
     assert -1 in ti._tasks
-    start = time.perf_counter()
+
     ti.register_tasks((length, ))
-    duration = time.perf_counter() - start
+    finished = await ti.ready_tasks()
+    assert finished == (length, )
+    # nothing should be pruned, because caller is still "acting" on task 10000
+
+    # give ready_tasks something to respond with at next call, so we don't wait for the timeout
+    ti.register_tasks((length + 1, ))
+
+    # start timer to measure pruning speed
+    start = time.perf_counter()
+
+    # caller indicates that she is done working on task 10000 by calling ready_tasks() again
+    finished = await ti.ready_tasks()
+    assert finished == (length + 1, )
+
+    # make sure pruning actually happened
     assert -1 not in ti._tasks
-    assert duration < 0.0005
+    # but not too much pruning
+    assert 0 in ti._tasks
+
+    # make sure pruning was fast enough
+    duration = time.perf_counter() - start
+    assert duration < 0.0001
+
+
+@pytest.mark.asyncio
+async def test_wait_to_prune_until_yielded():
+    """
+    We need to be able to mark dependencies as finished, after task completion
+    """
+    ti = OrderedTaskPreparation(NoPrerequisites, identity, lambda x: x - 1, max_depth=2)
+    ti.set_finished_dependency(-1)
+    ti.register_tasks(range(10))
+    # the old tasks aren't pruned yet, so duplicates with known parents are fine
+    ti.register_tasks((3, ), ignore_duplicates=True)
+    ready = await wait(ti.ready_tasks())
+    assert ready == tuple(range(10))
+
+    # old tasks STILL aren't pruned, until we indicate that we are finished processing
+    # them by calling ready_tasks on the *next* batch
+    ti.register_tasks((10, ))
+    ready = await wait(ti.ready_tasks())
+    assert ready == (10, )
+
+    # now old tasks are pruned
+    with pytest.raises(MissingDependency):
+        ti.register_tasks((3, ), ignore_duplicates=True)

--- a/tests/core/utils/test_root_tracker.py
+++ b/tests/core/utils/test_root_tracker.py
@@ -1,0 +1,177 @@
+import pytest
+
+from eth_utils import ValidationError
+from hypothesis import (
+    given,
+    settings,
+    strategies as st,
+)
+
+from trinity._utils.tree_root import Tree, RootTracker
+
+
+@given(st.permutations(range(10)))
+def test_tree_linking(add_order):
+    # node and parent id
+    nodes = (
+        ('A0', '_'),
+        ('A1', '_'),
+        ('B0', 'A0'),
+        ('C0', 'B0'),
+        ('C1', 'B0'),
+        ('C2', 'B0'),
+        ('D0', 'C0'),
+        ('D1', 'C0'),
+        ('D2', 'C0'),
+        ('E0', 'D0'),
+    )
+
+    tree = Tree()
+    for node_idx in add_order:
+        node, parent = nodes[node_idx]
+        tree.add(node, parent)
+
+    assert not tree.has_parent('A0')
+    assert not tree.has_parent('A1')
+    assert not tree.has_node('_')
+    assert tree.has_node('A0')
+    assert tree.has_node('A1')
+    assert tree.children_of('A0') == ('B0',)
+    assert tree.children_of('A1') == tuple()
+
+    for node, parent in nodes[2:]:
+        assert tree.has_node(node)
+
+        assert tree.has_parent(node)
+        assert tree.parent_of(node) == parent
+
+        children = tree.children_of(parent)
+        assert node in children
+
+        if parent in ('B0', 'C0'):
+            assert len(children) == 3
+        elif parent in ('A0', 'D0'):
+            assert len(children) == 1
+        else:
+            assert len(children) == 0
+
+
+@given(st.permutations(range(10)))
+def test_out_of_order_line(insertion_order):
+    tracker = RootTracker()
+    for node in insertion_order:
+        tracker.add(node, node - 1)
+
+    for expected_root in range(9):
+        for node in range(expected_root, 10):
+            root, depth = tracker.get_root(node)
+            assert depth == node - expected_root
+            assert root == expected_root
+
+        # always prune from the end
+        prune_root_id, _ = tracker.get_root(9)
+        tracker.prune(prune_root_id)
+
+        # root should not be retrievable anymore
+        with pytest.raises(ValidationError):
+            tracker.get_root(prune_root_id)
+
+
+@given(st.lists(st.integers(min_value=0, max_value=9)))
+def test_prune_reinsert_root_tracking(element_flipping):
+    tracker = RootTracker()
+
+    present = set()
+    for node in element_flipping:
+        if node in present:
+            prune_root_id, _ = tracker.get_root(node)
+            tracker.prune(prune_root_id)
+            present.remove(prune_root_id)
+        else:
+            tracker.add(node, node - 1)
+            present.add(node)
+
+        # validate all the present nodes have valid roots
+        for test_node in present:
+            root_id, depth = tracker.get_root(test_node)
+
+            # make sure parent is *not* present
+            assert root_id - 1 not in present
+
+            # make sure depth is correct
+            assert depth == test_node - root_id
+
+
+FULL_BINARY_TREE = [(layer, column) for layer in [0, 1, 2, 3] for column in range(2**layer)]
+
+
+@given(st.permutations(FULL_BINARY_TREE))
+def test_full_branching(insertion_order):
+    """Test full binary tree, in random order"""
+    def parent(node):
+        return (node[0] - 1, node[1] // 2)
+
+    tracker = RootTracker()
+    for node in insertion_order:
+        tracker.add(node, parent(node))
+
+    # prune all the way to the leaf of (3, 0)
+    for num_prunings in range(3):
+        root_id, depth = tracker.get_root((3, 0))
+        assert root_id[0] == num_prunings
+        assert depth == 3 - num_prunings
+        tracker.prune(root_id)
+        assert tracker.get_root((3, 7)) == ((1, 1), 2)
+
+
+@st.composite
+def subset_and_order(draw):
+    nodes_to_insert = draw(st.lists(st.sampled_from(FULL_BINARY_TREE), unique=True))
+    prune_order = draw(st.permutations(range(len(nodes_to_insert))))
+    return (nodes_to_insert, prune_order)
+
+
+@given(subset_and_order())
+@settings(max_examples=500)
+def test_sparse_branching(test_data):
+    nodes_to_insert, prune_order = test_data
+
+    def parent(node):
+        return (node[0] - 1, node[1] // 2)
+
+    def get_expected_root(node, present_nodes):
+        expected_depth = 0
+        expected_root = node
+        parent_node = parent(node)
+        while parent_node in present_nodes:
+            expected_depth += 1
+            expected_root = parent_node
+            parent_node = parent(parent_node)
+        return expected_root, expected_depth
+
+    tracker = RootTracker()
+    for node in nodes_to_insert:
+        tracker.add(node, parent(node))
+
+    # verify parent and depth of partially-built tree
+    for node in nodes_to_insert:
+        actual_root, actual_depth = tracker.get_root(node)
+        expected_root, expected_depth = get_expected_root(node, nodes_to_insert)
+        assert actual_root == expected_root
+        assert actual_depth == expected_depth
+
+    # prune
+    remaining_nodes = set(nodes_to_insert)
+    for prune_idx in [idx for idx in prune_order if idx < len(nodes_to_insert)]:
+        node_to_prune_from = nodes_to_insert[prune_idx]
+        if node_to_prune_from not in remaining_nodes:
+            continue
+        prune_root_id, _ = tracker.get_root(node_to_prune_from)
+        tracker.prune(prune_root_id)
+        remaining_nodes.remove(prune_root_id)
+
+        for node in remaining_nodes:
+            actual_root, actual_depth = tracker.get_root(node)
+            expected_root, expected_depth = get_expected_root(node, remaining_nodes)
+            assert actual_root == expected_root
+            assert actual_depth == expected_depth

--- a/trinity/_utils/datastructures.py
+++ b/trinity/_utils/datastructures.py
@@ -592,6 +592,9 @@ class OrderedTaskPreparation(Generic[TTask, TTaskID, TPrerequisite]):
         self._last_yielded_tasks = await queue_get_batch(self._ready_tasks, max_results)
         return self._last_yielded_tasks
 
+    def has_ready_tasks(self) -> bool:
+        return not self._ready_tasks.empty()
+
     def _is_ready(self, task: TTask) -> bool:
         dependency = self._dependency_of(task)
         if dependency in self._declared_finished:

--- a/trinity/_utils/datastructures.py
+++ b/trinity/_utils/datastructures.py
@@ -577,7 +577,7 @@ class OrderedTaskPreparation(Generic[TTask, TTaskID, TPrerequisite]):
             if task_completion.is_complete and self._is_ready(task):
                 self._mark_complete(task_id)
 
-    async def ready_tasks(self) -> Tuple[TTask, ...]:
+    async def ready_tasks(self, max_results: int = None) -> Tuple[TTask, ...]:
         """
         Return the next batch of tasks that are ready to process. If none are ready,
         hang until at least one task becomes ready.
@@ -589,7 +589,7 @@ class OrderedTaskPreparation(Generic[TTask, TTaskID, TPrerequisite]):
             self._prune_finished(task_id)
             self._prune_finished(task_id)
 
-        self._last_yielded_tasks = await queue_get_batch(self._ready_tasks)
+        self._last_yielded_tasks = await queue_get_batch(self._ready_tasks, max_results)
         return self._last_yielded_tasks
 
     def _is_ready(self, task: TTask) -> bool:

--- a/trinity/_utils/tree_root.py
+++ b/trinity/_utils/tree_root.py
@@ -1,0 +1,360 @@
+from typing import (
+    Dict,
+    Generic,
+    Optional,
+    Tuple,
+    TypeVar,
+)
+from eth_utils import ValidationError
+
+TNodeID = TypeVar('TNodeID')
+
+
+class Tree(Generic[TNodeID]):
+    """
+    A graph built by adding nodes which only know their parents. Each node
+    must have exactly one parent, but it need not be present at insertion time.
+
+    Because the Tree is built out-of-order, it may actually be a forest of trees
+    at any time.
+
+    Nodes can only be removed if their parent is not present
+    """
+    def __init__(self) -> None:
+        self._parents: Dict[TNodeID, TNodeID] = {}
+        self._children: Dict[TNodeID, Tuple[TNodeID, ...]] = {}
+
+    def has_node(self, node_id: TNodeID) -> bool:
+        return node_id in self._parents
+
+    def has_parent(self, node_id: TNodeID) -> bool:
+        return self.has_node(node_id) and self.has_node(self._parents[node_id])
+
+    def parent_of(self, node_id: TNodeID) -> TNodeID:
+        parent = self._parents[node_id]
+        if self.has_node(parent):
+            parent_children = self.children_of(parent)
+            if node_id not in parent_children:
+                raise ValidationError(
+                    f"Node {node_id} has parent {parent}, but the parent only has children "
+                    f"{parent_children}, not the original node."
+                )
+
+        return parent
+
+    def children_of(self, node_id: TNodeID) -> Tuple[TNodeID, ...]:
+        return self._children.get(node_id, tuple())
+
+    def add(self, node_id: TNodeID, parent_id: TNodeID) -> None:
+        if self.has_node(node_id):
+            raise ValidationError(f"must not re-add same node twice: {node_id}")
+        else:
+            self._parents[node_id] = parent_id
+            children = self._children.get(parent_id, tuple())
+            self._children[parent_id] = children + (node_id, )
+
+    def prune(self, node_id: TNodeID) -> None:
+        if self.has_parent(node_id):
+            raise ValidationError(
+                f"must not prune a node {node_id} that has a parent {self.parent_of(node_id)}"
+            )
+        else:
+            parent_id = self._parents.pop(node_id)
+
+            # remove node ID from parent's children
+            parent_children = self.children_of(parent_id)
+            new_parent_children = tuple(child for child in parent_children if child != node_id)
+            if len(new_parent_children):
+                self._children[parent_id] = new_parent_children
+            else:
+                del self._children[parent_id]
+
+
+class TreeRoot(Generic[TNodeID]):
+    """
+    This class tracks the root of a node in a tree (the node with no parents).
+    The root may be extended to recursively point to the eventual "true" root.
+
+    A key point is that the root is mutable. In this way, when a node is pruned,
+    all the children nodes that point to the root are updated at once, by updating
+    this single tree root.
+
+    The tree root extends in two cases:
+        - the root node was added before its parent, OR
+        - the root node is known to be a fork from its parent at addition time
+
+    Why is it important for these to be extensions, instead of updating the root node
+    to the new root?
+        - When a root node is added before its parent, the depths to the true root are
+        unknown, so the extension provides the opportunity to modify the offset to account
+        for the new depth.
+        - When a root node is a known fork, it is important to be able to mutate the root
+        for one side of the fork, and then mutate the root for the other side of the fork,
+        with distinct root objects.
+    """
+    def __init__(self, root_node_id: TNodeID) -> None:
+        # _root_id is the best-known root node at the time of node insertion
+        self._root_id = root_node_id
+        self._depth_offset = 0
+        self._extends_root: Optional[TreeRoot[TNodeID]] = None
+        self._depth_extension: Optional[int] = None
+
+    @property
+    def _is_extension(self) -> bool:
+        return self._extends_root is not None
+
+    def extend(self, tree_root: 'TreeRoot[TNodeID]', more_depth: int) -> None:
+        """
+        Indicate that what was once the original root now has a new root, because
+        a parent node was added. tree_root is the new root node, and more_depth
+        is how much deeper the new root is beyond the current root.
+        """
+        if self._is_extension:
+            raise ValidationError("Cannot extend a node that is already extended...")
+        self._depth_extension = more_depth
+        self._extends_root = tree_root
+
+    def _prune(self, from_node: TNodeID, to_node: TNodeID, old_depth_offset: int) -> None:
+        """
+        Meant for pruning one node at a time
+        """
+        if self._is_extension:
+            if self._extends_root._is_extension:
+                raise ValidationError(
+                    f"Cannot prune extension whose target {self._extends_root} is an extension"
+                )
+            else:
+                if to_node != self._root_id:
+                    raise ValidationError(
+                        f"Cannot prune an extension node to {to_node}, must prune to "
+                        f"its non-extension target: {self._root_id}"
+                    )
+                self._extends_root = None
+                self._depth_offset = old_depth_offset - 1 + self._depth_extension
+        else:
+            if from_node != self._root_id:
+                raise ValidationError(f"Pruned node {from_node} must be root: {self._root_id}")
+            elif old_depth_offset != self._depth_offset:
+                raise ValidationError(
+                    f"Trying to prune child node with unexpected offset: {old_depth_offset} "
+                    f"instead of expected {self._depth_offset}"
+                )
+            else:
+                self._depth_offset -= 1
+                self._root_id = to_node
+
+    def prune_to(self, child_pairs: Tuple[Tuple[TNodeID, 'TreeRoot[TNodeID]'], ...]) -> None:
+        """
+        Prune the root, to each of the children provided. Each child pair is the new
+        node ID for the child and the TreeRoot object for the child.
+        """
+        if self._is_extension:
+            raise ValidationError(f"Cannot prune an extension node: {self}")
+        for child_id, child_root in child_pairs:
+            if child_root._is_extension:
+                if child_id != child_root._root_id:
+                    raise ValidationError(
+                        f"The child root must be itself if it's not the pruned node; "
+                        f"child: {child_id}, pruning_node: {self}, child root: {child_root}"
+                    )
+                if child_root._extends_root is not self:
+                    raise ValidationError(
+                        f"The child extension root must be the pruned node {self}, "
+                        f"not {child_root._extends_root}"
+                    )
+            elif child_root is not self:
+                raise ValidationError(
+                    f"Error while pruning node: child root {child_root} is not extension "
+                    f"and is not the pruned node {self}"
+                )
+        prune_off_id = self.node_id
+        old_depth_offset = self.depth_offset
+        for child_id, child_root in child_pairs:
+            child_root._prune(prune_off_id, child_id, old_depth_offset)
+
+    @property
+    def node_id(self) -> TNodeID:
+        """
+        Return the node all the way at the true root
+        """
+        true_root, _ = self._get_true_root()
+        return true_root._root_id
+
+    @property
+    def depth_offset(self) -> int:
+        """
+        Return the depth all the way to the true root
+        """
+        true_root, extension = self._get_true_root()
+        return true_root._depth_offset + extension
+
+    def _get_true_root(self) -> Tuple['TreeRoot[TNodeID]', int]:
+        """
+        Return the true root (through all extensions), and the extended depth to it
+        """
+        candidate = self
+        extended_depth = 0
+        while candidate._is_extension:
+            extended_depth += candidate._depth_extension
+            candidate = candidate._extends_root
+        return candidate, extended_depth
+
+    def __repr__(self) -> str:
+        if self._is_extension:
+            return f"TreeRoot(<{self._extends_root!r}>, extended_by={self._depth_extension})"
+        else:
+            return f"TreeRoot({self._root_id}, offset={self._depth_offset})"
+
+
+class RootTracker(Generic[TNodeID]):
+    """
+    This class tracks a graph that is presumed to be a single tree. The tree is built up one
+    edge at a time, adding a new node, and the edge to its parent.
+
+    The graph can be "built" in arbitrary order, so the graph may become a forest of trees
+    at any moment. Additionally, nodes can be removed from the graph (pruned),
+    but only at the root of one of the trees (aka the root of that tree).
+
+    The primary thing tracked by this class is the root of each of the trees.
+    This makes pruning each tree a much faster operation. Unfortunately, the worst case
+    time to prune is still bad, O(n) of the depth of the tree. This worst case happens
+    when all the nodes are added in reverse order. In the best case, the lookup is O(1).
+
+    So it's important to understand how to optimize usage for the best case. Adding
+    parents before children will give the best performance. Every inverted addition of
+    a node will add a step to the root lookup time.
+    """
+    _roots: Dict[TNodeID, TreeRoot[TNodeID]]
+
+    # "original" because root may have an offset for the final depth after pruning or adding parents
+    _original_depth_to_root: Dict[TNodeID, int]
+
+    _cache: Dict[TNodeID, Tuple[TNodeID, int]]
+
+    def __init__(self) -> None:
+        self._tree = Tree[TNodeID]()
+        self._roots = {}
+        self._original_depth_to_root = {}
+        self._cache = {}
+
+    def add(self, node_id: TNodeID, parent_id: TNodeID) -> None:
+        """
+        Add a node, and an edge to its parent, whether or not the parent is added yet
+        """
+        self._cache = {}
+        self._tree.add(node_id, parent_id)
+
+        node_root, original_depth = self._get_new_root(node_id, parent_id)
+        self._roots[node_id] = node_root
+        self._original_depth_to_root[node_id] = original_depth
+
+        children = self._tree.children_of(node_id)
+        self._link_children(node_root, original_depth, children)
+
+    def get_root(self, node_id: TNodeID) -> Tuple[TNodeID, int]:
+        """
+        Look up the root of the tree that node_id is in, and the depth to that root.
+        """
+        if node_id not in self._roots:
+            raise ValidationError(f"Node {node_id} is not in the tree")
+        elif node_id in self._cache:
+            (root_node_id, root_depth) = self._cache[node_id]
+            if self._tree.has_parent(root_node_id):
+                self._cache.pop(root_node_id)
+                uncached_root = self.get_root(root_node_id)
+                raise ValidationError(
+                    f"RootTracker had stale and invalid cache for {node_id} root, "
+                    f" correct: {root_node_id}, stale: {uncached_root}")
+            else:
+                return (root_node_id, root_depth)
+        else:
+            root = self._roots[node_id]
+            original_depth = self._original_depth_to_root[node_id]
+            (root_node_id, root_depth) = (root.node_id, original_depth + root.depth_offset)
+            if self._tree.has_parent(root_node_id):
+                parent = self._tree.parent_of(root_node_id)
+                if parent in self._roots:
+                    parent_root = self._roots[parent]
+                else:
+                    parent_root = None
+                raise ValidationError(
+                    f"{root_node_id} has parent {parent}, but was going to be returned as a root. "
+                    f"{node_id} appears to have that bad root {root!r}, and the parent has bad "
+                    f"root {parent_root!r}"
+                )
+            self._cache[node_id] = (root_node_id, root_depth)
+            return self._cache[node_id]
+
+    def prune(self, prune_off_id: TNodeID) -> None:
+        """
+        Prune off the node prune_off_id, which must be the root of its tree
+        """
+        if prune_off_id not in self._original_depth_to_root:
+            raise ValidationError(f"prune id {prune_off_id} not in depths")
+        elif prune_off_id not in self._roots:
+            raise ValidationError(f"prune id {prune_off_id} not in roots")
+
+        self._cache = {}
+        root_to_prune = self._roots[prune_off_id]
+        node_id = root_to_prune.node_id
+        if node_id != prune_off_id:
+            raise ValidationError(
+                f"Can only prune of a root node, tried to prune {prune_off_id}, "
+                f"but the root is {root_to_prune}"
+            )
+        elif self._tree.has_parent(node_id):
+            parent = self._tree.parent_of(node_id)
+            raise ValidationError(
+                f"{node_id} has parent {parent}, but was about to be pruned"
+            )
+
+        child_nodes = self._tree.children_of(prune_off_id)
+        child_pairs = tuple((child_node, self._roots[child_node]) for child_node in child_nodes)
+        root_to_prune.prune_to(child_pairs)
+        for child_node, child_root in child_pairs:
+            if child_node != child_root.node_id:
+                raise ValidationError(
+                    f"Pruned child node should point to itself {child_node}, "
+                    f"instead of {child_root.node_id}"
+                )
+        self._tree.prune(prune_off_id)
+        self._original_depth_to_root.pop(prune_off_id)
+        del self._roots[prune_off_id]
+
+    def _get_new_root(self, node_id: TNodeID, parent_id: TNodeID) -> Tuple[TreeRoot[TNodeID], int]:
+        if self._tree.has_parent(node_id):
+            parent_root = self._roots[parent_id]
+            if len(self._tree.children_of(parent_id)) > 1:
+                node_root = TreeRoot(node_id)
+                node_root.extend(parent_root, 0)
+                original_depth = self._original_depth_to_root[parent_id] + 1
+            else:
+                node_root = parent_root
+                original_depth = self._original_depth_to_root[parent_id] + 1
+        else:
+            node_root = TreeRoot(node_id)
+            original_depth = 0
+
+        return node_root, original_depth
+
+    def _link_children(
+            self,
+            parent_root: TreeRoot[TNodeID],
+            parent_original_depth: int,
+            children: Tuple[TNodeID, ...]) -> None:
+
+        for child in children:
+            child_root = self._roots[child]
+
+            if child_root.depth_offset + self._original_depth_to_root[child] != 0:
+                raise ValidationError(
+                    "children without parents must have net depth 0: "
+                    f"but offset was {child_root.depth_offset} and original depth "
+                    f"was {self._original_depth_to_root[child]}."
+                )
+            else:
+                # original depth was 0, needs to be adjusted based on parent's original depth
+                ideal_original_depth = parent_original_depth + 1
+                actual_original_depth = self._original_depth_to_root[child]
+                # extension length = ideal - actual = ideal - 0
+                child_root.extend(parent_root, ideal_original_depth - actual_original_depth)

--- a/trinity/sync/common/headers.py
+++ b/trinity/sync/common/headers.py
@@ -468,7 +468,7 @@ class SkeletonSyncer(BaseService, Generic[TChainPeer]):
             self.logger.debug("Could not find any header at #%d: %s", block_num, exc)
             local_header = None
 
-        # Header just preceeding this one may or may not be in the database. Either way log an error
+        # Canonical header at same number may or may not be in the database. Either way log an error
         self.logger.debug(
             "%s returned starting header %s, which is not in our DB. "
             "Instead at #%d, our is header %s",

--- a/trinity/sync/common/headers.py
+++ b/trinity/sync/common/headers.py
@@ -163,7 +163,11 @@ class SkeletonSyncer(BaseService, Generic[TChainPeer]):
                 ]
                 await asyncio.gather(*validate_pair_coros, loop=self.get_event_loop())
             except ValidationError as e:
-                self.logger.warning("Received invalid headers from %s, disconnecting: %s", peer, e)
+                self.logger.warning(
+                    "Received an invalid header pair from %s, disconnecting: %s",
+                    peer,
+                    e,
+                )
                 raise
 
             # select and validate a single random gap, to test that skeleton peer has meat headers
@@ -669,7 +673,13 @@ class HeaderMeatSyncer(BaseService, PeerSubscriber, Generic[TChainPeer]):
                     SEAL_CHECK_RANDOM_SAMPLE_RATE,
                 ))
             except ValidationError as e:
-                self.logger.warning("Received invalid headers from %s, disconnecting: %s", peer, e)
+                self.logger.warning(
+                    "Received invalid header segment from %s against known parent %s, "
+                    "disconnecting: %s",
+                    peer,
+                    parent_header,
+                    e,
+                )
                 await peer.disconnect(DisconnectReason.subprotocol_error)
                 return tuple()
             else:

--- a/trinity/sync/full/chain.py
+++ b/trinity/sync/full/chain.py
@@ -744,11 +744,13 @@ class FastChainBodySyncer(BaseBodyChainSyncer):
         newly_completed_headers = tuple(concat(completed_header_groups))
 
         self.logger.debug(
-            "Got receipts for %d/%d headers from %s, with %d trivial headers",
+            "Got receipts for %d/%d headers from %s, %d trivial, from request for %r..%r",
             len(newly_completed_headers),
             len(all_headers) - len(trivial_headers),
             peer,
             len(trivial_headers),
+            all_headers[0],
+            all_headers[-1],
         )
         return newly_completed_headers + trivial_headers
 

--- a/trinity/sync/full/constants.py
+++ b/trinity/sync/full/constants.py
@@ -1,3 +1,17 @@
 # How old (in seconds) must our local head be to cause us to start with a
 # fast-sync before we switch to regular-sync.
 FAST_SYNC_CUTOFF = 60 * 60 * 24
+
+# How many headers/blocks should we queue up waiting to be persisted?
+# This buffer size is estimated using: NUM_BLOCKS_PERSISTED_PER_SEC * BUFFER_SECONDS * MARGIN
+#
+# NUM_BLOCKS_PERSISTED_PER_SEC = 200
+#   (rough estimate from personal NVMe SSD, with small blocks on Ropsten)
+#
+# BUFFER_SECONDS = 30
+#   (this should allow plenty of time for peers to fill in the buffer during db writes)
+#
+# MARGIN = 10
+#   (better to have a buffer that's too big than to artificially constrain performance)
+#
+HEADER_QUEUE_SIZE_TARGET = 60000


### PR DESCRIPTION
### What was wrong?

Fixes #200 (According to local simplified profiling)

It was quite slow to prune the tasks from `OrderedTaskPreparation`. According to the included test, it took ~5ms to prune one node in a simple 10k node line.

### How was it fixed?

Track references to the source points in the list, adjusted as the tree grows and is pruned. In the best case, a single line of 10k nodes, that means a single lookup instead of 10k lookups. In the included test, that means dropping from 5ms to ~0.05ms to prune.

TODO
- [x] add release notes entry
- [x] rebase/squash commits
- [x] linting & type hints
- [x] docstring comments on new classes & methods
- [x] remove assertions, after confirming that they are all be covered by tests now
- [x] make the veox bug non-fatal (unverified)
- [x] resolve the bug that veox reported
- [x] only prune node if it is `ready`

Moving to other issues/PRs:
- [ ] prune dangling uncles (ready or not!)
- [ ] handle case where a bunch of pruned tasks already in the database are re-queued in the fast syncer
- [ ] Fairly common PoW failures, appears to be that the local validation is failing, not that the received header is wrong
- [ ] There is no back-pressure when importing blocks is the bottleneck: we will race ahead getting more and more data from peers, sitting in memory waiting to be imported (in my sync, head was inching along around block 700k, but the in-memory data was racing ahead to 1.27M, using ~10G of RAM)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://i.pinimg.com/originals/7d/df/fa/7ddffa69a3a7b2f99041fda53ddc8fe3.jpg)
