### PR TITLE
Refactor how PeerPool listens for external EventBus requests

### DIFF
--- a/p2p/peer_pool_event_bus_api.py
+++ b/p2p/peer_pool_event_bus_api.py
@@ -1,0 +1,60 @@
+from typing import (
+    TYPE_CHECKING,
+)
+from cancel_token import (
+    CancelToken,
+)
+from lahja import (
+    Endpoint,
+)
+
+from p2p.events import (
+    ConnectToNodeCommand,
+    PeerCountRequest,
+    PeerCountResponse,
+)
+from p2p.kademlia import (
+    from_uris,
+)
+from p2p.service import (
+    BaseService,
+)
+
+if TYPE_CHECKING:
+    from p2p.peer_pool import (  # noqa: F401
+        BasePeerPool,
+    )
+
+
+class BasePeerPoolEventBusAPI(BaseService):
+    """
+    Base class to handle requests to the ``PeerPool`` that are coming through the ``EventBus``.
+    """
+
+    def __init__(self,
+                 event_bus: Endpoint,
+                 peer_pool: 'BasePeerPool',
+                 token: CancelToken = None) -> None:
+        super().__init__(token)
+        self._peer_pool = peer_pool
+        self._event_bus = event_bus
+
+    async def accept_connect_commands(self) -> None:
+        async for command in self.wait_iter(self._event_bus.stream(ConnectToNodeCommand)):
+            self.logger.debug('Received request to connect to %s', command.node)
+            self.run_task(self._peer_pool.connect_to_nodes(from_uris([command.node])))
+
+    async def handle_peer_count_requests(self) -> None:
+        async for req in self.wait_iter(self._event_bus.stream(PeerCountRequest)):
+            self._event_bus.broadcast(
+                PeerCountResponse(len(self._peer_pool)),
+                req.broadcast_config()
+            )
+
+    async def _run(self) -> None:
+        self.logger.info("Running BaseExternalPeerPoolAPI")
+
+        self.run_daemon_task(self.handle_peer_count_requests())
+        self.run_daemon_task(self.accept_connect_commands())
+
+        await self.cancel_token.wait()


### PR DESCRIPTION

### What was wrong?

The current way of hardcoding responses to external eventbus requests in the `PeerPool` is not sustainable on our way to #213 

### How was it fixed?

With this change, external requests to the PeerPool
can be defined by subclassing `BasePeerPoolEventBusAPI`
and setting that as `event_bus_api_class` on the specific
PeerPool class. This is symmetric with the handling of
the `peer_factory_class`.

This avoids polluting the PeerPool with lots of code
to handle specific requests and also opens up
extensibility in regard to the various different forms
of requests that the different concrete `PeerPool`
instances need to learn how to handle.

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses]()
