### PR TITLE
RANDAO processing

### DIFF
--- a/eth2/beacon/enums.py
+++ b/eth2/beacon/enums.py
@@ -11,3 +11,4 @@ class SignatureDomain(IntEnum):
     DOMAIN_ATTESTATION = 1
     DOMAIN_PROPOSAL = 2
     DOMAIN_EXIT = 3
+    DOMAIN_RANDAO = 4

--- a/eth2/beacon/helpers.py
+++ b/eth2/beacon/helpers.py
@@ -43,20 +43,6 @@ if TYPE_CHECKING:
     from eth2.beacon.types.validator_records import ValidatorRecord  # noqa: F401
 
 
-def slot_to_epoch(slot: SlotNumber, epoch_length: int) -> EpochNumber:
-    """
-    Return the epoch number of the given ``slot``.
-    """
-    return EpochNumber(slot // epoch_length)
-
-
-def get_current_epoch(state: 'BeaconState', epoch_length: int) -> EpochNumber:
-    """
-    Return the current epoch of the given ``state``.
-    """
-    return slot_to_epoch(state.slot, epoch_length)
-
-
 #
 # Time unit convertion
 #

--- a/eth2/beacon/helpers.py
+++ b/eth2/beacon/helpers.py
@@ -24,6 +24,7 @@ from eth2.beacon.enums import (
 )
 from eth2.beacon.typing import (
     BLSPubkey,
+    EpochNumber,
     Gwei,
     SlotNumber,
     ValidatorIndex,

--- a/eth2/beacon/helpers.py
+++ b/eth2/beacon/helpers.py
@@ -47,7 +47,7 @@ def slot_to_epoch(slot: SlotNumber, epoch_length: int) -> EpochNumber:
     """
     Return the epoch number of the given ``slot``.
     """
-    return slot // epoch_length
+    return EpochNumber(slot // epoch_length)
 
 
 def get_current_epoch(state: 'BeaconState', epoch_length: int) -> EpochNumber:

--- a/eth2/beacon/helpers.py
+++ b/eth2/beacon/helpers.py
@@ -37,11 +37,24 @@ from eth2.beacon.validation import (
 
 if TYPE_CHECKING:
     from eth2.beacon.types.attestation_data import AttestationData  # noqa: F401
-    from eth2.beacon.types.blocks import BaseBeaconBlock  # noqa: F401
     from eth2.beacon.types.states import BeaconState  # noqa: F401
     from eth2.beacon.types.forks import Fork  # noqa: F401
     from eth2.beacon.types.slashable_attestations import SlashableAttestation  # noqa: F401
     from eth2.beacon.types.validator_records import ValidatorRecord  # noqa: F401
+
+
+def slot_to_epoch(slot: SlotNumber, epoch_length: int) -> EpochNumber:
+    """
+    Return the epoch number of the given ``slot``.
+    """
+    return slot // epoch_length
+
+
+def get_current_epoch(state: 'BeaconState', epoch_length: int) -> EpochNumber:
+    """
+    Return the current epoch of the given ``state``.
+    """
+    return slot_to_epoch(state.slot, epoch_length)
 
 
 #

--- a/eth2/beacon/helpers.py
+++ b/eth2/beacon/helpers.py
@@ -24,7 +24,6 @@ from eth2.beacon.enums import (
 )
 from eth2.beacon.typing import (
     BLSPubkey,
-    EpochNumber,
     Gwei,
     SlotNumber,
     ValidatorIndex,

--- a/eth2/beacon/state_machines/forks/serenity/block_processing.py
+++ b/eth2/beacon/state_machines/forks/serenity/block_processing.py
@@ -50,6 +50,10 @@ def process_eth1_data(state: BeaconState,
     return state
 
 
+from eth2.beacon.typing import (
+    SlotNumber,
+)
+
 
 def process_randao(state: BeaconState,
                    block: BaseBeaconBlock,
@@ -73,8 +77,10 @@ def process_randao(state: BeaconState,
     )
 
     randao_mix_index = epoch % config.LATEST_RANDAO_MIXES_LENGTH
+    # FIXME: remove this once get_randao_mix is updated to accept epochs instead of slots
+    slot = SlotNumber(epoch)
     new_randao_mix = bitwise_xor(
-        get_randao_mix(state, epoch, config.LATEST_RANDAO_MIXES_LENGTH),
+        get_randao_mix(state, slot, config.LATEST_RANDAO_MIXES_LENGTH),
         hash_eth2(block.randao_reveal),
     )
 

--- a/eth2/beacon/state_machines/forks/serenity/block_processing.py
+++ b/eth2/beacon/state_machines/forks/serenity/block_processing.py
@@ -19,7 +19,6 @@ from eth2.beacon.state_machines.forks.serenity.block_validation import (
 
 from eth2.beacon.helpers import (
     get_beacon_proposer_index,
-    get_current_epoch,
     get_randao_mix,
 )
 
@@ -69,7 +68,7 @@ def process_randao(state: BeaconState,
     )
     proposer = state.validator_registry[proposer_index]
 
-    epoch = get_current_epoch(state, config.EPOCH_LENGTH)
+    epoch = state.current_epoch(config.EPOCH_LENGTH)
 
     validate_randao_reveal(
         randao_reveal=block.randao_reveal,

--- a/eth2/beacon/state_machines/forks/serenity/block_processing.py
+++ b/eth2/beacon/state_machines/forks/serenity/block_processing.py
@@ -8,7 +8,10 @@ from eth2._utils.numeric import (
 )
 from eth2.beacon._utils.hash import hash_eth2
 
-from eth2.beacon.configs import BeaconConfig
+from eth2.beacon.configs import (
+    BeaconConfig,
+    CommitteeConfig,
+)
 from eth2.beacon.types.states import BeaconState
 from eth2.beacon.types.blocks import BaseBeaconBlock
 from eth2.beacon.types.eth1_data_vote import Eth1DataVote
@@ -59,10 +62,7 @@ def process_randao(state: BeaconState,
     proposer_index = get_beacon_proposer_index(
         state=state,
         slot=state.slot,
-        genesis_epoch=config.GENESIS_EPOCH,
-        epoch_length=config.EPOCH_LENGTH,
-        target_committee_size=config.TARGET_COMMITTEE_SIZE,
-        shard_count=config.SHARD_COUNT,
+        committee_config=CommitteeConfig(config),
     )
     proposer = state.validator_registry[proposer_index]
 

--- a/eth2/beacon/state_machines/forks/serenity/block_processing.py
+++ b/eth2/beacon/state_machines/forks/serenity/block_processing.py
@@ -18,8 +18,10 @@ from eth2.beacon.state_machines.forks.serenity.block_validation import (
 )
 
 from eth2.beacon.helpers import (
-    get_beacon_proposer_index,
     get_randao_mix,
+)
+from eth2.beacon.committee_helpers import (
+    get_beacon_proposer_index,
 )
 
 
@@ -51,17 +53,13 @@ def process_eth1_data(state: BeaconState,
     return state
 
 
-from eth2.beacon.typing import (
-    SlotNumber,
-)
-
-
 def process_randao(state: BeaconState,
                    block: BaseBeaconBlock,
                    config: BeaconConfig) -> BeaconState:
     proposer_index = get_beacon_proposer_index(
         state=state,
         slot=state.slot,
+        genesis_epoch=config.GENESIS_EPOCH,
         epoch_length=config.EPOCH_LENGTH,
         target_committee_size=config.TARGET_COMMITTEE_SIZE,
         shard_count=config.SHARD_COUNT,
@@ -78,10 +76,13 @@ def process_randao(state: BeaconState,
     )
 
     randao_mix_index = epoch % config.LATEST_RANDAO_MIXES_LENGTH
-    # FIXME: remove this once get_randao_mix is updated to accept epochs instead of slots
-    slot = SlotNumber(epoch)
     new_randao_mix = bitwise_xor(
-        get_randao_mix(state, slot, config.LATEST_RANDAO_MIXES_LENGTH),
+        get_randao_mix(
+            state=state,
+            epoch=epoch,
+            epoch_length=config.EPOCH_LENGTH,
+            latest_randao_mixes_length=config.LATEST_RANDAO_MIXES_LENGTH,
+        ),
         hash_eth2(block.randao_reveal),
     )
 

--- a/eth2/beacon/state_machines/forks/serenity/block_processing.py
+++ b/eth2/beacon/state_machines/forks/serenity/block_processing.py
@@ -3,6 +3,9 @@ from eth_utils.toolz import (
 )
 
 from eth2._utils.tuple import update_tuple_item
+from eth2._utils.numeric import (
+    bitwise_xor,
+)
 from eth2.beacon._utils.hash import hash_eth2
 
 from eth2.beacon.configs import BeaconConfig
@@ -15,7 +18,6 @@ from eth2.beacon.state_machines.forks.serenity.block_validation import (
 )
 
 from eth2.beacon.helpers import (
-    bitwise_xor,
     get_beacon_proposer_index,
     get_current_epoch,
     get_randao_mix,

--- a/eth2/beacon/state_machines/forks/serenity/block_processing.py
+++ b/eth2/beacon/state_machines/forks/serenity/block_processing.py
@@ -3,11 +3,23 @@ from eth_utils.toolz import (
 )
 
 from eth2._utils.tuple import update_tuple_item
+from eth2.beacon._utils.hash import hash_eth2
 
 from eth2.beacon.configs import BeaconConfig
 from eth2.beacon.types.states import BeaconState
 from eth2.beacon.types.blocks import BaseBeaconBlock
 from eth2.beacon.types.eth1_data_vote import Eth1DataVote
+
+from eth2.beacon.state_machines.forks.serenity.block_validation import (
+    validate_randao_reveal,
+)
+
+from eth2.beacon.helpers import (
+    bitwise_xor,
+    get_beacon_proposer_index,
+    get_current_epoch,
+    get_randao_mix,
+)
 
 
 def process_eth1_data(state: BeaconState,
@@ -36,3 +48,40 @@ def process_eth1_data(state: BeaconState,
         )
 
     return state
+
+
+
+def process_randao(state: BeaconState,
+                   block: BaseBeaconBlock,
+                   config: BeaconConfig) -> BeaconState:
+    proposer_index = get_beacon_proposer_index(
+        state=state,
+        slot=state.slot,
+        epoch_length=config.EPOCH_LENGTH,
+        target_committee_size=config.TARGET_COMMITTEE_SIZE,
+        shard_count=config.SHARD_COUNT,
+    )
+    proposer = state.validator_registry[proposer_index]
+
+    epoch = get_current_epoch(state, config.EPOCH_LENGTH)
+
+    validate_randao_reveal(
+        randao_reveal=block.randao_reveal,
+        proposer_pubkey=proposer.pubkey,
+        epoch=epoch,
+        fork=state.fork,
+    )
+
+    randao_mix_index = epoch % config.LATEST_RANDAO_MIXES_LENGTH
+    new_randao_mix = bitwise_xor(
+        get_randao_mix(state, epoch, config.LATEST_RANDAO_MIXES_LENGTH),
+        hash_eth2(block.randao_reveal),
+    )
+
+    return state.copy(
+        latest_randao_mixes=update_tuple_item(
+            state.latest_randao_mixes,
+            randao_mix_index,
+            new_randao_mix,
+        ),
+    )

--- a/eth2/beacon/state_machines/forks/serenity/block_validation.py
+++ b/eth2/beacon/state_machines/forks/serenity/block_validation.py
@@ -333,9 +333,7 @@ def validate_randao_reveal(randao_reveal: BLSSignature,
                            epoch: EpochNumber,
                            fork: Fork) -> None:
     message = epoch.to_bytes(32, byteorder="big")
-    # FIXME: remove this once get_comain is updated to accept epochs instead of slots
-    slot = SlotNumber(epoch)
-    domain = get_domain(fork, slot, SignatureDomain.DOMAIN_RANDAO)
+    domain = get_domain(fork, epoch, SignatureDomain.DOMAIN_RANDAO)
 
     is_randao_reveal_valid = bls.verify(
         pubkey=proposer_pubkey,

--- a/eth2/beacon/state_machines/forks/serenity/block_validation.py
+++ b/eth2/beacon/state_machines/forks/serenity/block_validation.py
@@ -35,6 +35,8 @@ from eth2.beacon.types.attestation_data import AttestationData  # noqa: F401
 from eth2.beacon.types.proposal_signed_data import ProposalSignedData
 from eth2.beacon.types.forks import Fork
 from eth2.beacon.typing import (
+    BLSPubkey,
+    BLSSignature,
     EpochNumber,
     ShardNumber,
     SlotNumber,
@@ -326,8 +328,8 @@ def validate_attestation_aggregate_signature(state: BeaconState,
         )
 
 
-def validate_randao_reveal(randao_reveal: bls.BLSSignature,
-                           proposer_pubkey: bls.BLSPubkey,
+def validate_randao_reveal(randao_reveal: BLSSignature,
+                           proposer_pubkey: BLSPubkey,
                            epoch: EpochNumber,
                            fork: Fork) -> None:
     message = epoch.to_bytes(32, byteorder="big")

--- a/eth2/beacon/state_machines/forks/serenity/block_validation.py
+++ b/eth2/beacon/state_machines/forks/serenity/block_validation.py
@@ -40,6 +40,7 @@ from eth2.beacon.typing import (
     SlotNumber,
 )
 
+
 #
 # Slot validatation
 #

--- a/eth2/beacon/state_machines/forks/serenity/block_validation.py
+++ b/eth2/beacon/state_machines/forks/serenity/block_validation.py
@@ -328,9 +328,11 @@ def validate_attestation_aggregate_signature(state: BeaconState,
 def validate_randao_reveal(randao_reveal: bls.BLSSignature,
                            proposer_pubkey: bls.BLSPubkey,
                            epoch: EpochNumber,
-                           fork: Fork):
+                           fork: Fork) -> None:
     message = epoch.to_bytes(32, byteorder="big")
-    domain = get_domain(fork, epoch, SignatureDomain.DOMAIN_RANDAO)
+    # FIXME: remove this once get_comain is updated to accept epochs instead of slots
+    slot = SlotNumber(epoch)
+    domain = get_domain(fork, slot, SignatureDomain.DOMAIN_RANDAO)
 
     is_randao_reveal_valid = bls.verify(
         pubkey=proposer_pubkey,

--- a/eth2/beacon/typing.py
+++ b/eth2/beacon/typing.py
@@ -5,6 +5,7 @@ from typing import (
 
 
 SlotNumber = NewType('SlotNumber', int)  # uint64
+EpochNumber = NewType('EpochNumber', int)  # uint64
 ShardNumber = NewType('ShardNumber', int)  # uint64
 BLSPubkey = NewType('BLSPubkey', bytes)  # bytes48
 BLSSignature = NewType('BLSSignature', bytes)  # bytes96

--- a/eth2/beacon/typing.py
+++ b/eth2/beacon/typing.py
@@ -6,7 +6,6 @@ from typing import (
 
 SlotNumber = NewType('SlotNumber', int)  # uint64
 ShardNumber = NewType('ShardNumber', int)  # uint64
-EpochNumber = NewType('EpochNumber', int)  # uint64
 BLSPubkey = NewType('BLSPubkey', bytes)  # bytes48
 BLSSignature = NewType('BLSSignature', bytes)  # bytes96
 

--- a/tests/eth2/beacon/state_machines/forks/test_serenity_block_processing.py
+++ b/tests/eth2/beacon/state_machines/forks/test_serenity_block_processing.py
@@ -44,7 +44,7 @@ def test_randao_processing(sample_beacon_block_params,
                            sample_beacon_state_params,
                            sample_fork_params,
                            config):
-    proposer_privkey = 0
+    proposer_privkey = 1
     proposer_pubkey = bls.privtopub(proposer_privkey)
     state = SerenityBeaconState(**sample_beacon_state_params).copy(
         validator_registry=tuple(
@@ -86,7 +86,7 @@ def test_randao_processing_validates_randao_reveal(sample_beacon_block_params,
                                                    sample_beacon_state_params,
                                                    sample_fork_params,
                                                    config):
-    proposer_privkey = 0
+    proposer_privkey = 1
     proposer_pubkey = bls.privtopub(proposer_privkey)
     state = SerenityBeaconState(**sample_beacon_state_params).copy(
         validator_registry=tuple(

--- a/tests/eth2/beacon/state_machines/forks/test_serenity_block_processing.py
+++ b/tests/eth2/beacon/state_machines/forks/test_serenity_block_processing.py
@@ -1,12 +1,120 @@
 import pytest
 
+from eth.constants import (
+    ZERO_HASH32,
+)
+from eth_utils import (
+    ValidationError,
+)
+
+from eth2._utils import bls
+
+from eth2.beacon.types.forks import Fork
 from eth2.beacon.types.eth1_data_vote import Eth1DataVote
 from eth2.beacon.types.states import BeaconState
 from eth2.beacon.types.blocks import BeaconBlock
+from eth2.beacon.enums import SignatureDomain
+
+from eth2.beacon.helpers import (
+    get_current_epoch,
+    get_domain,
+)
+
+from eth2.beacon.state_machines.forks.serenity.blocks import (
+    SerenityBeaconBlock,
+)
+from eth2.beacon.state_machines.forks.serenity.states import (
+    SerenityBeaconState,
+)
+
+from eth2.beacon.state_machines.forks.serenity.block_processing import (
+    process_randao,
+)
+
+from tests.eth2.beacon.helpers import (
+    mock_validator_record,
+)
 
 from eth2.beacon.state_machines.forks.serenity.block_processing import (
     process_eth1_data,
 )
+
+
+def test_randao_processing(sample_beacon_block_params,
+                           sample_beacon_state_params,
+                           sample_fork_params,
+                           config):
+    proposer_privkey = 0
+    proposer_pubkey = bls.privtopub(proposer_privkey)
+    state = SerenityBeaconState(**sample_beacon_state_params).copy(
+        validator_registry=tuple(
+            mock_validator_record(proposer_pubkey)
+            for _ in range(config.TARGET_COMMITTEE_SIZE)
+        ),
+        validator_balances=(config.MAX_DEPOSIT_AMOUNT,) * config.TARGET_COMMITTEE_SIZE,
+
+        latest_randao_mixes=tuple(
+            ZERO_HASH32
+            for _ in range(config.LATEST_RANDAO_MIXES_LENGTH)
+        ),
+    )
+
+    epoch = get_current_epoch(state, epoch_length=config.EPOCH_LENGTH)
+    slot = epoch * config.EPOCH_LENGTH
+    message = epoch.to_bytes(32, byteorder="big")
+    fork = Fork(**sample_fork_params)
+    domain = get_domain(fork, slot, SignatureDomain.DOMAIN_RANDAO)
+    randao_reveal = bls.sign(message, proposer_privkey, domain)
+
+    block = SerenityBeaconBlock(**sample_beacon_block_params).copy(
+        randao_reveal=randao_reveal,
+    )
+
+    new_state = process_randao(state, block, config)
+
+    updated_index = epoch % config.LATEST_RANDAO_MIXES_LENGTH
+    original_mixes = state.latest_randao_mixes
+    updated_mixes = new_state.latest_randao_mixes
+
+    assert all(
+        updated == original if index != updated_index else updated != original
+        for index, (updated, original) in enumerate(zip(updated_mixes, original_mixes))
+    )
+
+
+def test_randao_processing_validates_randao_reveal(sample_beacon_block_params,
+                                                   sample_beacon_state_params,
+                                                   sample_fork_params,
+                                                   config):
+    proposer_privkey = 0
+    proposer_pubkey = bls.privtopub(proposer_privkey)
+    state = SerenityBeaconState(**sample_beacon_state_params).copy(
+        validator_registry=tuple(
+            mock_validator_record(proposer_pubkey)
+            for _ in range(config.TARGET_COMMITTEE_SIZE)
+        ),
+        validator_balances=(config.MAX_DEPOSIT_AMOUNT,) * config.TARGET_COMMITTEE_SIZE,
+
+        latest_randao_mixes=tuple(
+            ZERO_HASH32
+            for _ in range(config.LATEST_RANDAO_MIXES_LENGTH)
+        ),
+    )
+
+    epoch = get_current_epoch(state, epoch_length=config.EPOCH_LENGTH)
+    slot = epoch * config.EPOCH_LENGTH
+    message = (epoch + 1).to_bytes(32, byteorder="big")
+    fork = Fork(**sample_fork_params)
+    domain = get_domain(fork, slot, SignatureDomain.DOMAIN_RANDAO)
+    randao_reveal = bls.sign(message, proposer_privkey, domain)
+
+    block = SerenityBeaconBlock(**sample_beacon_block_params).copy(
+        randao_reveal=randao_reveal,
+    )
+
+    with pytest.raises(ValidationError):
+        process_randao(state, block, config)
+
 
 HASH1 = b"\x11" * 32
 HASH2 = b"\x22" * 32

--- a/tests/eth2/beacon/state_machines/forks/test_serenity_block_processing.py
+++ b/tests/eth2/beacon/state_machines/forks/test_serenity_block_processing.py
@@ -6,6 +6,9 @@ from eth.constants import (
 from eth_utils import (
     ValidationError,
 )
+from eth_utils.toolz import (
+    first,
+)
 
 from eth2._utils import bls
 
@@ -43,9 +46,9 @@ from eth2.beacon.state_machines.forks.serenity.block_processing import (
 def test_randao_processing(sample_beacon_block_params,
                            sample_beacon_state_params,
                            sample_fork_params,
+                           keymap,
                            config):
-    proposer_privkey = 1
-    proposer_pubkey = bls.privtopub(proposer_privkey)
+    proposer_pubkey, proposer_privkey = first(keymap.items())
     state = SerenityBeaconState(**sample_beacon_state_params).copy(
         validator_registry=tuple(
             mock_validator_record(proposer_pubkey)
@@ -85,9 +88,9 @@ def test_randao_processing(sample_beacon_block_params,
 def test_randao_processing_validates_randao_reveal(sample_beacon_block_params,
                                                    sample_beacon_state_params,
                                                    sample_fork_params,
+                                                   keymap,
                                                    config):
-    proposer_privkey = 1
-    proposer_pubkey = bls.privtopub(proposer_privkey)
+    proposer_pubkey, proposer_privkey = first(keymap.items())
     state = SerenityBeaconState(**sample_beacon_state_params).copy(
         validator_registry=tuple(
             mock_validator_record(proposer_pubkey)

--- a/tests/eth2/beacon/state_machines/forks/test_serenity_block_processing.py
+++ b/tests/eth2/beacon/state_machines/forks/test_serenity_block_processing.py
@@ -19,7 +19,6 @@ from eth2.beacon.types.blocks import BeaconBlock
 from eth2.beacon.enums import SignatureDomain
 
 from eth2.beacon.helpers import (
-    get_current_epoch,
     get_domain,
 )
 
@@ -62,7 +61,7 @@ def test_randao_processing(sample_beacon_block_params,
         ),
     )
 
-    epoch = get_current_epoch(state, epoch_length=config.EPOCH_LENGTH)
+    epoch = state.current_epoch(config.EPOCH_LENGTH)
     slot = epoch * config.EPOCH_LENGTH
     message = epoch.to_bytes(32, byteorder="big")
     fork = Fork(**sample_fork_params)
@@ -104,7 +103,7 @@ def test_randao_processing_validates_randao_reveal(sample_beacon_block_params,
         ),
     )
 
-    epoch = get_current_epoch(state, epoch_length=config.EPOCH_LENGTH)
+    epoch = state.current_epoch(config.EPOCH_LENGTH)
     slot = epoch * config.EPOCH_LENGTH
     message = (epoch + 1).to_bytes(32, byteorder="big")
     fork = Fork(**sample_fork_params)

--- a/tests/eth2/beacon/state_machines/forks/test_serenity_block_validation.py
+++ b/tests/eth2/beacon/state_machines/forks/test_serenity_block_validation.py
@@ -129,19 +129,21 @@ def test_validate_proposer_signature(
 
 
 @pytest.mark.parametrize(
-    ["is_valid", "epoch", "expected_epoch", "proposer_privkey", "expected_proposer_privkey"],
+    ["is_valid", "epoch", "expected_epoch", "proposer_key_index", "expected_proposer_key_index"],
     (
-        (True, 0, 0, 1, 1),
-        (True, 1, 1, 2, 2),
-        (False, 0, 1, 1, 1),
-        (False, 0, 0, 1, 2),
+        (True, 0, 0, 0, 0),
+        (True, 1, 1, 1, 1),
+        (False, 0, 1, 0, 0),
+        (False, 0, 0, 0, 1),
     )
 )
 def test_randao_reveal_validation(is_valid,
                                   epoch,
                                   expected_epoch,
-                                  proposer_privkey,
-                                  expected_proposer_privkey,
+                                  proposer_key_index,
+                                  expected_proposer_key_index,
+                                  privkeys,
+                                  pubkeys,
                                   sample_fork_params,
                                   config):
     message = epoch.to_bytes(32, byteorder="big")
@@ -149,9 +151,10 @@ def test_randao_reveal_validation(is_valid,
     fork = Fork(**sample_fork_params)
     domain = get_domain(fork, slot, SignatureDomain.DOMAIN_RANDAO)
 
+    proposer_privkey = privkeys[proposer_key_index]
     randao_reveal = bls.sign(message, proposer_privkey, domain)
 
-    expected_proposer_pubkey = bls.privtopub(expected_proposer_privkey)
+    expected_proposer_pubkey = pubkeys[expected_proposer_key_index]
 
     try:
         validate_randao_reveal(

--- a/tests/eth2/beacon/state_machines/forks/test_serenity_block_validation.py
+++ b/tests/eth2/beacon/state_machines/forks/test_serenity_block_validation.py
@@ -17,10 +17,16 @@ from eth2.beacon.types.proposal_signed_data import (
     ProposalSignedData,
 )
 from eth2.beacon.types.states import BeaconState
+from eth2.beacon.types.forks import Fork
+
+from eth2.beacon.helpers import (
+    get_domain,
+)
 
 from eth2.beacon.state_machines.forks.serenity.block_validation import (
     validate_block_slot,
     validate_proposer_signature,
+    validate_randao_reveal,
 )
 
 from tests.eth2.beacon.helpers import mock_validator_record
@@ -120,3 +126,43 @@ def test_validate_proposer_signature(
                 beacon_chain_shard_number,
                 CommitteeConfig(config),
             )
+
+
+@pytest.mark.parametrize(
+    ["is_valid", "epoch", "expected_epoch", "proposer_privkey", "expected_proposer_privkey"],
+    (
+        (True, 0, 0, 0, 0),
+        (True, 1, 1, 2, 2),
+        (False, 0, 1, 0, 0),
+        (False, 0, 0, 0, 1),
+    )
+)
+def test_randao_reveal_validation(is_valid,
+                                  epoch,
+                                  expected_epoch,
+                                  proposer_privkey,
+                                  expected_proposer_privkey,
+                                  sample_fork_params,
+                                  config):
+    message = epoch.to_bytes(32, byteorder="big")
+    slot = epoch * config.EPOCH_LENGTH
+    fork = Fork(**sample_fork_params)
+    domain = get_domain(fork, slot, SignatureDomain.DOMAIN_RANDAO)
+
+    randao_reveal = bls.sign(message, proposer_privkey, domain)
+
+    expected_proposer_pubkey = bls.privtopub(expected_proposer_privkey)
+
+    try:
+        validate_randao_reveal(
+            randao_reveal=randao_reveal,
+            proposer_pubkey=expected_proposer_pubkey,
+            epoch=expected_epoch,
+            fork=fork,
+        )
+    except ValidationError:
+        if is_valid:
+            raise
+    else:
+        if not is_valid:
+            pytest.fail("Did not raise")

--- a/tests/eth2/beacon/state_machines/forks/test_serenity_block_validation.py
+++ b/tests/eth2/beacon/state_machines/forks/test_serenity_block_validation.py
@@ -131,10 +131,10 @@ def test_validate_proposer_signature(
 @pytest.mark.parametrize(
     ["is_valid", "epoch", "expected_epoch", "proposer_privkey", "expected_proposer_privkey"],
     (
-        (True, 0, 0, 0, 0),
+        (True, 0, 0, 1, 1),
         (True, 1, 1, 2, 2),
-        (False, 0, 1, 0, 0),
-        (False, 0, 0, 0, 1),
+        (False, 0, 1, 1, 1),
+        (False, 0, 0, 1, 2),
     )
 )
 def test_randao_reveal_validation(is_valid,


### PR DESCRIPTION
### What was wrong?

RANDAO processing was missing and the original PR for this was outdated.

### How was it fixed?

Implemented the function `process_randao` plus the helpers `validate_randao`, `slot_to_epoch`, and `get_current_epoch` according to the spec.

However, some [signature checking tests](https://github.com/ethereum/trinity/compare/master...jannikluhn:randao-processing?expand=1#diff-814adfb940e4a4f6bbba14b955593107R135) are failing and I don't understand why: Even though a different message is signed, `bls.verify` still returns `True`. Any idea what the issue is? (this is the reason why I labeled it as WIP.)

There are two `FIXME` comments that I think should be addressed in #235 (or here, depending what's merged earlier, cc @NIC619 ).

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://user-images.githubusercontent.com/29854669/52138959-02a2b400-264f-11e9-8423-3fd7334e3a95.jpeg)