### PR TITLE
Use BaseService.cancellation() where possible

### DIFF
--- a/trinity/protocol/common/monitors.py
+++ b/trinity/protocol/common/monitors.py
@@ -78,7 +78,7 @@ class BaseChainTipMonitor(BaseService, PeerSubscriber):
     async def _run(self) -> None:
         self.run_daemon_task(self._handle_msg_loop())
         with self.subscribe(self._peer_pool):
-            await self.wait(self.events.cancelled.wait())
+            await self.cancellation()
 
     @contextmanager
     def _subscriber(self) -> Iterator[asyncio.Event]:

--- a/trinity/sync/full/chain.py
+++ b/trinity/sync/full/chain.py
@@ -120,7 +120,7 @@ class BaseBodyChainSyncer(BaseService, PeerSubscriber):
 
     async def _run(self) -> None:
         with self.subscribe(self._peer_pool):
-            await self.events.cancelled.wait()
+            await self.cancellation()
 
     async def _assign_body_download_to_peers(self) -> None:
         """


### PR DESCRIPTION
### What was wrong?

Some places where using different implementations to wait for service cancellations.

### How was it fixed?

Replace with `await self.cancellation()`

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](http://static.boredpanda.com/blog/wp-content/uuuploads/cute-baby-animals/cute-baby-animals-2.jpg)
