### PR TITLE
[WIP] Try a short pruning history

### DIFF
--- a/trinity/_utils/datastructures.py
+++ b/trinity/_utils/datastructures.py
@@ -436,7 +436,7 @@ class OrderedTaskPreparation(Generic[TTask, TTaskID, TPrerequisite]):
     _dependency_of: StaticMethod[Callable[[TTask], TTaskID]]
 
     # by default, how long should the integrator wait before pruning?
-    _default_max_depth = 10000  # not sure how to pick a good default here
+    _default_max_depth = 10  # not sure how to pick a good default here
 
     _prereq_tracker: Type[BaseTaskPrerequisites[TTask, TPrerequisite]]
 


### PR DESCRIPTION
### What was wrong?

During #236 I realized that if we keep a short history, maybe the naive approach is fast enough. That would be a lot less code.

### How was it fixed?

Cut history from 10k nodes to 10. Still need to test live syncing performance (my current office seems to block connections).  @veox if you feel like testing the performance on this branch, that would be sweet. I'll probably pick it back up on Monday morning.

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](http://4.bp.blogspot.com/-MxmyMr4W5C4/T2tpwgMIXsI/AAAAAAAAEgI/W7BqcNv_AOc/s640/cute-baby-animals-in-cup-002.jpg)
