### PR TITLE
 Remove `exit_count` and `validator_registry_exit_count`

### DIFF
--- a/eth2/beacon/on_startup.py
+++ b/eth2/beacon/on_startup.py
@@ -91,7 +91,6 @@ def get_initial_beacon_state(*,
         validator_registry=(),
         validator_balances=(),
         validator_registry_update_epoch=genesis_epoch,
-        validator_registry_exit_count=0,
 
         # Randomness and committees
         latest_randao_mixes=tuple(ZERO_HASH32 for _ in range(latest_randao_mixes_length)),

--- a/eth2/beacon/types/states.py
+++ b/eth2/beacon/types/states.py
@@ -57,7 +57,6 @@ class BeaconState(rlp.Serializable):
         ('validator_registry', CountableList(ValidatorRecord)),
         ('validator_balances', CountableList(uint64)),
         ('validator_registry_update_epoch', uint64),
-        ('validator_registry_exit_count', uint64),
 
         # Randomness and committees
         ('latest_randao_mixes', CountableList(hash32)),
@@ -101,7 +100,6 @@ class BeaconState(rlp.Serializable):
             validator_registry: Sequence[ValidatorRecord],
             validator_balances: Sequence[Gwei],
             validator_registry_update_epoch: EpochNumber,
-            validator_registry_exit_count: int,
             # Randomness and committees
             latest_randao_mixes: Sequence[Hash32],
             previous_epoch_start_shard: ShardNumber,
@@ -138,7 +136,6 @@ class BeaconState(rlp.Serializable):
             validator_registry=validator_registry,
             validator_balances=validator_balances,
             validator_registry_update_epoch=validator_registry_update_epoch,
-            validator_registry_exit_count=validator_registry_exit_count,
             # Randomness and committees
             latest_randao_mixes=latest_randao_mixes,
             previous_epoch_start_shard=previous_epoch_start_shard,
@@ -218,7 +215,6 @@ class BeaconState(rlp.Serializable):
             validator_registry=activated_genesis_validators,
             validator_balances=genesis_balances,
             validator_registry_update_epoch=genesis_epoch,
-            validator_registry_exit_count=0,
 
             # Randomness and committees
             latest_randao_mixes=tuple(

--- a/eth2/beacon/types/validator_records.py
+++ b/eth2/beacon/types/validator_records.py
@@ -40,8 +40,6 @@ class ValidatorRecord(rlp.Serializable):
         ('withdrawal_epoch', uint64),
         # Epoch when validator was penalized
         ('penalized_epoch', uint64),
-        # Exit counter when validator exited
-        ('exit_count', uint64),
         # Status flags
         ('status_flags', uint64),
     ]
@@ -55,7 +53,6 @@ class ValidatorRecord(rlp.Serializable):
                  exit_epoch: EpochNumber,
                  withdrawal_epoch: EpochNumber,
                  penalized_epoch: EpochNumber,
-                 exit_count: int,
                  status_flags: int) -> None:
         super().__init__(
             pubkey=pubkey,
@@ -66,7 +63,6 @@ class ValidatorRecord(rlp.Serializable):
             exit_epoch=exit_epoch,
             withdrawal_epoch=withdrawal_epoch,
             penalized_epoch=penalized_epoch,
-            exit_count=exit_count,
             status_flags=status_flags,
         )
 
@@ -93,6 +89,5 @@ class ValidatorRecord(rlp.Serializable):
             exit_epoch=FAR_FUTURE_EPOCH,
             withdrawal_epoch=FAR_FUTURE_EPOCH,
             penalized_epoch=FAR_FUTURE_EPOCH,
-            exit_count=0,
             status_flags=0,
         )

--- a/eth2/beacon/validator_status_helpers.py
+++ b/eth2/beacon/validator_status_helpers.py
@@ -78,15 +78,8 @@ def exit_validator(state: BeaconState,
     if validator.exit_epoch <= entry_exit_effect_epoch:
         return state
 
-    # Update state.validator_registry_exit_count
-    state = state.copy(
-        validator_registry_exit_count=state.validator_registry_exit_count + 1,
-    )
-
-    # Update validator.exit_epoch and exit_epoch.exit_count
     validator = validator.copy(
         exit_epoch=state.current_epoch(epoch_length) + entry_exit_delay,
-        exit_count=state.validator_registry_exit_count,
     )
     state = state.update_validator_registry(index, validator)
 

--- a/tests/eth2/beacon/conftest.py
+++ b/tests/eth2/beacon/conftest.py
@@ -148,7 +148,6 @@ def sample_beacon_state_params(sample_fork_params, sample_eth1_data_params):
         'validator_registry': (),
         'validator_balances': (),
         'validator_registry_update_epoch': 0,
-        'validator_registry_exit_count': 10,
         'latest_randao_mixes': (),
         'previous_epoch_start_shard': 1,
         'current_epoch_start_shard': 2,
@@ -299,7 +298,6 @@ def sample_validator_record_params():
         'exit_epoch': FAR_FUTURE_EPOCH,
         'withdrawal_epoch': FAR_FUTURE_EPOCH,
         'penalized_epoch': FAR_FUTURE_EPOCH,
-        'exit_count': 0,
         'status_flags': 0,
     }
 

--- a/tests/eth2/beacon/helpers.py
+++ b/tests/eth2/beacon/helpers.py
@@ -26,7 +26,6 @@ def mock_validator_record(pubkey,
         exit_epoch=FAR_FUTURE_EPOCH,
         withdrawal_epoch=FAR_FUTURE_EPOCH,
         penalized_epoch=FAR_FUTURE_EPOCH,
-        exit_count=0,
         status_flags=status_flags,
     )
 

--- a/tests/eth2/beacon/test_on_startup.py
+++ b/tests/eth2/beacon/test_on_startup.py
@@ -139,7 +139,6 @@ def test_get_initial_beacon_state(
     assert len(state.validator_registry) == validator_count
     assert len(state.validator_balances) == validator_count
     assert state.validator_registry_update_epoch == genesis_epoch
-    assert state.validator_registry_exit_count == 0
 
     # Randomness and committees
     assert len(state.latest_randao_mixes) == latest_randao_mixes_length

--- a/tests/eth2/beacon/test_validator_status_helpers.py
+++ b/tests/eth2/beacon/test_validator_status_helpers.py
@@ -133,7 +133,6 @@ def test_initiate_validator_exit(n_validators_state):
             200,
             2,
         ),
-
     ],
 )
 def test_exit_validator(num_validators,

--- a/tests/eth2/beacon/test_validator_status_helpers.py
+++ b/tests/eth2/beacon/test_validator_status_helpers.py
@@ -106,7 +106,6 @@ def test_initiate_validator_exit(n_validators_state):
         'committee',
         'state_slot',
         'exit_epoch',
-        'validator_registry_exit_count',
     ),
     [
         (
@@ -115,7 +114,6 @@ def test_initiate_validator_exit(n_validators_state):
             [4, 5, 6, 7],
             100,
             10,
-            2,
         ),
         (
             10,
@@ -123,7 +121,6 @@ def test_initiate_validator_exit(n_validators_state):
             [4, 5, 6, 7],
             100,
             110,
-            2,
         ),
         (
             10,
@@ -131,7 +128,6 @@ def test_initiate_validator_exit(n_validators_state):
             [4, 5, 6, 7],
             100,
             200,
-            2,
         ),
     ],
 )
@@ -140,13 +136,11 @@ def test_exit_validator(num_validators,
                         committee,
                         state_slot,
                         exit_epoch,
-                        validator_registry_exit_count,
                         n_validators_state,
                         epoch_length):
     # Unchanged
     state = n_validators_state.copy(
         slot=state_slot,
-        validator_registry_exit_count=validator_registry_exit_count,
     )
     index = 1
 
@@ -170,9 +164,7 @@ def test_exit_validator(num_validators,
     else:
         assert validator.exit_epoch > state.current_epoch(epoch_length) + entry_exit_delay
         result_validator = result_state.validator_registry[index]
-        assert result_state.validator_registry_exit_count == validator_registry_exit_count + 1
         assert result_validator.exit_epoch == state.current_epoch(epoch_length) + entry_exit_delay
-        assert result_validator.exit_count == result_state.validator_registry_exit_count
 
 
 @pytest.mark.parametrize(

--- a/tests/eth2/beacon/types/test_validator_record.py
+++ b/tests/eth2/beacon/types/test_validator_record.py
@@ -56,4 +56,3 @@ def test_create_pending_validator():
     assert validator.exit_epoch == FAR_FUTURE_EPOCH
     assert validator.withdrawal_epoch == FAR_FUTURE_EPOCH
     assert validator.penalized_epoch == FAR_FUTURE_EPOCH
-    assert validator.exit_count == 0


### PR DESCRIPTION
### What was wrong?

Fixes #245.

### How was it fixed?

Removed the fields from the definitions in `types`, removed any uses in the application logic and updated the tests accordingly.

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://i.ytimg.com/vi/Vaqw54clnPM/hqdefault.jpg)
