### PR TITLE
Constants arguments clean-up and shuffling lookahead

### DIFF
--- a/eth2/beacon/committee_helpers.py
+++ b/eth2/beacon/committee_helpers.py
@@ -163,14 +163,15 @@ def get_crosslink_committees_at_slot(
     """
     Return the list of ``(committee, shard)`` tuples for the ``slot``.
     """
-    genesis_epoch = committee_config.genesis_epoch
-    epoch_length = committee_config.epoch_length
-    target_committee_size = committee_config.target_committee_size
-    shard_count = committee_config.shard_count
-    seed_lookahead = committee_config.seed_lookahead
-    entry_exit_delay = committee_config.entry_exit_delay
-    latest_index_roots_length = committee_config.latest_index_roots_length
-    latest_randao_mixes_length = committee_config.latest_randao_mixes_length
+    genesis_epoch = committee_config.GENESIS_EPOCH
+    shard_count = committee_config.SHARD_COUNT
+    epoch_length = committee_config.EPOCH_LENGTH
+    target_committee_size = committee_config.TARGET_COMMITTEE_SIZE
+
+    seed_lookahead = committee_config.SEED_LOOKAHEAD
+    entry_exit_delay = committee_config.ENTRY_EXIT_DELAY
+    latest_index_roots_length = committee_config.LATEST_INDEX_ROOTS_LENGTH
+    latest_randao_mixes_length = committee_config.LATEST_RANDAO_MIXES_LENGTH
 
     epoch = slot_to_epoch(slot, epoch_length)
     current_epoch = state.current_epoch(epoch_length)

--- a/eth2/beacon/committee_helpers.py
+++ b/eth2/beacon/committee_helpers.py
@@ -176,7 +176,7 @@ def get_crosslink_committees_at_slot(
     epoch = slot_to_epoch(slot, epoch_length)
     current_epoch = state.current_epoch(epoch_length)
     previous_epoch = state.previous_epoch(epoch_length, genesis_epoch)
-    next_epoch = EpochNumber(current_epoch + 1)
+    next_epoch = state.next_epoch(epoch_length)
 
     validate_epoch_for_current_epoch(
         current_epoch=current_epoch,

--- a/eth2/beacon/committee_helpers.py
+++ b/eth2/beacon/committee_helpers.py
@@ -26,8 +26,8 @@ from eth2.beacon._utils.random import (
 from eth2.beacon.configs import (
     CommitteeConfig,
 )
+from eth2.beacon import helpers
 from eth2.beacon.helpers import (
-    generate_seed,
     get_active_validator_indices,
     slot_to_epoch,
 )
@@ -218,8 +218,14 @@ def get_crosslink_committees_at_slot(
         )
         shuffling_epoch = next_epoch
         epochs_since_last_registry_update = current_epoch - state.validator_registry_update_epoch
+        should_reseed = (
+            epochs_since_last_registry_update > 1 and
+            is_power_of_two(epochs_since_last_registry_update)
+        )
+
         if registry_change:
-            seed = generate_seed(
+            # for mocking this out in tests.
+            seed = helpers.generate_seed(
                 state=state,
                 epoch=next_epoch,
                 epoch_length=epoch_length,
@@ -231,11 +237,9 @@ def get_crosslink_committees_at_slot(
             shuffling_start_shard = (
                 state.current_epoch_start_shard + current_committees_per_epoch
             ) % shard_count
-        elif (
-            epochs_since_last_registry_update > 1 and
-            is_power_of_two(epochs_since_last_registry_update)
-        ):
-            seed = generate_seed(
+        elif should_reseed:
+            # for mocking this out in tests.
+            seed = helpers.generate_seed(
                 state=state,
                 epoch=next_epoch,
                 epoch_length=epoch_length,

--- a/eth2/beacon/committee_helpers.py
+++ b/eth2/beacon/committee_helpers.py
@@ -23,6 +23,9 @@ from eth2.beacon._utils.random import (
     shuffle,
     split,
 )
+from eth2.beacon.configs import (
+    CommitteeConfig,
+)
 from eth2.beacon.helpers import (
     generate_seed,
     get_active_validator_indices,
@@ -45,19 +48,6 @@ if TYPE_CHECKING:
     from eth2.beacon.types.attestation_data import AttestationData  # noqa: F401
     from eth2.beacon.types.states import BeaconState  # noqa: F401
     from eth2.beacon.types.validator_records import ValidatorRecord  # noqa: F401
-
-
-class CommitteeConfig:
-    def __init__(self, config):
-        self.genesis_epoch = config.GENESIS_EPOCH
-        self.shard_count = config.SHARD_COUNT
-        self.epoch_length = config.EPOCH_LENGTH
-        self.target_committee_size = config.TARGET_COMMITTEE_SIZE
-
-        self.seed_lookahead = config.SEED_LOOKAHEAD
-        self.entry_exit_delay = config.ENTRY_EXIT_DELAY
-        self.latest_index_roots_length = config.LATEST_INDEX_ROOTS_LENGTH
-        self.latest_randao_mixes_length = config.LATEST_INDEX_ROOTS_LENGTH
 
 
 def get_epoch_committee_count(
@@ -185,7 +175,7 @@ def get_crosslink_committees_at_slot(
     epoch = slot_to_epoch(slot, epoch_length)
     current_epoch = state.current_epoch(epoch_length)
     previous_epoch = state.previous_epoch(epoch_length, genesis_epoch)
-    next_epoch = current_epoch + 1
+    next_epoch = EpochNumber(current_epoch + 1)
 
     validate_epoch_for_current_epoch(
         current_epoch=current_epoch,

--- a/eth2/beacon/configs.py
+++ b/eth2/beacon/configs.py
@@ -67,13 +67,13 @@ BeaconConfig = NamedTuple(
 class CommitteeConfig:
     def __init__(self, config: BeaconConfig):
         # Basic
-        self.genesis_epoch = config.GENESIS_EPOCH
-        self.shard_count = config.SHARD_COUNT
-        self.epoch_length = config.EPOCH_LENGTH
-        self.target_committee_size = config.TARGET_COMMITTEE_SIZE
+        self.GENESIS_EPOCH = config.GENESIS_EPOCH
+        self.SHARD_COUNT = config.SHARD_COUNT
+        self.EPOCH_LENGTH = config.EPOCH_LENGTH
+        self.TARGET_COMMITTEE_SIZE = config.TARGET_COMMITTEE_SIZE
 
         # For seed
-        self.seed_lookahead = config.SEED_LOOKAHEAD
-        self.entry_exit_delay = config.ENTRY_EXIT_DELAY
-        self.latest_index_roots_length = config.LATEST_INDEX_ROOTS_LENGTH
-        self.latest_randao_mixes_length = config.LATEST_RANDAO_MIXES_LENGTH
+        self.SEED_LOOKAHEAD = config.SEED_LOOKAHEAD
+        self.ENTRY_EXIT_DELAY = config.ENTRY_EXIT_DELAY
+        self.LATEST_INDEX_ROOTS_LENGTH = config.LATEST_INDEX_ROOTS_LENGTH
+        self.LATEST_RANDAO_MIXES_LENGTH = config.LATEST_RANDAO_MIXES_LENGTH

--- a/eth2/beacon/configs.py
+++ b/eth2/beacon/configs.py
@@ -76,4 +76,4 @@ class CommitteeConfig:
         self.seed_lookahead = config.SEED_LOOKAHEAD
         self.entry_exit_delay = config.ENTRY_EXIT_DELAY
         self.latest_index_roots_length = config.LATEST_INDEX_ROOTS_LENGTH
-        self.latest_randao_mixes_length = config.LATEST_INDEX_ROOTS_LENGTH
+        self.latest_randao_mixes_length = config.LATEST_RANDAO_MIXES_LENGTH

--- a/eth2/beacon/configs.py
+++ b/eth2/beacon/configs.py
@@ -62,3 +62,18 @@ BeaconConfig = NamedTuple(
         ('MAX_EXITS', int),
     )
 )
+
+
+class CommitteeConfig:
+    def __init__(self, config: BeaconConfig):
+        # Basic
+        self.genesis_epoch = config.GENESIS_EPOCH
+        self.shard_count = config.SHARD_COUNT
+        self.epoch_length = config.EPOCH_LENGTH
+        self.target_committee_size = config.TARGET_COMMITTEE_SIZE
+
+        # For seed
+        self.seed_lookahead = config.SEED_LOOKAHEAD
+        self.entry_exit_delay = config.ENTRY_EXIT_DELAY
+        self.latest_index_roots_length = config.LATEST_INDEX_ROOTS_LENGTH
+        self.latest_randao_mixes_length = config.LATEST_INDEX_ROOTS_LENGTH

--- a/eth2/beacon/epoch_processing_helpers.py
+++ b/eth2/beacon/epoch_processing_helpers.py
@@ -15,6 +15,7 @@ from eth_utils import (
 )
 
 from eth2.beacon.committee_helpers import (
+    CommitteeConfig,
     get_attestation_participants,
 )
 from eth2.beacon.exceptions import (
@@ -70,10 +71,7 @@ def get_attesting_validator_indices(
         attestations: Sequence[PendingAttestationRecord],
         shard: ShardNumber,
         shard_block_root: Hash32,
-        genesis_epoch: EpochNumber,
-        epoch_length: int,
-        target_committee_size: int,
-        shard_count: int) -> Iterable[ValidatorIndex]:
+        committee_config: CommitteeConfig) -> Iterable[ValidatorIndex]:
     """
     Loop through ``attestations`` and check if ``shard``/``shard_block_root`` in the attestation
     matches the given ``shard``/``shard_block_root``.
@@ -86,10 +84,7 @@ def get_attesting_validator_indices(
                 state,
                 a.data,
                 a.aggregation_bitfield,
-                genesis_epoch,
-                epoch_length,
-                target_committee_size,
-                shard_count,
+                committee_config,
             )
 
 
@@ -99,11 +94,8 @@ def get_total_attesting_balance(
         shard: ShardNumber,
         shard_block_root: Hash32,
         attestations: Sequence[PendingAttestationRecord],
-        genesis_epoch: EpochNumber,
-        epoch_length: int,
         max_deposit_amount: Gwei,
-        target_committee_size: int,
-        shard_count: int) -> Gwei:
+        committee_config: CommitteeConfig) -> Gwei:
     return Gwei(
         sum(
             get_effective_balance(state.validator_balances, i, max_deposit_amount)
@@ -112,10 +104,7 @@ def get_total_attesting_balance(
                 attestations=attestations,
                 shard=shard,
                 shard_block_root=shard_block_root,
-                genesis_epoch=genesis_epoch,
-                epoch_length=epoch_length,
-                target_committee_size=target_committee_size,
-                shard_count=shard_count,
+                committee_config=committee_config,
             )
         )
     )
@@ -126,11 +115,8 @@ def get_winning_root(
         state: 'BeaconState',
         shard: ShardNumber,
         attestations: Sequence[PendingAttestationRecord],
-        genesis_epoch: EpochNumber,
-        epoch_length: int,
         max_deposit_amount: Gwei,
-        target_committee_size: int,
-        shard_count: int) -> Tuple[Hash32, Gwei]:
+        committee_config=CommitteeConfig) -> Tuple[Hash32, Gwei]:
     winning_root = None
     winning_root_balance: Gwei = Gwei(0)
     shard_block_roots = set(
@@ -145,11 +131,8 @@ def get_winning_root(
             shard=shard,
             shard_block_root=shard_block_root,
             attestations=attestations,
-            genesis_epoch=genesis_epoch,
-            epoch_length=epoch_length,
             max_deposit_amount=max_deposit_amount,
-            target_committee_size=target_committee_size,
-            shard_count=shard_count,
+            committee_config=committee_config,
         )
         if total_attesting_balance > winning_root_balance:
             winning_root = shard_block_root

--- a/eth2/beacon/epoch_processing_helpers.py
+++ b/eth2/beacon/epoch_processing_helpers.py
@@ -14,9 +14,12 @@ from eth_utils import (
     to_tuple,
 )
 
+
 from eth2.beacon.committee_helpers import (
-    CommitteeConfig,
     get_attestation_participants,
+)
+from eth2.beacon.configs import (
+    CommitteeConfig,
 )
 from eth2.beacon.exceptions import (
     NoWinningRootError,
@@ -116,7 +119,7 @@ def get_winning_root(
         shard: ShardNumber,
         attestations: Sequence[PendingAttestationRecord],
         max_deposit_amount: Gwei,
-        committee_config=CommitteeConfig) -> Tuple[Hash32, Gwei]:
+        committee_config: CommitteeConfig) -> Tuple[Hash32, Gwei]:
     winning_root = None
     winning_root_balance: Gwei = Gwei(0)
     shard_block_roots = set(

--- a/eth2/beacon/exceptions.py
+++ b/eth2/beacon/exceptions.py
@@ -25,8 +25,15 @@ class ProposerIndexError(PyEVMError):
     pass
 
 
-class NoWinningRootError(Exception):
+class NoWinningRootError(PyEVMError):
     """
     Raised when no shard block root is attested to among the attestations provided.
+    """
+    pass
+
+
+class NoValidatorAssignment(PyEVMError):
+    """
+    Raised when no potential crosslink committee assignment.
     """
     pass

--- a/eth2/beacon/exceptions.py
+++ b/eth2/beacon/exceptions.py
@@ -32,7 +32,7 @@ class NoWinningRootError(PyEVMError):
     pass
 
 
-class NoValidatorAssignment(PyEVMError):
+class NoCommitteeAssignment(PyEVMError):
     """
     Raised when no potential crosslink committee assignment.
     """

--- a/eth2/beacon/on_startup.py
+++ b/eth2/beacon/on_startup.py
@@ -161,7 +161,7 @@ def get_initial_beacon_state(*,
         state.validator_registry,
         genesis_epoch,
     )
-    index_root = hash_eth2(
+    genesis_active_index_root = hash_eth2(
         b''.join(
             [
                 index.to_bytes(32, 'big')
@@ -169,10 +169,9 @@ def get_initial_beacon_state(*,
             ]
         )
     )
-    latest_index_roots = update_tuple_item(
-        state.latest_index_roots,
-        genesis_epoch % latest_index_roots_length,
-        index_root,
+    latest_index_roots = tuple(
+        genesis_active_index_root
+        for index in latest_index_roots_length
     )
     state = state.copy(
         latest_index_roots=latest_index_roots,

--- a/eth2/beacon/on_startup.py
+++ b/eth2/beacon/on_startup.py
@@ -11,7 +11,6 @@ from eth.constants import (
     ZERO_HASH32,
 )
 
-from eth2._utils.tuple import update_tuple_item
 from eth2.beacon.constants import (
     EMPTY_SIGNATURE,
 )

--- a/eth2/beacon/on_startup.py
+++ b/eth2/beacon/on_startup.py
@@ -170,7 +170,7 @@ def get_initial_beacon_state(*,
     )
     latest_index_roots = tuple(
         genesis_active_index_root
-        for index in latest_index_roots_length
+        for _ in range(latest_index_roots_length)
     )
     state = state.copy(
         latest_index_roots=latest_index_roots,

--- a/eth2/beacon/on_startup.py
+++ b/eth2/beacon/on_startup.py
@@ -92,7 +92,7 @@ def get_initial_beacon_state(*,
         validator_registry_update_epoch=genesis_epoch,
 
         # Randomness and committees
-        latest_randao_mixes=tuple(ZERO_HASH32 for _ in range(latest_randao_mixes_length)),
+        latest_randao_mixes=(ZERO_HASH32,) * latest_randao_mixes_length,
         previous_epoch_start_shard=genesis_start_shard,
         current_epoch_start_shard=genesis_start_shard,
         previous_calculation_epoch=genesis_epoch,
@@ -107,16 +107,12 @@ def get_initial_beacon_state(*,
         finalized_epoch=genesis_epoch,
 
         # Recent state
-        latest_crosslinks=tuple([
-            CrosslinkRecord(epoch=genesis_epoch, shard_block_root=ZERO_HASH32)
-            for _ in range(shard_count)
-        ]),
-        latest_block_roots=tuple(ZERO_HASH32 for _ in range(latest_block_roots_length)),
-        latest_index_roots=tuple(ZERO_HASH32 for _ in range(latest_index_roots_length)),
-        latest_penalized_balances=tuple(
-            Gwei(0)
-            for _ in range(latest_penalized_exit_length)
+        latest_crosslinks=(
+            (CrosslinkRecord(epoch=genesis_epoch, shard_block_root=ZERO_HASH32),) * shard_count
         ),
+        latest_block_roots=(ZERO_HASH32,) * latest_block_roots_length,
+        latest_index_roots=(ZERO_HASH32,) * latest_index_roots_length,
+        latest_penalized_balances=(Gwei(0),) * latest_penalized_exit_length,
         latest_attestations=(),
         batched_block_roots=(),
 
@@ -168,10 +164,7 @@ def get_initial_beacon_state(*,
             ]
         )
     )
-    latest_index_roots = tuple(
-        genesis_active_index_root
-        for _ in range(latest_index_roots_length)
-    )
+    latest_index_roots = (genesis_active_index_root,) * latest_index_roots_length
     state = state.copy(
         latest_index_roots=latest_index_roots,
     )

--- a/eth2/beacon/state_machines/base.py
+++ b/eth2/beacon/state_machines/base.py
@@ -15,6 +15,9 @@ from eth._utils.datatypes import (
     Configurable,
 )
 
+from eth2.beacon.configs import (  # noqa: F401
+    BeaconConfig,
+)
 from eth2.beacon.db.chain import BaseBeaconChainDB
 from eth2.beacon.types.blocks import BaseBeaconBlock
 from eth2.beacon.types.states import BeaconState
@@ -24,9 +27,6 @@ from eth2.beacon.typing import (
 
 from .state_transitions import (
     BaseStateTransition,
-)
-from .configs import (  # noqa: F401
-    BeaconConfig,
 )
 
 

--- a/eth2/beacon/state_machines/forks/serenity/block_processing.py
+++ b/eth2/beacon/state_machines/forks/serenity/block_processing.py
@@ -4,11 +4,10 @@ from eth_utils.toolz import (
 
 from eth2._utils.tuple import update_tuple_item
 
+from eth2.beacon.configs import BeaconConfig
 from eth2.beacon.types.states import BeaconState
 from eth2.beacon.types.blocks import BaseBeaconBlock
 from eth2.beacon.types.eth1_data_vote import Eth1DataVote
-
-from eth2.beacon.state_machines.configs import BeaconConfig
 
 
 def process_eth1_data(state: BeaconState,

--- a/eth2/beacon/state_machines/forks/serenity/block_validation.py
+++ b/eth2/beacon/state_machines/forks/serenity/block_validation.py
@@ -12,6 +12,7 @@ from eth.constants import (
 from eth2._utils import bls as bls
 
 from eth2.beacon.committee_helpers import (
+    CommitteeConfig,
     get_beacon_proposer_index,
     get_attestation_participants,
 )
@@ -54,10 +55,7 @@ def validate_block_slot(state: BeaconState,
 def validate_proposer_signature(state: BeaconState,
                                 block: BaseBeaconBlock,
                                 beacon_chain_shard_number: ShardNumber,
-                                genesis_epoch: EpochNumber,
-                                epoch_length: int,
-                                target_committee_size: int,
-                                shard_count: int) -> None:
+                                committee_config=CommitteeConfig) -> None:
     block_without_signature_root = block.block_without_signature_root
 
     # TODO: Replace this root with tree hash root
@@ -71,15 +69,12 @@ def validate_proposer_signature(state: BeaconState,
     beacon_proposer_index = get_beacon_proposer_index(
         state,
         state.slot,
-        genesis_epoch,
-        epoch_length,
-        target_committee_size,
-        shard_count,
+        committee_config,
     )
     proposer_pubkey = state.validator_registry[beacon_proposer_index].pubkey
     domain = get_domain(
         state.fork,
-        state.current_epoch(epoch_length),
+        state.current_epoch(committee_config.epoch_length),
         SignatureDomain.DOMAIN_PROPOSAL
     )
 
@@ -103,12 +98,9 @@ def validate_proposer_signature(state: BeaconState,
 #
 def validate_attestation(state: BeaconState,
                          attestation: Attestation,
-                         genesis_epoch: EpochNumber,
-                         epoch_length: int,
                          min_attestation_inclusion_delay: int,
                          latest_block_roots_length: int,
-                         target_committee_size: int,
-                         shard_count: int) -> None:
+                         committee_config: CommitteeConfig) -> None:
     """
     Validate the given ``attestation``.
     Raise ``ValidationError`` if it's invalid.
@@ -117,23 +109,26 @@ def validate_attestation(state: BeaconState,
     validate_attestation_slot(
         attestation.data,
         state.slot,
-        epoch_length,
+        committee_config.epoch_length,
         min_attestation_inclusion_delay,
     )
 
     validate_attestation_justified_epoch(
         attestation.data,
-        state.current_epoch(epoch_length),
+        state.current_epoch(committee_config.epoch_length),
         state.previous_justified_epoch,
         state.justified_epoch,
-        epoch_length,
+        committee_config.epoch_length,
     )
 
     validate_attestation_justified_block_root(
         attestation.data,
         justified_block_root=get_block_root(
             state=state,
-            slot=get_epoch_start_slot(attestation.data.justified_epoch, epoch_length),
+            slot=get_epoch_start_slot(
+                attestation.data.justified_epoch,
+                committee_config.epoch_length,
+            ),
             latest_block_roots_length=latest_block_roots_length,
         ),
     )
@@ -148,10 +143,7 @@ def validate_attestation(state: BeaconState,
     validate_attestation_aggregate_signature(
         state,
         attestation,
-        genesis_epoch,
-        epoch_length,
-        target_committee_size,
-        shard_count,
+        committee_config,
     )
 
 
@@ -283,10 +275,7 @@ def validate_attestation_shard_block_root(attestation_data: AttestationData) -> 
 
 def validate_attestation_aggregate_signature(state: BeaconState,
                                              attestation: Attestation,
-                                             genesis_epoch: EpochNumber,
-                                             epoch_length: int,
-                                             target_committee_size: int,
-                                             shard_count: int) -> None:
+                                             committee_config: CommitteeConfig) -> None:
     """
     Validate ``aggregate_signature`` field of ``attestation``.
     Raise ``ValidationError`` if it's invalid.
@@ -299,10 +288,7 @@ def validate_attestation_aggregate_signature(state: BeaconState,
         state=state,
         attestation_data=attestation.data,
         bitfield=attestation.aggregation_bitfield,
-        genesis_epoch=genesis_epoch,
-        epoch_length=epoch_length,
-        target_committee_size=target_committee_size,
-        shard_count=shard_count,
+        committee_config=committee_config,
     )
     pubkeys = tuple(
         state.validator_registry[validator_index].pubkey
@@ -313,7 +299,7 @@ def validate_attestation_aggregate_signature(state: BeaconState,
     message = AttestationDataAndCustodyBit.create_attestation_message(attestation.data)
     domain = get_domain(
         fork=state.fork,
-        epoch=slot_to_epoch(attestation.data.slot, epoch_length),
+        epoch=slot_to_epoch(attestation.data.slot, committee_config.epoch_length),
         domain_type=SignatureDomain.DOMAIN_ATTESTATION,
     )
 

--- a/eth2/beacon/state_machines/forks/serenity/block_validation.py
+++ b/eth2/beacon/state_machines/forks/serenity/block_validation.py
@@ -76,7 +76,7 @@ def validate_proposer_signature(state: BeaconState,
     proposer_pubkey = state.validator_registry[beacon_proposer_index].pubkey
     domain = get_domain(
         state.fork,
-        state.current_epoch(committee_config.epoch_length),
+        state.current_epoch(committee_config.EPOCH_LENGTH),
         SignatureDomain.DOMAIN_PROPOSAL
     )
 
@@ -107,20 +107,21 @@ def validate_attestation(state: BeaconState,
     Validate the given ``attestation``.
     Raise ``ValidationError`` if it's invalid.
     """
+    epoch_length = committee_config.EPOCH_LENGTH
 
     validate_attestation_slot(
         attestation.data,
         state.slot,
-        committee_config.epoch_length,
+        epoch_length,
         min_attestation_inclusion_delay,
     )
 
     validate_attestation_justified_epoch(
         attestation.data,
-        state.current_epoch(committee_config.epoch_length),
+        state.current_epoch(epoch_length),
         state.previous_justified_epoch,
         state.justified_epoch,
-        committee_config.epoch_length,
+        epoch_length,
     )
 
     validate_attestation_justified_block_root(
@@ -129,7 +130,7 @@ def validate_attestation(state: BeaconState,
             state=state,
             slot=get_epoch_start_slot(
                 attestation.data.justified_epoch,
-                committee_config.epoch_length,
+                epoch_length,
             ),
             latest_block_roots_length=latest_block_roots_length,
         ),
@@ -301,7 +302,7 @@ def validate_attestation_aggregate_signature(state: BeaconState,
     message = AttestationDataAndCustodyBit.create_attestation_message(attestation.data)
     domain = get_domain(
         fork=state.fork,
-        epoch=slot_to_epoch(attestation.data.slot, committee_config.epoch_length),
+        epoch=slot_to_epoch(attestation.data.slot, committee_config.EPOCH_LENGTH),
         domain_type=SignatureDomain.DOMAIN_ATTESTATION,
     )
 

--- a/eth2/beacon/state_machines/forks/serenity/block_validation.py
+++ b/eth2/beacon/state_machines/forks/serenity/block_validation.py
@@ -12,9 +12,11 @@ from eth.constants import (
 from eth2._utils import bls as bls
 
 from eth2.beacon.committee_helpers import (
-    CommitteeConfig,
     get_beacon_proposer_index,
     get_attestation_participants,
+)
+from eth2.beacon.configs import (
+    CommitteeConfig,
 )
 from eth2.beacon.enums import (
     SignatureDomain,
@@ -55,7 +57,7 @@ def validate_block_slot(state: BeaconState,
 def validate_proposer_signature(state: BeaconState,
                                 block: BaseBeaconBlock,
                                 beacon_chain_shard_number: ShardNumber,
-                                committee_config=CommitteeConfig) -> None:
+                                committee_config: CommitteeConfig) -> None:
     block_without_signature_root = block.block_without_signature_root
 
     # TODO: Replace this root with tree hash root

--- a/eth2/beacon/state_machines/forks/serenity/configs.py
+++ b/eth2/beacon/state_machines/forks/serenity/configs.py
@@ -1,6 +1,8 @@
 from eth.constants import (
     ZERO_ADDRESS,
 )
+
+from eth2.beacon.configs import BeaconConfig
 from eth2.beacon.constants import (
     GWEI_PER_ETH,
 )
@@ -11,7 +13,6 @@ from eth2.beacon.typing import (
     ShardNumber,
     SlotNumber,
 )
-from eth2.beacon.state_machines.configs import BeaconConfig
 
 
 SERENITY_CONFIG = BeaconConfig(

--- a/eth2/beacon/state_machines/forks/serenity/epoch_processing.py
+++ b/eth2/beacon/state_machines/forks/serenity/epoch_processing.py
@@ -241,12 +241,12 @@ def _update_latest_index_roots(state: BeaconState,
     """
     Return the BeaconState with updated `latest_index_roots`.
     """
-    next_epoch = state.next_epoch(committee_config.epoch_length)
+    next_epoch = state.next_epoch(committee_config.EPOCH_LENGTH)
 
     # TODO: chanege to hash_tree_root
     active_validator_indices = get_active_validator_indices(
         state.validator_registry,
-        EpochNumber(next_epoch + committee_config.entry_exit_delay),
+        EpochNumber(next_epoch + committee_config.ENTRY_EXIT_DELAY),
     )
     index_root = hash_eth2(
         b''.join(
@@ -260,8 +260,8 @@ def _update_latest_index_roots(state: BeaconState,
     latest_index_roots = update_tuple_item(
         state.latest_index_roots,
         (
-            (next_epoch + committee_config.entry_exit_delay) %
-            committee_config.latest_index_roots_length
+            (next_epoch + committee_config.ENTRY_EXIT_DELAY) %
+            committee_config.LATEST_INDEX_ROOTS_LENGTH
         ),
         index_root,
     )

--- a/eth2/beacon/state_machines/forks/serenity/epoch_processing.py
+++ b/eth2/beacon/state_machines/forks/serenity/epoch_processing.py
@@ -17,6 +17,7 @@ from eth2.beacon.exceptions import (
     NoWinningRootError,
 )
 from eth2.beacon.committee_helpers import (
+    CommitteeConfig,
     get_crosslink_committees_at_slot,
     get_current_epoch_committee_count,
 )
@@ -83,10 +84,7 @@ def process_crosslinks(state: BeaconState, config: BeaconConfig) -> BeaconState:
         crosslink_committees_at_slot = get_crosslink_committees_at_slot(
             state,
             slot,
-            config.GENESIS_EPOCH,
-            config.EPOCH_LENGTH,
-            config.TARGET_COMMITTEE_SIZE,
-            config.SHARD_COUNT,
+            CommitteeConfig(config),
         )
         for crosslink_committee, shard in crosslink_committees_at_slot:
             try:
@@ -100,11 +98,8 @@ def process_crosslinks(state: BeaconState, config: BeaconConfig) -> BeaconState:
                         previous_epoch_attestations + current_epoch_attestations,
                         shard,
                     ),
-                    genesis_epoch=config.GENESIS_EPOCH,
-                    epoch_length=config.EPOCH_LENGTH,
                     max_deposit_amount=config.MAX_DEPOSIT_AMOUNT,
-                    target_committee_size=config.TARGET_COMMITTEE_SIZE,
-                    shard_count=config.SHARD_COUNT,
+                    committee_config=CommitteeConfig(config),
                 )
             except NoWinningRootError:
                 # No winning shard block root found for this shard.
@@ -266,6 +261,7 @@ def _update_latest_index_roots(state: BeaconState,
     return state.copy(
         latest_index_roots=latest_index_roots,
     )
+
 
 def process_final_updates(state: BeaconState,
                           config: BeaconConfig) -> BeaconState:

--- a/eth2/beacon/state_machines/forks/serenity/epoch_processing.py
+++ b/eth2/beacon/state_machines/forks/serenity/epoch_processing.py
@@ -17,9 +17,12 @@ from eth2.beacon.exceptions import (
     NoWinningRootError,
 )
 from eth2.beacon.committee_helpers import (
-    CommitteeConfig,
     get_crosslink_committees_at_slot,
     get_current_epoch_committee_count,
+)
+from eth2.beacon.configs import (
+    BeaconConfig,
+    CommitteeConfig,
 )
 from eth2.beacon.epoch_processing_helpers import (
     get_current_epoch_attestations,
@@ -40,7 +43,6 @@ from eth2.beacon._utils.hash import (
 from eth2.beacon.types.attestations import Attestation
 from eth2.beacon.types.crosslink_records import CrosslinkRecord
 from eth2.beacon.types.states import BeaconState
-from eth2.beacon.state_machines.configs import BeaconConfig
 
 
 #

--- a/eth2/beacon/state_machines/forks/serenity/operation_processing.py
+++ b/eth2/beacon/state_machines/forks/serenity/operation_processing.py
@@ -1,11 +1,10 @@
-from eth2.beacon.committee_helpers import (
+from eth2.beacon.configs import (
+    BeaconConfig,
     CommitteeConfig,
 )
-
 from eth2.beacon.types.blocks import BaseBeaconBlock
 from eth2.beacon.types.pending_attestation_records import PendingAttestationRecord
 from eth2.beacon.types.states import BeaconState
-from eth2.beacon.state_machines.configs import BeaconConfig
 
 from .block_validation import (
     validate_attestation,

--- a/eth2/beacon/state_machines/forks/serenity/operation_processing.py
+++ b/eth2/beacon/state_machines/forks/serenity/operation_processing.py
@@ -1,3 +1,7 @@
+from eth2.beacon.committee_helpers import (
+    CommitteeConfig,
+)
+
 from eth2.beacon.types.blocks import BaseBeaconBlock
 from eth2.beacon.types.pending_attestation_records import PendingAttestationRecord
 from eth2.beacon.types.states import BeaconState
@@ -24,12 +28,9 @@ def process_attestations(state: BeaconState,
         validate_attestation(
             state,
             attestation,
-            config.GENESIS_EPOCH,
-            config.EPOCH_LENGTH,
             config.MIN_ATTESTATION_INCLUSION_DELAY,
             config.LATEST_BLOCK_ROOTS_LENGTH,
-            config.TARGET_COMMITTEE_SIZE,
-            config.SHARD_COUNT,
+            CommitteeConfig(config),
         )
 
     # update_latest_attestations

--- a/eth2/beacon/state_machines/forks/serenity/state_transitions.py
+++ b/eth2/beacon/state_machines/forks/serenity/state_transitions.py
@@ -4,6 +4,7 @@ from eth_typing import (
 
 from eth2._utils.merkle import get_merkle_root
 from eth2.beacon.committee_helpers import (
+    CommitteeConfig,
     get_beacon_proposer_index,
 )
 from eth2.beacon.state_machines.configs import BeaconConfig
@@ -48,10 +49,6 @@ class SerenityStateTransition(BaseStateTransition):
                             state: BeaconState,
                             previous_block_root: Hash32) -> BeaconState:
         LATEST_BLOCK_ROOTS_LENGTH = self.config.LATEST_BLOCK_ROOTS_LENGTH
-        GENESIS_EPOCH = self.config.GENESIS_EPOCH
-        EPOCH_LENGTH = self.config.EPOCH_LENGTH
-        TARGET_COMMITTEE_SIZE = self.config.TARGET_COMMITTEE_SIZE
-        SHARD_COUNT = self.config.SHARD_COUNT
 
         # Update state.slot
         state = state.copy(
@@ -63,10 +60,7 @@ class SerenityStateTransition(BaseStateTransition):
         beacon_proposer_index = get_beacon_proposer_index(
             state,
             state.slot,
-            GENESIS_EPOCH,
-            EPOCH_LENGTH,
-            TARGET_COMMITTEE_SIZE,
-            SHARD_COUNT,
+            CommitteeConfig(self.config),
         )
         old_validator_record = updated_validator_registry[beacon_proposer_index]
         updated_validator_record = old_validator_record.copy(

--- a/eth2/beacon/state_machines/forks/serenity/state_transitions.py
+++ b/eth2/beacon/state_machines/forks/serenity/state_transitions.py
@@ -4,10 +4,12 @@ from eth_typing import (
 
 from eth2._utils.merkle import get_merkle_root
 from eth2.beacon.committee_helpers import (
-    CommitteeConfig,
     get_beacon_proposer_index,
 )
-from eth2.beacon.state_machines.configs import BeaconConfig
+from eth2.beacon.configs import (
+    BeaconConfig,
+    CommitteeConfig,
+)
 from eth2.beacon.state_machines.state_transitions import BaseStateTransition
 from eth2.beacon.types.blocks import BaseBeaconBlock
 from eth2.beacon.types.states import BeaconState
@@ -94,10 +96,7 @@ class SerenityStateTransition(BaseStateTransition):
                 state,
                 block,
                 beacon_chain_shard_number=self.config.BEACON_CHAIN_SHARD_NUMBER,
-                genesis_epoch=self.config.GENESIS_EPOCH,
-                epoch_length=self.config.EPOCH_LENGTH,
-                target_committee_size=self.config.TARGET_COMMITTEE_SIZE,
-                shard_count=self.config.SHARD_COUNT
+                committee_config=CommitteeConfig(self.config),
             )
         # TODO: state = process_randao(state, block, self.config)
         # TODO: state = process_eth1_data(state, block, self.config)

--- a/eth2/beacon/state_machines/state_transitions.py
+++ b/eth2/beacon/state_machines/state_transitions.py
@@ -10,10 +10,9 @@ from eth._utils.datatypes import (
     Configurable,
 )
 
+from eth2.beacon.configs import BeaconConfig
 from eth2.beacon.types.blocks import BaseBeaconBlock
 from eth2.beacon.types.states import BeaconState
-
-from eth2.beacon.state_machines.configs import BeaconConfig
 
 
 class BaseStateTransition(Configurable, ABC):

--- a/eth2/beacon/tools/builder/committee_assignment.py
+++ b/eth2/beacon/tools/builder/committee_assignment.py
@@ -1,0 +1,21 @@
+from typing import (
+    Tuple,
+    NamedTuple,
+)
+
+from eth2.beacon.typing import (
+    ShardNumber,
+    SlotNumber,
+    ValidatorIndex,
+)
+
+
+CommitteeAssignment = NamedTuple(
+    'CommitteeAssignment',
+    (
+        ('committee', Tuple[ValidatorIndex, ...]),
+        ('shard', ShardNumber),
+        ('slot', SlotNumber),
+        ('is_proposer', bool)
+    )
+)

--- a/eth2/beacon/tools/builder/initializer.py
+++ b/eth2/beacon/tools/builder/initializer.py
@@ -5,13 +5,11 @@ from typing import (
     Type,
 )
 
+from eth2.beacon.configs import BeaconConfig
 from eth2.beacon.on_startup import (
     get_genesis_block,
     get_initial_beacon_state,
 )
-
-from eth2.beacon.state_machines.configs import BeaconConfig
-
 from eth2.beacon.types.blocks import (
     BaseBeaconBlock,
 )

--- a/eth2/beacon/tools/builder/proposer.py
+++ b/eth2/beacon/tools/builder/proposer.py
@@ -13,8 +13,11 @@ from eth2.beacon.enums import (
     SignatureDomain,
 )
 from eth2.beacon.committee_helpers import (
-    CommitteeConfig,
     get_beacon_proposer_index,
+)
+from eth2.beacon.configs import (
+    BeaconConfig,
+    CommitteeConfig,
 )
 from eth2.beacon.exceptions import (
     ProposerIndexError,
@@ -27,7 +30,6 @@ from eth2.beacon.helpers import (
 from eth2.beacon.state_machines.base import (
     BaseBeaconStateMachine,
 )
-from eth2.beacon.state_machines.configs import BeaconConfig
 
 from eth2.beacon.types.attestations import Attestation
 from eth2.beacon.types.blocks import (

--- a/eth2/beacon/tools/builder/proposer.py
+++ b/eth2/beacon/tools/builder/proposer.py
@@ -13,6 +13,7 @@ from eth2.beacon.enums import (
     SignatureDomain,
 )
 from eth2.beacon.committee_helpers import (
+    CommitteeConfig,
     get_beacon_proposer_index,
 )
 from eth2.beacon.exceptions import (
@@ -53,10 +54,7 @@ def validate_proposer_index(state: BeaconState,
             slot=slot,
         ),
         slot,
-        config.GENESIS_EPOCH,
-        config.EPOCH_LENGTH,
-        config.TARGET_COMMITTEE_SIZE,
-        config.SHARD_COUNT,
+        CommitteeConfig(config),
     )
 
     if validator_index != beacon_proposer_index:
@@ -146,10 +144,7 @@ def create_mock_block(*,
             slot=slot,
         ),
         slot,
-        config.GENESIS_EPOCH,
-        config.EPOCH_LENGTH,
-        config.TARGET_COMMITTEE_SIZE,
-        config.SHARD_COUNT,
+        CommitteeConfig(config),
     )
     proposer_pubkey = state.validator_registry[proposer_index].pubkey
     proposer_privkey = keymap[proposer_pubkey]

--- a/eth2/beacon/tools/builder/validator.py
+++ b/eth2/beacon/tools/builder/validator.py
@@ -35,7 +35,7 @@ from eth2.beacon.configs import (
     CommitteeConfig,
 )
 from eth2.beacon.exceptions import (
-    NoValidatorAssignment,
+    NoCommitteeAssignment,
 )
 from eth2.beacon.helpers import (
     get_block_root,
@@ -56,9 +56,12 @@ from eth2.beacon.typing import (
     BLSSignature,
     Bitfield,
     CommitteeIndex,
-    ShardNumber,
     SlotNumber,
     ValidatorIndex,
+)
+
+from .committee_assignment import (
+    CommitteeAssignment,
 )
 
 
@@ -268,16 +271,15 @@ def get_next_epoch_committee_assignment(
         state: BeaconState,
         config: BeaconConfig,
         validator_index: ValidatorIndex
-) -> Tuple[Iterable[ValidatorIndex], ShardNumber, SlotNumber, bool]:
+) -> CommitteeAssignment:
     """
-    Return the committee assignment in the next epoch for ``validator_index``
+    Return the ``CommitteeAssignment`` in the next epoch for ``validator_index``
     and ``registry_change``.
-    ``assignment`` returned is a tuple of the following form:
-        * ``assignment[0]`` is the list of validators in the committee
-        * ``assignment[1]`` is the shard to which the committee is assigned
-        * ``assignment[2]`` is the slot at which the committee is assigned
-        * ``assignment[3]`` is a bool signalling if the validator is expected to propose
-            a beacon block at the assigned slot.
+    ``CommitteeAssignment.committee`` is the tuple array of validators in the committee
+    ``CommitteeAssignment.shard`` is the shard to which the committee is assigned
+    ``CommitteeAssignment.slot`` is the slot at which the committee is assigned
+    ``CommitteeAssignment.is_proposer`` is a bool signalling if the validator is expected to
+        propose a beacon block at the assigned slot.
     """
     current_epoch = state.current_epoch(config.EPOCH_LENGTH)
     next_epoch = current_epoch + 1
@@ -303,6 +305,6 @@ def get_next_epoch_committee_assignment(
                     slot % len(first_committee_at_slot)
                 ] == validator_index
 
-                assignment = (validators, shard, slot, is_proposer)
-                return assignment
-    raise NoValidatorAssignment
+                return CommitteeAssignment(validators, shard, slot, is_proposer)
+
+    raise NoCommitteeAssignment

--- a/eth2/beacon/tools/builder/validator.py
+++ b/eth2/beacon/tools/builder/validator.py
@@ -34,6 +34,9 @@ from eth2.beacon.configs import (
     BeaconConfig,
     CommitteeConfig,
 )
+from eth2.beacon.exceptions import (
+    NoValidatorAssignment,
+)
 from eth2.beacon.helpers import (
     get_block_root,
     get_domain,
@@ -302,4 +305,4 @@ def get_next_epoch_committee_assignment(
 
                 assignment = (validators, shard, slot, is_proposer)
                 return assignment
-    return None
+    raise NoValidatorAssignment

--- a/eth2/beacon/tools/builder/validator.py
+++ b/eth2/beacon/tools/builder/validator.py
@@ -28,8 +28,11 @@ from eth2.beacon.enums import (
     SignatureDomain,
 )
 from eth2.beacon.committee_helpers import (
-    CommitteeConfig,
     get_crosslink_committees_at_slot,
+)
+from eth2.beacon.configs import (
+    BeaconConfig,
+    CommitteeConfig,
 )
 from eth2.beacon.helpers import (
     get_block_root,
@@ -37,7 +40,6 @@ from eth2.beacon.helpers import (
     get_epoch_start_slot,
     slot_to_epoch,
 )
-from eth2.beacon.state_machines.configs import BeaconConfig
 from eth2.beacon.types.attestations import Attestation
 from eth2.beacon.types.attestation_data import AttestationData
 from eth2.beacon.types.attestation_data_and_custody_bits import (
@@ -300,3 +302,4 @@ def get_next_epoch_committee_assignment(
 
                 assignment = (validators, shard, slot, is_proposer)
                 return assignment
+    return None

--- a/eth2/beacon/types/states.py
+++ b/eth2/beacon/types/states.py
@@ -217,10 +217,7 @@ class BeaconState(rlp.Serializable):
             validator_registry_update_epoch=genesis_epoch,
 
             # Randomness and committees
-            latest_randao_mixes=tuple(
-                ZERO_HASH32
-                for _ in range(latest_randao_mixes_length)
-            ),
+            latest_randao_mixes=(ZERO_HASH32,) * latest_randao_mixes_length,
             previous_epoch_start_shard=genesis_start_shard,
             current_epoch_start_shard=genesis_start_shard,
             previous_calculation_epoch=genesis_epoch,
@@ -235,15 +232,11 @@ class BeaconState(rlp.Serializable):
             finalized_epoch=genesis_epoch,
 
             # Recent state
-            latest_crosslinks=tuple(
-                CrosslinkRecord(
-                    epoch=genesis_epoch,
-                    shard_block_root=ZERO_HASH32,
-                )
-                for _ in range(shard_count)
+            latest_crosslinks=(
+                (CrosslinkRecord(epoch=genesis_epoch, shard_block_root=ZERO_HASH32),) * shard_count
             ),
-            latest_block_roots=tuple(ZERO_HASH32 for _ in range(latest_block_roots_length)),
-            latest_index_roots=tuple(ZERO_HASH32 for _ in range(latest_index_roots_length)),
+            latest_block_roots=(ZERO_HASH32,) * latest_block_roots_length,
+            latest_index_roots=(ZERO_HASH32,) * latest_index_roots_length,
             latest_penalized_balances=(Gwei(0),) * latest_penalized_exit_length,
             latest_attestations=(),
             batched_block_roots=(),

--- a/eth2/beacon/types/states.py
+++ b/eth2/beacon/types/states.py
@@ -296,7 +296,10 @@ class BeaconState(rlp.Serializable):
 
     def previous_epoch(self, epoch_length: int, genesis_epoch: int) -> EpochNumber:
         current_epoch: EpochNumber = self.current_epoch(epoch_length)
-        return EpochNumber(current_epoch - 1) if current_epoch > genesis_epoch else current_epoch
+        if current_epoch == genesis_epoch:
+            return current_epoch
+        else:
+            return EpochNumber(current_epoch - 1)
 
     def next_epoch(self, epoch_length: int) -> EpochNumber:
         return EpochNumber(self.current_epoch(epoch_length) + 1)

--- a/eth2/beacon/validation.py
+++ b/eth2/beacon/validation.py
@@ -27,8 +27,7 @@ def validate_slot(slot: int, title: str="Slot") -> None:
 def validate_epoch_for_current_epoch(
         current_epoch: EpochNumber,
         given_epoch: EpochNumber,
-        genesis_epoch: EpochNumber,
-        epoch_length: int) -> None:
+        genesis_epoch: EpochNumber) -> None:
     previous_epoch = current_epoch - 1 if current_epoch > genesis_epoch else current_epoch
     next_epoch = current_epoch + 1
 
@@ -38,7 +37,7 @@ def validate_epoch_for_current_epoch(
             f"or equal to given_epoch ({given_epoch})"
         )
 
-    if given_epoch >= next_epoch:
+    if given_epoch > next_epoch:
         raise ValidationError(
             f"given_epoch ({given_epoch}) should be less than next_epoch ({next_epoch})"
         )

--- a/eth2/beacon/validator_status_helpers.py
+++ b/eth2/beacon/validator_status_helpers.py
@@ -111,11 +111,11 @@ def _settle_penality_to_validator_and_whistleblower(
     state.validator_balances[index] -= whistleblower_reward
     validator.penalized_epoch = slot_to_epoch(state.slot)
     """
-    EPOCH_LENGTH = committee_config.EPOCH_LENGTH
+    epoch_length = committee_config.EPOCH_LENGTH
 
     # Update `state.latest_penalized_balances`
     current_epoch_penalization_index = state.current_epoch(
-        EPOCH_LENGTH) % latest_penalized_exit_length
+        epoch_length) % latest_penalized_exit_length
     effective_balance = get_effective_balance(
         state.validator_balances,
         validator_index,
@@ -152,7 +152,7 @@ def _settle_penality_to_validator_and_whistleblower(
     # Update validator's balance and `penalized_epoch` field
     validator = state.validator_registry[validator_index]
     validator = validator.copy(
-        penalized_epoch=state.current_epoch(EPOCH_LENGTH),
+        penalized_epoch=state.current_epoch(epoch_length),
     )
     state = state.update_validator(
         validator_index,
@@ -174,9 +174,9 @@ def penalize_validator(state: BeaconState,
 
     Exit the validator, penalize the validator, and reward the whistleblower.
     """
-    EPOCH_LENGTH = committee_config.EPOCH_LENGTH
-    ENTRY_EXIT_DELAY = committee_config.ENTRY_EXIT_DELAY
-    state = exit_validator(state, index, EPOCH_LENGTH, ENTRY_EXIT_DELAY)
+    epoch_length = committee_config.EPOCH_LENGTH
+    entry_exit_delay = committee_config.ENTRY_EXIT_DELAY
+    state = exit_validator(state, index, epoch_length, entry_exit_delay)
     state = _settle_penality_to_validator_and_whistleblower(
         state=state,
         validator_index=index,

--- a/eth2/beacon/validator_status_helpers.py
+++ b/eth2/beacon/validator_status_helpers.py
@@ -111,7 +111,7 @@ def _settle_penality_to_validator_and_whistleblower(
     state.validator_balances[index] -= whistleblower_reward
     validator.penalized_epoch = slot_to_epoch(state.slot)
     """
-    EPOCH_LENGTH = committee_config.epoch_length
+    EPOCH_LENGTH = committee_config.EPOCH_LENGTH
 
     # Update `state.latest_penalized_balances`
     current_epoch_penalization_index = state.current_epoch(
@@ -174,8 +174,8 @@ def penalize_validator(state: BeaconState,
 
     Exit the validator, penalize the validator, and reward the whistleblower.
     """
-    EPOCH_LENGTH = committee_config.epoch_length
-    ENTRY_EXIT_DELAY = committee_config.entry_exit_delay
+    EPOCH_LENGTH = committee_config.EPOCH_LENGTH
+    ENTRY_EXIT_DELAY = committee_config.ENTRY_EXIT_DELAY
     state = exit_validator(state, index, EPOCH_LENGTH, ENTRY_EXIT_DELAY)
     state = _settle_penality_to_validator_and_whistleblower(
         state=state,

--- a/tests/eth2/beacon/conftest.py
+++ b/tests/eth2/beacon/conftest.py
@@ -9,11 +9,14 @@ from eth_utils import (
 
 import eth2._utils.bls as bls
 from eth2.beacon._utils.hash import hash_eth2
+from eth2.beacon.configs import (
+    BeaconConfig,
+    CommitteeConfig,
+)
 from eth2.beacon.constants import (
     EMPTY_SIGNATURE,
     FAR_FUTURE_EPOCH,
 )
-
 from eth2.beacon.types.attestation_data import AttestationData
 from eth2.beacon.types.crosslink_records import CrosslinkRecord
 from eth2.beacon.types.deposit_data import DepositData
@@ -32,7 +35,6 @@ from eth2.beacon.types.blocks import (
 from eth2.beacon.types.forks import (
     Fork,
 )
-from eth2.beacon.state_machines.configs import BeaconConfig
 from eth2.beacon.state_machines.forks.serenity import (
     SerenityStateMachine,
 )
@@ -728,3 +730,11 @@ def fixture_sm_class(config):
         __name__='SerenityStateMachineForTesting',
         config=config,
     )
+
+
+#
+# CommitteeConfig
+#
+@pytest.fixture
+def committee_config(config):
+    return CommitteeConfig(config)

--- a/tests/eth2/beacon/state_machines/forks/test_serenity_block_validation.py
+++ b/tests/eth2/beacon/state_machines/forks/test_serenity_block_validation.py
@@ -6,7 +6,7 @@ from eth_utils import (
 
 from eth2._utils import bls
 
-from eth2.beacon.committee_helpers import (
+from eth2.beacon.configs import (
     CommitteeConfig,
 )
 from eth2.beacon.enums import (

--- a/tests/eth2/beacon/state_machines/forks/test_serenity_block_validation.py
+++ b/tests/eth2/beacon/state_machines/forks/test_serenity_block_validation.py
@@ -6,6 +6,9 @@ from eth_utils import (
 
 from eth2._utils import bls
 
+from eth2.beacon.committee_helpers import (
+    CommitteeConfig,
+)
 from eth2.beacon.enums import (
     SignatureDomain,
 )
@@ -74,7 +77,8 @@ def test_validate_proposer_signature(
         beacon_chain_shard_number,
         genesis_epoch,
         target_committee_size,
-        max_deposit_amount):
+        max_deposit_amount,
+        config):
 
     state = BeaconState(**sample_beacon_state_params).copy(
         validator_registry=tuple(
@@ -106,10 +110,7 @@ def test_validate_proposer_signature(
             state,
             proposed_block,
             beacon_chain_shard_number,
-            genesis_epoch,
-            epoch_length,
-            target_committee_size,
-            shard_count,
+            CommitteeConfig(config),
         )
     else:
         with pytest.raises(ValidationError):
@@ -117,8 +118,5 @@ def test_validate_proposer_signature(
                 state,
                 proposed_block,
                 beacon_chain_shard_number,
-                genesis_epoch,
-                epoch_length,
-                target_committee_size,
-                shard_count
+                CommitteeConfig(config),
             )

--- a/tests/eth2/beacon/state_machines/forks/test_serenity_epoch_processing.py
+++ b/tests/eth2/beacon/state_machines/forks/test_serenity_epoch_processing.py
@@ -22,9 +22,10 @@ from eth2._utils.bitfield import (
     get_empty_bitfield,
 )
 from eth2.beacon.committee_helpers import (
+    CommitteeConfig,
     get_crosslink_committees_at_slot,
     get_current_epoch_committee_count,
-    get_next_epoch_committee_count,
+    # get_next_epoch_committee_count,
 )
 from eth2.beacon.helpers import (
     get_active_validator_indices,
@@ -402,10 +403,7 @@ def test_process_crosslinks(
         for committee, _shard in get_crosslink_committees_at_slot(
             state,
             slot_in_cur_epoch,
-            config.GENESIS_EPOCH,
-            config.EPOCH_LENGTH,
-            target_committee_size,
-            shard_count,
+            CommitteeConfig(config),
         ):
             if _shard == shard:
                 # Sample validators attesting to this shard.

--- a/tests/eth2/beacon/state_machines/forks/test_serenity_epoch_processing.py
+++ b/tests/eth2/beacon/state_machines/forks/test_serenity_epoch_processing.py
@@ -24,6 +24,7 @@ from eth2._utils.bitfield import (
 from eth2.beacon.committee_helpers import (
     get_crosslink_committees_at_slot,
     get_current_epoch_committee_count,
+    get_next_epoch_committee_count,
 )
 from eth2.beacon.helpers import (
     get_active_validator_indices,
@@ -132,7 +133,8 @@ def test_update_latest_index_roots(genesis_state,
                                    config,
                                    state_slot,
                                    epoch_length,
-                                   latest_index_roots_length):
+                                   latest_index_roots_length,
+                                   entry_exit_delay):
     state = genesis_state.copy(
         slot=state_slot,
     )
@@ -154,7 +156,7 @@ def test_update_latest_index_roots(genesis_state,
     )
 
     assert result_state.latest_index_roots[
-        state.next_epoch(epoch_length) % latest_index_roots_length
+        (state.next_epoch(epoch_length) + entry_exit_delay) % latest_index_roots_length
     ] == index_root
 
 

--- a/tests/eth2/beacon/state_machines/forks/test_serenity_epoch_processing.py
+++ b/tests/eth2/beacon/state_machines/forks/test_serenity_epoch_processing.py
@@ -24,7 +24,6 @@ from eth2._utils.bitfield import (
 from eth2.beacon.committee_helpers import (
     get_crosslink_committees_at_slot,
     get_current_epoch_committee_count,
-    # get_next_epoch_committee_count,  TODO
 )
 from eth2.beacon.configs import (
     CommitteeConfig,
@@ -133,7 +132,7 @@ def test_check_if_update_validator_registry(genesis_state,
     ]
 )
 def test_update_latest_index_roots(genesis_state,
-                                   config,
+                                   committee_config,
                                    state_slot,
                                    epoch_length,
                                    latest_index_roots_length,
@@ -142,7 +141,7 @@ def test_update_latest_index_roots(genesis_state,
         slot=state_slot,
     )
 
-    result_state = _update_latest_index_roots(state, config)
+    result_state = _update_latest_index_roots(state, committee_config)
 
     # TODO: chanege to hash_tree_root
     index_root = hash_eth2(

--- a/tests/eth2/beacon/state_machines/forks/test_serenity_epoch_processing.py
+++ b/tests/eth2/beacon/state_machines/forks/test_serenity_epoch_processing.py
@@ -22,10 +22,12 @@ from eth2._utils.bitfield import (
     get_empty_bitfield,
 )
 from eth2.beacon.committee_helpers import (
-    CommitteeConfig,
     get_crosslink_committees_at_slot,
     get_current_epoch_committee_count,
-    # get_next_epoch_committee_count,
+    # get_next_epoch_committee_count,  TODO
+)
+from eth2.beacon.configs import (
+    CommitteeConfig,
 )
 from eth2.beacon.helpers import (
     get_active_validator_indices,

--- a/tests/eth2/beacon/state_machines/test_attestation_validation.py
+++ b/tests/eth2/beacon/state_machines/test_attestation_validation.py
@@ -249,10 +249,10 @@ def test_validate_attestation_aggregate_signature(genesis_state,
                                                   random,
                                                   sample_attestation_data_params,
                                                   is_valid,
-                                                  genesis_epoch,
                                                   target_committee_size,
                                                   shard_count,
-                                                  keymap):
+                                                  keymap,
+                                                  committee_config):
     state = genesis_state
 
     # choose committee
@@ -260,10 +260,7 @@ def test_validate_attestation_aggregate_signature(genesis_state,
     crosslink_committee = get_crosslink_committees_at_slot(
         state=state,
         slot=slot,
-        genesis_epoch=genesis_epoch,
-        epoch_length=epoch_length,
-        target_committee_size=target_committee_size,
-        shard_count=shard_count,
+        committee_config=committee_config,
     )[0]
     committee, shard = crosslink_committee
     committee_size = len(committee)
@@ -291,10 +288,7 @@ def test_validate_attestation_aggregate_signature(genesis_state,
         validate_attestation_aggregate_signature(
             state,
             attestation,
-            genesis_epoch,
-            epoch_length,
-            target_committee_size,
-            shard_count,
+            committee_config,
         )
     else:
         # mess up signature
@@ -308,8 +302,5 @@ def test_validate_attestation_aggregate_signature(genesis_state,
             validate_attestation_aggregate_signature(
                 state,
                 attestation,
-                genesis_epoch,
-                epoch_length,
-                target_committee_size,
-                shard_count,
+                committee_config,
             )

--- a/tests/eth2/beacon/state_machines/test_state_transition.py
+++ b/tests/eth2/beacon/state_machines/test_state_transition.py
@@ -2,6 +2,7 @@ import pytest
 
 from eth2.beacon.db.chain import BeaconChainDB
 from eth2.beacon.committee_helpers import (
+    CommitteeConfig,
     get_beacon_proposer_index,
 )
 from eth2.beacon.state_machines.forks.serenity.blocks import (
@@ -91,10 +92,7 @@ def test_per_slot_transition(base_db,
     beacon_proposer_index = get_beacon_proposer_index(
         state,
         state.slot + 1,
-        st.config.GENESIS_EPOCH,
-        st.config.EPOCH_LENGTH,
-        st.config.TARGET_COMMITTEE_SIZE,
-        st.config.SHARD_COUNT,
+        CommitteeConfig(st.config),
     )
     for validator_index, _ in enumerate(updated_state.validator_registry):
         if validator_index != beacon_proposer_index:

--- a/tests/eth2/beacon/state_machines/test_state_transition.py
+++ b/tests/eth2/beacon/state_machines/test_state_transition.py
@@ -2,8 +2,10 @@ import pytest
 
 from eth2.beacon.db.chain import BeaconChainDB
 from eth2.beacon.committee_helpers import (
-    CommitteeConfig,
     get_beacon_proposer_index,
+)
+from eth2.beacon.configs import (
+    CommitteeConfig,
 )
 from eth2.beacon.state_machines.forks.serenity.blocks import (
     SerenityBeaconBlock,

--- a/tests/eth2/beacon/test_beacon_validation.py
+++ b/tests/eth2/beacon/test_beacon_validation.py
@@ -62,7 +62,10 @@ def test_validate_slot(slot, is_valid):
             2, 2, True,
         ),
         (
-            2, 3, False,  # next_epoch == epoch
+            2, 3, True,  # next_epoch == epoch
+        ),
+        (
+            2, 4, False,  # next_epoch < epoch
         ),
     ]
 )
@@ -77,7 +80,6 @@ def test_validate_epoch_for_current_epoch(
             current_epoch=current_epoch,
             given_epoch=epoch,
             genesis_epoch=genesis_epoch,
-            epoch_length=epoch_length
         )
     else:
         with pytest.raises(ValidationError):
@@ -85,7 +87,6 @@ def test_validate_epoch_for_current_epoch(
                 current_epoch=current_epoch,
                 given_epoch=epoch,
                 genesis_epoch=genesis_epoch,
-                epoch_length=epoch_length
             )
 
 

--- a/tests/eth2/beacon/test_committee_helpers.py
+++ b/tests/eth2/beacon/test_committee_helpers.py
@@ -226,7 +226,8 @@ def test_get_crosslink_committees_at_slot(
         epoch_length,
         target_committee_size,
         shard_count,
-        genesis_epoch):
+        genesis_epoch,
+        committee_config):
 
     state = n_validators_state.copy(
         slot=current_slot,
@@ -235,10 +236,7 @@ def test_get_crosslink_committees_at_slot(
     crosslink_committees_at_slot = get_crosslink_committees_at_slot(
         state=state,
         slot=slot,
-        genesis_epoch=genesis_epoch,
-        epoch_length=epoch_length,
-        target_committee_size=target_committee_size,
-        shard_count=shard_count,
+        committee_config=committee_config,
     )
     assert len(crosslink_committees_at_slot) > 0
     for crosslink_committee in crosslink_committees_at_slot:
@@ -282,16 +280,14 @@ def test_get_beacon_proposer_index(
         sample_state,
         genesis_epoch,
         target_committee_size,
-        shard_count):
+        shard_count,
+        committee_config):
 
     from eth2.beacon import committee_helpers
 
     def mock_get_crosslink_committees_at_slot(state,
                                               slot,
-                                              genesis_epoch,
-                                              epoch_length,
-                                              target_committee_size,
-                                              shard_count):
+                                              committee_config):
         return (
             (committee, 1,),
         )
@@ -305,10 +301,7 @@ def test_get_beacon_proposer_index(
         proposer_index = get_beacon_proposer_index(
             sample_state,
             slot,
-            genesis_epoch,
-            epoch_length,
-            target_committee_size,
-            shard_count,
+            committee_config,
         )
         assert proposer_index == committee[slot % len(committee)]
     else:
@@ -316,10 +309,7 @@ def test_get_beacon_proposer_index(
             get_beacon_proposer_index(
                 sample_state,
                 slot,
-                genesis_epoch,
-                epoch_length,
-                target_committee_size,
-                shard_count,
+                committee_config,
             )
 
 
@@ -373,6 +363,7 @@ def test_get_attestation_participants(
         genesis_epoch,
         target_committee_size,
         shard_count,
+        committee_config,
         sample_attestation_data_params):
     shard = 1
 
@@ -380,10 +371,7 @@ def test_get_attestation_participants(
 
     def mock_get_crosslink_committees_at_slot(state,
                                               slot,
-                                              genesis_epoch,
-                                              epoch_length,
-                                              target_committee_size,
-                                              shard_count):
+                                              committee_config):
         return (
             (committee, shard,),
         )
@@ -404,20 +392,14 @@ def test_get_attestation_participants(
                 state=sample_state,
                 attestation_data=attestation_data,
                 bitfield=aggregation_bitfield,
-                genesis_epoch=genesis_epoch,
-                epoch_length=epoch_length,
-                target_committee_size=target_committee_size,
-                shard_count=shard_count,
+                committee_config=committee_config,
             )
     else:
         result = get_attestation_participants(
             state=sample_state,
             attestation_data=attestation_data,
             bitfield=aggregation_bitfield,
-            genesis_epoch=genesis_epoch,
-            epoch_length=epoch_length,
-            target_committee_size=target_committee_size,
-            shard_count=shard_count,
+            committee_config=committee_config,
         )
 
         assert result == expected

--- a/tests/eth2/beacon/test_committee_helpers.py
+++ b/tests/eth2/beacon/test_committee_helpers.py
@@ -18,6 +18,9 @@ from eth2.beacon.committee_helpers import (
     get_previous_epoch_committee_count,
     get_shuffling,
 )
+from eth2.beacon.helpers import (
+    slot_to_epoch,
+)
 from eth2.beacon.types.attestation_data import (
     AttestationData,
 )
@@ -262,24 +265,39 @@ def test_get_prev_or_cur_epoch_committee_count(
 
 @pytest.mark.parametrize(
     (
+        'n,'
         'current_slot,'
         'slot,'
         'epoch_length,'
         'target_committee_size,'
         'shard_count,'
+        'registry_change,'
+
+        'should_reseed,'
+        'previous_calculation_epoch,'
+        'current_calculation_epoch,'
+        'shuffling_epoch,'
     ),
     [
         # genesis_epoch == previous_epoch == slot_to_epoch(slot) == current_epoch
-        (0, 5, 10, 10, 10),
+        (10, 0, 5, 10, 2, 3, False, False, 0, 0, 0),
         # genesis_epoch == previous_epoch == slot_to_epoch(slot) < current_epoch
-        (10, 5, 10, 10, 10),
+        (10, 10, 5, 10, 2, 3, False, False, 0, 1, 0),
         # genesis_epoch < previous_epoch == slot_to_epoch(slot) < current_epoch
-        (20, 11, 10, 10, 10),
+        (10, 20, 11, 10, 2, 3, False, False, 1, 2, 1),
         # genesis_epoch == previous_epoch < slot_to_epoch(slot) == current_epoch
-        (10, 11, 10, 10, 10),
+        (10, 10, 11, 10, 2, 3, False, False, 0, 1, 1,),
+        # genesis_epoch == previous_epoch < slot_to_epoch(slot) == next_epoch
+        (100, 4, 9, 4, 2, 3, False, False, 0, 1, 2),
+        # genesis_epoch == previous_epoch < slot_to_epoch(slot) == next_epoch
+        (100, 4, 9, 4, 2, 3, True, False, 0, 1, 2),
+        # genesis_epoch == previous_epoch < slot_to_epoch(slot) == next_epoch, need_reseed
+        # epochs_since_last_registry_update > 1 and is_power_of_two(epochs_since_last_registry_update)  # noqa: E501
+        (100, 8, 13, 4, 2, 3, False, True, 1, 2, 3),
     ],
 )
 def test_get_crosslink_committees_at_slot(
+        monkeypatch,
         n_validators_state,
         current_slot,
         slot,
@@ -287,22 +305,101 @@ def test_get_crosslink_committees_at_slot(
         target_committee_size,
         shard_count,
         genesis_epoch,
-        committee_config):
+        committee_config,
+        registry_change,
+        should_reseed,
+        previous_calculation_epoch,
+        current_calculation_epoch,
+        shuffling_epoch):
+    # Mock generate_seed
+    new_seed = b'\x88' * 32
+
+    def mock_generate_seed(state,
+                           epoch,
+                           epoch_length,
+                           seed_lookahead,
+                           entry_exit_delay,
+                           latest_index_roots_length,
+                           latest_randao_mixes_length):
+        return new_seed
+
+    monkeypatch.setattr(
+        'eth2.beacon.helpers.generate_seed',
+        mock_generate_seed
+    )
 
     state = n_validators_state.copy(
         slot=current_slot,
+        previous_calculation_epoch=previous_calculation_epoch,
+        current_calculation_epoch=current_calculation_epoch,
+        previous_epoch_seed=b'\x11' * 32,
+        current_epoch_seed=b'\x22' * 32,
     )
 
     crosslink_committees_at_slot = get_crosslink_committees_at_slot(
         state=state,
         slot=slot,
         committee_config=committee_config,
+        registry_change=registry_change,
     )
     assert len(crosslink_committees_at_slot) > 0
     for crosslink_committee in crosslink_committees_at_slot:
         committee, shard = crosslink_committee
         assert len(committee) > 0
         assert shard < shard_count
+
+    #
+    # Check shuffling_start_shard
+    #
+    offset = slot % epoch_length
+
+    result_slot_start_shard = crosslink_committees_at_slot[0][1]
+    current_committees_per_epoch = get_current_epoch_committee_count(
+        state=state,
+        shard_count=shard_count,
+        epoch_length=epoch_length,
+        target_committee_size=target_committee_size,
+    )
+    committees_per_slot = current_committees_per_epoch // epoch_length
+
+    if registry_change:
+        shuffling_start_shard = (
+            state.current_epoch_start_shard + current_committees_per_epoch
+        ) % shard_count
+    else:
+        shuffling_start_shard = state.current_epoch_start_shard
+        assert result_slot_start_shard == (
+            shuffling_start_shard +
+            committees_per_slot * offset
+        ) % shard_count
+
+    #
+    # Check seed
+    #
+    epoch = slot_to_epoch(slot, epoch_length)
+    current_epoch = state.current_epoch(epoch_length)
+    previous_epoch = state.previous_epoch(epoch_length, genesis_epoch)
+    next_epoch = current_epoch + 1
+
+    if epoch == previous_epoch:
+        seed = state.previous_epoch_seed
+    elif epoch == current_epoch:
+        seed = state.current_epoch_seed
+    elif epoch == next_epoch:
+        if registry_change or should_reseed:
+            seed = new_seed
+        else:
+            seed = state.current_epoch_seed
+
+    shuffling = get_shuffling(
+        seed=seed,
+        validators=state.validator_registry,
+        epoch=shuffling_epoch,
+        epoch_length=epoch_length,
+        target_committee_size=target_committee_size,
+        shard_count=shard_count,
+    )
+    assert shuffling[committees_per_slot * offset] == crosslink_committees_at_slot[0][0]
 
 
 @pytest.mark.parametrize(

--- a/tests/eth2/beacon/test_epoch_processing_helpers.py
+++ b/tests/eth2/beacon/test_epoch_processing_helpers.py
@@ -55,7 +55,7 @@ def test_get_attesting_validator_indices(
         target_committee_size,
         shard_count,
         genesis_epoch,
-        epoch_length,
+        committee_config,
         sample_state,
         sample_attestation_data_params,
         sample_attestation_params):
@@ -66,10 +66,7 @@ def test_get_attesting_validator_indices(
 
     def mock_get_crosslink_committees_at_slot(state,
                                               slot,
-                                              genesis_epoch,
-                                              epoch_length,
-                                              target_committee_size,
-                                              shard_count):
+                                              committee_config):
         return (
             (committee, shard,),
         )
@@ -134,10 +131,7 @@ def test_get_attesting_validator_indices(
         attestations=attestations,
         shard=shard,
         shard_block_root=shard_block_root_1,
-        genesis_epoch=genesis_epoch,
-        epoch_length=epoch_length,
-        target_committee_size=target_committee_size,
-        shard_count=shard_count,
+        committee_config=committee_config,
     )
     # Check that result is the union of two participants set
     # `attestation_participants_1` and `attestation_participants_2`
@@ -151,10 +145,7 @@ def test_get_attesting_validator_indices(
         attestations=attestations,
         shard=shard,
         shard_block_root=shard_block_root_2,
-        genesis_epoch=genesis_epoch,
-        epoch_length=epoch_length,
-        target_committee_size=target_committee_size,
-        shard_count=shard_count,
+        committee_config=committee_config,
     )
     # Check that result is the `not_attestation_participants_1` set
     assert set(shard_block_root_2_attesting_validator) == set(not_attestation_participants_1)
@@ -246,6 +237,7 @@ def test_get_winning_root(
         block_root_1_participants,
         block_root_2_participants,
         config,
+        committee_config,
         n_validators_state,
         sample_attestation_data_params,
         sample_attestation_params):
@@ -256,10 +248,7 @@ def test_get_winning_root(
 
     def mock_get_crosslink_committees_at_slot(state,
                                               slot,
-                                              genesis_epoch,
-                                              epoch_length,
-                                              target_committee_size,
-                                              shard_count):
+                                              committee_config):
         return (
             (committee, shard,),
         )
@@ -308,21 +297,15 @@ def test_get_winning_root(
             state=n_validators_state,
             shard=shard,
             attestations=attestations,
-            genesis_epoch=config.GENESIS_EPOCH,
-            epoch_length=config.EPOCH_LENGTH,
             max_deposit_amount=config.MAX_DEPOSIT_AMOUNT,
-            target_committee_size=config.TARGET_COMMITTEE_SIZE,
-            shard_count=config.SHARD_COUNT,
+            committee_config=committee_config,
         )
         attesting_validators_indices = get_attesting_validator_indices(
             state=n_validators_state,
             attestations=attestations,
             shard=shard,
             shard_block_root=winning_root,
-            genesis_epoch=config.GENESIS_EPOCH,
-            epoch_length=config.EPOCH_LENGTH,
-            target_committee_size=config.TARGET_COMMITTEE_SIZE,
-            shard_count=config.SHARD_COUNT,
+            committee_config=committee_config,
         )
         total_attesting_balance = sum(
             get_effective_balance(

--- a/tests/eth2/beacon/test_validator_status_helpers.py
+++ b/tests/eth2/beacon/test_validator_status_helpers.py
@@ -181,19 +181,13 @@ def test_settle_penality_to_validator_and_whistleblower(monkeypatch,
                                                         n_validators_state,
                                                         latest_penalized_exit_length,
                                                         whistleblower_reward_quotient,
-                                                        genesis_epoch,
-                                                        epoch_length,
                                                         max_deposit_amount,
-                                                        target_committee_size,
-                                                        shard_count):
+                                                        committee_config):
     from eth2.beacon import committee_helpers
 
     def mock_get_crosslink_committees_at_slot(state,
                                               slot,
-                                              genesis_epoch,
-                                              epoch_length,
-                                              target_committee_size,
-                                              shard_count):
+                                              committee_config):
         return (
             (committee, 1,),
         )
@@ -209,10 +203,7 @@ def test_settle_penality_to_validator_and_whistleblower(monkeypatch,
     whistleblower_index = get_beacon_proposer_index(
         state,
         state.slot,
-        genesis_epoch,
-        epoch_length,
-        target_committee_size,
-        shard_count,
+        committee_config,
     )
     effective_balance = max_deposit_amount
 
@@ -228,16 +219,15 @@ def test_settle_penality_to_validator_and_whistleblower(monkeypatch,
         validator_index=validator_index,
         latest_penalized_exit_length=latest_penalized_exit_length,
         whistleblower_reward_quotient=whistleblower_reward_quotient,
-        genesis_epoch=genesis_epoch,
-        epoch_length=epoch_length,
         max_deposit_amount=max_deposit_amount,
-        target_committee_size=target_committee_size,
-        shard_count=shard_count,
+        committee_config=committee_config,
     )
 
     # Check `state.latest_penalized_balances`
     latest_penalized_balances_list = list(state.latest_penalized_balances)
-    last_penalized_epoch = state.current_epoch(epoch_length) % latest_penalized_exit_length
+    last_penalized_epoch = (
+        state.current_epoch(committee_config.epoch_length) % latest_penalized_exit_length
+    )
     latest_penalized_balances_list[last_penalized_epoch] = max_deposit_amount
     latest_penalized_balances = tuple(latest_penalized_balances_list)
 
@@ -273,15 +263,13 @@ def test_penalize_validator(monkeypatch,
                             entry_exit_delay,
                             max_deposit_amount,
                             target_committee_size,
-                            shard_count):
+                            shard_count,
+                            committee_config):
     from eth2.beacon import committee_helpers
 
     def mock_get_crosslink_committees_at_slot(state,
                                               slot,
-                                              genesis_epoch,
-                                              epoch_length,
-                                              target_committee_size,
-                                              shard_count):
+                                              committee_config):
         return (
             (committee, 1,),
         )
@@ -298,14 +286,10 @@ def test_penalize_validator(monkeypatch,
     result_state = penalize_validator(
         state=state,
         index=index,
-        genesis_epoch=genesis_epoch,
-        epoch_length=epoch_length,
         latest_penalized_exit_length=latest_penalized_exit_length,
         whistleblower_reward_quotient=whistleblower_reward_quotient,
-        entry_exit_delay=entry_exit_delay,
         max_deposit_amount=max_deposit_amount,
-        target_committee_size=target_committee_size,
-        shard_count=shard_count,
+        committee_config=committee_config,
     )
 
     # Just check if `prepare_validator_for_withdrawal` applied these two functions
@@ -315,11 +299,8 @@ def test_penalize_validator(monkeypatch,
         validator_index=index,
         latest_penalized_exit_length=latest_penalized_exit_length,
         whistleblower_reward_quotient=whistleblower_reward_quotient,
-        genesis_epoch=genesis_epoch,
-        epoch_length=epoch_length,
         max_deposit_amount=max_deposit_amount,
-        target_committee_size=target_committee_size,
-        shard_count=shard_count,
+        committee_config=committee_config,
     )
 
     assert result_state == expected_state

--- a/tests/eth2/beacon/test_validator_status_helpers.py
+++ b/tests/eth2/beacon/test_validator_status_helpers.py
@@ -226,7 +226,7 @@ def test_settle_penality_to_validator_and_whistleblower(monkeypatch,
     # Check `state.latest_penalized_balances`
     latest_penalized_balances_list = list(state.latest_penalized_balances)
     last_penalized_epoch = (
-        state.current_epoch(committee_config.epoch_length) % latest_penalized_exit_length
+        state.current_epoch(committee_config.EPOCH_LENGTH) % latest_penalized_exit_length
     )
     latest_penalized_balances_list[last_penalized_epoch] = max_deposit_amount
     latest_penalized_balances = tuple(latest_penalized_balances_list)

--- a/tests/eth2/beacon/tools/builder/test_builder_validator.py
+++ b/tests/eth2/beacon/tools/builder/test_builder_validator.py
@@ -12,6 +12,7 @@ from eth2._utils.bitfield import (
 )
 from eth2.beacon.tools.builder.validator import (
     aggregate_votes,
+    get_next_epoch_committee_assignments,
     verify_votes,
 )
 
@@ -71,3 +72,33 @@ def test_aggregate_votes(votes_count, random, privkeys, pubkeys):
 
     aggregated_pubs = bls.aggregate_pubkeys(pubs)
     assert bls.verify(message, aggregated_pubs, sigs, domain)
+
+
+@pytest.mark.parametrize(
+    (
+        'num_validators,'
+        'epoch_length,'
+        'target_committee_size,'
+        'shard_count,'
+    ),
+    [
+        (40, 16, 1, 2),
+    ]
+)
+def test_get_next_epoch_committee_assignments(genesis_state, epoch_length, config, num_validators):
+    state = genesis_state
+    print('')
+    for validator_index in range(num_validators):
+        print('#######')
+        print(f'validator_index={validator_index}')
+        result = get_next_epoch_committee_assignments(state, config, validator_index)
+
+        for epoch in result:
+            committee = epoch[0]
+            shard = epoch[1]
+            slot = epoch[2]
+            is_proposer = epoch[3]
+
+            print(
+                f"   committee={committee}, shard={shard}, slot={slot}, is_proposer={is_proposer}"
+            )

--- a/tests/eth2/beacon/tools/builder/test_builder_validator.py
+++ b/tests/eth2/beacon/tools/builder/test_builder_validator.py
@@ -87,16 +87,19 @@ def test_aggregate_votes(votes_count, random, privkeys, pubkeys):
         'epoch_length,'
         'target_committee_size,'
         'shard_count,'
+        'registry_change,'
     ),
     [
-        (40, 16, 1, 2),
+        (40, 16, 1, 2, True),
+        (40, 16, 1, 2, False),
     ]
 )
 def test_get_next_epoch_committee_assignment(genesis_state,
                                              epoch_length,
                                              shard_count,
                                              config,
-                                             num_validators):
+                                             num_validators,
+                                             registry_change):
     state = genesis_state
     proposer_count = 0
     shard_validator_count = [
@@ -107,7 +110,12 @@ def test_get_next_epoch_committee_assignment(genesis_state,
     next_epoch_start = get_epoch_start_slot(state.current_epoch(epoch_length) + 1, epoch_length)
 
     for validator_index in range(num_validators):
-        assignment = get_next_epoch_committee_assignment(state, config, validator_index)
+        assignment = get_next_epoch_committee_assignment(
+            state,
+            config,
+            validator_index,
+            registry_change,
+        )
         assert assignment.slot >= next_epoch_start
         assert assignment.slot < next_epoch_start + epoch_length
         if assignment.is_proposer:
@@ -144,4 +152,4 @@ def test_get_next_epoch_committee_assignment_no_assignment(genesis_state,
     )
 
     with pytest.raises(NoCommitteeAssignment):
-        get_next_epoch_committee_assignment(state, config, validator_index)
+        get_next_epoch_committee_assignment(state, config, validator_index, True)

--- a/tests/eth2/beacon/tools/builder/test_builder_validator.py
+++ b/tests/eth2/beacon/tools/builder/test_builder_validator.py
@@ -12,7 +12,7 @@ from eth2._utils.bitfield import (
 )
 from eth2.beacon.tools.builder.validator import (
     aggregate_votes,
-    get_next_epoch_committee_assignments,
+    get_next_epoch_committee_assignment,
     verify_votes,
 )
 
@@ -85,20 +85,16 @@ def test_aggregate_votes(votes_count, random, privkeys, pubkeys):
         (40, 16, 1, 2),
     ]
 )
-def test_get_next_epoch_committee_assignments(genesis_state, epoch_length, config, num_validators):
+def test_get_next_epoch_committee_assignment(genesis_state, epoch_length, config, num_validators):
     state = genesis_state
-    print('')
+    proposer_count = 0
     for validator_index in range(num_validators):
-        print('#######')
-        print(f'validator_index={validator_index}')
-        result = get_next_epoch_committee_assignments(state, config, validator_index)
-
-        for epoch in result:
-            committee = epoch[0]
-            shard = epoch[1]
-            slot = epoch[2]
-            is_proposer = epoch[3]
-
+        assignment = get_next_epoch_committee_assignment(state, config, validator_index)
+        if assignment is not None:
+            committee, shard, slot, is_proposer = assignment
             print(
                 f"   committee={committee}, shard={shard}, slot={slot}, is_proposer={is_proposer}"
             )
+        if is_proposer:
+            proposer_count += 1
+    assert proposer_count == epoch_length

--- a/tests/eth2/beacon/tools/builder/test_builder_validator.py
+++ b/tests/eth2/beacon/tools/builder/test_builder_validator.py
@@ -11,7 +11,7 @@ from eth2._utils.bitfield import (
     has_voted,
 )
 from eth2.beacon.exceptions import (
-    NoValidatorAssignment,
+    NoCommitteeAssignment,
 )
 from eth2.beacon.helpers import (
     get_epoch_start_slot,
@@ -108,16 +108,13 @@ def test_get_next_epoch_committee_assignment(genesis_state,
 
     for validator_index in range(num_validators):
         assignment = get_next_epoch_committee_assignment(state, config, validator_index)
-        assert len(assignment) == 4
-        committee, shard, slot, is_proposer = assignment
-        assert len(committee) > 0
-        assert slot >= next_epoch_start
-        assert slot < next_epoch_start + epoch_length
-        if is_proposer:
+        assert assignment.slot >= next_epoch_start
+        assert assignment.slot < next_epoch_start + epoch_length
+        if assignment.is_proposer:
             proposer_count += 1
 
-        shard_validator_count[shard] += 1
-        slots.append(slot)
+        shard_validator_count[assignment.shard] += 1
+        slots.append(assignment.slot)
 
     assert proposer_count == epoch_length
     assert sum(shard_validator_count) == num_validators
@@ -146,5 +143,5 @@ def test_get_next_epoch_committee_assignment_no_assignment(genesis_state,
         )
     )
 
-    with pytest.raises(NoValidatorAssignment):
+    with pytest.raises(NoCommitteeAssignment):
         get_next_epoch_committee_assignment(state, config, validator_index)


### PR DESCRIPTION
### What was wrong?
1. Refactor: clean up constants arguments by adding `CommitteeConfig`
2. Fix #258

### How was it fixed?

#### 1. Refactor: clean up constants arguments by adding `CommitteeConfig`
Sorry for that this PR became more about refactoring than just add a new feature.
When I tried to implement #258, I have to revamp `get_crosslink_committees_at_slot` helper; and with this new feature, I have to pass **four more constants into `get_crosslink_committees_at_slot` and all the function that calls it**.
That's a stronger signal of that some 💩 code here that we need to fix... 
Per https://github.com/ethereum/trinity/issues/146#issuecomment-460908609, I mentioned passing the shuffling-required constants into `ShufflingConfig`, but after some recent changes, it looks better to have a subset of `BeaconConfig` - `CommitteeConfig` to mitigate it.

```python
class CommitteeConfig:
    def __init__(self, config: BeaconConfig):
        # Basic
        self.genesis_epoch = config.GENESIS_EPOCH
        self.shard_count = config.SHARD_COUNT
        self.epoch_length = config.EPOCH_LENGTH
        self.target_committee_size = config.TARGET_COMMITTEE_SIZE

        # For seed
        self.seed_lookahead = config.SEED_LOOKAHEAD
        self.entry_exit_delay = config.ENTRY_EXIT_DELAY
        self.latest_index_roots_length = config.LATEST_INDEX_ROOTS_LENGTH
        self.latest_randao_mixes_length = config.LATEST_INDEX_ROOTS_LENGTH
```

1. It's initialized with `BeaconConfig` in `StateMachine` layer.
2. Also, `BeaconConfig` has been moved from `eth2/beacon/state_machines/configs.py` → `eth2/beacon/configs.py`.
3. Pros: less ugly arguments passing.
4. Cons: lose some awareness of what are the configuration parameters we are testing. 

While this PR is WIP, @pipermerriam @jannikluhn @ralexstokes @djrtwo , any thoughts on this refactoring?

#### 2. Shuffling lookahead

- Update `get_crosslink_committees_at_slot` for shuffling lookahead function `get_next_epoch_committee_assignment ` for the validator to check if they are assigned in the incoming epoch and the context they need.
- Use case: https://github.com/ethereum/eth2.0-specs/blob/dev/specs/validator/0_beacon-chain-validator.md#responsibility-lookahead
- `get_next_epoch_committee_assignment` returns `NoCommitteeAssignment` when no assignment for the given `validator_index`.

#### Cute Animal Picture

![aquarium-ocean-fish-jumping-dolphin-animal-water-906176](https://user-images.githubusercontent.com/9263930/52721198-20bfcb00-2fe4-11e9-82e8-8080a756898e.jpg)
