### PR TITLE
Update generate seed

### DIFF
--- a/eth2/beacon/committee_helpers.py
+++ b/eth2/beacon/committee_helpers.py
@@ -16,9 +16,6 @@ from eth_typing import (
 from eth2._utils.bitfield import (
     has_voted,
 )
-from eth2._utils.numeric import (
-    bitwise_xor,
-)
 from eth2.beacon._utils.random import (
     shuffle,
     split,
@@ -88,7 +85,6 @@ def get_shuffling(*,
     )
 
     # Shuffle
-    seed = bitwise_xor(seed, Hash32(epoch.to_bytes(32, byteorder="big")))
     shuffled_active_validator_indices = shuffle(active_validator_indices, seed)
 
     # Split the shuffled list into committees_per_epoch pieces

--- a/eth2/beacon/helpers.py
+++ b/eth2/beacon/helpers.py
@@ -150,8 +150,9 @@ def generate_seed(state: 'BeaconState',
         entry_exit_delay=entry_exit_delay,
         latest_index_roots_length=latest_index_roots_length,
     )
+    epoch_as_bytes = epoch.to_bytes(32, byteorder="little")
 
-    return hash_eth2(randao_mix + active_index_root)
+    return hash_eth2(randao_mix + active_index_root + epoch_as_bytes)
 
 
 def get_active_index_root(state: 'BeaconState',

--- a/tests/eth2/beacon/test_helpers.py
+++ b/tests/eth2/beacon/test_helpers.py
@@ -738,6 +738,8 @@ def test_generate_seed(monkeypatch,
     state = genesis_state
     epoch = 1
 
+    epoch_as_bytes = epoch.to_bytes(32, 'little')
+
     seed = generate_seed(
         state=state,
         epoch=epoch,
@@ -759,5 +761,5 @@ def test_generate_seed(monkeypatch,
             epoch_length=epoch_length,
             entry_exit_delay=entry_exit_delay,
             latest_index_roots_length=latest_index_roots_length,
-        )
+        ) + epoch_as_bytes
     )

--- a/tests/eth2/beacon/test_helpers.py
+++ b/tests/eth2/beacon/test_helpers.py
@@ -708,7 +708,7 @@ def test_generate_seed(monkeypatch,
                             latest_randao_mixes_length):
         return hash_eth2(
             state.root +
-            abs(epoch).to_bytes(32, byteorder='little') +
+            epoch.to_bytes(32, byteorder='little') +
             latest_randao_mixes_length.to_bytes(32, byteorder='little')
         )
 
@@ -719,7 +719,7 @@ def test_generate_seed(monkeypatch,
                                    latest_index_roots_length):
         return hash_eth2(
             state.root +
-            abs(epoch).to_bytes(32, byteorder='little') +
+            epoch.to_bytes(32, byteorder='little') +
             epoch_length.to_bytes(32, byteorder='little') +
             latest_index_roots_length.to_bytes(32, byteorder='little')
         )

--- a/tests/eth2/beacon/test_helpers.py
+++ b/tests/eth2/beacon/test_helpers.py
@@ -708,8 +708,8 @@ def test_generate_seed(monkeypatch,
                             latest_randao_mixes_length):
         return hash_eth2(
             state.root +
-            abs(epoch).to_bytes(32, byteorder='big') +
-            latest_randao_mixes_length.to_bytes(32, byteorder='big')
+            abs(epoch).to_bytes(32, byteorder='little') +
+            latest_randao_mixes_length.to_bytes(32, byteorder='little')
         )
 
     def mock_get_active_index_root(state,
@@ -719,9 +719,9 @@ def test_generate_seed(monkeypatch,
                                    latest_index_roots_length):
         return hash_eth2(
             state.root +
-            abs(epoch).to_bytes(32, byteorder='big') +
-            epoch_length.to_bytes(32, byteorder='big') +
-            latest_index_roots_length.to_bytes(32, byteorder='big')
+            abs(epoch).to_bytes(32, byteorder='little') +
+            epoch_length.to_bytes(32, byteorder='little') +
+            latest_index_roots_length.to_bytes(32, byteorder='little')
         )
 
     monkeypatch.setattr(


### PR DESCRIPTION
### What was wrong?

Fixes #257.

### How was it fixed?

Moved the mixing of the epoch into the seed at `generate_seed` helper, instead of inside the shuffling function, following the spec update.

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://cdn.shopify.com/s/files/1/0522/3629/products/cute-koala-sleeping_2048x.JPG?v=1493829620)
