### PR TITLE
Speed up power of 2 check

### DIFF
--- a/eth2/_utils/numeric.py
+++ b/eth2/_utils/numeric.py
@@ -1,5 +1,3 @@
-import math
-
 from eth_typing import (
     Hash32,
 )
@@ -21,4 +19,4 @@ def is_power_of_two(value: int) -> bool:
     if value == 0:
         return False
     else:
-        return 2**int(math.log2(value)) == value
+        return bool(value and not (value & (value - 1)))

--- a/tests/eth2/numeric-utils/test_power.py
+++ b/tests/eth2/numeric-utils/test_power.py
@@ -1,3 +1,5 @@
+import math
+
 from hypothesis import (
     given,
     strategies as st,
@@ -22,7 +24,19 @@ def slow_is_power_of_two(value):
     return num == value
 
 
+def fast_is_power_of_two(value: int) -> bool:
+    """
+    Check if ``value`` is a power of two integer.
+    """
+    if value == 0:
+        return False
+    else:
+        return 2**int(math.log2(value)) == value
+
+
 @given(st.integers(0, 2**256))
 def test_is_power_of_two(value):
-    expected = slow_is_power_of_two(value)
-    assert expected == is_power_of_two(value)
+    slow_expected = slow_is_power_of_two(value)
+    fast_expected = fast_is_power_of_two(value)
+    assert slow_expected == fast_expected
+    assert fast_expected == is_power_of_two(value)


### PR DESCRIPTION
### What was wrong?

Stumbled across a faster way to check if something is a power of two.

### How was it fixed?

Implemented the solution from this SO question.

https://stackoverflow.com/questions/29480680/finding-if-a-number-is-a-power-of-2-using-recursion

Quick profiling shows it is roughly 3x faster.

```
FN: is_power_of_two       PER_SEC: 4176094
FN: slow_is_power_of_two  PER_SEC: 79828
FN: fast_is_power_of_two  PER_SEC: 1359661
```

#### Cute Animal Picture

![golden-retriever-friends-with-hamster-and-birds-16](https://user-images.githubusercontent.com/824194/52745707-f4cd2700-2f9c-11e9-9bf4-7c51c9b63432.jpg)

