### PR TITLE
Implement `process_proposer_slashings`

### DIFF
--- a/eth2/beacon/configs.py
+++ b/eth2/beacon/configs.py
@@ -48,7 +48,7 @@ BeaconConfig = NamedTuple(
         ('SEED_LOOKAHEAD', int),
         ('ENTRY_EXIT_DELAY', int),
         ('ETH1_DATA_VOTING_PERIOD', int),
-        ('MIN_VALIDATOR_WITHDRAWAL_TIME', int),
+        ('MIN_VALIDATOR_WITHDRAWABILITY_DELAY', int),
         # Reward and penalty quotients
         ('BASE_REWARD_QUOTIENT', int),
         ('WHISTLEBLOWER_REWARD_QUOTIENT', int),

--- a/eth2/beacon/state_machines/forks/serenity/block_validation.py
+++ b/eth2/beacon/state_machines/forks/serenity/block_validation.py
@@ -182,8 +182,8 @@ def validate_proposer_slashing_block_root(proposer_slashing: ProposerSlashing) -
         raise ValidationError(
             "proposer_slashing.proposal_data_1.block_root "
             f"({proposer_slashing.proposal_data_1.block_root}) "
-            " should not equal to proposer_slashing.proposal_data_2.block_root"
-            f" ({proposer_slashing.proposal_data_2.block_root})"
+            "should not be equal to proposer_slashing.proposal_data_2.block_root "
+            f"({proposer_slashing.proposal_data_2.block_root})"
         )
 
 
@@ -192,7 +192,7 @@ def validate_proposer_slashing_slashed_epoch(proposer_slashed_epoch: EpochNumber
     if proposer_slashed_epoch <= state_current_epoch:
         raise ValidationError(
             f"proposer.slashed_epoch ({proposer_slashed_epoch}) "
-            f" should be greater than current epoch ({state_current_epoch})"
+            f"should be greater than current epoch ({state_current_epoch})"
         )
 
 
@@ -213,10 +213,9 @@ def validate_proposal_signature(proposal_signed_data: ProposalSignedData,
     )
     if not proposal_signature_is_valid:
         raise ValidationError(
-            "Proposal signature is invalid:"
-            f"\tProposer pubkey: {pubkey}"
-            f"\tMessage: {proposal_signed_data.root}"
-            f"\tSignature: {proposal_signature}"
+            "Proposal signature is invalid: "
+            f"proposer pubkey: {pubkey}, message: {proposal_signed_data.root}, "
+            f"signature: {proposal_signature}"
         )
 
 

--- a/eth2/beacon/state_machines/forks/serenity/block_validation.py
+++ b/eth2/beacon/state_machines/forks/serenity/block_validation.py
@@ -143,17 +143,21 @@ def validate_proposer_slashing(state: BeaconState,
         state.current_epoch(epoch_length),
     )
 
-    validate_signature(proposal_signed_data=proposer_slashing.proposal_data_1,
-                       proposal_signature=proposer_slashing.proposal_signature_1,
-                       pubkey=proposer.pubkey,
-                       fork=state.fork,
-                       epoch_length=epoch_length)
+    validate_proposal_signature(
+        proposal_signed_data=proposer_slashing.proposal_data_1,
+        proposal_signature=proposer_slashing.proposal_signature_1,
+        pubkey=proposer.pubkey,
+        fork=state.fork,
+        epoch_length=epoch_length,
+    )
 
-    validate_signature(proposal_signed_data=proposer_slashing.proposal_data_2,
-                       proposal_signature=proposer_slashing.proposal_signature_2,
-                       pubkey=proposer.pubkey,
-                       fork=state.fork,
-                       epoch_length=epoch_length)
+    validate_proposal_signature(
+        proposal_signed_data=proposer_slashing.proposal_data_2,
+        proposal_signature=proposer_slashing.proposal_signature_2,
+        pubkey=proposer.pubkey,
+        fork=state.fork,
+        epoch_length=epoch_length,
+    )
 
 
 def validate_proposer_slashing_slot(proposer_slashing: ProposerSlashing) -> None:
@@ -192,11 +196,11 @@ def validate_proposer_slashing_slashed_epoch(proposer_slashed_epoch: EpochNumber
         )
 
 
-def validate_signature(proposal_signed_data: ProposalSignedData,
-                       proposal_signature: BLSSignature,
-                       pubkey: BLSPubkey,
-                       fork: Fork,
-                       epoch_length: int) -> None:
+def validate_proposal_signature(proposal_signed_data: ProposalSignedData,
+                                proposal_signature: BLSSignature,
+                                pubkey: BLSPubkey,
+                                fork: Fork,
+                                epoch_length: int) -> None:
     proposal_signature_is_valid = bls.verify(
         pubkey=pubkey,
         message=proposal_signed_data.root,  # TODO: use hash_tree_root

--- a/eth2/beacon/state_machines/forks/serenity/block_validation.py
+++ b/eth2/beacon/state_machines/forks/serenity/block_validation.py
@@ -39,14 +39,15 @@ from eth2.beacon.helpers import (
     get_domain,
     slot_to_epoch,
 )
-from eth2.beacon.types.attestation_data_and_custody_bits import AttestationDataAndCustodyBit
-from eth2.beacon.types.blocks import BaseBeaconBlock  # noqa: F401
-from eth2.beacon.types.forks import Fork
-from eth2.beacon.types.states import BeaconState  # noqa: F401
 from eth2.beacon.types.attestations import Attestation  # noqa: F401
 from eth2.beacon.types.attestation_data import AttestationData  # noqa: F401
+from eth2.beacon.types.attestation_data_and_custody_bits import AttestationDataAndCustodyBit
+from eth2.beacon.types.blocks import BaseBeaconBlock  # noqa: F401
+from eth2.beacon.types.forks import Fork  # noqa: F401
 from eth2.beacon.types.proposal_signed_data import ProposalSignedData
 from eth2.beacon.types.slashable_attestations import SlashableAttestation  # noqa: F401
+from eth2.beacon.types.proposer_slashings import ProposerSlashing
+from eth2.beacon.types.states import BeaconState  # noqa: F401
 from eth2.beacon.typing import (
     Bitfield,
     BLSPubkey,
@@ -116,6 +117,102 @@ def validate_proposer_signature(state: BeaconState,
             f"Invalid Proposer Signature on block, beacon_proposer_index={beacon_proposer_index}, "
             f"pubkey={proposer_pubkey}, message={proposal_root},"
             f"block.signature={block.signature}, domain={domain}"
+        )
+
+
+#
+# Proposer slashing validation
+#
+def validate_proposer_slashing(state: BeaconState,
+                               proposer_slashing: ProposerSlashing,
+                               epoch_length: int) -> None:
+    """
+    Validate the given ``proposer_slashing``.
+    Raise ``ValidationError`` if it's invalid.
+    """
+    proposer = state.validator_registry[proposer_slashing.proposer_index]
+
+    validate_proposer_slashing_slot(proposer_slashing)
+
+    validate_proposer_slashing_shard(proposer_slashing)
+
+    validate_proposer_slashing_block_root(proposer_slashing)
+
+    validate_proposer_slashing_slashed_epoch(
+        proposer.slashed_epoch,
+        state.current_epoch(epoch_length),
+    )
+
+    validate_signature(proposal_signed_data=proposer_slashing.proposal_data_1,
+                       proposal_signature=proposer_slashing.proposal_signature_1,
+                       pubkey=proposer.pubkey,
+                       fork=state.fork,
+                       epoch_length=epoch_length)
+
+    validate_signature(proposal_signed_data=proposer_slashing.proposal_data_2,
+                       proposal_signature=proposer_slashing.proposal_signature_2,
+                       pubkey=proposer.pubkey,
+                       fork=state.fork,
+                       epoch_length=epoch_length)
+
+
+def validate_proposer_slashing_slot(proposer_slashing: ProposerSlashing) -> None:
+    if proposer_slashing.proposal_data_1.slot != proposer_slashing.proposal_data_2.slot:
+        raise ValidationError(
+            f"proposer_slashing.proposal_data_1.slot ({proposer_slashing.proposal_data_1.slot}) !="
+            f" proposer_slashing.proposal_data_2.slot ({proposer_slashing.proposal_data_2.slot})"
+        )
+
+
+def validate_proposer_slashing_shard(proposer_slashing: ProposerSlashing) -> None:
+    if proposer_slashing.proposal_data_1.shard != proposer_slashing.proposal_data_2.shard:
+        raise ValidationError(
+            f"proposer_slashing.proposal_data_1.shard ({proposer_slashing.proposal_data_1.shard}) "
+            f"!= proposer_slashing.proposal_data_2.shard"
+            f" ({proposer_slashing.proposal_data_2.shard})"
+        )
+
+
+def validate_proposer_slashing_block_root(proposer_slashing: ProposerSlashing) -> None:
+    if proposer_slashing.proposal_data_1.block_root == proposer_slashing.proposal_data_2.block_root:
+        raise ValidationError(
+            "proposer_slashing.proposal_data_1.block_root "
+            f"({proposer_slashing.proposal_data_1.block_root}) "
+            " should not equal to proposer_slashing.proposal_data_2.block_root"
+            f" ({proposer_slashing.proposal_data_2.block_root})"
+        )
+
+
+def validate_proposer_slashing_slashed_epoch(proposer_slashed_epoch: EpochNumber,
+                                             state_current_epoch: EpochNumber) -> None:
+    if proposer_slashed_epoch <= state_current_epoch:
+        raise ValidationError(
+            f"proposer.slashed_epoch ({proposer_slashed_epoch}) "
+            f" should be greater than current epoch ({state_current_epoch})"
+        )
+
+
+def validate_signature(proposal_signed_data: ProposalSignedData,
+                       proposal_signature: BLSSignature,
+                       pubkey: BLSPubkey,
+                       fork: Fork,
+                       epoch_length: int) -> None:
+    proposal_signature_is_valid = bls.verify(
+        pubkey=pubkey,
+        message=proposal_signed_data.root,  # TODO: use hash_tree_root
+        signature=proposal_signature,
+        domain=get_domain(
+            fork,
+            slot_to_epoch(proposal_signed_data.slot, epoch_length),
+            SignatureDomain.DOMAIN_PROPOSAL,
+        )
+    )
+    if not proposal_signature_is_valid:
+        raise ValidationError(
+            "Proposal signature is invalid:"
+            f"\tProposer pubkey: {pubkey}"
+            f"\tMessage: {proposal_signed_data.root}"
+            f"\tSignature: {proposal_signature}"
         )
 
 

--- a/eth2/beacon/state_machines/forks/serenity/configs.py
+++ b/eth2/beacon/state_machines/forks/serenity/configs.py
@@ -45,7 +45,7 @@ SERENITY_CONFIG = BeaconConfig(
     SEED_LOOKAHEAD=2**0,  # (= 1) epochs
     ENTRY_EXIT_DELAY=2**2,  # (= 4) epochs
     ETH1_DATA_VOTING_PERIOD=2**4,  # (= 16) epochs
-    MIN_VALIDATOR_WITHDRAWAL_TIME=2**8,  # (= 256) epochs
+    MIN_VALIDATOR_WITHDRAWABILITY_DELAY=2**8,  # (= 256) epochs
     # Reward and penalty quotients
     BASE_REWARD_QUOTIENT=2**10,  # (= 1,024)
     WHISTLEBLOWER_REWARD_QUOTIENT=2**9,  # (= 512)

--- a/eth2/beacon/state_machines/forks/serenity/operation_processing.py
+++ b/eth2/beacon/state_machines/forks/serenity/operation_processing.py
@@ -7,10 +7,39 @@ from eth2.beacon.configs import (
 from eth2.beacon.types.blocks import BaseBeaconBlock
 from eth2.beacon.types.pending_attestation_records import PendingAttestationRecord
 from eth2.beacon.types.states import BeaconState
+from eth2.beacon.validator_status_helpers import (
+    slash_validator,
+)
 
 from .block_validation import (
     validate_attestation,
+    validate_proposer_slashing,
 )
+
+
+def process_proposer_slashings(state: BeaconState,
+                               block: BaseBeaconBlock,
+                               config: BeaconConfig) -> BeaconState:
+    if len(block.body.proposer_slashings) > config.MAX_PROPOSER_SLASHINGS:
+        raise ValidationError(
+            f"The block ({block}) has too many proposer slashings:\n"
+            f"\tFound {len(block.body.proposer_slashings)} proposer slashings, "
+            f"maximum: {config.MAX_PROPOSER_SLASHINGS}"
+        )
+
+    for proposer_slashing in block.body.proposer_slashings:
+        validate_proposer_slashing(state, proposer_slashing, config.EPOCH_LENGTH)
+
+        state = slash_validator(
+            state=state,
+            index=proposer_slashing.proposer_index,
+            latest_penalized_exit_length=config.LATEST_PENALIZED_EXIT_LENGTH,
+            whistleblower_reward_quotient=config.WHISTLEBLOWER_REWARD_QUOTIENT,
+            max_deposit_amount=config.MAX_DEPOSIT_AMOUNT,
+            committee_config=CommitteeConfig(config),
+        )
+
+    return state
 
 
 def process_attestations(state: BeaconState,

--- a/eth2/beacon/state_machines/forks/serenity/state_transitions.py
+++ b/eth2/beacon/state_machines/forks/serenity/state_transitions.py
@@ -22,6 +22,7 @@ from .epoch_processing import (
 )
 from .operation_processing import (
     process_attestations,
+    process_proposer_slashings,
 )
 from .block_validation import (
     validate_block_slot,
@@ -91,7 +92,7 @@ class SerenityStateTransition(BaseStateTransition):
         state = process_eth1_data(state, block)
 
         # Operations
-        # TODO: state = process_proposer_slashings(state, block, self.config)
+        state = process_proposer_slashings(state, block, self.config)
         # TODO: state = process_attester_slashings(state, block, self.config)
         state = process_attestations(state, block, self.config)
         # TODO: state = process_deposits(state, block, self.config)

--- a/eth2/beacon/tools/builder/validator.py
+++ b/eth2/beacon/tools/builder/validator.py
@@ -191,11 +191,10 @@ def create_mock_proposer_slashing_at_block(state: BeaconState,
                                            config: BeaconConfig,
                                            keymap: Dict[BLSPubkey, int],
                                            block_root_1: Hash32,
-                                           block_root_2: Hash32):
+                                           block_root_2: Hash32,
+                                           proposer_index: ValidatorIndex):
     epoch_length = config.EPOCH_LENGTH
     beacon_chain_shard_number = config.BEACON_CHAIN_SHARD_NUMBER
-
-    proposer_index = 0
 
     proposal_data_1, proposal_signature_1 = create_proposal_data_and_signature(
         state,

--- a/eth2/beacon/tools/builder/validator.py
+++ b/eth2/beacon/tools/builder/validator.py
@@ -133,15 +133,17 @@ def sign_proof_of_possession(deposit_input: DepositInput,
     )
 
 
-def sign_attestation(message: bytes,
+def sign_transaction(*,
+                     message: bytes,
                      privkey: int,
                      fork: Fork,
                      slot: SlotNumber,
+                     signature_domain: SignatureDomain,
                      epoch_length: int) -> BLSSignature:
     domain = get_domain(
         fork,
         slot_to_epoch(slot, epoch_length),
-        SignatureDomain.DOMAIN_ATTESTATION,
+        signature_domain,
     )
     return bls.sign(
         message=message,
@@ -191,7 +193,7 @@ def create_mock_signed_attestation(state: BeaconState,
 
     # Use privkeys to sign the attestation
     signatures = [
-        sign_attestation(
+        sign_transaction(
             message=message,
             privkey=keymap[
                 state.validator_registry[
@@ -200,6 +202,7 @@ def create_mock_signed_attestation(state: BeaconState,
             ],
             fork=state.fork,
             slot=attestation_data.slot,
+            signature_domain=SignatureDomain.DOMAIN_ATTESTATION,
             epoch_length=epoch_length,
         )
         for committee_index in voting_committee_indices

--- a/eth2/beacon/types/validator_records.py
+++ b/eth2/beacon/types/validator_records.py
@@ -31,7 +31,7 @@ class ValidatorRecord(ssz.Serializable):
         # Epoch when validator withdrew
         ('withdrawal_epoch', uint64),
         # Epoch when validator was penalized
-        ('penalized_epoch', uint64),
+        ('slashed_epoch', uint64),
         # Status flags
         ('status_flags', uint64),
     ]
@@ -42,7 +42,7 @@ class ValidatorRecord(ssz.Serializable):
                  activation_epoch: EpochNumber,
                  exit_epoch: EpochNumber,
                  withdrawal_epoch: EpochNumber,
-                 penalized_epoch: EpochNumber,
+                 slashed_epoch: EpochNumber,
                  status_flags: int) -> None:
         super().__init__(
             pubkey=pubkey,
@@ -50,7 +50,7 @@ class ValidatorRecord(ssz.Serializable):
             activation_epoch=activation_epoch,
             exit_epoch=exit_epoch,
             withdrawal_epoch=withdrawal_epoch,
-            penalized_epoch=penalized_epoch,
+            slashed_epoch=slashed_epoch,
             status_flags=status_flags,
         )
 
@@ -73,6 +73,6 @@ class ValidatorRecord(ssz.Serializable):
             activation_epoch=FAR_FUTURE_EPOCH,
             exit_epoch=FAR_FUTURE_EPOCH,
             withdrawal_epoch=FAR_FUTURE_EPOCH,
-            penalized_epoch=FAR_FUTURE_EPOCH,
+            slashed_epoch=FAR_FUTURE_EPOCH,
             status_flags=0,
         )

--- a/eth2/beacon/validator_status_helpers.py
+++ b/eth2/beacon/validator_status_helpers.py
@@ -1,3 +1,7 @@
+from eth_utils import (
+    ValidationError,
+)
+
 from eth2._utils.tuple import (
     update_tuple_item,
 )
@@ -13,11 +17,13 @@ from eth2.beacon.enums import (
 from eth2.beacon.helpers import (
     get_entry_exit_effect_epoch,
     get_effective_balance,
+    get_epoch_start_slot,
 )
 from eth2.beacon.types.states import BeaconState
 from eth2.beacon.typing import (
     EpochNumber,
     Gwei,
+    SlotNumber,
     ValidatorIndex,
 )
 
@@ -109,7 +115,7 @@ def _settle_penality_to_validator_and_whistleblower(
     whistleblower_reward = get_effective_balance(state, index) // WHISTLEBLOWER_REWARD_QUOTIENT
     state.validator_balances[whistleblower_index] += whistleblower_reward
     state.validator_balances[index] -= whistleblower_reward
-    validator.penalized_epoch = slot_to_epoch(state.slot)
+    validator.slashed_epoch = slot_to_epoch(state.slot)
     """
     epoch_length = committee_config.EPOCH_LENGTH
 
@@ -149,10 +155,10 @@ def _settle_penality_to_validator_and_whistleblower(
         state.validator_balances[whistleblower_index] + whistleblower_reward,
     )
 
-    # Update validator's balance and `penalized_epoch` field
+    # Update validator's balance and `slashed_epoch` field
     validator = state.validator_registry[validator_index]
     validator = validator.copy(
-        penalized_epoch=state.current_epoch(epoch_length),
+        slashed_epoch=state.current_epoch(epoch_length),
     )
     state = state.update_validator(
         validator_index,
@@ -163,19 +169,26 @@ def _settle_penality_to_validator_and_whistleblower(
     return state
 
 
-def penalize_validator(state: BeaconState,
-                       index: ValidatorIndex,
-                       latest_penalized_exit_length: int,
-                       whistleblower_reward_quotient: int,
-                       max_deposit_amount: Gwei,
-                       committee_config: CommitteeConfig) -> BeaconState:
+def slash_validator(*,
+                    state: BeaconState,
+                    index: ValidatorIndex,
+                    latest_penalized_exit_length: int,
+                    whistleblower_reward_quotient: int,
+                    max_deposit_amount: Gwei,
+                    committee_config: CommitteeConfig) -> BeaconState:
     """
-    Penalize the validator with the given ``index``.
+    Slash the validator with index ``index``.
 
     Exit the validator, penalize the validator, and reward the whistleblower.
     """
     epoch_length = committee_config.EPOCH_LENGTH
     entry_exit_delay = committee_config.ENTRY_EXIT_DELAY
+
+    validator = state.validator_registry[index]
+
+    # [TO BE REMOVED IN PHASE 2]
+    _validate_withdrawal_epoch(state.slot, validator.withdrawal_epoch, epoch_length)
+
     state = exit_validator(state, index, epoch_length, entry_exit_delay)
     state = _settle_penality_to_validator_and_whistleblower(
         state=state,
@@ -199,3 +212,17 @@ def prepare_validator_for_withdrawal(state: BeaconState, index: ValidatorIndex) 
     state = state.update_validator_registry(index, validator)
 
     return state
+
+
+#
+# Validation
+#
+def _validate_withdrawal_epoch(state_slot: SlotNumber,
+                               validator_withdrawal_epoch: EpochNumber,
+                               epoch_length: int):
+    # TODO: change to `validate_withdrawable_epoch`
+    if state_slot >= get_epoch_start_slot(validator_withdrawal_epoch, epoch_length):
+        raise ValidationError(
+            f"state.slot ({state_slot}) should be than "
+            f"validator.withdrawal_epoch ({validator_withdrawal_epoch})"
+        )

--- a/eth2/beacon/validator_status_helpers.py
+++ b/eth2/beacon/validator_status_helpers.py
@@ -198,16 +198,29 @@ def slash_validator(*,
         max_deposit_amount=max_deposit_amount,
         committee_config=committee_config,
     )
+
+    # Update validator
+    current_epoch = state.current_epoch(epoch_length)
+    validator = validator.copy(
+        slashed_epoch=current_epoch,
+        withdrawal_epoch=current_epoch + latest_penalized_exit_length,
+    )
+    state.update_validator_registry(index, validator)
+
     return state
 
 
-def prepare_validator_for_withdrawal(state: BeaconState, index: ValidatorIndex) -> BeaconState:
+def prepare_validator_for_withdrawal(state: BeaconState,
+                                     index: ValidatorIndex,
+                                     epoch_length: int,
+                                     min_validator_withdrawability_delay: int) -> BeaconState:
     """
     Set the validator with the given ``index`` with ``WITHDRAWABLE`` flag.
     """
     validator = state.validator_registry[index]
     validator = validator.copy(
-        status_flags=validator.status_flags | ValidatorStatusFlags.WITHDRAWABLE
+        status_flags=validator.status_flags | ValidatorStatusFlags.WITHDRAWABLE,
+        withdrawal_epoch=state.current_epoch(epoch_length) + min_validator_withdrawability_delay
     )
     state = state.update_validator_registry(index, validator)
 

--- a/eth2/beacon/validator_status_helpers.py
+++ b/eth2/beacon/validator_status_helpers.py
@@ -219,7 +219,7 @@ def prepare_validator_for_withdrawal(state: BeaconState, index: ValidatorIndex) 
 #
 def _validate_withdrawal_epoch(state_slot: SlotNumber,
                                validator_withdrawal_epoch: EpochNumber,
-                               epoch_length: int):
+                               epoch_length: int) -> None:
     # TODO: change to `validate_withdrawable_epoch`
     if state_slot >= get_epoch_start_slot(validator_withdrawal_epoch, epoch_length):
         raise ValidationError(

--- a/eth2/beacon/validator_status_helpers.py
+++ b/eth2/beacon/validator_status_helpers.py
@@ -223,6 +223,6 @@ def _validate_withdrawal_epoch(state_slot: SlotNumber,
     # TODO: change to `validate_withdrawable_epoch`
     if state_slot >= get_epoch_start_slot(validator_withdrawal_epoch, epoch_length):
         raise ValidationError(
-            f"state.slot ({state_slot}) should be than "
+            f"state.slot ({state_slot}) should be less than "
             f"validator.withdrawal_epoch ({validator_withdrawal_epoch})"
         )

--- a/tests/eth2/beacon/conftest.py
+++ b/tests/eth2/beacon/conftest.py
@@ -297,7 +297,7 @@ def sample_validator_record_params():
         'activation_epoch': FAR_FUTURE_EPOCH,
         'exit_epoch': FAR_FUTURE_EPOCH,
         'withdrawal_epoch': FAR_FUTURE_EPOCH,
-        'penalized_epoch': FAR_FUTURE_EPOCH,
+        'slashed_epoch': FAR_FUTURE_EPOCH,
         'status_flags': 0,
     }
 

--- a/tests/eth2/beacon/conftest.py
+++ b/tests/eth2/beacon/conftest.py
@@ -510,8 +510,8 @@ def eth1_data_voting_period():
 
 
 @pytest.fixture
-def min_validator_withdrawal_time():
-    return SERENITY_CONFIG.MIN_VALIDATOR_WITHDRAWAL_TIME
+def min_validator_withdrawability_delay():
+    return SERENITY_CONFIG.MIN_VALIDATOR_WITHDRAWABILITY_DELAY
 
 
 @pytest.fixture
@@ -669,7 +669,7 @@ def config(
         seed_lookahead,
         entry_exit_delay,
         eth1_data_voting_period,
-        min_validator_withdrawal_time,
+        min_validator_withdrawability_delay,
         base_reward_quotient,
         whistleblower_reward_quotient,
         includer_reward_quotient,
@@ -706,7 +706,7 @@ def config(
         SEED_LOOKAHEAD=seed_lookahead,
         ENTRY_EXIT_DELAY=entry_exit_delay,
         ETH1_DATA_VOTING_PERIOD=eth1_data_voting_period,
-        MIN_VALIDATOR_WITHDRAWAL_TIME=min_validator_withdrawal_time,
+        MIN_VALIDATOR_WITHDRAWABILITY_DELAY=min_validator_withdrawability_delay,
         BASE_REWARD_QUOTIENT=base_reward_quotient,
         WHISTLEBLOWER_REWARD_QUOTIENT=whistleblower_reward_quotient,
         INCLUDER_REWARD_QUOTIENT=includer_reward_quotient,

--- a/tests/eth2/beacon/helpers.py
+++ b/tests/eth2/beacon/helpers.py
@@ -23,7 +23,7 @@ def mock_validator_record(pubkey,
         activation_epoch=SERENITY_CONFIG.GENESIS_EPOCH if is_active else FAR_FUTURE_EPOCH,
         exit_epoch=FAR_FUTURE_EPOCH,
         withdrawal_epoch=FAR_FUTURE_EPOCH,
-        penalized_epoch=FAR_FUTURE_EPOCH,
+        slashed_epoch=FAR_FUTURE_EPOCH,
         status_flags=status_flags,
     )
 

--- a/tests/eth2/beacon/state_machines/forks/test_serenity_block_proposer_slashing_validation.py
+++ b/tests/eth2/beacon/state_machines/forks/test_serenity_block_proposer_slashing_validation.py
@@ -1,0 +1,59 @@
+from eth2.beacon.enums import (
+    SignatureDomain,
+)
+from eth2.beacon.state_machines.forks.serenity.block_validation import (
+    validate_proposer_slashing,
+)
+from eth2.beacon.tools.builder.validator import (
+    sign_transaction,
+)
+from eth2.beacon.types.proposal_signed_data import ProposalSignedData
+from eth2.beacon.types.proposer_slashings import ProposerSlashing
+
+
+def test_validate_proposer_slashing_valid(epoch_length,
+                                          genesis_state,
+                                          beacon_chain_shard_number,
+                                          keymap):
+    state = genesis_state
+    proposer_index = 0
+
+    block_root_1 = b'\x11' * 32
+    proposal_data_1 = ProposalSignedData(
+        state.slot,
+        beacon_chain_shard_number,
+        block_root_1,
+    )
+    proposal_signature_1 = sign_transaction(
+        message=proposal_data_1.root,
+        privkey=keymap[state.validator_registry[proposer_index].pubkey],
+        fork=state.fork,
+        slot=proposal_data_1.slot,
+        signature_domain=SignatureDomain.DOMAIN_PROPOSAL,
+        epoch_length=epoch_length,
+    )
+
+    block_root_2 = b'\x22' * 32
+    proposal_data_2 = ProposalSignedData(
+        state.slot,
+        beacon_chain_shard_number,
+        block_root_2,
+    )
+    proposal_signature_2 = sign_transaction(
+        message=proposal_data_2.root,
+        privkey=keymap[state.validator_registry[proposer_index].pubkey],
+        fork=state.fork,
+        slot=proposal_data_2.slot,
+        signature_domain=SignatureDomain.DOMAIN_PROPOSAL,
+        epoch_length=epoch_length,
+    )
+
+    proposer_slashing = ProposerSlashing(
+        proposer_index=proposer_index,
+        proposal_data_1=proposal_data_1,
+        proposal_data_2=proposal_data_2,
+        proposal_signature_1=proposal_signature_1,
+        proposal_signature_2=proposal_signature_2,
+    )
+
+    validate_proposer_slashing(state, proposer_slashing, epoch_length)

--- a/tests/eth2/beacon/state_machines/forks/test_serenity_block_proposer_slashing_validation.py
+++ b/tests/eth2/beacon/state_machines/forks/test_serenity_block_proposer_slashing_validation.py
@@ -4,9 +4,6 @@ from eth_utils import (
     ValidationError,
 )
 
-from eth2.beacon.enums import (
-    SignatureDomain,
-)
 from eth2.beacon.state_machines.forks.serenity.block_validation import (
     validate_proposer_slashing,
     validate_proposer_slashing_block_root,
@@ -16,79 +13,44 @@ from eth2.beacon.state_machines.forks.serenity.block_validation import (
     validate_proposal_signature,
 )
 from eth2.beacon.tools.builder.validator import (
-    sign_transaction,
+    create_mock_proposer_slashing_at_block,
 )
-from eth2.beacon.types.proposal_signed_data import ProposalSignedData
-from eth2.beacon.types.proposer_slashings import ProposerSlashing
 
 
-def get_valid_proposer_slashing(epoch_length,
-                                state,
-                                beacon_chain_shard_number,
+def get_valid_proposer_slashing(state,
                                 keymap,
+                                config,
                                 proposer_index=0):
-    block_root_1 = b'\x11' * 32
-    proposal_data_1 = ProposalSignedData(
-        state.slot,
-        beacon_chain_shard_number,
-        block_root_1,
-    )
-    proposal_signature_1 = sign_transaction(
-        message=proposal_data_1.root,
-        privkey=keymap[state.validator_registry[proposer_index].pubkey],
-        fork=state.fork,
-        slot=proposal_data_1.slot,
-        signature_domain=SignatureDomain.DOMAIN_PROPOSAL,
-        epoch_length=epoch_length,
-    )
-
-    block_root_2 = b'\x22' * 32
-    proposal_data_2 = ProposalSignedData(
-        state.slot,
-        beacon_chain_shard_number,
-        block_root_2,
-    )
-    proposal_signature_2 = sign_transaction(
-        message=proposal_data_2.root,
-        privkey=keymap[state.validator_registry[proposer_index].pubkey],
-        fork=state.fork,
-        slot=proposal_data_2.slot,
-        signature_domain=SignatureDomain.DOMAIN_PROPOSAL,
-        epoch_length=epoch_length,
-    )
-
-    return ProposerSlashing(
-        proposer_index=proposer_index,
-        proposal_data_1=proposal_data_1,
-        proposal_data_2=proposal_data_2,
-        proposal_signature_1=proposal_signature_1,
-        proposal_signature_2=proposal_signature_2,
+    return create_mock_proposer_slashing_at_block(
+        state,
+        config,
+        keymap,
+        block_root_1=b'\x11' * 32,
+        block_root_2=b'\x22' * 32,
     )
 
 
-def test_validate_proposer_slashing_valid(epoch_length,
-                                          genesis_state,
-                                          beacon_chain_shard_number,
-                                          keymap):
+def test_validate_proposer_slashing_valid(genesis_state,
+                                          keymap,
+                                          epoch_length,
+                                          config):
     state = genesis_state
     valid_proposer_slashing = get_valid_proposer_slashing(
-        epoch_length,
         state,
-        beacon_chain_shard_number,
         keymap,
+        config,
     )
     validate_proposer_slashing(state, valid_proposer_slashing, epoch_length)
 
 
-def test_validate_proposer_slashing_slot(epoch_length,
-                                         genesis_state,
-                                         beacon_chain_shard_number,
-                                         keymap):
+def test_validate_proposer_slashing_slot(genesis_state,
+                                         keymap,
+                                         config):
+    state = genesis_state
     valid_proposer_slashing = get_valid_proposer_slashing(
-        epoch_length,
-        genesis_state,
-        beacon_chain_shard_number,
+        state,
         keymap,
+        config,
     )
     # Valid
     validate_proposer_slashing_slot(valid_proposer_slashing)
@@ -105,16 +67,16 @@ def test_validate_proposer_slashing_slot(epoch_length,
         validate_proposer_slashing_slot(invalid_proposer_slashing)
 
 
-def test_validate_proposer_slashing_shard(epoch_length,
-                                          genesis_state,
-                                          beacon_chain_shard_number,
-                                          keymap):
+def test_validate_proposer_slashing_shard(genesis_state,
+                                          keymap,
+                                          config):
+    state = genesis_state
     valid_proposer_slashing = get_valid_proposer_slashing(
-        epoch_length,
-        genesis_state,
-        beacon_chain_shard_number,
+        state,
         keymap,
+        config,
     )
+
     # Valid
     validate_proposer_slashing_shard(valid_proposer_slashing)
 
@@ -130,16 +92,16 @@ def test_validate_proposer_slashing_shard(epoch_length,
         validate_proposer_slashing_shard(invalid_proposer_slashing)
 
 
-def test_validate_proposer_slashing_block_root(epoch_length,
-                                               genesis_state,
-                                               beacon_chain_shard_number,
-                                               keymap):
+def test_validate_proposer_slashing_block_root(genesis_state,
+                                               keymap,
+                                               config):
+    state = genesis_state
     valid_proposer_slashing = get_valid_proposer_slashing(
-        epoch_length,
-        genesis_state,
-        beacon_chain_shard_number,
+        state,
         keymap,
+        config,
     )
+
     # Valid
     validate_proposer_slashing_block_root(valid_proposer_slashing)
 
@@ -182,16 +144,14 @@ def test_validate_proposer_slashing_slashed_epoch(epoch_length,
 
 def test_validate_proposal_signature(epoch_length,
                                      genesis_state,
-                                     beacon_chain_shard_number,
-                                     keymap):
+                                     keymap,
+                                     config):
     state = genesis_state
     proposer_index = 0
     valid_proposer_slashing = get_valid_proposer_slashing(
-        epoch_length,
         state,
-        beacon_chain_shard_number,
         keymap,
-        proposer_index,
+        config,
     )
     proposer = state.validator_registry[proposer_index]
 

--- a/tests/eth2/beacon/state_machines/forks/test_serenity_block_proposer_slashing_validation.py
+++ b/tests/eth2/beacon/state_machines/forks/test_serenity_block_proposer_slashing_validation.py
@@ -27,6 +27,7 @@ def get_valid_proposer_slashing(state,
         keymap,
         block_root_1=b'\x11' * 32,
         block_root_2=b'\x22' * 32,
+        proposer_index=proposer_index,
     )
 
 

--- a/tests/eth2/beacon/state_machines/forks/test_serenity_block_proposer_slashing_validation.py
+++ b/tests/eth2/beacon/state_machines/forks/test_serenity_block_proposer_slashing_validation.py
@@ -1,8 +1,19 @@
+import pytest
+
+from eth_utils import (
+    ValidationError,
+)
+
 from eth2.beacon.enums import (
     SignatureDomain,
 )
 from eth2.beacon.state_machines.forks.serenity.block_validation import (
     validate_proposer_slashing,
+    validate_proposer_slashing_block_root,
+    validate_proposer_slashing_slashed_epoch,
+    validate_proposer_slashing_slot,
+    validate_proposer_slashing_shard,
+    validate_proposal_signature,
 )
 from eth2.beacon.tools.builder.validator import (
     sign_transaction,
@@ -11,13 +22,11 @@ from eth2.beacon.types.proposal_signed_data import ProposalSignedData
 from eth2.beacon.types.proposer_slashings import ProposerSlashing
 
 
-def test_validate_proposer_slashing_valid(epoch_length,
-                                          genesis_state,
-                                          beacon_chain_shard_number,
-                                          keymap):
-    state = genesis_state
-    proposer_index = 0
-
+def get_valid_proposer_slashing(epoch_length,
+                                state,
+                                beacon_chain_shard_number,
+                                keymap,
+                                proposer_index=0):
     block_root_1 = b'\x11' * 32
     proposal_data_1 = ProposalSignedData(
         state.slot,
@@ -48,7 +57,7 @@ def test_validate_proposer_slashing_valid(epoch_length,
         epoch_length=epoch_length,
     )
 
-    proposer_slashing = ProposerSlashing(
+    return ProposerSlashing(
         proposer_index=proposer_index,
         proposal_data_1=proposal_data_1,
         proposal_data_2=proposal_data_2,
@@ -56,4 +65,153 @@ def test_validate_proposer_slashing_valid(epoch_length,
         proposal_signature_2=proposal_signature_2,
     )
 
-    validate_proposer_slashing(state, proposer_slashing, epoch_length)
+
+def test_validate_proposer_slashing_valid(epoch_length,
+                                          genesis_state,
+                                          beacon_chain_shard_number,
+                                          keymap):
+    state = genesis_state
+    valid_proposer_slashing = get_valid_proposer_slashing(
+        epoch_length,
+        state,
+        beacon_chain_shard_number,
+        keymap,
+    )
+    validate_proposer_slashing(state, valid_proposer_slashing, epoch_length)
+
+
+def test_validate_proposer_slashing_slot(epoch_length,
+                                         genesis_state,
+                                         beacon_chain_shard_number,
+                                         keymap):
+    valid_proposer_slashing = get_valid_proposer_slashing(
+        epoch_length,
+        genesis_state,
+        beacon_chain_shard_number,
+        keymap,
+    )
+    # Valid
+    validate_proposer_slashing_slot(valid_proposer_slashing)
+
+    proposal_data_1 = valid_proposer_slashing.proposal_data_1.copy(
+        slot=valid_proposer_slashing.proposal_data_2.slot + 1
+    )
+    invalid_proposer_slashing = valid_proposer_slashing.copy(
+        proposal_data_1=proposal_data_1,
+    )
+
+    # Invalid
+    with pytest.raises(ValidationError):
+        validate_proposer_slashing_slot(invalid_proposer_slashing)
+
+
+def test_validate_proposer_slashing_shard(epoch_length,
+                                          genesis_state,
+                                          beacon_chain_shard_number,
+                                          keymap):
+    valid_proposer_slashing = get_valid_proposer_slashing(
+        epoch_length,
+        genesis_state,
+        beacon_chain_shard_number,
+        keymap,
+    )
+    # Valid
+    validate_proposer_slashing_shard(valid_proposer_slashing)
+
+    proposal_data_1 = valid_proposer_slashing.proposal_data_1.copy(
+        shard=valid_proposer_slashing.proposal_data_2.shard + 1
+    )
+    invalid_proposer_slashing = valid_proposer_slashing.copy(
+        proposal_data_1=proposal_data_1,
+    )
+
+    # Invalid
+    with pytest.raises(ValidationError):
+        validate_proposer_slashing_shard(invalid_proposer_slashing)
+
+
+def test_validate_proposer_slashing_block_root(epoch_length,
+                                               genesis_state,
+                                               beacon_chain_shard_number,
+                                               keymap):
+    valid_proposer_slashing = get_valid_proposer_slashing(
+        epoch_length,
+        genesis_state,
+        beacon_chain_shard_number,
+        keymap,
+    )
+    # Valid
+    validate_proposer_slashing_block_root(valid_proposer_slashing)
+
+    proposal_data_1 = valid_proposer_slashing.proposal_data_1.copy(
+        block_root=valid_proposer_slashing.proposal_data_2.block_root
+    )
+    invalid_proposer_slashing = valid_proposer_slashing.copy(
+        proposal_data_1=proposal_data_1,
+    )
+
+    # Invalid
+    with pytest.raises(ValidationError):
+        validate_proposer_slashing_block_root(invalid_proposer_slashing)
+
+
+@pytest.mark.parametrize(
+    (
+        'proposer_slashed_epoch', 'state_current_epoch', 'success'
+    ),
+    [
+        (2, 1, True),
+        (1, 1, False),
+        (1, 2, False),
+    ],
+)
+def test_validate_proposer_slashing_slashed_epoch(epoch_length,
+                                                  genesis_state,
+                                                  beacon_chain_shard_number,
+                                                  keymap,
+                                                  proposer_slashed_epoch,
+                                                  state_current_epoch,
+                                                  success):
+    # Invalid
+    if success:
+        validate_proposer_slashing_slashed_epoch(proposer_slashed_epoch, state_current_epoch)
+    else:
+        with pytest.raises(ValidationError):
+            validate_proposer_slashing_slashed_epoch(proposer_slashed_epoch, state_current_epoch)
+
+
+def test_validate_proposal_signature(epoch_length,
+                                     genesis_state,
+                                     beacon_chain_shard_number,
+                                     keymap):
+    state = genesis_state
+    proposer_index = 0
+    valid_proposer_slashing = get_valid_proposer_slashing(
+        epoch_length,
+        state,
+        beacon_chain_shard_number,
+        keymap,
+        proposer_index,
+    )
+    proposer = state.validator_registry[proposer_index]
+
+    # Valid
+    validate_proposal_signature(
+        proposal_signed_data=valid_proposer_slashing.proposal_data_1,
+        proposal_signature=valid_proposer_slashing.proposal_signature_1,
+        pubkey=proposer.pubkey,
+        fork=state.fork,
+        epoch_length=epoch_length,
+    )
+
+    # Invalid
+    wrong_proposer_index = proposer_index + 1
+    wrong_proposer = state.validator_registry[wrong_proposer_index]
+    with pytest.raises(ValidationError):
+        validate_proposal_signature(
+            proposal_signed_data=valid_proposer_slashing.proposal_data_1,
+            proposal_signature=valid_proposer_slashing.proposal_signature_1,
+            pubkey=wrong_proposer.pubkey,
+            fork=state.fork,
+            epoch_length=epoch_length,
+        )

--- a/tests/eth2/beacon/state_machines/forks/test_serenity_operation_processing.py
+++ b/tests/eth2/beacon/state_machines/forks/test_serenity_operation_processing.py
@@ -12,9 +12,11 @@ from eth2.beacon.state_machines.forks.serenity.blocks import (
 )
 from eth2.beacon.state_machines.forks.serenity.operation_processing import (
     process_attestations,
+    process_proposer_slashings,
 )
 from eth2.beacon.tools.builder.validator import (
     create_mock_signed_attestations_at_slot,
+    create_mock_proposer_slashing_at_block,
 )
 
 
@@ -54,6 +56,72 @@ def test_process_max_attestations(genesis_state,
             block,
             config,
         )
+
+
+@pytest.mark.parametrize(
+    (
+        'num_validators',
+        'epoch_length',
+        'target_committee_size',
+        'shard_count',
+        'block_root_1',
+        'block_root_2',
+        'success'
+    ),
+    [
+        (10, 2, 2, 2, b'\x11' * 32, b'\x22' * 32, True),
+        (10, 2, 2, 2, b'\x11' * 32, b'\x11' * 32, False),
+    ]
+)
+def test_process_proposer_slashings(genesis_state,
+                                    sample_beacon_block_params,
+                                    sample_beacon_block_body_params,
+                                    config,
+                                    keymap,
+                                    block_root_1,
+                                    block_root_2,
+                                    success):
+    current_slot = 1
+    state = genesis_state.copy(
+        slot=current_slot,
+    )
+
+    proposer_index = 0
+    propsoer_slashing = create_mock_proposer_slashing_at_block(
+        state,
+        config,
+        keymap,
+        block_root_1=block_root_1,
+        block_root_2=block_root_2,
+        proposer_index=proposer_index,
+    )
+    proposer_slashings = (propsoer_slashing,)
+
+    block_body = BeaconBlockBody(**sample_beacon_block_body_params).copy(
+        proposer_slashings=proposer_slashings,
+    )
+    block = SerenityBeaconBlock(**sample_beacon_block_params).copy(
+        slot=current_slot,
+        body=block_body,
+    )
+
+    if success:
+        new_state = process_proposer_slashings(
+            state,
+            block,
+            config,
+        )
+        # Check if slashed
+        assert (
+            new_state.validator_balances[proposer_index] < state.validator_balances[proposer_index]
+        )
+    else:
+        with pytest.raises(ValidationError):
+            process_proposer_slashings(
+                state,
+                block,
+                config,
+            )
 
 
 @pytest.mark.parametrize(

--- a/tests/eth2/beacon/state_machines/forks/test_serenity_operation_processing.py
+++ b/tests/eth2/beacon/state_machines/forks/test_serenity_operation_processing.py
@@ -87,7 +87,7 @@ def test_process_proposer_slashings(genesis_state,
     )
 
     proposer_index = 0
-    propsoer_slashing = create_mock_proposer_slashing_at_block(
+    proposer_slashing = create_mock_proposer_slashing_at_block(
         state,
         config,
         keymap,
@@ -95,7 +95,7 @@ def test_process_proposer_slashings(genesis_state,
         block_root_2=block_root_2,
         proposer_index=proposer_index,
     )
-    proposer_slashings = (propsoer_slashing,)
+    proposer_slashings = (proposer_slashing,)
 
     block_body = BeaconBlockBody(**sample_beacon_block_body_params).copy(
         proposer_slashings=proposer_slashings,

--- a/tests/eth2/beacon/types/test_validator_record.py
+++ b/tests/eth2/beacon/types/test_validator_record.py
@@ -51,4 +51,4 @@ def test_create_pending_validator():
     assert validator.activation_epoch == FAR_FUTURE_EPOCH
     assert validator.exit_epoch == FAR_FUTURE_EPOCH
     assert validator.withdrawal_epoch == FAR_FUTURE_EPOCH
-    assert validator.penalized_epoch == FAR_FUTURE_EPOCH
+    assert validator.slashed_epoch == FAR_FUTURE_EPOCH


### PR DESCRIPTION
### What was wrong?
- Part of #238
- Implement `process_proposer_slashings`
- Spec reference: https://github.com/ethereum/eth2.0-specs/blob/f2e547e62909d98181eeebf22e6323ff5ca3e103/specs/core/0_beacon-chain.md#proposer-slashings-1

### How was it fixed?
1. Implement `process_proposer_slashings` for processing per-block `ProposalSlashing` transactions (operations).
2. Implement `validate_proposer_slashing` for validate each `ProposalSlashing`  transactions (was called "operations")
3. Add tests for `validate_proposer_slashing`
4. Modify `eth2.beacon.tools.builder.validator.sign_attestation` to more generic helper `sign_transaction`.
5. Add test for `process_proposer_slashings`.
6. Rename `penalized_epoch` -> `slashed_epoch` (#282)
7. Rename `penalize_validator` -> `slash_validator` (#282) and update logic.
 
#### Cute Animal Picture
![manchots_empereurs_tobogannent](https://user-images.githubusercontent.com/9263930/52910064-15fb8380-32cd-11e9-83ee-f7a786bd6fa9.JPG)
