### PR TITLE
Enable per-block `process_eth1_data`

### DIFF
--- a/eth2/beacon/state_machines/forks/serenity/block_processing.py
+++ b/eth2/beacon/state_machines/forks/serenity/block_processing.py
@@ -29,8 +29,7 @@ from eth2.beacon.committee_helpers import (
 
 
 def process_eth1_data(state: BeaconState,
-                      block: BaseBeaconBlock,
-                      config: BeaconConfig) -> BeaconState:
+                      block: BaseBeaconBlock) -> BeaconState:
     try:
         vote_index, original_vote = first(
             (index, eth1_data_vote)

--- a/eth2/beacon/state_machines/forks/serenity/state_transitions.py
+++ b/eth2/beacon/state_machines/forks/serenity/state_transitions.py
@@ -14,6 +14,9 @@ from eth2.beacon.state_machines.state_transitions import BaseStateTransition
 from eth2.beacon.types.blocks import BaseBeaconBlock
 from eth2.beacon.types.states import BeaconState
 
+from .block_processing import (
+    process_eth1_data,
+)
 from .epoch_processing import (
     process_crosslinks,
     process_final_updates,
@@ -99,7 +102,7 @@ class SerenityStateTransition(BaseStateTransition):
                 committee_config=CommitteeConfig(self.config),
             )
         # TODO: state = process_randao(state, block, self.config)
-        # TODO: state = process_eth1_data(state, block, self.config)
+        state = process_eth1_data(state, block)
 
         # Operations
         # TODO: state = process_proposer_slashings(state, block, self.config)

--- a/tests/eth2/beacon/state_machines/forks/test_serenity_block_processing.py
+++ b/tests/eth2/beacon/state_machines/forks/test_serenity_block_processing.py
@@ -132,8 +132,7 @@ def test_process_eth1_data(original_votes,
                            block_data,
                            expected_votes,
                            sample_beacon_state_params,
-                           sample_beacon_block_params,
-                           config):
+                           sample_beacon_block_params):
     eth1_data_votes = tuple(
         Eth1DataVote(data, vote_count)
         for data, vote_count in original_votes
@@ -146,7 +145,7 @@ def test_process_eth1_data(original_votes,
         eth1_data=block_data,
     )
 
-    updated_state = process_eth1_data(state, block, config)
+    updated_state = process_eth1_data(state, block)
     updated_votes = tuple(
         (vote.eth1_data, vote.vote_count)
         for vote in updated_state.eth1_data_votes


### PR DESCRIPTION
### What was wrong?
`process_eth1_data` is not being used in per-block processing.

### How was it fixed?
- Uncomment `state = process_eth1_data(state, block, self.config)`
- Remove the unused parameter `config`.

[//]: # (For important changes, please add a new entry to the release notes file)
[//]: # (See: https://trinity-client.readthedocs.io/en/latest/contributing.html#pull-requests)

#### Cute Animal Picture

![koala_jumping_at_lpks](https://user-images.githubusercontent.com/9263930/52916182-41a35b80-3317-11e9-8ea6-df1fd34f4341.jpg)
