### PR TITLE
Implement `process_attester_slashings`

### DIFF
--- a/eth2/beacon/state_machines/forks/serenity/block_validation.py
+++ b/eth2/beacon/state_machines/forks/serenity/block_validation.py
@@ -488,7 +488,7 @@ def generate_aggregate_pubkeys_from_indices(
 
 
 def _validate_custody_bitfield(custody_bitfield: Bitfield) -> None:
-    # NOTE: to be removed in phase 1.
+    # TODO: to be removed in phase 1.
     empty_custody_bitfield = b'\x00' * len(custody_bitfield)
     if custody_bitfield != empty_custody_bitfield:
         raise ValidationError(
@@ -641,7 +641,9 @@ def verify_slashable_attestation_signature(state: 'BeaconState',
         SignatureDomain.DOMAIN_ATTESTATION,
     )
 
-    # No custody bit 1 indice
+    # No custody bit 1 indice votes in phase 0, so we only need to process custody bit 0
+    # for efficiency.
+    # TODO: to be removed in phase 1.
     if len(all_indices[1]) == 0:
         pubkeys = pubkeys[:1]
         message_hashes = message_hashes[:1]

--- a/eth2/beacon/state_machines/forks/serenity/block_validation.py
+++ b/eth2/beacon/state_machines/forks/serenity/block_validation.py
@@ -228,20 +228,11 @@ def validate_attester_slashing(state: BeaconState,
 
     validate_attester_slashing_different_data(slashable_attestation_1, slashable_attestation_2)
 
-    is_double_vote_slashing = is_double_vote(
-        slashable_attestation_1.data,
-        slashable_attestation_2.data,
+    validate_attester_slashing_slashing_conditions(
+        slashable_attestation_1,
+        slashable_attestation_2,
         slots_per_epoch,
     )
-    is_surround_vote_slashing = is_surround_vote(
-        slashable_attestation_1.data,
-        slashable_attestation_2.data,
-        slots_per_epoch,
-    )
-    if not (is_double_vote_slashing or is_surround_vote_slashing):
-        raise ValidationError(
-            "The `AttesterSlashing` object doesn't meet `is_double_vote` or `is_surround_vote`"
-        )
 
     validate_slashable_attestation(
         state,
@@ -267,6 +258,26 @@ def validate_attester_slashing_different_data(
             f"({slashable_attestation_1.data}) "
             "should not be equal to slashable_attestation_2.data "
             f"({slashable_attestation_2.data})"
+        )
+
+
+def validate_attester_slashing_slashing_conditions(
+        slashable_attestation_1: SlashableAttestation,
+        slashable_attestation_2: SlashableAttestation,
+        slots_per_epoch: int) -> None:
+    is_double_vote_slashing = is_double_vote(
+        slashable_attestation_1.data,
+        slashable_attestation_2.data,
+        slots_per_epoch,
+    )
+    is_surround_vote_slashing = is_surround_vote(
+        slashable_attestation_1.data,
+        slashable_attestation_2.data,
+        slots_per_epoch,
+    )
+    if not (is_double_vote_slashing or is_surround_vote_slashing):
+        raise ValidationError(
+            "The `AttesterSlashing` object doesn't meet `is_double_vote` or `is_surround_vote`"
         )
 
 

--- a/eth2/beacon/state_machines/forks/serenity/block_validation.py
+++ b/eth2/beacon/state_machines/forks/serenity/block_validation.py
@@ -281,6 +281,13 @@ def validate_attester_slashing_slashing_conditions(
         )
 
 
+def validate_slashable_indices(slashable_indices: Sequence[ValidatorIndex]) -> None:
+    if len(slashable_indices) < 1:
+        raise ValidationError(
+            "len(slashable_indices) should be greater or equal to 1"
+        )
+
+
 #
 # Attestation validation
 #

--- a/eth2/beacon/state_machines/forks/serenity/block_validation.py
+++ b/eth2/beacon/state_machines/forks/serenity/block_validation.py
@@ -1,7 +1,8 @@
 import functools
-from typing import (
+from typing import (  # noqa: F401
     Iterable,
     Sequence,
+    Tuple,
     TYPE_CHECKING,
 )
 
@@ -37,11 +38,14 @@ from eth2.beacon.helpers import (
     get_epoch_start_slot,
     get_block_root,
     get_domain,
+    is_double_vote,
+    is_surround_vote,
     slot_to_epoch,
 )
 from eth2.beacon.types.attestations import Attestation  # noqa: F401
 from eth2.beacon.types.attestation_data import AttestationData  # noqa: F401
 from eth2.beacon.types.attestation_data_and_custody_bits import AttestationDataAndCustodyBit
+from eth2.beacon.types.attester_slashings import AttesterSlashing  # noqa: F401
 from eth2.beacon.types.blocks import BaseBeaconBlock  # noqa: F401
 from eth2.beacon.types.forks import Fork  # noqa: F401
 from eth2.beacon.types.proposal_signed_data import ProposalSignedData
@@ -209,6 +213,60 @@ def validate_proposal_signature(proposal_signed_data: ProposalSignedData,
             "Proposal signature is invalid: "
             f"proposer pubkey: {pubkey}, message_hash: {proposal_signed_data.root}, "
             f"signature: {proposal_signature}"
+        )
+
+
+#
+# Attester slashing validation
+#
+def validate_attester_slashing(state: BeaconState,
+                               attester_slashing: AttesterSlashing,
+                               max_indices_per_slashable_vote: int,
+                               slots_per_epoch: int) -> None:
+    slashable_attestation_1 = attester_slashing.slashable_attestation_1
+    slashable_attestation_2 = attester_slashing.slashable_attestation_2
+
+    validate_attester_slashing_different_data(slashable_attestation_1, slashable_attestation_2)
+
+    is_double_vote_slashing = is_double_vote(
+        slashable_attestation_1.data,
+        slashable_attestation_2.data,
+        slots_per_epoch,
+    )
+    is_surround_vote_slashing = is_surround_vote(
+        slashable_attestation_1.data,
+        slashable_attestation_2.data,
+        slots_per_epoch,
+    )
+    if not (is_double_vote_slashing or is_surround_vote_slashing):
+        raise ValidationError(
+            "The `AttesterSlashing` object doesn't meet `is_double_vote` or `is_surround_vote`"
+        )
+
+    validate_slashable_attestation(
+        state,
+        slashable_attestation_1,
+        max_indices_per_slashable_vote,
+        slots_per_epoch,
+    )
+
+    validate_slashable_attestation(
+        state,
+        slashable_attestation_2,
+        max_indices_per_slashable_vote,
+        slots_per_epoch,
+    )
+
+
+def validate_attester_slashing_different_data(
+        slashable_attestation_1: SlashableAttestation,
+        slashable_attestation_2: SlashableAttestation) -> None:
+    if slashable_attestation_1.data == slashable_attestation_2.data:
+        raise ValidationError(
+            "slashable_attestation_1.data "
+            f"({slashable_attestation_1.data}) "
+            "should not be equal to slashable_attestation_2.data "
+            f"({slashable_attestation_2.data})"
         )
 
 
@@ -551,10 +609,11 @@ def verify_slashable_attestation_signature(state: 'BeaconState',
     Ensure we have a valid aggregate signature for the ``slashable_attestation``.
     """
     all_indices = slashable_attestation.custody_bit_indices
-
-    pubkeys = generate_aggregate_pubkeys_from_indices(state.validator_registry, *all_indices)
-
-    message_hashes = slashable_attestation.message_hashes
+    pubkeys: Tuple[BLSPubkey, ...] = generate_aggregate_pubkeys_from_indices(
+        state.validator_registry,
+        *all_indices,
+    )
+    message_hashes: Tuple[Hash32, ...] = slashable_attestation.message_hashes
 
     signature = slashable_attestation.aggregate_signature
 
@@ -563,6 +622,11 @@ def verify_slashable_attestation_signature(state: 'BeaconState',
         slot_to_epoch(slashable_attestation.data.slot, slots_per_epoch),
         SignatureDomain.DOMAIN_ATTESTATION,
     )
+
+    # No custody bit 1 indice
+    if len(all_indices[1]) == 0:
+        pubkeys = pubkeys[:1]
+        message_hashes = message_hashes[:1]
 
     return bls.verify_multiple(
         pubkeys=pubkeys,

--- a/eth2/beacon/state_machines/forks/serenity/operation_processing.py
+++ b/eth2/beacon/state_machines/forks/serenity/operation_processing.py
@@ -1,20 +1,31 @@
-from eth_utils import ValidationError
+from typing import (
+    Iterable,
+)
+from eth_utils import (
+    to_tuple,
+    ValidationError,
+)
 
 from eth2.beacon.configs import (
     BeaconConfig,
     CommitteeConfig,
 )
+from eth2.beacon.types.attester_slashings import AttesterSlashing
 from eth2.beacon.types.blocks import BaseBeaconBlock
 from eth2.beacon.types.pending_attestation_records import PendingAttestationRecord
 from eth2.beacon.types.states import BeaconState
 from eth2.beacon.validator_status_helpers import (
     slash_validator,
 )
+from eth2.beacon.typing import (
+    ValidatorIndex,
+)
 
 from .block_validation import (
     validate_attestation,
     validate_attester_slashing,
     validate_proposer_slashing,
+    validate_slashable_indices,
 )
 
 
@@ -43,6 +54,20 @@ def process_proposer_slashings(state: BeaconState,
     return state
 
 
+@to_tuple
+def _get_slashable_indices(state: BeaconState,
+                           config: BeaconConfig,
+                           attester_slashing: AttesterSlashing) -> Iterable[ValidatorIndex]:
+    current_epoch = state.current_epoch(config.SLOTS_PER_EPOCH)
+    for index in attester_slashing.slashable_attestation_1.validator_indices:
+        should_be_slashed = (
+            index in attester_slashing.slashable_attestation_2.validator_indices and
+            state.validator_registry[index].slashed_epoch > current_epoch
+        )
+        if should_be_slashed:
+            yield index
+
+
 def process_attester_slashings(state: BeaconState,
                                block: BaseBeaconBlock,
                                config: BeaconConfig) -> BeaconState:
@@ -61,15 +86,9 @@ def process_attester_slashings(state: BeaconState,
             config.SLOTS_PER_EPOCH,
         )
 
-        current_epoch = state.current_epoch(config.SLOTS_PER_EPOCH)
-        slashable_indices = tuple(
-            index
-            for index in attester_slashing.slashable_attestation_1.validator_indices
-            if index in (
-                attester_slashing.slashable_attestation_2.validator_indices and
-                state.validator_registry[index].slashed_epoch > current_epoch
-            )
-        )
+        slashable_indices = _get_slashable_indices(state, config, attester_slashing)
+
+        validate_slashable_indices(slashable_indices)
         for index in slashable_indices:
             state = slash_validator(
                 state=state,

--- a/eth2/beacon/state_machines/forks/serenity/operation_processing.py
+++ b/eth2/beacon/state_machines/forks/serenity/operation_processing.py
@@ -58,11 +58,10 @@ def process_proposer_slashings(state: BeaconState,
 def _get_slashable_indices(state: BeaconState,
                            config: BeaconConfig,
                            attester_slashing: AttesterSlashing) -> Iterable[ValidatorIndex]:
-    current_epoch = state.current_epoch(config.SLOTS_PER_EPOCH)
     for index in attester_slashing.slashable_attestation_1.validator_indices:
         should_be_slashed = (
             index in attester_slashing.slashable_attestation_2.validator_indices and
-            state.validator_registry[index].slashed_epoch > current_epoch
+            not state.validator_registry[index].slashed
         )
         if should_be_slashed:
             yield index

--- a/eth2/beacon/state_machines/forks/serenity/slot_processing.py
+++ b/eth2/beacon/state_machines/forks/serenity/slot_processing.py
@@ -1,0 +1,37 @@
+from eth_typing import (
+    Hash32,
+)
+
+from eth2._utils.merkle import get_merkle_root
+from eth2.beacon.configs import (
+    BeaconConfig,
+)
+from eth2.beacon.types.states import BeaconState
+
+
+def process_slot_transition(state: BeaconState,
+                            config: BeaconConfig,
+                            previous_block_root: Hash32) -> BeaconState:
+    latest_block_roots_length = config.LATEST_BLOCK_ROOTS_LENGTH
+
+    # Update state.slot
+    state = state.copy(
+        slot=state.slot + 1
+    )
+
+    # Update state.latest_block_roots
+    updated_latest_block_roots = list(state.latest_block_roots)
+    previous_block_root_index = (state.slot - 1) % latest_block_roots_length
+    updated_latest_block_roots[previous_block_root_index] = previous_block_root
+
+    # Update state.batched_block_roots
+    updated_batched_block_roots = state.batched_block_roots
+    if state.slot % latest_block_roots_length == 0:
+        updated_batched_block_roots += (get_merkle_root(updated_latest_block_roots),)
+
+    state = state.copy(
+        latest_block_roots=tuple(updated_latest_block_roots),
+        batched_block_roots=updated_batched_block_roots,
+    )
+
+    return state

--- a/eth2/beacon/tools/builder/validator.py
+++ b/eth2/beacon/tools/builder/validator.py
@@ -249,7 +249,11 @@ def create_mock_slashable_attestation(state: BeaconState,
     shard = Shard(0)
 
     # Use genesis block root as `beacon_block_root`, only for tests.
-    beacon_block_root = get_block_root(state, 0, config.LATEST_BLOCK_ROOTS_LENGTH)
+    beacon_block_root = get_block_root(
+        state,
+        config.GENESIS_SLOT,
+        config.LATEST_BLOCK_ROOTS_LENGTH,
+    )
 
     # Get `epoch_boundary_root`
     epoch_boundary_root = _get_epoch_boundary_root(state, config, beacon_block_root)
@@ -290,9 +294,10 @@ def create_mock_slashable_attestation(state: BeaconState,
         signature_domain=SignatureDomain.DOMAIN_ATTESTATION,
         slots_per_epoch=config.SLOTS_PER_EPOCH,
     )
+    validator_indices = tuple(committee[i] for i in voting_committee_indices)
 
     return SlashableAttestation(
-        validator_indices=sorted(voting_committee_indices),
+        validator_indices=sorted(validator_indices),
         data=attestation_data,
         custody_bitfield=get_empty_bitfield(len(voting_committee_indices)),
         aggregate_signature=signature,
@@ -303,9 +308,9 @@ def create_mock_attester_slashing_is_double_vote(
         state: BeaconState,
         config: BeaconConfig,
         keymap: Dict[BLSPubkey, int],
-        attestation_epoch: Slot) -> AttesterSlashing:
+        attestation_epoch: Epoch) -> AttesterSlashing:
     attestation_slot_1 = get_epoch_start_slot(attestation_epoch, config.SLOTS_PER_EPOCH)
-    attestation_slot_2 = attestation_slot_1 + 1
+    attestation_slot_2 = Slot(attestation_slot_1 + 1)
 
     slashable_attestation_1 = create_mock_slashable_attestation(
         state,
@@ -330,10 +335,10 @@ def create_mock_attester_slashing_is_surround_vote(
         state: BeaconState,
         config: BeaconConfig,
         keymap: Dict[BLSPubkey, int],
-        attestation_epoch: Slot) -> AttesterSlashing:
+        attestation_epoch: Epoch) -> AttesterSlashing:
     # target_epoch_2 < target_epoch_1
     attestation_slot_2 = get_epoch_start_slot(attestation_epoch, config.SLOTS_PER_EPOCH)
-    attestation_slot_1 = attestation_slot_2 + config.SLOTS_PER_EPOCH
+    attestation_slot_1 = Slot(attestation_slot_2 + config.SLOTS_PER_EPOCH)
 
     slashable_attestation_1 = create_mock_slashable_attestation(
         state.copy(

--- a/eth2/beacon/tools/builder/validator.py
+++ b/eth2/beacon/tools/builder/validator.py
@@ -244,11 +244,9 @@ def create_mock_slashable_attestation(state: BeaconState,
     """
     Create `SlashableAttestation` that is signed by one attester.
     """
-    committee, shard = get_crosslink_committees_at_slot(
-        state=state,
-        slot=attestation_slot,
-        committee_config=CommitteeConfig(config),
-    )[0]
+    attester_index = ValidatorIndex(0)
+    committee = (attester_index,)
+    shard = Shard(0)
     attestation_data = create_mock_attestation_data_at_slot(
         state,
         config,

--- a/eth2/beacon/validator_status_helpers.py
+++ b/eth2/beacon/validator_status_helpers.py
@@ -184,7 +184,7 @@ def slash_validator(*,
 
     validator = state.validator_registry[index]
 
-    # [TO BE REMOVED IN PHASE 2]
+    # TODO: [TO BE REMOVED IN PHASE 2]
     _validate_withdrawable_epoch(state.slot, validator.withdrawable_epoch, slots_per_epoch)
 
     state = exit_validator(state, index, slots_per_epoch, activation_exit_delay)

--- a/tests/eth2/beacon/state_machines/forks/test_serenity_block_attester_slashing_validation.py
+++ b/tests/eth2/beacon/state_machines/forks/test_serenity_block_attester_slashing_validation.py
@@ -4,23 +4,68 @@ from eth_utils import (
     ValidationError,
 )
 
+from eth2.beacon.helpers import (
+    is_double_vote,
+    is_surround_vote,
+)
 from eth2.beacon.state_machines.forks.serenity.block_validation import (
     validate_attester_slashing,
     validate_attester_slashing_different_data,
+    validate_attester_slashing_slashing_conditions,
 )
 from eth2.beacon.tools.builder.validator import (
-    create_mock_double_voted_attester_slashing,
+    create_mock_attester_slashing_is_double_vote,
+    create_mock_attester_slashing_is_surround_vote,
+    create_mock_slashable_attestation,
 )
 
 
-def get_valid_attester_slashing(attesting_state,
-                                keymap,
-                                config):
-    return create_mock_double_voted_attester_slashing(
+@pytest.mark.parametrize(
+    (
+        'num_validators',
+        'slots_per_epoch',
+        'target_committee_size',
+        'shard_count',
+    ),
+    [
+        (40, 2, 2, 2),
+    ]
+)
+def test_validate_proposer_slashing_valid_double_vote(
+        genesis_state,
+        keymap,
+        slots_per_epoch,
+        max_indices_per_slashable_vote,
+        config):
+    attesting_state = genesis_state.copy(
+        slot=genesis_state.slot + slots_per_epoch,
+    )
+    valid_attester_slashing = create_mock_attester_slashing_is_double_vote(
         attesting_state,
         config,
         keymap,
         attestation_epoch=0,
+    )
+
+    assert is_double_vote(
+        valid_attester_slashing.slashable_attestation_1.data,
+        valid_attester_slashing.slashable_attestation_2.data,
+        slots_per_epoch,
+    )
+    assert not is_surround_vote(
+        valid_attester_slashing.slashable_attestation_1.data,
+        valid_attester_slashing.slashable_attestation_2.data,
+        slots_per_epoch,
+    )
+
+    state = attesting_state.copy(
+        slot=attesting_state.slot + 1,
+    )
+    validate_attester_slashing(
+        state,
+        valid_attester_slashing,
+        max_indices_per_slashable_vote,
+        slots_per_epoch,
     )
 
 
@@ -35,26 +80,39 @@ def get_valid_attester_slashing(attesting_state,
         (40, 2, 2, 2),
     ]
 )
-def test_validate_proposer_slashing_valid(genesis_state,
-                                          keymap,
-                                          slots_per_epoch,
-                                          max_indices_per_slashable_vote,
-                                          config):
+def test_validate_proposer_slashing_valid_is_surround_vote(
+        genesis_state,
+        keymap,
+        slots_per_epoch,
+        max_indices_per_slashable_vote,
+        config):
     attesting_state = genesis_state.copy(
         slot=genesis_state.slot + slots_per_epoch,
     )
-    valid_proposer_slashing = get_valid_attester_slashing(
+    valid_attester_slashing = create_mock_attester_slashing_is_surround_vote(
         attesting_state,
-        keymap,
         config,
+        keymap,
+        attestation_epoch=attesting_state.current_epoch(slots_per_epoch),
+    )
+
+    assert not is_double_vote(
+        valid_attester_slashing.slashable_attestation_1.data,
+        valid_attester_slashing.slashable_attestation_2.data,
+        slots_per_epoch,
+    )
+    assert is_surround_vote(
+        valid_attester_slashing.slashable_attestation_1.data,
+        valid_attester_slashing.slashable_attestation_2.data,
+        slots_per_epoch,
     )
 
     state = attesting_state.copy(
-        slot=attesting_state.slot + 1,
+        slot=attesting_state.slot + config.SLOTS_PER_EPOCH,
     )
     validate_attester_slashing(
         state,
-        valid_proposer_slashing,
+        valid_attester_slashing,
         max_indices_per_slashable_vote,
         slots_per_epoch,
     )
@@ -75,19 +133,63 @@ def test_validate_attester_slashing_different_data(
         genesis_state,
         keymap,
         slots_per_epoch,
-        max_indices_per_slashable_vote,
         config):
     attesting_state = genesis_state.copy(
         slot=genesis_state.slot + slots_per_epoch,
     )
-    valid_proposer_slashing = get_valid_attester_slashing(
+    valid_attester_slashing = create_mock_attester_slashing_is_double_vote(
         attesting_state,
-        keymap,
         config,
+        keymap,
+        attestation_epoch=0,
     )
 
     with pytest.raises(ValidationError):
         validate_attester_slashing_different_data(
-            valid_proposer_slashing.slashable_attestation_1,
-            valid_proposer_slashing.slashable_attestation_1,  # Put the same SlashableAttestation
+            valid_attester_slashing.slashable_attestation_1,
+            valid_attester_slashing.slashable_attestation_1,  # Put the same SlashableAttestation
+        )
+
+
+@pytest.mark.parametrize(
+    (
+        'num_validators',
+        'slots_per_epoch',
+        'target_committee_size',
+        'shard_count',
+    ),
+    [
+        (40, 2, 2, 2),
+    ]
+)
+def test_validate_attester_slashing_slashing_conditions(
+        genesis_state,
+        keymap,
+        slots_per_epoch,
+        config):
+    attesting_state_1 = genesis_state.copy(
+        slot=genesis_state.slot + slots_per_epoch,
+    )
+    attesting_state_2 = attesting_state_1.copy(
+        slot=attesting_state_1.slot + slots_per_epoch,
+    )
+
+    slashable_attestation_1 = create_mock_slashable_attestation(
+        attesting_state_1,
+        config,
+        keymap,
+        attestation_slot=attesting_state_1.slot + slots_per_epoch,
+    )
+    slashable_attestation_2 = create_mock_slashable_attestation(
+        attesting_state_2,
+        config,
+        keymap,
+        attestation_slot=attesting_state_2.slot + slots_per_epoch,
+    )
+
+    with pytest.raises(ValidationError):
+        validate_attester_slashing_slashing_conditions(
+            slashable_attestation_1,
+            slashable_attestation_2,
+            slots_per_epoch,
         )

--- a/tests/eth2/beacon/state_machines/forks/test_serenity_block_attester_slashing_validation.py
+++ b/tests/eth2/beacon/state_machines/forks/test_serenity_block_attester_slashing_validation.py
@@ -1,0 +1,93 @@
+import pytest
+
+from eth_utils import (
+    ValidationError,
+)
+
+from eth2.beacon.state_machines.forks.serenity.block_validation import (
+    validate_attester_slashing,
+    validate_attester_slashing_different_data,
+)
+from eth2.beacon.tools.builder.validator import (
+    create_mock_double_voted_attester_slashing,
+)
+
+
+def get_valid_attester_slashing(attesting_state,
+                                keymap,
+                                config):
+    return create_mock_double_voted_attester_slashing(
+        attesting_state,
+        config,
+        keymap,
+        attestation_epoch=0,
+    )
+
+
+@pytest.mark.parametrize(
+    (
+        'num_validators',
+        'slots_per_epoch',
+        'target_committee_size',
+        'shard_count',
+    ),
+    [
+        (40, 2, 2, 2),
+    ]
+)
+def test_validate_proposer_slashing_valid(genesis_state,
+                                          keymap,
+                                          slots_per_epoch,
+                                          max_indices_per_slashable_vote,
+                                          config):
+    attesting_state = genesis_state.copy(
+        slot=genesis_state.slot + slots_per_epoch,
+    )
+    valid_proposer_slashing = get_valid_attester_slashing(
+        attesting_state,
+        keymap,
+        config,
+    )
+
+    state = attesting_state.copy(
+        slot=attesting_state.slot + 1,
+    )
+    validate_attester_slashing(
+        state,
+        valid_proposer_slashing,
+        max_indices_per_slashable_vote,
+        slots_per_epoch,
+    )
+
+
+@pytest.mark.parametrize(
+    (
+        'num_validators',
+        'slots_per_epoch',
+        'target_committee_size',
+        'shard_count',
+    ),
+    [
+        (40, 2, 2, 2),
+    ]
+)
+def test_validate_attester_slashing_different_data(
+        genesis_state,
+        keymap,
+        slots_per_epoch,
+        max_indices_per_slashable_vote,
+        config):
+    attesting_state = genesis_state.copy(
+        slot=genesis_state.slot + slots_per_epoch,
+    )
+    valid_proposer_slashing = get_valid_attester_slashing(
+        attesting_state,
+        keymap,
+        config,
+    )
+
+    with pytest.raises(ValidationError):
+        validate_attester_slashing_different_data(
+            valid_proposer_slashing.slashable_attestation_1,
+            valid_proposer_slashing.slashable_attestation_1,  # Put the same SlashableAttestation
+        )

--- a/tests/eth2/beacon/state_machines/forks/test_serenity_block_attester_slashing_validation.py
+++ b/tests/eth2/beacon/state_machines/forks/test_serenity_block_attester_slashing_validation.py
@@ -12,6 +12,7 @@ from eth2.beacon.state_machines.forks.serenity.block_validation import (
     validate_attester_slashing,
     validate_attester_slashing_different_data,
     validate_attester_slashing_slashing_conditions,
+    validate_slashable_indices,
 )
 from eth2.beacon.tools.builder.validator import (
     create_mock_attester_slashing_is_double_vote,
@@ -193,3 +194,22 @@ def test_validate_attester_slashing_slashing_conditions(
             slashable_attestation_2,
             slots_per_epoch,
         )
+
+
+@pytest.mark.parametrize(
+    (
+        'slashable_indices',
+        'success',
+    ),
+    [
+        ((), False),
+        ((1,), True),
+        ((1, 2), True),
+    ]
+)
+def test_validate_slashable_indices(slashable_indices, success):
+    if success:
+        validate_slashable_indices(slashable_indices)
+    else:
+        with pytest.raises(ValidationError):
+            validate_slashable_indices(slashable_indices)

--- a/tests/eth2/beacon/state_machines/forks/test_serenity_operation_processing.py
+++ b/tests/eth2/beacon/state_machines/forks/test_serenity_operation_processing.py
@@ -13,8 +13,10 @@ from eth2.beacon.state_machines.forks.serenity.blocks import (
 from eth2.beacon.state_machines.forks.serenity.operation_processing import (
     process_attestations,
     process_proposer_slashings,
+    process_attester_slashings,
 )
 from eth2.beacon.tools.builder.validator import (
+    create_mock_attester_slashing_is_double_vote,
     create_mock_signed_attestations_at_slot,
     create_mock_proposer_slashing_at_block,
 )
@@ -124,6 +126,69 @@ def test_process_proposer_slashings(genesis_state,
                 block,
                 config,
             )
+
+
+@pytest.mark.parametrize(
+    (
+        'num_validators',
+        'slots_per_epoch',
+        'target_committee_size',
+        'shard_count',
+        'min_attestation_inclusion_delay',
+        'success'
+    ),
+    [
+        (100, 2, 2, 2, 1, True),
+    ]
+)
+def test_process_attester_slashings(genesis_state,
+                                    sample_beacon_block_params,
+                                    sample_beacon_block_body_params,
+                                    config,
+                                    keymap,
+                                    min_attestation_inclusion_delay,
+                                    success):
+    attesting_state = genesis_state.copy(
+        slot=genesis_state.slot + config.SLOTS_PER_EPOCH,
+    )
+    valid_attester_slashing = create_mock_attester_slashing_is_double_vote(
+        attesting_state,
+        config,
+        keymap,
+        attestation_epoch=0,
+    )
+
+    block_body = BeaconBlockBody(**sample_beacon_block_body_params).copy(
+        attester_slashings=(valid_attester_slashing,),
+    )
+
+    state = attesting_state.copy(
+        slot=attesting_state.slot + min_attestation_inclusion_delay,
+    )
+    block = SerenityBeaconBlock(**sample_beacon_block_params).copy(
+        slot=state.slot,
+        body=block_body,
+    )
+
+    attester_index = valid_attester_slashing.slashable_attestation_1.validator_indices[0]
+
+    if success:
+        new_state = process_attester_slashings(
+            state,
+            block,
+            config,
+        )
+        # Check if slashed
+        assert (
+            new_state.validator_balances[attester_index] < state.validator_balances[attester_index]
+        )
+    # else:
+    #     with pytest.raises(ValidationError):
+    #         process_proposer_slashings(
+    #             state,
+    #             block,
+    #             config,
+    #         )
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
### What was wrong?
- Part of #238
- Implement `process_attester_slashings` and related validations
- Spec reference: https://github.com/ethereum/eth2.0-specs/blob/26908d55790fcb24bdf89c13957a54bba3d75e22/specs/core/0_beacon-chain.md#attester-slashings-1

### How was it fixed?
1. Implement `process_attester_slashings`
2. Implement `validate_attester_slashing` for validating each `AttesterSlashing`
3. Add `validate_attester_slashing` tests in `tests/eth2/beacon/state_machines/forks/test_serenity_block_attester_slashing_validation.py`

4. Address https://github.com/ethereum/eth2.0-specs/issues/651

#### TODO:
- [x] Add test for `process_attester_slashing`

#### Cute Animal Picture

![nature-animal-wildlife-wild-zoo-fur-red-brown-mammal-fauna-kangaroo-close-up-australia-furry-vertebrate-marsupial-outback-macropodidae-macropus-macropod-horse-like-mammal-587557](https://user-images.githubusercontent.com/9263930/53114487-ce9c1e00-357e-11e9-8d67-973e279fc3fa.jpg)
