### PR TITLE
Fix attestation, previous epoch logic and builder tools

### DIFF
--- a/eth2/beacon/committee_helpers.py
+++ b/eth2/beacon/committee_helpers.py
@@ -184,17 +184,7 @@ def get_crosslink_committees_at_slot(
         genesis_epoch=genesis_epoch,
     )
 
-    if epoch == previous_epoch:
-        committees_per_epoch = get_previous_epoch_committee_count(
-            state=state,
-            shard_count=shard_count,
-            slots_per_epoch=slots_per_epoch,
-            target_committee_size=target_committee_size,
-        )
-        seed = state.previous_shuffling_seed
-        shuffling_epoch = state.previous_shuffling_epoch
-        shuffling_start_shard = state.previous_shuffling_start_shard
-    elif epoch == current_epoch:
+    if epoch == current_epoch:
         committees_per_epoch = get_current_epoch_committee_count(
             state=state,
             shard_count=shard_count,
@@ -204,6 +194,16 @@ def get_crosslink_committees_at_slot(
         seed = state.current_shuffling_seed
         shuffling_epoch = state.current_shuffling_epoch
         shuffling_start_shard = state.current_shuffling_start_shard
+    elif epoch == previous_epoch:
+        committees_per_epoch = get_previous_epoch_committee_count(
+            state=state,
+            shard_count=shard_count,
+            slots_per_epoch=slots_per_epoch,
+            target_committee_size=target_committee_size,
+        )
+        seed = state.previous_shuffling_seed
+        shuffling_epoch = state.previous_shuffling_epoch
+        shuffling_start_shard = state.previous_shuffling_start_shard
     elif epoch == next_epoch:
         current_committees_per_epoch = get_current_epoch_committee_count(
             state=state,

--- a/eth2/beacon/state_machines/forks/serenity/block_validation.py
+++ b/eth2/beacon/state_machines/forks/serenity/block_validation.py
@@ -320,7 +320,7 @@ def validate_attestation_justified_epoch(attestation_data: AttestationData,
     Validate ``justified_epoch`` field of ``attestation_data``.
     Raise ``ValidationError`` if it's invalid.
     """
-    if attestation_data.slot >= get_epoch_start_slot(current_epoch, slots_per_epoch):
+    if slot_to_epoch(attestation_data.slot + 1, slots_per_epoch) >= current_epoch:
         if attestation_data.justified_epoch != justified_epoch:
             raise ValidationError(
                 "Attestation ``slot`` is after recent epoch transition but attestation"

--- a/eth2/beacon/types/states.py
+++ b/eth2/beacon/types/states.py
@@ -295,11 +295,7 @@ class BeaconState(ssz.Serializable):
         return slot_to_epoch(self.slot, slots_per_epoch)
 
     def previous_epoch(self, slots_per_epoch: int, genesis_epoch: int) -> Epoch:
-        current_epoch: Epoch = self.current_epoch(slots_per_epoch)
-        if current_epoch == genesis_epoch:
-            return current_epoch
-        else:
-            return Epoch(current_epoch - 1)
+        return Epoch(max(self.current_epoch(slots_per_epoch) - 1, genesis_epoch))
 
     def next_epoch(self, slots_per_epoch: int) -> Epoch:
         return Epoch(self.current_epoch(slots_per_epoch) + 1)

--- a/tests/eth2/beacon/conftest.py
+++ b/tests/eth2/beacon/conftest.py
@@ -57,7 +57,7 @@ def privkeys():
     Rationales:
     1. Making the privkeys be small integers to make multiplying easier for tests.
     2. Using ``2**i`` instead of ``i``:
-        The combinations of validators would not lead to unique pubkeys.
+        If using ``i``, the combinations of privkeys would not lead to unique pubkeys.
     """
     return [2 ** i for i in range(100)]
 

--- a/tests/eth2/beacon/conftest.py
+++ b/tests/eth2/beacon/conftest.py
@@ -8,7 +8,6 @@ from eth_utils import (
 )
 
 import eth2._utils.bls as bls
-from eth2.beacon._utils.hash import hash_eth2
 from eth2.beacon.configs import (
     BeaconConfig,
     CommitteeConfig,
@@ -54,7 +53,13 @@ DEFAULT_NUM_VALIDATORS = 40
 
 @pytest.fixture(scope="session")
 def privkeys():
-    return [int.from_bytes(hash_eth2(str(i).encode('utf-8'))[:4], 'big') for i in range(100)]
+    """
+    Rationales:
+    1. Making the privkeys be small integers to make multiplying easier for tests.
+    2. Using ``2**i`` instead of ``i``:
+        The combinations of validators would not lead to unique pubkeys.
+    """
+    return [2 ** i for i in range(100)]
 
 
 @pytest.fixture(scope="session")

--- a/tests/eth2/beacon/state_machines/forks/test_serenity_block_attestation_validation.py
+++ b/tests/eth2/beacon/state_machines/forks/test_serenity_block_attestation_validation.py
@@ -113,7 +113,6 @@ def test_validate_attestation_justified_epoch(
     )
 
     if is_valid:
-        # slot_to_epoch(attestation_data.slot + 1, slots_per_epoch) >= current_epoch
         validate_attestation_justified_epoch(
             attestation_data,
             current_epoch,

--- a/tests/eth2/beacon/state_machines/forks/test_serenity_block_attestation_validation.py
+++ b/tests/eth2/beacon/state_machines/forks/test_serenity_block_attestation_validation.py
@@ -90,13 +90,12 @@ def test_validate_attestation_slot(sample_attestation_data_params,
         'is_valid,'
     ),
     [
-        (13, 1, 2, 0, 1, 5, True),
-        (13, 0, 2, 0, 1, 5, False),  # targeting previous_justified_epoch, should be targeting justified_epoch # noqa: E501
-        (13, 4, 2, 0, 1, 5, False),  # targeting future epoch, should be targeting justified_epoch
-        (29, 1, 3, 1, 2, 10, True),
-        (29, 2, 3, 1, 2, 10, False),  # targeting justified_epoch, should be targeting previous_justified_epoch # noqa: E501
-        (29, 3, 3, 1, 2, 10, False),  # targeting future epoch, should be targeting previous_justified_epoch # noqa: E501
-        (10, 1, 1, 1, 1, 10, True),
+        # slot_to_epoch(attestation_data.slot + 1, slots_per_epoch) >= current_epoch
+        (23, 2, 3, 1, 2, 8, True),  # attestation_data.justified_epoch == justified_epoch
+        (23, 1, 3, 1, 2, 8, False),  # attestation_data.justified_epoch != justified_epoch
+        # slot_to_epoch(attestation_data.slot + 1, slots_per_epoch) < current_epoch
+        (22, 1, 3, 1, 2, 8, True),  # attestation_data.justified_epoch == previous_justified_epoch
+        (22, 2, 3, 1, 2, 8, False),  # attestation_data.justified_epoch != previous_justified_epoch
     ]
 )
 def test_validate_attestation_justified_epoch(
@@ -114,6 +113,7 @@ def test_validate_attestation_justified_epoch(
     )
 
     if is_valid:
+        # slot_to_epoch(attestation_data.slot + 1, slots_per_epoch) >= current_epoch
         validate_attestation_justified_epoch(
             attestation_data,
             current_epoch,

--- a/tests/eth2/beacon/state_machines/forks/test_serenity_operation_processing.py
+++ b/tests/eth2/beacon/state_machines/forks/test_serenity_operation_processing.py
@@ -21,6 +21,7 @@ from eth2.beacon.tools.builder.validator import (
 
 
 def test_process_max_attestations(genesis_state,
+                                  genesis_block,
                                   sample_beacon_block_params,
                                   sample_beacon_block_body_params,
                                   config,
@@ -32,11 +33,12 @@ def test_process_max_attestations(genesis_state,
     )
 
     attestations = create_mock_signed_attestations_at_slot(
-        state,
-        config,
-        attestation_slot,
-        keymap,
-        1.0,
+        state=state,
+        config=config,
+        attestation_slot=attestation_slot,
+        beacon_block_root=genesis_block.root,
+        keymap=keymap,
+        voted_attesters_ratio=1.0,
     )
 
     attestations_count = len(attestations)
@@ -140,6 +142,7 @@ def test_process_proposer_slashings(genesis_state,
     ]
 )
 def test_process_attestations(genesis_state,
+                              genesis_block,
                               sample_beacon_block_params,
                               sample_beacon_block_body_params,
                               config,
@@ -153,11 +156,12 @@ def test_process_attestations(genesis_state,
     )
 
     attestations = create_mock_signed_attestations_at_slot(
-        state,
-        config,
-        attestation_slot,
-        keymap,
-        1.0,
+        state=state,
+        config=config,
+        attestation_slot=attestation_slot,
+        beacon_block_root=genesis_block.root,
+        keymap=keymap,
+        voted_attesters_ratio=1.0,
     )
 
     assert len(attestations) > 0

--- a/tests/eth2/beacon/test_committee_helpers.py
+++ b/tests/eth2/beacon/test_committee_helpers.py
@@ -386,10 +386,10 @@ def test_get_crosslink_committees_at_slot(
     previous_epoch = state.previous_epoch(slots_per_epoch, genesis_epoch)
     next_epoch = current_epoch + 1
 
-    if epoch == previous_epoch:
-        seed = state.previous_shuffling_seed
-    elif epoch == current_epoch:
+    if epoch == current_epoch:
         seed = state.current_shuffling_seed
+    elif epoch == previous_epoch:
+        seed = state.previous_shuffling_seed
     elif epoch == next_epoch:
         if registry_change or should_reseed:
             seed = new_seed


### PR DESCRIPTION
### What was wrong?
To fix #294, also need to fix other issues to make `test_demo.py` work.

### How was it fixed?
1. Address ethereum/eth2.0-specs#672: fix up previous epoch logic around genesis
2. Address ethereum/eth2.0-specs#627: fix off by one attestaton issue
3. Fix `create_mock_signed_attestation`: Address ethereum/eth2.0-specs#671
4. Fix `test_demo.py`
	1. Use map `attestations_map: Dict[Slot, Sequence[Attestation]]` to keep the generated attestations, and include them when reache `MIN_ATTESTATION_INCLUSION_DELAY`.
	2. Add justification assertions

#### Cute Animal Picture
![albino_kangaroo](https://user-images.githubusercontent.com/9263930/53227777-36a34f00-36ba-11e9-809a-4f291d25cbcd.jpg)
(Foto: Heike Katthagen)