### PR TITLE
Print pid when isolated plugin starts

### DIFF
--- a/trinity/extensibility/plugin.py
+++ b/trinity/extensibility/plugin.py
@@ -290,7 +290,7 @@ class BaseIsolatedPlugin(BasePlugin):
         )
 
         self._process.start()
-        self.logger.info("Plugin started: %s", self.name)
+        self.logger.info("Plugin started: %s (pid=%d)", self.name, self._process.pid)
 
     def _prepare_start(self) -> None:
         log_queue = self.context.boot_kwargs['log_queue']


### PR DESCRIPTION
### What was wrong?

Currently, when an isolated plugin starts we do not print the `pid` of the new process. This is a missed opportunity because it is really convenient to e.g. say `py-spy -p <pid-of-some-isolated-plugin>` to trace down performance issues.

### How was it fixed?

Added `pid` to the logging output.

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://media.giphy.com/media/cMso9wDwqSy3e/giphy_s.gif)
