### PR TITLE
Ensure networking process is killed before db process

### DIFF
--- a/trinity/main.py
+++ b/trinity/main.py
@@ -135,7 +135,7 @@ def trinity_boot(args: Namespace,
         kill_trinity_gracefully(
             trinity_config,
             logger,
-            (database_server_process, networking_process),
+            (networking_process, database_server_process),
             plugin_manager,
             main_endpoint,
             reason=reason


### PR DESCRIPTION

### What was wrong?

Since the networking process currently depends on the database process, it is safer to first kill the networking process and then the db process.

### How was it fixed?

Swap the order in which these processes are killed.

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://images.boredomfiles.com/wp-content/uploads/sites/5/2018/10/6608060-zFNPPyG-1539272863-728-5afdeaad2b-1539608064.jpg)
