### PR TITLE
Fix typing in eth2.beacon.tools

### DIFF
--- a/eth2/beacon/tools/builder/initializer.py
+++ b/eth2/beacon/tools/builder/initializer.py
@@ -5,6 +5,10 @@ from typing import (
     Type,
 )
 
+from eth_typing import (
+    Hash32,
+)
+
 from eth2.beacon.configs import BeaconConfig
 from eth2.beacon.on_genesis import (
     get_genesis_block,
@@ -35,8 +39,8 @@ def create_mock_genesis_validator_deposits(
         pubkeys: Sequence[BLSPubkey],
         keymap: Dict[BLSPubkey, int]) -> Tuple[Deposit, ...]:
     # Mock data
-    withdrawal_credentials = b'\x22' * 32
-    deposit_timestamp = 0
+    withdrawal_credentials = Hash32(b'\x22' * 32)
+    deposit_timestamp = Timestamp(0)
     fork = Fork(
         previous_version=config.GENESIS_FORK_VERSION,
         current_version=config.GENESIS_FORK_VERSION,
@@ -45,8 +49,8 @@ def create_mock_genesis_validator_deposits(
 
     genesis_validator_deposits = tuple(
         Deposit(
-            branch=(
-                b'\x11' * 32
+            branch=tuple(
+                Hash32(b'\x11' * 32)
                 for j in range(10)
             ),
             index=i,
@@ -80,7 +84,7 @@ def create_mock_genesis(
         config: BeaconConfig,
         keymap: Dict[BLSPubkey, int],
         genesis_block_class: Type[BaseBeaconBlock],
-        genesis_time: Timestamp=0) -> Tuple[BeaconState, BaseBeaconBlock]:
+        genesis_time: Timestamp=Timestamp(0)) -> Tuple[BeaconState, BaseBeaconBlock]:
     latest_eth1_data = Eth1Data.create_empty_data()
 
     assert num_validators <= len(keymap)

--- a/eth2/beacon/tools/builder/proposer.py
+++ b/eth2/beacon/tools/builder/proposer.py
@@ -47,7 +47,7 @@ from eth2.beacon.tools.builder.validator import (
 def validate_proposer_index(state: BeaconState,
                             config: BeaconConfig,
                             slot: Slot,
-                            validator_index: ValidatorIndex):
+                            validator_index: ValidatorIndex) -> None:
     beacon_proposer_index = get_beacon_proposer_index(
         state.copy(
             slot=slot,
@@ -65,7 +65,7 @@ def create_block_on_state(
         state: BeaconState,
         config: BeaconConfig,
         state_machine: BaseBeaconStateMachine,
-        block_class: BaseBeaconBlock,
+        block_class: Type[BaseBeaconBlock],
         parent_block: BaseBeaconBlock,
         slot: Slot,
         validator_index: ValidatorIndex,


### PR DESCRIPTION
### What was wrong?

There is no`__init__.py` in `eth2/beacon/tools/`, so it looks like mypy is not checking the typing there.

### How was it fixed?

Add `__init__.py` and fix typing

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://upload.wikimedia.org/wikipedia/commons/thumb/7/72/Inia.jpg/1600px-Inia.jpg)
https://commons.wikimedia.org/wiki/File:Inia.jpg
