### PR TITLE
Log a lot more info when header parent is missing

### DIFF
--- a/trinity/sync/common/headers.py
+++ b/trinity/sync/common/headers.py
@@ -468,7 +468,7 @@ class SkeletonSyncer(BaseService, Generic[TChainPeer]):
             self.logger.debug("Could not find any header at #%d: %s", block_num, exc)
             local_header = None
 
-        # Header just preceeding this one may or may not be in the database. Either way log an error
+        # Canonical header at same number may or may not be in the database. Either way log an error
         self.logger.debug(
             "%s returned starting header %s, which is not in our DB. "
             "Instead at #%d, our is header %s",


### PR DESCRIPTION
### What was wrong?

There is a pretty mysterious bug related to syncing headers, where a header comes in from a peer when its parent is not in the DB: #308 

### How was it fixed?

Added some logging to collect relevant info about the incoming invalid header.

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://c1.staticflickr.com/9/8069/8190687133_4b72782e47_b.jpg)
