### PR TITLE
Rename `message` to `message_hash` and fix type to `Hash32`

### DIFF
--- a/eth2/beacon/deposit_helpers.py
+++ b/eth2/beacon/deposit_helpers.py
@@ -39,7 +39,7 @@ def validate_proof_of_possession(state: BeaconState,
     is_valid_signature = bls.verify(
         pubkey=pubkey,
         # TODO: change to hash_tree_root(deposit_input) when we have SSZ tree hashing
-        message=deposit_input.root,
+        message_hash=deposit_input.root,
         signature=proof_of_possession,
         domain=get_domain(
             state.fork,

--- a/eth2/beacon/tools/builder/proposer.py
+++ b/eth2/beacon/tools/builder/proposer.py
@@ -110,7 +110,7 @@ def create_block_on_state(
     ).root
 
     signature = sign_transaction(
-        message=proposal_root,
+        message_hash=proposal_root,
         privkey=privkey,
         fork=state.fork,
         slot=slot,

--- a/eth2/beacon/types/slashable_attestations.py
+++ b/eth2/beacon/types/slashable_attestations.py
@@ -87,9 +87,9 @@ class SlashableAttestation(ssz.Serializable):
         return (custody_bit_0_indices, custody_bit_1_indices)
 
     @property
-    def messages(self) -> Tuple[Hash32, Hash32]:
+    def message_hashes(self) -> Tuple[Hash32, Hash32]:
         """
-        Build the messages that validators are expected to sign for an
+        Build the message_hashes that validators are expected to sign for an
         ``AttesterSlashing`` operation.
         """
         # TODO: change to hash_tree_root when we have SSZ tree hashing

--- a/tests/eth2/beacon/state_machines/forks/test_serenity_block_processing.py
+++ b/tests/eth2/beacon/state_machines/forks/test_serenity_block_processing.py
@@ -63,10 +63,10 @@ def test_randao_processing(sample_beacon_block_params,
 
     epoch = state.current_epoch(config.SLOTS_PER_EPOCH)
     slot = epoch * config.SLOTS_PER_EPOCH
-    message = epoch.to_bytes(32, byteorder="big")
+    message_hash = epoch.to_bytes(32, byteorder="big")
     fork = Fork(**sample_fork_params)
     domain = get_domain(fork, slot, SignatureDomain.DOMAIN_RANDAO)
-    randao_reveal = bls.sign(message, proposer_privkey, domain)
+    randao_reveal = bls.sign(message_hash, proposer_privkey, domain)
 
     block = SerenityBeaconBlock(**sample_beacon_block_params).copy(
         randao_reveal=randao_reveal,
@@ -105,10 +105,10 @@ def test_randao_processing_validates_randao_reveal(sample_beacon_block_params,
 
     epoch = state.current_epoch(config.SLOTS_PER_EPOCH)
     slot = epoch * config.SLOTS_PER_EPOCH
-    message = (epoch + 1).to_bytes(32, byteorder="big")
+    message_hash = (epoch + 1).to_bytes(32, byteorder="big")
     fork = Fork(**sample_fork_params)
     domain = get_domain(fork, slot, SignatureDomain.DOMAIN_RANDAO)
-    randao_reveal = bls.sign(message, proposer_privkey, domain)
+    randao_reveal = bls.sign(message_hash, proposer_privkey, domain)
 
     block = SerenityBeaconBlock(**sample_beacon_block_params).copy(
         randao_reveal=randao_reveal,

--- a/tests/eth2/beacon/tools/builder/test_builder_validator.py
+++ b/tests/eth2/beacon/tools/builder/test_builder_validator.py
@@ -42,20 +42,20 @@ def test_aggregate_votes(votes_count, random, privkeys, pubkeys):
     domain = 0
 
     random_votes = random.sample(range(bit_count), votes_count)
-    message = b'hello'
+    message_hash = b'\x12' * 32
 
     # Get votes: (committee_index, sig, public_key)
     votes = [
         (
             committee_index,
-            bls.sign(message, privkeys[committee_index], domain),
+            bls.sign(message_hash, privkeys[committee_index], domain),
             pubkeys[committee_index],
         )
         for committee_index in random_votes
     ]
 
     # Verify
-    sigs, committee_indices = verify_votes(message, votes, domain)
+    sigs, committee_indices = verify_votes(message_hash, votes, domain)
 
     # Aggregate the votes
     bitfield, sigs = aggregate_votes(
@@ -78,7 +78,7 @@ def test_aggregate_votes(votes_count, random, privkeys, pubkeys):
     assert len(voted_index) == len(votes)
 
     aggregated_pubs = bls.aggregate_pubkeys(pubs)
-    assert bls.verify(message, aggregated_pubs, sigs, domain)
+    assert bls.verify(message_hash, aggregated_pubs, sigs, domain)
 
 
 @pytest.mark.parametrize(

--- a/tests/eth2/beacon/types/test_slashable_attestation.py
+++ b/tests/eth2/beacon/types/test_slashable_attestation.py
@@ -93,7 +93,7 @@ def test_custody_bit_indices(
 def test_messages(sample_slashable_attestation_params):
     slashable_attestation = SlashableAttestation(**sample_slashable_attestation_params)
 
-    assert slashable_attestation.messages == (
+    assert slashable_attestation.message_hashes == (
         AttestationDataAndCustodyBit(slashable_attestation.data, False).root,
         AttestationDataAndCustodyBit(slashable_attestation.data, True).root,
     )


### PR DESCRIPTION
### What was wrong?
Fix #295 

### How was it fixed?
1. Rename `message` to `message_hash`
2. Rename `messages` to `message_hashes`
3. Fix type to `Hash32`



#### Cute Animal Picture


![640px-eudyptula_minor_-perth_zoo _australia_-swimming-8a_ 1](https://user-images.githubusercontent.com/9263930/53475273-83b46600-3aaa-11e9-8e6e-1eaa783b2427.jpg)
(Photo: JP Bennett from Yamato, Japan CC 2.0)