### PR TITLE
Ensure wait_iter handles StopAsyncIteration properly

### DIFF
--- a/tests/p2p/test_service.py
+++ b/tests/p2p/test_service.py
@@ -70,6 +70,24 @@ async def test_cancel_exits_async_generator():
 
 
 @pytest.mark.asyncio
+async def test_wait_iter_stops_when_generator_is_done():
+    service = WaitService()
+    asyncio.ensure_future(service.run())
+
+    async def async_iterator():
+        yield 1
+        await asyncio.sleep(0.5)
+        yield 1
+
+    count = 0
+    async for val in service.wait_iter(async_iterator()):
+        count += val
+
+    assert count == 2
+    await service.cancel()
+
+
+@pytest.mark.asyncio
 async def test_service_tasks_do_not_leak_memory():
     service = WaitService()
     asyncio.ensure_future(service.run())


### PR DESCRIPTION
### What was wrong?

Currently, when we run `trinity` and then stop it using `CTRL+C` we'll see three of these errors.

```
   ERROR  02-27 17:01:55               asyncio  Task exception was never retrieved
future: <Task finished coro=<async_generator_asend()> exception=StopAsyncIteration()>
StopAsyncIteration 
    INFO  02-27 17:01:55            FullServer  Closing server...
 WARNING  02-27 17:01:55  ETHHeaderChainSyncer  Tried to cancel <trinity.protocol.eth.sync.ETHHeaderChainSyncer object at 0x7f8155e07358>, but it was already cancelled
    INFO  02-27 17:01:55         PluginManager  Shutting down PluginManager with scope <class 'trinity.extensibility.plugin_manager.SharedProcessScope'>
    INFO  02-27 17:01:55         PluginManager  Stopping plugin: Syncer Plugin
    INFO  02-27 17:01:55         PluginManager  Successfully stopped plugin: Syncer Plugin
   ERROR  02-27 17:01:55               asyncio  Task exception was never retrieved
future: <Task finished coro=<async_generator_asend()> exception=StopAsyncIteration()>
StopAsyncIteration
   ERROR  02-27 17:01:55               asyncio  Task exception was never retrieved
future: <Task finished coro=<async_generator_asend()> exception=StopAsyncIteration()>
StopAsyncIteration
```

These errors appeared first when we started to use `wait_iter` to consume the `event_bus.stream(...)` API. The `wait_iter` is needed to ensure we stop streaming when a cancel token is triggered. However, it appears there's a problem where we don't handle the `StopAsyncIteration` exception properly.

We can get a bit more info if we run `PYTHONASYNCIODEBUG=1 trinity` which will then expand the error message (of a single error of these) into this.

```
   ERROR  02-27 17:06:29               asyncio  Task exception was never retrieved
future: <Task finished coro=<async_generator_asend()> exception=StopAsyncIteration() created at /home/cburgdorf/Documents/hacking/ef/trinity/venv/lib/python3.6/site-packages/cancel_token/token.py:126>
source_traceback: Object created at (most recent call last):
  File "<string>", line 1, in <module>
  File "/usr/lib/python3.6/multiprocessing/spawn.py", line 105, in spawn_main
    exitcode = _main(fd)
  File "/usr/lib/python3.6/multiprocessing/spawn.py", line 118, in _main
    return self._bootstrap()
  File "/usr/lib/python3.6/multiprocessing/process.py", line 258, in _bootstrap
    self.run()
  File "/usr/lib/python3.6/multiprocessing/process.py", line 93, in run
    self._target(*self._args, **self._kwargs)
  File "/home/cburgdorf/Documents/hacking/ef/trinity/trinity/_utils/profiling.py", line 31, in inner
    return fn(*args, **kwargs)
  File "/home/cburgdorf/Documents/hacking/ef/trinity/trinity/_utils/logging.py", line 161, in inner
    return fn(*args, **inner_kwargs)
  File "/home/cburgdorf/Documents/hacking/ef/trinity/trinity/main.py", line 195, in launch_node
    loop.run_forever()
  File "/usr/lib/python3.6/asyncio/coroutines.py", line 126, in send
    return self.gen.send(value)
  File "/home/cburgdorf/Documents/hacking/ef/trinity/p2p/service.py", line 139, in _run_task_wrapper
    await awaitable
  File "/usr/lib/python3.6/asyncio/coroutines.py", line 110, in __next__
    return self.gen.send(None)
  File "/home/cburgdorf/Documents/hacking/ef/trinity/p2p/service.py", line 158, in _run_daemon_task_wrapper
    await awaitable
  File "/usr/lib/python3.6/asyncio/coroutines.py", line 110, in __next__
    return self.gen.send(None)
  File "/home/cburgdorf/Documents/hacking/ef/trinity/trinity/nodes/base.py", line 61, in handle_network_id_requests
    async for req in self.wait_iter(self.event_bus.stream(NetworkIdRequest)):
  File "/home/cburgdorf/Documents/hacking/ef/trinity/p2p/cancellable.py", line 66, in wait_iter
    timeout=timeout,
  File "/usr/lib/python3.6/asyncio/coroutines.py", line 110, in __next__
    return self.gen.send(None)
  File "/home/cburgdorf/Documents/hacking/ef/trinity/p2p/cancellable.py", line 20, in wait
    return await self.wait_first(awaitable, token=token, timeout=timeout)
  File "/usr/lib/python3.6/asyncio/coroutines.py", line 110, in __next__
    return self.gen.send(None)
  File "/home/cburgdorf/Documents/hacking/ef/trinity/p2p/cancellable.py", line 42, in wait_first
    return await token_chain.cancellable_wait(*awaitables, timeout=timeout)
  File "/usr/lib/python3.6/asyncio/coroutines.py", line 110, in __next__
    return self.gen.send(None)
  File "/home/cburgdorf/Documents/hacking/ef/trinity/venv/lib/python3.6/site-packages/cancel_token/token.py", line 126, in cancellable_wait
    futures = [asyncio.ensure_future(a, loop=self.loop) for a in awaitables + (self.wait(),)]
  File "/home/cburgdorf/Documents/hacking/ef/trinity/venv/lib/python3.6/site-packages/cancel_token/token.py", line 126, in <listcomp>
    futures = [asyncio.ensure_future(a, loop=self.loop) for a in awaitables + (self.wait(),)]
StopAsyncIteration
```

### How was it fixed?

**Let's first make it clear that I believe the following is a hack and that my main motivation to open up this PR as is, is to fire up imagination so that some :unicorn: can show me how to do it properly** :sweat_smile: 

1. Previously in `wait_iter` we did this:

```
        while True:
            try:
                yield await self.wait(
                    aiter.__anext__(),
                    token=token,
                    timeout=timeout,
                )
            except StopAsyncIteration:
                break
```

However, it appears that we never catch the `StopAsyncIteration` this way.

2. This change moves the `__anext()__` into a helper function where we then catch the exception and trigger a special `CancelToken` .

3. The special token is then used in the `while` loop to decide whether it should move on or not

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](http://churchofchristarticles.com/blog/wp-content/uploads/2017/12/shame.jpg)
