### PR TITLE
Update boolean flag to match its name

### DIFF
--- a/eth2/beacon/state_machines/base.py
+++ b/eth2/beacon/state_machines/base.py
@@ -74,7 +74,7 @@ class BaseBeaconStateMachine(Configurable, ABC):
     @abstractmethod
     def import_block(self,
                      block: BaseBeaconBlock,
-                     check_proposer_signature: bool=False) -> Tuple[BeaconState, BaseBeaconBlock]:
+                     check_proposer_signature: bool=True) -> Tuple[BeaconState, BaseBeaconBlock]:
         pass
 
     @staticmethod
@@ -139,7 +139,7 @@ class BeaconStateMachine(BaseBeaconStateMachine):
     #
     def import_block(self,
                      block: BaseBeaconBlock,
-                     check_proposer_signature: bool=False) -> Tuple[BeaconState, BaseBeaconBlock]:
+                     check_proposer_signature: bool=True) -> Tuple[BeaconState, BaseBeaconBlock]:
         state = self.state_transition.apply_state_transition(
             self.state,
             block,

--- a/eth2/beacon/state_machines/forks/serenity/state_transitions.py
+++ b/eth2/beacon/state_machines/forks/serenity/state_transitions.py
@@ -40,7 +40,7 @@ class SerenityStateTransition(BaseStateTransition):
     def apply_state_transition(self,
                                state: BeaconState,
                                block: BaseBeaconBlock,
-                               check_proposer_signature: bool=False) -> BeaconState:
+                               check_proposer_signature: bool=True) -> BeaconState:
         while state.slot != block.slot:
             state = self.per_slot_transition(state, block.parent_root)
             if state.slot == block.slot:
@@ -79,10 +79,10 @@ class SerenityStateTransition(BaseStateTransition):
     def per_block_transition(self,
                              state: BeaconState,
                              block: BaseBeaconBlock,
-                             check_proposer_signature: bool=False) -> BeaconState:
+                             check_proposer_signature: bool=True) -> BeaconState:
         # TODO: finish per-block processing logic as the spec
         validate_block_slot(state, block)
-        if not check_proposer_signature:
+        if check_proposer_signature:
             validate_proposer_signature(
                 state,
                 block,

--- a/eth2/beacon/state_machines/state_transitions.py
+++ b/eth2/beacon/state_machines/state_transitions.py
@@ -25,7 +25,7 @@ class BaseStateTransition(Configurable, ABC):
     def apply_state_transition(self,
                                state: BeaconState,
                                block: BaseBeaconBlock,
-                               check_proposer_signature: bool=False) -> BeaconState:
+                               check_proposer_signature: bool=True) -> BeaconState:
         pass
 
     @abstractmethod
@@ -38,7 +38,7 @@ class BaseStateTransition(Configurable, ABC):
     def per_block_transition(self,
                              state: BeaconState,
                              block: BaseBeaconBlock,
-                             check_proposer_signature: bool=False) -> BeaconState:
+                             check_proposer_signature: bool=True) -> BeaconState:
         pass
 
     @abstractmethod

--- a/eth2/beacon/tools/builder/proposer.py
+++ b/eth2/beacon/tools/builder/proposer.py
@@ -99,7 +99,7 @@ def create_block_on_state(
     )
 
     # Apply state transition to get state root
-    state, block = state_machine.import_block(block, check_proposer_signature=True)
+    state, block = state_machine.import_block(block, check_proposer_signature=False)
 
     # Sign
     empty_signature_block_root = block.block_without_signature_root


### PR DESCRIPTION
### What was wrong?

Fixes #320.


### How was it fixed?

Updating the use of the boolean flag to match the logic implied by its name.

Also changed the default of the flag's parameter from `True` to `False`. Open to flipping it back as this depends on how frequently we will be typing one over the other. My thinking is to keep the "simpler" option (aka defaults) for the normal/frequent case ("I'm importing a block off the wire, so I need to verify the signature") and allow the kwargs to specialize to the *ahem* special use sites.

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://proxy.duckduckgo.com/iu/?u=https%3A%2F%2Fcdn0.wideopenpets.com%2Fwp-content%2Fuploads%2F2017%2F10%2Ffox-ears-e1509040158874.jpg&f=1)
