### PR TITLE
Print client version strings in (debug-level) summary of remotes

### DIFF
--- a/p2p/peer.py
+++ b/p2p/peer.py
@@ -195,7 +195,7 @@ class BasePeer(BaseService):
         self.privkey = privkey
 
         # The self-identifying string that the remote names itself.
-        self.client_version_string = None
+        self.client_version_string = ''
 
         # Networking reader and writer objects for communication
         self.reader = connection.reader

--- a/p2p/peer.py
+++ b/p2p/peer.py
@@ -489,7 +489,7 @@ class BasePeer(BaseService):
         original_version = msg['client_version_string']
         client_version_string = original_version[:256] + ('...' if original_version[256:] else '')
         if client_version_string.isprintable():
-            self.client_version_string = client_version_string.strip('\t\n\r\x0b\x0c')
+            self.client_version_string = client_version_string.strip()
         else:
             self.client_version_string = repr(client_version_string)
 

--- a/p2p/peer.py
+++ b/p2p/peer.py
@@ -486,10 +486,12 @@ class BasePeer(BaseService):
 
         # limit number of chars to be displayed, and try to keep printable ones only
         # MAGIC 256: arbitrary, "should be enough for everybody"
-        client_version_string = msg['client_version_string'][:256].strip('\t\n\r\x0b\x0c')
-        if not client_version_string.isprintable():
-            client_version_string = client_version_string.encode("utf-8", "replace").decode()
-        self.client_version_string = client_version_string
+        original_version = msg['client_version_string']
+        client_version_string = original_version[:256] + ('...' if original_version[256:] else '')
+        if client_version_string.isprintable():
+            self.client_version_string = client_version_string.strip('\t\n\r\x0b\x0c')
+        else:
+            self.client_version_string = repr(client_version_string)
 
         # Check whether to support Snappy Compression or not
         # based on other peer's p2p protocol version

--- a/p2p/peer.py
+++ b/p2p/peer.py
@@ -194,6 +194,9 @@ class BasePeer(BaseService):
         # The private key this peer uses for identification and encryption.
         self.privkey = privkey
 
+        # The self-identifying string that the remote names itself.
+        self.client_version_string = None
+
         # Networking reader and writer objects for communication
         self.reader = connection.reader
         self.writer = connection.writer
@@ -480,6 +483,13 @@ class BasePeer(BaseService):
         if not isinstance(cmd, Hello):
             await self.disconnect(DisconnectReason.bad_protocol)
             raise HandshakeFailure(f"Expected a Hello msg, got {cmd}, disconnecting")
+
+        # limit number of chars to be displayed, and try to keep printable ones only
+        # MAGIC 256: arbitrary, "should be enough for everybody"
+        client_version_string = msg['client_version_string'][:256].strip('\t\n\r\x0b\x0c')
+        if not client_version_string.isprintable():
+            client_version_string = client_version_string.encode("utf-8", "replace").decode()
+        self.client_version_string = client_version_string
 
         # Check whether to support Snappy Compression or not
         # based on other peer's p2p protocol version

--- a/p2p/peer_pool.py
+++ b/p2p/peer_pool.py
@@ -346,6 +346,7 @@ class BasePeerPool(BaseService, AsyncIterable[BasePeer]):
                     "%s: uptime=%s, received_msgs=%d, most_received=%s(%d)",
                     peer, peer.uptime, peer.received_msgs_count,
                     most_received_type, count)
+                self.logger.debug("client_version_string='%s'", peer.client_version_string)
                 for line in peer.get_extra_stats():
                     self.logger.debug("    %s", line)
             self.logger.debug("== End peer details == ")


### PR DESCRIPTION
### What was wrong?

Nothing.

### How was it fixed?

This gives an additional insight into remotes, and is a first step in debugging possible remote-specific failures.

The string-to-print part that will be retained in memory is limited in size; and is minimally "sanitised". First, tabs/newlines and other "whitespace" is stripped (always); if the string is still unprintable at this point, then illegal characters are "replaced" with question marks:

https://docs.python.org/3/howto/unicode.html#the-string-type

(search `replace`).

[//]: # (For important changes, please add a new entry to the release notes file)
[//]: # (See: https://trinity-client.readthedocs.io/en/latest/contributing.html#pull-requests)

Result looks like:

```
    INFO  03-01 17:10:07           ETHPeerPool  Connected peers: 2 inbound, 0 outbound                                                                                                                                                         
    INFO  03-01 17:10:07           ETHPeerPool  Peer subscribers: 4, longest queue: ETHChainTipMonitor(0)                                                                                                                                      
   DEBUG  03-01 17:10:07           ETHPeerPool  == Peer details ==                                                                                                                                                                             
   DEBUG  03-01 17:10:07           ETHPeerPool  ETHPeer <Node(0x19ac@122.224.9.37)>: uptime=0:00:12:56, received_msgs=3001, most_received=Transactions (cmd_id=18)(2657)                                                                       
   DEBUG  03-01 17:10:07           ETHPeerPool  client_version_string='Geth/v1.8.11-stable/linux-amd64/go1.9.2'
   DEBUG  03-01 17:10:07           ETHPeerPool      BlockBodies: msgs=110  items=103249  rtt=1.50/4.77/0.97  ips=811.37318  timeouts=3  quality=95                                                                                             
   DEBUG  03-01 17:10:07           ETHPeerPool      BlockHeaders: msgs=32  items=5954  rtt=4.31/1.34/0.33  ips=365.00735  timeouts=0  quality=80                                                                                               
   DEBUG  03-01 17:10:07           ETHPeerPool      NodeData: None
   DEBUG  03-01 17:10:07           ETHPeerPool      Receipts: msgs=62  items=119995  rtt=3.11/6.11/1.25  ips=939.43918  timeouts=1  quality=94
   DEBUG  03-01 17:10:07           ETHPeerPool  ETHPeer <Node(0x1835@47.95.231.69)>: uptime=0:00:12:55, received_msgs=1010, most_received=Transactions (cmd_id=18)(609)                 
   DEBUG  03-01 17:10:07           ETHPeerPool  client_version_string='Geth/v1.8.8-stable-2688dab4/linux-amd64/go1.10'
   DEBUG  03-01 17:10:07           ETHPeerPool      BlockBodies: msgs=140  items=141741  rtt=0.96/2.86/0.56  ips=1220.73794  timeouts=0  quality=99                                                                                            
   DEBUG  03-01 17:10:07           ETHPeerPool      BlockHeaders: msgs=28  items=4994  rtt=5.39/1.08/0.26  ips=346.78782  timeouts=1  quality=71                                                                                               
   DEBUG  03-01 17:10:07           ETHPeerPool      NodeData: None                                                                                                                                                                             
   DEBUG  03-01 17:10:07           ETHPeerPool      Receipts: msgs=75  items=149558  rtt=1.81/3.41/0.61  ips=1481.79904  timeouts=1  quality=93                                                                                                
   DEBUG  03-01 17:10:07           ETHPeerPool  == End peer details ==
```

### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://www.petmd.com/sites/default/files/ESA-495746427.jpg)

Source: [petmd.com](https://www.petmd.com/dog/care/emotional-support-pets-explained)