### PR TITLE
Sync with ethereum/eth2.0-specs#699: fix committee assignment bugs

### DIFF
--- a/eth2/beacon/committee_helpers.py
+++ b/eth2/beacon/committee_helpers.py
@@ -158,7 +158,7 @@ def get_next_epoch_committee_count(
     )
 
 
-def _get_shuffling_contextis_current_epoch(
+def _get_shuffling_context_is_current_epoch(
         state: 'BeaconState',
         committee_config: CommitteeConfig) -> ShufflingContext:
     return ShufflingContext(
@@ -174,7 +174,7 @@ def _get_shuffling_contextis_current_epoch(
     )
 
 
-def _get_shuffling_contextis_previous_epoch(
+def _get_shuffling_context_is_previous_epoch(
         state: 'BeaconState',
         committee_config: CommitteeConfig) -> ShufflingContext:
     return ShufflingContext(
@@ -188,6 +188,7 @@ def _get_shuffling_contextis_previous_epoch(
         shuffling_epoch=state.previous_shuffling_epoch,
         shuffling_start_shard=state.previous_shuffling_start_shard,
     )
+
 
 #
 # Helpers for get_crosslink_committees_at_slot
@@ -262,8 +263,8 @@ def _get_shuffling_contextis_next_epoch_no_registry_change_no_reseed(
             slots_per_epoch=committee_config.SLOTS_PER_EPOCH,
             target_committee_size=committee_config.TARGET_COMMITTEE_SIZE,
         ),
-        shuffling_epoch=state.current_shuffling_epoch,
         seed=state.current_shuffling_seed,
+        shuffling_epoch=state.current_shuffling_epoch,
         shuffling_start_shard=state.current_shuffling_start_shard,
     )
 
@@ -294,9 +295,9 @@ def get_crosslink_committees_at_slot(
     )
 
     if epoch == current_epoch:
-        shuffling_context = _get_shuffling_contextis_current_epoch(state, committee_config)
+        shuffling_context = _get_shuffling_context_is_current_epoch(state, committee_config)
     elif epoch == previous_epoch:
-        shuffling_context = _get_shuffling_contextis_previous_epoch(state, committee_config)
+        shuffling_context = _get_shuffling_context_is_previous_epoch(state, committee_config)
     elif epoch == next_epoch:
         epochs_since_last_registry_update = current_epoch - state.validator_registry_update_epoch
         should_reseed = (

--- a/eth2/beacon/committee_helpers.py
+++ b/eth2/beacon/committee_helpers.py
@@ -207,19 +207,6 @@ def get_crosslink_committees_at_slot(
         shuffling_epoch = state.previous_shuffling_epoch
         shuffling_start_shard = state.previous_shuffling_start_shard
     elif epoch == next_epoch:
-        current_committees_per_epoch = get_current_epoch_committee_count(
-            state=state,
-            shard_count=shard_count,
-            slots_per_epoch=slots_per_epoch,
-            target_committee_size=target_committee_size,
-        )
-        committees_per_epoch = get_next_epoch_committee_count(
-            state=state,
-            shard_count=shard_count,
-            slots_per_epoch=slots_per_epoch,
-            target_committee_size=target_committee_size,
-        )
-        shuffling_epoch = next_epoch
         epochs_since_last_registry_update = current_epoch - state.validator_registry_update_epoch
         should_reseed = (
             epochs_since_last_registry_update > 1 and
@@ -227,6 +214,13 @@ def get_crosslink_committees_at_slot(
         )
 
         if registry_change:
+            committees_per_epoch = get_next_epoch_committee_count(
+                state=state,
+                shard_count=shard_count,
+                slots_per_epoch=slots_per_epoch,
+                target_committee_size=target_committee_size,
+            )
+            shuffling_epoch = next_epoch
             # for mocking this out in tests.
             seed = helpers.generate_seed(
                 state=state,
@@ -237,10 +231,23 @@ def get_crosslink_committees_at_slot(
                 latest_active_index_roots_length=latest_active_index_roots_length,
                 latest_randao_mixes_length=latest_randao_mixes_length,
             )
+            current_committees_per_epoch = get_current_epoch_committee_count(
+                state=state,
+                shard_count=shard_count,
+                slots_per_epoch=slots_per_epoch,
+                target_committee_size=target_committee_size,
+            )
             shuffling_start_shard = (
                 state.current_shuffling_start_shard + current_committees_per_epoch
             ) % shard_count
         elif should_reseed:
+            committees_per_epoch = get_next_epoch_committee_count(
+                state=state,
+                shard_count=shard_count,
+                slots_per_epoch=slots_per_epoch,
+                target_committee_size=target_committee_size,
+            )
+            shuffling_epoch = next_epoch
             # for mocking this out in tests.
             seed = helpers.generate_seed(
                 state=state,
@@ -253,6 +260,13 @@ def get_crosslink_committees_at_slot(
             )
             shuffling_start_shard = state.current_shuffling_start_shard
         else:
+            committees_per_epoch = get_current_epoch_committee_count(
+                state=state,
+                shard_count=shard_count,
+                slots_per_epoch=slots_per_epoch,
+                target_committee_size=target_committee_size,
+            )
+            shuffling_epoch = state.current_shuffling_epoch
             seed = state.current_shuffling_seed
             shuffling_start_shard = state.current_shuffling_start_shard
 

--- a/eth2/beacon/committee_helpers.py
+++ b/eth2/beacon/committee_helpers.py
@@ -158,6 +158,10 @@ def get_next_epoch_committee_count(
     )
 
 
+#
+# Helpers for get_crosslink_committees_at_slot
+#
+
 def _get_shuffling_context_is_current_epoch(
         state: 'BeaconState',
         committee_config: CommitteeConfig) -> ShufflingContext:
@@ -190,9 +194,6 @@ def _get_shuffling_context_is_previous_epoch(
     )
 
 
-#
-# Helpers for get_crosslink_committees_at_slot
-#
 def _get_shuffling_contextis_next_epoch_registry_change(
         state: 'BeaconState',
         next_epoch: Epoch,

--- a/eth2/beacon/committee_helpers.py
+++ b/eth2/beacon/committee_helpers.py
@@ -32,7 +32,9 @@ from eth2.beacon.helpers import (
     get_active_validator_indices,
     slot_to_epoch,
 )
-
+from eth2.beacon.datastructures.shuffling_context import (
+    ShufflingContext,
+)
 from eth2.beacon.typing import (
     Bitfield,
     Epoch,
@@ -156,6 +158,116 @@ def get_next_epoch_committee_count(
     )
 
 
+def _get_shuffling_contextis_current_epoch(
+        state: 'BeaconState',
+        committee_config: CommitteeConfig) -> ShufflingContext:
+    return ShufflingContext(
+        committees_per_epoch=get_current_epoch_committee_count(
+            state=state,
+            shard_count=committee_config.SHARD_COUNT,
+            slots_per_epoch=committee_config.SLOTS_PER_EPOCH,
+            target_committee_size=committee_config.TARGET_COMMITTEE_SIZE,
+        ),
+        seed=state.current_shuffling_seed,
+        shuffling_epoch=state.current_shuffling_epoch,
+        shuffling_start_shard=state.current_shuffling_start_shard,
+    )
+
+
+def _get_shuffling_contextis_previous_epoch(
+        state: 'BeaconState',
+        committee_config: CommitteeConfig) -> ShufflingContext:
+    return ShufflingContext(
+        committees_per_epoch=get_previous_epoch_committee_count(
+            state=state,
+            shard_count=committee_config.SHARD_COUNT,
+            slots_per_epoch=committee_config.SLOTS_PER_EPOCH,
+            target_committee_size=committee_config.TARGET_COMMITTEE_SIZE,
+        ),
+        seed=state.previous_shuffling_seed,
+        shuffling_epoch=state.previous_shuffling_epoch,
+        shuffling_start_shard=state.previous_shuffling_start_shard,
+    )
+
+#
+# Helpers for get_crosslink_committees_at_slot
+#
+def _get_shuffling_contextis_next_epoch_registry_change(
+        state: 'BeaconState',
+        next_epoch: Epoch,
+        committee_config: CommitteeConfig) -> ShufflingContext:
+    current_committees_per_epoch = get_current_epoch_committee_count(
+        state=state,
+        shard_count=committee_config.SHARD_COUNT,
+        slots_per_epoch=committee_config.SLOTS_PER_EPOCH,
+        target_committee_size=committee_config.TARGET_COMMITTEE_SIZE,
+    )
+    return ShufflingContext(
+        committees_per_epoch=get_next_epoch_committee_count(
+            state=state,
+            shard_count=committee_config.SHARD_COUNT,
+            slots_per_epoch=committee_config.SLOTS_PER_EPOCH,
+            target_committee_size=committee_config.TARGET_COMMITTEE_SIZE,
+        ),
+        seed=helpers.generate_seed(
+            state=state,
+            epoch=next_epoch,
+            slots_per_epoch=committee_config.SLOTS_PER_EPOCH,
+            min_seed_lookahead=committee_config.MIN_SEED_LOOKAHEAD,
+            activation_exit_delay=committee_config.SLOTS_PER_EPOCH,
+            latest_active_index_roots_length=committee_config.LATEST_ACTIVE_INDEX_ROOTS_LENGTH,
+            latest_randao_mixes_length=committee_config.LATEST_RANDAO_MIXES_LENGTH,
+        ),
+        shuffling_epoch=next_epoch,
+        # for mocking this out in tests.
+        shuffling_start_shard=(
+            state.current_shuffling_start_shard + current_committees_per_epoch
+        ) % committee_config.SHARD_COUNT,
+    )
+
+
+def _get_shuffling_contextis_next_epoch_should_reseed(
+        state: 'BeaconState',
+        next_epoch: Epoch,
+        committee_config: CommitteeConfig) -> ShufflingContext:
+    return ShufflingContext(
+        committees_per_epoch=get_next_epoch_committee_count(
+            state=state,
+            shard_count=committee_config.SHARD_COUNT,
+            slots_per_epoch=committee_config.SLOTS_PER_EPOCH,
+            target_committee_size=committee_config.TARGET_COMMITTEE_SIZE,
+        ),
+        # for mocking this out in tests.
+        seed=helpers.generate_seed(
+            state=state,
+            epoch=next_epoch,
+            slots_per_epoch=committee_config.SLOTS_PER_EPOCH,
+            min_seed_lookahead=committee_config.MIN_SEED_LOOKAHEAD,
+            activation_exit_delay=committee_config.SLOTS_PER_EPOCH,
+            latest_active_index_roots_length=committee_config.LATEST_ACTIVE_INDEX_ROOTS_LENGTH,
+            latest_randao_mixes_length=committee_config.LATEST_RANDAO_MIXES_LENGTH,
+        ),
+        shuffling_epoch=next_epoch,
+        shuffling_start_shard=state.current_shuffling_start_shard,
+    )
+
+
+def _get_shuffling_contextis_next_epoch_no_registry_change_no_reseed(
+        state: 'BeaconState',
+        committee_config: CommitteeConfig) -> ShufflingContext:
+    return ShufflingContext(
+        committees_per_epoch=get_current_epoch_committee_count(
+            state=state,
+            shard_count=committee_config.SHARD_COUNT,
+            slots_per_epoch=committee_config.SLOTS_PER_EPOCH,
+            target_committee_size=committee_config.TARGET_COMMITTEE_SIZE,
+        ),
+        shuffling_epoch=state.current_shuffling_epoch,
+        seed=state.current_shuffling_seed,
+        shuffling_start_shard=state.current_shuffling_start_shard,
+    )
+
+
 @to_tuple
 def get_crosslink_committees_at_slot(
         state: 'BeaconState',
@@ -170,11 +282,6 @@ def get_crosslink_committees_at_slot(
     slots_per_epoch = committee_config.SLOTS_PER_EPOCH
     target_committee_size = committee_config.TARGET_COMMITTEE_SIZE
 
-    min_seed_lookahead = committee_config.MIN_SEED_LOOKAHEAD
-    activation_exit_delay = committee_config.ACTIVATION_EXIT_DELAY
-    latest_active_index_roots_length = committee_config.LATEST_ACTIVE_INDEX_ROOTS_LENGTH
-    latest_randao_mixes_length = committee_config.LATEST_RANDAO_MIXES_LENGTH
-
     epoch = slot_to_epoch(slot, slots_per_epoch)
     current_epoch = state.current_epoch(slots_per_epoch)
     previous_epoch = state.previous_epoch(slots_per_epoch, genesis_epoch)
@@ -187,25 +294,9 @@ def get_crosslink_committees_at_slot(
     )
 
     if epoch == current_epoch:
-        committees_per_epoch = get_current_epoch_committee_count(
-            state=state,
-            shard_count=shard_count,
-            slots_per_epoch=slots_per_epoch,
-            target_committee_size=target_committee_size,
-        )
-        seed = state.current_shuffling_seed
-        shuffling_epoch = state.current_shuffling_epoch
-        shuffling_start_shard = state.current_shuffling_start_shard
+        shuffling_context = _get_shuffling_contextis_current_epoch(state, committee_config)
     elif epoch == previous_epoch:
-        committees_per_epoch = get_previous_epoch_committee_count(
-            state=state,
-            shard_count=shard_count,
-            slots_per_epoch=slots_per_epoch,
-            target_committee_size=target_committee_size,
-        )
-        seed = state.previous_shuffling_seed
-        shuffling_epoch = state.previous_shuffling_epoch
-        shuffling_start_shard = state.previous_shuffling_start_shard
+        shuffling_context = _get_shuffling_contextis_previous_epoch(state, committee_config)
     elif epoch == next_epoch:
         epochs_since_last_registry_update = current_epoch - state.validator_registry_update_epoch
         should_reseed = (
@@ -214,74 +305,35 @@ def get_crosslink_committees_at_slot(
         )
 
         if registry_change:
-            committees_per_epoch = get_next_epoch_committee_count(
-                state=state,
-                shard_count=shard_count,
-                slots_per_epoch=slots_per_epoch,
-                target_committee_size=target_committee_size,
+            shuffling_context = _get_shuffling_contextis_next_epoch_registry_change(
+                state,
+                next_epoch,
+                committee_config,
             )
-            shuffling_epoch = next_epoch
-            # for mocking this out in tests.
-            seed = helpers.generate_seed(
-                state=state,
-                epoch=next_epoch,
-                slots_per_epoch=slots_per_epoch,
-                min_seed_lookahead=min_seed_lookahead,
-                activation_exit_delay=activation_exit_delay,
-                latest_active_index_roots_length=latest_active_index_roots_length,
-                latest_randao_mixes_length=latest_randao_mixes_length,
-            )
-            current_committees_per_epoch = get_current_epoch_committee_count(
-                state=state,
-                shard_count=shard_count,
-                slots_per_epoch=slots_per_epoch,
-                target_committee_size=target_committee_size,
-            )
-            shuffling_start_shard = (
-                state.current_shuffling_start_shard + current_committees_per_epoch
-            ) % shard_count
         elif should_reseed:
-            committees_per_epoch = get_next_epoch_committee_count(
-                state=state,
-                shard_count=shard_count,
-                slots_per_epoch=slots_per_epoch,
-                target_committee_size=target_committee_size,
+            shuffling_context = _get_shuffling_contextis_next_epoch_should_reseed(
+                state,
+                next_epoch,
+                committee_config,
             )
-            shuffling_epoch = next_epoch
-            # for mocking this out in tests.
-            seed = helpers.generate_seed(
-                state=state,
-                epoch=next_epoch,
-                slots_per_epoch=slots_per_epoch,
-                min_seed_lookahead=min_seed_lookahead,
-                activation_exit_delay=activation_exit_delay,
-                latest_active_index_roots_length=latest_active_index_roots_length,
-                latest_randao_mixes_length=latest_randao_mixes_length,
-            )
-            shuffling_start_shard = state.current_shuffling_start_shard
         else:
-            committees_per_epoch = get_current_epoch_committee_count(
-                state=state,
-                shard_count=shard_count,
-                slots_per_epoch=slots_per_epoch,
-                target_committee_size=target_committee_size,
+            shuffling_context = _get_shuffling_contextis_next_epoch_no_registry_change_no_reseed(
+                state,
+                committee_config,
             )
-            shuffling_epoch = state.current_shuffling_epoch
-            seed = state.current_shuffling_seed
-            shuffling_start_shard = state.current_shuffling_start_shard
 
     shuffling = get_shuffling(
-        seed=seed,
+        seed=shuffling_context.seed,
         validators=state.validator_registry,
-        epoch=shuffling_epoch,
+        epoch=shuffling_context.shuffling_epoch,
         slots_per_epoch=slots_per_epoch,
         target_committee_size=target_committee_size,
         shard_count=shard_count,
     )
     offset = slot % slots_per_epoch
-    committees_per_slot = committees_per_epoch // slots_per_epoch
+    committees_per_slot = shuffling_context.committees_per_epoch // slots_per_epoch
     slot_start_shard = (
-        shuffling_start_shard +
+        shuffling_context.shuffling_start_shard +
         committees_per_slot * offset
     ) % shard_count
 

--- a/eth2/beacon/datastructures/shuffling_context.py
+++ b/eth2/beacon/datastructures/shuffling_context.py
@@ -1,0 +1,19 @@
+from typing import (
+    NamedTuple,
+)
+
+from eth_typing import (
+    Hash32,
+)
+
+from eth2.beacon.typing import (
+    Epoch,
+    Shard,
+)
+
+
+class ShufflingContext(NamedTuple):
+    committees_per_epoch: int
+    seed: Hash32
+    shuffling_epoch: Epoch
+    shuffling_start_shard: Shard

--- a/eth2/beacon/state_machines/forks/serenity/epoch_processing.py
+++ b/eth2/beacon/state_machines/forks/serenity/epoch_processing.py
@@ -883,9 +883,9 @@ def _process_validator_registry_with_update(current_epoch_committee_count: int,
 
     # Update step-by-step since updated `state.current_shuffling_epoch`
     # is used to calculate other value). Follow the spec tightly now.
-    state = _update_shuffling_epoch(state, config.SLOTS_PER_EPOCH)
-
     state = _update_shuffling_start_shard(state, current_epoch_committee_count, config.SHARD_COUNT)
+
+    state = _update_shuffling_epoch(state, config.SLOTS_PER_EPOCH)
 
     state = _update_shuffling_seed(
         state,


### PR DESCRIPTION
### What was wrong?

Spec PR:  ethereum/eth2.0-specs#699

### How was it fixed?
1. Sync with ethereum/eth2.0-specs#699
2. Refactor `get_crosslink_committees_at_slot` with `ShufflingContext`

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses]()
