### PR TITLE
Remove broken code in test

### DIFF
--- a/trinity/protocol/eth/peer.py
+++ b/trinity/protocol/eth/peer.py
@@ -28,13 +28,12 @@ from .commands import (
     NewBlock,
     Status,
 )
-from .constants import MAX_HEADERS_FETCH
+from . import constants
 from .proto import ETHProtocol
 from .handlers import ETHExchangeHandler
 
 
 class ETHPeer(BaseChainPeer):
-    max_headers_fetch = MAX_HEADERS_FETCH
 
     supported_sub_protocols = [ETHProtocol]
     sub_proto: ETHProtocol = None
@@ -44,6 +43,10 @@ class ETHPeer(BaseChainPeer):
     def get_extra_stats(self) -> List[str]:
         stats_pairs = self.requests.get_stats().items()
         return ['%s: %s' % (cmd_name, stats) for cmd_name, stats in stats_pairs]
+
+    @property
+    def max_headers_fetch(self) -> int:
+        return constants.MAX_HEADERS_FETCH
 
     @property
     def requests(self) -> ETHExchangeHandler:

--- a/trinity/protocol/les/peer.py
+++ b/trinity/protocol/les/peer.py
@@ -30,13 +30,13 @@ from trinity.protocol.common.peer import (
     BaseChainPeerPool,
 )
 
+from . import (
+    constants,
+)
 from .commands import (
     Announce,
     Status,
     StatusV2,
-)
-from .constants import (
-    MAX_HEADERS_FETCH,
 )
 from .proto import (
     LESProtocol,
@@ -46,7 +46,6 @@ from .handlers import LESExchangeHandler
 
 
 class LESPeer(BaseChainPeer):
-    max_headers_fetch = MAX_HEADERS_FETCH
 
     supported_sub_protocols = [LESProtocol, LESProtocolV2]
     sub_proto: LESProtocol = None
@@ -56,6 +55,10 @@ class LESPeer(BaseChainPeer):
     def get_extra_stats(self) -> List[str]:
         stats_pairs = self.requests.get_stats().items()
         return ['%s: %s' % (cmd_name, stats) for cmd_name, stats in stats_pairs]
+
+    @property
+    def max_headers_fetch(self) -> int:
+        return constants.MAX_HEADERS_FETCH
 
     @property
     def requests(self) -> LESExchangeHandler:


### PR DESCRIPTION
### What was wrong?

The monkeypatch doesn't work here.  We can clearly see that when we run:

```
pytest tests/core/p2p-proto/test_sync.py -k 'test_fast_syncer' --log-cli-level 0
```

relevant logs:

```
Successfully decoded GetBlockHeaders (cmd_id=19) msg: {'block_number_or_hash': 21, 'max_headers': 192, 'skip': 0, 'reverse': False}
```

### How was it fixed?

Removed it for now but I actually wish it would work because what it tries to do is actually useful. One can set something like `client_peer.max_headers_fetch` to get it working for the most part but the `SkeletonSync` does also import and use `MAX_HEADERS_FETCH` so this solution doesn't work everywhere.

I tried to figure out why the monkeypatch doesn't work here and I guess it has to do with the module being loaded earlier from somewhere but I couldn't figure something out that works.

@lithp This is the kind of stuff that makes me cautious regarding globals. Do you have an idea how to to properly change these constants under test so that the changes take effect everywhere where they are importet?

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses]()
