### PR TITLE
Cancel service on BrokenProcessPool error

### DIFF
--- a/docs/release_notes/trinity.rst
+++ b/docs/release_notes/trinity.rst
@@ -4,7 +4,7 @@ Trinity
 Unreleased (latest source)
 --------------------------
 
-None
+- `#336 <https://github.com/ethereum/trinity/pull/336>`_: Bugfix: Ensure Trinity shuts down if the process pool dies (fatal error)
 
 0.1.0-alpha.23
 --------------------------


### PR DESCRIPTION
### What was wrong?

I ran into this error while running #236.

```
 WARNING  02-28 12:34:58      ETHRequestServer  ETHRequestServer msg queue is full; discarding Transactions (cmd_id=18) msg from ETHPeer <Node(0x16cd@54.169.187.61)>
 WARNING  02-28 12:34:58               ETHPeer  Peer ETHPeer <Node(0x16cd@54.169.187.61)> has no subscribers for msg type Transactions
 WARNING  02-28 12:34:58      ETHRequestServer  ETHRequestServer msg queue is full; discarding Transactions (cmd_id=18) msg from ETHPeer <Node(0x16cd@54.169.187.61)>
 WARNING  02-28 12:34:58               ETHPeer  Peer ETHPeer <Node(0x16cd@54.169.187.61)> has no subscribers for msg type Transactions
   DEBUG  02-28 12:34:58              protocol  client > Frame(fin=True, opcode=1, data=b'{"emit": ["node-ping", {"clientTime": 1551357298558, "id": "snake charmers"}]}', rsv1=False, rsv2=False, rsv3=False)
   DEBUG  02-28 12:34:58              protocol  client < Frame(fin=True, opcode=1, data=b'{"emit":["node-pong",{"clientTime":1551357298558,"serverTime":1551357298614}]}', rsv1=False, rsv2=False, rsv3=False)
   DEBUG  02-28 12:34:58              protocol  client > Frame(fin=True, opcode=1, data=b'{"emit": ["latency", {"latency": 18, "id": "snake charmers"}]}', rsv1=False, rsv2=False, rsv3=False)
 WARNING  02-28 12:34:59      ETHRequestServer  ETHRequestServer msg queue is full; discarding Transactions (cmd_id=18) msg from ETHPeer <Node(0x16cd@54.169.187.61)>
 WARNING  02-28 12:34:59               ETHPeer  Peer ETHPeer <Node(0x16cd@54.169.187.61)> has no subscribers for msg type Transactions
   DEBUG  02-28 12:34:59              protocol  client > Frame(fin=True, opcode=1, data=b'{"emit": ["stats", {"stats": {"active": true, "uptime": 100, "peers": 9}, "id": "snake charmers"}]}', rsv1=False, rsv2=False, rsv3=False)
   DEBUG  02-28 12:34:59              protocol  client > Frame(fin=True, opcode=1, data=b'{"emit": ["block", {"block": {"number": 2383314, "hash": "0x16460531ee938050fcb999a5a339d363e628b72b544cf083bf9b9a268ba56fbc", "difficulty": 82536903352106, "totalDifficulty": 70005999794407817405, "transactions": [], "uncles": []}, "id": "snake charmers"}]}', rsv1=False, rsv2=False, rsv3=False)
   DEBUG  02-28 12:34:59     DiscoveryProtocol  Ignoring find_node request from unknown node <Node(0x0088@116.202.24.113)>
   ERROR  02-28 12:34:59   FastChainBodySyncer  Unknown error when getting receipts
Traceback (most recent call last):
  File "/home/ubuntu/trinity/trinity/sync/full/chain.py", line 790, in _request_receipts
    receipt_bundles = await peer.requests.get_receipts(batch)
  File "/home/ubuntu/trinity/trinity/protocol/eth/exchanges.py", line 127, in __call__
    timeout,
  File "/home/ubuntu/trinity/trinity/protocol/common/exchanges.py", line 83, in get_result
    timeout,
  File "/home/ubuntu/trinity/trinity/protocol/common/managers.py", line 293, in get_result
    payload
  File "/home/ubuntu/trinity/p2p/service.py", line 236, in _run_in_executor
    return await self.wait(loop.run_in_executor(executor, callback, *args))
  File "uvloop/loop.pyx", line 2512, in uvloop.loop.Loop.run_in_executor
  File "/usr/lib/python3.6/concurrent/futures/process.py", line 452, in submit
    raise BrokenProcessPool('A child process terminated '
concurrent.futures.process.BrokenProcessPool: A child process terminated abruptly, the process pool is not usable anymore
```

This might be related to what @carver mentioned that our node is growing memory because it gets data faster than it can write it to the db.

Related or not, what happened here is that the node kept running but was broken.

### How was it fixed?

Catch the `BrokenProcessPool` error and cancel the service which in turn will cause the node to shutdown.

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](http://africanwildlifeconservationfund.org/wp-content/uploads/2017/12/Wild_Dog_Species_01.jpg)
