### PR TITLE
Fix pruning with consecutive finished dependencies

### DIFF
--- a/tests/core/utils/test_root_tracker.py
+++ b/tests/core/utils/test_root_tracker.py
@@ -114,7 +114,6 @@ def binary_parent(node):
     st.integers(min_value=0, max_value=6),
     min_size=3,
 ))
-#@settings(max_examples=20000)
 def test_prune_reinsert_root_tracking_binary_tree(element_flipping):
     tracker = RootTracker()
 

--- a/trinity/_utils/datastructures.py
+++ b/trinity/_utils/datastructures.py
@@ -511,7 +511,13 @@ class OrderedTaskPreparation(Generic[TTask, TTaskID, TPrerequisite]):
             )
         self._tasks[task_id] = completed
         self._declared_finished.add(task_id)
-        self._roots.add(task_id, self._dependency_of(finished_task))
+
+        dependency_id = self._dependency_of(finished_task)
+        self._roots.add(task_id, dependency_id)
+        if dependency_id in self._tasks:
+            # set a finished dependency that has a parent already entered. Mark this as a dependency
+            self._dependencies[dependency_id].add(task_id)
+
         # note that this task is intentionally *not* added to self._unready
 
     def register_tasks(self, tasks: Tuple[TTask, ...], ignore_duplicates: bool = False) -> None:

--- a/trinity/_utils/tree_root.py
+++ b/trinity/_utils/tree_root.py
@@ -323,7 +323,15 @@ class RootTracker(Generic[TNodeID]):
 
     def _get_new_root(self, node_id: TNodeID, parent_id: TNodeID) -> Tuple[TreeRoot[TNodeID], int]:
         if self._tree.has_parent(node_id):
-            parent_root = self._roots[parent_id]
+            try:
+                parent_root = self._roots[parent_id]
+            except KeyError as e:
+                tree_parent = self._tree.parent_of(node_id)
+                raise ValidationError(
+                    f"When adding node {node_id} with parent {parent_id}, The tree says that "
+                    f"parent {tree_parent} is present, but the parent is missing from roots."
+                ) from e
+
             if len(self._tree.children_of(parent_id)) > 1:
                 node_root = TreeRoot(node_id)
                 node_root.extend(parent_root, 0)

--- a/trinity/_utils/tree_root.py
+++ b/trinity/_utils/tree_root.py
@@ -335,10 +335,9 @@ class RootTracker(Generic[TNodeID]):
             if len(self._tree.children_of(parent_id)) > 1:
                 node_root = TreeRoot(node_id)
                 node_root.extend(parent_root, 0)
-                original_depth = self._original_depth_to_root[parent_id] + 1
             else:
                 node_root = parent_root
-                original_depth = self._original_depth_to_root[parent_id] + 1
+            original_depth = self._original_depth_to_root[parent_id] + 1
         else:
             node_root = TreeRoot(node_id)
             original_depth = 0

--- a/trinity/sync/common/headers.py
+++ b/trinity/sync/common/headers.py
@@ -728,7 +728,20 @@ class BaseHeaderChainSyncer(BaseService, HeaderSyncerAPI, Generic[TChainPeer]):
         self._chain = chain
         self._peer_pool = peer_pool
         self._tip_monitor = self.tip_monitor_class(peer_pool, token=self.cancel_token)
+        self._last_target_header_hash: Hash32 = None
         self._skeleton: SkeletonSyncer[TChainPeer] = None
+
+        # Track if there is capacity for syncing more headers
+        self._buffer_capacity = asyncio.Event()
+
+        self._reset_buffer()
+
+    async def clear_buffer(self) -> None:
+        if self._skeleton is not None:
+            await self._skeleton.cancel()
+        self._reset_buffer()
+
+    def _reset_buffer(self) -> None:
         # stitch together headers as they come in
         self._stitcher = OrderedTaskPreparation(
             # we don't have to do any prep work on the headers, just linearize them, so empty enum
@@ -741,12 +754,15 @@ class BaseHeaderChainSyncer(BaseService, HeaderSyncerAPI, Generic[TChainPeer]):
         )
         # When downloading the headers into the gaps left by the syncer, they must be linearized
         # by the stitcher
-        self._meat = HeaderMeatSyncer(chain, peer_pool, self._stitcher, token)
-        self._last_target_header_hash: Hash32 = None
+        self._meat = HeaderMeatSyncer(
+            self._chain,
+            self._peer_pool,
+            self._stitcher,
+            self.cancel_token,
+        )
 
-        # Track if there is capacity for syncing more headers
-        self._buffer_capacity = asyncio.Event()
-        self._buffer_capacity.set()  # start with capacity
+        # Queue has reset, so always start with capacity
+        self._buffer_capacity.set()
 
     async def new_sync_headers(
             self,

--- a/trinity/sync/common/headers.py
+++ b/trinity/sync/common/headers.py
@@ -493,6 +493,17 @@ class HeaderSyncerAPI(ABC):
             yield
 
     @abstractmethod
+    async def clear_buffer(self) -> None:
+        """
+        Whatever headers have been received until now, dump them all and restart.
+        This is a last resort, to be used only when a consumer seems to receive
+        headers out of other and decides they have no other option besides reset.
+
+        It wastes a lot of previously completed work.
+        """
+        pass
+
+    @abstractmethod
     def get_target_header_hash(self) -> Hash32:
         pass
 

--- a/trinity/sync/full/chain.py
+++ b/trinity/sync/full/chain.py
@@ -476,7 +476,9 @@ class FastChainBodySyncer(BaseBodyChainSyncer):
                     )
                 except HeaderNotFound:
                     await self._log_header_link_failure(headers[0])
-                    raise
+                    await self._header_syncer.clear_buffer()
+                    # wait for new headers to come back in from a restarted skeleton sync
+                    continue
 
                 # This appears to be a fork, since the parent header is persisted,
                 self.logger.info(

--- a/trinity/sync/full/chain.py
+++ b/trinity/sync/full/chain.py
@@ -62,6 +62,7 @@ from trinity.sync.common.headers import HeaderSyncerAPI
 from trinity.sync.common.peers import WaitingPeers
 from trinity.sync.full.constants import (
     HEADER_QUEUE_SIZE_TARGET,
+    BLOCK_QUEUE_SIZE_TARGET,
 )
 from trinity._utils.datastructures import (
     MissingDependency,
@@ -82,7 +83,7 @@ BlockBodyBundle = Tuple[
 ]
 
 # How big should the pending request queue get, as a multiple of the largest request size
-REQUEST_BUFFER_MULTIPLIER = 8
+REQUEST_BUFFER_MULTIPLIER = 16
 
 
 class BaseBodyChainSyncer(BaseService, PeerSubscriber):
@@ -583,7 +584,7 @@ class FastChainBodySyncer(BaseBodyChainSyncer):
         while self.is_operational:
             # This tracker waits for all prerequisites to be complete, and returns headers in
             # order, so that each header's parent is already persisted.
-            get_completed_coro = self._block_persist_tracker.ready_tasks(HEADER_QUEUE_SIZE_TARGET)
+            get_completed_coro = self._block_persist_tracker.ready_tasks(BLOCK_QUEUE_SIZE_TARGET)
             completed_headers = await self.wait(get_completed_coro)
 
             if self._block_persist_tracker.has_ready_tasks():

--- a/trinity/sync/full/chain.py
+++ b/trinity/sync/full/chain.py
@@ -539,11 +539,12 @@ class FastChainBodySyncer(BaseBodyChainSyncer):
         while self.is_operational:
             await self.sleep(5)
             self.logger.debug(
-                "(in progress, queued, max size) of bodies, receipts: %r",
+                "(in progress, queued, max size) of bodies, receipts: %r. Write capacity? %s",
                 [(q.num_in_progress(), len(q), q._maxsize) for q in (
                     self._block_body_tasks,
                     self._receipt_tasks,
                 )],
+                "yes" if self._db_buffer_capacity.is_set() else "no",
             )
 
             stats = self.tracker.report()

--- a/trinity/sync/full/constants.py
+++ b/trinity/sync/full/constants.py
@@ -11,7 +11,8 @@ FAST_SYNC_CUTOFF = 60 * 60 * 24
 # BUFFER_SECONDS = 30
 #   (this should allow plenty of time for peers to fill in the buffer during db writes)
 #
-# MARGIN = 10
-#   (better to have a buffer that's too big than to artificially constrain performance)
-#
-HEADER_QUEUE_SIZE_TARGET = 60000
+HEADER_QUEUE_SIZE_TARGET = 6000
+
+# How many blocks to persist at a time
+# Only need a few seconds of buffer on the DB write side.
+BLOCK_QUEUE_SIZE_TARGET = 1000


### PR DESCRIPTION
### What was wrong?

Fixes #344 

I added a test to reproduce: if you set two chained finished dependencies, then try to prune the oldest one, it crashes because we didn't link one finished dependencies as a dependency of the other.

### How was it fixed?

Check if the parent of a finished dependency is already present, and link it as a dependency, if so. Pruning works as expected, now.

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](http://cache.desktopnexus.com/thumbseg/2421/2421699-bigthumbnail.jpg)
