### PR TITLE
Fix `Attestation` ordering: `aggregation_bitfield` before `data`

### DIFF
--- a/eth2/beacon/tools/builder/validator.py
+++ b/eth2/beacon/tools/builder/validator.py
@@ -450,8 +450,8 @@ def create_mock_signed_attestation(state: BeaconState,
 
     # create attestation from attestation_data, particpipant_bitfield, and signature
     return Attestation(
-        data=attestation_data,
         aggregation_bitfield=aggregation_bitfield,
+        data=attestation_data,
         custody_bitfield=Bitfield(b'\x00' * len(aggregation_bitfield)),
         aggregate_signature=aggregate_signature,
     )

--- a/eth2/beacon/types/attestations.py
+++ b/eth2/beacon/types/attestations.py
@@ -18,9 +18,10 @@ from eth2.beacon.constants import EMPTY_SIGNATURE
 class Attestation(ssz.Serializable):
 
     fields = [
-        ('data', AttestationData),
         # Attester aggregation bitfield
         ('aggregation_bitfield', bytes_sedes),
+        # Attester aggregation bitfield
+        ('data', AttestationData),
         # Proof of custody bitfield
         ('custody_bitfield', bytes_sedes),
         # BLS aggregate signature
@@ -28,13 +29,13 @@ class Attestation(ssz.Serializable):
     ]
 
     def __init__(self,
-                 data: AttestationData,
                  aggregation_bitfield: Bitfield,
+                 data: AttestationData,
                  custody_bitfield: Bitfield,
                  aggregate_signature: BLSSignature=EMPTY_SIGNATURE) -> None:
         super().__init__(
-            data,
             aggregation_bitfield,
+            data,
             custody_bitfield,
             aggregate_signature,
         )

--- a/eth2/beacon/types/attestations.py
+++ b/eth2/beacon/types/attestations.py
@@ -20,7 +20,7 @@ class Attestation(ssz.Serializable):
     fields = [
         # Attester aggregation bitfield
         ('aggregation_bitfield', bytes_sedes),
-        # Attester aggregation bitfield
+        # Attestation data
         ('data', AttestationData),
         # Proof of custody bitfield
         ('custody_bitfield', bytes_sedes),

--- a/tests/core/p2p-proto/bcc/test_commands.py
+++ b/tests/core/p2p-proto/bcc/test_commands.py
@@ -161,6 +161,7 @@ async def test_send_single_attestation(request, event_loop):
     alice, msg_buffer = await get_command_setup(request, event_loop)
 
     attestation = Attestation(
+        aggregation_bitfield=b"\x00\x00\x00",
         data=AttestationData(
             slot=0,
             shard=1,
@@ -171,7 +172,6 @@ async def test_send_single_attestation(request, event_loop):
             justified_epoch=SERENITY_CONFIG.GENESIS_EPOCH,
             justified_block_root=ZERO_HASH32,
         ),
-        aggregation_bitfield=b"\x00\x00\x00",
         custody_bitfield=b"\x00\x00\x00",
     )
 

--- a/tests/core/p2p-proto/bcc/test_commands.py
+++ b/tests/core/p2p-proto/bcc/test_commands.py
@@ -188,6 +188,7 @@ async def test_send_multiple_attestations(request, event_loop):
 
     attestations = tuple(
         Attestation(
+            aggregation_bitfield=b"\x00\x00\x00",
             data=AttestationData(
                 slot=0,
                 shard=shard,
@@ -198,7 +199,6 @@ async def test_send_multiple_attestations(request, event_loop):
                 justified_epoch=SERENITY_CONFIG.GENESIS_EPOCH,
                 justified_block_root=ZERO_HASH32,
             ),
-            aggregation_bitfield=b"\x00\x00\x00",
             custody_bitfield=b"\x00\x00\x00",
         ) for shard in range(10)
     )

--- a/tests/eth2/beacon/conftest.py
+++ b/tests/eth2/beacon/conftest.py
@@ -92,8 +92,8 @@ def sample_proposer_slashing_params(sample_proposal_signed_data_params):
 @pytest.fixture
 def sample_attestation_params(sample_attestation_data_params):
     return {
-        'data': AttestationData(**sample_attestation_data_params),
         'aggregation_bitfield': b'\12' * 16,
+        'data': AttestationData(**sample_attestation_data_params),
         'custody_bitfield': b'\34' * 16,
         'aggregate_signature': [0, 0],
     }

--- a/tests/eth2/beacon/state_machines/forks/test_serenity_epoch_processing.py
+++ b/tests/eth2/beacon/state_machines/forks/test_serenity_epoch_processing.py
@@ -331,12 +331,12 @@ def test_process_crosslinks(
                 # Generate the attestation
                 cur_epoch_attestations.append(
                     Attestation(**sample_attestation_params).copy(
+                        aggregation_bitfield=aggregation_bitfield,
                         data=AttestationData(**sample_attestation_data_params).copy(
                             slot=slot_in_cur_epoch,
                             shard=shard,
                             crosslink_data_root=crosslink_data_root,
                         ),
-                        aggregation_bitfield=aggregation_bitfield,
                     )
                 )
 

--- a/tests/eth2/beacon/test_epoch_processing_helpers.py
+++ b/tests/eth2/beacon/test_epoch_processing_helpers.py
@@ -277,19 +277,19 @@ def test_get_winning_root(
     attestations = (
         # Attestation to `crosslink_data_root_1` by `attestation_participants_1`
         Attestation(**sample_attestation_params).copy(
+            aggregation_bitfield=root_1_participants_bitfield,
             data=AttestationData(**sample_attestation_data_params).copy(
                 shard=shard,
                 crosslink_data_root=competing_block_roots[0],
             ),
-            aggregation_bitfield=root_1_participants_bitfield
         ),
         # Attestation to `crosslink_data_root_2` by `attestation_participants_2`
         Attestation(**sample_attestation_params).copy(
+            aggregation_bitfield=root_2_participants_bitfield,
             data=AttestationData(**sample_attestation_data_params).copy(
                 shard=shard,
                 crosslink_data_root=competing_block_roots[1],
             ),
-            aggregation_bitfield=root_2_participants_bitfield
         ),
     )
 
@@ -384,27 +384,27 @@ def test_get_epoch_boundary_attester_indices(monkeypatch,
     attestations = [
         # Attestation to `block_root_1` by `attestation_participants_1`
         Attestation(**sample_attestation_params).copy(
+            aggregation_bitfield=aggregation_bitfield_1,
             data=AttestationData(**sample_attestation_data_params).copy(
                 justified_epoch=1,
                 epoch_boundary_root=block_root_1,
             ),
-            aggregation_bitfield=aggregation_bitfield_1
         ),
         # Attestation to `block_root_1` by `attestation_participants_2`
         Attestation(**sample_attestation_params).copy(
+            aggregation_bitfield=aggregation_bitfield_2,
             data=AttestationData(**sample_attestation_data_params).copy(
                 justified_epoch=1,
                 epoch_boundary_root=block_root_1,
             ),
-            aggregation_bitfield=aggregation_bitfield_2
         ),
         # Attestation to `block_root_2` by `not_attestation_participants_1`
         Attestation(**sample_attestation_params).copy(
+            aggregation_bitfield=not_aggregation_bitfield_1,
             data=AttestationData(**sample_attestation_data_params).copy(
                 justified_epoch=2,
                 epoch_boundary_root=block_root_2,
             ),
-            aggregation_bitfield=not_aggregation_bitfield_1
         ),
     ]
 
@@ -496,40 +496,40 @@ def test_get_epoch_boundary_attesting_balances(
 
     current_epoch_attestations = (
         Attestation(**sample_attestation_params).copy(
+            aggregation_bitfield=aggregation_bitfield_1,
             data=AttestationData(**sample_attestation_data_params).copy(
                 slot=194,
                 justified_epoch=2,
                 epoch_boundary_root=current_epoch_boundary_root,
             ),
-            aggregation_bitfield=aggregation_bitfield_1
         ),
         Attestation(**sample_attestation_params).copy(
+            aggregation_bitfield=aggregation_bitfield_2,
             data=AttestationData(**sample_attestation_data_params).copy(
                 slot=193,
                 justified_epoch=2,
                 epoch_boundary_root=current_epoch_boundary_root,
             ),
-            aggregation_bitfield=aggregation_bitfield_2
         ),
 
     )
 
     previous_epoch_attestations = (
         Attestation(**sample_attestation_params).copy(
+            aggregation_bitfield=aggregation_bitfield_1,
             data=AttestationData(**sample_attestation_data_params).copy(
                 slot=129,
                 justified_epoch=previous_justified_epoch,
                 epoch_boundary_root=previous_epoch_boundary_root,
             ),
-            aggregation_bitfield=aggregation_bitfield_1
         ),
         Attestation(**sample_attestation_params).copy(
+            aggregation_bitfield=aggregation_bitfield_2,
             data=AttestationData(**sample_attestation_data_params).copy(
                 slot=130,
                 justified_epoch=previous_justified_epoch,
                 epoch_boundary_root=previous_epoch_boundary_root,
             ),
-            aggregation_bitfield=aggregation_bitfield_2
         ),
     )
 


### PR DESCRIPTION
### What was wrong?
Sync with the spec
#343 task 1: `Attestation`: fix fields ordering https://github.com/ethereum/eth2.0-specs/blob/dev/specs/core/0_beacon-chain.md#attestation

### How was it fixed?
Simply reorder it.

#### Cute Animal Picture

![hedgehog-child-3636026_640](https://user-images.githubusercontent.com/9263930/53682795-6bf01280-3d34-11e9-9488-b96dd3851f5c.jpg)
