### PR TITLE
Bugfix: `AttestationDataAndCustodyBit` root bug

### DIFF
--- a/eth2/beacon/types/attestation_data_and_custody_bits.py
+++ b/eth2/beacon/types/attestation_data_and_custody_bits.py
@@ -38,7 +38,7 @@ class AttestationDataAndCustodyBit(ssz.Serializable):
     @property
     def hash(self) -> Hash32:
         if self._hash is None:
-            self._hash = hash_eth2(ssz.encode(self.data))
+            self._hash = hash_eth2(ssz.encode(self))
         return self._hash
 
     @property

--- a/eth2/beacon/types/slashable_attestations.py
+++ b/eth2/beacon/types/slashable_attestations.py
@@ -94,6 +94,6 @@ class SlashableAttestation(ssz.Serializable):
         """
         # TODO: change to hash_tree_root when we have SSZ tree hashing
         return (
-            AttestationDataAndCustodyBit(self.data, False).root,
-            AttestationDataAndCustodyBit(self.data, True).root,
+            AttestationDataAndCustodyBit(data=self.data, custody_bit=False).root,
+            AttestationDataAndCustodyBit(data=self.data, custody_bit=True).root,
         )

--- a/tests/eth2/beacon/state_machines/forks/test_serenity_block_validation.py
+++ b/tests/eth2/beacon/state_machines/forks/test_serenity_block_validation.py
@@ -302,7 +302,7 @@ def _correct_slashable_attestation_params(
 
     (validator_indices, signatures) = _get_indices_and_signatures(
         num_validators,
-        message_hashes[0],
+        message_hashes[0],  # custody bit is False
         privkeys,
         fork,
         slot_to_epoch(params["data"].slot, slots_per_epoch),

--- a/tests/eth2/beacon/state_machines/forks/test_serenity_block_validation.py
+++ b/tests/eth2/beacon/state_machines/forks/test_serenity_block_validation.py
@@ -302,7 +302,7 @@ def _correct_slashable_attestation_params(
 
     (validator_indices, signatures) = _get_indices_and_signatures(
         num_validators,
-        message_hashes[1],
+        message_hashes[0],
         privkeys,
         fork,
         slot_to_epoch(params["data"].slot, slots_per_epoch),


### PR DESCRIPTION
### What was wrong?

Leftover of the previous changes. We should include the whole `AttestationDataAndCustodyBit` in `AttestationDataAndCustodyBit.root`.

### How was it fixed?
1. Hash the whole encoded SSZ object.
2. Fix the tests - signing the custody bit 0 for tests

[//]: # (For important changes, please add a new entry to the release notes file)
[//]: # (See: https://trinity-client.readthedocs.io/en/latest/contributing.html#pull-requests)

#### Cute Animal Picture

![african-1862972_640](https://user-images.githubusercontent.com/9263930/53684886-4839c600-3d4e-11e9-84b6-9c42853493de.jpg)
