### PR TITLE
Update `AttesationData`: `latest_crosslink_root: Hash32` to `latest_crosslink: CrosslinkRecord`

### DIFF
--- a/eth2/beacon/tools/builder/validator.py
+++ b/eth2/beacon/tools/builder/validator.py
@@ -263,7 +263,7 @@ def create_mock_slashable_attestation(state: BeaconState,
         get_epoch_start_slot(state.justified_epoch, config.SLOTS_PER_EPOCH),
         config.LATEST_BLOCK_ROOTS_LENGTH,
     )
-    latest_crosslink_root = state.latest_crosslinks[shard].crosslink_data_root
+    latest_crosslink = state.latest_crosslinks[shard]
 
     attestation_data = attestation_data = AttestationData(
         slot=attestation_slot,
@@ -271,7 +271,7 @@ def create_mock_slashable_attestation(state: BeaconState,
         beacon_block_root=beacon_block_root,
         epoch_boundary_root=epoch_boundary_root,
         crosslink_data_root=ZERO_HASH32,
-        latest_crosslink_root=latest_crosslink_root,
+        latest_crosslink=latest_crosslink,
         justified_epoch=state.justified_epoch,
         justified_block_root=justified_block_root,
     )
@@ -493,7 +493,7 @@ def create_mock_signed_attestations_at_slot(
         committee, shard = crosslink_committee
 
         num_voted_attesters = int(len(committee) * voted_attesters_ratio)
-        latest_crosslink_root = state.latest_crosslinks[shard].crosslink_data_root
+        latest_crosslink = state.latest_crosslinks[shard]
 
         attestation_data = AttestationData(
             slot=attestation_slot,
@@ -501,7 +501,7 @@ def create_mock_signed_attestations_at_slot(
             beacon_block_root=beacon_block_root,
             epoch_boundary_root=epoch_boundary_root,
             crosslink_data_root=ZERO_HASH32,
-            latest_crosslink_root=latest_crosslink_root,
+            latest_crosslink=latest_crosslink,
             justified_epoch=state.justified_epoch,
             justified_block_root=justified_block_root,
         )

--- a/eth2/beacon/types/attestation_data.py
+++ b/eth2/beacon/types/attestation_data.py
@@ -13,6 +13,7 @@ from eth2.beacon.typing import (
     Slot,
     Shard,
 )
+from eth2.beacon.types.crosslink_records import CrosslinkRecord
 
 
 class AttestationData(ssz.Serializable):
@@ -29,7 +30,7 @@ class AttestationData(ssz.Serializable):
         # Shard block root being attested to
         ('crosslink_data_root', bytes32),
         # Last crosslink hash
-        ('latest_crosslink_root', bytes32),
+        ('latest_crosslink', CrosslinkRecord),
         # epoch of the last justified beacon block
         ('justified_epoch', uint64),
         # Hash of the last justified beacon block
@@ -42,7 +43,7 @@ class AttestationData(ssz.Serializable):
                  beacon_block_root: Hash32,
                  epoch_boundary_root: Hash32,
                  crosslink_data_root: Hash32,
-                 latest_crosslink_root: Hash32,
+                 latest_crosslink: CrosslinkRecord,
                  justified_epoch: Epoch,
                  justified_block_root: Hash32) -> None:
         super().__init__(
@@ -51,7 +52,7 @@ class AttestationData(ssz.Serializable):
             beacon_block_root,
             epoch_boundary_root,
             crosslink_data_root,
-            latest_crosslink_root,
+            latest_crosslink,
             justified_epoch,
             justified_block_root,
         )

--- a/eth2/beacon/types/crosslink_records.py
+++ b/eth2/beacon/types/crosslink_records.py
@@ -8,6 +8,7 @@ from ssz.sedes import (
     bytes32,
 )
 
+from eth2.beacon._utils.hash import hash_eth2
 from eth2.beacon.typing import Epoch
 
 
@@ -28,3 +29,17 @@ class CrosslinkRecord(ssz.Serializable):
             epoch=epoch,
             crosslink_data_root=crosslink_data_root,
         )
+
+    _hash = None
+
+    @property
+    def hash(self) -> Hash32:
+        if self._hash is None:
+            self._hash = hash_eth2(ssz.encode(self))
+        return self._hash
+
+    @property
+    def root(self) -> Hash32:
+        # Alias of `hash`.
+        # Using flat hash, will likely use SSZ tree hash.
+        return self.hash

--- a/tests/core/p2p-proto/bcc/test_commands.py
+++ b/tests/core/p2p-proto/bcc/test_commands.py
@@ -2,18 +2,18 @@ import pytest
 
 import ssz
 
+from eth.constants import (
+    ZERO_HASH32,
+)
+
 from eth2.beacon.types.attestations import Attestation
 from eth2.beacon.types.attestation_data import AttestationData
 from eth2.beacon.types.blocks import (
     BeaconBlock,
     BeaconBlockBody,
 )
-
-from eth.constants import (
-    ZERO_HASH32,
-)
-
 from eth2.beacon.types.eth1_data import Eth1Data
+from eth2.beacon.types.crosslink_records import CrosslinkRecord
 
 from p2p.peer import (
     MsgBuffer,
@@ -167,7 +167,7 @@ async def test_send_single_attestation(request, event_loop):
             beacon_block_root=ZERO_HASH32,
             epoch_boundary_root=ZERO_HASH32,
             crosslink_data_root=ZERO_HASH32,
-            latest_crosslink_root=ZERO_HASH32,
+            latest_crosslink=CrosslinkRecord(SERENITY_CONFIG.GENESIS_EPOCH, ZERO_HASH32),
             justified_epoch=SERENITY_CONFIG.GENESIS_EPOCH,
             justified_block_root=ZERO_HASH32,
         ),
@@ -194,7 +194,7 @@ async def test_send_multiple_attestations(request, event_loop):
                 beacon_block_root=ZERO_HASH32,
                 epoch_boundary_root=ZERO_HASH32,
                 crosslink_data_root=ZERO_HASH32,
-                latest_crosslink_root=ZERO_HASH32,
+                latest_crosslink=CrosslinkRecord(SERENITY_CONFIG.GENESIS_EPOCH, ZERO_HASH32),
                 justified_epoch=SERENITY_CONFIG.GENESIS_EPOCH,
                 justified_block_root=ZERO_HASH32,
             ),

--- a/tests/eth2/beacon/conftest.py
+++ b/tests/eth2/beacon/conftest.py
@@ -100,14 +100,14 @@ def sample_attestation_params(sample_attestation_data_params):
 
 
 @pytest.fixture
-def sample_attestation_data_params():
+def sample_attestation_data_params(sample_crosslink_record_params):
     return {
         'slot': 10,
         'shard': 12,
         'beacon_block_root': b'\x11' * 32,
         'epoch_boundary_root': b'\x22' * 32,
         'crosslink_data_root': b'\x33' * 32,
-        'latest_crosslink_root': b'\x44' * 32,
+        'latest_crosslink': CrosslinkRecord(**sample_crosslink_record_params),
         'justified_epoch': 0,
         'justified_block_root': b'\x55' * 32,
     }

--- a/tests/eth2/beacon/state_machines/forks/test_serenity_block_attestation_validation.py
+++ b/tests/eth2/beacon/state_machines/forks/test_serenity_block_attestation_validation.py
@@ -27,6 +27,7 @@ from eth2.beacon.tools.builder.validator import (
     create_mock_signed_attestation,
 )
 from eth2.beacon.types.attestation_data import AttestationData
+from eth2.beacon.types.crosslink_records import CrosslinkRecord
 
 
 @pytest.mark.parametrize(
@@ -138,8 +139,8 @@ def test_validate_attestation_justified_epoch(
         'is_valid,'
     ),
     [
-        (b'\x42' * 32, b'\x35' * 32, False),  # attestation.justified_block_root != justified_block_root # noqa: E501
-        (b'\x42' * 32, b'\x42' * 32, True),
+        (b'\x33' * 32, b'\x22' * 32, False),  # attestation.justified_block_root != justified_block_root # noqa: E501
+        (b'\x33' * 32, b'\x33' * 32, True),
     ]
 )
 def test_validate_attestation_justified_block_root(sample_attestation_data_params,
@@ -165,41 +166,69 @@ def test_validate_attestation_justified_block_root(sample_attestation_data_param
 
 @pytest.mark.parametrize(
     (
-        'attestation_latest_crosslink_root,'
+        'attestation_latest_crosslink,'
         'attestation_crosslink_data_root,'
-        'latest_crosslink_root,'
+        'state_latest_crosslink,'
         'is_valid,'
     ),
     [
-        (b'\x66' * 32, b'\x42' * 32, b'\x35' * 32, False),
-        (b'\x42' * 32, b'\x42' * 32, b'\x66' * 32, False),
-        (b'\x66' * 32, b'\x42' * 32, b'\x42' * 32, True),
-        (b'\x42' * 32, b'\x35' * 32, b'\x42' * 32, True),
-        (b'\x42' * 32, b'\x42' * 32, b'\x42' * 32, True),
+        (
+            CrosslinkRecord(0, b'\x11' * 32),
+            b'\x33' * 32,
+            CrosslinkRecord(0, b'\x22' * 32),
+            False,
+        ),
+        (
+            CrosslinkRecord(0, b'\x33' * 32),
+            b'\x33' * 32,
+            CrosslinkRecord(0, b'\x11' * 32),
+            False,
+        ),
+        (
+            CrosslinkRecord(0, b'\x11' * 32),
+            b'\x33' * 32,
+            CrosslinkRecord(0, b'\x33' * 32),
+            True,
+        ),
+        (
+            CrosslinkRecord(0, b'\x33' * 32),
+            b'\x22' * 32,
+            CrosslinkRecord(0, b'\x33' * 32),
+            True,
+        ),
+        (
+            CrosslinkRecord(0, b'\x33' * 32),
+            b'\x33' * 32,
+            CrosslinkRecord(0, b'\x33' * 32),
+            True,
+        ),
     ]
 )
 def test_validate_attestation_latest_crosslink_root(sample_attestation_data_params,
-                                                    attestation_latest_crosslink_root,
+                                                    attestation_latest_crosslink,
                                                     attestation_crosslink_data_root,
-                                                    latest_crosslink_root,
+                                                    state_latest_crosslink,
+                                                    slots_per_epoch,
                                                     is_valid):
-    sample_attestation_data_params['latest_crosslink_root'] = attestation_latest_crosslink_root
+    sample_attestation_data_params['latest_crosslink'] = attestation_latest_crosslink
     sample_attestation_data_params['crosslink_data_root'] = attestation_crosslink_data_root
     attestation_data = AttestationData(**sample_attestation_data_params).copy(
-        latest_crosslink_root=attestation_latest_crosslink_root,
+        latest_crosslink=attestation_latest_crosslink,
         crosslink_data_root=attestation_crosslink_data_root,
     )
 
     if is_valid:
         validate_attestation_latest_crosslink_root(
             attestation_data,
-            latest_crosslink_root,
+            state_latest_crosslink,
+            slots_per_epoch=slots_per_epoch,
         )
     else:
         with pytest.raises(ValidationError):
             validate_attestation_latest_crosslink_root(
                 attestation_data,
-                latest_crosslink_root,
+                state_latest_crosslink,
+                slots_per_epoch=slots_per_epoch,
             )
 
 
@@ -210,8 +239,8 @@ def test_validate_attestation_latest_crosslink_root(sample_attestation_data_para
     ),
     [
         (ZERO_HASH32, True),
-        (b'\x35' * 32, False),
-        (b'\x66' * 32, False),
+        (b'\x22' * 32, False),
+        (b'\x11' * 32, False),
     ]
 )
 def test_validate_attestation_crosslink_data_root(sample_attestation_data_params,

--- a/tests/eth2/beacon/state_machines/forks/test_serenity_block_attestation_validation.py
+++ b/tests/eth2/beacon/state_machines/forks/test_serenity_block_attestation_validation.py
@@ -204,12 +204,12 @@ def test_validate_attestation_justified_block_root(sample_attestation_data_param
         ),
     ]
 )
-def test_validate_attestation_latest_crosslink_root(sample_attestation_data_params,
-                                                    attestation_latest_crosslink,
-                                                    attestation_crosslink_data_root,
-                                                    state_latest_crosslink,
-                                                    slots_per_epoch,
-                                                    is_valid):
+def test_validate_attestation_latest_crosslink(sample_attestation_data_params,
+                                               attestation_latest_crosslink,
+                                               attestation_crosslink_data_root,
+                                               state_latest_crosslink,
+                                               slots_per_epoch,
+                                               is_valid):
     sample_attestation_data_params['latest_crosslink'] = attestation_latest_crosslink
     sample_attestation_data_params['crosslink_data_root'] = attestation_crosslink_data_root
     attestation_data = AttestationData(**sample_attestation_data_params).copy(

--- a/tests/eth2/beacon/types/test_slashable_attestation.py
+++ b/tests/eth2/beacon/types/test_slashable_attestation.py
@@ -25,19 +25,6 @@ def test_defaults(sample_slashable_attestation_params):
     assert ssz.encode(slashable_attestation)
 
 
-def test_hash(sample_slashable_attestation_params):
-    slashable_attestation = SlashableAttestation(**sample_slashable_attestation_params)
-
-    # NOTE: this hash was simply copied from the existing implementation
-    # which should be the keccak-256 of the rlp serialization of `votes`.
-    # Given that this value will change soon (cf. ssz tree hash), we just
-    # do this to get the test passing for now and will need to update later
-    # if we expect the hash computation is not working correctly
-    hash_hex = "8cba2c190eae977ba16cbcc7ef1b95b32384fd12e86292ca8a91cc320eaeac9c"
-
-    assert slashable_attestation.hash == bytes.fromhex(hash_hex)
-
-
 def test_root(sample_slashable_attestation_params):
     slashable_attestation = SlashableAttestation(**sample_slashable_attestation_params)
 


### PR DESCRIPTION
### What was wrong?
#343 task 4: Update `AttesationData`: `latest_crosslink_root: Hash32` to `latest_crosslink: CrosslinkRecord`


### How was it fixed?
1. Rename `AttesationData.latest_crosslink_root` to `AttesationData.latest_crosslink`.
2. Change the type to `CrosslinkRecord` and fix the related logic.
3. Remove the outdated `SlashableAttestation.hash` tests


#### Cute Animal Picture

![hedgehog-child-1759027_640](https://user-images.githubusercontent.com/9263930/53685334-1d527080-3d54-11e9-88a0-624a0e00a9b6.jpg)
