### PR TITLE
A more helpful db-shell

### DIFF
--- a/trinity/plugins/builtin/attach/console.py
+++ b/trinity/plugins/builtin/attach/console.py
@@ -111,7 +111,7 @@ def db_shell(use_ipython: bool, database_dir: Path, trinity_config: TrinityConfi
       - `db`: base database object
       - `chaindb`: `ChainDB` instance
       - `trinity_config`: `TrinityConfig` instance
-      - `chain_config`: `Eth1AppConfig` instance
+      - `chain_config`: `ChainConfig` instance
       - `chain`: `Chain` instance
     """
 

--- a/trinity/plugins/builtin/attach/plugin.py
+++ b/trinity/plugins/builtin/attach/plugin.py
@@ -69,6 +69,6 @@ class DbShellPlugin(BaseMainProcessPlugin):
 
         if trinity_config.has_app_config(Eth1AppConfig):
             config = trinity_config.get_app_config(Eth1AppConfig)
-            db_shell(self.use_ipython, config.database_dir)
+            db_shell(self.use_ipython, config.database_dir, trinity_config)
         else:
             self.logger.error("DB Shell does only support the Ethereum 1 node at this time")


### PR DESCRIPTION
### What was wrong?

The `db-shell` is quite nice, but it only exposes the `ChainDB`.  Given this is a low level utility it would be nice to have access to more of the *stuff*

### How was it fixed?

Expanded the variables available in the local context to include

- `db` the base db instance
- `trinity_config`: the `TrinityConfig` instances
- `chain_config`: the `Eth1AppConfig` instance
- `chain`: the `Chain` instance.

#### Cute Animal Picture

![foxwdinner](https://user-images.githubusercontent.com/824194/53748407-87f1d200-3e62-11e9-9c74-e72fadff504b.jpg)

