### PR TITLE
Update genesis slot

### DIFF
--- a/eth2/beacon/state_machines/forks/serenity/configs.py
+++ b/eth2/beacon/state_machines/forks/serenity/configs.py
@@ -14,6 +14,9 @@ from eth2.beacon.typing import (
     Slot,
 )
 
+GENESIS_SLOT = Slot(2**32)
+SLOTS_PER_EPOCH = 2**6
+
 
 SERENITY_CONFIG = BeaconConfig(
     # Misc
@@ -34,14 +37,14 @@ SERENITY_CONFIG = BeaconConfig(
     MAX_DEPOSIT_AMOUNT=Gwei(2**5 * GWEI_PER_ETH),  # (= 32,000,000,00) Gwei
     # Genesis values
     GENESIS_FORK_VERSION=0,
-    GENESIS_SLOT=Slot(0),
-    GENESIS_EPOCH=slot_to_epoch(Slot(0), 2**6),  # GENESIS_EPOCH=slot_to_epoch(GENESIS_SLOT)
+    GENESIS_SLOT=GENESIS_SLOT,
+    GENESIS_EPOCH=slot_to_epoch(GENESIS_SLOT, SLOTS_PER_EPOCH),
     GENESIS_START_SHARD=Shard(0),
     BLS_WITHDRAWAL_PREFIX_BYTE=b'\x00',
     # Time parameters
     SECONDS_PER_SLOT=Second(6),  # seconds
     MIN_ATTESTATION_INCLUSION_DELAY=2**2,  # (= 4) slots
-    SLOTS_PER_EPOCH=2**6,  # (= 64) slots
+    SLOTS_PER_EPOCH=SLOTS_PER_EPOCH,  # (= 64) slots
     MIN_SEED_LOOKAHEAD=2**0,  # (= 1) epochs
     ACTIVATION_EXIT_DELAY=2**2,  # (= 4) epochs
     EPOCHS_PER_ETH1_VOTING_PERIOD=2**4,  # (= 16) epochs

--- a/tests/eth2/beacon/chains/conftest.py
+++ b/tests/eth2/beacon/chains/conftest.py
@@ -26,7 +26,7 @@ def _beacon_chain_with_block_validation(
     klass = chain_cls.configure(
         __name__='TestChain',
         sm_configuration=(
-            (0, fixture_sm_class),
+            (genesis_state.slot, fixture_sm_class),
         ),
         chain_id=5566,
     )

--- a/tests/eth2/beacon/chains/test_chain.py
+++ b/tests/eth2/beacon/chains/test_chain.py
@@ -62,6 +62,7 @@ def test_canonical_chain(valid_chain):
     assert result_block == block
 
 
+@pytest.mark.long
 @pytest.mark.parametrize(
     (
         'num_validators,slots_per_epoch,target_committee_size,shard_count'

--- a/tests/eth2/beacon/chains/test_chain.py
+++ b/tests/eth2/beacon/chains/test_chain.py
@@ -38,8 +38,8 @@ def valid_chain(beacon_chain_with_block_validation):
         (100, 20, 10, 10),
     ]
 )
-def test_canonical_chain(valid_chain):
-    genesis_block = valid_chain.get_canonical_block_by_slot(0)
+def test_canonical_chain(valid_chain, genesis_slot):
+    genesis_block = valid_chain.get_canonical_block_by_slot(genesis_slot)
 
     # Our chain fixture is created with only the genesis header, so initially that's the head of
     # the canonical chain.

--- a/tests/eth2/beacon/helpers.py
+++ b/tests/eth2/beacon/helpers.py
@@ -3,22 +3,23 @@ from eth_utils import to_tuple
 from eth.constants import (
     ZERO_HASH32,
 )
+from eth2.beacon.configs import BeaconConfig
 from eth2.beacon.constants import (
     FAR_FUTURE_EPOCH,
 )
 from eth2.beacon.types.validator_records import (
     ValidatorRecord,
 )
-from eth2.beacon.state_machines.forks.serenity.configs import SERENITY_CONFIG
 
 
 def mock_validator_record(pubkey,
+                          config: BeaconConfig,
                           withdrawal_credentials=ZERO_HASH32,
                           is_active=True):
     return ValidatorRecord(
         pubkey=pubkey,
         withdrawal_credentials=withdrawal_credentials,
-        activation_epoch=SERENITY_CONFIG.GENESIS_EPOCH if is_active else FAR_FUTURE_EPOCH,
+        activation_epoch=config.GENESIS_EPOCH if is_active else FAR_FUTURE_EPOCH,
         exit_epoch=FAR_FUTURE_EPOCH,
         withdrawable_epoch=FAR_FUTURE_EPOCH,
         initiated_exit=False,

--- a/tests/eth2/beacon/state_machines/forks/test_serenity_block_attestation_validation.py
+++ b/tests/eth2/beacon/state_machines/forks/test_serenity_block_attestation_validation.py
@@ -270,12 +270,13 @@ def test_validate_attestation_crosslink_data_root(sample_attestation_data_params
         'target_committee_size,'
         'shard_count,'
         'is_valid,'
+        'genesis_slot'
     ),
     [
-        (10, 2, 2, 2, True),
-        (40, 4, 3, 5, True),
-        (20, 5, 3, 2, True),
-        (20, 5, 3, 2, False),
+        (10, 2, 2, 2, True, 0),
+        (40, 4, 3, 5, True, 0),
+        (20, 5, 3, 2, True, 0),
+        (20, 5, 3, 2, False, 0),
     ],
 )
 def test_validate_attestation_aggregate_signature(genesis_state,

--- a/tests/eth2/beacon/state_machines/forks/test_serenity_block_processing.py
+++ b/tests/eth2/beacon/state_machines/forks/test_serenity_block_processing.py
@@ -50,7 +50,7 @@ def test_randao_processing(sample_beacon_block_params,
     proposer_pubkey, proposer_privkey = first(keymap.items())
     state = SerenityBeaconState(**sample_beacon_state_params).copy(
         validator_registry=tuple(
-            mock_validator_record(proposer_pubkey)
+            mock_validator_record(proposer_pubkey, config)
             for _ in range(config.TARGET_COMMITTEE_SIZE)
         ),
         validator_balances=(config.MAX_DEPOSIT_AMOUNT,) * config.TARGET_COMMITTEE_SIZE,
@@ -92,7 +92,7 @@ def test_randao_processing_validates_randao_reveal(sample_beacon_block_params,
     proposer_pubkey, proposer_privkey = first(keymap.items())
     state = SerenityBeaconState(**sample_beacon_state_params).copy(
         validator_registry=tuple(
-            mock_validator_record(proposer_pubkey)
+            mock_validator_record(proposer_pubkey, config)
             for _ in range(config.TARGET_COMMITTEE_SIZE)
         ),
         validator_balances=(config.MAX_DEPOSIT_AMOUNT,) * config.TARGET_COMMITTEE_SIZE,

--- a/tests/eth2/beacon/state_machines/forks/test_serenity_block_validation.py
+++ b/tests/eth2/beacon/state_machines/forks/test_serenity_block_validation.py
@@ -104,7 +104,7 @@ def test_validate_proposer_signature(
 
     state = BeaconState(**sample_beacon_state_params).copy(
         validator_registry=tuple(
-            mock_validator_record(proposer_pubkey)
+            mock_validator_record(proposer_pubkey, config)
             for _ in range(10)
         ),
         validator_balances=(max_deposit_amount,) * 10,

--- a/tests/eth2/beacon/state_machines/forks/test_serenity_epoch_processing.py
+++ b/tests/eth2/beacon/state_machines/forks/test_serenity_epoch_processing.py
@@ -174,6 +174,14 @@ def test_justification_without_mock(sample_beacon_state_params,
 
 
 @pytest.mark.parametrize(
+    (
+        "genesis_slot,"
+    ),
+    [
+        (0),
+    ]
+)
+@pytest.mark.parametrize(
     # Each state contains epoch, current_epoch_justifiable, previous_epoch_justifiable,
     # previous_justified_epoch, justified_epoch, justification_bitfield, and finalized_epoch.
     # Specify the last epoch processed state at the end of the items.
@@ -268,6 +276,7 @@ def test_process_justification(monkeypatch,
         'target_committee_size,'
         'shard_count,'
         'success_crosslink_in_cur_epoch,'
+        'genesis_slot,'
     ),
     [
         (
@@ -276,6 +285,7 @@ def test_process_justification(monkeypatch,
             9,
             10,
             False,
+            0,
         ),
         (
             90,
@@ -283,6 +293,7 @@ def test_process_justification(monkeypatch,
             9,
             10,
             True,
+            0,
         ),
     ]
 )
@@ -373,6 +384,7 @@ def test_process_crosslinks(
         'shard_count,'
         'min_attestation_inclusion_delay,'
         'inactivity_penalty_quotient,'
+        'genesis_slot,'
     ),
     [
         (
@@ -382,6 +394,7 @@ def test_process_crosslinks(
             2,
             4,
             10,
+            0,
         )
     ]
 )
@@ -571,6 +584,7 @@ def test_process_rewards_and_penalties_for_finality(
 @pytest.mark.parametrize(
     (
         'n,'
+        'genesis_slot,'
         'slots_per_epoch,'
         'target_committee_size,'
         'shard_count,'
@@ -584,6 +598,7 @@ def test_process_rewards_and_penalties_for_finality(
     [
         (
             20,
+            0,
             10,
             2,
             10,
@@ -687,7 +702,8 @@ def test_process_rewards_and_penalties_for_attestation_inclusion(
         'target_committee_size,'
         'shard_count,'
         'current_slot,'
-        'num_attesting_validators'
+        'num_attesting_validators,'
+        'genesis_slot,'
     ),
     [
         (
@@ -697,6 +713,7 @@ def test_process_rewards_and_penalties_for_attestation_inclusion(
             10,
             100,
             3,
+            0,
         ),
         (
             50,
@@ -705,6 +722,7 @@ def test_process_rewards_and_penalties_for_attestation_inclusion(
             10,
             100,
             4,
+            0,
         ),
     ]
 )
@@ -845,6 +863,14 @@ def test_process_rewards_and_penalties_for_crosslinks(
 #
 # Ejections
 #
+@pytest.mark.parametrize(
+    (
+        'genesis_slot,'
+    ),
+    [
+        (0),
+    ]
+)
 def test_process_ejections(genesis_state, config, activation_exit_delay):
     current_epoch = 8
     state = genesis_state.copy(

--- a/tests/eth2/beacon/state_machines/forks/test_serenity_operation_processing.py
+++ b/tests/eth2/beacon/state_machines/forks/test_serenity_operation_processing.py
@@ -35,9 +35,8 @@ def test_process_max_attestations(genesis_state,
                                   sample_beacon_block_params,
                                   sample_beacon_block_body_params,
                                   config,
-                                  keymap,
-                                  genesis_slot):
-    attestation_slot = genesis_slot
+                                  keymap):
+    attestation_slot = config.GENESIS_SLOT
     current_slot = attestation_slot + config.MIN_ATTESTATION_INCLUSION_DELAY
     state = genesis_state.copy(
         slot=current_slot,
@@ -93,9 +92,8 @@ def test_process_proposer_slashings(genesis_state,
                                     keymap,
                                     block_root_1,
                                     block_root_2,
-                                    success,
-                                    genesis_slot):
-    current_slot = genesis_slot + 1
+                                    success):
+    current_slot = config.GENESIS_SLOT + 1
     state = genesis_state.copy(
         slot=current_slot,
     )

--- a/tests/eth2/beacon/state_machines/forks/test_serenity_operation_processing.py
+++ b/tests/eth2/beacon/state_machines/forks/test_serenity_operation_processing.py
@@ -35,8 +35,9 @@ def test_process_max_attestations(genesis_state,
                                   sample_beacon_block_params,
                                   sample_beacon_block_body_params,
                                   config,
-                                  keymap):
-    attestation_slot = 0
+                                  keymap,
+                                  genesis_slot):
+    attestation_slot = genesis_slot
     current_slot = attestation_slot + config.MIN_ATTESTATION_INCLUSION_DELAY
     state = genesis_state.copy(
         slot=current_slot,
@@ -92,8 +93,9 @@ def test_process_proposer_slashings(genesis_state,
                                     keymap,
                                     block_root_1,
                                     block_root_2,
-                                    success):
-    current_slot = 1
+                                    success,
+                                    genesis_slot):
+    current_slot = genesis_slot + 1
     state = genesis_state.copy(
         slot=current_slot,
     )
@@ -230,11 +232,12 @@ def test_process_attester_slashings(genesis_state,
         'target_committee_size,'
         'shard_count,'
         'success,'
+        'genesis_slot,'
     ),
     [
-        (10, 2, 1, 2, 2, True),
-        (10, 2, 1, 2, 2, False),
-        (40, 4, 2, 3, 5, True),
+        (10, 2, 1, 2, 2, True, 0),
+        (10, 2, 1, 2, 2, False, 0),
+        (40, 4, 2, 3, 5, True, 0),
     ]
 )
 def test_process_attestations(genesis_state,

--- a/tests/eth2/beacon/state_machines/test_demo.py
+++ b/tests/eth2/beacon/state_machines/test_demo.py
@@ -15,6 +15,7 @@ from eth2.beacon.tools.builder.validator import (
 )
 
 
+@pytest.mark.long
 @pytest.mark.parametrize(
     (
         'num_validators,'

--- a/tests/eth2/beacon/state_machines/test_demo.py
+++ b/tests/eth2/beacon/state_machines/test_demo.py
@@ -32,6 +32,8 @@ def test_demo(base_db,
               num_validators,
               config,
               keymap,
+              genesis_slot,
+              genesis_epoch,
               fixture_sm_class):
     chaindb = BeaconChainDB(base_db)
 
@@ -42,7 +44,7 @@ def test_demo(base_db,
         genesis_block_class=SerenityBeaconBlock,
     )
     for i in range(num_validators):
-        assert genesis_state.validator_registry[i].is_active(0)
+        assert genesis_state.validator_registry[i].is_active(genesis_slot)
 
     chaindb.persist_block(genesis_block, SerenityBeaconBlock)
     chaindb.persist_state(genesis_state)
@@ -55,8 +57,8 @@ def test_demo(base_db,
 
     attestations_map = {}  # Dict[Slot, Sequence[Attestation]]
 
-    for current_slot in range(1, chain_length):
-        if current_slot > config.MIN_ATTESTATION_INCLUSION_DELAY:
+    for current_slot in range(genesis_slot + 1, genesis_slot + chain_length):
+        if current_slot > genesis_slot + config.MIN_ATTESTATION_INCLUSION_DELAY:
             attestations = attestations_map[current_slot - config.MIN_ATTESTATION_INCLUSION_DELAY]
         else:
             attestations = ()
@@ -104,9 +106,9 @@ def test_demo(base_db,
         )
         attestations_map[attestation_slot] = attestations
 
-    assert state.slot == chain_length - 1
+    assert state.slot == chain_length - 1 + genesis_slot
     assert isinstance(sm.block, SerenityBeaconBlock)
 
     # Justification assertions
-    assert state.justified_epoch == 2
-    assert state.finalized_epoch == 1
+    assert state.justified_epoch == 2 + genesis_epoch
+    assert state.finalized_epoch == 1 + genesis_epoch

--- a/tests/eth2/beacon/state_machines/test_demo.py
+++ b/tests/eth2/beacon/state_machines/test_demo.py
@@ -32,9 +32,9 @@ def test_demo(base_db,
               num_validators,
               config,
               keymap,
-              genesis_slot,
-              genesis_epoch,
               fixture_sm_class):
+    genesis_slot = config.GENESIS_SLOT
+    genesis_epoch = config.GENESIS_EPOCH
     chaindb = BeaconChainDB(base_db)
 
     genesis_state, genesis_block = create_mock_genesis(

--- a/tests/eth2/beacon/state_machines/test_state_transition.py
+++ b/tests/eth2/beacon/state_machines/test_state_transition.py
@@ -13,6 +13,14 @@ from eth2._utils.merkle import get_merkle_root
 
 @pytest.mark.parametrize(
     (
+        'genesis_slot,'
+    ),
+    [
+        (0),
+    ]
+)
+@pytest.mark.parametrize(
+    (
         'num_validators,'
         'slots_per_epoch,'
         'min_attestation_inclusion_delay,'

--- a/tests/eth2/beacon/test_committee_helpers.py
+++ b/tests/eth2/beacon/test_committee_helpers.py
@@ -77,7 +77,8 @@ def test_get_next_epoch_committee_count(n_validators_state,
                                         shard_count,
                                         slots_per_epoch,
                                         target_committee_size,
-                                        expected_committee_count):
+                                        expected_committee_count,
+                                        config):
     state = n_validators_state
 
     current_epoch_committee_count = get_current_epoch_committee_count(
@@ -96,11 +97,12 @@ def test_get_next_epoch_committee_count(n_validators_state,
     assert next_epoch_committee_count == expected_committee_count
 
     # Exit all validators
+    exit_epoch = state.current_epoch(slots_per_epoch) + 1
     for index, validator in enumerate(state.validator_registry):
         state = state.update_validator_registry(
             validator_index=index,
             validator=validator.copy(
-                exit_epoch=state.current_epoch(slots_per_epoch) + 1,
+                exit_epoch=exit_epoch,
             ),
         )
 
@@ -120,6 +122,14 @@ def test_get_next_epoch_committee_count(n_validators_state,
     assert next_epoch_committee_count == slots_per_epoch
 
 
+@pytest.mark.parametrize(
+    (
+        'genesis_slot,'
+    ),
+    [
+        (0),
+    ],
+)
 @pytest.mark.parametrize(
     (
         'num_validators,'
@@ -270,6 +280,15 @@ def test_get_prev_or_cur_epoch_committee_count(
 
 @pytest.mark.parametrize(
     (
+        'genesis_slot,'
+        'genesis_epoch,'
+    ),
+    [
+        (0, 0),
+    ],
+)
+@pytest.mark.parametrize(
+    (
         'n,'
         'current_slot,'
         'slot,'
@@ -316,6 +335,7 @@ def test_get_prev_or_cur_epoch_committee_count(
 )
 def test_get_crosslink_committees_at_slot(
         monkeypatch,
+        genesis_slot,
         n_validators_state,
         current_slot,
         slot,
@@ -440,6 +460,15 @@ def test_get_crosslink_committees_at_slot(
         (True),
         (False)
     ]
+)
+@pytest.mark.parametrize(
+    (
+        'genesis_slot,'
+        'genesis_epoch,'
+    ),
+    [
+        (0, 0),
+    ],
 )
 @pytest.mark.parametrize(
     (

--- a/tests/eth2/beacon/test_epoch_processing_helpers.py
+++ b/tests/eth2/beacon/test_epoch_processing_helpers.py
@@ -71,6 +71,14 @@ def get_aggregation_bitfield(attestation_participants, target_committee_size):
 
 @settings(max_examples=1)
 @given(random=st.randoms())
+@pytest.mark.parametrize(
+    (
+        'genesis_slot,'
+    ),
+    [
+        (0),
+    ]
+)
 def test_get_current_and_previous_epoch_attestations(random,
                                                      sample_state,
                                                      genesis_epoch,
@@ -123,10 +131,10 @@ def test_get_current_and_previous_epoch_attestations(random,
 @given(random=st.randoms())
 @pytest.mark.parametrize(
     (
-        'slots_per_epoch,latest_block_roots_length,'
+        'slots_per_epoch,latest_block_roots_length,genesis_slot'
     ),
     [
-        (10, 100),
+        (10, 100, 0),
     ]
 )
 def test_get_previous_epoch_head_attestations(
@@ -433,8 +441,16 @@ def test_get_epoch_boundary_attester_indices(monkeypatch,
 @settings(max_examples=1)
 @given(random=st.randoms())
 @pytest.mark.parametrize(
-    "n,",
-    (16,),
+    (
+        'n,'
+        'genesis_slot,'
+    ),
+    [
+        (
+            16,
+            0,
+        ),
+    ]
 )
 def test_get_epoch_boundary_attesting_balances(
     monkeypatch,

--- a/tests/eth2/beacon/test_validator_status_helpers.py
+++ b/tests/eth2/beacon/test_validator_status_helpers.py
@@ -47,12 +47,14 @@ def test_activate_validator(is_genesis,
                             genesis_epoch,
                             slots_per_epoch,
                             activation_exit_delay,
-                            max_deposit_amount):
+                            max_deposit_amount,
+                            config):
     validator_count = 10
     state = filled_beacon_state.copy(
         validator_registry=tuple(
             mock_validator_record(
                 pubkey=index.to_bytes(48, 'little'),
+                config=config,
                 is_active=False,
             )
             for index in range(validator_count)

--- a/tests/eth2/beacon/tools/builder/test_builder_validator.py
+++ b/tests/eth2/beacon/tools/builder/test_builder_validator.py
@@ -24,6 +24,7 @@ from eth2.beacon.tools.builder.validator import (
 )
 
 
+@pytest.mark.slow
 @settings(max_examples=1)
 @given(random=st.randoms())
 @pytest.mark.parametrize(

--- a/tests/eth2/beacon/tools/builder/test_builder_validator.py
+++ b/tests/eth2/beacon/tools/builder/test_builder_validator.py
@@ -100,12 +100,13 @@ def test_aggregate_votes(votes_count, random, privkeys, pubkeys):
         'shard_count,'
         'state_epoch,'
         'epoch,'
+        'genesis_slot,'
     ),
     [
-        (40, 16, 1, 2, 0, 0),  # genesis
-        (40, 16, 1, 2, 1, 1),  # current epoch
-        (40, 16, 1, 2, 1, 0),  # previous epoch
-        (40, 16, 1, 2, 1, 2),  # next epoch
+        (40, 16, 1, 2, 0, 0, 0),  # genesis
+        (40, 16, 1, 2, 1, 1, 0),  # current epoch
+        (40, 16, 1, 2, 1, 0, 0),  # previous epoch
+        (40, 16, 1, 2, 1, 2, 0),  # next epoch
     ]
 )
 def test_get_committee_assignment(genesis_state,

--- a/tests/eth2/beacon/types/test_states.py
+++ b/tests/eth2/beacon/types/test_states.py
@@ -24,12 +24,12 @@ def test_defaults(sample_beacon_state_params):
     assert ssz.encode(state)
 
 
-def test_validator_registry_and_balances_length(sample_beacon_state_params):
+def test_validator_registry_and_balances_length(sample_beacon_state_params, config):
     # When len(BeaconState.validator_registry) != len(BeaconState.validtor_balances)
     with pytest.raises(ValueError):
         BeaconState(**sample_beacon_state_params).copy(
             validator_registry=tuple(
-                mock_validator_record(pubkey)
+                mock_validator_record(pubkey, config)
                 for pubkey in range(10)
             ),
         )
@@ -40,11 +40,13 @@ def test_validator_registry_and_balances_length(sample_beacon_state_params):
 )
 def test_num_validators(expected,
                         max_deposit_amount,
-                        filled_beacon_state):
+                        filled_beacon_state,
+                        config):
     state = filled_beacon_state.copy(
         validator_registry=tuple(
             mock_validator_record(
                 pubkey,
+                config,
             )
             for pubkey in range(expected)
         ),
@@ -86,9 +88,9 @@ def test_hash(sample_beacon_state_params):
 def test_update_validator(n_validators_state,
                           validator_index,
                           new_pubkey,
-                          new_balance):
+                          new_balance, config):
     state = n_validators_state
-    validator = mock_validator_record(new_pubkey)
+    validator = mock_validator_record(new_pubkey, config)
 
     if validator_index < state.num_validators:
         result_state = state.update_validator(


### PR DESCRIPTION
### What was wrong?

Fixes #259.

### How was it fixed?

Updated the default genesis slot to the specified value, `2**32`. Moreover, we now compute the genesis epoch from the genesis slot value.

Many tests were hard-coded to a genesis slot of `0` -- they should all pass but I put all of those changes into its own commit in case you just want to see the configuration changes.

I also marked some tests as `slow` or `long`. You can {run, skip} these tests w/ `pytest -{m,k}-{slow,long}` which may be helpful to you.

[//]: # (For important changes, please add a new entry to the release notes file)
[//]: # (See: https://trinity-client.readthedocs.io/en/latest/contributing.html#pull-requests)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://proxy.duckduckgo.com/iu/?u=http%3A%2F%2Fanimals.ekstrax.com%2Fwp-content%2Fuploads%2F2014%2F03%2Fcute-duck-pictures-10.jpg&f=1)
