### PR TITLE
Enable eth1 data voting per epoch

### DIFF
--- a/eth2/beacon/state_machines/forks/serenity/epoch_processing.py
+++ b/eth2/beacon/state_machines/forks/serenity/epoch_processing.py
@@ -88,10 +88,16 @@ from eth2.beacon.typing import (
 #
 # Eth1 data votes
 #
+def _majority_threshold(config: BeaconConfig) -> int:
+    """
+    Return the value constituting the majority threshold for an Eth1 data vote.
+    """
+    return config.EPOCHS_PER_ETH1_VOTING_PERIOD * config.SLOTS_PER_EPOCH
+
 
 @curry
 def _is_majority_vote(config: BeaconConfig, vote: Eth1DataVote) -> bool:
-    return vote.vote_count * 2 > config.EPOCHS_PER_ETH1_VOTING_PERIOD * config.SLOTS_PER_EPOCH
+    return vote.vote_count * 2 > _majority_threshold(config)
 
 
 def _update_eth1_vote_if_exists(state: BeaconState, config: BeaconConfig) -> BeaconState:

--- a/eth2/beacon/state_machines/forks/serenity/epoch_processing.py
+++ b/eth2/beacon/state_machines/forks/serenity/epoch_processing.py
@@ -93,6 +93,7 @@ from eth2.beacon.typing import (
 def _is_majority_vote(config: BeaconConfig, vote: Eth1DataVote) -> bool:
     return vote.vote_count * 2 > config.EPOCHS_PER_ETH1_VOTING_PERIOD * config.SLOTS_PER_EPOCH
 
+
 def _update_eth1_vote_if_exists(state: BeaconState, config: BeaconConfig) -> BeaconState:
     """
     This function searches the 'pending' Eth1 data votes in ``state`` to find one Eth1 data vote

--- a/eth2/beacon/state_machines/forks/serenity/state_transitions.py
+++ b/eth2/beacon/state_machines/forks/serenity/state_transitions.py
@@ -18,6 +18,7 @@ from .block_validation import (
     validate_proposer_signature,
 )
 from .epoch_processing import (
+    process_eth1_data_votes,
     process_justification,
     process_crosslinks,
     process_ejections,
@@ -88,7 +89,7 @@ class SerenityStateTransition(BaseStateTransition):
         return state
 
     def per_epoch_transition(self, state: BeaconState, block: BaseBeaconBlock) -> BeaconState:
-        # TODO: state = process_eth1_data_votes(state, self.config)
+        state = process_eth1_data_votes(state, self.config)
         state = process_justification(state, self.config)
         state = process_crosslinks(state, self.config)
         state = process_rewards_and_penalties(state, self.config)

--- a/tests/eth2/beacon/state_machines/forks/test_serenity_epoch_processing.py
+++ b/tests/eth2/beacon/state_machines/forks/test_serenity_epoch_processing.py
@@ -111,7 +111,7 @@ def test_ensure_majority_votes(sample_eth1_data_vote_params, config):
 
 
 def _some_bytes(seed):
-    return hash_eth2(b'some_hash' + seed.to_bytes(32, 'little'))
+    return hash_eth2(b'some_hash' + abs(seed).to_bytes(32, 'little'))
 
 
 @pytest.mark.parametrize(

--- a/tests/eth2/beacon/state_machines/forks/test_serenity_epoch_processing.py
+++ b/tests/eth2/beacon/state_machines/forks/test_serenity_epoch_processing.py
@@ -111,8 +111,8 @@ def test_ensure_majority_votes(sample_eth1_data_vote_params, config):
             assert not _is_majority_vote(config, vote)
 
 
-def _random_bytes(size):
-    return bytes(random.getrandbits(8) for _ in range(size))
+def _some_bytes(seed):
+    return hash_eth2(b'some_hash' + seed.to_bytes(32, 'little'))
 
 
 @pytest.mark.parametrize(
@@ -142,8 +142,8 @@ def test_ensure_update_eth1_vote_if_exists(sample_beacon_state_params,
     data_votes = tuple(
         Eth1DataVote(
             eth1_data=Eth1Data(
-                deposit_root=_random_bytes(32),
-                block_hash=_random_bytes(32),
+                deposit_root=_some_bytes(offset),
+                block_hash=_some_bytes(offset),
             ),
             vote_count=threshold + offset,
         ) for offset in vote_offsets

--- a/tests/eth2/beacon/state_machines/forks/test_serenity_epoch_processing.py
+++ b/tests/eth2/beacon/state_machines/forks/test_serenity_epoch_processing.py
@@ -1,5 +1,4 @@
 import pytest
-import random
 
 from hypothesis import (
     given,


### PR DESCRIPTION
### What was wrong?

Fixes #326.

### How was it fixed?

Adds the per-epoch processing for eth1 data votes.

- [x] TODO: add tests

[//]: # (For important changes, please add a new entry to the release notes file)
[//]: # (See: https://trinity-client.readthedocs.io/en/latest/contributing.html#pull-requests)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://proxy.duckduckgo.com/iu/?u=https%3A%2F%2Fwallpapertag.com%2Fwallpaper%2Ffull%2F4%2Fa%2F6%2F921918-cool-cute-horse-wallpapers-2560x1600.jpg&f=1)
