### PR TITLE
Slightly reduce eventbus traffic caused by PeerPool

### DIFF
--- a/docs/release_notes/trinity.rst
+++ b/docs/release_notes/trinity.rst
@@ -4,6 +4,7 @@ Trinity
 Unreleased (latest source)
 --------------------------
 
+- `#386 <https://github.com/ethereum/trinity/pull/386>`_: Slightly reduce eventbus traffic that the peer pool causes
 - `#336 <https://github.com/ethereum/trinity/pull/336>`_: Bugfix: Ensure Trinity shuts down if the process pool dies (fatal error)
 
 0.1.0-alpha.23

--- a/p2p/constants.py
+++ b/p2p/constants.py
@@ -112,6 +112,8 @@ SEAL_CHECK_RANDOM_SAMPLE_RATE = 48
 # aborting the connection attempt.
 DEFAULT_PEER_BOOT_TIMEOUT = 20
 
+# Name of the endpoint that the discovery uses to connect to the eventbus
+DISCOVERY_EVENTBUS_ENDPOINT = 'discovery'
 # Interval at which peer pool is checked for potential new candidates
 DISOVERY_INTERVAL = 2
 # Timeout used when fetching peer candidates from discovery

--- a/trinity/plugins/builtin/peer_discovery/plugin.py
+++ b/trinity/plugins/builtin/peer_discovery/plugin.py
@@ -13,6 +13,9 @@ from eth_typing import (
 from eth.constants import (
     GENESIS_BLOCK_NUMBER
 )
+from p2p.constants import (
+    DISCOVERY_EVENTBUS_ENDPOINT,
+)
 from p2p.discovery import (
     get_v5_topic,
     DiscoveryByTopicProtocol,
@@ -147,6 +150,10 @@ class PeerDiscoveryPlugin(BaseIsolatedPlugin):
     @property
     def name(self) -> str:
         return "Discovery"
+
+    @property
+    def normalized_name(self) -> str:
+        return DISCOVERY_EVENTBUS_ENDPOINT
 
     def on_ready(self, manager_eventbus: TrinityEventBusEndpoint) -> None:
         self.start()


### PR DESCRIPTION
### What was wrong?

The `PeerPool` was sending `eventbus.request(...)` without explicitly routing them to the discovery process exclusively. This even had a TODO comment in the code but then was forgotten when after a Lahja release.

### How was it fixed?

Ensure requests are bound by a `BroadcastConfig` that specifies the discovery process as a recipient. 

[//]: # (For important changes, please add a new entry to the release notes file)
[//]: # (See: https://trinity-client.readthedocs.io/en/latest/contributing.html#pull-requests)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://pbs.twimg.com/media/DfLOp8yWsAAy3fI.jpg)
