### PR TITLE
Several Fast sync fixes: header parent log, consecutive header batching & no unnecessary backtracking

### DIFF
--- a/trinity/_utils/datastructures.py
+++ b/trinity/_utils/datastructures.py
@@ -552,7 +552,9 @@ class OrderedTaskPreparation(Generic[TTask, TTaskID, TPrerequisite]):
             if not self._accept_dangling_tasks and dependency_id not in self._tasks:
                 raise MissingDependency(
                     f"Cannot prepare task {prereq_tracker!r} with id {task_id} and "
-                    f"dependency {dependency_id} before preparing its dependency"
+                    f"dependency {dependency_id} before preparing its dependency "
+                    f"among tasks {task_meta_info!r}, from the original registration: "
+                    f"{tasks!r}."
                 )
             else:
                 self._tasks[task_id] = prereq_tracker

--- a/trinity/sync/full/chain.py
+++ b/trinity/sync/full/chain.py
@@ -558,9 +558,11 @@ class FastChainBodySyncer(BaseBodyChainSyncer):
             canonical_tip = None
 
         self.logger.debug(
-            "Header syncer returned header %s, which has no parent in our DB. "
-            "Instead at #%d, our header is %s, whose parent is %s, with canonical tip %s. "
-            "The highest received header is %d. Triggered by missing dependency: %s",
+            (
+                "Header syncer returned header %s, which has no parent in our DB. "
+                "Instead at #%d, our header is %s, whose parent is %s, with canonical tip %s. "
+                "The highest received header is %d. Triggered by missing dependency: %s"
+            ),
             first_header,
             block_num,
             local_header,


### PR DESCRIPTION
### What was wrong?

#347 had a bug during logging, due to a stray comma.

Also, fix #387 

### How was it fixed?

Fix the bug by deleting the comma and add more logging.

Force header syncer to send consecutive headers in a single batch.

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://www.ethdenver.com/wp-content/themes/understrap/img/bufficorn_magic_geometri1.jpg)
