### PR TITLE
flake8-bugbear

### DIFF
--- a/eth2/beacon/tools/builder/initializer.py
+++ b/eth2/beacon/tools/builder/initializer.py
@@ -79,12 +79,15 @@ def create_mock_genesis_validator_deposits(
     return genesis_validator_deposits
 
 
+ZERO_TIMESTAMP = Timestamp(0)
+
+
 def create_mock_genesis(
         num_validators: int,
         config: BeaconConfig,
         keymap: Dict[BLSPubkey, int],
         genesis_block_class: Type[BaseBeaconBlock],
-        genesis_time: Timestamp=Timestamp(0)) -> Tuple[BeaconState, BaseBeaconBlock]:
+        genesis_time: Timestamp=ZERO_TIMESTAMP) -> Tuple[BeaconState, BaseBeaconBlock]:
     latest_eth1_data = Eth1Data.create_empty_data()
 
     assert num_validators <= len(keymap)

--- a/p2p/peer_pool.py
+++ b/p2p/peer_pool.py
@@ -88,11 +88,14 @@ class BasePeerPool(BaseService, AsyncIterable[BasePeer]):
                  privkey: datatypes.PrivateKey,
                  context: BasePeerContext,
                  max_peers: int = DEFAULT_MAX_PEERS,
-                 peer_info: BasePeerInfo = NoopPeerInfo(),
+                 peer_info: BasePeerInfo = None,
                  token: CancelToken = None,
                  event_bus: Endpoint = None
                  ) -> None:
         super().__init__(token)
+
+        if peer_info is None:
+            peer_info = NoopPeerInfo()
 
         self.peer_info = peer_info
 

--- a/scripts/release/test_package.py
+++ b/scripts/release/test_package.py
@@ -22,7 +22,7 @@ def find_wheel(project_path):
     return wheels[0]
 
 
-def install_wheel(venv_path, wheel_path, extras=tuple()):
+def install_wheel(venv_path, wheel_path, extras=()):
     if extras:
         extra_suffix = f"[{','.join(extras)}]"
     else:

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ deps = {
         "web3==4.4.1",
         "lahja==0.11.2",
         "termcolor>=1.1.0,<2.0.0",
-        "uvloop==0.11.2;platform_system=='Linux' or platform_system=='Darwin' or platform_system=='FreeBSD'",
+        "uvloop==0.11.2;platform_system=='Linux' or platform_system=='Darwin' or platform_system=='FreeBSD'",  # noqa: E501
         "websockets==5.0.1",
         "jsonschema==2.6.0",
         "mypy_extensions>=0.4.1,<1.0.0",
@@ -45,6 +45,7 @@ deps = {
     ],
     'lint': [
         "flake8==3.5.0",
+        "flake8-bugbear==18.8.0",
         "mypy==0.641",
     ],
     'doc': [
@@ -58,9 +59,11 @@ deps = {
         "bumpversion>=0.5.3,<1",
         "wheel",
         "setuptools>=36.2.0",
-        # Fixing this dependency due to: pytest 3.6.4 has requirement pluggy<0.8,>=0.5, but you'll have pluggy 0.8.0 which is incompatible.
+        # Fixing this dependency due to: pytest 3.6.4 has requirement
+        # pluggy<0.8,>=0.5, but you'll have pluggy 0.8.0 which is incompatible.
         "pluggy==0.7.1",
-        # Fixing this dependency due to: requests 2.20.1 has requirement idna<2.8,>=2.5, but you'll have idna 2.8 which is incompatible.
+        # Fixing this dependency due to: requests 2.20.1 has requirement
+        # idna<2.8,>=2.5, but you'll have idna 2.8 which is incompatible.
         "idna==2.7",
         # idna 2.7 is not supported by requests 2.18
         "requests>=2.20,<3",

--- a/tests/core/json-rpc/test_ipc.py
+++ b/tests/core/json-rpc/test_ipc.py
@@ -42,7 +42,9 @@ def wait_for(path):
     return False
 
 
-def build_request(method, params=[]):
+def build_request(method, params=None):
+    if params is None:
+        params = []
     request = {
         'jsonrpc': '2.0',
         'id': 3,

--- a/tests/core/p2p-proto/bcc/helpers.py
+++ b/tests/core/p2p-proto/bcc/helpers.py
@@ -68,7 +68,7 @@ def create_branch(length, root=None, **start_kwargs):
     parent = create_test_block(parent=root, **start_kwargs)
     yield parent
 
-    for slot in range(root.slot + 2, root.slot + length + 1):
+    for _ in range(root.slot + 2, root.slot + length + 1):
         child = create_test_block(parent)
         yield child
         parent = child

--- a/tests/core/p2p-proto/test_peer_block_header_validator_api.py
+++ b/tests/core/p2p-proto/test_peer_block_header_validator_api.py
@@ -33,7 +33,7 @@ def mk_header_chain(length):
     if length == 1:
         return
 
-    for i in range(length - 1):
+    for _ in range(length - 1):
         header = BlockHeader(
             difficulty=100,
             block_number=parent.block_number + 1,

--- a/tests/core/p2p-proto/test_stats.py
+++ b/tests/core/p2p-proto/test_stats.py
@@ -33,7 +33,7 @@ def mk_header_chain(length):
     if length == 1:
         return
 
-    for i in range(length - 1):
+    for _ in range(length - 1):
         header = BlockHeader(
             difficulty=100,
             block_number=parent.block_number + 1,

--- a/tests/eth2/beacon/chains/test_chain.py
+++ b/tests/eth2/beacon/chains/test_chain.py
@@ -79,7 +79,7 @@ def test_import_blocks(valid_chain,
     state = genesis_state
     blocks = (genesis_block,)
     valid_chain_2 = copy.deepcopy(valid_chain)
-    for i in range(3):
+    for _ in range(3):
         block = create_mock_block(
             state=state,
             config=config,

--- a/tests/eth2/beacon/state_machines/forks/test_serenity_block_validation.py
+++ b/tests/eth2/beacon/state_machines/forks/test_serenity_block_validation.py
@@ -219,10 +219,12 @@ def test_get_pubkey_for_indices(activated_genesis_validators, data):
         assert activated_genesis_validators[validator_index].pubkey == pubkey
 
 
-def _list_and_index(data, max_size=None, elements=st.integers()):
+def _list_and_index(data, max_size=None, elements=None):
     """
     Hypothesis helper function cribbed from their docs on @composite
     """
+    if elements is None:
+        elements = st.integers()
     xs = data.draw(st.lists(elements, max_size=max_size, unique=True))
     i = data.draw(st.integers(min_value=0, max_value=max(len(xs) - 1, 0)))
     return (xs, i)

--- a/tests/eth2/beacon/state_machines/forks/test_serenity_epoch_processing.py
+++ b/tests/eth2/beacon/state_machines/forks/test_serenity_epoch_processing.py
@@ -863,7 +863,7 @@ def test_process_rewards_and_penalties_for_crosslinks(
             expected_rewards_received[index] -= penalty
 
     # Check the rewards/penalties match
-    for index, reward_received in rewards_received.items():
+    for index, _ in rewards_received.items():
         assert rewards_received[index] == expected_rewards_received[index]
 
 

--- a/tests/p2p/test_kademlia.py
+++ b/tests/p2p/test_kademlia.py
@@ -67,7 +67,7 @@ def test_routingtable_neighbours():
         assert table.add_node(random_node()) is None
         assert i == len(table) - 1
 
-    for i in range(100):
+    for _ in range(100):
         node = random_node()
         nearest_bucket = table.buckets_by_distance_to(node.id)[0]
         if not nearest_bucket.nodes:
@@ -80,7 +80,7 @@ def test_routingtable_neighbours():
 
 def test_routingtable_get_random_nodes():
     table = kademlia.RoutingTable(random_node())
-    for i in range(100):
+    for _ in range(100):
         assert table.add_node(random_node()) is None
 
     nodes = list(table.get_random_nodes(50))

--- a/tests/plugins/tx_pool/test_default_transaction_validator.py
+++ b/tests/plugins/tx_pool/test_default_transaction_validator.py
@@ -57,7 +57,7 @@ def test_tx_class_resolution(initial_block_number,
     validator.get_appropriate_tx_class.cache_clear()
 
     # Check that the validator uses the correct tx class when we have reached the tip of the chain
-    for n in range(10):
+    for _ in range(10):
         chain.mine_block()
 
     assert validator.get_appropriate_tx_class() == expected_future_tx_class


### PR DESCRIPTION
### What was wrong?

Our linter doesn't prevent a few things that are preventable at the linter level.  
[`flake8-bugbear`](https://github.com/PyCQA/flake8-bugbear) does.

### How was it fixed?

Added `flake8-bugbear` to the linting CI run and fixed a few errors it found.

#### Cute Animal Picture

![bugbear](https://user-images.githubusercontent.com/824194/54098420-2eb20300-437a-11e9-8b23-fb0a90a3d83e.jpg)

