### PR TITLE
Add cache for some helpers

### DIFF
--- a/eth2/beacon/committee_helpers.py
+++ b/eth2/beacon/committee_helpers.py
@@ -279,6 +279,7 @@ def _get_shuffling_contextis_next_epoch_no_registry_change_no_reseed(
     )
 
 
+@functools.lru_cache(maxsize=128)
 @to_tuple
 def get_crosslink_committees_at_slot(
         state: 'BeaconState',

--- a/eth2/beacon/committee_helpers.py
+++ b/eth2/beacon/committee_helpers.py
@@ -1,3 +1,4 @@
+import functools
 from typing import (
     Iterable,
     Sequence,
@@ -68,6 +69,7 @@ def get_epoch_committee_count(
     ) * slots_per_epoch
 
 
+@functools.lru_cache(maxsize=128)
 def get_shuffling(*,
                   seed: Hash32,
                   validators: Sequence['ValidatorRecord'],

--- a/tests/eth2/beacon/test_committee_helpers.py
+++ b/tests/eth2/beacon/test_committee_helpers.py
@@ -226,6 +226,8 @@ def test_get_shuffling_cache(activated_genesis_validators,
         )
     one_hundred_shuffles_time = time.time() - start_time
     assert one_hundred_shuffles_time < one_shuffle_time * 2
+    print('one_shuffle_time', one_shuffle_time)
+    print('one_hundred_shuffles_time', one_hundred_shuffles_time)
 
 
 @pytest.mark.parametrize(

--- a/tests/eth2/beacon/test_committee_helpers.py
+++ b/tests/eth2/beacon/test_committee_helpers.py
@@ -1,5 +1,7 @@
-import pytest
+import time
+
 import itertools
+import pytest
 
 from eth_utils import (
     ValidationError,
@@ -179,6 +181,51 @@ def test_get_shuffling_is_complete(activated_genesis_validators,
         for index in range(len(activated_genesis_validators))
     )
     assert sorted(validator_indices) == sorted(activated_genesis_validator_indices)
+
+
+@pytest.mark.parametrize(
+    (
+        'genesis_slot,'
+    ),
+    [
+        (0),
+    ],
+)
+@pytest.mark.parametrize(
+    (
+        'num_validators,'
+        'slots_per_epoch,'
+        'target_committee_size,'
+        'shard_count,'
+        'epoch'
+    ),
+    [
+        (1000, 20, 10, 100, 0),
+
+    ],
+)
+def test_get_shuffling_cache(activated_genesis_validators,
+                             committee_config,
+                             epoch):
+    start_time = time.time()
+    get_shuffling(
+        seed=b'\x55' * 32,
+        validators=activated_genesis_validators,
+        epoch=epoch,
+        committee_config=committee_config,
+    )
+    one_shuffle_time = time.time() - start_time
+
+    start_time = time.time()
+    for _ in range(100):
+        get_shuffling(
+            seed=b'\x66' * 32,
+            validators=activated_genesis_validators,
+            epoch=epoch,
+            committee_config=committee_config,
+        )
+    one_hundred_shuffles_time = time.time() - start_time
+    assert one_hundred_shuffles_time < one_shuffle_time * 2
 
 
 @pytest.mark.parametrize(

--- a/tests/eth2/beacon/test_committee_helpers.py
+++ b/tests/eth2/beacon/test_committee_helpers.py
@@ -226,8 +226,6 @@ def test_get_shuffling_cache(activated_genesis_validators,
         )
     one_hundred_shuffles_time = time.time() - start_time
     assert one_hundred_shuffles_time < one_shuffle_time * 2
-    print('one_shuffle_time', one_shuffle_time)
-    print('one_hundred_shuffles_time', one_hundred_shuffles_time)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
### What was wrong?
We call these functions frequenty:
* `get_shuffling`
* `get_crosslink_committees_at_slot`

And `shuffle` takes quite a long time for computation.


### How was it fixed?
Add cache to the two of the most frequently called functions.
* `get_shuffling`
* `get_crosslink_committees_at_slot`

#### Cute Animal Picture

![cat-2838801_640](https://user-images.githubusercontent.com/9263930/54110814-527a5500-441d-11e9-817a-c683eb9b76ee.jpg)
