### PR TITLE
Use new Lahja `filter_predicate` API

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,8 @@ deps = {
         "plyvel==1.0.5",
         "py-evm==0.2.0a42",
         "web3==4.4.1",
-        "lahja==0.11.2",
+        #"lahja==0.11.2",
+        "lahja@git+https://github.com/cburgdorf/lahja-1.git@christoph/perf/filter-predicate",
         "termcolor>=1.1.0,<2.0.0",
         "uvloop==0.11.2;platform_system=='Linux' or platform_system=='Darwin' or platform_system=='FreeBSD'",  # noqa: E501
         "websockets==5.0.1",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -25,6 +25,7 @@ from eth.vm.forks.spurious_dragon import SpuriousDragonVM
 
 from lahja import (
     ConnectionConfig,
+    ListenerConfig,
 )
 
 from trinity.config import (
@@ -136,7 +137,9 @@ async def event_bus(event_loop):
         path=ipc_path
     )
     await endpoint.start_serving(networking_connection_config, event_loop)
-    await endpoint.connect_to_endpoints(networking_connection_config)
+    await endpoint.add_listener_endpoints(
+        ListenerConfig.from_connection_config(networking_connection_config)
+    )
     try:
         yield endpoint
     finally:

--- a/trinity/bootstrap.py
+++ b/trinity/bootstrap.py
@@ -12,6 +12,7 @@ from typing import (
 
 from lahja import (
     ConnectionConfig,
+    ListenerConfig,
 )
 
 from trinity.exceptions import (
@@ -203,7 +204,9 @@ def main_entry(trinity_boot: BootFn,
 
         # We listen on events such as `ShutdownRequested` which may or may not originate on
         # the `main_endpoint` which is why we connect to our own endpoint here
-        main_endpoint.connect_to_endpoints_blocking(main_connection_config)
+        main_endpoint.add_listener_endpoints_blocking(
+            ListenerConfig.from_connection_config(main_connection_config)
+        )
         trinity_boot(
             args,
             trinity_config,

--- a/trinity/events.py
+++ b/trinity/events.py
@@ -4,7 +4,7 @@ from typing import (
 
 from lahja import (
     BaseEvent,
-    ConnectionConfig,
+    ListenerConfig,
 )
 
 
@@ -24,8 +24,8 @@ class EventBusConnected(BaseEvent):
     :class:`~lahja.endpoint.Endpoint`, making them aware of other endpoints they can connect to.
     """
 
-    def __init__(self, connection_config: ConnectionConfig) -> None:
-        self.connection_config = connection_config
+    def __init__(self, listener_config: ListenerConfig) -> None:
+        self.listener_config = listener_config
 
 
 class AvailableEndpointsUpdated(BaseEvent):
@@ -35,5 +35,5 @@ class AvailableEndpointsUpdated(BaseEvent):
     lists all available endpoints that are known at the time when the event is raised.
     """
 
-    def __init__(self, available_endpoints: Tuple[ConnectionConfig, ...]) -> None:
+    def __init__(self, available_endpoints: Tuple[ListenerConfig, ...]) -> None:
         self.available_endpoints = available_endpoints

--- a/trinity/main.py
+++ b/trinity/main.py
@@ -11,6 +11,7 @@ from typing import (
 
 from lahja import (
     ConnectionConfig,
+    ListenerConfig,
 )
 
 from eth.db.backends.base import BaseDB
@@ -178,12 +179,12 @@ def launch_node(args: Namespace, trinity_config: TrinityConfig) -> None:
             networking_connection_config,
             loop,
         )
-        endpoint.auto_connect_new_announced_endpoints()
-        endpoint.connect_to_endpoints_blocking(
-            ConnectionConfig.from_name(MAIN_EVENTBUS_ENDPOINT, trinity_config.ipc_dir),
+        endpoint.auto_add_announced_listener_endpoints()
+        endpoint.add_listener_endpoints_blocking(
+            ListenerConfig.from_name(MAIN_EVENTBUS_ENDPOINT, trinity_config.ipc_dir),
             # Plugins that run within the networking process broadcast and receive on the
             # the same endpoint
-            networking_connection_config,
+            ListenerConfig.from_connection_config(networking_connection_config),
         )
         endpoint.announce_endpoint()
         # This is a second PluginManager instance governing plugins in a shared process.


### PR DESCRIPTION
### What was wrong?

Currently, there are a number of high frequency events that we can not broadcast efficiently because it would waste a lot of resources in Trinity, slowing other important tasks down.

A good example for that are new transactions broadcasted by peers. It's our goal to migrate to an architecture where the `PeerPool` runs in its own process and is only concerned with pure peer IO leaving the handling of messages (and hence db lookups etc) to other processes.

Under that model, the `PeerPool` would simply broadcast new incoming transactions leaving it to other processes to deal with them. The `PeerPool` should not know and care *who* is interested in the new transactions (a transaction pool plugin, a transaction analyzer plugin etc.).

However, simply pushing these transactions into each and every process isn't the right answer either. Processes should be able to opt-in to these events.

### How was it fixed?

The upcoming [lahja release](https://github.com/ethereum/lahja/pull/34) introduces a new feature that allows lahja endpoints to shield themselve from events that they don't need. This does **not** affect any events that are deliberately directed towards some endpoint - those do always reach the recipient! 

This PR uses that feature and sets things up so that `BasePlugin` has a method `should_receive_broadcast(event: BaseEvent) -> bool` that shields plugins from all events that are not deliberately sent to it (With the exception of `AvailableEndpointsUpdated` that all plugins should receive).

To stick with our example and assuming we have a `PeerPool` that relays events on the event bus, a plugin that wants to receive new transactions can overwrite `should_receive_broadcast` to allow such event to reach it. 

The PR also renames some APIs to better reflect what they do and align with the renames in the lahja library.

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://media.mnn.com/assets/images/2014/11/burrowing-owls-parliament.jpg.653x0_q80_crop-smart.jpg)
