### PR TITLE
Avoid unnecessary clamp on `previous_epoch` by `genesis_epoch`

### DIFF
--- a/eth2/beacon/committee_helpers.py
+++ b/eth2/beacon/committee_helpers.py
@@ -357,9 +357,8 @@ def get_beacon_proposer_index(state: 'BeaconState',
     Return the beacon proposer index for the ``slot``.
     """
     epoch = slot_to_epoch(slot, committee_config.SLOTS_PER_EPOCH)
-    current_epoch = state.current_epoch(committee_config.SLOTS_PER_EPOCH)
-    next_epoch = Epoch(current_epoch + 1)
     previous_epoch = state.previous_epoch(committee_config.SLOTS_PER_EPOCH)
+    next_epoch = state.next_epoch(committee_config.SLOTS_PER_EPOCH)
 
     validate_epoch_within_previous_and_next(epoch, previous_epoch, next_epoch)
 

--- a/eth2/beacon/committee_helpers.py
+++ b/eth2/beacon/committee_helpers.py
@@ -289,13 +289,12 @@ def get_crosslink_committees_at_slot(
     """
     Return the list of ``(committee, shard)`` tuples for the ``slot``.
     """
-    genesis_epoch = committee_config.GENESIS_EPOCH
     shard_count = committee_config.SHARD_COUNT
     slots_per_epoch = committee_config.SLOTS_PER_EPOCH
 
     epoch = slot_to_epoch(slot, slots_per_epoch)
     current_epoch = state.current_epoch(slots_per_epoch)
-    previous_epoch = state.previous_epoch(slots_per_epoch, genesis_epoch)
+    previous_epoch = state.previous_epoch(slots_per_epoch)
     next_epoch = state.next_epoch(slots_per_epoch)
 
     validate_epoch_within_previous_and_next(epoch, previous_epoch, next_epoch)
@@ -359,11 +358,8 @@ def get_beacon_proposer_index(state: 'BeaconState',
     """
     epoch = slot_to_epoch(slot, committee_config.SLOTS_PER_EPOCH)
     current_epoch = state.current_epoch(committee_config.SLOTS_PER_EPOCH)
-    previous_epoch = state.previous_epoch(
-        committee_config.SLOTS_PER_EPOCH,
-        committee_config.GENESIS_EPOCH,
-    )
     next_epoch = Epoch(current_epoch + 1)
+    previous_epoch = state.previous_epoch(committee_config.SLOTS_PER_EPOCH)
 
     validate_epoch_within_previous_and_next(epoch, previous_epoch, next_epoch)
 

--- a/eth2/beacon/epoch_processing_helpers.py
+++ b/eth2/beacon/epoch_processing_helpers.py
@@ -56,12 +56,11 @@ if TYPE_CHECKING:
 def get_previous_epoch_boundary_attestations(
         state: 'BeaconState',
         slots_per_epoch: int,
-        genesis_epoch: Epoch,
         latest_block_roots_length: int) -> Iterable[PendingAttestationRecord]:
     beacon_block_root = get_block_root(
         state,
         get_epoch_start_slot(
-            state.previous_epoch(slots_per_epoch, genesis_epoch),
+            state.previous_epoch(slots_per_epoch),
             slots_per_epoch,
         ),
         latest_block_roots_length,
@@ -75,7 +74,6 @@ def get_previous_epoch_boundary_attestations(
 def get_previous_epoch_matching_head_attestations(
         state: 'BeaconState',
         slots_per_epoch: int,
-        genesis_epoch: Epoch,
         latest_block_roots_length: int) -> Iterable[PendingAttestationRecord]:
     for attestation in state.previous_epoch_attestations:
         beacon_block_root = get_block_root(
@@ -167,7 +165,6 @@ def get_epoch_boundary_attesting_balances(
         previous_epoch: Epoch,
         state: 'BeaconState',
         config: 'BeaconConfig') -> Tuple[Gwei, Gwei]:
-
     previous_epoch_boundary_root = get_block_root(
         state,
         get_epoch_start_slot(previous_epoch, config.SLOTS_PER_EPOCH),

--- a/eth2/beacon/epoch_processing_helpers.py
+++ b/eth2/beacon/epoch_processing_helpers.py
@@ -164,7 +164,7 @@ def get_epoch_boundary_attester_indices(
 def get_attesting_indices(state: 'BeaconState',
                           attestations: Sequence[PendingAttestationRecord],
                           config: CommitteeConfig) -> Sequence[ValidatorIndex]:
-    output = set()
+    output: Set[ValidatorIndex] = set()
     for a in attestations:
         participants = get_attestation_participants(state, a.data, a.aggregation_bitfield, config)
         output = output.union(participants)

--- a/eth2/beacon/epoch_processing_helpers.py
+++ b/eth2/beacon/epoch_processing_helpers.py
@@ -159,10 +159,10 @@ def get_epoch_boundary_attester_indices(
             ),
             config.LATEST_BLOCK_ROOTS_LENGTH
         )
-        is_expected_justified_epoch = a.data.justified_epoch == expected_justified_epoch
-        is_expected_root = a.data.epoch_boundary_root == root
-        should_yield_attestation = is_expected_justified_epoch and is_expected_root
-        if should_yield_attestation:
+        matches_justified_epoch = a.data.justified_epoch == expected_justified_epoch
+        matches_block_root = a.data.epoch_boundary_root == root
+        should_include = matches_justified_epoch and matches_block_root
+        if should_include:
             yield from get_attestation_participants(
                 state,
                 a.data,

--- a/eth2/beacon/epoch_processing_helpers.py
+++ b/eth2/beacon/epoch_processing_helpers.py
@@ -167,7 +167,7 @@ def get_epoch_boundary_attester_indices(
                 state,
                 a.data,
                 a.aggregation_bitfield,
-                config,
+                CommitteeConfig(config),
             )
 
 

--- a/eth2/beacon/epoch_processing_helpers.py
+++ b/eth2/beacon/epoch_processing_helpers.py
@@ -163,7 +163,7 @@ def get_epoch_boundary_attester_indices(
 @to_tuple
 def get_attesting_indices(state: 'BeaconState',
                           attestations: Sequence[PendingAttestationRecord],
-                          config: CommitteeConfig) -> Sequence[ValidatorIndex]:
+                          config: CommitteeConfig) -> Tuple[ValidatorIndex]:
     output: Set[ValidatorIndex] = set()
     for a in attestations:
         participants = get_attestation_participants(state, a.data, a.aggregation_bitfield, config)
@@ -186,21 +186,21 @@ def _get_boundary_attestations_in_epoch(
         state: 'BeaconState',
         attestations: Sequence[PendingAttestationRecord],
         epoch: Epoch,
-        config: 'BeaconConfig') -> Sequence[PendingAttestationRecord]:
+        config: 'BeaconConfig') -> Tuple[PendingAttestationRecord]:
     slot = get_epoch_start_slot(epoch, config.SLOTS_PER_EPOCH)
-    return [
+    return tuple(
         a for a in attestations
         if a.data.epoch_boundary_root == get_block_root(
             state,
             slot,
             config.LATEST_BLOCK_ROOTS_LENGTH
         )
-    ]
+    )
 
 
 def _get_current_epoch_boundary_attestations(
         state: 'BeaconState',
-        config: 'BeaconConfig') -> Sequence[PendingAttestationRecord]:
+        config: 'BeaconConfig') -> Tuple[PendingAttestationRecord]:
     current_epoch = state.current_epoch(config.SLOTS_PER_EPOCH)
     current_epoch_attestations = state.current_epoch_attestations
 
@@ -214,7 +214,7 @@ def _get_current_epoch_boundary_attestations(
 
 def _get_previous_epoch_boundary_attestations(
         state: 'BeaconState',
-        config: 'BeaconConfig') -> Sequence[PendingAttestationRecord]:
+        config: 'BeaconConfig') -> Tuple[PendingAttestationRecord]:
     previous_epoch = state.previous_epoch(config.SLOTS_PER_EPOCH)
     previous_epoch_attestations = state.previous_epoch_attestations
 

--- a/eth2/beacon/epoch_processing_helpers.py
+++ b/eth2/beacon/epoch_processing_helpers.py
@@ -168,7 +168,7 @@ def get_attesting_indices(state: 'BeaconState',
     for a in attestations:
         participants = get_attestation_participants(state, a.data, a.aggregation_bitfield, config)
         output = output.union(participants)
-    return sorted(list(output))
+    return sorted(output)
 
 
 def get_attesting_balance(state: 'BeaconState',

--- a/eth2/beacon/state_machines/forks/serenity/epoch_processing.py
+++ b/eth2/beacon/state_machines/forks/serenity/epoch_processing.py
@@ -210,7 +210,7 @@ def _get_finalized_epoch(
 def process_justification(state: BeaconState, config: BeaconConfig) -> BeaconState:
 
     current_epoch = state.current_epoch(config.SLOTS_PER_EPOCH)
-    previous_epoch = state.previous_epoch(config.SLOTS_PER_EPOCH, config.GENESIS_EPOCH)
+    previous_epoch = state.previous_epoch(config.SLOTS_PER_EPOCH)
 
     current_epoch_justifiable, previous_epoch_justifiable = _current_previous_epochs_justifiable(
         state,
@@ -275,7 +275,7 @@ def process_crosslinks(state: BeaconState, config: BeaconConfig) -> BeaconState:
         for index in range(len(state.validator_registry))
     }
     previous_epoch_start_slot = get_epoch_start_slot(
-        state.previous_epoch(config.SLOTS_PER_EPOCH, config.GENESIS_EPOCH),
+        state.previous_epoch(config.SLOTS_PER_EPOCH),
         config.SLOTS_PER_EPOCH,
     )
     next_epoch_start_slot = get_epoch_start_slot(
@@ -523,7 +523,6 @@ def _process_rewards_and_penalties_for_finality(
     previous_epoch_boundary_attestations = get_previous_epoch_boundary_attestations(
         state,
         config.SLOTS_PER_EPOCH,
-        config.GENESIS_EPOCH,
         config.LATEST_BLOCK_ROOTS_LENGTH,
     )
     previous_epoch_boundary_attester_indices = get_attester_indices_from_attestations(
@@ -535,7 +534,6 @@ def _process_rewards_and_penalties_for_finality(
     previous_epoch_head_attestations = get_previous_epoch_matching_head_attestations(
         state,
         config.SLOTS_PER_EPOCH,
-        config.GENESIS_EPOCH,
         config.LATEST_BLOCK_ROOTS_LENGTH,
     )
     previous_epoch_head_attester_indices = get_attester_indices_from_attestations(
@@ -582,7 +580,7 @@ def _process_rewards_and_penalties_for_crosslinks(
         effective_balances: Dict[ValidatorIndex, Gwei],
         base_rewards: Dict[ValidatorIndex, Gwei]) -> Tuple[Dict[ValidatorIndex, Gwei], Dict[ValidatorIndex, Gwei]]:  # noqa: E501
     previous_epoch_start_slot = get_epoch_start_slot(
-        state.previous_epoch(config.SLOTS_PER_EPOCH, config.GENESIS_EPOCH),
+        state.previous_epoch(config.SLOTS_PER_EPOCH),
         config.SLOTS_PER_EPOCH,
     )
     current_epoch_start_slot = get_epoch_start_slot(
@@ -637,7 +635,7 @@ def process_rewards_and_penalties(state: BeaconState, config: BeaconConfig) -> B
     previous_epoch_active_validator_indices = set(
         get_active_validator_indices(
             state.validator_registry,
-            state.previous_epoch(config.SLOTS_PER_EPOCH, config.GENESIS_EPOCH)
+            state.previous_epoch(config.SLOTS_PER_EPOCH)
         )
     )
     previous_total_balance: Gwei = get_total_balance(

--- a/eth2/beacon/state_machines/forks/serenity/epoch_processing.py
+++ b/eth2/beacon/state_machines/forks/serenity/epoch_processing.py
@@ -638,6 +638,11 @@ def process_rewards_and_penalties(state: BeaconState, config: BeaconConfig) -> B
             state.previous_epoch(config.SLOTS_PER_EPOCH)
         )
     )
+
+    # do not proceed if there are no validators in the previous epoch
+    if not previous_epoch_active_validator_indices:
+        return state
+
     previous_total_balance: Gwei = get_total_balance(
         state.validator_balances,
         tuple(previous_epoch_active_validator_indices),

--- a/eth2/beacon/state_machines/forks/serenity/operation_processing.py
+++ b/eth2/beacon/state_machines/forks/serenity/operation_processing.py
@@ -139,7 +139,7 @@ def process_attestations(state: BeaconState,
         )
 
     # update attestations
-    previous_epoch = state.previous_epoch(config.SLOTS_PER_EPOCH, config.GENESIS_EPOCH)
+    previous_epoch = state.previous_epoch(config.SLOTS_PER_EPOCH)
     current_epoch = state.current_epoch(config.SLOTS_PER_EPOCH)
     new_previous_epoch_pending_attestations = []
     new_current_epoch_pending_attestations = []

--- a/eth2/beacon/tools/builder/validator.py
+++ b/eth2/beacon/tools/builder/validator.py
@@ -636,8 +636,8 @@ def get_committee_assignment(
         propose a beacon block at the assigned slot.
     """
     current_epoch = state.current_epoch(config.SLOTS_PER_EPOCH)
-    previous_epoch = state.previous_epoch(config.SLOTS_PER_EPOCH, config.GENESIS_EPOCH)
     next_epoch = Epoch(current_epoch + 1)
+    previous_epoch = state.previous_epoch(config.SLOTS_PER_EPOCH)
 
     validate_epoch_within_previous_and_next(epoch, previous_epoch, next_epoch)
 

--- a/eth2/beacon/tools/builder/validator.py
+++ b/eth2/beacon/tools/builder/validator.py
@@ -635,9 +635,8 @@ def get_committee_assignment(
     ``CommitteeAssignment.is_proposer`` is a bool signalling if the validator is expected to
         propose a beacon block at the assigned slot.
     """
-    current_epoch = state.current_epoch(config.SLOTS_PER_EPOCH)
-    next_epoch = Epoch(current_epoch + 1)
     previous_epoch = state.previous_epoch(config.SLOTS_PER_EPOCH)
+    next_epoch = state.next_epoch(config.SLOTS_PER_EPOCH)
 
     validate_epoch_within_previous_and_next(epoch, previous_epoch, next_epoch)
 

--- a/eth2/beacon/types/states.py
+++ b/eth2/beacon/types/states.py
@@ -303,7 +303,7 @@ class BeaconState(ssz.Serializable):
     def current_epoch(self, slots_per_epoch: int) -> Epoch:
         return slot_to_epoch(self.slot, slots_per_epoch)
 
-    def previous_epoch(self, slots_per_epoch: int, genesis_epoch: int) -> Epoch:
+    def previous_epoch(self, slots_per_epoch: int) -> Epoch:
         return Epoch(self.current_epoch(slots_per_epoch) - 1)
 
     def next_epoch(self, slots_per_epoch: int) -> Epoch:

--- a/eth2/beacon/types/states.py
+++ b/eth2/beacon/types/states.py
@@ -304,7 +304,7 @@ class BeaconState(ssz.Serializable):
         return slot_to_epoch(self.slot, slots_per_epoch)
 
     def previous_epoch(self, slots_per_epoch: int, genesis_epoch: int) -> Epoch:
-        return Epoch(max(self.current_epoch(slots_per_epoch) - 1, genesis_epoch))
+        return Epoch(self.current_epoch(slots_per_epoch) - 1)
 
     def next_epoch(self, slots_per_epoch: int) -> Epoch:
         return Epoch(self.current_epoch(slots_per_epoch) + 1)

--- a/tests/eth2/beacon/state_machines/forks/test_serenity_epoch_processing.py
+++ b/tests/eth2/beacon/state_machines/forks/test_serenity_epoch_processing.py
@@ -740,7 +740,7 @@ def test_process_rewards_and_penalties_for_finality(
     }
 
     prev_epoch_start_slot = get_epoch_start_slot(
-        state.previous_epoch(config.SLOTS_PER_EPOCH, config.GENESIS_EPOCH), slots_per_epoch,
+        state.previous_epoch(config.SLOTS_PER_EPOCH), slots_per_epoch,
     )
     prev_epoch_crosslink_committees = [
         get_crosslink_committees_at_slot(

--- a/tests/eth2/beacon/state_machines/test_state_transition.py
+++ b/tests/eth2/beacon/state_machines/test_state_transition.py
@@ -16,7 +16,8 @@ from eth2._utils.merkle.normal import get_merkle_root
         'genesis_slot,'
     ),
     [
-        (0),
+        # start high enough so that we do not end up with negative numbers
+        (104),
     ]
 )
 @pytest.mark.parametrize(
@@ -54,6 +55,8 @@ def test_per_slot_transition(base_db,
                              config,
                              state_slot,
                              keymap):
+    state_slot += config.GENESIS_SLOT
+
     chaindb = BeaconChainDB(base_db)
     chaindb.persist_block(genesis_block, SerenityBeaconBlock)
     chaindb.persist_state(genesis_state)

--- a/tests/eth2/beacon/test_committee_helpers.py
+++ b/tests/eth2/beacon/test_committee_helpers.py
@@ -471,8 +471,8 @@ def test_get_crosslink_committees_at_slot(
     #
     epoch = slot_to_epoch(slot, slots_per_epoch)
     current_epoch = state.current_epoch(slots_per_epoch)
-    next_epoch = current_epoch + 1
     previous_epoch = state.previous_epoch(slots_per_epoch)
+    next_epoch = state.next_epoch(slots_per_epoch)
 
     if epoch == current_epoch:
         seed = state.current_shuffling_seed

--- a/tests/eth2/beacon/test_committee_helpers.py
+++ b/tests/eth2/beacon/test_committee_helpers.py
@@ -326,10 +326,9 @@ def test_get_prev_or_cur_epoch_committee_count(
 @pytest.mark.parametrize(
     (
         'genesis_slot,'
-        'genesis_epoch,'
     ),
     [
-        (0, 0),
+        0,
     ],
 )
 @pytest.mark.parametrize(
@@ -387,7 +386,6 @@ def test_get_crosslink_committees_at_slot(
         slots_per_epoch,
         target_committee_size,
         shard_count,
-        genesis_epoch,
         committee_config,
         registry_change,
         should_reseed,
@@ -473,8 +471,8 @@ def test_get_crosslink_committees_at_slot(
     #
     epoch = slot_to_epoch(slot, slots_per_epoch)
     current_epoch = state.current_epoch(slots_per_epoch)
-    previous_epoch = state.previous_epoch(slots_per_epoch, genesis_epoch)
     next_epoch = current_epoch + 1
+    previous_epoch = state.previous_epoch(slots_per_epoch)
 
     if epoch == current_epoch:
         seed = state.current_shuffling_seed
@@ -507,10 +505,9 @@ def test_get_crosslink_committees_at_slot(
 @pytest.mark.parametrize(
     (
         'genesis_slot,'
-        'genesis_epoch,'
     ),
     [
-        (0, 0),
+        0,
     ],
 )
 @pytest.mark.parametrize(
@@ -547,7 +544,6 @@ def test_get_beacon_proposer_index(
         registry_change,
         success,
         sample_state,
-        genesis_epoch,
         target_committee_size,
         shard_count,
         committee_config):
@@ -632,7 +628,6 @@ def test_get_attestation_participants(
         aggregation_bitfield,
         expected,
         sample_state,
-        genesis_epoch,
         target_committee_size,
         shard_count,
         committee_config,

--- a/tests/eth2/beacon/test_epoch_processing_helpers.py
+++ b/tests/eth2/beacon/test_epoch_processing_helpers.py
@@ -77,7 +77,6 @@ def get_aggregation_bitfield(attestation_participants, target_committee_size):
 )
 def test_get_current_and_previous_epoch_attestations(random,
                                                      sample_state,
-                                                     genesis_epoch,
                                                      slots_per_epoch,
                                                      sample_attestation_data_params,
                                                      sample_attestation_params):
@@ -135,7 +134,6 @@ def test_get_current_and_previous_epoch_attestations(random,
 def test_get_previous_epoch_matching_head_attestations(
         random,
         sample_state,
-        genesis_epoch,
         slots_per_epoch,
         latest_block_roots_length,
         sample_attestation_data_params,
@@ -196,7 +194,6 @@ def test_get_previous_epoch_matching_head_attestations(
     result = get_previous_epoch_matching_head_attestations(
         state,
         slots_per_epoch,
-        genesis_epoch,
         latest_block_roots_length,
     )
     assert set(previous_epoch_head_attestations) == set(result)


### PR DESCRIPTION
### What was wrong?

Fixes #382.


### How was it fixed?

Updated the calculation hanging off the `BeaconState`.

[//]: # (For important changes, please add a new entry to the release notes file)
[//]: # (See: https://trinity-client.readthedocs.io/en/latest/contributing.html#pull-requests)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://proxy.duckduckgo.com/iu/?u=http%3A%2F%2Fwallpapershome.com%2Fimages%2Fpages%2Fpic_hs%2F4504.jpg&f=1)
