### PR TITLE
Fix broken configuration of individual loggers

### DIFF
--- a/docs/release_notes/trinity.rst
+++ b/docs/release_notes/trinity.rst
@@ -4,6 +4,7 @@ Trinity
 Unreleased (latest source)
 --------------------------
 
+- `#400 <https://github.com/ethereum/trinity/pull/400>`_: Bugfix: Respect configuration of individual logger (e.g -l p2p.discovery=ERROR)
 - `#386 <https://github.com/ethereum/trinity/pull/386>`_: Slightly reduce eventbus traffic that the peer pool causes
 - `#336 <https://github.com/ethereum/trinity/pull/336>`_: Bugfix: Ensure Trinity shuts down if the process pool dies (fatal error)
 

--- a/tests/integration/test_trinity_cli.py
+++ b/tests/integration/test_trinity_cli.py
@@ -159,3 +159,20 @@ async def test_does_not_throw(async_process_runner, command):
     # This is our last line of defence. This test basically observes the first
     # 20 seconds of the Trinity boot process and fails if Trinity logs any exceptions
     await run_command_and_detect_errors(async_process_runner, command, 20)
+
+
+@pytest.mark.parametrize(
+    'command, expected_to_contain_log',
+    (
+        (('trinity', '-l=DEBUG2'), True),
+        # We expect not to contain it because we set the p2p.discovery logger to only log errors
+        (('trinity', '-l=DEBUG2', '-l', 'p2p.discovery=ERROR'), False,)
+    )
+)
+@pytest.mark.asyncio
+async def test_logger(async_process_runner, command, expected_to_contain_log):
+    await async_process_runner.run(command, timeout_sec=20)
+    actually_contains_log = await contains_all(async_process_runner.stderr, {
+        "DiscoveryProtocol  >>> ping",
+    })
+    assert actually_contains_log == expected_to_contain_log

--- a/tests/integration/test_trinity_cli.py
+++ b/tests/integration/test_trinity_cli.py
@@ -45,7 +45,7 @@ from trinity._utils.async_iter import (
 @pytest.mark.asyncio
 async def test_full_boot(async_process_runner, command):
     # UPNP discovery can delay things, we use a timeout longer than the discovery timeout
-    await async_process_runner.run(command, timeout_sec=40)
+    await async_process_runner.run(command, timeout_sec=20)
     assert await contains_all(async_process_runner.stderr, {
         "Started DB server process",
         "Started networking process",
@@ -64,7 +64,7 @@ async def test_full_boot(async_process_runner, command):
 @pytest.mark.asyncio
 async def test_txpool_full_boot(async_process_runner, command):
     # UPNP discovery can delay things, we use a timeout longer than the discovery timeout
-    await async_process_runner.run(command, timeout_sec=40)
+    await async_process_runner.run(command, timeout_sec=20)
     assert await contains_all(async_process_runner.stderr, {
         "Started DB server process",
         "Started networking process",
@@ -83,7 +83,7 @@ async def test_txpool_full_boot(async_process_runner, command):
 )
 @pytest.mark.asyncio
 async def test_txpool_deactivated(async_process_runner, command):
-    await async_process_runner.run(command, timeout_sec=40)
+    await async_process_runner.run(command, timeout_sec=20)
     assert await contains_all(async_process_runner.stderr, {
         "Started DB server process",
         "Started networking process",
@@ -101,7 +101,7 @@ async def test_txpool_deactivated(async_process_runner, command):
 @pytest.mark.asyncio
 async def test_light_boot(async_process_runner, command):
     # UPNP discovery can delay things, we use a timeout longer than the discovery timeout
-    await async_process_runner.run(command, timeout_sec=40)
+    await async_process_runner.run(command, timeout_sec=20)
     assert await contains_all(async_process_runner.stderr, {
         "Started DB server process",
         "Started networking process",
@@ -117,7 +117,7 @@ async def test_light_boot(async_process_runner, command):
 )
 @pytest.mark.asyncio
 async def test_web3(command, async_process_runner):
-    await async_process_runner.run(command, timeout_sec=30)
+    await async_process_runner.run(command, timeout_sec=20)
     assert await contains_all(async_process_runner.stderr, {
         "Started DB server process",
         "Started networking process",

--- a/trinity/_utils/logging.py
+++ b/trinity/_utils/logging.py
@@ -154,9 +154,10 @@ def with_queued_logging(fn: Callable[..., Any]) -> Callable[..., Any]:
             raise KeyError(f"The `log_queue` argument is required when calling `{fn.__name__}`")
         else:
             level = kwargs.get('log_level', logging.INFO)
+            levels = kwargs.get('log_levels', {})
             setup_queue_logging(log_queue, level)
-
-            inner_kwargs = dissoc(kwargs, 'log_queue', 'log_level')
+            setup_log_levels(levels)
+            inner_kwargs = dissoc(kwargs, 'log_queue', 'log_level', 'log_levels')
 
             return fn(*args, **inner_kwargs)
     return inner

--- a/trinity/bootstrap.py
+++ b/trinity/bootstrap.py
@@ -185,6 +185,7 @@ def main_entry(trinity_boot: BootFn,
     extra_kwargs = {
         'log_queue': log_queue,
         'log_level': min_configured_log_level,
+        'log_levels': args.log_levels if args.log_levels else {},
         'profile': args.profile,
     }
 

--- a/trinity/extensibility/plugin.py
+++ b/trinity/extensibility/plugin.py
@@ -47,6 +47,7 @@ from trinity._utils.mp import (
     ctx,
 )
 from trinity._utils.logging import (
+    setup_log_levels,
     setup_queue_logging,
 )
 from trinity._utils.os import (
@@ -296,6 +297,8 @@ class BaseIsolatedPlugin(BasePlugin):
         log_queue = self.context.boot_kwargs['log_queue']
         level = self.context.boot_kwargs.get('log_level', logging.INFO)
         setup_queue_logging(log_queue, level)
+        if self.context.args.log_levels:
+            setup_log_levels(self.context.args.log_levels)
         connection_config = ConnectionConfig.from_name(
             self.normalized_name, self.context.trinity_config.ipc_dir
         )


### PR DESCRIPTION
### What was wrong?

Trinity can be configured to set log levels individually per module. However that wasn't working properly because it was only setup for the main process leaving out the `db`, `networking` as well as all isolated plugin processes.

E.g. if one tries to run `trinity -l DEBUG2 -l p2p.discovery=ERROR` to enable all `DEBUG2` logs except for those from `p2p.discovery`, it just doesn't have any effect.

### How was it fixed?

Used `setup_log_levels` in all processes.


[//]: # (For important changes, please add a new entry to the release notes file)
[//]: # (See: https://trinity-client.readthedocs.io/en/latest/contributing.html#pull-requests)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://piximus.net/media/12321/animal-planet-135-18.jpg)
