### PR TITLE
Fix broken docker image build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -234,6 +234,13 @@ jobs:
         environment:
           TOXENV: py37-wheel-cli
 
+  docker-image-build-test:
+    machine: true
+    steps:
+      - checkout
+      - run: docker build -t ethereum/trinity:test-build .
+      - run: docker run ethereum/trinity:test-build --help
+
 workflows:
   version: 2
   test:
@@ -265,3 +272,5 @@ workflows:
 
       - py36-lint
       - py37-lint
+
+      - docker-image-build-test

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,10 @@ WORKDIR /usr/src/app
 
 COPY . /usr/src/app
 
+# Install deps
+RUN apt-get update
+RUN apt-get -y install libsnappy-dev
+
 RUN pip install -e .[dev]  --no-cache-dir
 RUN pip install -U trinity --no-cache-dir
 


### PR DESCRIPTION
### What was wrong?

During docker image build, snappy was not being installed which is a requirement now.

### How was it fixed?

Install `libsnappy-dev` during docker image build.

[//]: # (For important changes, please add a new entry to the release notes file)
[//]: # (See: https://trinity-client.readthedocs.io/en/latest/contributing.html#pull-requests)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://www.desibucket.com/db2/01/29950/29950.jpg)
