### PR TITLE
Fix RTD doc build

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,10 +1,12 @@
 # https://docs.readthedocs.io/en/latest/yaml-config.html
+version: 2
 build:
   image: latest
 python:
   version: 3.6
-  pip_install: True
-  extra_requirements:
-    - p2p
-    - trinity
-    - doc
+  install:
+    - method: pip
+      path: .
+      extra_requirements:
+        - trinity
+        - doc

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -50,6 +50,7 @@ autodoc_default_options = {
     'undoc-members': None,
 }
 
+autodoc_mock_imports = ["snappy"]
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
+import os
 from setuptools import setup, find_packages
 
 
@@ -11,7 +12,6 @@ deps = {
         "netifaces>=0.10.7<1",
         "pysha3>=1.0.0,<2.0.0",
         "upnpclient>=0.0.8,<1",
-        "python-snappy>=0.5.3",
     ],
     'trinity': [
         "async-generator==1.10",
@@ -82,6 +82,11 @@ deps = {
     ],
 }
 
+# NOTE: Snappy breaks RTD builds. Until we have a more mature solution
+# we conditionally add python-snappy based on the presence of an env var
+rtd_build_env = os.environ.get('READTHEDOCS', False)
+if not rtd_build_env:
+    deps['p2p'].append("python-snappy>=0.5.3")
 
 deps['dev'] = (
     deps['dev'] +


### PR DESCRIPTION
### What was wrong?

Trinity docs build were failing due to dependency on snappy for required packages during installation. RTD builds docs in docker containers and installing `libsnappy` in the environment is not feasible.

### How was it fixed?

Simplified doc build process by removing necessity to install trinity packages as suggested by @carver. Separated Sphinx requirements into single txt file.

This might require more work. Let me know how to improve it so we can start auto shipping latest docs.

[//]: # (For important changes, please add a new entry to the release notes file)
[//]: # (See: https://trinity-client.readthedocs.io/en/latest/contributing.html#pull-requests)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://wallpapertag.com/wallpaper/full/1/0/5/468498-gorgerous-cute-baby-animal-wallpaper-2560x1600-xiaomi.jpg)
