### PR TITLE
Weaken criterion for attestation inclusion

### DIFF
--- a/eth2/beacon/state_machines/forks/serenity/block_validation.py
+++ b/eth2/beacon/state_machines/forks/serenity/block_validation.py
@@ -362,13 +362,12 @@ def validate_attestation_slot(attestation_data: AttestationData,
             f"needed greater than or equal to `GENESIS_SLOT` ({genesis_slot})"
         )
 
-    if state_slot >= attestation_data.slot + slots_per_epoch:
+    if state_slot > attestation_data.slot + slots_per_epoch:
         raise ValidationError(
-            "Attestation slot plus `SLOTS_PER_EPOCH` is too low; "
-            "must exceed the current state:\n"
+            "Attestation slot plus `SLOTS_PER_EPOCH` is too low\n"
             f"\tFound: {attestation_data.slot + slots_per_epoch} "
             f"({attestation_data.slot} + {slots_per_epoch}), "
-            f"Needed greater than: {state_slot}"
+            f"Needed greater than or equal to: {state_slot}"
         )
 
     if attestation_data.slot + min_attestation_inclusion_delay > state_slot:

--- a/tests/eth2/beacon/state_machines/forks/test_serenity_block_attestation_validation.py
+++ b/tests/eth2/beacon/state_machines/forks/test_serenity_block_attestation_validation.py
@@ -46,11 +46,11 @@ from eth2.beacon.types.crosslink_records import CrosslinkRecord
         # in bounds at lower end
         (8, 2 + 8, True),
         # in bounds at high end
-        (8, 8 + 4 - 1, True),
+        (8, 8 + 4, True),
         # attestation_slot < genesis_slot
         (7, 2 + 8, False),
-        # state_slot >= attestation_data.slot + slots_per_epoch
-        (8, 8 + 4, False),
+        # state_slot > attestation_data.slot + slots_per_epoch
+        (8, 8 + 4 + 1, False),
         # attestation_data.slot + min_attestation_inclusion_delay > state_slot
         (8, 8 - 2, False),
     ]


### PR DESCRIPTION
### What was wrong?
Fix #411 


### How was it fixed?

Change
```python
    assert state.slot < attestation.data.slot + SLOTS_PER_EPOCH
```
to
```python
    assert state.slot <= attestation.data.slot + SLOTS_PER_EPOCH
```

#### Cute Animal Picture

![moose-602659_640](https://user-images.githubusercontent.com/9263930/54484512-5980e780-48a3-11e9-9cdc-d28099d769f2.jpg)
