### PR TITLE
Update `validate_voluntary_exit`

### DIFF
--- a/eth2/beacon/configs.py
+++ b/eth2/beacon/configs.py
@@ -52,6 +52,7 @@ BeaconConfig = NamedTuple(
         ('ACTIVATION_EXIT_DELAY', int),
         ('EPOCHS_PER_ETH1_VOTING_PERIOD', int),
         ('MIN_VALIDATOR_WITHDRAWABILITY_DELAY', int),
+        ('PERSISTENT_COMMITTEE_PERIOD', int),
         # Reward and penalty quotients
         ('BASE_REWARD_QUOTIENT', int),
         ('WHISTLEBLOWER_REWARD_QUOTIENT', int),

--- a/eth2/beacon/state_machines/forks/serenity/block_validation.py
+++ b/eth2/beacon/state_machines/forks/serenity/block_validation.py
@@ -33,13 +33,15 @@ from eth2.beacon.committee_helpers import (
 from eth2.beacon.configs import (
     CommitteeConfig,
 )
+from eth2.beacon.constants import (
+    FAR_FUTURE_EPOCH,
+)
 from eth2.beacon.enums import (
     SignatureDomain,
 )
 from eth2.beacon.helpers import (
     get_block_root,
     get_epoch_start_slot,
-    get_delayed_activation_exit_epoch,
     get_domain,
     is_double_vote,
     is_surround_vote,
@@ -716,41 +718,41 @@ def validate_voluntary_exit(state: 'BeaconState',
     validator = state.validator_registry[voluntary_exit.validator_index]
     current_epoch = state.current_epoch(slots_per_epoch)
 
-    validate_voluntary_exit_validator_exit_epoch(
-        state,
-        validator,
-        current_epoch,
-        slots_per_epoch=slots_per_epoch,
-        activation_exit_delay=activation_exit_delay,
-    )
+    validate_voluntary_exit_validator_exit_epoch(validator)
+
+    validate_voluntary_exit_initiated_exit(validator)
 
     validate_voluntary_exit_epoch(voluntary_exit, current_epoch)
 
     validate_voluntary_exit_signature(state, voluntary_exit, validator)
 
 
-def validate_voluntary_exit_validator_exit_epoch(state: 'BeaconState',
-                                                 validator: 'ValidatorRecord',
-                                                 current_epoch: Epoch,
-                                                 slots_per_epoch: int,
-                                                 activation_exit_delay: int) -> None:
-    current_epoch = state.current_epoch(slots_per_epoch)
-
-    # Verify the validator has not yet exited
-    delayed_activation_exit_epoch = get_delayed_activation_exit_epoch(
-        current_epoch,
-        activation_exit_delay,
-    )
-    if validator.exit_epoch <= delayed_activation_exit_epoch:
+def validate_voluntary_exit_validator_exit_epoch(validator: 'ValidatorRecord') -> None:
+    """
+    Verify the validator has not yet exited.
+    """
+    if validator.exit_epoch != FAR_FUTURE_EPOCH:
         raise ValidationError(
-            f"validator.exit_epoch ({validator.exit_epoch}) should be greater than "
-            f"delayed_activation_exit_epoch ({delayed_activation_exit_epoch})"
+            f"validator.exit_epoch ({validator.exit_epoch}) should be equal to "
+            f"FAR_FUTURE_EPOCH ({FAR_FUTURE_EPOCH})"
+        )
+
+
+def validate_voluntary_exit_initiated_exit(validator: 'ValidatorRecord') -> None:
+    """
+    Verify the validator has not initiated an exit.
+    """
+    if validator.initiated_exit is True:
+        raise ValidationError(
+            f"validator.initiated_exit ({validator.initiated_exit}) should be False"
         )
 
 
 def validate_voluntary_exit_epoch(voluntary_exit: 'VoluntaryExit',
                                   current_epoch: Epoch) -> None:
-    # Exits must specify an epoch when they become valid; they are not valid before then
+    """
+    Exits must specify an epoch when they become valid; they are not valid before then.
+    """
     if current_epoch < voluntary_exit.epoch:
         raise ValidationError(
             f"voluntary_exit.epoch ({voluntary_exit.epoch}) should be less than or equal to "
@@ -761,6 +763,9 @@ def validate_voluntary_exit_epoch(voluntary_exit: 'VoluntaryExit',
 def validate_voluntary_exit_signature(state: 'BeaconState',
                                       voluntary_exit: 'VoluntaryExit',
                                       validator: 'ValidatorRecord') -> None:
+    """
+    Verify signature.
+    """
     domain = get_domain(state.fork, voluntary_exit.epoch, SignatureDomain.DOMAIN_EXIT)
     is_valid_signature = bls.verify(
         pubkey=validator.pubkey,

--- a/eth2/beacon/state_machines/forks/serenity/block_validation.py
+++ b/eth2/beacon/state_machines/forks/serenity/block_validation.py
@@ -714,7 +714,7 @@ def validate_slashable_attestation(state: 'BeaconState',
 def validate_voluntary_exit(state: 'BeaconState',
                             voluntary_exit: 'VoluntaryExit',
                             slots_per_epoch: int,
-                            activation_exit_delay: int) -> None:
+                            persistent_committee_period: int) -> None:
     validator = state.validator_registry[voluntary_exit.validator_index]
     current_epoch = state.current_epoch(slots_per_epoch)
 
@@ -723,6 +723,8 @@ def validate_voluntary_exit(state: 'BeaconState',
     validate_voluntary_exit_initiated_exit(validator)
 
     validate_voluntary_exit_epoch(voluntary_exit, current_epoch)
+
+    validate_voluntary_exit_persistent(validator, current_epoch, persistent_committee_period)
 
     validate_voluntary_exit_signature(state, voluntary_exit, validator)
 
@@ -757,6 +759,20 @@ def validate_voluntary_exit_epoch(voluntary_exit: 'VoluntaryExit',
         raise ValidationError(
             f"voluntary_exit.epoch ({voluntary_exit.epoch}) should be less than or equal to "
             f"current epoch ({current_epoch})"
+        )
+
+
+def validate_voluntary_exit_persistent(validator: 'ValidatorRecord',
+                                       current_epoch: Epoch,
+                                       persistent_committee_period: int) -> None:
+    """
+    # Must have been in the validator set long enough
+    """
+    if current_epoch - validator.activation_epoch < persistent_committee_period:
+        raise ValidationError(
+            "current_epoch - validator.activation_epoch "
+            f"({current_epoch} - {validator.activation_epoch}) should be greater than or equal to "
+            f"PERSISTENT_COMMITTEE_PERIOD ({persistent_committee_period})"
         )
 
 

--- a/eth2/beacon/state_machines/forks/serenity/configs.py
+++ b/eth2/beacon/state_machines/forks/serenity/configs.py
@@ -52,6 +52,7 @@ SERENITY_CONFIG = BeaconConfig(
     ACTIVATION_EXIT_DELAY=2**2,  # (= 4) epochs
     EPOCHS_PER_ETH1_VOTING_PERIOD=2**4,  # (= 16) epochs
     MIN_VALIDATOR_WITHDRAWABILITY_DELAY=2**8,  # (= 256) epochs
+    PERSISTENT_COMMITTEE_PERIOD=2**11,  # (= 2,048) epochs
     # Reward and penalty quotients
     BASE_REWARD_QUOTIENT=2**10,  # (= 1,024)
     WHISTLEBLOWER_REWARD_QUOTIENT=2**9,  # (= 512)

--- a/eth2/beacon/state_machines/forks/serenity/operation_processing.py
+++ b/eth2/beacon/state_machines/forks/serenity/operation_processing.py
@@ -162,7 +162,7 @@ def process_voluntary_exits(state: BeaconState,
             state,
             voluntary_exit,
             config.SLOTS_PER_EPOCH,
-            config.ACTIVATION_EXIT_DELAY,
+            config.PERSISTENT_COMMITTEE_PERIOD,
         )
         # Run the exit
         state = initiate_validator_exit(state, voluntary_exit.validator_index)

--- a/tests/eth2/beacon/conftest.py
+++ b/tests/eth2/beacon/conftest.py
@@ -551,6 +551,11 @@ def min_validator_withdrawability_delay():
 
 
 @pytest.fixture
+def persistent_committee_period():
+    return SERENITY_CONFIG.PERSISTENT_COMMITTEE_PERIOD
+
+
+@pytest.fixture
 def base_reward_quotient():
     return SERENITY_CONFIG.BASE_REWARD_QUOTIENT
 
@@ -718,6 +723,7 @@ def config(
         activation_exit_delay,
         epochs_per_eth1_voting_period,
         min_validator_withdrawability_delay,
+        persistent_committee_period,
         base_reward_quotient,
         whistleblower_reward_quotient,
         attestation_inclusion_reward_quotient,
@@ -759,6 +765,7 @@ def config(
         ACTIVATION_EXIT_DELAY=activation_exit_delay,
         EPOCHS_PER_ETH1_VOTING_PERIOD=epochs_per_eth1_voting_period,
         MIN_VALIDATOR_WITHDRAWABILITY_DELAY=min_validator_withdrawability_delay,
+        PERSISTENT_COMMITTEE_PERIOD=persistent_committee_period,
         BASE_REWARD_QUOTIENT=base_reward_quotient,
         WHISTLEBLOWER_REWARD_QUOTIENT=whistleblower_reward_quotient,
         ATTESTATION_INCLUSION_REWARD_QUOTIENT=attestation_inclusion_reward_quotient,

--- a/tests/eth2/beacon/state_machines/forks/test_serenity_block_voluntary_exit_validation.py
+++ b/tests/eth2/beacon/state_machines/forks/test_serenity_block_voluntary_exit_validation.py
@@ -29,11 +29,10 @@ from eth2.beacon.tools.builder.validator import (
         'num_validators',
         'slots_per_epoch',
         'target_committee_size',
-        'activation_exit_delay',
         'persistent_committee_period',
     ),
     [
-        (40, 2, 2, 2, 16),
+        (40, 2, 2, 16),
     ]
 )
 def test_validate_voluntary_exit(
@@ -219,8 +218,6 @@ def test_validate_voluntary_exit_persistent(
         activation_epoch=activation_epoch,
     )
     state = state.update_validator_registry(validator_index, validator)
-
-    validator_index = 0
 
     if success:
         validate_voluntary_exit_persistent(

--- a/tests/eth2/beacon/state_machines/forks/test_serenity_operation_processing.py
+++ b/tests/eth2/beacon/state_machines/forks/test_serenity_operation_processing.py
@@ -10,6 +10,9 @@ from eth2.beacon.committee_helpers import (
 from eth2.beacon.configs import (
     CommitteeConfig,
 )
+from eth2.beacon.helpers import (
+    get_epoch_start_slot,
+)
 from eth2.beacon.types.blocks import (
     BeaconBlockBody,
 )
@@ -325,8 +328,17 @@ def test_process_voluntary_exits(genesis_state,
                                  keymap,
                                  min_attestation_inclusion_delay,
                                  success):
-    state = genesis_state
+    state = genesis_state.copy(
+        slot=get_epoch_start_slot(
+            config.GENESIS_EPOCH + config.PERSISTENT_COMMITTEE_PERIOD,
+            config.SLOTS_PER_EPOCH,
+        ),
+    )
     validator_index = 0
+    validator = state.validator_registry[validator_index].copy(
+        activation_epoch=config.GENESIS_EPOCH,
+    )
+    state = state.update_validator_registry(validator_index, validator)
     valid_voluntary_exit = create_mock_voluntary_exit(
         state,
         config,

--- a/tests/eth2/beacon/state_machines/forks/test_serenity_operation_processing.py
+++ b/tests/eth2/beacon/state_machines/forks/test_serenity_operation_processing.py
@@ -326,7 +326,6 @@ def test_process_voluntary_exits(genesis_state,
                                  sample_beacon_block_body_params,
                                  config,
                                  keymap,
-                                 min_attestation_inclusion_delay,
                                  success):
     state = genesis_state.copy(
         slot=get_epoch_start_slot(


### PR DESCRIPTION
### What was wrong?

Fix #412 and #413

### How was it fixed?

Add and edit the validation rules of voluntary exit.
```python
    # Verify the validator has not yet exited
    assert validator.exit_epoch == FAR_FUTURE_EPOCH

    # Verify the validator has not initiated an exit
    assert validator.initiated_exit is False

    # Must have been in the validator set long enough
    assert get_current_epoch(state) - validator.activation_epoch >= PERSISTENT_COMMITTEE_PERIOD
```

#### Cute Animal Picture

![moose-931640_640](https://user-images.githubusercontent.com/9263930/54485534-5989e300-48b5-11e9-9f2f-b6ef23812ea0.jpg)
