### PR TITLE
Fix missing merkle module

### DIFF
--- a/eth2/_utils/merkle/sparse.py
+++ b/eth2/_utils/merkle/sparse.py
@@ -81,7 +81,7 @@ def calc_merkle_tree_from_leaves(leaves: Sequence[Hash32]) -> MerkleTree:
             tree = update_tuple_item(  # type: ignore
                 tree,
                 0,
-                tuple(list(tree[0]) + [EmptyNodeHashes[i]]),
+                tuple(tree[0]) + tuple([EmptyNodeHashes[i]]),
             )
         tree = tuple((_hash_layer(tree[0]),) + tree)  # type: ignore
     return MerkleTree(tree)

--- a/eth2/_utils/merkle/sparse.py
+++ b/eth2/_utils/merkle/sparse.py
@@ -7,6 +7,7 @@ not considered to be part of the tree.
 
 from typing import (
     Sequence,
+    Tuple,
     Union,
 )
 
@@ -75,15 +76,15 @@ def get_merkle_root_from_items(items: Sequence[Union[bytes, bytearray]]) -> Hash
 def calc_merkle_tree_from_leaves(leaves: Sequence[Hash32]) -> MerkleTree:
     if len(leaves) == 0:
         raise ValueError("No leaves given")
-    tree = (leaves,)
+    tree: Tuple[Sequence[Hash32], ...] = (leaves,)
     for i in range(TreeDepth):
         if len(tree[0]) % 2 == 1:
-            tree = update_tuple_item(  # type: ignore
+            tree = update_tuple_item(
                 tree,
                 0,
-                tuple(tree[0]) + tuple([EmptyNodeHashes[i]]),
+                tuple(tree[0]) + (EmptyNodeHashes[i],),
             )
-        tree = tuple((_hash_layer(tree[0]),) + tree)  # type: ignore
+        tree = (_hash_layer(tree[0]),) + tree
     return MerkleTree(tree)
 
 

--- a/eth2/_utils/merkle/sparse.py
+++ b/eth2/_utils/merkle/sparse.py
@@ -78,9 +78,13 @@ def calc_merkle_tree_from_leaves(leaves: Sequence[Hash32]) -> MerkleTree:
     tree = (leaves,)
     for i in range(TreeDepth):
         if len(tree[0]) % 2 == 1:
-            tree = update_tuple_item(tree, 0, tree[0] + (EmptyNodeHashes[i],))
-        tree = (_hash_layer(tree[0]),) + tree
-    return tree
+            tree = update_tuple_item(  # type: ignore
+                tree,
+                0,
+                tuple(list(tree[0]) + [EmptyNodeHashes[i]]),
+            )
+        tree = tuple((_hash_layer(tree[0]),) + tree)  # type: ignore
+    return MerkleTree(tree)
 
 
 def get_merkle_root(leaves: Sequence[Hash32]) -> Hash32:


### PR DESCRIPTION
### What was wrong?
`ModuleNotFoundError: No module named 'eth2._utils.merkle'`


### How was it fixed?
- [x] Create `eth2._utils.merkle` module
- [x]  fix mypy type checking.
    - [x] Change helpers in `common.py` to `@to_tuple + yield + Iterable type` pattern
    - [x] ignore type check for assigning concatenated tuples to tuple since mypy does not support it yet as suggested in [this issue](https://github.com/python/mypy/issues/224)

[//]: # (For important changes, please add a new entry to the release notes file)
[//]: # (See: https://trinity-client.readthedocs.io/en/latest/contributing.html#pull-requests)

#### Cute Animal Picture


![](https://www.publicdomainpictures.net/pictures/40000/velka/cute-dog-1362593345bn4.jpg)
