### PR TITLE
Mock `get_beacon_proposer_index` in attestation inclusion test

### DIFF
--- a/tests/eth2/beacon/state_machines/forks/test_serenity_epoch_processing.py
+++ b/tests/eth2/beacon/state_machines/forks/test_serenity_epoch_processing.py
@@ -777,6 +777,7 @@ def test_process_rewards_and_penalties_for_finality(
     ]
 )
 def test_process_rewards_and_penalties_for_attestation_inclusion(
+        monkeypatch,
         n_validators_state,
         config,
         slots_per_epoch,
@@ -788,6 +789,27 @@ def test_process_rewards_and_penalties_for_attestation_inclusion(
         inclusion_slots,
         base_reward,
         expected_rewards_received):
+    # Mock `get_beacon_proposer_index
+    from eth2.beacon.state_machines.forks.serenity import epoch_processing
+
+    def mock_get_beacon_proposer_index(state,
+                                       slot,
+                                       committee_config,
+                                       registry_change=False):
+        mock_proposer_for_slot = {
+            31: 6,
+            32: 16,
+            35: 19,
+            38: 15,
+        }
+        return mock_proposer_for_slot[slot]
+
+    monkeypatch.setattr(
+        epoch_processing,
+        'get_beacon_proposer_index',
+        mock_get_beacon_proposer_index
+    )
+
     state = n_validators_state.copy(
         slot=current_slot,
     )


### PR DESCRIPTION
### What was wrong?
Result of `get_beacon_proposer_index` changes every time sampling algorithm or source of entropy changes and this makes maintaining the attestation inclusion test painful.

### How was it fixed?
Mock `get_beacon_proposer_index` in the test.

[//]: # (For important changes, please add a new entry to the release notes file)
[//]: # (See: https://trinity-client.readthedocs.io/en/latest/contributing.html#pull-requests)

#### Cute Animal Picture

![](https://pixnio.com/free-images/2018/11/21/2018-11-21-13-09-28-1200x798.jpg)
