### PR TITLE
Do not check withdrawal credentials for existing validators

### DIFF
--- a/eth2/beacon/deposit_helpers.py
+++ b/eth2/beacon/deposit_helpers.py
@@ -78,16 +78,16 @@ def process_deposit(*,
     """
     Process a deposit from Ethereum 1.0.
     """
-    validate_proof_of_possession(
-        state=state,
-        pubkey=pubkey,
-        proof_of_possession=proof_of_possession,
-        withdrawal_credentials=withdrawal_credentials,
-        slots_per_epoch=slots_per_epoch,
-    )
-
     validator_pubkeys = tuple(v.pubkey for v in state.validator_registry)
     if pubkey not in validator_pubkeys:
+        validate_proof_of_possession(
+            state=state,
+            pubkey=pubkey,
+            proof_of_possession=proof_of_possession,
+            withdrawal_credentials=withdrawal_credentials,
+            slots_per_epoch=slots_per_epoch,
+        )
+    
         validator = ValidatorRecord.create_pending_validator(
             pubkey=pubkey,
             withdrawal_credentials=withdrawal_credentials,


### PR DESCRIPTION
### What was wrong?

Fix #417


### How was it fixed?

Move `validate_proof_of_possession` to only checking for new validators.


#### Cute Animal Picture

![squirrel-1376824_640](https://user-images.githubusercontent.com/9263930/54486899-c0b19280-48c9-11e9-9acd-f206cda41f0c.jpg)
