### PR TITLE
Initialize index to fix unhandled exception

### DIFF
--- a/trinity/sync/common/headers.py
+++ b/trinity/sync/common/headers.py
@@ -8,7 +8,7 @@ from typing import (
     Callable,
     FrozenSet,
     Generic,
-    Iterable,
+    Sequence,
     Tuple,
     Type,
 )
@@ -691,7 +691,7 @@ class HeaderMeatSyncer(BaseService, PeerSubscriber, Generic[TChainPeer]):
             raise
 
 
-def first_nonconsecutive_header(headers: Iterable[BlockHeader]) -> int:
+def first_nonconsecutive_header(headers: Sequence[BlockHeader]) -> int:
     """
     :return: index of first child that does not match parent header, or a number
         past the end if all are consecutive
@@ -701,7 +701,7 @@ def first_nonconsecutive_header(headers: Iterable[BlockHeader]) -> int:
             return index + 1
 
     # return an index off the end to indicate that all headers are consecutive
-    return index + 2
+    return len(headers)
 
 
 class BaseHeaderChainSyncer(BaseService, HeaderSyncerAPI, Generic[TChainPeer]):


### PR DESCRIPTION
### What was wrong?

When `first_nonconsecutive_header` is called with an empty `Iterable`it crashes with `index used before assignment`

### How was it fixed?

Assign `index` to `0` at the begin of the function. I'm not entirely sure if `2` is the semantically valid response for an empty Iterable but the function should certainly not crash when called with an empty `Iterable`. 

[//]: # (For important changes, please add a new entry to the release notes file)
[//]: # (See: https://trinity-client.readthedocs.io/en/latest/contributing.html#pull-requests)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://static1.squarespace.com/static/556323dee4b006bb6875f975/t/59c925de8fd4d2c4919409cd/1519057009957/Roseate_Spoonbill_Bald_eagle_nest_Cape_May_Joe_Gliozzo_Photography.jpg)
