### PR TITLE
Ignore lock time in request timeout

### DIFF
--- a/trinity/protocol/common/constants.py
+++ b/trinity/protocol/common/constants.py
@@ -4,3 +4,10 @@ ROUND_TRIP_TIMEOUT = 20.0
 # Timeout used when performing the check to ensure peers are on the same side of chain splits as
 # us.
 CHAIN_SPLIT_CHECK_TIMEOUT = 15
+
+
+# We send requests to peers one at a time, but might initiate a few locally before
+# they are sent. This is an estimate of how many get queued locally. The reason we
+# estimate the queue length is to determine how long a timeout to use when
+# waiting for the lock to send the next queued peer request.
+NUM_QUEUED_REQUESTS = 3

--- a/trinity/protocol/common/managers.py
+++ b/trinity/protocol/common/managers.py
@@ -82,8 +82,6 @@ class ResponseCandidateStream(
         """
         outer_timeout = self.response_timeout if timeout is None else timeout
 
-        start_at = time.perf_counter()
-
         # The _lock ensures that we never have two concurrent requests to a
         # single peer for a single command pair in flight.
         try:
@@ -93,6 +91,8 @@ class ResponseCandidateStream(
                 f"Timed out waiting for {self.response_msg_name} request lock "
                 f"or peer: {self._peer}"
             )
+
+        start_at = time.perf_counter()
 
         if timeout is not None or tracker.total_msgs < 20:
             inner_timeout = outer_timeout

--- a/trinity/protocol/common/managers.py
+++ b/trinity/protocol/common/managers.py
@@ -29,7 +29,7 @@ from p2p._utils import ensure_global_asyncio_executor
 
 from trinity.exceptions import AlreadyWaiting
 
-from .constants import ROUND_TRIP_TIMEOUT
+from .constants import ROUND_TRIP_TIMEOUT, NUM_QUEUED_REQUESTS
 from .normalizers import BaseNormalizer
 from .trackers import BasePerformanceTracker
 from .types import (
@@ -85,7 +85,7 @@ class ResponseCandidateStream(
         # The _lock ensures that we never have two concurrent requests to a
         # single peer for a single command pair in flight.
         try:
-            await self.wait(self._lock.acquire(), timeout=outer_timeout)
+            await self.wait(self._lock.acquire(), timeout=outer_timeout * NUM_QUEUED_REQUESTS)
         except TimeoutError:
             raise AlreadyWaiting(
                 f"Timed out waiting for {self.response_msg_name} request lock "


### PR DESCRIPTION
### What was wrong?

When we get a lot of consistently quick responses from a peer, our timeout reduces. When we locally queue up two peer requests of the same time, one of them locks waiting for the other. Right now, that lock time is counted toward the peer timeout (but not toward the time in the tracker!). So we start timing out quick peers and dropping them!

cc @cburgdorf -- thanks for the indirect reminder to post some of the patches that were in my local branches.

### How was it fixed?

- Stop using the lock time as part of the request timeout
- Leave a little wiggle room in the lock timeout for the previous few requests to complete

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://www.dive-the-world.com/images/gallery/pages/medium/908ee3e701-shutterstock-243077710-nudibranch.jpg)
