### PR TITLE
misc: fix linting (extraneous whitespace)

### DIFF
--- a/eth2/beacon/deposit_helpers.py
+++ b/eth2/beacon/deposit_helpers.py
@@ -87,7 +87,7 @@ def process_deposit(*,
             withdrawal_credentials=withdrawal_credentials,
             slots_per_epoch=slots_per_epoch,
         )
-    
+
         validator = ValidatorRecord.create_pending_validator(
             pubkey=pubkey,
             withdrawal_credentials=withdrawal_credentials,


### PR DESCRIPTION
### What was wrong?

CI lint jobs fail:

`/home/circleci/repo/eth2/beacon/deposit_helpers.py:90:1: W293 blank line contains whitespace`

`git blame` shows origin as commit ae5df6d18, part of PR #427. Not sure why CI didn't catch it there.

### How was it fixed?

What the fine comb says: remove unnecessary whitespace.

[//]: # (For important changes, please add a new entry to the release notes file)
[//]: # (See: https://trinity-client.readthedocs.io/en/latest/contributing.html#pull-requests)

### Notes

There are warnings, too - don't know when these started showing.

```
py37-lint runtests: commands[0] | flake8 /home/veox/src/trinity/p2p
/home/veox/src/trinity/.tox/py37-lint/lib/python3.7/site-packages/pycodestyle.py:113: FutureWarning: Possible nested set at position 1
  EXTRANEOUS_WHITESPACE_REGEX = re.compile(r'[[({] | []}),;:]')
py37-lint runtests: commands[1] | flake8 /home/veox/src/trinity/tests
/home/veox/src/trinity/.tox/py37-lint/lib/python3.7/site-packages/pycodestyle.py:113: FutureWarning: Possible nested set at position 1
  EXTRANEOUS_WHITESPACE_REGEX = re.compile(r'[[({] | []}),;:]')
py37-lint runtests: commands[2] | flake8 /home/veox/src/trinity/trinity
/home/veox/src/trinity/.tox/py37-lint/lib/python3.7/site-packages/pycodestyle.py:113: FutureWarning: Possible nested set at position 1
  EXTRANEOUS_WHITESPACE_REGEX = re.compile(r'[[({] | []}),;:]')
py37-lint runtests: commands[3] | flake8 /home/veox/src/trinity/scripts               
/home/veox/src/trinity/.tox/py37-lint/lib/python3.7/site-packages/pycodestyle.py:113: FutureWarning: Possible nested set at position 1
  EXTRANEOUS_WHITESPACE_REGEX = re.compile(r'[[({] | []}),;:]')
py37-lint runtests: commands[4] | flake8 /home/veox/src/trinity/eth2
/home/veox/src/trinity/.tox/py37-lint/lib/python3.7/site-packages/pycodestyle.py:113: FutureWarning: Possible nested set at position 1
  EXTRANEOUS_WHITESPACE_REGEX = re.compile(r'[[({] | []}),;:]')                                                
py37-lint runtests: commands[5] | flake8 --exclude=/home/veox/src/trinity/libp2p/p2pclient/pb /home/veox/src/trinity/libp2p                                                                                                                   
/home/veox/src/trinity/.tox/py37-lint/lib/python3.7/site-packages/pycodestyle.py:113: FutureWarning: Possible nested set at position 1
  EXTRANEOUS_WHITESPACE_REGEX = re.compile(r'[[({] | []}),;:]')
py37-lint runtests: commands[6] | mypy --follow-imports=silent --warn-unused-ignores --ignore-missing-imports --no-strict-optional --check-untyped-defs --disallow-incomplete-defs --disallow-untyped-defs --disallow-any-generics -p p2p -p trinity -p eth2 -p libp2p
___________________________________________________________________________________________________________________ summary ___________________________________________________________________________________________________________________
  py37-lint: commands succeeded
  congratulations :)
```

@carver [says](https://gitter.im/ethereum/trinity?at=5c9149fcfcaf7b5f73dfa18b) on gitter:

> [@ralexstokes] said something about non-linter problems, so maybe there is something flake he will still look into when he gets back

I assume he meant these.

### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://www.gannett-cdn.com/media/2018/04/26/WIGroup/StevensPoint/636603397304299606-chickadee-with-nesting-material.jpg?width=1080&quality=50)

Found on: [daily herald](https://eu.wausaudailyherald.com/story/life/2018/04/26/animal-hair-dryer-lint-out-and-dead-twigs-leaves-according-new-bird-nest/553794002/)