### PR TITLE
Attempt to fix flaky CI with a much longer timeout

### DIFF
--- a/tests/libp2p/p2pclient/test_p2pclient_integration.py
+++ b/tests/libp2p/p2pclient/test_p2pclient_integration.py
@@ -34,7 +34,7 @@ import libp2p.p2pclient.pb.p2pd_pb2 as p2pd_pb
 
 
 NUM_P2PDS = 4
-TIMEOUT_DURATION = 30  # seconds
+TIMEOUT_DURATION = 120  # seconds
 
 
 @pytest.fixture(scope="module")


### PR DESCRIPTION
### What was wrong?

Trying to remove flaky CI testing w/ a longer timeout.

While not ideal, it seems that we are otherwise managing daemons/clients properly so it seems that sometimes CI doesn't launch the `p2pd` daemon subprocess in a timely fashion and it leads to tests blowing up.

### How was it fixed?

Extending the timeout.

[//]: # (For important changes, please add a new entry to the release notes file)
[//]: # (See: https://trinity-client.readthedocs.io/en/latest/contributing.html#pull-requests)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://proxy.duckduckgo.com/iu/?u=http%3A%2F%2Fwww.nakedcapitalism.com%2Fwp-content%2Fuploads%2F2015%2F10%2Fcute-baby-fox.jpg&f=1)
