### PR TITLE
Add additional sleep and remove useless `read`

### DIFF
--- a/tests/libp2p/p2pclient/test_p2pclient_integration.py
+++ b/tests/libp2p/p2pclient/test_p2pclient_integration.py
@@ -1029,6 +1029,6 @@ async def test_pubsub_client_subscribe(p2pds):
     assert PeerID(pubsub_msg_2_0.from_field) == peer_id_0
     # test case: unsubscribe by closing the stream
     writer_0.close()
-    await asyncio.sleep(0.1)
+    await asyncio.sleep(0)
     assert topic not in await p2pds[0].pubsub.get_topics()
     assert peer_id_0 not in await p2pds[1].pubsub.list_peers(topic)

--- a/tests/libp2p/p2pclient/test_p2pclient_integration.py
+++ b/tests/libp2p/p2pclient/test_p2pclient_integration.py
@@ -1029,6 +1029,6 @@ async def test_pubsub_client_subscribe(p2pds):
     assert PeerID(pubsub_msg_2_0.from_field) == peer_id_0
     # test case: unsubscribe by closing the stream
     writer_0.close()
-    await reader_0.read() == b""
+    await asyncio.sleep(0.1)
     assert topic not in await p2pds[0].pubsub.get_topics()
     assert peer_id_0 not in await p2pds[1].pubsub.list_peers(topic)


### PR DESCRIPTION
### What was wrong?
CI fails several times in `tests/libp2p/p2pclient/test_p2pclient_integration.py::test_pubsub_client_subscribe` at , e.g. [this failure](https://circleci.com/gh/ethereum/trinity/19539). I guess it is because `StreamWriter` is not closed successfully before the query `await p2pds[0].pubsub.get_topics()`. The code is [here](https://github.com/ethereum/trinity/blob/master/tests/libp2p/p2pclient/test_p2pclient_integration.py#L1033). 

### How was it fixed?
Sleep for a short period, to yield the execution to the closing transport. Still need to confirm if this is the exact reason. I ran the test in my local machine with this patch 100 times, and no failure happens.

[//]: # (For important changes, please add a new entry to the release notes file)
[//]: # (See: https://trinity-client.readthedocs.io/en/latest/contributing.html#pull-requests)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://scontent.ftpe8-3.fna.fbcdn.net/v/t1.0-9/53671890_1198104457050620_1422814844305801216_n.jpg?_nc_cat=111&_nc_ht=scontent.ftpe8-3.fna&oh=c9121aefa372931b5dbd297d3c5ede39&oe=5D114CCB)
