### PR TITLE
Connect to preferred nodes even if discovery off

### DIFF
--- a/docs/release_notes/trinity.rst
+++ b/docs/release_notes/trinity.rst
@@ -4,6 +4,7 @@ Trinity
 Unreleased (latest source)
 --------------------------
 
+- `#436 <https://github.com/ethereum/trinity/pull/436>`_: Feauture: connect to preferred nodes even when discovery is disabled
 - `#400 <https://github.com/ethereum/trinity/pull/400>`_: Bugfix: Respect configuration of individual logger (e.g -l p2p.discovery=ERROR)
 - `#386 <https://github.com/ethereum/trinity/pull/386>`_: Slightly reduce eventbus traffic that the peer pool causes
 - `#336 <https://github.com/ethereum/trinity/pull/336>`_: Bugfix: Ensure Trinity shuts down if the process pool dies (fatal error)

--- a/p2p/peer_pool.py
+++ b/p2p/peer_pool.py
@@ -261,7 +261,7 @@ class BasePeerPool(BaseService, AsyncIterable[BasePeer]):
         Returns None if the remote is unreachable, times out or is useless.
         """
         if remote in self.connected_nodes:
-            self.logger.debug("Skipping %s; already connected to it", remote)
+            self.logger.debug2("Skipping %s; already connected to it", remote)
             return None
         if not self.peer_info.should_connect_to(remote):
             return None

--- a/trinity/plugins/builtin/peer_discovery/plugin.py
+++ b/trinity/plugins/builtin/peer_discovery/plugin.py
@@ -21,8 +21,8 @@ from p2p.discovery import (
     DiscoveryByTopicProtocol,
     DiscoveryProtocol,
     DiscoveryService,
-    NoopDiscoveryService,
     PreferredNodeDiscoveryProtocol,
+    StaticDiscoveryService,
 )
 from p2p.kademlia import (
     Address,
@@ -127,8 +127,9 @@ class DiscoveryBootstrapService(BaseService):
             )
 
         if self.is_discovery_disabled:
-            discovery_service: BaseService = NoopDiscoveryService(
+            discovery_service: BaseService = StaticDiscoveryService(
                 self.event_bus,
+                self.trinity_config.preferred_nodes,
                 self.cancel_token,
             )
         else:


### PR DESCRIPTION
### What was wrong?

I wanted discovery off but to connect to a particular preferred node, ie~
```sh
trinity --disable-discovery --preferred-node "enode..."
```

Trinity never attempted to connect to the preferred node.

### How was it fixed?

Replace the `NoopDiscoveryService` with a `StaticDiscoveryService` which only connects to the preferred nodes. (This should cleanly downgrade to the noop case if no preferred nodes are set)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://kids.nationalgeographic.com/content/dam/kids/photos/animals/Invertebrates/H-P/nudibranch_white.adapt.945.1.png)
