### PR TITLE
Get rid of sync methods in BaseAsyncChainDB

### DIFF
--- a/tests/core/database/test_database_over_ipc_manager.py
+++ b/tests/core/database/test_database_over_ipc_manager.py
@@ -82,10 +82,11 @@ def manager(database_server_ipc_path):
     return _manager
 
 
-def test_chaindb_over_ipc_manager(manager):
+@pytest.mark.asyncio
+async def test_chaindb_over_ipc_manager(manager):
     chaindb = manager.get_chaindb()
 
-    header = chaindb.get_canonical_head()
+    header = await chaindb.coro_get_canonical_head()
 
     assert header == ROPSTEN_GENESIS_HEADER
 

--- a/trinity/db/eth1/chain.py
+++ b/trinity/db/eth1/chain.py
@@ -15,21 +15,20 @@ from typing import (
 from eth_typing import Hash32
 
 from eth.db.backends.base import BaseAtomicDB
-from eth.db.chain import BaseChainDB
 from eth.rlp.blocks import BaseBlock
 from eth.rlp.headers import BlockHeader
 from eth.rlp.receipts import Receipt
 from eth.rlp.transactions import BaseTransaction
 
+from trinity.db.eth1.header import BaseAsyncHeaderDB
 from trinity._utils.mp import (
     async_method,
-    sync_method,
 )
 
 
-class BaseAsyncChainDB(BaseChainDB):
+class BaseAsyncChainDB(BaseAsyncHeaderDB):
     """
-    Abstract base class extends the abstract ``BaseChainDB`` with async APIs.
+    Abstract base class for the async counterpart to ``BaseChainDB``.
     """
 
     @abstractmethod
@@ -88,29 +87,6 @@ class AsyncChainDBPreProxy(BaseAsyncChainDB):
     coro_get_block_transactions = async_method('get_block_transactions')
     coro_get_block_uncles = async_method('get_block_uncles')
     coro_get_receipts = async_method('get_receipts')
-
-    add_receipt = sync_method('add_receipt')
-    add_transaction = sync_method('add_transaction')
-    exists = sync_method('exists')
-    get = sync_method('get')
-    get_block_header_by_hash = sync_method('get_block_header_by_hash')
-    get_block_transactions = sync_method('get_block_transactions')
-    get_block_transaction_hashes = sync_method('get_block_transaction_hashes')
-    get_block_uncles = sync_method('get_block_uncles')
-    get_canonical_head = sync_method('get_canonical_head')
-    get_receipt_by_index = sync_method('get_receipt_by_index')
-    get_receipts = sync_method('get_receipts')
-    get_score = sync_method('get_score')
-    get_transaction_by_index = sync_method('get_transaction_by_index')
-    get_transaction_index = sync_method('get_transaction_index')
-    header_exists = sync_method('header_exists')
-    get_canonical_block_header_by_number = sync_method('get_canonical_block_header_by_number')
-    get_canonical_block_hash = sync_method('get_canonical_block_hash')
-    persist_block = sync_method('persist_block')
-    persist_header = sync_method('persist_header')
-    persist_header_chain = sync_method('persist_header_chain')
-    persist_uncles = sync_method('persist_uncles')
-    persist_trie_data_dict = sync_method('persist_trie_data_dict')
 
 
 class AsyncChainDBProxy(BaseProxy, AsyncChainDBPreProxy):

--- a/trinity/db/eth1/header.py
+++ b/trinity/db/eth1/header.py
@@ -17,9 +17,6 @@ from eth_typing import (
 from eth.db.backends.base import (
     BaseAtomicDB,
 )
-from eth.db.header import (
-    BaseHeaderDB,
-)
 from eth.rlp.headers import BlockHeader
 
 from trinity._utils.mp import (
@@ -28,9 +25,9 @@ from trinity._utils.mp import (
 )
 
 
-class BaseAsyncHeaderDB(BaseHeaderDB):
+class BaseAsyncHeaderDB:
     """
-    Abstract base class extends the abstract ``BaseHeaderDB`` with async APIs.
+    Abstract base class for the async counterpart to ``BaseHeaderDB``.
     """
     @abstractmethod
     async def coro_get_canonical_block_hash(self, block_number: BlockNumber) -> Hash32:

--- a/trinity/initialization.py
+++ b/trinity/initialization.py
@@ -1,6 +1,7 @@
 import os
 
 from eth.db.backends.base import BaseAtomicDB
+from eth.db.chain import BaseChainDB
 from eth.exceptions import CanonicalHeadNotFound
 
 from p2p import ecies
@@ -11,7 +12,6 @@ from trinity.config import (
     ChainConfig,
     TrinityConfig,
 )
-from trinity.db.eth1.chain import BaseAsyncChainDB
 from trinity.exceptions import (
     MissingPath,
 )
@@ -52,7 +52,7 @@ def is_data_dir_initialized(trinity_config: TrinityConfig) -> bool:
     return True
 
 
-def is_database_initialized(chaindb: BaseAsyncChainDB) -> bool:
+def is_database_initialized(chaindb: BaseChainDB) -> bool:
     try:
         chaindb.get_canonical_head()
     except CanonicalHeadNotFound:
@@ -105,7 +105,7 @@ def initialize_data_dir(trinity_config: TrinityConfig) -> None:
 
 
 def initialize_database(chain_config: ChainConfig,
-                        chaindb: BaseAsyncChainDB,
+                        chaindb: BaseChainDB,
                         base_db: BaseAtomicDB) -> None:
     try:
         chaindb.get_canonical_head()

--- a/trinity/sync/light/service.py
+++ b/trinity/sync/light/service.py
@@ -301,7 +301,7 @@ class LightPeerChain(PeerSubscriber, BaseService, BaseLightPeerChain):
         head_number = peer.head_number
         if head_number - header.block_number > MAX_REORG_DEPTH:
             # The peer claims to be far ahead of the header we requested
-            if self.headerdb.get_canonical_block_hash(header.block_number) == block_hash:
+            if await self.headerdb.coro_get_canonical_block_hash(header.block_number) == block_hash:
                 # Our node believes that the header at the reference hash is canonical,
                 # so treat the peer as malicious
                 raise BadLESResponse(


### PR DESCRIPTION
### What was wrong?

`BaseAsyncChainDB` inherited from `BaseChainDB` and therefore inherited all *abstract synchronous* which then further leads to us having to implement these *synchronous*  methods on the `AsyncChainDBProxy` which is problematic for two reasons:

1. [It is confusing](https://github.com/ethereum/trinity/pull/307#discussion_r267678406) (should I choose the sync or async version)?

2. It can lead to bugs or performance issues when one uses a sync methods where an async method should be used (in fact, this PR discovered such thing)

### How was it fixed?

1. Make `BaseAsyncChainDB` inherit from `BaseAsyncHeaderDB` instead of `BaseChainDB`. Not only fixes that our problems, it is also *symmetric* with `BaseChainDB` inheriting from `BaseHeaderDB`.

2. Fix all issues that were discovered by this change

Shout out to @ChihChengLiang who reminded me of this inconsistency in the code base.

[//]: # (For important changes, please add a new entry to the release notes file)
[//]: # (See: https://trinity-client.readthedocs.io/en/latest/contributing.html#pull-requests)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://www.telegraph.co.uk/content/dam/news/2016/05/26/594184b-Panda_napping_trans_NvBQzQNjv4BqpJliwavx4coWFCaEkEsb3kvxIt-lGGWCWqwLa_RXJU8.jpg?imwidth=450)
