### PR TITLE
Set a custom network ID if genesis file supplied

### DIFF
--- a/trinity/assets/eip1085.schema.json
+++ b/trinity/assets/eip1085.schema.json
@@ -115,7 +115,7 @@
         },
         "extraData": {
           "type": "string",
-          "pattern": "^0x([0-9a-fA-F]{2}){32}$"
+          "pattern": "^0x([0-9a-fA-F]{2}){0,32}$"
         },
         "gasLimit": {
           "type": "string",

--- a/trinity/bootstrap.py
+++ b/trinity/bootstrap.py
@@ -112,10 +112,12 @@ def main_entry(trinity_boot: BootFn,
     plugin_manager.amend_argparser_config(parser, subparser)
     args = parser.parse_args()
 
-    if args.network_id not in PRECONFIGURED_NETWORKS:
+    if not args.genesis and args.network_id not in PRECONFIGURED_NETWORKS:
         raise NotImplementedError(
-            f"Unsupported network id: {args.network_id}.  Only the ropsten and mainnet "
-            "networks are supported."
+            f"Unsupported network id: {args.network_id}. To use a network besides "
+            "mainnet or ropsten, you must supply a genesis file with a flag, like "
+            "`--genesis path/to/genesis.json`, also you must specify a data "
+            "directory with `--data-dir path/to/data/directory`"
         )
 
     has_ambigous_logging_config = (

--- a/trinity/config.py
+++ b/trinity/config.py
@@ -267,6 +267,8 @@ class TrinityConfig:
                 self.bootstrap_nodes = tuple(
                     KademliaNode.from_uri(enode) for enode in ROPSTEN_BOOTNODES
                 )
+            else:
+                self.bootstrap_nodes = tuple()
         else:
             self.bootstrap_nodes = bootstrap_nodes
 


### PR DESCRIPTION
### What was wrong?

I wanted to run with a custom genesis file, and my instinct was to set a custom network ID (didn't seem right to use the mainnet ID). This was explicitly forbidden.

### How was it fixed?

- I relaxed the constraint, so that if you supply a genesis file, then you can also use a custom network ID.
- Also updated the schema to accept <32 characters for genesis extraData, since that seems permitted by the yellow paper (note: the chain builder tool creates a genesis with `extra_data=b''` by default)
- Set bootstrap nodes to empty if they aren't supplied with a custom network ID

Note that if you use a custom network id without bootnodes or preferred nodes then obviously it won't connect to anyone. (somewhat related to #436 )

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://3c1703fe8d.site.internapcdn.net/newman/gfx/news/2017/1-marinescient.jpg)
