### PR TITLE
Switch to long-running release notes PR

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -5,7 +5,8 @@
 ### How was it fixed?
 
 
-[//]: # (For important changes, please add a new entry to the release notes file)
+[//]: # (For important changes, please add a new entry to the running release notes PR)
+[//]: # (You can find the current one using: https://github.com/ethereum/trinity/pulls?q=is%3Aopen+is%3Apr+label%3A%22Release+Notes%22 )
 [//]: # (See: https://trinity-client.readthedocs.io/en/latest/contributing.html#pull-requests)
 
 #### Cute Animal Picture


### PR DESCRIPTION
### What was wrong?

Some issues with including release notes in each PR:
- ripe for conflicts: people likely to add their own line to the beginning or end of the list
- requires pushing ones to get the PR number, then again. Potentially wastes a whole suite of test-runs.

### How was it fixed?

- Created a new label that should go on the running PR
- Change the notes to reference it

This should probably not merge until we have created the running PR (will do after I track down this libp2p issue that broke master)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://kids.nationalgeographic.com/content/dam/kids/photos/animals/Invertebrates/H-P/nudibranch_pink_yellow.ngsversion.1443092857933.png)
