### PR TITLE
Make the block importing functionality swappable

### DIFF
--- a/trinity/sync/common/chain.py
+++ b/trinity/sync/common/chain.py
@@ -1,3 +1,4 @@
+from abc import ABC, abstractmethod
 from typing import (
     AsyncIterator,
     Tuple,
@@ -19,6 +20,9 @@ from eth_typing import (
 from eth_utils import (
     encode_hex,
     ValidationError,
+)
+from eth.rlp.blocks import (
+    BaseBlock,
 )
 from eth.rlp.headers import (
     BlockHeader,
@@ -252,3 +256,21 @@ class PeerHeaderSyncer(BaseService):
 
         for header in iter_headers:
             yield header
+
+
+class BaseBlockImporter(ABC):
+    @abstractmethod
+    async def import_block(
+            self,
+            block: BaseBlock) -> Tuple[BaseBlock, Tuple[BaseBlock, ...], Tuple[BaseBlock, ...]]:
+        pass
+
+
+class SimpleBlockImporter(BaseBlockImporter):
+    def __init__(self, chain: BaseAsyncChain) -> None:
+        self._chain = chain
+
+    async def import_block(
+            self,
+            block: BaseBlock) -> Tuple[BaseBlock, Tuple[BaseBlock, ...], Tuple[BaseBlock, ...]]:
+        return await self._chain.coro_import_block(block, perform_validation=True)


### PR DESCRIPTION
### What was wrong?

In the new "beam sync", I want to reuse *almost* all the functionality of the regular syncer, but with a modified block import.

### How was it fixed?

Modified the regular syncer to take a new class is that is solely responsible for block import. In the new "beam sync", we swap in a block importer that requests any missing trie nodes that are found while executing the block.

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://www.dive-the-world.com/images/gallery/pages/medium/2ca4a435a2-burma-nudibranch.jpg)