### PR TITLE
Unify some fast & regular syncer logic

### DIFF
--- a/trinity/_utils/datastructures.py
+++ b/trinity/_utils/datastructures.py
@@ -368,7 +368,6 @@ class BaseOrderedTaskPreparation(ABC, Generic[TTask, TTaskID]):
         pass
 
 
-
 class OrderedTaskPreparation(
         BaseOrderedTaskPreparation[TTask, TTaskID],
         Generic[TTask, TTaskID, TPrerequisite]):

--- a/trinity/_utils/datastructures.py
+++ b/trinity/_utils/datastructures.py
@@ -1,3 +1,4 @@
+from abc import ABC, abstractmethod
 from asyncio import (
     AbstractEventLoop,
     Lock,
@@ -349,7 +350,28 @@ class NoPrerequisites(Enum):
     pass
 
 
-class OrderedTaskPreparation(Generic[TTask, TTaskID, TPrerequisite]):
+class BaseOrderedTaskPreparation(ABC, Generic[TTask, TTaskID]):
+    @abstractmethod
+    def set_finished_dependency(self, finished_task: TTask) -> None:
+        pass
+
+    @abstractmethod
+    def register_tasks(self, tasks: Tuple[TTask, ...], ignore_duplicates: bool = False) -> None:
+        pass
+
+    @abstractmethod
+    async def ready_tasks(self, max_results: int = None) -> Tuple[TTask, ...]:
+        pass
+
+    @abstractmethod
+    def has_ready_tasks(self) -> bool:
+        pass
+
+
+
+class OrderedTaskPreparation(
+        BaseOrderedTaskPreparation[TTask, TTaskID],
+        Generic[TTask, TTaskID, TPrerequisite]):
     """
     This class is useful when a series of tasks with prerequisites must be run
     sequentially. The prerequisites may be finished in any order, but the

--- a/trinity/db/eth1/chain.py
+++ b/trinity/db/eth1/chain.py
@@ -32,6 +32,10 @@ class BaseAsyncChainDB(BaseAsyncHeaderDB):
     """
 
     @abstractmethod
+    async def coro_exists(self, key: bytes) -> bool:
+        pass
+
+    @abstractmethod
     async def coro_get(self, key: bytes) -> bytes:
         pass
 
@@ -73,6 +77,7 @@ class AsyncChainDBPreProxy(BaseAsyncChainDB):
     def __init__(self, db: BaseAtomicDB) -> None:
         pass
 
+    coro_exists = async_method('exists')
     coro_get = async_method('get')
     coro_get_block_header_by_hash = async_method('get_block_header_by_hash')
     coro_get_canonical_head = async_method('get_canonical_head')

--- a/trinity/sync/common/headers.py
+++ b/trinity/sync/common/headers.py
@@ -63,7 +63,7 @@ from trinity._utils.datastructures import (
     TaskQueue,
 )
 from trinity._utils.headers import (
-    skip_headers_in_db,
+    skip_complete_headers,
 )
 from trinity._utils.humanize import (
     humanize_hash,
@@ -255,6 +255,14 @@ class SkeletonSyncer(BaseService, Generic[TChainPeer]):
                 # Return the newest one
                 return skeleton_launch_headers[-1]
 
+    async def _should_skip_header(self, header: BlockHeader) -> bool:
+        """
+        Should we skip trying to import this header?
+        Return True if the syncing of header appears to be complete.
+        This is fairly relaxed about the definition, preferring speed over slow precision.
+        """
+        return await self._db.coro_header_exists(header.hash)
+
     async def _find_launch_headers(self, peer: TChainPeer) -> Tuple[BlockHeader, ...]:
         """
         When getting started with a peer, find exactly where the headers start differing from the
@@ -280,7 +288,9 @@ class SkeletonSyncer(BaseService, Generic[TChainPeer]):
             )
 
         # identify headers that are not already stored locally
-        new_headers = await skip_headers_in_db(launch_headers, self._db, self)
+        new_headers = await self.wait(
+            skip_complete_headers(launch_headers, self.logger, self._should_skip_header)
+        )
 
         if len(new_headers) == 0:
             self.logger.debug(


### PR DESCRIPTION
### What was wrong?

The fast syncer got a lot of love, and the regular syncer missed out on a lot of those updates, because it was duplicated. When testing out regular sync, it was obvious it needed all the same upgrades.

### How was it fixed?

Combined the relevant logic, isolating a few pieces that are different. Had to ask mypy very nicely to allow me to make the changes.

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://flyandsea.com/wp-content/uploads/RickNudi2-940web.jpg)
