### PR TITLE
Implement `process_deposits`

### DIFF
--- a/eth2/_utils/merkle/common.py
+++ b/eth2/_utils/merkle/common.py
@@ -74,3 +74,20 @@ def get_merkle_proof(tree: MerkleTree, item_index: int) -> Iterable[Hash32]:
     proof_indices = [i ^ 1 for i in branch_indices][:-1]  # get sibling by flipping rightmost bit
     for layer, proof_index in zip(reversed(tree), proof_indices):
         yield layer[proof_index]
+
+
+def verify_merkle_branch(leaf: Hash32,
+                         proof: Sequence[Hash32],
+                         depth: int,
+                         index: int,
+                         root: Hash32) -> bool:
+    """
+    Verify that the given ``leaf`` is on the merkle branch ``branch``.
+    """
+    value = leaf
+    for i in range(depth):
+        if index // (2**i) % 2:
+            value = hash_eth2(proof[i] + value)
+        else:
+            value = hash_eth2(value + proof[i])
+    return value == root

--- a/eth2/_utils/merkle/common.py
+++ b/eth2/_utils/merkle/common.py
@@ -82,7 +82,7 @@ def verify_merkle_branch(leaf: Hash32,
                          index: int,
                          root: Hash32) -> bool:
     """
-    Verify that the given ``leaf`` is on the merkle branch ``branch``.
+    Verify that the given ``leaf`` is on the merkle branch ``proof``.
     """
     value = leaf
     for i in range(depth):

--- a/eth2/_utils/merkle/normal.py
+++ b/eth2/_utils/merkle/normal.py
@@ -94,20 +94,3 @@ def get_merkle_root(leaves: Sequence[Hash32]) -> Hash32:
     Note: it has to be a full tree, i.e., `len(values)` is an exact power of 2.
     """
     return get_root(calc_merkle_tree_from_leaves(leaves))
-
-
-def verify_merkle_branch(leaf: Hash32,
-                         branch: Sequence[Hash32],
-                         depth: int,
-                         index: int,
-                         root: Hash32) -> bool:
-    """
-    Verify that the given ``leaf`` is on the merkle branch ``branch``.
-    """
-    value = leaf
-    for i in range(depth):
-        if index // (2**i) % 2:
-            value = hash_eth2(branch[i] + value)
-        else:
-            value = hash_eth2(value + branch[i])
-    return value == root

--- a/eth2/_utils/merkle/normal.py
+++ b/eth2/_utils/merkle/normal.py
@@ -94,3 +94,20 @@ def get_merkle_root(leaves: Sequence[Hash32]) -> Hash32:
     Note: it has to be a full tree, i.e., `len(values)` is an exact power of 2.
     """
     return get_root(calc_merkle_tree_from_leaves(leaves))
+
+
+def verify_merkle_branch(leaf: Hash32,
+                         branch: Sequence[Hash32],
+                         depth: int,
+                         index: int,
+                         root: Hash32) -> bool:
+    """
+    Verify that the given ``leaf`` is on the merkle branch ``branch``.
+    """
+    value = leaf
+    for i in range(depth):
+        if index // (2**i) % 2:
+            value = hash_eth2(branch[i] + value)
+        else:
+            value = hash_eth2(value + branch[i])
+    return value == root

--- a/eth2/_utils/merkle/sparse.py
+++ b/eth2/_utils/merkle/sparse.py
@@ -5,10 +5,10 @@ only a single element, the leaves as many as there are data items in the tree. T
 not considered to be part of the tree.
 """
 
-from typing import (  # noqa: F401
+from typing import (
     Sequence,
-    Tuple,
     Union,
+    TYPE_CHECKING,
 )
 
 from cytoolz import (
@@ -33,6 +33,8 @@ from .common import (  # noqa: F401
     MerkleProof,
 )
 
+if TYPE_CHECKING:
+    from typing import Tuple  # noqa: F401
 
 TreeDepth = 32
 EmptyNodeHashes = tuple(

--- a/eth2/_utils/merkle/sparse.py
+++ b/eth2/_utils/merkle/sparse.py
@@ -7,7 +7,6 @@ not considered to be part of the tree.
 
 from typing import (
     Sequence,
-    Tuple,
     Union,
 )
 

--- a/eth2/_utils/merkle/sparse.py
+++ b/eth2/_utils/merkle/sparse.py
@@ -5,8 +5,9 @@ only a single element, the leaves as many as there are data items in the tree. T
 not considered to be part of the tree.
 """
 
-from typing import (
+from typing import (  # noqa: F401
     Sequence,
+    Tuple,
     Union,
 )
 

--- a/eth2/beacon/constants.py
+++ b/eth2/beacon/constants.py
@@ -5,7 +5,8 @@ from eth_typing import (
     BLSSignature,
 )
 from eth2.beacon.typing import (
-    Epoch
+    Epoch,
+    Timestamp,
 )
 
 
@@ -14,6 +15,8 @@ GWEI_PER_ETH = 10**9
 FAR_FUTURE_EPOCH = Epoch(2**64 - 1)
 
 GENESIS_PARENT_ROOT = ZERO_HASH32
+
+ZERO_TIMESTAMP = Timestamp(0)
 
 #
 # shuffle function

--- a/eth2/beacon/on_genesis.py
+++ b/eth2/beacon/on_genesis.py
@@ -62,7 +62,7 @@ def get_genesis_block(genesis_state_root: Hash32,
 def get_genesis_beacon_state(*,
                              genesis_validator_deposits: Sequence[Deposit],
                              genesis_time: Timestamp,
-                             latest_eth1_data: Eth1Data,
+                             genesis_eth1_data: Eth1Data,
                              genesis_slot: Slot,
                              genesis_epoch: Epoch,
                              genesis_fork_version: int,
@@ -75,7 +75,8 @@ def get_genesis_beacon_state(*,
                              max_deposit_amount: Gwei,
                              latest_slashed_exit_length: int,
                              latest_randao_mixes_length: int,
-                             activation_exit_delay: int) -> BeaconState:
+                             activation_exit_delay: int,
+                             deposit_contract_tree_depth: int) -> BeaconState:
     state = BeaconState(
         # Misc
         slot=genesis_slot,
@@ -118,20 +119,18 @@ def get_genesis_beacon_state(*,
         batched_block_roots=(),
 
         # Ethereum 1.0 chain data
-        latest_eth1_data=latest_eth1_data,
+        latest_eth1_data=genesis_eth1_data,
         eth1_data_votes=(),
-        deposit_index=len(genesis_validator_deposits),
+        deposit_index=0,
     )
 
     # Process genesis deposits
     for deposit in genesis_validator_deposits:
         state = process_deposit(
             state=state,
-            pubkey=deposit.deposit_data.deposit_input.pubkey,
-            amount=deposit.deposit_data.amount,
-            proof_of_possession=deposit.deposit_data.deposit_input.proof_of_possession,
-            withdrawal_credentials=deposit.deposit_data.deposit_input.withdrawal_credentials,
+            deposit=deposit,
             slots_per_epoch=slots_per_epoch,
+            deposit_contract_tree_depth=deposit_contract_tree_depth,
         )
 
     # Process genesis activations

--- a/eth2/beacon/state_machines/forks/serenity/block_validation.py
+++ b/eth2/beacon/state_machines/forks/serenity/block_validation.py
@@ -58,6 +58,7 @@ from eth2.beacon.types.slashable_attestations import SlashableAttestation
 from eth2.beacon.types.proposer_slashings import ProposerSlashing
 from eth2.beacon.types.states import BeaconState
 from eth2.beacon.types.voluntary_exits import VoluntaryExit
+from eth2.beacon.types.validator_records import ValidatorRecord
 from eth2.beacon.typing import (
     Bitfield,
     Epoch,
@@ -68,9 +69,6 @@ from eth2.beacon.typing import (
 from eth2.beacon.validation import (
     validate_bitfield,
 )
-
-if TYPE_CHECKING:
-    from eth2.beacon.types.validator_records import ValidatorRecord  # noqa: F401
 
 
 #

--- a/eth2/beacon/state_machines/forks/serenity/block_validation.py
+++ b/eth2/beacon/state_machines/forks/serenity/block_validation.py
@@ -15,7 +15,6 @@ from eth_utils import (
     to_tuple,
     ValidationError,
 )
-import ssz
 
 from eth.constants import (
     ZERO_HASH32,
@@ -24,12 +23,6 @@ from eth.constants import (
 from py_ecc import bls
 from eth2._utils import (
     bitfield,
-)
-from eth2._utils.merkle import (
-    verify_merkle_branch,
-)
-from eth2.beacon._utils import (
-    hash_eth2,
 )
 from eth2.beacon.committee_helpers import (
     get_beacon_proposer_index,
@@ -805,35 +798,4 @@ def validate_voluntary_exit_signature(state: 'BeaconState',
             f"Invalid VoluntaryExit signature, validator_index={voluntary_exit.validator_index}, "
             f"pubkey={validator.pubkey}, message_hash={voluntary_exit.signed_root},"
             f"signature={voluntary_exit.signature}, domain={domain}"
-        )
-
-
-#
-# Deposits
-#
-def validate_deposit(state: BeaconState,
-                     deposit: Deposit,
-                     deposit_contract_tree_depth: int):
-    if deposit.index != state.deposit_index:
-        raise ValidationError(
-            f"deposit.index ({deposit.index}) is not equal to "
-            f"state.deposit_index ({state.deposit_index})"
-        )
-
-    serialized_deposit_data = ssz.encode(deposit.deposit_data)
-    leaf = hash_eth2(serialized_deposit_data)
-    is_valid_branch = verify_merkle_branch(
-        leaf,
-        deposit.branch,
-        deposit_contract_tree_depth,
-        deposit.index,
-        state.latest_eth1_data.deposit_root,
-    )
-    if not is_valid_branch:
-        raise ValidationError(
-            f"deposit.branch ({deposit.branch}) is invalid against "
-            f"leaf={leaf}, "
-            f"deposit_contract_tree_depth={deposit_contract_tree_depth}, "
-            f"deposit.index={deposit.index} "
-            f"state.latest_eth1_data.deposit_root={state.latest_eth1_data.deposit_root}"
         )

--- a/eth2/beacon/state_machines/forks/serenity/block_validation.py
+++ b/eth2/beacon/state_machines/forks/serenity/block_validation.py
@@ -46,19 +46,18 @@ from eth2.beacon.helpers import (
     is_surround_vote,
     slot_to_epoch,
 )
-from eth2.beacon.types.attestations import Attestation  # noqa: F401
-from eth2.beacon.types.attestation_data import AttestationData  # noqa: F401
+from eth2.beacon.types.attestations import Attestation
+from eth2.beacon.types.attestation_data import AttestationData
 from eth2.beacon.types.attestation_data_and_custody_bits import AttestationDataAndCustodyBit
-from eth2.beacon.types.attester_slashings import AttesterSlashing  # noqa: F401
-from eth2.beacon.types.blocks import BaseBeaconBlock  # noqa: F401
+from eth2.beacon.types.attester_slashings import AttesterSlashing
+from eth2.beacon.types.blocks import BaseBeaconBlock
 from eth2.beacon.types.crosslink_records import CrosslinkRecord
-from eth2.beacon.types.deposits import Deposit  # noqa: F401
-from eth2.beacon.types.forks import Fork  # noqa: F401
+from eth2.beacon.types.forks import Fork
 from eth2.beacon.types.proposal import Proposal
-from eth2.beacon.types.slashable_attestations import SlashableAttestation  # noqa: F401
+from eth2.beacon.types.slashable_attestations import SlashableAttestation
 from eth2.beacon.types.proposer_slashings import ProposerSlashing
-from eth2.beacon.types.states import BeaconState  # noqa: F401
-from eth2.beacon.types.voluntary_exits import VoluntaryExit  # noqa: F401
+from eth2.beacon.types.states import BeaconState
+from eth2.beacon.types.voluntary_exits import VoluntaryExit
 from eth2.beacon.typing import (
     Bitfield,
     Epoch,
@@ -481,7 +480,7 @@ def validate_attestation_crosslink_data_root(attestation_data: AttestationData) 
 
 
 @to_tuple
-def get_pubkey_for_indices(validators: Sequence['ValidatorRecord'],
+def get_pubkey_for_indices(validators: Sequence[ValidatorRecord],
                            indices: Sequence[ValidatorIndex]) -> Iterable[BLSPubkey]:
     for index in indices:
         yield validators[index].pubkey
@@ -489,7 +488,7 @@ def get_pubkey_for_indices(validators: Sequence['ValidatorRecord'],
 
 @to_tuple
 def generate_aggregate_pubkeys_from_indices(
-        validators: Sequence['ValidatorRecord'],
+        validators: Sequence[ValidatorRecord],
         *indices: Sequence[Sequence['ValidatorIndex']]) -> Iterable[BLSPubkey]:
     get_pubkeys = functools.partial(get_pubkey_for_indices, validators)
     return map(
@@ -633,8 +632,8 @@ def validate_randao_reveal(randao_reveal: BLSSignature,
 #
 # Slashable attestation validation
 #
-def verify_slashable_attestation_signature(state: 'BeaconState',
-                                           slashable_attestation: 'SlashableAttestation',
+def verify_slashable_attestation_signature(state: BeaconState,
+                                           slashable_attestation: SlashableAttestation,
                                            slots_per_epoch: int) -> bool:
     """
     Ensure we have a valid aggregate signature for the ``slashable_attestation``.
@@ -669,8 +668,8 @@ def verify_slashable_attestation_signature(state: 'BeaconState',
     )
 
 
-def validate_slashable_attestation(state: 'BeaconState',
-                                   slashable_attestation: 'SlashableAttestation',
+def validate_slashable_attestation(state: BeaconState,
+                                   slashable_attestation: SlashableAttestation,
                                    max_indices_per_slashable_vote: int,
                                    slots_per_epoch: int) -> None:
     """
@@ -714,8 +713,8 @@ def validate_slashable_attestation(state: 'BeaconState',
 #
 # Voluntary Exit
 #
-def validate_voluntary_exit(state: 'BeaconState',
-                            voluntary_exit: 'VoluntaryExit',
+def validate_voluntary_exit(state: BeaconState,
+                            voluntary_exit: VoluntaryExit,
                             slots_per_epoch: int,
                             persistent_committee_period: int) -> None:
     validator = state.validator_registry[voluntary_exit.validator_index]
@@ -732,7 +731,7 @@ def validate_voluntary_exit(state: 'BeaconState',
     validate_voluntary_exit_signature(state, voluntary_exit, validator)
 
 
-def validate_voluntary_exit_validator_exit_epoch(validator: 'ValidatorRecord') -> None:
+def validate_voluntary_exit_validator_exit_epoch(validator: ValidatorRecord) -> None:
     """
     Verify the validator has not yet exited.
     """
@@ -743,7 +742,7 @@ def validate_voluntary_exit_validator_exit_epoch(validator: 'ValidatorRecord') -
         )
 
 
-def validate_voluntary_exit_initiated_exit(validator: 'ValidatorRecord') -> None:
+def validate_voluntary_exit_initiated_exit(validator: ValidatorRecord) -> None:
     """
     Verify the validator has not initiated an exit.
     """
@@ -753,7 +752,7 @@ def validate_voluntary_exit_initiated_exit(validator: 'ValidatorRecord') -> None
         )
 
 
-def validate_voluntary_exit_epoch(voluntary_exit: 'VoluntaryExit',
+def validate_voluntary_exit_epoch(voluntary_exit: VoluntaryExit,
                                   current_epoch: Epoch) -> None:
     """
     Exits must specify an epoch when they become valid; they are not valid before then.
@@ -765,7 +764,7 @@ def validate_voluntary_exit_epoch(voluntary_exit: 'VoluntaryExit',
         )
 
 
-def validate_voluntary_exit_persistent(validator: 'ValidatorRecord',
+def validate_voluntary_exit_persistent(validator: ValidatorRecord,
                                        current_epoch: Epoch,
                                        persistent_committee_period: int) -> None:
     """
@@ -779,9 +778,9 @@ def validate_voluntary_exit_persistent(validator: 'ValidatorRecord',
         )
 
 
-def validate_voluntary_exit_signature(state: 'BeaconState',
-                                      voluntary_exit: 'VoluntaryExit',
-                                      validator: 'ValidatorRecord') -> None:
+def validate_voluntary_exit_signature(state: BeaconState,
+                                      voluntary_exit: VoluntaryExit,
+                                      validator: ValidatorRecord) -> None:
     """
     Verify signature.
     """

--- a/eth2/beacon/state_machines/forks/serenity/operation_processing.py
+++ b/eth2/beacon/state_machines/forks/serenity/operation_processing.py
@@ -31,7 +31,6 @@ from eth2.beacon.deposit_helpers import (
 from .block_validation import (
     validate_attestation,
     validate_attester_slashing,
-    validate_deposit,
     validate_proposer_slashing,
     validate_slashable_indices,
     validate_voluntary_exit,
@@ -207,13 +206,13 @@ def process_deposits(state: BeaconState,
             f"\tFound {len(block.body.deposits)} deposits, "
             f"maximum: {config.MAX_DEPOSITS}"
         )
+
     for deposit in block.body.deposits:
-        validate_deposit(state, deposit, deposit_contract_tree_depth)
-        process_deposit(
+        state = process_deposit(
             state,
-            pubkey,
-            amount,
-            proof_of_possession,
-            withdrawal_credentials,
+            deposit,
             slots_per_epoch=config.SLOTS_PER_EPOCH,
+            deposit_contract_tree_depth=config.DEPOSIT_CONTRACT_TREE_DEPTH,
         )
+
+    return state

--- a/eth2/beacon/state_machines/forks/serenity/state_transitions.py
+++ b/eth2/beacon/state_machines/forks/serenity/state_transitions.py
@@ -31,6 +31,7 @@ from .epoch_processing import (
 from .operation_processing import (
     process_attestations,
     process_attester_slashings,
+    process_deposits,
     process_proposer_slashings,
     process_voluntary_exits,
 )
@@ -104,7 +105,7 @@ class SerenityStateTransition(BaseStateTransition):
         state = process_proposer_slashings(state, block, self.config)
         state = process_attester_slashings(state, block, self.config)
         state = process_attestations(state, block, self.config)
-        # TODO: state = process_deposits(state, block, self.config)
+        state = process_deposits(state, block, self.config)
         state = process_voluntary_exits(state, block, self.config)
         # TODO: state = process_transfers(state, block, self.config)
 

--- a/eth2/beacon/tools/builder/initializer.py
+++ b/eth2/beacon/tools/builder/initializer.py
@@ -9,7 +9,22 @@ from eth_typing import (
     BLSPubkey,
     Hash32,
 )
+import ssz
 
+from eth.constants import (
+    ZERO_HASH32,
+)
+
+from eth2._utils.merkle.common import (
+    get_merkle_proof,
+)
+from eth2._utils.merkle.sparse import (
+    calc_merkle_tree_from_leaves,
+    get_merkle_root,
+)
+from eth2.beacon._utils.hash import (
+    hash_eth2,
+)
 from eth2.beacon.configs import BeaconConfig
 from eth2.beacon.on_genesis import (
     get_genesis_block,
@@ -19,64 +34,62 @@ from eth2.beacon.types.blocks import (
     BaseBeaconBlock,
 )
 from eth2.beacon.types.deposits import Deposit
-from eth2.beacon.types.deposit_data import DepositData
-from eth2.beacon.types.deposit_input import DepositInput
+from eth2.beacon.types.deposit_data import DepositData  # noqa: F401
 from eth2.beacon.types.eth1_data import Eth1Data
 from eth2.beacon.types.forks import Fork
 from eth2.beacon.types.states import BeaconState
 from eth2.beacon.typing import (
     Timestamp,
+    ValidatorIndex,
 )
 
 from eth2.beacon.tools.builder.validator import (
-    sign_proof_of_possession,
+    create_mock_deposit_data,
 )
 
 
-def create_mock_genesis_validator_deposits(
+def create_mock_genesis_validator_deposits_and_root(
         num_validators: int,
         config: BeaconConfig,
         pubkeys: Sequence[BLSPubkey],
-        keymap: Dict[BLSPubkey, int]) -> Tuple[Deposit, ...]:
+        keymap: Dict[BLSPubkey, int]) -> Tuple[Tuple[Deposit, ...], Hash32]:
     # Mock data
     withdrawal_credentials = Hash32(b'\x22' * 32)
-    deposit_timestamp = Timestamp(0)
     fork = Fork(
         previous_version=config.GENESIS_FORK_VERSION.to_bytes(4, 'little'),
         current_version=config.GENESIS_FORK_VERSION.to_bytes(4, 'little'),
         epoch=config.GENESIS_EPOCH,
     )
 
+    deposit_data_array = tuple()  # type: Tuple[DepositData, ...]
+    deposit_data_leaves = tuple()  # type: Tuple[Hash32, ...]
+
+    for i in range(num_validators):
+        deposit_data = create_mock_deposit_data(
+            config=config,
+            pubkeys=pubkeys,
+            keymap=keymap,
+            validator_index=ValidatorIndex(i),
+            withdrawal_credentials=withdrawal_credentials,
+            fork=fork,
+        )
+        item = hash_eth2(ssz.encode(deposit_data))
+        deposit_data_leaves += (item,)
+        deposit_data_array += (deposit_data,)
+
+    tree = calc_merkle_tree_from_leaves(deposit_data_leaves)
+    root = get_merkle_root(deposit_data_leaves)
+
     genesis_validator_deposits = tuple(
         Deposit(
-            branch=tuple(
-                Hash32(b'\x11' * 32)
-                for j in range(10)
-            ),
+            proof=get_merkle_proof(tree, item_index=i),
             index=i,
-            deposit_data=DepositData(
-                deposit_input=DepositInput(
-                    pubkey=pubkeys[i],
-                    withdrawal_credentials=withdrawal_credentials,
-                    proof_of_possession=sign_proof_of_possession(
-                        deposit_input=DepositInput(
-                            pubkey=pubkeys[i],
-                            withdrawal_credentials=withdrawal_credentials,
-                        ),
-                        privkey=keymap[pubkeys[i]],
-                        fork=fork,
-                        slot=config.GENESIS_SLOT,
-                        slots_per_epoch=config.SLOTS_PER_EPOCH,
-                    ),
-                ),
-                amount=config.MAX_DEPOSIT_AMOUNT,
-                timestamp=deposit_timestamp,
-            ),
+            deposit_data=deposit_data_array[i],
         )
         for i in range(num_validators)
     )
 
-    return genesis_validator_deposits
+    return genesis_validator_deposits, root
 
 
 ZERO_TIMESTAMP = Timestamp(0)
@@ -88,22 +101,26 @@ def create_mock_genesis(
         keymap: Dict[BLSPubkey, int],
         genesis_block_class: Type[BaseBeaconBlock],
         genesis_time: Timestamp=ZERO_TIMESTAMP) -> Tuple[BeaconState, BaseBeaconBlock]:
-    latest_eth1_data = Eth1Data.create_empty_data()
-
     assert num_validators <= len(keymap)
 
     pubkeys = list(keymap)[:num_validators]
 
-    genesis_validator_deposits = create_mock_genesis_validator_deposits(
+    genesis_validator_deposits, deposit_root = create_mock_genesis_validator_deposits_and_root(
         num_validators=num_validators,
         config=config,
         pubkeys=pubkeys,
         keymap=keymap,
     )
+
+    genesis_eth1_data = Eth1Data(
+        deposit_root=deposit_root,
+        block_hash=ZERO_HASH32,
+    )
+
     state = get_genesis_beacon_state(
         genesis_validator_deposits=genesis_validator_deposits,
         genesis_time=genesis_time,
-        latest_eth1_data=latest_eth1_data,
+        genesis_eth1_data=genesis_eth1_data,
         genesis_slot=config.GENESIS_SLOT,
         genesis_epoch=config.GENESIS_EPOCH,
         genesis_fork_version=config.GENESIS_FORK_VERSION,
@@ -117,6 +134,7 @@ def create_mock_genesis(
         latest_slashed_exit_length=config.LATEST_SLASHED_EXIT_LENGTH,
         latest_randao_mixes_length=config.LATEST_RANDAO_MIXES_LENGTH,
         activation_exit_delay=config.ACTIVATION_EXIT_DELAY,
+        deposit_contract_tree_depth=config.DEPOSIT_CONTRACT_TREE_DEPTH,
     )
 
     block = get_genesis_block(

--- a/eth2/beacon/tools/builder/initializer.py
+++ b/eth2/beacon/tools/builder/initializer.py
@@ -26,6 +26,9 @@ from eth2.beacon._utils.hash import (
     hash_eth2,
 )
 from eth2.beacon.configs import BeaconConfig
+from eth2.beacon.constants import (
+    ZERO_TIMESTAMP,
+)
 from eth2.beacon.on_genesis import (
     get_genesis_block,
     get_genesis_beacon_state,
@@ -90,9 +93,6 @@ def create_mock_genesis_validator_deposits_and_root(
     )
 
     return genesis_validator_deposits, root
-
-
-ZERO_TIMESTAMP = Timestamp(0)
 
 
 def create_mock_genesis(

--- a/eth2/beacon/tools/builder/validator.py
+++ b/eth2/beacon/tools/builder/validator.py
@@ -68,6 +68,7 @@ from eth2.beacon.typing import (
     Bitfield,
     CommitteeIndex,
     Epoch,
+    Gwei,
     Shard,
     Slot,
     Timestamp,
@@ -558,7 +559,11 @@ def create_deposit_data(*,
                         privkey: int,
                         withdrawal_credentials: Hash32,
                         fork: Fork,
-                        deposit_timestamp: Timestamp) -> DepositData:
+                        deposit_timestamp: Timestamp,
+                        amount: Gwei=None) -> DepositData:
+    if amount is None:
+        amount = config.MAX_DEPOSIT_AMOUNT
+
     return DepositData(
         deposit_input=DepositInput(
             pubkey=pubkey,
@@ -574,9 +579,12 @@ def create_deposit_data(*,
                 slots_per_epoch=config.SLOTS_PER_EPOCH,
             ),
         ),
-        amount=config.MAX_DEPOSIT_AMOUNT,
+        amount=amount,
         timestamp=deposit_timestamp,
     )
+
+
+ZERO_TIMESTAMP = Timestamp(0)
 
 
 def create_mock_deposit_data(*,
@@ -586,7 +594,7 @@ def create_mock_deposit_data(*,
                              validator_index: ValidatorIndex,
                              withdrawal_credentials: Hash32,
                              fork: Fork,
-                             deposit_timestamp: Timestamp=Timestamp(0)) -> DepositData:
+                             deposit_timestamp: Timestamp=ZERO_TIMESTAMP) -> DepositData:
     if deposit_timestamp is None:
         deposit_timestamp = Timestamp(int(time.time()))
 
@@ -598,30 +606,6 @@ def create_mock_deposit_data(*,
         fork=fork,
         deposit_timestamp=deposit_timestamp,
     )
-
-
-# def create_mock_deposit(*,
-#                         config: BeaconConfig,
-#                         pubkeys: Sequence[BLSPubkey],
-#                         keymap: Dict[BLSPubkey, int],
-#                         validator_index: ValidatorIndex,
-#                         deposit_index: int,
-#                         withdrawal_credentials: Hash32,
-#                         fork: Fork,
-#                         proof: Sequence[Hash32]=None,
-#                         deposit_timestamp: Timestamp=0,
-#                         ):
-#     if branch is None:
-#         branch = tuple(
-#             Hash32(b'\x11' * 32)
-#             for j in range(32)
-#         )
-
-#     return Deposit(
-#         branch=branch,
-#         index=deposit_index,
-#         deposit_data=deposit_data,
-#     )
 
 
 #

--- a/eth2/beacon/tools/builder/validator.py
+++ b/eth2/beacon/tools/builder/validator.py
@@ -30,6 +30,10 @@ from eth2._utils.bitfield import (
     set_voted,
 )
 from py_ecc import bls
+
+from eth2.beacon.constants import (
+    ZERO_TIMESTAMP,
+)
 from eth2.beacon.enums import (
     SignatureDomain,
 )
@@ -582,9 +586,6 @@ def create_deposit_data(*,
         amount=amount,
         timestamp=deposit_timestamp,
     )
-
-
-ZERO_TIMESTAMP = Timestamp(0)
 
 
 def create_mock_deposit_data(*,

--- a/eth2/beacon/types/deposit_input.py
+++ b/eth2/beacon/types/deposit_input.py
@@ -36,9 +36,19 @@ class DepositInput(ssz.Serializable):
         )
 
     _root = None
+    _signed_root = None
 
     @property
     def root(self) -> Hash32:
         if self._root is None:
             self._root = hash_eth2(ssz.encode(self))
         return self._root
+
+    @property
+    def signed_root(self) -> Hash32:
+        # TODO: Use SSZ built-in function
+        if self._signed_root is None:
+            self._signed_root = hash_eth2(
+                ssz.encode(self.copy(proof_of_possession=EMPTY_SIGNATURE))
+            )
+        return self._signed_root

--- a/eth2/beacon/types/deposits.py
+++ b/eth2/beacon/types/deposits.py
@@ -24,7 +24,7 @@ class Deposit(ssz.Serializable):
 
     fields = [
         # Merkle branch in the deposit tree
-        ('branch', List(bytes32)),
+        ('proof', List(bytes32)),
         # Index in the deposit tree
         ('index', uint64),
         # Deposit data
@@ -32,11 +32,11 @@ class Deposit(ssz.Serializable):
     ]
 
     def __init__(self,
-                 branch: Sequence[Hash32],
+                 proof: Sequence[Hash32],
                  index: int,
                  deposit_data: DepositData)-> None:
         super().__init__(
-            branch,
+            proof,
             index,
             deposit_data,
         )

--- a/tests/eth2/beacon/conftest.py
+++ b/tests/eth2/beacon/conftest.py
@@ -230,7 +230,7 @@ def sample_deposit_data_params(sample_deposit_input_params):
 @pytest.fixture
 def sample_deposit_params(sample_deposit_data_params):
     return {
-        'branch': (),
+        'proof': (),
         'index': 5,
         'deposit_data': DepositData(**sample_deposit_data_params)
     }

--- a/tests/eth2/beacon/state_machines/forks/test_serenity_block_voluntary_exit_validation.py
+++ b/tests/eth2/beacon/state_machines/forks/test_serenity_block_voluntary_exit_validation.py
@@ -1,4 +1,3 @@
-
 import pytest
 
 from eth_utils import (

--- a/tests/eth2/beacon/test_deposit_helpers.py
+++ b/tests/eth2/beacon/test_deposit_helpers.py
@@ -1,20 +1,27 @@
-import pytest
+import ssz
 
-from eth_utils import (
-    ValidationError,
+from eth2._utils.merkle.common import (
+    get_merkle_proof,
+)
+from eth2._utils.merkle.sparse import (
+    calc_merkle_tree_from_leaves,
+    get_merkle_root,
+)
+from eth2.beacon._utils.hash import (
+    hash_eth2,
 )
 
 from eth2.beacon.deposit_helpers import (
     add_pending_validator,
     process_deposit,
-    validate_proof_of_possession,
 )
+from eth2.beacon.types.forks import Fork
 from eth2.beacon.types.states import BeaconState
 from eth2.beacon.types.validator_records import ValidatorRecord
-from eth2.beacon.types.deposit_input import DepositInput
+from eth2.beacon.types.deposits import Deposit
 
 from eth2.beacon.tools.builder.validator import (
-    sign_proof_of_possession,
+    create_mock_deposit_data,
 )
 
 
@@ -40,60 +47,11 @@ def test_add_pending_validator(sample_beacon_state_params,
     assert state.validator_registry[-1] == validator
 
 
-@pytest.mark.parametrize(
-    "expected",
-    (
-        (True),
-        (ValidationError),
-    ),
-)
-def test_validate_proof_of_possession(
-        slots_per_epoch,
-        sample_beacon_state_params,
-        pubkeys,
-        privkeys,
-        expected):
-    state = BeaconState(**sample_beacon_state_params)
-
-    privkey = privkeys[0]
-    pubkey = pubkeys[0]
-    withdrawal_credentials = b'\x34' * 32
-
-    deposit_input = DepositInput(
-        pubkey=pubkey,
-        withdrawal_credentials=withdrawal_credentials,
-    )
-    if expected is True:
-        proof_of_possession = sign_proof_of_possession(
-            deposit_input,
-            privkey,
-            state.fork,
-            state.slot,
-            slots_per_epoch,
-        )
-
-        validate_proof_of_possession(
-            state=state,
-            pubkey=pubkey,
-            proof_of_possession=proof_of_possession,
-            withdrawal_credentials=withdrawal_credentials,
-            slots_per_epoch=slots_per_epoch,
-        )
-    else:
-        proof_of_possession = b'\x11' * 96
-        with pytest.raises(ValidationError):
-            validate_proof_of_possession(
-                state=state,
-                pubkey=pubkey,
-                proof_of_possession=proof_of_possession,
-                withdrawal_credentials=withdrawal_credentials,
-                slots_per_epoch=slots_per_epoch,
-            )
-
-
-def test_process_deposit(slots_per_epoch,
+def test_process_deposit(config,
+                         slots_per_epoch,
+                         deposit_contract_tree_depth,
                          sample_beacon_state_params,
-                         privkeys,
+                         keymap,
                          pubkeys,
                          max_deposit_amount):
     state = BeaconState(**sample_beacon_state_params).copy(
@@ -101,62 +59,54 @@ def test_process_deposit(slots_per_epoch,
         validator_registry=(),
     )
 
-    privkey_1 = privkeys[0]
+    validator_index = 0
     pubkey_1 = pubkeys[0]
     amount = max_deposit_amount
     withdrawal_credentials = b'\x34' * 32
-
-    deposit_input = DepositInput(
-        pubkey=pubkey_1,
-        withdrawal_credentials=withdrawal_credentials,
+    fork = Fork(
+        previous_version=config.GENESIS_FORK_VERSION.to_bytes(4, 'little'),
+        current_version=config.GENESIS_FORK_VERSION.to_bytes(4, 'little'),
+        epoch=config.GENESIS_EPOCH,
     )
-    proof_of_possession = sign_proof_of_possession(
-        deposit_input,
-        privkey_1,
-        state.fork,
-        state.slot,
-        slots_per_epoch,
+    deposit_data = create_mock_deposit_data(
+        config=config,
+        pubkeys=pubkeys,
+        keymap=keymap,
+        validator_index=validator_index,
+        withdrawal_credentials=withdrawal_credentials,
+        fork=fork,
+    )
+
+    item = hash_eth2(ssz.encode(deposit_data))
+    test_deposit_data_leaves = (item,)
+    tree = calc_merkle_tree_from_leaves(test_deposit_data_leaves)
+    root = get_merkle_root(test_deposit_data_leaves)
+    proof = list(get_merkle_proof(tree, item_index=validator_index))
+
+    state = state.copy(
+        latest_eth1_data=state.latest_eth1_data.copy(
+            deposit_root=root,
+        ),
+    )
+
+    deposit = Deposit(
+        proof=proof,
+        index=validator_index,
+        deposit_data=deposit_data,
     )
 
     # Add the first validator
     result_state = process_deposit(
         state=state,
-        pubkey=pubkey_1,
-        amount=amount,
-        proof_of_possession=proof_of_possession,
-        withdrawal_credentials=withdrawal_credentials,
+        deposit=deposit,
         slots_per_epoch=slots_per_epoch,
+        deposit_contract_tree_depth=deposit_contract_tree_depth,
     )
 
     assert len(result_state.validator_registry) == 1
-    index = 0
-    assert result_state.validator_registry[0].pubkey == pubkey_1
-    assert result_state.validator_registry[index].withdrawal_credentials == withdrawal_credentials
-    assert result_state.validator_balances[index] == amount
+    validator = result_state.validator_registry[validator_index]
+    assert validator.pubkey == pubkey_1
+    assert validator.withdrawal_credentials == withdrawal_credentials
+    assert result_state.validator_balances[validator_index] == amount
     # test immutable
     assert len(state.validator_registry) == 0
-
-    # Add the second validator
-    privkey_2 = privkeys[1]
-    pubkey_2 = pubkeys[1]
-    deposit_input = DepositInput(
-        pubkey=pubkey_2,
-        withdrawal_credentials=withdrawal_credentials,
-    )
-    proof_of_possession = sign_proof_of_possession(
-        deposit_input,
-        privkey_2,
-        state.fork,
-        state.slot,
-        slots_per_epoch,
-    )
-    result_state = process_deposit(
-        state=result_state,
-        pubkey=pubkey_2,
-        amount=amount,
-        proof_of_possession=proof_of_possession,
-        withdrawal_credentials=withdrawal_credentials,
-        slots_per_epoch=slots_per_epoch,
-    )
-    assert len(result_state.validator_registry) == 2
-    assert result_state.validator_registry[1].pubkey == pubkey_2

--- a/tests/eth2/beacon/test_deposit_helpers.py
+++ b/tests/eth2/beacon/test_deposit_helpers.py
@@ -1,3 +1,9 @@
+import pytest
+
+from eth_utils import (
+    ValidationError,
+)
+
 import ssz
 
 from eth2._utils.merkle.common import (
@@ -14,6 +20,8 @@ from eth2.beacon._utils.hash import (
 from eth2.beacon.deposit_helpers import (
     add_pending_validator,
     process_deposit,
+    validate_deposit_order,
+    validate_deposit_proof,
 )
 from eth2.beacon.types.forks import Fork
 from eth2.beacon.types.states import BeaconState
@@ -25,44 +33,16 @@ from eth2.beacon.tools.builder.validator import (
 )
 
 
-def test_add_pending_validator(sample_beacon_state_params,
-                               sample_validator_record_params):
-
-    validator_registry_len = 2
-    state = BeaconState(**sample_beacon_state_params).copy(
-        validator_registry=[
-            ValidatorRecord(**sample_validator_record_params)
-            for _ in range(validator_registry_len)
-        ],
-        validator_balances=(100,) * validator_registry_len,
-    )
-    validator = ValidatorRecord(**sample_validator_record_params)
-    amount = 5566
-    state = add_pending_validator(
-        state,
-        validator,
-        amount,
-    )
-
-    assert state.validator_registry[-1] == validator
-
-
-def test_process_deposit(config,
-                         slots_per_epoch,
-                         deposit_contract_tree_depth,
-                         sample_beacon_state_params,
-                         keymap,
-                         pubkeys,
-                         max_deposit_amount):
+def create_mock_deposit(config,
+                        sample_beacon_state_params,
+                        keymap,
+                        pubkeys,
+                        withdrawal_credentials,
+                        validator_index):
     state = BeaconState(**sample_beacon_state_params).copy(
         slot=1,
         validator_registry=(),
     )
-
-    validator_index = 0
-    pubkey_1 = pubkeys[0]
-    amount = max_deposit_amount
-    withdrawal_credentials = b'\x34' * 32
     fork = Fork(
         previous_version=config.GENESIS_FORK_VERSION.to_bytes(4, 'little'),
         current_version=config.GENESIS_FORK_VERSION.to_bytes(4, 'little'),
@@ -95,18 +75,134 @@ def test_process_deposit(config,
         deposit_data=deposit_data,
     )
 
+    return state, deposit
+
+
+def test_add_pending_validator(sample_beacon_state_params,
+                               sample_validator_record_params):
+
+    validator_registry_len = 2
+    state = BeaconState(**sample_beacon_state_params).copy(
+        validator_registry=[
+            ValidatorRecord(**sample_validator_record_params)
+            for _ in range(validator_registry_len)
+        ],
+        validator_balances=(100,) * validator_registry_len,
+    )
+    validator = ValidatorRecord(**sample_validator_record_params)
+    amount = 5566
+    state = add_pending_validator(
+        state,
+        validator,
+        amount,
+    )
+
+    assert state.validator_registry[-1] == validator
+
+
+@pytest.mark.parametrize(
+    (
+        'deposit_index',
+        'success',
+    ),
+    [
+        (0, True),
+        (1, False),
+    ]
+)
+def test_validate_deposit_order(config,
+                                sample_beacon_state_params,
+                                keymap,
+                                pubkeys,
+                                deposit_index,
+                                success):
+    validator_index = 0
+    withdrawal_credentials = b'\x34' * 32
+    state, deposit = create_mock_deposit(
+        config,
+        sample_beacon_state_params,
+        keymap,
+        pubkeys,
+        withdrawal_credentials,
+        validator_index,
+    )
+    deposit = deposit.copy(
+        index=deposit_index,
+    )
+
+    if success:
+        validate_deposit_order(state, deposit)
+    else:
+        with pytest.raises(ValidationError):
+            validate_deposit_order(state, deposit)
+
+
+@pytest.mark.parametrize(
+    (
+        'deposit_index',
+        'success',
+    ),
+    [
+        (0, True),
+        (1, False),
+    ]
+)
+def test_validate_deposit_proof(config,
+                                sample_beacon_state_params,
+                                keymap,
+                                pubkeys,
+                                deposit_contract_tree_depth,
+                                deposit_index,
+                                success):
+    validator_index = 0
+    withdrawal_credentials = b'\x34' * 32
+    state, deposit = create_mock_deposit(
+        config,
+        sample_beacon_state_params,
+        keymap,
+        pubkeys,
+        withdrawal_credentials,
+        validator_index,
+    )
+    deposit = deposit.copy(
+        index=deposit_index,
+    )
+
+    if success:
+        validate_deposit_proof(state, deposit, deposit_contract_tree_depth)
+    else:
+        with pytest.raises(ValidationError):
+            validate_deposit_proof(state, deposit, deposit_contract_tree_depth)
+
+
+def test_process_deposit(config,
+                         deposit_contract_tree_depth,
+                         sample_beacon_state_params,
+                         keymap,
+                         pubkeys):
+    validator_index = 0
+    withdrawal_credentials = b'\x34' * 32
+    state, deposit = create_mock_deposit(
+        config,
+        sample_beacon_state_params,
+        keymap,
+        pubkeys,
+        withdrawal_credentials,
+        validator_index,
+    )
+
     # Add the first validator
     result_state = process_deposit(
         state=state,
         deposit=deposit,
-        slots_per_epoch=slots_per_epoch,
+        slots_per_epoch=config.SLOTS_PER_EPOCH,
         deposit_contract_tree_depth=deposit_contract_tree_depth,
     )
 
     assert len(result_state.validator_registry) == 1
     validator = result_state.validator_registry[validator_index]
-    assert validator.pubkey == pubkey_1
+    assert validator.pubkey == pubkeys[validator_index]
     assert validator.withdrawal_credentials == withdrawal_credentials
-    assert result_state.validator_balances[validator_index] == amount
+    assert result_state.validator_balances[validator_index] == config.MAX_DEPOSIT_AMOUNT
     # test immutable
     assert len(state.validator_registry) == 0

--- a/trinity/config.py
+++ b/trinity/config.py
@@ -103,12 +103,6 @@ ROPSTEN_EIP1085_PATH = ASSETS_DIR / 'eip1085' / 'ropsten.json'
 PRECONFIGURED_NETWORKS = {MAINNET_NETWORK_ID, ROPSTEN_NETWORK_ID}
 
 
-privkeys = tuple(2 ** i for i in range(100))
-keymap = {}
-for k in privkeys:
-    keymap[bls.privtopub(k)] = k
-
-
 def _load_preconfigured_genesis_config(network_id: int) -> Dict[str, Any]:
     if network_id == MAINNET_NETWORK_ID:
         with MAINNET_EIP1085_PATH.open('r') as mainnet_genesis_file:
@@ -625,8 +619,15 @@ class BeaconChainConfig:
     def initialize_chain(self,
                          base_db: BaseAtomicDB) -> 'BeaconChain':
         config = SERENITY_CONFIG
+
+        # Only used for testing
+        num_validators = 10
+        privkeys = tuple(2 ** i for i in range(num_validators))
+        keymap = {}
+        for k in privkeys:
+            keymap[bls.privtopub(k)] = k
         state, block = create_mock_genesis(
-            num_validators=10,
+            num_validators=num_validators,
             config=config,
             keymap=keymap,
             genesis_block_class=SerenityBeaconBlock,


### PR DESCRIPTION
### What was wrong?
Fix #238 


### How was it fixed?
1. Rework `process_deposit` - generalize it to be used in processing genesis and deposit operation.
2. Add `process_deposits`
3. Sync related parameter names:
    - Use `genesis_eth1_data` in `get_genesis_beacon_state`
    - `Deposit.branch` -> `Deposit.proof`
4. Update `trinity/config.py` - use `create_mock_genesis` for chain initialization

#### Cute Animal Picture

![animals-2608662_640](https://user-images.githubusercontent.com/9263930/55056659-adf54580-50a1-11e9-862b-0bbb78c73c9d.jpg)
