### PR TITLE
Fix async beacon chain db

### DIFF
--- a/tests/core/p2p-proto/bcc/helpers.py
+++ b/tests/core/p2p-proto/bcc/helpers.py
@@ -56,6 +56,7 @@ class FakeAsyncBeaconChainDB(BaseAsyncBeaconChainDB, BeaconChainDB):
     coro_get_canonical_block_by_slot = async_passthrough('get_canonical_block_by_slot')
     coro_get_canonical_block_root_by_slot = async_passthrough('get_canonical_block_root_by_slot')
     coro_get_canonical_head = async_passthrough('get_canonical_head')
+    coro_get_finalized_head = async_passthrough('get_finalized_head')
     coro_get_block_by_root = async_passthrough('get_block_by_root')
     coro_get_score = async_passthrough('get_score')
     coro_block_exists = async_passthrough('block_exists')

--- a/tests/core/p2p-proto/bcc/helpers.py
+++ b/tests/core/p2p-proto/bcc/helpers.py
@@ -15,6 +15,7 @@ from eth.constants import (
 from eth.db.atomic import AtomicDB
 
 from eth2.beacon.db.chain import BeaconChainDB
+from trinity.db.beacon.chain import BaseAsyncBeaconChainDB
 from eth2.beacon.types.blocks import (
     BeaconBlock,
     BeaconBlockBody,
@@ -37,6 +38,32 @@ from p2p.tools.paragon.helpers import (
 from eth2.beacon.constants import (
     EMPTY_SIGNATURE,
 )
+from tests.core.integration_test_helpers import (
+    async_passthrough,
+)
+from eth.db.backends.base import (
+    BaseAtomicDB,
+)
+
+
+class FakeAsyncBeaconChainDB(BaseAsyncBeaconChainDB, BeaconChainDB):
+
+    def __init__(self, db: BaseAtomicDB) -> None:
+        self.db = db
+
+    coro_persist_block = async_passthrough('persist_block')
+    coro_get_canonical_block_root = async_passthrough('get_canonical_block_root')
+    coro_get_canonical_block_by_slot = async_passthrough('get_canonical_block_by_slot')
+    coro_get_canonical_block_root_by_slot = async_passthrough('get_canonical_block_root_by_slot')
+    coro_get_canonical_head = async_passthrough('get_canonical_head')
+    coro_get_block_by_root = async_passthrough('get_block_by_root')
+    coro_get_score = async_passthrough('get_score')
+    coro_block_exists = async_passthrough('block_exists')
+    coro_persist_block_chain = async_passthrough('persist_block_chain')
+    coro_get_state_by_root = async_passthrough('get_state_by_root')
+    coro_persist_state = async_passthrough('persist_state')
+    coro_exists = async_passthrough('exists')
+    coro_get = async_passthrough('get')
 
 
 def create_test_block(parent=None, **kwargs):
@@ -74,16 +101,16 @@ def create_branch(length, root=None, **start_kwargs):
         parent = child
 
 
-def get_chain_db(blocks=()):
+async def get_chain_db(blocks=()):
     db = AtomicDB()
-    chain_db = BeaconChainDB(db)
-    chain_db.persist_block_chain(blocks, BeaconBlock)
+    chain_db = FakeAsyncBeaconChainDB(db)
+    await chain_db.coro_persist_block_chain(blocks, BeaconBlock)
     return chain_db
 
 
-def get_genesis_chain_db():
+async def get_genesis_chain_db():
     genesis = create_test_block(slot=0)
-    return get_chain_db((genesis,))
+    return await get_chain_db((genesis,))
 
 
 async def _setup_alice_and_bob_factories(alice_chain_db, bob_chain_db):

--- a/tests/core/p2p-proto/bcc/test_commands.py
+++ b/tests/core/p2p-proto/bcc/test_commands.py
@@ -38,8 +38,8 @@ async def get_command_setup(request, event_loop):
     alice, bob = await get_directly_linked_peers(
         request,
         event_loop,
-        alice_chain_db=get_genesis_chain_db(),
-        bob_chain_db=get_genesis_chain_db(),
+        alice_chain_db=await get_genesis_chain_db(),
+        bob_chain_db=await get_genesis_chain_db(),
     )
     msg_buffer = MsgBuffer()
     bob.add_subscriber(msg_buffer)

--- a/tests/core/p2p-proto/bcc/test_handshake.py
+++ b/tests/core/p2p-proto/bcc/test_handshake.py
@@ -23,8 +23,8 @@ from .helpers import (
 @pytest.mark.asyncio
 async def test_directly_linked_peers_without_handshake():
     alice, bob = await get_directly_linked_peers_without_handshake(
-        alice_chain_db=get_genesis_chain_db(),
-        bob_chain_db=get_genesis_chain_db(),
+        alice_chain_db=await get_genesis_chain_db(),
+        bob_chain_db=await get_genesis_chain_db(),
     )
     assert alice.sub_proto is None
     assert bob.sub_proto is None
@@ -35,8 +35,8 @@ async def test_directly_linked_peers(request, event_loop):
     alice, bob = await get_directly_linked_peers(
         request,
         event_loop,
-        alice_chain_db=get_genesis_chain_db(),
-        bob_chain_db=get_genesis_chain_db(),
+        alice_chain_db=await get_genesis_chain_db(),
+        bob_chain_db=await get_genesis_chain_db(),
     )
     assert isinstance(alice.sub_proto, BCCProtocol)
     assert isinstance(bob.sub_proto, BCCProtocol)
@@ -48,8 +48,8 @@ async def test_directly_linked_peers(request, event_loop):
 @pytest.mark.asyncio
 async def test_unidirectional_handshake():
     alice, bob = await get_directly_linked_peers_without_handshake(
-        alice_chain_db=get_genesis_chain_db(),
-        bob_chain_db=get_genesis_chain_db(),
+        alice_chain_db=await get_genesis_chain_db(),
+        bob_chain_db=await get_genesis_chain_db(),
     )
     alice_chain_db = alice.context.chain_db
     alice_genesis_hash = alice_chain_db.get_canonical_block_by_slot(0, BeaconBlock).hash
@@ -84,8 +84,8 @@ async def test_unidirectional_handshake():
 @pytest.mark.asyncio
 async def test_handshake_wrong_network_id():
     alice, bob = await get_directly_linked_peers_without_handshake(
-        alice_chain_db=get_genesis_chain_db(),
-        bob_chain_db=get_genesis_chain_db(),
+        alice_chain_db=await get_genesis_chain_db(),
+        bob_chain_db=await get_genesis_chain_db(),
     )
     alice.context.network_id += 1
     await asyncio.gather(alice.do_p2p_handshake(), bob.do_p2p_handshake())

--- a/tests/core/p2p-proto/bcc/test_handshake.py
+++ b/tests/core/p2p-proto/bcc/test_handshake.py
@@ -41,8 +41,10 @@ async def test_directly_linked_peers(request, event_loop):
     assert isinstance(alice.sub_proto, BCCProtocol)
     assert isinstance(bob.sub_proto, BCCProtocol)
 
-    assert alice.head_slot == bob.context.chain_db.get_canonical_head(BeaconBlock).slot
-    assert bob.head_slot == alice.context.chain_db.get_canonical_head(BeaconBlock).slot
+    alice_head = await alice.context.chain_db.coro_get_canonical_head(BeaconBlock)
+    bob_head = await bob.context.chain_db.coro_get_canonical_head(BeaconBlock)
+    assert alice.head_slot == bob_head.slot
+    assert bob.head_slot == alice_head.slot
 
 
 @pytest.mark.asyncio
@@ -52,8 +54,10 @@ async def test_unidirectional_handshake():
         bob_chain_db=await get_genesis_chain_db(),
     )
     alice_chain_db = alice.context.chain_db
-    alice_genesis_hash = alice_chain_db.get_canonical_block_by_slot(0, BeaconBlock).hash
-    alice_head_slot = alice_chain_db.get_canonical_head(BeaconBlock).slot
+    alice_genesis = await alice_chain_db.coro_get_canonical_block_by_slot(0, BeaconBlock)
+    alice_genesis_hash = alice_genesis.hash
+    alice_head = await alice_chain_db.coro_get_canonical_head(BeaconBlock)
+    alice_head_slot = alice_head.slot
 
     await asyncio.gather(alice.do_p2p_handshake(), bob.do_p2p_handshake())
 

--- a/tests/core/p2p-proto/bcc/test_requests.py
+++ b/tests/core/p2p-proto/bcc/test_requests.py
@@ -26,8 +26,8 @@ from .helpers import (
 
 
 async def get_request_server_setup(request, event_loop, chain_db):
-    genesis = chain_db.get_canonical_block_by_slot(0, BeaconBlock)
-    alice_chain_db = get_chain_db((genesis,))
+    genesis = await chain_db.coro_get_canonical_block_by_slot(0, BeaconBlock)
+    alice_chain_db = await get_chain_db((genesis,))
     alice, alice_peer_pool, bob, bob_peer_pool = await get_directly_linked_peers_in_peer_pools(
         request,
         event_loop,
@@ -52,7 +52,7 @@ async def get_request_server_setup(request, event_loop, chain_db):
 @pytest.mark.asyncio
 async def test_get_single_block_by_slot(request, event_loop):
     block = create_test_block(slot=0)
-    chain_db = get_chain_db((block,))
+    chain_db = await get_chain_db((block,))
     alice, response_buffer = await get_request_server_setup(request, event_loop, chain_db)
 
     alice.sub_proto.send_get_blocks(block.hash, 1, request_id=5)
@@ -68,7 +68,7 @@ async def test_get_single_block_by_slot(request, event_loop):
 @pytest.mark.asyncio
 async def test_get_single_block_by_root(request, event_loop):
     block = create_test_block(slot=0)
-    chain_db = get_chain_db((block,))
+    chain_db = await get_chain_db((block,))
     alice, response_buffer = await get_request_server_setup(request, event_loop, chain_db)
 
     alice.sub_proto.send_get_blocks(0, 1, request_id=5)
@@ -84,7 +84,7 @@ async def test_get_single_block_by_root(request, event_loop):
 @pytest.mark.asyncio
 async def test_get_no_blocks(request, event_loop):
     block = create_test_block(slot=0)
-    chain_db = get_chain_db((block,))
+    chain_db = await get_chain_db((block,))
     alice, response_buffer = await get_request_server_setup(request, event_loop, chain_db)
 
     alice.sub_proto.send_get_blocks(0, 0, request_id=5)
@@ -100,7 +100,7 @@ async def test_get_no_blocks(request, event_loop):
 @pytest.mark.asyncio
 async def test_get_unknown_block_by_slot(request, event_loop):
     block = create_test_block(slot=0)
-    chain_db = get_chain_db((block,))
+    chain_db = await get_chain_db((block,))
     alice, response_buffer = await get_request_server_setup(request, event_loop, chain_db)
 
     alice.sub_proto.send_get_blocks(100, 1, request_id=5)
@@ -116,7 +116,7 @@ async def test_get_unknown_block_by_slot(request, event_loop):
 @pytest.mark.asyncio
 async def test_get_unknown_block_by_root(request, event_loop):
     block = create_test_block(slot=0)
-    chain_db = get_chain_db((block,))
+    chain_db = await get_chain_db((block,))
     alice, response_buffer = await get_request_server_setup(request, event_loop, chain_db)
 
     alice.sub_proto.send_get_blocks(b"\x00" * 32, 1, request_id=5)
@@ -131,7 +131,7 @@ async def test_get_unknown_block_by_root(request, event_loop):
 
 @pytest.mark.asyncio
 async def test_get_canonical_block_range_by_slot(request, event_loop):
-    chain_db = get_chain_db()
+    chain_db = await get_chain_db()
 
     genesis = create_test_block(slot=0)
     base_branch = create_branch(3, root=genesis)
@@ -140,7 +140,7 @@ async def test_get_canonical_block_range_by_slot(request, event_loop):
     canonical_branch = create_branch(4, root=base_branch[-1], state_root=b"\x11" * 32)
 
     for branch in [[genesis], base_branch, non_canonical_branch, canonical_branch]:
-        chain_db.persist_block_chain(branch, BeaconBlock)
+        await chain_db.coro_persist_block_chain(branch, BeaconBlock)
 
     alice, response_buffer = await get_request_server_setup(request, event_loop, chain_db)
 
@@ -157,7 +157,7 @@ async def test_get_canonical_block_range_by_slot(request, event_loop):
 
 @pytest.mark.asyncio
 async def test_get_canonical_block_range_by_root(request, event_loop):
-    chain_db = get_chain_db()
+    chain_db = await get_chain_db()
 
     genesis = create_test_block(slot=0)
     base_branch = create_branch(3, root=genesis)
@@ -165,7 +165,7 @@ async def test_get_canonical_block_range_by_root(request, event_loop):
     canonical_branch = create_branch(4, root=base_branch[-1], state_root=b"\x11" * 32)
 
     for branch in [[genesis], base_branch, non_canonical_branch, canonical_branch]:
-        chain_db.persist_block_chain(branch, BeaconBlock)
+        await chain_db.coro_persist_block_chain(branch, BeaconBlock)
 
     alice, response_buffer = await get_request_server_setup(request, event_loop, chain_db)
 
@@ -182,7 +182,7 @@ async def test_get_canonical_block_range_by_root(request, event_loop):
 
 @pytest.mark.asyncio
 async def test_get_incomplete_canonical_block_range(request, event_loop):
-    chain_db = get_chain_db()
+    chain_db = await get_chain_db()
 
     genesis = create_test_block(slot=0)
     base_branch = create_branch(3, root=genesis)
@@ -190,7 +190,7 @@ async def test_get_incomplete_canonical_block_range(request, event_loop):
     canonical_branch = create_branch(4, root=base_branch[-1], state_root=b"\x11" * 32)
 
     for branch in [[genesis], base_branch, non_canonical_branch, canonical_branch]:
-        chain_db.persist_block_chain(branch, BeaconBlock)
+        await chain_db.coro_persist_block_chain(branch, BeaconBlock)
 
     alice, response_buffer = await get_request_server_setup(request, event_loop, chain_db)
 
@@ -207,7 +207,7 @@ async def test_get_incomplete_canonical_block_range(request, event_loop):
 
 @pytest.mark.asyncio
 async def test_get_non_canonical_branch(request, event_loop):
-    chain_db = get_chain_db()
+    chain_db = await get_chain_db()
 
     genesis = create_test_block(slot=0)
     base_branch = create_branch(3, root=genesis)
@@ -215,7 +215,7 @@ async def test_get_non_canonical_branch(request, event_loop):
     canonical_branch = create_branch(4, root=base_branch[-1], state_root=b"\x11" * 32)
 
     for branch in [[genesis], base_branch, non_canonical_branch, canonical_branch]:
-        chain_db.persist_block_chain(branch, BeaconBlock)
+        await chain_db.coro_persist_block_chain(branch, BeaconBlock)
 
     alice, response_buffer = await get_request_server_setup(request, event_loop, chain_db)
 

--- a/tests/core/proxies/test_proxy_implementation.py
+++ b/tests/core/proxies/test_proxy_implementation.py
@@ -7,6 +7,9 @@ from trinity.db.eth1.chain import (
 from trinity.db.eth1.header import (
     AsyncHeaderDBPreProxy,
 )
+from trinity.db.beacon.chain import (
+    AsyncBeaconChainDBPreProxy,
+)
 
 
 def test_can_instantiate_proxy():
@@ -15,3 +18,4 @@ def test_can_instantiate_proxy():
     assert AsyncHeaderDBPreProxy(None) is not None
     assert AsyncChainDBPreProxy(None) is not None
     assert AsyncDBPreProxy() is not None
+    assert AsyncBeaconChainDBPreProxy() is not None

--- a/trinity/db/beacon/chain.py
+++ b/trinity/db/beacon/chain.py
@@ -30,7 +30,7 @@ class BaseAsyncBeaconChainDB:
     """
 
     @abstractmethod
-    def coro_persist_block(
+    async def coro_persist_block(
             self,
             block: BaseBeaconBlock,
             block_class: Type[BaseBeaconBlock]
@@ -42,43 +42,44 @@ class BaseAsyncBeaconChainDB:
     #
 
     @abstractmethod
-    def coro_get_canonical_block_root(self, slot: int) -> Hash32:
+    async def coro_get_canonical_block_root(self, slot: int) -> Hash32:
         pass
 
     @abstractmethod
-    def coro_get_canonical_block_by_slot(self,
-                                         slot: int,
-                                         block_class: Type[BaseBeaconBlock]) -> BaseBeaconBlock:
+    async def coro_get_canonical_block_by_slot(
+            self,
+            slot: int,
+            block_class: Type[BaseBeaconBlock]) -> BaseBeaconBlock:
         pass
 
     @abstractmethod
-    def coro_get_canonical_block_root_by_slot(self, slot: int) -> Hash32:
+    async def coro_get_canonical_block_root_by_slot(self, slot: int) -> Hash32:
         pass
 
     @abstractmethod
-    def coro_get_canonical_head(self, block_class: Type[BaseBeaconBlock]) -> BaseBeaconBlock:
+    async def coro_get_canonical_head(self, block_class: Type[BaseBeaconBlock]) -> BaseBeaconBlock:
         pass
 
     @abstractmethod
-    def coro_get_finalized_head(self, block_class: Type[BaseBeaconBlock]) -> BaseBeaconBlock:
+    async def coro_get_finalized_head(self, block_class: Type[BaseBeaconBlock]) -> BaseBeaconBlock:
         pass
 
     @abstractmethod
-    def coro_get_block_by_root(self,
-                               block_root: Hash32,
-                               block_class: Type[BaseBeaconBlock]) -> BaseBeaconBlock:
+    async def coro_get_block_by_root(self,
+                                     block_root: Hash32,
+                                     block_class: Type[BaseBeaconBlock]) -> BaseBeaconBlock:
         pass
 
     @abstractmethod
-    def coro_get_score(self, block_root: Hash32) -> int:
+    async def coro_get_score(self, block_root: Hash32) -> int:
         pass
 
     @abstractmethod
-    def coro_block_exists(self, block_root: Hash32) -> bool:
+    async def coro_block_exists(self, block_root: Hash32) -> bool:
         pass
 
     @abstractmethod
-    def coro_persist_block_chain(
+    async def coro_persist_block_chain(
             self,
             blocks: Iterable[BaseBeaconBlock],
             block_class: Type[BaseBeaconBlock]
@@ -89,23 +90,23 @@ class BaseAsyncBeaconChainDB:
     # Beacon State
     #
     @abstractmethod
-    def coro_get_state_by_root(self, state_root: Hash32) -> BeaconState:
+    async def coro_get_state_by_root(self, state_root: Hash32) -> BeaconState:
         pass
 
     @abstractmethod
-    def coro_persist_state(self,
-                           state: BeaconState) -> None:
+    async def coro_persist_state(self,
+                                 state: BeaconState) -> None:
         pass
 
     #
     # Raw Database API
     #
     @abstractmethod
-    def coro_exists(self, key: bytes) -> bool:
+    async def coro_exists(self, key: bytes) -> bool:
         pass
 
     @abstractmethod
-    def coro_get(self, key: bytes) -> bytes:
+    async def coro_get(self, key: bytes) -> bytes:
         pass
 
 

--- a/trinity/db/beacon/chain.py
+++ b/trinity/db/beacon/chain.py
@@ -1,4 +1,7 @@
-from abc import abstractmethod
+from abc import (
+    ABC,
+    abstractmethod,
+)
 # Typeshed definitions for multiprocessing.managers is incomplete, so ignore them for now:
 # https://github.com/python/typeshed/blob/85a788dbcaa5e9e9a62e55f15d44530cd28ba830/stdlib/3/multiprocessing/managers.pyi#L3
 from multiprocessing.managers import (  # type: ignore
@@ -24,7 +27,7 @@ from trinity._utils.mp import (
 )
 
 
-class BaseAsyncBeaconChainDB:
+class BaseAsyncBeaconChainDB(ABC):
     """
     Abstract base class defines async counterparts of the sync ``BaseBeaconChainDB`` APIs.
     """

--- a/trinity/db/beacon/chain.py
+++ b/trinity/db/beacon/chain.py
@@ -116,20 +116,20 @@ class AsyncBeaconChainDBPreProxy(BaseAsyncBeaconChainDB):
     ``BaseProxy`` for the purpose of improved testability.
     """
 
-    coro_persist_block = async_method('coro_persist_block')
-    coro_get_canonical_block_root = async_method('coro_get_canonical_block_root')
-    coro_get_canonical_block_by_slot = async_method('coro_get_canonical_block_by_slot')
-    coro_get_canonical_block_root_by_slot = async_method('coro_get_canonical_block_root_by_slot')
-    coro_get_canonical_head = async_method('coro_get_canonical_head')
-    coro_get_finalized_head = async_method('coro_get_finalized_head')
-    coro_get_block_by_root = async_method('coro_get_block_by_root')
-    coro_get_score = async_method('coro_get_score')
-    coro_block_exists = async_method('coro_block_exists')
-    coro_persist_block_chain = async_method('coro_persist_block_chain')
-    coro_get_state_by_root = async_method('coro_get_state_by_root')
-    coro_persist_state = async_method('coro_persist_state')
-    coro_exists = async_method('coro_exists')
-    coro_get = async_method('coro_get')
+    coro_persist_block = async_method('persist_block')
+    coro_get_canonical_block_root = async_method('get_canonical_block_root')
+    coro_get_canonical_block_by_slot = async_method('get_canonical_block_by_slot')
+    coro_get_canonical_block_root_by_slot = async_method('get_canonical_block_root_by_slot')
+    coro_get_canonical_head = async_method('get_canonical_head')
+    coro_get_finalized_head = async_method('get_finalized_head')
+    coro_get_block_by_root = async_method('get_block_by_root')
+    coro_get_score = async_method('get_score')
+    coro_block_exists = async_method('block_exists')
+    coro_persist_block_chain = async_method('persist_block_chain')
+    coro_get_state_by_root = async_method('get_state_by_root')
+    coro_persist_state = async_method('persist_state')
+    coro_exists = async_method('exists')
+    coro_get = async_method('get')
 
 
 class AsyncBeaconChainDBProxy(BaseProxy, AsyncBeaconChainDBPreProxy):

--- a/trinity/db/beacon/chain.py
+++ b/trinity/db/beacon/chain.py
@@ -37,6 +37,10 @@ class BaseAsyncBeaconChainDB:
     ) -> Tuple[Tuple[bytes, ...], Tuple[bytes, ...]]:
         pass
 
+    #
+    # Canonical Chain API
+    #
+
     @abstractmethod
     def coro_get_canonical_block_root(self, slot: int) -> Hash32:
         pass
@@ -53,6 +57,10 @@ class BaseAsyncBeaconChainDB:
 
     @abstractmethod
     def coro_get_canonical_head(self, block_class: Type[BaseBeaconBlock]) -> BaseBeaconBlock:
+        pass
+
+    @abstractmethod
+    def coro_get_finalized_head(self, block_class: Type[BaseBeaconBlock]) -> BaseBeaconBlock:
         pass
 
     @abstractmethod
@@ -112,6 +120,7 @@ class AsyncBeaconChainDBPreProxy(BaseAsyncBeaconChainDB):
     coro_get_canonical_block_by_slot = async_method('coro_get_canonical_block_by_slot')
     coro_get_canonical_block_root_by_slot = async_method('coro_get_canonical_block_root_by_slot')
     coro_get_canonical_head = async_method('coro_get_canonical_head')
+    coro_get_finalized_head = async_method('coro_get_finalized_head')
     coro_get_block_by_root = async_method('coro_get_block_by_root')
     coro_get_score = async_method('coro_get_score')
     coro_block_exists = async_method('coro_block_exists')

--- a/trinity/db/eth1/header.py
+++ b/trinity/db/eth1/header.py
@@ -21,7 +21,6 @@ from eth.rlp.headers import BlockHeader
 
 from trinity._utils.mp import (
     async_method,
-    sync_method,
 )
 
 

--- a/trinity/db/eth1/header.py
+++ b/trinity/db/eth1/header.py
@@ -85,16 +85,6 @@ class AsyncHeaderDBPreProxy(BaseAsyncHeaderDB):
     coro_persist_header = async_method('persist_header')
     coro_persist_header_chain = async_method('persist_header_chain')
 
-    get_block_header_by_hash = sync_method('get_block_header_by_hash')
-    get_canonical_block_hash = sync_method('get_canonical_block_hash')
-    get_canonical_block_header_by_number = sync_method('get_canonical_block_header_by_number')
-    get_canonical_head = sync_method('get_canonical_head')
-    get_score = sync_method('get_score')
-    header_exists = sync_method('header_exists')
-    get_canonical_block_hash = sync_method('get_canonical_block_hash')
-    persist_header = sync_method('persist_header')
-    persist_header_chain = sync_method('persist_header_chain')
-
 
 class AsyncHeaderDBProxy(BaseProxy, AsyncHeaderDBPreProxy):
     """

--- a/trinity/protocol/bcc/context.py
+++ b/trinity/protocol/bcc/context.py
@@ -1,10 +1,10 @@
 from p2p.peer import BasePeerContext
 
-from eth2.beacon.db.chain import BaseBeaconChainDB
+from trinity.db.beacon.chain import BaseAsyncBeaconChainDB
 
 
 class BeaconContext(BasePeerContext):
 
-    def __init__(self, chain_db: BaseBeaconChainDB, network_id: int) -> None:
+    def __init__(self, chain_db: BaseAsyncBeaconChainDB, network_id: int) -> None:
         self.chain_db = chain_db
         self.network_id = network_id

--- a/trinity/protocol/bcc/servers.py
+++ b/trinity/protocol/bcc/servers.py
@@ -1,22 +1,12 @@
-import itertools
 from typing import (
     cast,
-    Iterable,
+    AsyncIterator,
     FrozenSet,
     Type,
 )
 
 from eth_typing import (
     Hash32,
-)
-
-from eth_utils import (
-    to_tuple,
-)
-from eth_utils.toolz import (
-    cons,
-    sliding_window,
-    take,
 )
 
 from cancel_token import CancelToken
@@ -27,7 +17,7 @@ from p2p.protocol import Command
 
 from eth.exceptions import BlockNotFound
 
-from eth2.beacon.db.chain import BaseBeaconChainDB
+from trinity.db.beacon.chain import BaseAsyncBeaconChainDB
 from eth2.beacon.types.blocks import (
     BaseBeaconBlock,
     BeaconBlock,
@@ -53,7 +43,7 @@ class BCCRequestServer(BaseRequestServer):
     })
 
     def __init__(self,
-                 db: BaseBeaconChainDB,
+                 db: BaseAsyncBeaconChainDB,
                  peer_pool: BCCPeerPool,
                  token: CancelToken = None) -> None:
         super().__init__(peer_pool, token)
@@ -80,14 +70,17 @@ class BCCRequestServer(BaseRequestServer):
             if isinstance(block_slot_or_root, int):
                 # TODO: pass accurate `block_class: Type[BaseBeaconBlock]` under
                 # per BeaconStateMachine fork
-                start_block = self.db.get_canonical_block_by_slot(
+                start_block = await self.db.coro_get_canonical_block_by_slot(
                     Slot(block_slot_or_root),
                     BeaconBlock,
                 )
             elif isinstance(block_slot_or_root, bytes):
                 # TODO: pass accurate `block_class: Type[BaseBeaconBlock]` under
                 # per BeaconStateMachine fork
-                start_block = self.db.get_block_by_root(Hash32(block_slot_or_root), BeaconBlock)
+                start_block = await self.db.coro_get_block_by_root(
+                    Hash32(block_slot_or_root),
+                    BeaconBlock,
+                )
             else:
                 raise TypeError(
                     f"Invariant: unexpected type for 'block_slot_or_root': "
@@ -103,7 +96,8 @@ class BCCRequestServer(BaseRequestServer):
                 max_blocks,
                 start_block,
             )
-            blocks = self._get_blocks(start_block, max_blocks)
+            blocks = tuple([b async for b in self._get_blocks(start_block, max_blocks)])
+
         else:
             self.logger.debug2("%s requested unknown block %s", block_slot_or_root)
             blocks = ()
@@ -111,10 +105,9 @@ class BCCRequestServer(BaseRequestServer):
         self.logger.debug2("Replying to %s with %d blocks", peer, len(blocks))
         peer.sub_proto.send_blocks(blocks, request_id)
 
-    @to_tuple
-    def _get_blocks(self,
-                    start_block: BaseBeaconBlock,
-                    max_blocks: int) -> Iterable[BaseBeaconBlock]:
+    async def _get_blocks(self,
+                          start_block: BaseBeaconBlock,
+                          max_blocks: int) -> AsyncIterator[BaseBeaconBlock]:
         if max_blocks < 0:
             raise Exception("Invariant: max blocks cannot be negative")
 
@@ -123,21 +116,20 @@ class BCCRequestServer(BaseRequestServer):
 
         yield start_block
 
-        blocks_generator = cons(start_block, (
-            # TODO: pass accurate `block_class: Type[BaseBeaconBlock]` under
-            # per BeaconStateMachine fork
-            self.db.get_canonical_block_by_slot(slot, BeaconBlock)
-            for slot in itertools.count(start_block.slot + 1)
-        ))
-        max_blocks_generator = take(max_blocks, blocks_generator)
-
         try:
             # ensure only a connected chain is returned (breaks might occur if the start block is
             # not part of the canonical chain or if the canonical chain changes during execution)
-            for parent, child in sliding_window(2, max_blocks_generator):
-                if child.parent_root == parent.hash:
-                    yield child
+            start = start_block.slot + 1
+            end = start + max_blocks - 1
+            parent = start_block
+            for slot in range(start, end):
+                # TODO: pass accurate `block_class: Type[BaseBeaconBlock]` under
+                # per BeaconStateMachine fork
+                block = await self.db.coro_get_canonical_block_by_slot(slot, BeaconBlock)
+                if block.parent_root == parent.hash:
+                    yield block
                 else:
                     break
+                parent = block
         except BlockNotFound:
             return

--- a/trinity/sync/beacon/chain.py
+++ b/trinity/sync/beacon/chain.py
@@ -68,7 +68,7 @@ class BeaconChainSyncer(BaseService):
                 raise Exception("Invariant: Cannot exceed max retries")
 
             try:
-                self.sync_peer = await self.select_sync_peer()
+                self.sync_peer = await self.wait(self.select_sync_peer())
             except ValidationError as exception:
                 self.logger.info(f"No suitable peers to sync with: {exception}")
                 if is_last_retry:

--- a/trinity/sync/beacon/chain.py
+++ b/trinity/sync/beacon/chain.py
@@ -134,7 +134,7 @@ class BeaconChainSyncer(BaseService):
             last_block = batch[-1]
 
             try:
-                await self.chain_db.coro_persist_block_chain(batch, BeaconBlock)  # type:ignore
+                await self.chain_db.coro_persist_block_chain(batch, BeaconBlock)
             except ValidationError as exception:
                 self.logger.info(f"Received invalid batch from {self.sync_peer}: {exception}")
                 break

--- a/trinity/sync/beacon/chain.py
+++ b/trinity/sync/beacon/chain.py
@@ -88,7 +88,7 @@ class BeaconChainSyncer(BaseService):
             self.logger.info("Failed to find suitable sync peer in time")
             return
 
-        await self.sync()
+        await self.wait(self.sync())
 
         new_head = await self.chain_db.coro_get_canonical_head(BeaconBlock)
         self.logger.info(f"Sync with {self.sync_peer} finished, new head: {new_head}")


### PR DESCRIPTION
### What was wrong?

Sync methods block the loop https://github.com/ethereum/trinity/pull/307#discussion_r267699499, and BCC peer is still using them to access chain database.

### How was it fixed?

- Use BaseAsyncBeaconChainDB and async methods in BeaconChainSyncer and BeaconContext
- Change abstract methods in BaseAsyncBeaconChainDB from sync to async
- Add FakeAsyncBeaconChainDB to test 
- Fix all related tests

Also, remove sync methods in AsyncHeaderDBPreProxy

(Genesis slots are not addressed in this PR)

#### Cute Animal Picture

![image](https://user-images.githubusercontent.com/3391420/54823572-3dd27280-4ce3-11e9-9dd8-6267f4100e9d.png)
This cat caused my eyes allergy today 🙀 