### PR TITLE
Bugfix Regular sync when incoming header is not in memory

### DIFF
--- a/tests/core/integration_test_helpers.py
+++ b/tests/core/integration_test_helpers.py
@@ -104,6 +104,7 @@ class FakeAsyncRopstenChain(RopstenChain):
 
 class FakeAsyncMainnetChain(MainnetChain):
     chaindb_class = FakeAsyncChainDB
+    coro_get_canonical_head = async_passthrough('get_canonical_head')
     coro_import_block = coro_import_block
     coro_validate_chain = async_passthrough('validate_chain')
     coro_validate_receipt = async_passthrough('validate_receipt')
@@ -111,6 +112,7 @@ class FakeAsyncMainnetChain(MainnetChain):
 
 class FakeAsyncChain(MiningChain):
     coro_import_block = coro_import_block
+    coro_get_canonical_head = async_passthrough('get_canonical_head')
     coro_validate_chain = async_passthrough('validate_chain')
     coro_validate_receipt = async_passthrough('validate_receipt')
     chaindb_class = FakeAsyncChainDB

--- a/trinity/sync/full/chain.py
+++ b/trinity/sync/full/chain.py
@@ -990,7 +990,7 @@ class RegularChainBodySyncer(BaseBodyChainSyncer):
         """
         async for headers in self._sync_from_headers(
                 self._block_import_tracker,
-                self.db.coro_header_exists):
+                self._should_skip_header):
 
             # Sometimes duplicates are added to the queue, when switching from one sync to another.
             # We can simply ignore them.


### PR DESCRIPTION
### What was wrong?

#446 had a bug (although it didn't actually make things worse, just didn't fix something that it promised to X)

In the scenario where a header comes in that's not in memory (say because you pruned old headers and switched peers), the check for whether a header was in the db was wrong.

### How was it fixed?

The fix was an easy one-liner. The longer part was making a test that actually triggers it.

The rough idea was to start up a two regular syncers at the same time. They both consider the db to be at genesis.
- start syncer 1 while syncer 2 is paused
- only let syncer 1 grab a single header, and then after it finishes syncing the block, make it shut down
- after that block is synced, start up syncer 2
- syncer 2 now receives a header at block # 2, which is a surprise, but one the syncer needs to handle

This code path is what wasn't being tested, and why the bug from #446 got missed

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://www.bigbluediving.com/media/k2/items/cache/0b242dd5a6f3b60d9c07a5d96a2bc449_XL.jpg)