### PR TITLE
Creators of the genesis state should provide a `genesis_eth1_data`

### DIFF
--- a/eth2/beacon/on_genesis.py
+++ b/eth2/beacon/on_genesis.py
@@ -62,7 +62,7 @@ def get_genesis_block(genesis_state_root: Hash32,
 def get_genesis_beacon_state(*,
                              genesis_validator_deposits: Sequence[Deposit],
                              genesis_time: Timestamp,
-                             latest_eth1_data: Eth1Data,
+                             genesis_eth1_data: Eth1Data,
                              genesis_slot: Slot,
                              genesis_epoch: Epoch,
                              genesis_fork_version: int,
@@ -117,7 +117,7 @@ def get_genesis_beacon_state(*,
         batched_block_roots=(),
 
         # Ethereum 1.0 chain data
-        latest_eth1_data=latest_eth1_data,
+        latest_eth1_data=genesis_eth1_data,
         eth1_data_votes=(),
         deposit_index=len(genesis_validator_deposits),
     )

--- a/eth2/beacon/tools/builder/initializer.py
+++ b/eth2/beacon/tools/builder/initializer.py
@@ -88,7 +88,7 @@ def create_mock_genesis(
         keymap: Dict[BLSPubkey, int],
         genesis_block_class: Type[BaseBeaconBlock],
         genesis_time: Timestamp=ZERO_TIMESTAMP) -> Tuple[BeaconState, BaseBeaconBlock]:
-    latest_eth1_data = Eth1Data.create_empty_data()
+    genesis_eth1_data = Eth1Data.create_empty_data()
 
     assert num_validators <= len(keymap)
 
@@ -103,7 +103,7 @@ def create_mock_genesis(
     state = get_genesis_beacon_state(
         genesis_validator_deposits=genesis_validator_deposits,
         genesis_time=genesis_time,
-        latest_eth1_data=latest_eth1_data,
+        genesis_eth1_data=genesis_eth1_data,
         genesis_slot=config.GENESIS_SLOT,
         genesis_epoch=config.GENESIS_EPOCH,
         genesis_fork_version=config.GENESIS_FORK_VERSION,

--- a/tests/eth2/beacon/test_on_genesis.py
+++ b/tests/eth2/beacon/test_on_genesis.py
@@ -166,7 +166,7 @@ def test_get_genesis_beacon_state(
     assert len(state.batched_block_roots) == 0
 
     # Ethereum 1.0 chain data
-    assert state.latest_eth1_data == latest_eth1_data
+    assert state.latest_eth1_data == genesis_eth1_data
     assert len(state.eth1_data_votes) == 0
     assert state.deposit_index == len(genesis_validator_deposits)
 

--- a/tests/eth2/beacon/test_on_genesis.py
+++ b/tests/eth2/beacon/test_on_genesis.py
@@ -104,12 +104,12 @@ def test_get_genesis_beacon_state(
         for i in range(validator_count)
     )
     genesis_time = 10
-    latest_eth1_data = Eth1Data(**sample_eth1_data_params)
+    genesis_eth1_data = Eth1Data(**sample_eth1_data_params)
 
     state = get_genesis_beacon_state(
         genesis_validator_deposits=genesis_validator_deposits,
         genesis_time=genesis_time,
-        latest_eth1_data=latest_eth1_data,
+        genesis_eth1_data=genesis_eth1_data,
         genesis_epoch=genesis_epoch,
         genesis_slot=genesis_slot,
         genesis_fork_version=genesis_fork_version,


### PR DESCRIPTION
not a `latest_eth1_data`. this is just a small naming change to sync the spec

This is part of breaking up a large number of changes in #397 into a series of smaller, independent changes.

### What was wrong?

Name change.

### How was it fixed?

Changing the name.

[//]: # (For important changes, please add a new entry to the release notes file)
[//]: # (See: https://trinity-client.readthedocs.io/en/latest/contributing.html#pull-requests)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://proxy.duckduckgo.com/iu/?u=https%3A%2F%2Ftse2.mm.bing.net%2Fth%3Fid%3DOIP.fxxmdSnYOOC61Cy36Wm-2gHaG0%26pid%3D15.1&f=1)
