### PR TITLE
Update fields of `Transfer` container

### DIFF
--- a/eth2/beacon/types/transfers.py
+++ b/eth2/beacon/types/transfers.py
@@ -23,9 +23,9 @@ from eth2.beacon.typing import (
 class Transfer(ssz.Serializable):
     fields = [
         # Sender index
-        ('from_validator_index', uint64),
+        ('sender', uint64),
         # Recipient index
-        ('to_validator_index', uint64),
+        ('recipient', uint64),
         # Amount in Gwei
         ('amount', uint64),
         # Fee in Gwei for block proposer
@@ -39,16 +39,16 @@ class Transfer(ssz.Serializable):
     ]
 
     def __init__(self,
-                 from_validator_index: ValidatorIndex,
-                 to_validator_index: ValidatorIndex,
+                 sender: ValidatorIndex,
+                 recipient: ValidatorIndex,
                  amount: Gwei,
                  fee: Gwei,
                  slot: Slot,
                  pubkey: BLSPubkey,
                  signature: BLSSignature=EMPTY_SIGNATURE) -> None:
         super().__init__(
-            from_validator_index=from_validator_index,
-            to_validator_index=to_validator_index,
+            sender=sender,
+            recipient=recipient,
             amount=amount,
             fee=fee,
             slot=slot,

--- a/tests/eth2/beacon/conftest.py
+++ b/tests/eth2/beacon/conftest.py
@@ -295,8 +295,8 @@ def sample_slashable_attestation_params(sample_attestation_data_params):
 @pytest.fixture
 def sample_transfer_params():
     return {
-        'from_validator_index': 10,
-        'to_validator_index': 12,
+        'sender': 10,
+        'recipient': 12,
         'amount': 10 * 10**9,
         'fee': 5 * 10**9,
         'slot': 5,

--- a/tests/eth2/beacon/types/test_transfer.py
+++ b/tests/eth2/beacon/types/test_transfer.py
@@ -8,5 +8,5 @@ from eth2.beacon.types.transfers import (
 def test_defaults(sample_transfer_params):
     transfer = Transfer(**sample_transfer_params)
 
-    assert transfer.to_validator_index == sample_transfer_params['to_validator_index']
+    assert transfer.recipient == sample_transfer_params['recipient']
     assert ssz.encode(transfer)


### PR DESCRIPTION
### What was wrong?

Updates the name of the container to match the spec.

### How was it fixed?

search/replace

[//]: # (For important changes, please add a new entry to the release notes file)
[//]: # (See: https://trinity-client.readthedocs.io/en/latest/contributing.html#pull-requests)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://proxy.duckduckgo.com/iu/?u=https%3A%2F%2Ftse1.mm.bing.net%2Fth%3Fid%3DOIP.V6G6Jhd9ZpCUPTpG6_DjHAHaE6%26pid%3D15.1&f=1)
