### PR TITLE
[WIP] Add `ValidatorPlugin`

### DIFF
--- a/trinity/main_beacon.py
+++ b/trinity/main_beacon.py
@@ -46,6 +46,7 @@ from trinity.initialization import (
 )
 from trinity.plugins.registry import (
     BASE_PLUGINS,
+    ETH2_NODE_PLUGINS,
 )
 from trinity._utils.ipc import (
     wait_for_ipc,
@@ -66,7 +67,12 @@ from trinity._utils.proxy import (
 
 
 def main_beacon() -> None:
-    main_entry(trinity_boot, APP_IDENTIFIER_BEACON, BASE_PLUGINS, (BeaconAppConfig,))
+    main_entry(
+        trinity_boot,
+        APP_IDENTIFIER_BEACON,
+        BASE_PLUGINS + ETH2_NODE_PLUGINS,
+        (BeaconAppConfig,),
+    )
 
 
 def trinity_boot(args: Namespace,

--- a/trinity/plugins/eth2/validator/plugin.py
+++ b/trinity/plugins/eth2/validator/plugin.py
@@ -1,0 +1,38 @@
+import asyncio
+from argparse import (
+    ArgumentParser,
+    _SubParsersAction,
+)
+from trinity.endpoint import TrinityEventBusEndpoint
+from trinity.extensibility import BaseIsolatedPlugin
+
+
+class ValidatorPlugin(BaseIsolatedPlugin):
+
+    @property
+    def name(self) -> str:
+        return "Validator"
+
+    def configure_parser(self, arg_parser: ArgumentParser, subparser: _SubParsersAction) -> None:
+        arg_parser.add_argument(
+            "--validator",
+            action="store_true",
+            help="Run as the validator node",
+        )
+
+    def on_ready(self, manager_eventbus: TrinityEventBusEndpoint) -> None:
+        args = self.context.args
+        if args.validator:
+            self.start()
+
+    def do_start(self) -> None:
+        loop = asyncio.get_event_loop()
+        # trinity_config = self.context.trinity_config
+
+        # TODO:
+        #   - Add a `ValidatorService` that print something every N seconds.
+        #   - Get access to data/event from `BeaconNode`, through `EventBus` or other ways.
+        #   - The service broadcasts a block through `BeaconNode` every N seconds.
+        #   - The service broadcasts a block if it finds itself selected as a proposer.
+        loop.run_forever()
+        loop.close()

--- a/trinity/plugins/registry.py
+++ b/trinity/plugins/registry.py
@@ -30,6 +30,7 @@ from trinity.plugins.builtin.syncer.plugin import (
     SyncerPlugin,
 )
 from trinity.plugins.eth2.beacon.plugin import BeaconNodePlugin
+from trinity.plugins.eth2.validator.plugin import ValidatorPlugin
 from trinity.plugins.builtin.tx_pool.plugin import (
     TxPlugin,
 )
@@ -52,7 +53,6 @@ BASE_PLUGINS: Tuple[BasePlugin, ...] = (
     FixUncleanShutdownPlugin(),
     JsonRpcServerPlugin(),
     PeerDiscoveryPlugin(),
-    BeaconNodePlugin(),
 )
 
 
@@ -67,6 +67,12 @@ ETH1_NODE_PLUGINS: Tuple[BasePlugin, ...] = (
         NoopSyncStrategy(),
     ), FastThenFullSyncStrategy),
     TxPlugin(),
+)
+
+
+ETH2_NODE_PLUGINS: Tuple[BasePlugin, ...] = (
+    BeaconNodePlugin(),
+    ValidatorPlugin(),
 )
 
 


### PR DESCRIPTION
### What was wrong?
Based on https://github.com/ethereum/trinity/pull/307, we can start implementing validator's functionalities. 


### How was it fixed?
- Add a `ValidatorPlugin` as an `BaseIsolatedPlubgin`, without the actual `ValidatorServer` running, which should be finished in the next step.
- Add the flag `--validator` to `trinity-beacon` for `ValidatorPlugin`.

#### TODO
- [ ] Get access to data/event from `BeaconNode`, through `EventBus` or other ways.
- [ ] Run `ValidatorServer` in `ValidatorPlugin` that broadcast blocks when needed.
  - Steps
    - [ ] The service broadcasts a block through `BeaconNode` every N seconds.
    - [ ] The service broadcasts a block only if it finds itself selected as a proposer.

[//]: # (For important changes, please add a new entry to the release notes file)
[//]: # (See: https://trinity-client.readthedocs.io/en/latest/contributing.html#pull-requests)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://i.imgur.com/1wSvUGi.jpg)
