### PR TITLE
Refactor how PeerPool listens for external EventBus requests

### DIFF
--- a/p2p/events.py
+++ b/p2p/events.py
@@ -37,22 +37,3 @@ class RandomBootnodeRequest(BaseRequestResponseEvent[PeerCandidatesResponse]):
     @staticmethod
     def expected_response_type() -> Type[PeerCandidatesResponse]:
         return PeerCandidatesResponse
-
-
-class PeerCountResponse(BaseEvent):
-
-    def __init__(self, peer_count: int) -> None:
-        self.peer_count = peer_count
-
-
-class PeerCountRequest(BaseRequestResponseEvent[PeerCountResponse]):
-
-    @staticmethod
-    def expected_response_type() -> Type[PeerCountResponse]:
-        return PeerCountResponse
-
-
-class ConnectToNodeCommand(BaseEvent):
-
-    def __init__(self, node: str) -> None:
-        self.node = node

--- a/p2p/peer_pool.py
+++ b/p2p/peer_pool.py
@@ -37,10 +37,7 @@ from p2p.constants import (
     REQUEST_PEER_CANDIDATE_TIMEOUT,
 )
 from p2p.events import (
-    ConnectToNodeCommand,
     PeerCandidatesRequest,
-    PeerCountRequest,
-    PeerCountResponse,
     RandomBootnodeRequest,
 )
 from p2p.exceptions import (
@@ -90,7 +87,7 @@ class BasePeerPool(BaseService, AsyncIterable[BasePeer]):
                  max_peers: int = DEFAULT_MAX_PEERS,
                  peer_info: BasePeerInfo = None,
                  token: CancelToken = None,
-                 event_bus: Endpoint = None
+                 event_bus: Endpoint = None,
                  ) -> None:
         super().__init__(token)
 
@@ -106,19 +103,6 @@ class BasePeerPool(BaseService, AsyncIterable[BasePeer]):
         self.connected_nodes: Dict[Node, BasePeer] = {}
         self._subscribers: List[PeerSubscriber] = []
         self.event_bus = event_bus
-
-    async def accept_connect_commands(self) -> None:
-        async for command in self.wait_iter(self.event_bus.stream(ConnectToNodeCommand)):
-            self.logger.debug('Received request to connect to %s', command.node)
-            self.run_task(self.connect_to_nodes(from_uris([command.node])))
-
-    async def handle_peer_count_requests(self) -> None:
-        async for req in self.wait_iter(self.event_bus.stream(PeerCountRequest)):
-                # We are listening for all `PeerCountRequest` events but we ensure to only send a
-                # `PeerCountResponse` to the callsite that made the request.  We do that by
-                # retrieving a `BroadcastConfig` from the request via the
-                # `event.broadcast_config()` API.
-                self.event_bus.broadcast(PeerCountResponse(len(self)), req.broadcast_config())
 
     async def maybe_connect_more_peers(self) -> None:
         while self.is_operational:
@@ -239,9 +223,8 @@ class BasePeerPool(BaseService, AsyncIterable[BasePeer]):
         # FIXME: PeerPool should probably no longer be a BaseService, but for now we're keeping it
         # so in order to ensure we cancel all peers when we terminate.
         if self.event_bus is not None:
-            self.run_daemon_task(self.handle_peer_count_requests())
             self.run_daemon_task(self.maybe_connect_more_peers())
-            self.run_daemon_task(self.accept_connect_commands())
+
         self.run_daemon_task(self._periodically_report_stats())
         await self.cancel_token.wait()
 

--- a/tests/core/json-rpc/test_ipc.py
+++ b/tests/core/json-rpc/test_ipc.py
@@ -14,14 +14,14 @@ from eth_utils import (
     to_hex,
 )
 
-from p2p.events import (
-    PeerCountRequest,
-    PeerCountResponse,
-    ConnectToNodeCommand,
-)
 from trinity.nodes.events import (
     NetworkIdRequest,
     NetworkIdResponse,
+)
+from trinity.protocol.common.events import (
+    ConnectToNodeCommand,
+    PeerCountRequest,
+    PeerCountResponse,
 )
 from trinity.sync.common.events import (
     SyncingRequest,

--- a/trinity-external-plugins/examples/peer_count_reporter/peer_count_reporter_plugin/plugin.py
+++ b/trinity-external-plugins/examples/peer_count_reporter/peer_count_reporter_plugin/plugin.py
@@ -4,11 +4,11 @@
 from argparse import ArgumentParser, _SubParsersAction
 import asyncio
 
-from p2p.events import PeerCountRequest
 from p2p.service import BaseService
 from lahja import Endpoint
 from trinity.endpoint import TrinityEventBusEndpoint
 from trinity.extensibility import BaseIsolatedPlugin
+from trinity.protocol.common.events import PeerCountRequest
 from trinity._utils.shutdown import exit_with_service_and_endpoint
 
 

--- a/trinity/plugins/builtin/ethstats/ethstats_service.py
+++ b/trinity/plugins/builtin/ethstats/ethstats_service.py
@@ -5,9 +5,6 @@ import websockets
 from eth.chains.base import (
     BaseChain,
 )
-from p2p.events import (
-    PeerCountRequest,
-)
 from p2p.service import (
     BaseService,
 )
@@ -36,6 +33,9 @@ from trinity.plugins.builtin.ethstats.ethstats_client import (
     EthstatsMessage,
     EthstatsData,
     timestamp_ms,
+)
+from trinity.protocol.common.events import (
+    PeerCountRequest,
 )
 
 

--- a/trinity/protocol/common/events.py
+++ b/trinity/protocol/common/events.py
@@ -1,0 +1,27 @@
+from typing import (
+    Type,
+)
+
+from lahja import (
+    BaseEvent,
+    BaseRequestResponseEvent,
+)
+
+
+class ConnectToNodeCommand(BaseEvent):
+
+    def __init__(self, node: str) -> None:
+        self.node = node
+
+
+class PeerCountResponse(BaseEvent):
+
+    def __init__(self, peer_count: int) -> None:
+        self.peer_count = peer_count
+
+
+class PeerCountRequest(BaseRequestResponseEvent[PeerCountResponse]):
+
+    @staticmethod
+    def expected_response_type() -> Type[PeerCountResponse]:
+        return PeerCountResponse

--- a/trinity/protocol/common/peer_pool_event_bus.py
+++ b/trinity/protocol/common/peer_pool_event_bus.py
@@ -1,0 +1,58 @@
+from cancel_token import (
+    CancelToken,
+)
+from lahja import (
+    Endpoint,
+)
+
+from p2p.kademlia import (
+    from_uris,
+)
+from p2p.peer_pool import (
+    BasePeerPool,
+)
+from p2p.service import (
+    BaseService,
+)
+
+from .events import (
+    ConnectToNodeCommand,
+    PeerCountRequest,
+    PeerCountResponse,
+)
+
+
+class BasePeerPoolEventBusRequestHandler(BaseService):
+    """
+    Base request handler that picks up requests from the event bus and delegates them to the
+    peer pool either to perform some action or resolve to some response.
+    Subclasses should extend this class with custom event handlers.
+    """
+
+    def __init__(self,
+                 event_bus: Endpoint,
+                 peer_pool: BasePeerPool,
+                 token: CancelToken = None) -> None:
+        super().__init__(token)
+        self._peer_pool = peer_pool
+        self._event_bus = event_bus
+
+    async def accept_connect_commands(self) -> None:
+        async for command in self.wait_iter(self._event_bus.stream(ConnectToNodeCommand)):
+            self.logger.debug('Received request to connect to %s', command.node)
+            self.run_task(self._peer_pool.connect_to_nodes(from_uris([command.node])))
+
+    async def handle_peer_count_requests(self) -> None:
+        async for req in self.wait_iter(self._event_bus.stream(PeerCountRequest)):
+            self._event_bus.broadcast(
+                PeerCountResponse(len(self._peer_pool)),
+                req.broadcast_config()
+            )
+
+    async def _run(self) -> None:
+        self.logger.info("Running BasePeerPoolEventBusRequestHandler")
+
+        self.run_daemon_task(self.handle_peer_count_requests())
+        self.run_daemon_task(self.accept_connect_commands())
+
+        await self.cancel_token.wait()

--- a/trinity/rpc/modules/admin.py
+++ b/trinity/rpc/modules/admin.py
@@ -1,8 +1,6 @@
-
-from p2p.events import ConnectToNodeCommand
-
 from trinity.constants import TO_NETWORKING_BROADCAST_CONFIG
 from trinity.endpoint import TrinityEventBusEndpoint
+from trinity.protocol.common.events import ConnectToNodeCommand
 from trinity.rpc.modules import BaseRPCModule
 from trinity._utils.validation import validate_enode_uri
 

--- a/trinity/rpc/modules/net.py
+++ b/trinity/rpc/modules/net.py
@@ -1,7 +1,8 @@
-from p2p.events import PeerCountRequest
+
 from trinity.constants import TO_NETWORKING_BROADCAST_CONFIG
 from trinity.endpoint import TrinityEventBusEndpoint
 from trinity.nodes.events import NetworkIdRequest
+from trinity.protocol.common.events import PeerCountRequest
 from trinity.rpc.modules import BaseRPCModule
 
 

--- a/trinity/server.py
+++ b/trinity/server.py
@@ -53,6 +53,7 @@ from trinity.db.beacon.chain import BaseAsyncBeaconChainDB
 from trinity.endpoint import TrinityEventBusEndpoint
 from trinity.protocol.common.context import ChainContext
 from trinity.protocol.common.peer import BasePeerPool
+from trinity.protocol.common.peer_pool_event_bus import BasePeerPoolEventBusRequestHandler
 from trinity.protocol.common.servers import BaseRequestServer
 from trinity.protocol.eth.peer import ETHPeerPool
 from trinity.protocol.eth.servers import ETHRequestServer
@@ -112,6 +113,7 @@ class BaseServer(BaseService, Generic[TPeerPool]):
         # child services
         self.upnp_service = UPnPService(port, token=self.cancel_token)
         self.peer_pool = self._make_peer_pool()
+        self._peer_pool_request_handler = self._make_peer_pool_request_handler(self.peer_pool)
         self.request_server = self._make_request_server()
 
         if not bootstrap_nodes:
@@ -120,6 +122,14 @@ class BaseServer(BaseService, Generic[TPeerPool]):
     @abstractmethod
     def _make_peer_pool(self) -> TPeerPool:
         pass
+
+    def _make_peer_pool_request_handler(self,
+                                        peer_pool: TPeerPool) -> BasePeerPoolEventBusRequestHandler:
+        return BasePeerPoolEventBusRequestHandler(
+            self.event_bus,
+            peer_pool,
+            self.cancel_token
+        )
 
     @abstractmethod
     def _make_request_server(self) -> BaseRequestServer:
@@ -156,6 +166,7 @@ class BaseServer(BaseService, Generic[TPeerPool]):
         self.logger.info('peers: max_peers=%s', self.max_peers)
 
         self.run_daemon(self.peer_pool)
+        self.run_daemon(self._peer_pool_request_handler)
         self.run_daemon(self.request_server)
 
         # UPNP service is still experimental and not essential, so we don't use run_daemon() for


### PR DESCRIPTION
### What was wrong?

Currently, the `PeerPool` directly handles requests from the event bus to get the peer count or to connect to a specific node. This hinders extensibility and pollutes the peer pool with things it should not be concerned with.

### How was it fixed?

This is a spin off from my branch that breaks the peer pool, request server and sync into isolated plugins. This is an attempt to slice out some chunks of that work.

The does:

- create a `BasePeerPoolEventBusRequestHandler` that is run by whoever runs the peer pool
- moves all the events that aren't intrinsically needed by the `PeerPool` to `trinity.protocol.common.events.py`

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses]()
