### PR TITLE
Refactor how PeerPool listens for external EventBus requests

### DIFF
--- a/p2p/events.py
+++ b/p2p/events.py
@@ -37,22 +37,3 @@ class RandomBootnodeRequest(BaseRequestResponseEvent[PeerCandidatesResponse]):
     @staticmethod
     def expected_response_type() -> Type[PeerCandidatesResponse]:
         return PeerCandidatesResponse
-
-
-class PeerCountResponse(BaseEvent):
-
-    def __init__(self, peer_count: int) -> None:
-        self.peer_count = peer_count
-
-
-class PeerCountRequest(BaseRequestResponseEvent[PeerCountResponse]):
-
-    @staticmethod
-    def expected_response_type() -> Type[PeerCountResponse]:
-        return PeerCountResponse
-
-
-class ConnectToNodeCommand(BaseEvent):
-
-    def __init__(self, node: str) -> None:
-        self.node = node

--- a/p2p/peer.py
+++ b/p2p/peer.py
@@ -23,6 +23,7 @@ from typing import (
     Type,
     TYPE_CHECKING,
 )
+import typing_extensions
 
 import sha3
 
@@ -163,6 +164,32 @@ class BasePeerBootManager(BaseService):
 
 class BasePeerContext:
     pass
+
+
+class IdentifiablePeer(typing_extensions.Protocol):
+    """
+    A protocol used to identify a peer based on the presence of an ``uri`` property. The
+    peer pool uses this to lookup and match DTO peers against the actual real peer instance.
+    The ``BaseDTOPeer`` qualifies for this protocol but usage of the ``BaseDTOPeer`` isn't
+    strictly needed. E.g. one might implement a different DTO class that derives from
+    ``NamedTuple`` which is fine as long as it defines an ``uri`` property.
+    """
+
+    @property
+    @abstractmethod
+    def uri(self) -> str:
+        pass
+
+
+class BaseDTOPeer:
+    """
+    A peer solely meant as a Data Transfer Object (DTO) to travel across process boundaries.
+    It's a shallow, pickleable representation of a peer that carries enough information to
+    make the peer identifiable within the actual pool of real peers.
+    """
+
+    def __init__(self, uri: str):
+        self.uri = uri
 
 
 class BasePeer(BaseService):

--- a/p2p/tools/paragon/__init__.py
+++ b/p2p/tools/paragon/__init__.py
@@ -8,9 +8,11 @@ from .proto import (  # noqa: F401
 )
 from .peer import (  # noqa: F401
     ParagonContext,
+    ParagonMockPeerPoolWithConnectedPeers,
     ParagonPeer,
     ParagonPeerFactory,
     ParagonPeerPool,
+    ParagonPeerPoolEventServer,
 )
 from .helpers import (  # noqa: F401
     get_directly_connected_streams,

--- a/p2p/tools/paragon/events.py
+++ b/p2p/tools/paragon/events.py
@@ -1,0 +1,14 @@
+from lahja import (
+    BaseEvent,
+)
+from p2p.peer import (
+    IdentifiablePeer,
+)
+
+
+class GetSumRequest(BaseEvent):
+
+    def __init__(self, peer: IdentifiablePeer, a: int, b: int) -> None:
+        self.peer = peer
+        self.a = a
+        self.b = b

--- a/setup.py
+++ b/setup.py
@@ -29,6 +29,7 @@ deps = {
         "websockets==5.0.1",
         "jsonschema==2.6.0",
         "mypy_extensions>=0.4.1,<1.0.0",
+        "typing_extensions>=3.7.2,<4.0.0",
     ],
     'test': [
         "hypothesis==3.69.5",

--- a/tests/core/integration_test_helpers.py
+++ b/tests/core/integration_test_helpers.py
@@ -29,6 +29,10 @@ from trinity.db.base import BaseAsyncDB
 from trinity.db.eth1.chain import BaseAsyncChainDB
 from trinity.db.eth1.header import BaseAsyncHeaderDB
 
+from trinity.protocol.common.peer_pool_event_bus import (
+    PeerPoolEventServer,
+)
+
 ZIPPED_FIXTURES_PATH = Path(__file__).parent.parent / 'integration' / 'fixtures'
 
 
@@ -165,3 +169,16 @@ def load_fixture_db(db_fixture, db_class=LevelDB):
     with ZipFile(zipped_path, 'r') as zipped, TemporaryDirectory() as tmpdir:
         zipped.extractall(tmpdir)
         yield db_class(Path(tmpdir) / db_fixture.value)
+
+
+async def make_peer_pool_answer_event_bus_requests(event_bus, peer_pool, handler_type=None):
+
+    handler_type = PeerPoolEventServer if handler_type is None else handler_type
+
+    peer_pool_event_bus_request_handler = handler_type(
+        event_bus,
+        peer_pool,
+        peer_pool.cancel_token
+    )
+    asyncio.ensure_future(peer_pool_event_bus_request_handler.run())
+    await peer_pool_event_bus_request_handler.events.started.wait()

--- a/tests/core/json-rpc/test_ipc.py
+++ b/tests/core/json-rpc/test_ipc.py
@@ -14,14 +14,14 @@ from eth_utils import (
     to_hex,
 )
 
-from p2p.events import (
-    PeerCountRequest,
-    PeerCountResponse,
-    ConnectToNodeCommand,
-)
 from trinity.nodes.events import (
     NetworkIdRequest,
     NetworkIdResponse,
+)
+from trinity.protocol.common.events import (
+    ConnectToNodeCommand,
+    PeerCountRequest,
+    PeerCountResponse,
 )
 from trinity.sync.common.events import (
     SyncingRequest,

--- a/tests/p2p/test_peer_pool_event_bus_request_handler.py
+++ b/tests/p2p/test_peer_pool_event_bus_request_handler.py
@@ -1,0 +1,26 @@
+import pytest
+
+from trinity.protocol.common.events import PeerCountRequest
+
+from p2p.tools.paragon import (
+    get_directly_linked_peers,
+    ParagonMockPeerPoolWithConnectedPeers,
+    ParagonPeerPoolEventServer,
+)
+
+from tests.core.integration_test_helpers import (
+    make_peer_pool_answer_event_bus_requests,
+)
+
+
+@pytest.mark.asyncio
+async def test_event_bus_requests_against_peer_pool(request, event_loop, event_bus):
+
+    alice, bob = await get_directly_linked_peers(request, event_loop)
+    peer_pool = ParagonMockPeerPoolWithConnectedPeers([alice, bob])
+    await make_peer_pool_answer_event_bus_requests(
+        event_bus, peer_pool, handler_type=ParagonPeerPoolEventServer)
+
+    res = await event_bus.request(PeerCountRequest())
+
+    assert res.peer_count == 2

--- a/trinity-external-plugins/examples/peer_count_reporter/peer_count_reporter_plugin/plugin.py
+++ b/trinity-external-plugins/examples/peer_count_reporter/peer_count_reporter_plugin/plugin.py
@@ -4,11 +4,11 @@
 from argparse import ArgumentParser, _SubParsersAction
 import asyncio
 
-from p2p.events import PeerCountRequest
 from p2p.service import BaseService
 from lahja import Endpoint
 from trinity.endpoint import TrinityEventBusEndpoint
 from trinity.extensibility import BaseIsolatedPlugin
+from trinity.protocol.common.events import PeerCountRequest
 from trinity._utils.shutdown import exit_with_service_and_endpoint
 
 

--- a/trinity/plugins/builtin/ethstats/ethstats_service.py
+++ b/trinity/plugins/builtin/ethstats/ethstats_service.py
@@ -5,9 +5,6 @@ import websockets
 from eth.chains.base import (
     BaseChain,
 )
-from p2p.events import (
-    PeerCountRequest,
-)
 from p2p.service import (
     BaseService,
 )
@@ -36,6 +33,9 @@ from trinity.plugins.builtin.ethstats.ethstats_client import (
     EthstatsMessage,
     EthstatsData,
     timestamp_ms,
+)
+from trinity.protocol.common.events import (
+    PeerCountRequest,
 )
 
 

--- a/trinity/protocol/common/events.py
+++ b/trinity/protocol/common/events.py
@@ -1,0 +1,53 @@
+from typing import (
+    Type,
+)
+
+from lahja import (
+    BaseEvent,
+    BaseRequestResponseEvent,
+)
+
+from p2p.peer import (
+    IdentifiablePeer,
+)
+from p2p.p2p_proto import (
+    DisconnectReason,
+)
+
+
+class ConnectToNodeCommand(BaseEvent):
+    """
+    Event that wraps a node URI that the pool should connect to.
+    """
+
+    def __init__(self, node: str) -> None:
+        self.node = node
+
+
+class PeerCountResponse(BaseEvent):
+    """
+    Response event that wraps the count of peers connected to the pool.
+    """
+
+    def __init__(self, peer_count: int) -> None:
+        self.peer_count = peer_count
+
+
+class PeerCountRequest(BaseRequestResponseEvent[PeerCountResponse]):
+    """
+    Request event to get the count of peers connected to the pool.
+    """
+
+    @staticmethod
+    def expected_response_type() -> Type[PeerCountResponse]:
+        return PeerCountResponse
+
+
+class DisconnectPeerEvent(BaseEvent):
+    """
+    Event broadcasted when we want to disconnect from a peer
+    """
+
+    def __init__(self, peer: IdentifiablePeer, reason: DisconnectReason) -> None:
+        self.peer = peer
+        self.reason = reason

--- a/trinity/protocol/common/peer_pool_event_bus.py
+++ b/trinity/protocol/common/peer_pool_event_bus.py
@@ -1,0 +1,101 @@
+from typing import (
+    cast,
+    Generic,
+    TypeVar,
+)
+from cancel_token import (
+    CancelToken,
+)
+from lahja import (
+    Endpoint,
+)
+
+from p2p.exceptions import (
+    PeerConnectionLost,
+)
+from p2p.kademlia import (
+    from_uris,
+)
+from p2p.peer import (
+    BasePeer,
+    IdentifiablePeer,
+)
+from p2p.peer_pool import (
+    BasePeerPool,
+)
+from p2p.service import (
+    BaseService,
+)
+
+from .events import (
+    ConnectToNodeCommand,
+    DisconnectPeerEvent,
+    PeerCountRequest,
+    PeerCountResponse,
+)
+
+
+TPeer = TypeVar('TPeer', bound=BasePeer)
+
+
+class PeerPoolEventServer(BaseService, Generic[TPeer]):
+    """
+    Base request handler that listens for requests on the event bus that should be delegated to
+    the peer pool to either perform an action or return some response. Subclasses should extend
+    this class with custom event handlers.
+    """
+
+    def __init__(self,
+                 event_bus: Endpoint,
+                 peer_pool: BasePeerPool,
+                 token: CancelToken = None) -> None:
+        super().__init__(token)
+        self.peer_pool = peer_pool
+        self.event_bus = event_bus
+
+    async def accept_connect_commands(self) -> None:
+        async for command in self.wait_iter(self.event_bus.stream(ConnectToNodeCommand)):
+            self.logger.debug('Received request to connect to %s', command.node)
+            self.run_task(self.peer_pool.connect_to_nodes(from_uris([command.node])))
+
+    async def handle_peer_count_requests(self) -> None:
+        async for req in self.wait_iter(self.event_bus.stream(PeerCountRequest)):
+            self.event_bus.broadcast(
+                PeerCountResponse(len(self.peer_pool)),
+                req.broadcast_config()
+            )
+
+    async def handle_disconnect_peer_events(self) -> None:
+        async for ev in self.wait_iter(self.event_bus.stream(DisconnectPeerEvent)):
+            try:
+                peer = self.get_peer(ev.peer)
+            except PeerConnectionLost:
+                pass
+            else:
+                peer.disconnect(ev.reason)
+
+    async def _run(self) -> None:
+        self.logger.debug("Running PeerPoolEventServer")
+
+        self.run_daemon_task(self.handle_peer_count_requests())
+        self.run_daemon_task(self.accept_connect_commands())
+        self.run_daemon_task(self.handle_disconnect_peer_events())
+
+        await self.cancel_token.wait()
+
+    def get_peer(self, dto_peer: IdentifiablePeer) -> TPeer:
+
+        try:
+            peer = self.peer_pool.connected_nodes[dto_peer.uri]
+        except KeyError:
+            self.logger.debug("Peer %s does not exist in the pool anymore", dto_peer.uri)
+            raise PeerConnectionLost()
+        else:
+            if not peer.is_operational:
+                self.logger.debug("Peer %s is not operational when selecting from pool", peer)
+                raise PeerConnectionLost()
+            else:
+                return cast(TPeer, peer)
+
+
+DefaultPeerPoolEventBusRequestHandler = PeerPoolEventServer[BasePeer]

--- a/trinity/rpc/modules/admin.py
+++ b/trinity/rpc/modules/admin.py
@@ -1,8 +1,6 @@
-
-from p2p.events import ConnectToNodeCommand
-
 from trinity.constants import TO_NETWORKING_BROADCAST_CONFIG
 from trinity.endpoint import TrinityEventBusEndpoint
+from trinity.protocol.common.events import ConnectToNodeCommand
 from trinity.rpc.modules import BaseRPCModule
 from trinity._utils.validation import validate_enode_uri
 

--- a/trinity/rpc/modules/net.py
+++ b/trinity/rpc/modules/net.py
@@ -1,7 +1,8 @@
-from p2p.events import PeerCountRequest
+
 from trinity.constants import TO_NETWORKING_BROADCAST_CONFIG
 from trinity.endpoint import TrinityEventBusEndpoint
 from trinity.nodes.events import NetworkIdRequest
+from trinity.protocol.common.events import PeerCountRequest
 from trinity.rpc.modules import BaseRPCModule
 
 


### PR DESCRIPTION
### What was wrong?

Currently, the `PeerPool` directly listens for certain events on the event bus that it reacts upon. This is problematic because:

- it pollutes the `PeerPool` with concerns it should not care about
- it's bad for extensibility of such actions for various different peer pool implementations

### How was it fixed?

- Move handling of such events to a `BasePeerPoolEventBusRequestHandler`
- Move all events that aren't intrinsically needed by the `PeerPool` to `trinity.protocol.common.events`


[//]: # (For important changes, please add a new entry to the release notes file)
[//]: # (See: https://trinity-client.readthedocs.io/en/latest/contributing.html#pull-requests)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://mymodernmet.com/wp/wp-content/uploads/2018/09/Amy-Kennedy_Guffaw-comedy-wildlife-awards.jpg)
