### PR TITLE
Remove duplicate assignment

### DIFF
--- a/eth2/beacon/tools/builder/validator.py
+++ b/eth2/beacon/tools/builder/validator.py
@@ -276,7 +276,7 @@ def create_mock_slashable_attestation(state: BeaconState,
     )
     latest_crosslink = state.latest_crosslinks[shard]
 
-    attestation_data = attestation_data = AttestationData(
+    attestation_data = AttestationData(
         slot=attestation_slot,
         shard=shard,
         beacon_block_root=beacon_block_root,


### PR DESCRIPTION
### What was wrong?

Some code was merged in that accidentally assigns to the same variable twice.

### How was it fixed?

Remove the duplicate assignment.


[//]: # (For important changes, please add a new entry to the release notes file)
[//]: # (See: https://trinity-client.readthedocs.io/en/latest/contributing.html#pull-requests)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://proxy.duckduckgo.com/iu/?u=https%3A%2F%2Ftse3.mm.bing.net%2Fth%3Fid%3DOIP.OHWM6E8JLe0_Ir81ZrAXcAHaFp%26pid%3DApi&f=1)
