### PR TITLE
Run plugin tests in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -245,6 +245,13 @@ jobs:
       - image: circleci/python:3.6
         environment:
           TOXENV: py36-wheel-cli
+  py36-plugins:
+    <<: *common
+    docker:
+      - image: circleci/python:3.6
+        environment:
+          TOXENV: py36-plugins
+
 
   py37-core:
     <<: *common
@@ -282,6 +289,13 @@ jobs:
       - image: circleci/python:3.7
         environment:
           TOXENV: py37-wheel-cli
+  py37-plugins:
+    <<: *common
+    docker:
+      - image: circleci/python:3.7
+        environment:
+          TOXENV: py37-plugins
+
 
   docker-image-build-test:
     machine: true
@@ -301,6 +315,7 @@ workflows:
       - py37-p2p
       - py37-eth2
       - py37-libp2p
+      - py37-plugins
 
       - py36-rpc-state-byzantium
       - py36-rpc-state-constantinople
@@ -316,6 +331,7 @@ workflows:
       - py36-p2p
       - py36-eth2
       - py36-libp2p
+      - py36-plugins
 
       - py36-integration
       - py36-lightchain_integration

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # The Trinity Ethereum Client
 
 [![Join the chat at https://gitter.im/ethereum/trinity](https://badges.gitter.im/ethereum/trinity.svg)](https://gitter.im/ethereum/trinity)
+[![CircleCI](https://circleci.com/gh/gsmadi/trinity/tree/master.svg?style=shield)](https://circleci.com/gh/gsmadi/trinity/tree/master)
 [![Documentation Status](https://readthedocs.org/projects/trinity-client/badge/?version=latest)](https://trinity-client.readthedocs.io/en/latest/?badge=latest)
-
 
 Trinity is a client for the Ethereum protocol including the existing 1.0 chain as well as emerging support for the upcoming Ethereum 2.0 / Serenity spec. For the offical website, visit https://trinity.ethereum.org/
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # The Trinity Ethereum Client
 
 [![Join the chat at https://gitter.im/ethereum/trinity](https://badges.gitter.im/ethereum/trinity.svg)](https://gitter.im/ethereum/trinity)
-[![CircleCI](https://circleci.com/gh/gsmadi/trinity/tree/master.svg?style=shield)](https://circleci.com/gh/gsmadi/trinity/tree/master)
+[![CircleCI](https://circleci.com/gh/ethereum/trinity/tree/master.svg?style=shield)](https://circleci.com/gh/ethereum/trinity/tree/master)
 [![Documentation Status](https://readthedocs.org/projects/trinity-client/badge/?version=latest)](https://trinity-client.readthedocs.io/en/latest/?badge=latest)
 
 Trinity is a client for the Ethereum protocol including the existing 1.0 chain as well as emerging support for the upcoming Ethereum 2.0 / Serenity spec. For the offical website, visit https://trinity.ethereum.org/

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist=
-    py{36,37}-{core,p2p,integration,lightchain_integration,eth2}
+    py{36,37}-{core,p2p,integration,lightchain_integration,eth2,plugins}
     py{36}-long_run_integration
     py{36}-rpc-state-{frontier,homestead,tangerine_whistle,spurious_dragon,byzantium,constantinople,quadratic}
     py{36}-rpc-blockchain
@@ -22,6 +22,7 @@ commands=
     core: pytest -n 4 {posargs:tests/core/}
     eth2: pytest -n 4 {posargs:tests/eth2}
     p2p: pytest -n 4 {posargs:tests/p2p}
+    plugins: pytest -n 4 {posargs:tests/plugins/}
     rpc-blockchain: pytest -n 4 {posargs:tests/json-fixtures-over-rpc/test_rpc_fixtures.py -k 'not GeneralStateTests'}
     rpc-state-frontier: pytest -n 4 {posargs:tests/json-fixtures-over-rpc/test_rpc_fixtures.py -k 'GeneralStateTests and not stQuadraticComplexityTest and Frontier'}
     rpc-state-homestead: pytest -n 4 {posargs:tests/json-fixtures-over-rpc/test_rpc_fixtures.py -k 'GeneralStateTests and not stQuadraticComplexityTest and Homestead'}


### PR DESCRIPTION
### What was wrong?

Our CI was not running plugin tests during builds. As we start ramping up the plugin refactor its important to constantly monitor the health of these tests.

### How was it fixed?

Simply added some jobs to execute plugin tests for Py 3.6 and 3.7.

Also included the CircleCI build badge in the README.


[//]: # (For important changes, please add a new entry to the release notes file)
[//]: # (See: https://trinity-client.readthedocs.io/en/latest/contributing.html#pull-requests)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://wcrates.files.wordpress.com/2015/03/cute-animal-photos.jpg)
