### PR TITLE
Perf: Don't create intermediate tuples in normalizer

### DIFF
--- a/trinity/protocol/common/types.py
+++ b/trinity/protocol/common/types.py
@@ -38,8 +38,11 @@ ReceiptsByBlock = Tuple[Tuple[Receipt, ...], ...]
 ReceiptsBundles = Tuple[Tuple[Tuple[Receipt, ...], Tuple[Hash32, Dict[Hash32, bytes]]], ...]
 
 # (BlockBody, (txn_root, txn_trie_data), uncles_hash)
-BlockBodyBundles = Tuple[Tuple[
+
+BlockBodyBundle = Tuple[
     BlockBody,
     Tuple[Hash32, Dict[Hash32, bytes]],
     Hash32,
-], ...]
+]
+
+BlockBodyBundles = Tuple[BlockBodyBundle, ...]


### PR DESCRIPTION
### What was wrong?

**THIS IS A WEIRD ONE:**

I *thought* I've found a potential performance issue within our normalizer code but after crunching some numbers, I'm actually not so sure anymore.

Our current code creates intermediate tuples and thereby loop over the data more often than needed. At least, that's how I understand it and we can in fact, prove that getting rid of the intermediate tuples runs faster.

Here's a simplified snipped demoing the performance difference.

With intermediate tuples:

```python
def multiply(x):
    return x * 10

def test():
    msg = tuple(x for x in range(5))

    uncles_hashes = tuple(map(
        multiply,
        tuple(x for x in msg)
    ))
    transaction_roots_and_trie_data = tuple(map(
        multiply,
        tuple(x for x in msg)
    ))

    body_bundles = tuple(zip(msg, transaction_roots_and_trie_data, uncles_hashes))
    return body_bundles

import timeit
print(timeit.timeit('test()', globals=globals()))
```

Prints: `5.469376810011454`

Without intermediate tuples:

```python
def multiply(x):
    return x * 10

def test():
    msg = tuple(x for x in range(5))

    uncles_hashes = map(
        multiply,
        (x for x in msg)
    )
    transaction_roots_and_trie_data = map(
        multiply,
        (x for x in msg)
    )

    body_bundles = tuple(zip(msg, transaction_roots_and_trie_data, uncles_hashes))
    return body_bundles

import timeit
print(timeit.timeit('test()', globals=globals()))
```

Prints: `4.732703522982774`

~~**However!** It turns out, that the more elements we have in `msg`, the number flip and the version with the intermediate tuples does actually run faster. E.g. if we change the code to be `msg = tuple(x for x in range(50))`, then, the version with the intermediate tuples runs consistently faster. This is surprising to me as I would have thought the opposite should be the case.~~ 

:middle_finger: Must have been something weird.


### How was it fixed?

- removed intermediate tuples
- turned one place into a loop to avoid traversing the same set twice

### TODO:

- [] add changelog entry for perf improvement

[//]: # (For important changes, please add a new entry to the release notes file)
[//]: # (See: https://trinity-client.readthedocs.io/en/latest/contributing.html#pull-requests)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://i.redd.it/jvycibe85ir11.jpg)
