### PR TITLE
Shutdown Trinity if Discovery crashes

### DIFF
--- a/trinity/plugins/builtin/peer_discovery/plugin.py
+++ b/trinity/plugins/builtin/peer_discovery/plugin.py
@@ -140,7 +140,10 @@ class DiscoveryBootstrapService(BaseService):
                 self.cancel_token,
             )
 
-        await discovery_service.run()
+        try:
+            await discovery_service.run()
+        except Exception:
+            self.event_bus.request_shutdown("Discovery ended unexpectedly")
 
 
 class PeerDiscoveryPlugin(BaseIsolatedPlugin):


### PR DESCRIPTION
### What was wrong?

Currently, if the `DiscoveryService` crashes, Trinity keeps running. I think a crash in the discovery should cause a full shutdown to not go unnoticed.

### How was it fixed?

Wrap in a try/except and call `request_shutdown` for any escaped error. 

Related: I think the plugin system could do a better assistance job and I put a paragraph into https://github.com/ethereum/trinity/issues/460 to look into this, when we overhaul the API.

- [x] add changelog entry

[//]: # (For important changes, please add a new entry to the release notes file)
[//]: # (See: https://trinity-client.readthedocs.io/en/latest/contributing.html#pull-requests)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](http://i.imgur.com/189tL2E.jpg)
