### PR TITLE
Drop merkle root in favor of hash_tree_root

### DIFF
--- a/eth2/beacon/state_machines/forks/serenity/epoch_processing.py
+++ b/eth2/beacon/state_machines/forks/serenity/epoch_processing.py
@@ -1194,8 +1194,7 @@ def _update_historical_roots(state: BeaconState,
             state_roots=state.latest_state_roots,
             slots_per_historical_root=config.SLOTS_PER_HISTORICAL_ROOT,
         )
-        next_root = historical_batch.hash_tree_root
-        updated_historical_roots += (next_root,)
+        updated_historical_roots += (historical_batch.hash_tree_root,)
 
     return state.copy(
         historical_roots=updated_historical_roots

--- a/eth2/beacon/state_machines/forks/serenity/epoch_processing.py
+++ b/eth2/beacon/state_machines/forks/serenity/epoch_processing.py
@@ -17,7 +17,6 @@ from eth_utils.toolz import (
 )
 
 from eth2.beacon import helpers
-from eth2._utils.merkle.normal import get_merkle_root
 from eth2._utils.numeric import (
     is_power_of_two,
 )
@@ -69,6 +68,7 @@ from eth2.beacon.types.attestations import Attestation
 from eth2.beacon.types.pending_attestation_records import PendingAttestationRecord
 from eth2.beacon.types.crosslink_records import CrosslinkRecord
 from eth2.beacon.types.eth1_data_vote import Eth1DataVote
+from eth2.beacon.types.historical_batch import HistoricalBatch
 from eth2.beacon.types.states import BeaconState
 from eth2.beacon.typing import (
     Epoch,
@@ -1189,8 +1189,13 @@ def _update_historical_roots(state: BeaconState,
     epochs_per_historical_root = config.SLOTS_PER_HISTORICAL_ROOT // config.SLOTS_PER_EPOCH
     should_update_historical_roots = next_epoch % epochs_per_historical_root == 0
     if should_update_historical_roots:
-        roots = state.latest_block_roots + state.latest_state_roots
-        updated_historical_roots += (get_merkle_root(roots),)
+        historical_batch = HistoricalBatch(
+            block_roots=state.latest_block_roots,
+            state_roots=state.latest_state_roots,
+            slots_per_historical_root=config.SLOTS_PER_HISTORICAL_ROOT,
+        )
+        next_root = historical_batch.hash_tree_root
+        updated_historical_roots += (next_root,)
 
     return state.copy(
         historical_roots=updated_historical_roots

--- a/eth2/beacon/types/historical_batch.py
+++ b/eth2/beacon/types/historical_batch.py
@@ -1,0 +1,44 @@
+from typing import (
+    Sequence,
+)
+
+from eth_typing import (
+    Hash32,
+)
+
+import ssz
+from ssz.sedes import (
+    bytes32,
+    List,
+)
+
+
+class HistoricalBatch(ssz.Serializable):
+
+    fields = [
+        # Block roots
+        ('block_roots', List(bytes32)),
+        # State roots
+        ('state_roots', List(bytes32)),
+    ]
+
+    def __init__(self,
+                 *,
+                 block_roots: Sequence[Hash32],
+                 state_roots: Sequence[Hash32],
+                 slots_per_historical_root: int) -> None:
+        assert len(block_roots) == slots_per_historical_root
+        assert len(state_roots) == slots_per_historical_root
+
+        super().__init__(
+            block_roots=block_roots,
+            state_roots=state_roots,
+        )
+
+    _hash_tree_root = None
+
+    @property
+    def hash_tree_root(self) -> Hash32:
+        if self._hash_tree_root is None:
+            self._hash_tree_root = ssz.hash_tree_root(self)
+        return self._hash_tree_root

--- a/tests/eth2/beacon/state_machines/test_state_transition.py
+++ b/tests/eth2/beacon/state_machines/test_state_transition.py
@@ -7,8 +7,7 @@ from eth2.beacon.state_machines.forks.serenity.blocks import (
 from eth2.beacon.tools.builder.proposer import (
     create_mock_block,
 )
-
-from eth2._utils.merkle.normal import get_merkle_root
+from eth2.beacon.types.historical_batch import HistoricalBatch
 
 
 @pytest.mark.parametrize(
@@ -100,8 +99,11 @@ def test_per_slot_transition(base_db,
 
     # historical_roots
     if updated_state.slot % st.config.SLOTS_PER_HISTORICAL_ROOT == 0:
-        assert updated_state.historical_roots[-1] == get_merkle_root(
-            updated_state.latest_block_roots
+        historical_batch = HistoricalBatch(
+            block_roots=state.latest_block_roots,
+            state_roots=state.latest_state_roots,
+            slots_per_historical_root=config.SLOTS_PER_HISTORICAL_ROOT,
         )
+        assert updated_state.historical_roots[-1] == historical_batch.hash_tree_root
     else:
         assert updated_state.historical_roots == state.historical_roots


### PR DESCRIPTION
### What was wrong?

Fixes #419.

### How was it fixed?

- Adds `HistoricalBatch` data type introduced in the spec.

- Uses the `hash_tree_root` of the `HistoricalBatch` in lieu of the `merkle_root` when adding historical roots to the state accumulator.


[//]: # (For important changes, please add a new entry to the release notes file)
[//]: # (See: https://trinity-client.readthedocs.io/en/latest/contributing.html#pull-requests)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://proxy.duckduckgo.com/iu/?u=https%3A%2F%2Ftse3.mm.bing.net%2Fth%3Fid%3DOIP.C0l9TvCoMtN_VHxfPE0t3QHaFV%26pid%3DApi&f=1)
