### PR TITLE
Reorder sequence of epoch processing during state transition

### DIFF
--- a/eth2/beacon/state_machines/forks/serenity/block_validation.py
+++ b/eth2/beacon/state_machines/forks/serenity/block_validation.py
@@ -368,7 +368,7 @@ def validate_attestation_source_epoch_and_root(state: BeaconState,
     Validate ``source_epoch`` and ``source_root`` fields of ``attestation_data``.
     Raise ``ValidationError`` if it's invalid.
     """
-    if slot_to_epoch(attestation_data.slot + 1, slots_per_epoch) >= current_epoch:
+    if slot_to_epoch(attestation_data.slot, slots_per_epoch) >= current_epoch:
         # Case 1: current epoch attestations
         if attestation_data.source_epoch != state.current_justified_epoch:
             raise ValidationError(

--- a/eth2/beacon/state_machines/forks/serenity/state_transitions.py
+++ b/eth2/beacon/state_machines/forks/serenity/state_transitions.py
@@ -45,11 +45,11 @@ class SerenityStateTransition(BaseStateTransition):
                                check_proposer_signature: bool=True) -> BeaconState:
         while state.slot != block.slot:
             state = self.cache_state(state)
+            if (state.slot + 1) % self.config.SLOTS_PER_EPOCH == 0:
+                state = self.per_epoch_transition(state)
             state = self.per_slot_transition(state)
             if state.slot == block.slot:
                 state = self.per_block_transition(state, block, check_proposer_signature)
-            if (state.slot + 1) % self.config.SLOTS_PER_EPOCH == 0:
-                state = self.per_epoch_transition(state)
 
         return state
 

--- a/eth2/beacon/state_machines/forks/serenity/state_transitions.py
+++ b/eth2/beacon/state_machines/forks/serenity/state_transitions.py
@@ -43,7 +43,7 @@ class SerenityStateTransition(BaseStateTransition):
                                state: BeaconState,
                                block: BaseBeaconBlock,
                                check_proposer_signature: bool=True) -> BeaconState:
-        while state.slot != block.slot:
+        for _ in range(state.slot, block.slot):
             state = self.cache_state(state)
             if (state.slot + 1) % self.config.SLOTS_PER_EPOCH == 0:
                 state = self.per_epoch_transition(state)

--- a/eth2/beacon/state_machines/forks/serenity/state_transitions.py
+++ b/eth2/beacon/state_machines/forks/serenity/state_transitions.py
@@ -43,6 +43,9 @@ class SerenityStateTransition(BaseStateTransition):
                                state: BeaconState,
                                block: BaseBeaconBlock,
                                check_proposer_signature: bool=True) -> BeaconState:
+        if state.slot == block.slot:
+            return state
+
         for _ in range(state.slot, block.slot):
             state = self.cache_state(state)
             if (state.slot + 1) % self.config.SLOTS_PER_EPOCH == 0:
@@ -50,7 +53,12 @@ class SerenityStateTransition(BaseStateTransition):
             state = self.per_slot_transition(state)
             if state.slot == block.slot:
                 state = self.per_block_transition(state, block, check_proposer_signature)
-
+                break
+        else:
+            raise Exception(
+                f"Invariant: state.slot ({state.slot}) should be less "
+                "than block.slot ({block.slot}) so that state transition terminates"
+            )
         return state
 
     def apply_state_transition_without_block(self,
@@ -62,11 +70,21 @@ class SerenityStateTransition(BaseStateTransition):
         See docs for :meth:`eth2.beacon.state_machines.state_transitions.BaseStateTransition.apply_state_transition_without_block`  # noqa: E501
         for more information about the behavior of this method.
         """
+        if state.slot == slot:
+            return state
+
         for _ in range(state.slot, slot):
             state = self.cache_state(state)
             if (state.slot + 1) % self.config.SLOTS_PER_EPOCH == 0:
                 state = self.per_epoch_transition(state)
             state = self.per_slot_transition(state)
+            if state.slot == slot:
+                break
+        else:
+            raise Exception(
+                f"Invariant: state.slot ({state.slot}) should be less than slot ({slot}) "
+                "so that state transition terminates"
+            )
         return state
 
     def cache_state(self, state: BeaconState) -> BeaconState:

--- a/eth2/beacon/state_machines/forks/serenity/state_transitions.py
+++ b/eth2/beacon/state_machines/forks/serenity/state_transitions.py
@@ -62,11 +62,7 @@ class SerenityStateTransition(BaseStateTransition):
         See docs for :meth:`eth2.beacon.state_machines.state_transitions.BaseStateTransition.apply_state_transition_without_block`  # noqa: E501
         for more information about the behavior of this method.
         """
-        # the loop body yields the state *after* applying the state transition
-        # to uphold the claims of this function, we want to range to one *before*
-        # the requested slot
-        target_slot = slot - 1
-        for _ in range(state.slot, target_slot):
+        for _ in range(state.slot, slot):
             state = self.cache_state(state)
             if (state.slot + 1) % self.config.SLOTS_PER_EPOCH == 0:
                 state = self.per_epoch_transition(state)

--- a/eth2/beacon/state_machines/forks/serenity/state_transitions.py
+++ b/eth2/beacon/state_machines/forks/serenity/state_transitions.py
@@ -43,7 +43,7 @@ class SerenityStateTransition(BaseStateTransition):
                                state: BeaconState,
                                block: BaseBeaconBlock,
                                check_proposer_signature: bool=True) -> BeaconState:
-        if state.slot == block.slot:
+        if state.slot >= block.slot:
             return state
 
         for _ in range(state.slot, block.slot):
@@ -70,7 +70,7 @@ class SerenityStateTransition(BaseStateTransition):
         See docs for :meth:`eth2.beacon.state_machines.state_transitions.BaseStateTransition.apply_state_transition_without_block`  # noqa: E501
         for more information about the behavior of this method.
         """
-        if state.slot == slot:
+        if state.slot >= slot:
             return state
 
         for _ in range(state.slot, slot):

--- a/eth2/beacon/tools/builder/validator.py
+++ b/eth2/beacon/tools/builder/validator.py
@@ -493,7 +493,6 @@ def create_mock_signed_attestations_at_slot(
         attestation_slot,
     )
     crosslink_committees_at_slot = get_crosslink_committees_at_slot(
-        # To avoid the epoch boundary cases
         state,
         attestation_slot,
         CommitteeConfig(config),

--- a/tests/eth2/beacon/state_machines/forks/test_serenity_block_attestation_validation.py
+++ b/tests/eth2/beacon/state_machines/forks/test_serenity_block_attestation_validation.py
@@ -109,20 +109,20 @@ def test_validate_attestation_slot(sample_attestation_data_params,
         'is_valid',
     ),
     [
-        # slot_to_epoch(attestation_data.slot + 1, slots_per_epoch) >= current_epoch
+        # slot_to_epoch(attestation_data.slot, slots_per_epoch) >= current_epoch
         # attestation_data.source_epoch == state.current_justified_epoch
-        (23, 2, b'\x22' * 32, True),
+        (24, 2, b'\x22' * 32, True),
         # attestation_data.source_epoch != state.current_justified_epoch
-        (23, 3, b'\x22' * 32, False),
+        (24, 3, b'\x22' * 32, False),
         # attestation_data.source_root != state.current_justified_root
-        (23, 2, b'\x33' * 32, False),
-        # slot_to_epoch(attestation_data.slot + 1, slots_per_epoch) < current_epoch
+        (24, 2, b'\x33' * 32, False),
+        # slot_to_epoch(attestation_data.slot, slots_per_epoch) < current_epoch
         # attestation_data.source_epoch == state.previous_justified_epoch
-        (22, 1, b'\x11' * 32, True),
+        (23, 1, b'\x11' * 32, True),
         # attestation_data.source_epoch != state.previous_justified_epoch
-        (22, 2, b'\x11' * 32, False),
+        (23, 2, b'\x11' * 32, False),
         # attestation_data.source_root != state.current_justified_root
-        (22, 1, b'\x33' * 32, False),
+        (23, 1, b'\x33' * 32, False),
     ]
 )
 def test_validate_attestation_source_epoch_and_root(

--- a/tests/eth2/beacon/state_machines/test_demo.py
+++ b/tests/eth2/beacon/state_machines/test_demo.py
@@ -57,7 +57,7 @@ def test_demo(base_db,
 
     attestations_map = {}  # Dict[Slot, Sequence[Attestation]]
 
-    for current_slot in range(genesis_slot + 1, genesis_slot + chain_length):
+    for current_slot in range(genesis_slot + 1, genesis_slot + chain_length + 1):
         if current_slot > genesis_slot + config.MIN_ATTESTATION_INCLUSION_DELAY:
             attestations = attestations_map[current_slot - config.MIN_ATTESTATION_INCLUSION_DELAY]
         else:
@@ -105,7 +105,7 @@ def test_demo(base_db,
         )
         attestations_map[attestation_slot] = attestations
 
-    assert state.slot == chain_length - 1 + genesis_slot
+    assert state.slot == chain_length + genesis_slot
     assert isinstance(sm.block, SerenityBeaconBlock)
 
     # Justification assertions


### PR DESCRIPTION
### What was wrong?

Fixes #391.
Fixes #145.

### How was it fixed?

Reorder the sequence in which the various elements of the state transition are executed.

This PR also makes a slight change to how we iterate over slots during the state transition with the intention of being safer with respect to how the block and state's slot can relate to each other (see #145).

[//]: # (For important changes, please add a new entry to the release notes file)
[//]: # (See: https://trinity-client.readthedocs.io/en/latest/contributing.html#pull-requests)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://proxy.duckduckgo.com/iu/?u=https%3A%2F%2Ftse2.mm.bing.net%2Fth%3Fid%3DOIP.UlJejzPXbiurjh1o4JqDTgHaEo%26pid%3DApi&f=1)
