### PR TITLE
Attempt to connect to peers concurrently.

### DIFF
--- a/p2p/_utils.py
+++ b/p2p/_utils.py
@@ -8,6 +8,15 @@ from typing import Tuple
 import rlp
 
 
+def clamp(lower_bound: int, upper_bound: int, value: int) -> int:
+    if value < lower_bound:
+        return lower_bound
+    elif value > upper_bound:
+        return upper_bound
+    else:
+        return value
+
+
 def sxor(s1: bytes, s2: bytes) -> bytes:
     if len(s1) != len(s2):
         raise ValueError("Cannot sxor strings of different length")

--- a/p2p/exceptions.py
+++ b/p2p/exceptions.py
@@ -24,6 +24,13 @@ class PeerConnectionLost(BaseP2PError):
     pass
 
 
+class IneligiblePeer(BaseP2PError):
+    """
+    Raised when a peer is not a valid connection candidate.
+    """
+    pass
+
+
 class HandshakeFailure(BaseP2PError):
     """
     Raised when the protocol handshake was unsuccessful.

--- a/p2p/peer_pool.py
+++ b/p2p/peer_pool.py
@@ -23,6 +23,7 @@ from eth_keys import (
 )
 from eth_utils.toolz import (
     groupby,
+    take,
 )
 from lahja import (
     Endpoint,
@@ -41,6 +42,8 @@ from p2p.events import (
     RandomBootnodeRequest,
 )
 from p2p.exceptions import (
+    BaseP2PError,
+    IneligiblePeer,
     BadAckMessage,
     HandshakeFailure,
     MalformedMessage,
@@ -72,6 +75,22 @@ from p2p.service import (
 
 
 TO_DISCOVERY_BROADCAST_CONFIG = BroadcastConfig(filter_endpoint=DISCOVERY_EVENTBUS_ENDPOINT)
+
+
+COMMON_PEER_CONNECTION_EXCEPTIONS = cast(Tuple[Type[BaseP2PError], ...], (
+    PeerConnectionLost,
+    TimeoutError,
+    UnreachablePeer,
+))
+
+# This should contain all exceptions that should not propogate during a
+# standard attempt to connect to a peer.
+ALLOWED_PEER_CONNECTION_EXCEPTIONS = cast(Tuple[Type[BaseP2PError], ...], (
+    IneligiblePeer,
+    BadAckMessage,
+    MalformedMessage,
+    HandshakeFailure,
+)) + COMMON_PEER_CONNECTION_EXCEPTIONS
 
 
 class BasePeerPool(BaseService, AsyncIterable[BasePeer]):
@@ -127,7 +146,7 @@ class BasePeerPool(BaseService, AsyncIterable[BasePeer]):
                 # node as well.
                 if not len(self):
                     try:
-                        response = await self.wait(
+                        bootnodes_response = await self.wait(
                             self.event_bus.request(
                                 RandomBootnodeRequest(),
                                 TO_DISCOVERY_BROADCAST_CONFIG
@@ -139,9 +158,12 @@ class BasePeerPool(BaseService, AsyncIterable[BasePeer]):
                             "Discovery did not answer RandomBootnodeRequest in time"
                         )
                         continue
+                    candidates = response.candidates + bootnodes_response.candidates
+                else:
+                    candidates = response.candidates
 
-                self.logger.debug2("Received candidates to connect to (%s)", response.candidates)
-                await self.connect_to_nodes(from_uris(response.candidates))
+                self.logger.debug2("Received candidates to connect to (%s)", candidates)
+                await self.connect_to_nodes(from_uris(candidates))
 
     def __len__(self) -> int:
         return len(self.connected_nodes)
@@ -245,14 +267,10 @@ class BasePeerPool(BaseService, AsyncIterable[BasePeer]):
         """
         if remote in self.connected_nodes:
             self.logger.debug2("Skipping %s; already connected to it", remote)
-            return None
+            raise IneligiblePeer(f"Already connected to {remote}")
         if not self.peer_info.should_connect_to(remote):
-            return None
-        expected_exceptions = (
-            PeerConnectionLost,
-            TimeoutError,
-            UnreachablePeer,
-        )
+            raise IneligiblePeer(f"Peer database rejected peer candidate: {remote}")
+
         try:
             self.logger.debug2("Connecting to %s...", remote)
             # We use self.wait() as well as passing our CancelToken to handshake() as a workaround
@@ -264,40 +282,97 @@ class BasePeerPool(BaseService, AsyncIterable[BasePeer]):
             # Pass it on to instruct our main loop to stop.
             raise
         except BadAckMessage:
-            # This is kept separate from the `expected_exceptions` to be sure that we aren't
+            # This is kept separate from the
+            # `COMMON_PEER_CONNECTION_EXCEPTIONS` to be sure that we aren't
             # silencing an error in our authentication code.
             self.logger.error('Got bad auth ack from %r', remote)
             # dump the full stacktrace in the debug logs
             self.logger.debug('Got bad auth ack from %r', remote, exc_info=True)
+            raise
         except MalformedMessage:
-            # This is kept separate from the `expected_exceptions` to be sure that we aren't
+            # This is kept separate from the
+            # `COMMON_PEER_CONNECTION_EXCEPTIONS` to be sure that we aren't
             # silencing an error in how we decode messages during handshake.
             self.logger.error('Got malformed response from %r during handshake', remote)
             # dump the full stacktrace in the debug logs
             self.logger.debug('Got malformed response from %r', remote, exc_info=True)
+            raise
         except HandshakeFailure as e:
             self.logger.debug("Could not complete handshake with %r: %s", remote, repr(e))
             self.peer_info.record_failure(remote, e)
-        except expected_exceptions as e:
+            raise
+        except COMMON_PEER_CONNECTION_EXCEPTIONS as e:
             self.logger.debug("Could not complete handshake with %r: %s", remote, repr(e))
+            raise
         except Exception:
             self.logger.exception("Unexpected error during auth/p2p handshake with %r", remote)
-        return None
+            raise
 
     async def connect_to_nodes(self, nodes: Iterator[Node]) -> None:
-        for node in nodes:
+        # create an generator for the nodes
+        nodes_iter = iter(nodes)
+
+        while True:
             if self.is_full or not self.is_operational:
                 return
 
-            # TODO: Consider changing connect() to raise an exception instead of returning None,
-            # as discussed in
-            # https://github.com/ethereum/py-evm/pull/139#discussion_r152067425
+            # only attempt to connect to up to the maximum number of available
+            # peer slots that are open.
+            available_peer_slots = min(10, max(1, self.max_peers - len(self)))
+            batch = tuple(take(available_peer_slots, nodes_iter))
+
+            # There are no more *known* nodes to connect to.
+            if not batch:
+                return
+
+            self.logger.debug(
+                'Initiating %d peer connection attempts with %d open peer slots',
+                len(batch),
+                available_peer_slots,
+            )
+            # Try to connect to the peers concurrently.
+            # TODO: does this need to be wrapped in `self.wait`...
+            await asyncio.gather(
+                *(self.connect_to_node(node) for node in batch),
+                loop=self.get_event_loop(),
+            )
+
+    async def connect_to_node(self, node: Node) -> None:
+        """
+        Connect to a single node quietly aborting if the peer pool is full or
+        shutting down, or one of the expected peer level exceptions is raised
+        while connecting.
+        """
+        if self.is_full or not self.is_operational:
+            return
+
+        try:
             peer = await self.connect(node)
-            if peer is not None:
-                await self.start_peer(peer)
+        except ALLOWED_PEER_CONNECTION_EXCEPTIONS:
+            return
+
+        # Check again to see if we have *become* full since the previous
+        # check.
+        if self.is_full:
+            self.logger.debug(
+                "Successfully connected to %s but peer pool is full.  Disconnecting.",
+                peer,
+            )
+            await peer.disconnect(DisconnectReason.too_many_peers)
+            return
+        elif not self.is_operational:
+            self.logger.debug(
+                "Successfully connected to %s but peer pool no longer operational.  Disconnecting.",
+                peer,
+            )
+            await peer.disconnect(DisconnectReason.client_quitting)
+            return
+        else:
+            await self.start_peer(peer)
 
     def _peer_finished(self, peer: BaseService) -> None:
-        """Remove the given peer from our list of connected nodes.
+        """
+        Remove the given peer from our list of connected nodes.
         This is passed as a callback to be called when a peer finishes.
         """
         peer = cast(BasePeer, peer)

--- a/tests/p2p/test_clamp_util.py
+++ b/tests/p2p/test_clamp_util.py
@@ -1,0 +1,19 @@
+import pytest
+
+from p2p._utils import clamp
+
+
+@pytest.mark.parametrize(
+    'lower_bound,upper_bound,value,expected',
+    (
+        (5, 8, 4, 5),
+        (5, 8, 5, 5),
+        (5, 8, 6, 6),
+        (5, 8, 7, 7),
+        (5, 8, 8, 8),
+        (5, 8, 9, 8),
+    ),
+)
+def test_numeric_clamp_utility(lower_bound, upper_bound, value, expected):
+    result = clamp(lower_bound, upper_bound, value)
+    assert result == expected

--- a/trinity/sync/common/headers.py
+++ b/trinity/sync/common/headers.py
@@ -164,7 +164,7 @@ class SkeletonSyncer(BaseService, Generic[TChainPeer]):
                     self.wait(self._chain.coro_validate_chain(parent, (child, )))
                     for parent, child in pairs
                 ]
-                await asyncio.gather(*validate_pair_coros, loop=self.get_event_loop())
+                await self.wait(asyncio.gather(*validate_pair_coros, loop=self.get_event_loop()))
             except ValidationError as e:
                 self.logger.warning(
                     "Received an invalid header pair from %s, disconnecting: %s",


### PR DESCRIPTION
### What was wrong?

Two things:

1. There was a bug in how the `PeerCandidateResponse` was handled.  In the case where the peer pool was empty, the peer pool would first make a request for peer candidates sourced from the discovery protocol, but then it would overwrite that response with a request for bootnodes, resulting in trinity only ever sourcing it's first outbound connection when the peer pool is empty from a bootnode.
2. Attempts to connect to new peers were done synchronously, not attempting a new connection until the previous attempt had finished.  This is very slow.

### How was it fixed?

- Fixed the bug to ensure that the bootnodes do not overwrite the nodes found from discovery.
- Updated the connection code so that we attempt connections concurrently.
- Also changed how `PeerPool.connect` works to raise exceptions instead of returning `None` on a failure.

#### Cute Animal Picture

![miniature cattle echuca](https://user-images.githubusercontent.com/824194/56048694-4546d380-5d05-11e9-8976-693a8977bdf3.jpg)

