### PR TITLE
Move sourcing of peer candidates into a backend system

### DIFF
--- a/p2p/constants.py
+++ b/p2p/constants.py
@@ -114,7 +114,10 @@ DEFAULT_PEER_BOOT_TIMEOUT = 20
 
 # Name of the endpoint that the discovery uses to connect to the eventbus
 DISCOVERY_EVENTBUS_ENDPOINT = 'discovery'
-# Interval at which peer pool is checked for potential new candidates
-DISOVERY_INTERVAL = 2
+# Interval at which peer pool requests new connection candidates
+PEER_CONNECT_INTERVAL = 2
+# Maximum number of sequential connection attempts that can be made before
+# hitting the rate limit
+MAX_SEQUENTIAL_PEER_CONNECT = 5
 # Timeout used when fetching peer candidates from discovery
 REQUEST_PEER_CANDIDATE_TIMEOUT = 0.5

--- a/p2p/peer_backend.py
+++ b/p2p/peer_backend.py
@@ -1,0 +1,64 @@
+from abc import ABC, abstractmethod
+from typing import (
+    Iterable,
+    NamedTuple,
+)
+
+from lahja import (
+    Endpoint,
+    BroadcastConfig,
+)
+
+from p2p.constants import (
+    DISCOVERY_EVENTBUS_ENDPOINT,
+)
+from p2p.kademlia import (
+    from_uris,
+    Node,
+)
+from p2p.events import (
+    PeerCandidatesRequest,
+    RandomBootnodeRequest,
+)
+
+
+class PoolMeta(NamedTuple):
+    num_connected_peers: int
+    num_requested: int
+
+
+class BasePeerBackend(ABC):
+    @abstractmethod
+    async def get_peer_candidates(self, pool_info: PoolMeta) -> Iterable[Node]:
+        pass
+
+
+TO_DISCOVERY_BROADCAST_CONFIG = BroadcastConfig(filter_endpoint=DISCOVERY_EVENTBUS_ENDPOINT)
+
+
+class DiscoveryPeerBackend(BasePeerBackend):
+    def __init__(self, event_bus: Endpoint) -> None:
+        self.event_bus = event_bus
+
+    async def get_peer_candidates(self, pool_info: PoolMeta) -> Iterable[Node]:
+        response = await self.event_bus.request(
+            PeerCandidatesRequest(pool_info.num_requested),
+            TO_DISCOVERY_BROADCAST_CONFIG,
+        )
+        return from_uris(response.candidates)
+
+
+class BootnodesPeerBackend(BasePeerBackend):
+    def __init__(self, event_bus: Endpoint) -> None:
+        self.event_bus = event_bus
+
+    async def get_peer_candidates(self, pool_info: PoolMeta) -> Iterable[Node]:
+        if pool_info.num_connected_peers == 0:
+            response = await self.event_bus.request(
+                RandomBootnodeRequest(),
+                TO_DISCOVERY_BROADCAST_CONFIG
+            )
+
+            return from_uris(response.candidates)
+        else:
+            return ()

--- a/p2p/peer_pool.py
+++ b/p2p/peer_pool.py
@@ -35,7 +35,8 @@ from p2p.constants import (
     DEFAULT_MAX_PEERS,
     DEFAULT_PEER_BOOT_TIMEOUT,
     DISCOVERY_EVENTBUS_ENDPOINT,
-    DISOVERY_INTERVAL,
+    PEER_CONNECT_INTERVAL,
+    MAX_SEQUENTIAL_PEER_CONNECT,
     REQUEST_PEER_CANDIDATE_TIMEOUT,
 )
 from p2p.exceptions import (
@@ -156,10 +157,10 @@ class BasePeerPool(BaseService, AsyncIterable[BasePeer]):
 
     async def maybe_connect_more_peers(self) -> None:
         # allowed to operate at a maximum rate of 1 check every 2 seconds
-        rate_limiter = token_bucket(0.5, 5)
+        rate_limiter = token_bucket(1 / PEER_CONNECT_INTERVAL, MAX_SEQUENTIAL_PEER_CONNECT)
         while True:
             if self.is_full:
-                await self.sleep(DISOVERY_INTERVAL)
+                await self.sleep(PEER_CONNECT_INTERVAL)
                 continue
             await self.wait(rate_limiter.__anext__())
 

--- a/tests/p2p/test_burstable_rate_limiter.py
+++ b/tests/p2p/test_burstable_rate_limiter.py
@@ -27,5 +27,4 @@ async def test_burstable_rate_limiter_allows_burst():
 
     end_at = time.perf_counter()
     delta = end_at - start_at
-    print('DELTA:', delta)
     assert delta < 0.001

--- a/tests/p2p/test_burstable_rate_limiter.py
+++ b/tests/p2p/test_burstable_rate_limiter.py
@@ -1,25 +1,13 @@
+import asyncio
 import pytest
 import time
 
-from p2p._utils import burstable_rate_limiter
+from p2p._utils import token_bucket
 
 
 @pytest.mark.asyncio
-async def test_burstable_rate_limiter_hits_limit():
-    limiter = burstable_rate_limiter(5, 0.01)
-
-    start_at = time.perf_counter()
-    for _ in range(25):
-        await limiter.__anext__()
-
-    end_at = time.perf_counter()
-    delta = end_at - start_at
-    assert abs(delta - 0.05) < 0.01
-
-
-@pytest.mark.asyncio
-async def test_burstable_rate_limiter_allows_burst():
-    limiter = burstable_rate_limiter(10, 0.01)
+async def test_token_bucket_initial_tokens():
+    limiter = token_bucket(1000, 10)
 
     start_at = time.perf_counter()
     for _ in range(10):
@@ -27,4 +15,50 @@ async def test_burstable_rate_limiter_allows_burst():
 
     end_at = time.perf_counter()
     delta = end_at - start_at
-    assert delta < 0.001
+    # since the bucket starts out full the loop
+    # should take near zero time
+    assert delta < 0.0001
+
+
+@pytest.mark.asyncio
+async def test_token_bucket_hits_limit():
+    limiter = token_bucket(1000, 10)
+
+    start_at = time.perf_counter()
+    # first 10 tokens should be roughly instant
+    # next 10 tokens should each take 1/1000th second each to generate.
+    for _ in range(20):
+        await limiter.__anext__()
+
+    end_at = time.perf_counter()
+
+    expected_delta = 10 / 1000
+    delta = end_at - start_at
+    print('DELTA:', delta, expected_delta)
+
+    # allow up to 10% drift from expected result
+    assert abs(1 - (delta / expected_delta)) < 0.1
+
+
+@pytest.mark.asyncio
+async def test_token_bucket_refills_itself():
+    limiter = token_bucket(1000, 10)
+
+    # consume all of the tokens
+    for _ in range(10):
+        await limiter.__anext__()
+
+    # enough time for the bucket to fully refill
+    await asyncio.sleep(20 / 1000)
+
+    start_at = time.perf_counter()
+
+    for _ in range(10):
+        await limiter.__anext__()
+
+    end_at = time.perf_counter()
+
+    delta = end_at - start_at
+    # since the capacity should have been fully refilled, second loop time
+    # should take near zero time
+    assert delta < 0.0001

--- a/tests/p2p/test_burstable_rate_limiter.py
+++ b/tests/p2p/test_burstable_rate_limiter.py
@@ -1,0 +1,31 @@
+import pytest
+import time
+
+from p2p._utils import burstable_rate_limiter
+
+
+@pytest.mark.asyncio
+async def test_burstable_rate_limiter_hits_limit():
+    limiter = burstable_rate_limiter(5, 0.01)
+
+    start_at = time.perf_counter()
+    for _ in range(25):
+        await limiter.__anext__()
+
+    end_at = time.perf_counter()
+    delta = end_at - start_at
+    assert abs(delta - 0.05) < 0.01
+
+
+@pytest.mark.asyncio
+async def test_burstable_rate_limiter_allows_burst():
+    limiter = burstable_rate_limiter(10, 0.01)
+
+    start_at = time.perf_counter()
+    for _ in range(10):
+        await limiter.__anext__()
+
+    end_at = time.perf_counter()
+    delta = end_at - start_at
+    print('DELTA:', delta)
+    assert delta < 0.001


### PR DESCRIPTION
### What was wrong?

We want to try and re-use known good peers from historical connection data.  This is a preliminary step towards this since the current construct doesn't lend itself well to extension outside of the `p2p` code which will be needed in the trinity side.

### How was it fixed?

Peer candidates are now sourced across a set of *backends*, each of which can source peers however it chooses.

#### Cute Animal Picture

![85152cb53f52a7e54e317f5a4f7b64ec](https://user-images.githubusercontent.com/824194/56053941-b5a82180-5d12-11e9-875b-725bd74dff9a.jpg)

