### PR TITLE
Fix ecies deprecation warning

### DIFF
--- a/p2p/ecies.py
+++ b/p2p/ecies.py
@@ -55,8 +55,8 @@ def ecdh_agree(privkey: datatypes.PrivateKey, pubkey: datatypes.PublicKey) -> by
     pubkey_bytes = b'\x04' + pubkey.to_bytes()
     try:
         # either of these can raise a ValueError:
-        pubkey_nums = ec.EllipticCurvePublicNumbers.from_encoded_point(CURVE, pubkey_bytes)
-        ec_pubkey = pubkey_nums.public_key(default_backend())
+        pubkey_nums = ec.EllipticCurvePublicKey.from_encoded_point(CURVE, pubkey_bytes)
+        ec_pubkey = pubkey_nums.public_numbers().public_key(default_backend())
     except ValueError as exc:
         # Not all bytes can be made into valid public keys, see the warning at
         # https://cryptography.io/en/latest/hazmat/primitives/asymmetric/ec/


### PR DESCRIPTION
### What was wrong?

Deprecation warnings were being issued from APIs we were using in the `p2p.ecies` modules.

### How was it fixed?

Followed instructions in the warning message to update to the non-depracated APIs.

#### Cute Animal Picture

![060103_cattle_hmed_6p grid-6x2](https://user-images.githubusercontent.com/824194/56059730-fa878480-5d21-11e9-8c00-1f0015b8ee39.jpg)
