### PR TITLE
[WIP] Support lahja#36

### DIFF
--- a/trinity/bootstrap.py
+++ b/trinity/bootstrap.py
@@ -144,7 +144,6 @@ def main_entry(trinity_boot: BootFn,
     if args.log_levels:
         setup_log_levels(args.log_levels)
 
-    main_endpoint.track_and_propagate_available_endpoints()
     try:
         trinity_config = TrinityConfig.from_parser_args(args, app_identifier, sub_configs)
     except AmbigiousFileSystem:
@@ -203,6 +202,7 @@ def main_entry(trinity_boot: BootFn,
             trinity_config.ipc_dir
         )
         main_endpoint.start_serving_nowait(main_connection_config)
+        main_endpoint.track_and_propagate_available_endpoints()
 
         # We listen on events such as `ShutdownRequested` which may or may not originate on
         # the `main_endpoint` which is why we connect to our own endpoint here

--- a/trinity/events.py
+++ b/trinity/events.py
@@ -27,6 +27,9 @@ class EventBusConnected(BaseEvent):
     def __init__(self, connection_config: ConnectionConfig) -> None:
         self.connection_config = connection_config
 
+    def __repr__(self) -> str:
+        return f'EventBusConnected({self.connection_config})'
+
 
 class AvailableEndpointsUpdated(BaseEvent):
     """
@@ -37,3 +40,6 @@ class AvailableEndpointsUpdated(BaseEvent):
 
     def __init__(self, available_endpoints: Tuple[ConnectionConfig, ...]) -> None:
         self.available_endpoints = available_endpoints
+
+    def __repr__(self) -> str:
+        return f'AvailableEndpointsUpdated({self.available_endpoints})'

--- a/trinity/extensibility/plugin.py
+++ b/trinity/extensibility/plugin.py
@@ -274,6 +274,16 @@ class BaseIsolatedPlugin(BasePlugin):
 
     _process: Process = None
 
+    def __init__(self) -> None:
+        super().__init__()
+        self._event_bus = None
+
+    @property
+    def event_bus(self) -> TrinityEventBusEndpoint:
+        if self._event_bus is None:
+            self._event_bus = TrinityEventBusEndpoint()
+        return self._event_bus
+
     @property
     def process(self) -> Process:
         """

--- a/trinity/extensibility/plugin_manager.py
+++ b/trinity/extensibility/plugin_manager.py
@@ -99,7 +99,7 @@ class MainAndIsolatedProcessScope(BaseManagerProcessScope):
             # created here for API symmetry. Endpoints are pickleable *before* they are connected,
             # which means, this Endpoint will be pickled and transferred into the new process
             # together with the rest of the `PluginContext`.
-            plugin.set_context(PluginContext(TrinityEventBusEndpoint(), boot_info,))
+            plugin.set_context(PluginContext(None, boot_info,))
 
 
 class SharedProcessScope(BaseManagerProcessScope):


### PR DESCRIPTION
### What was wrong?

Not yet ready to merge. This is just a hack and it still has ugly output when the process exits: 

```
Traceback (most recent call last):
  File "/home/brian/.pyenv/versions/3.7.0/lib/python3.7/threading.py", line 917, in _bootstrap_inner
    self.run()
  File "/home/brian/.pyenv/versions/3.7.0/lib/python3.7/threading.py", line 865, in run
    self._target(*self._args, **self._kwargs)
  File "/home/brian/ef/lahja/lahja/endpoint.py", line 147, in _run
    self.condition.wait()
  File "/home/brian/.pyenv/versions/3.7.0/lib/python3.7/multiprocessing/managers.py", line 1032, in __exit__
    return self._callmethod('release')
  File "/home/brian/.pyenv/versions/3.7.0/lib/python3.7/multiprocessing/managers.py", line 795, in _callmethod
    conn.send((self._id, methodname, args, kwds))
  File "/home/brian/.pyenv/versions/3.7.0/lib/python3.7/multiprocessing/connection.py", line 207, in send
    self._send_bytes(_ForkingPickler.dumps(obj))
  File "/home/brian/.pyenv/versions/3.7.0/lib/python3.7/multiprocessing/connection.py", line 405, in _send_bytes
    self._send(header + buf)
  File "/home/brian/.pyenv/versions/3.7.0/lib/python3.7/multiprocessing/connection.py", line 369, in _send
    n = write(self._handle, buf)
BrokenPipeError: [Errno 32] Broken pipe
```

However, without this PR trinity experiences some [crazy segfaults](https://github.com/ethereum/lahja/pull/36#issuecomment-482758419) when running under lahja#36. With this PR, those segfaults are gone and everything else appears to go normally!

### How was it fixed?

Endpoints are no longer sent across process boundaries.

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses]()
