### PR TITLE
Use RPC module class as conventional (& default) module name

### DIFF
--- a/trinity/rpc/modules/admin.py
+++ b/trinity/rpc/modules/admin.py
@@ -11,10 +11,6 @@ class Admin(BaseRPCModule):
     def __init__(self, event_bus: TrinityEventBusEndpoint) -> None:
         self.event_bus = event_bus
 
-    @property
-    def name(self) -> str:
-        return 'admin'
-
     async def addPeer(self, node: str) -> None:
         validate_enode_uri(node, require_ip=True)
 

--- a/trinity/rpc/modules/beacon.py
+++ b/trinity/rpc/modules/beacon.py
@@ -3,9 +3,5 @@ from trinity.rpc.modules import BeaconChainRPCModule
 
 class Beacon(BeaconChainRPCModule):
 
-    @property
-    def name(self) -> str:
-        return 'beacon'
-
     async def currentSlot(self) -> str:
         return hex(666)

--- a/trinity/rpc/modules/eth.py
+++ b/trinity/rpc/modules/eth.py
@@ -143,10 +143,6 @@ class Eth(Eth1ChainRPCModule):
     Any attribute without an underscore is publicly accessible.
     """
 
-    @property
-    def name(self) -> str:
-        return 'eth'
-
     async def accounts(self) -> List[str]:
         # trinity does not manage accounts for the user
         return []

--- a/trinity/rpc/modules/evm.py
+++ b/trinity/rpc/modules/evm.py
@@ -32,10 +32,6 @@ from trinity.rpc.modules import (
 
 class EVM(Eth1ChainRPCModule):
 
-    @property
-    def name(self) -> str:
-        return 'evm'
-
     @format_params(normalize_blockchain_fixtures)
     async def resetToGenesisFixture(self, chain_info: Any) -> BaseChain:
         """

--- a/trinity/rpc/modules/main.py
+++ b/trinity/rpc/modules/main.py
@@ -1,5 +1,4 @@
 from abc import (
-    abstractmethod,
     ABC,
 )
 from typing import (
@@ -33,9 +32,11 @@ class ChainReplacementEvent(BaseEvent, Generic[TChain]):
 class BaseRPCModule(ABC):
 
     @property
-    @abstractmethod
     def name(self) -> str:
-        pass
+        # By default the name is the lower-case class name.
+        # This encourages a standard name of the module, but can
+        # be overridden if necessary.
+        return self.__class__.__name__.lower()
 
 
 class ChainBasedRPCModule(BaseRPCModule, Generic[TChain]):

--- a/trinity/rpc/modules/net.py
+++ b/trinity/rpc/modules/net.py
@@ -11,10 +11,6 @@ class Net(BaseRPCModule):
     def __init__(self, event_bus: TrinityEventBusEndpoint):
         self.event_bus = event_bus
 
-    @property
-    def name(self) -> str:
-        return 'net'
-
     async def version(self) -> str:
         """
         Returns the current network ID.

--- a/trinity/rpc/modules/web3.py
+++ b/trinity/rpc/modules/web3.py
@@ -10,10 +10,6 @@ from trinity.rpc.modules import (
 
 class Web3(BaseRPCModule):
 
-    @property
-    def name(self) -> str:
-        return 'web3'
-
     async def clientVersion(self) -> str:
         """
         Returns the current client version.


### PR DESCRIPTION
### What was wrong?

#12 introduced a new requirement to explicitly name the modules. Seemed unnecessary, and it's nice to strongly encourage naming the class the same as the module in the RPC.

### How was it fixed?

Implement the default name as the lower-cased class name (like it was before #12), but implement it on the class instead of in the `RPCServer` (which I agree was a suboptimal place to name it).

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://www.myinterestingfacts.com/wp-content/uploads/2014/02/Gopher-Cute.jpg)
