### PR TITLE
github: update issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,6 +1,6 @@
-* py-evm Version: x.x.x
+* Trinity version: x.x.x
 * OS: osx/linux/win
-* Python Version (python --version):
+* Python version (output of `python --version`):
 * Environment (output of `pip freeze`):
 
 ### What is wrong?


### PR DESCRIPTION
### What was wrong?

After the `py-evm`/`trinity` repo split, the issue template still references `py-evm`.

### How was it fixed?

Changed to `trinity`, other minor fixes.

[//]: # (For important changes, please add a new entry to the release notes file)
[//]: # (See: https://trinity-client.readthedocs.io/en/latest/contributing.html#pull-requests)

### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://assets.atlasobscura.com/article_images/64090/image.jpg)

Source: Felicia, [Tim Fielding, Fermilab (via AO)](https://www.atlasobscura.com/articles/felicia-ferret-particle-accelerator-fermilab)