### PR TITLE
Specify the cryptography library as a p2p dependency since it is

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,6 +9,8 @@ deps = {
         "asyncio-cancel-token==0.1.0a2",
         "async_lru>=0.1.0,<1.0.0",
         "eth-hash>=0.1.4,<1",
+        # cryptography does not use semver and allows breaking changes within `0.3` version bumps.
+        "cryptography>=2.6,<2.9",
         "netifaces>=0.10.7<1",
         "pysha3>=1.0.0,<2.0.0",
         "upnpclient>=0.0.8,<1",

--- a/setup.py
+++ b/setup.py
@@ -8,9 +8,9 @@ deps = {
     'p2p': [
         "asyncio-cancel-token==0.1.0a2",
         "async_lru>=0.1.0,<1.0.0",
-        "eth-hash>=0.1.4,<1",
         # cryptography does not use semver and allows breaking changes within `0.3` version bumps.
-        "cryptography>=2.6,<2.9",
+        "cryptography>=2.5,<2.7",
+        "eth-hash>=0.1.4,<1",
         "netifaces>=0.10.7<1",
         "pysha3>=1.0.0,<2.0.0",
         "upnpclient>=0.0.8,<1",


### PR DESCRIPTION
### What was wrong?

https://github.com/ethereum/trinity/pull/497 migrated to a new cryptography API since the old one was deprecated.  Turns out we don't locally specify a `cryptography` dependency (it was coming from py-evm).

### How was it fixed?

Explicitely specified the dependency.

#### Cute Animal Picture

![baby-Zebra-1024x682](https://user-images.githubusercontent.com/824194/56371203-e926f800-61b9-11e9-860b-c1fbeb50fd2e.jpg)

