### PR TITLE
Create log directory, if data dir is empty

### DIFF
--- a/tests/core/initialization/test_initialize_data_dir.py
+++ b/tests/core/initialization/test_initialize_data_dir.py
@@ -2,12 +2,18 @@ import pytest
 
 import os
 
+from trinity._utils.filesystem import (
+    is_under_path,
+)
 from trinity.initialization import (
     is_data_dir_initialized,
     initialize_data_dir,
 )
 from trinity.config import (
     TrinityConfig,
+)
+from trinity.exceptions import (
+    MissingPath,
 )
 
 
@@ -16,11 +22,9 @@ def trinity_config():
     return TrinityConfig(network_id=1)
 
 
-@pytest.fixture
-def data_dir(trinity_config):
+def _manually_add_datadir(trinity_config):
     os.makedirs(trinity_config.data_dir, exist_ok=True)
     assert os.path.exists(trinity_config.data_dir)
-    return trinity_config.data_dir
 
 
 def test_initializing_data_dir_from_nothing(trinity_config):
@@ -32,7 +36,8 @@ def test_initializing_data_dir_from_nothing(trinity_config):
     assert is_data_dir_initialized(trinity_config)
 
 
-def test_initializing_data_dir_from_empty_data_dir(trinity_config, data_dir):
+def test_initializing_data_dir_from_empty_data_dir(trinity_config):
+    _manually_add_datadir(trinity_config)
     assert not is_data_dir_initialized(trinity_config)
 
     initialize_data_dir(trinity_config)
@@ -40,10 +45,60 @@ def test_initializing_data_dir_from_empty_data_dir(trinity_config, data_dir):
     assert is_data_dir_initialized(trinity_config)
 
 
-def test_initializing_data_dir_with_missing_nodekey(trinity_config, data_dir):
+def test_initializing_data_dir_with_missing_nodekey(trinity_config):
+    _manually_add_datadir(trinity_config)
     assert not os.path.exists(trinity_config.nodekey_path)
     assert not is_data_dir_initialized(trinity_config)
 
     initialize_data_dir(trinity_config)
 
     assert is_data_dir_initialized(trinity_config)
+
+
+def test_always_creates_logs_folder_in_default_dir(trinity_config):
+    # log dir is in default path, data dir has other data in it, but is missing logs folder
+    assert is_under_path(trinity_config.trinity_root_dir, trinity_config.log_dir)
+    _manually_add_datadir(trinity_config)
+    file_in_data_dir = trinity_config.data_dir / "other_things_present"
+    file_in_data_dir.touch()
+    assert not trinity_config.log_dir.exists()
+    assert not is_data_dir_initialized(trinity_config)
+
+    # should create log dir
+    initialize_data_dir(trinity_config)
+
+    assert trinity_config.log_dir.exists()
+
+
+def test_creates_log_dir_in_non_default_data_dir_with_clean_folder(trinity_config):
+    # log dir is not in default path, data dir has no other data/folders in it
+    trinity_config.data_dir = trinity_config.trinity_root_dir.parent / "custom-data-dir"
+    _manually_add_datadir(trinity_config)
+    assert not is_under_path(trinity_config.trinity_root_dir, trinity_config.log_dir)
+    assert not is_under_path(trinity_config.trinity_root_dir, trinity_config.data_dir)
+    assert is_under_path(trinity_config.data_dir, trinity_config.log_dir)
+    assert not any(trinity_config.data_dir.iterdir())
+    assert not is_data_dir_initialized(trinity_config)
+
+    # should create log dir
+    initialize_data_dir(trinity_config)
+
+    assert trinity_config.log_dir.exists()
+
+
+def test_ignore_log_dir_in_non_default_data_dir_with_dirty_folder(trinity_config):
+    # log dir is not in default path, data dir has other data in it, and is missing logs folder
+    trinity_config.data_dir = trinity_config.trinity_root_dir.parent / "custom-data-dir"
+    _manually_add_datadir(trinity_config)
+    assert not is_under_path(trinity_config.trinity_root_dir, trinity_config.log_dir)
+    assert is_under_path(trinity_config.data_dir, trinity_config.log_dir)
+    file_in_data_dir = trinity_config.data_dir / "other_things_present"
+    file_in_data_dir.touch()
+    assert not trinity_config.log_dir.exists()
+    assert not is_data_dir_initialized(trinity_config)
+
+    # should *not* create log dir
+    with pytest.raises(MissingPath, match="logging"):
+        initialize_data_dir(trinity_config)
+
+    assert not trinity_config.log_dir.exists()

--- a/trinity/initialization.py
+++ b/trinity/initialization.py
@@ -97,7 +97,15 @@ def initialize_data_dir(trinity_config: TrinityConfig) -> None:
     # Logfile
     should_create_logdir = (
         not trinity_config.log_dir.exists() and
-        is_under_path(trinity_config.trinity_root_dir, trinity_config.log_dir)
+        (
+            # If we're in the default path, always create the log directory
+            is_under_path(trinity_config.trinity_root_dir, trinity_config.log_dir) or
+            (
+                # If we're in a custom path, create the log directory if the data dir is empty
+                is_under_path(trinity_config.data_dir, trinity_config.log_dir) and
+                not any(trinity_config.data_dir.iterdir())
+            )
+        )
     )
     if should_create_logdir:
         trinity_config.log_dir.mkdir(parents=True, exist_ok=True)


### PR DESCRIPTION
### What was wrong?

Fixes #105

### How was it fixed?

In a common case, where the custom data directory is empty (and the log directory is a subdirectory), trinity will create the log directory for you.

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://upload.wikimedia.org/wikipedia/commons/7/7d/Cute_worm.jpg)
