### PR TITLE
Store disconnect reason and retain info from failed handshakes

### DIFF
--- a/p2p/peer.py
+++ b/p2p/peer.py
@@ -201,6 +201,7 @@ class BasePeer(BaseService):
     listen_port = 30303
     # Will be set upon the successful completion of a P2P handshake.
     sub_proto: protocol.Protocol = None
+    disconnect_reason: DisconnectReason = None
 
     def __init__(self,
                  remote: Node,
@@ -624,6 +625,7 @@ class BasePeer(BaseService):
             )
         self.logger.debug("Disconnecting from remote peer %s; reason: %s", self.remote, reason.name)
         self.base_protocol.send_disconnect(reason.value)
+        self.disconnect_reason = reason
         self.close()
 
     async def disconnect(self, reason: DisconnectReason) -> None:

--- a/trinity/protocol/eth/proto.py
+++ b/trinity/protocol/eth/proto.py
@@ -57,7 +57,7 @@ class ETHProtocol(HasExtendedDebugLogger, Protocol):
     def send_handshake(self, chain_info: ChainInfo) -> None:
         resp = {
             'protocol_version': self.version,
-            'network_id': self.peer.network_id,
+            'network_id': self.peer.local_network_id,
             'td': chain_info.total_difficulty,
             'best_hash': chain_info.block_hash,
             'genesis_hash': chain_info.genesis_hash,

--- a/trinity/protocol/les/proto.py
+++ b/trinity/protocol/les/proto.py
@@ -56,7 +56,7 @@ class LESProtocol(Protocol):
     def send_handshake(self, chain_info: ChainInfo) -> None:
         resp = {
             'protocolVersion': self.version,
-            'networkId': self.peer.network_id,
+            'networkId': self.peer.local_network_id,
             'headTd': chain_info.total_difficulty,
             'headHash': chain_info.block_hash,
             'headNum': chain_info.block_number,
@@ -178,7 +178,7 @@ class LESProtocolV2(LESProtocol):
         resp = {
             'announceType': constants.LES_ANNOUNCE_SIMPLE,
             'protocolVersion': self.version,
-            'networkId': self.peer.network_id,
+            'networkId': self.peer.local_network_id,
             'headTd': chain_info.total_difficulty,
             'headHash': chain_info.block_hash,
             'headNum': chain_info.block_number,


### PR DESCRIPTION
### What was wrong?

As part of peer tracking I found I needed two pieces of information about peers that were not preserved.

- The reason for disconnection.
- The info from the status message about network_id and genesis_hash

### How was it fixed?

- Added a new `Peer.disconnect_reason` property which is populated upon disconnection.
- Adjusted the existing `Peer.network_id` and `Peer.genesis` properties to denote they are *local*
- Changed the structure of `process_sub_proto_handhaske` to preserve the contents prior to raising any exceptions due to mismatched values.

#### Cute Animal Picture

![ff6deb8c1512ed487d7b6c257c408c8c](https://user-images.githubusercontent.com/824194/56434746-26ab8400-6293-11e9-91c9-fad59454124e.jpg)
