### PR TITLE
Persist state after we have performed full validation of the block

### DIFF
--- a/eth2/beacon/chains/base.py
+++ b/eth2/beacon/chains/base.py
@@ -380,12 +380,12 @@ class BeaconChain(BaseBeaconChain):
         )
         state, imported_block = self.get_state_machine(base_block_for_import).import_block(block)
 
-        # TODO: Now it just persists all state. Should design how to clean up the old state.
-        self.chaindb.persist_state(state)
-
         # Validate the imported block.
         if perform_validation:
             validate_imported_block_unchanged(imported_block, block)
+
+        # TODO: Now it just persists all state. Should design how to clean up the old state.
+        self.chaindb.persist_state(state)
 
         (
             new_canonical_blocks,


### PR DESCRIPTION
### What was wrong?

The code prior to this commit wrote the updated state to the database, before
checking that the imported block matched the state root we compute ourselves.

You can imagine a DoS attack where Trinity is flooded with bad blocks and the
state database explodes in size by saving the resulting state but ultimately
discarding the invalid block. After depleting the node's resources, the client
would become unresponsive.


### How was it fixed?

This commit avoids this scenario by performing the full validation before
writing any data to disk.


[//]: # (For important changes, please add a new entry to the release notes file)
[//]: # (See: https://trinity-client.readthedocs.io/en/latest/contributing.html#pull-requests)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://proxy.duckduckgo.com/iu/?u=https%3A%2F%2Ftse1.mm.bing.net%2Fth%3Fid%3DOIP.WQBsgNvlZwcc9tEsGfu7YwHaE-%26pid%3DApi&f=1)