### PR TITLE
make Peer.supported_sub_protocols a public property

### DIFF
--- a/p2p/peer.py
+++ b/p2p/peer.py
@@ -196,7 +196,7 @@ class BasePeer(BaseService):
     conn_idle_timeout = CONN_IDLE_TIMEOUT
     # Must be defined in subclasses. All items here must be Protocol classes representing
     # different versions of the same P2P sub-protocol (e.g. ETH, LES, etc).
-    _supported_sub_protocols: List[Type[protocol.Protocol]] = []
+    supported_sub_protocols: List[Type[protocol.Protocol]] = []
     # FIXME: Must be configurable.
     listen_port = 30303
     # Will be set upon the successful completion of a P2P handshake.
@@ -359,7 +359,7 @@ class BasePeer(BaseService):
 
     @property
     def capabilities(self) -> List[Tuple[str, int]]:
-        return [(klass.name, klass.version) for klass in self._supported_sub_protocols]
+        return [(klass.name, klass.version) for klass in self.supported_sub_protocols]
 
     def get_protocol_command_for(self, msg: bytes) -> protocol.Command:
         """Return the Command corresponding to the cmd_id encoded in the given msg."""
@@ -664,7 +664,7 @@ class BasePeer(BaseService):
             raise NoMatchingPeerCapabilities()
         _, highest_matching_version = max(matching_capabilities, key=operator.itemgetter(1))
         offset = self.base_protocol.cmd_length
-        for proto_class in self._supported_sub_protocols:
+        for proto_class in self.supported_sub_protocols:
             if proto_class.version == highest_matching_version:
                 return proto_class(self, offset, snappy_support)
         raise NoMatchingPeerCapabilities()

--- a/p2p/tools/paragon/peer.py
+++ b/p2p/tools/paragon/peer.py
@@ -26,7 +26,7 @@ from .proto import ParagonProtocol
 
 
 class ParagonPeer(BasePeer):
-    _supported_sub_protocols = [ParagonProtocol]
+    supported_sub_protocols = [ParagonProtocol]
     sub_proto: ParagonProtocol = None
 
     async def send_sub_proto_handshake(self) -> None:

--- a/tests/core/p2p-proto/test_peer.py
+++ b/tests/core/p2p-proto/test_peer.py
@@ -103,5 +103,5 @@ class LESProtocolV3(LESProtocol):
 class ProtoMatchingPeer(LESPeer):
 
     def __init__(self, supported_sub_protocols, snappy_support):
-        self._supported_sub_protocols = supported_sub_protocols
+        self.supported_sub_protocols = supported_sub_protocols
         self.base_protocol = P2PProtocol(self, snappy_support)

--- a/trinity/protocol/bcc/peer.py
+++ b/trinity/protocol/bcc/peer.py
@@ -43,7 +43,7 @@ from trinity.protocol.bcc.context import (
 
 class BCCPeer(BasePeer):
 
-    _supported_sub_protocols = [BCCProtocol]
+    supported_sub_protocols = [BCCProtocol]
     sub_proto: BCCProtocol = None
 
     _requests: BCCExchangeHandler = None

--- a/trinity/protocol/eth/peer.py
+++ b/trinity/protocol/eth/peer.py
@@ -36,7 +36,7 @@ from .handlers import ETHExchangeHandler
 class ETHPeer(BaseChainPeer):
     max_headers_fetch = MAX_HEADERS_FETCH
 
-    _supported_sub_protocols = [ETHProtocol]
+    supported_sub_protocols = [ETHProtocol]
     sub_proto: ETHProtocol = None
 
     _requests: ETHExchangeHandler = None

--- a/trinity/protocol/les/peer.py
+++ b/trinity/protocol/les/peer.py
@@ -46,7 +46,7 @@ from .handlers import LESExchangeHandler
 class LESPeer(BaseChainPeer):
     max_headers_fetch = MAX_HEADERS_FETCH
 
-    _supported_sub_protocols = [LESProtocol, LESProtocolV2]
+    supported_sub_protocols = [LESProtocol, LESProtocolV2]
     sub_proto: LESProtocol = None
 
     _requests: LESExchangeHandler = None


### PR DESCRIPTION
### What was wrong?

As part of tracking information about peers we connect to for #24 it was necessary to access what sub protos a peer class can support.  This was hidden away on a private property of the `Peer` class.

### How was it fixed?

Moved it to `Peer.supported_sub_protos` to make the property public.

#### Cute Animal Picture

![cute-baby-penguin-8](https://user-images.githubusercontent.com/824194/56620283-a2843400-65e5-11e9-9891-06640f68d825.jpg)

