### PR TITLE
make PeerPool.event_bus a reliably typed property

### DIFF
--- a/p2p/peer_pool.py
+++ b/p2p/peer_pool.py
@@ -263,7 +263,7 @@ class BasePeerPool(BaseService, AsyncIterable[BasePeer]):
     async def _run(self) -> None:
         # FIXME: PeerPool should probably no longer be a BaseService, but for now we're keeping it
         # so in order to ensure we cancel all peers when we terminate.
-        if self.has_event_bus is not None:
+        if self.has_event_bus:
             self.run_daemon_task(self.maybe_connect_more_peers())
 
         self.run_daemon_task(self._periodically_report_stats())


### PR DESCRIPTION
### What was wrong?

The `PeerPool.event_bus` ends up being an `Optional[Endpoint]` type which makes the type checker complain when you use it for things that don't allow optionals.

### How was it fixed?

Moved the storage onto `_event_bus` and wrote an `@property` getter method that raises an `AttributeError` if the event bus isn't present, allowing the type checker to know that it is indeed an `Endpoint` type.

#### Cute Animal Picture


![CejhRX](https://user-images.githubusercontent.com/824194/56620388-f8f17280-65e5-11e9-97e8-11930dec82e2.jpg)
