### PR TITLE
Make kademlia.Node pickleable

### DIFF
--- a/p2p/events.py
+++ b/p2p/events.py
@@ -8,17 +8,16 @@ from lahja import (
     BaseRequestResponseEvent,
 )
 
+from .kademlia import Node
+
 
 class BaseDiscoveryServiceResponse(BaseEvent):
-
-    def __init__(self, error: Exception) -> None:
-        self.error = error
+    pass
 
 
 class PeerCandidatesResponse(BaseDiscoveryServiceResponse):
 
-    def __init__(self, candidates: Tuple[str, ...], error: Exception=None) -> None:
-        super().__init__(error)
+    def __init__(self, candidates: Tuple[Node, ...]) -> None:
         self.candidates = candidates
 
 

--- a/p2p/kademlia.py
+++ b/p2p/kademlia.py
@@ -9,6 +9,7 @@ import time
 from typing import (
     Any,
     cast,
+    Dict,
     Iterable,
     Iterator,
     List,
@@ -142,18 +143,13 @@ class Node:
     def __hash__(self) -> int:
         return hash(self.pubkey)
 
-# TODO: check if we can make the nodes pickable and get rid of these
-# https://github.com/ethereum/py-evm/issues/1578
+    def __getstate__(self) -> Dict[Any, Any]:
+        return {'enode': self.uri()}
 
-
-def to_uris(nodes: Iterable[Node]) -> Iterator[str]:
-    for node in nodes:
-        yield node.uri()
-
-
-def from_uris(uris: Iterable[str]) -> Iterator[Node]:
-    for uri in uris:
-        yield Node.from_uri(uri)
+    def __setstate__(self, state: Dict[Any, Any]) -> None:
+        enode = state.pop('enode')
+        node = self.from_uri(enode)
+        self.__dict__.update(node.__dict__)
 
 
 @total_ordering

--- a/p2p/peer.py
+++ b/p2p/peer.py
@@ -23,7 +23,6 @@ from typing import (
     Type,
     TYPE_CHECKING,
 )
-import typing_extensions
 
 import sha3
 
@@ -164,21 +163,6 @@ class BasePeerBootManager(BaseService):
 
 class BasePeerContext:
     pass
-
-
-class IdentifiablePeer(typing_extensions.Protocol):
-    """
-    A protocol used to identify a peer based on the presence of an ``uri`` property. The
-    peer pool uses this to lookup and match DTO peers against the actual real peer instance.
-    The ``BaseDTOPeer`` qualifies for this protocol but usage of the ``BaseDTOPeer`` isn't
-    strictly needed. E.g. one might implement a different DTO class that derives from
-    ``NamedTuple`` which is fine as long as it defines an ``uri`` property.
-    """
-
-    @property
-    @abstractmethod
-    def uri(self) -> str:
-        pass
 
 
 class BaseDTOPeer:

--- a/p2p/peer_backend.py
+++ b/p2p/peer_backend.py
@@ -12,7 +12,6 @@ from p2p.constants import (
     DISCOVERY_EVENTBUS_ENDPOINT,
 )
 from p2p.kademlia import (
-    from_uris,
     Node,
 )
 from p2p.events import (
@@ -43,7 +42,7 @@ class DiscoveryPeerBackend(BasePeerBackend):
             PeerCandidatesRequest(num_requested),
             TO_DISCOVERY_BROADCAST_CONFIG,
         )
-        return from_uris(response.candidates)
+        return response.candidates
 
 
 class BootnodesPeerBackend(BasePeerBackend):
@@ -59,6 +58,6 @@ class BootnodesPeerBackend(BasePeerBackend):
                 TO_DISCOVERY_BROADCAST_CONFIG
             )
 
-            return from_uris(response.candidates)
+            return response.candidates
         else:
             return ()

--- a/p2p/tools/paragon/events.py
+++ b/p2p/tools/paragon/events.py
@@ -1,14 +1,12 @@
 from lahja import (
     BaseEvent,
 )
-from p2p.peer import (
-    IdentifiablePeer,
-)
+from p2p.kademlia import Node
 
 
 class GetSumRequest(BaseEvent):
 
-    def __init__(self, peer: IdentifiablePeer, a: int, b: int) -> None:
-        self.peer = peer
+    def __init__(self, remote: Node, a: int, b: int) -> None:
+        self.remote = remote
         self.a = a
         self.b = b

--- a/p2p/tools/paragon/peer.py
+++ b/p2p/tools/paragon/peer.py
@@ -64,7 +64,7 @@ class ParagonPeerPoolEventServer(PeerPoolEventServer[ParagonPeer]):
     async def handle_get_sum_requests(self) -> None:
         async for req in self.wait_iter(self.event_bus.stream(GetSumRequest)):
             try:
-                peer = self.get_peer(req.peer)
+                peer = self.get_peer(req.remote)
             except PeerConnectionLost:
                 pass
             else:
@@ -80,7 +80,7 @@ class ParagonMockPeerPoolWithConnectedPeers(ParagonPeerPool):
     def __init__(self, peers: Iterable[ParagonPeer]) -> None:
         super().__init__(privkey=None, context=None)
         for peer in peers:
-            self.connected_nodes[peer.remote.uri()] = peer
+            self.connected_nodes[peer.remote] = peer
 
     async def _run(self) -> None:
         raise NotImplementedError("This is a mock PeerPool implementation, you must not _run() it")

--- a/tests/core/json-rpc/test_ipc.py
+++ b/tests/core/json-rpc/test_ipc.py
@@ -597,4 +597,4 @@ async def test_admin_addPeer_fires_message(
     assert result == {'id': 3, 'jsonrpc': '2.0', 'result': None}
 
     event = await asyncio.wait_for(future, timeout=0.1, loop=event_loop)
-    assert event.node == enode
+    assert event.remote.uri() == enode

--- a/tests/core/p2p-proto/test_server.py
+++ b/tests/core/p2p-proto/test_server.py
@@ -181,7 +181,7 @@ async def test_peer_pool_answers_connect_commands(event_loop, event_bus, server)
     assert len(server.peer_pool.connected_nodes) == 0
 
     event_bus.broadcast(
-        ConnectToNodeCommand(RECEIVER_REMOTE.uri()),
+        ConnectToNodeCommand(RECEIVER_REMOTE),
         TO_NETWORKING_BROADCAST_CONFIG
     )
 

--- a/tests/p2p/test_kademlia_node_picklable.py
+++ b/tests/p2p/test_kademlia_node_picklable.py
@@ -1,0 +1,9 @@
+import pickle
+
+from p2p.tools.factories import NodeFactory
+
+
+def test_kademlia_node_is_pickleable():
+    node = NodeFactory()
+    result = pickle.loads(pickle.dumps(node))
+    assert result == node

--- a/trinity/protocol/common/events.py
+++ b/trinity/protocol/common/events.py
@@ -7,9 +7,7 @@ from lahja import (
     BaseRequestResponseEvent,
 )
 
-from p2p.peer import (
-    IdentifiablePeer,
-)
+from p2p.kademlia import Node
 from p2p.p2p_proto import (
     DisconnectReason,
 )
@@ -20,8 +18,8 @@ class ConnectToNodeCommand(BaseEvent):
     Event that wraps a node URI that the pool should connect to.
     """
 
-    def __init__(self, node: str) -> None:
-        self.node = node
+    def __init__(self, remote: Node) -> None:
+        self.remote = remote
 
 
 class PeerCountResponse(BaseEvent):
@@ -48,6 +46,6 @@ class DisconnectPeerEvent(BaseEvent):
     Event broadcasted when we want to disconnect from a peer
     """
 
-    def __init__(self, peer: IdentifiablePeer, reason: DisconnectReason) -> None:
-        self.peer = peer
+    def __init__(self, remote: Node, reason: DisconnectReason) -> None:
+        self.remote = remote
         self.reason = reason

--- a/trinity/rpc/modules/admin.py
+++ b/trinity/rpc/modules/admin.py
@@ -1,3 +1,4 @@
+from p2p.kademlia import Node
 from p2p.validation import validate_enode_uri
 
 from trinity.constants import TO_NETWORKING_BROADCAST_CONFIG
@@ -11,10 +12,10 @@ class Admin(BaseRPCModule):
     def __init__(self, event_bus: TrinityEventBusEndpoint) -> None:
         self.event_bus = event_bus
 
-    async def addPeer(self, node: str) -> None:
-        validate_enode_uri(node, require_ip=True)
+    async def addPeer(self, uri: str) -> None:
+        validate_enode_uri(uri, require_ip=True)
 
         self.event_bus.broadcast(
-            ConnectToNodeCommand(node),
+            ConnectToNodeCommand(Node.from_uri(uri)),
             TO_NETWORKING_BROADCAST_CONFIG
         )


### PR DESCRIPTION
### What was wrong?

The `kademlia.Node` class was not pickleable due to the embedded `eth_keys.PublicKey` object which contains a reference to it's backend which is implemented as a module (this should be eventually be fixed upstream to make the key backend implementations pickleable)

### How was it fixed?

Used the API that python uses for handling pickle-ing of stateful objects, using the enode URI as the data transfer representation and then re-constructing it on the other side.

- [x] need to update the various places where @cburgdorf implemented workarounds for this issue to just use the `Node` classes now that they work.

#### Cute Animal Picture

![2F93D1CA00000578-0-image-a-10_1450825493645](https://user-images.githubusercontent.com/824194/56620570-9a78c400-65e6-11e9-9dbc-165ae40a7d7a.jpg)

