### PR TITLE
Endpoint.broadcast() is now async

### DIFF
--- a/p2p/peer_pool.py
+++ b/p2p/peer_pool.py
@@ -253,7 +253,7 @@ class BasePeerPool(BaseService, AsyncIterable[BasePeer]):
             await peer.disconnect(DisconnectReason.timeout)
             return
         except HandshakeFailure as err:
-            self.connection_tracker.record_failure(peer.remote, err)
+            await self.connection_tracker.record_failure(peer.remote, err)
             raise
         else:
             if peer.is_operational:
@@ -348,7 +348,7 @@ class BasePeerPool(BaseService, AsyncIterable[BasePeer]):
             raise
         except HandshakeFailure as e:
             self.logger.debug("Could not complete handshake with %r: %s", remote, repr(e))
-            self.connection_tracker.record_failure(remote, e)
+            await self.connection_tracker.record_failure(remote, e)
             raise
         except COMMON_PEER_CONNECTION_EXCEPTIONS as e:
             self.logger.debug("Could not complete handshake with %r: %s", remote, repr(e))

--- a/p2p/tracking/connection.py
+++ b/p2p/tracking/connection.py
@@ -41,14 +41,14 @@ class BaseConnectionTracker(ABC):
     """
     logger = logging.getLogger('p2p.tracking.connection.ConnectionTracker')
 
-    def record_failure(self, remote: Node, failure: BaseP2PError) -> None:
+    async def record_failure(self, remote: Node, failure: BaseP2PError) -> None:
         timeout_seconds = get_timeout_for_failure(failure)
         failure_name = type(failure).__name__
 
-        return self.record_blacklist(remote, timeout_seconds, failure_name)
+        return await self.record_blacklist(remote, timeout_seconds, failure_name)
 
     @abstractmethod
-    def record_blacklist(self, remote: Node, timeout_seconds: int, reason: str) -> None:
+    async def record_blacklist(self, remote: Node, timeout_seconds: int, reason: str) -> None:
         pass
 
     @abstractmethod
@@ -57,7 +57,7 @@ class BaseConnectionTracker(ABC):
 
 
 class NoopConnectionTracker(BaseConnectionTracker):
-    def record_blacklist(self, remote: Node, timeout_seconds: int, reason: str) -> None:
+    async def record_blacklist(self, remote: Node, timeout_seconds: int, reason: str) -> None:
         pass
 
     async def should_connect_to(self, remote: Node) -> bool:

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ deps = {
         "plyvel==1.0.5",
         "py-evm==0.2.0a42",
         "web3==4.4.1",
-        "lahja==0.11.2",
+        "lahja @ git+https://git@github.com/lithp/lahja@d69aea8020e8d89dfdac50dc19878b516feabd4c",
         "termcolor>=1.1.0,<2.0.0",
         "uvloop==0.11.2;platform_system=='Linux' or platform_system=='Darwin' or platform_system=='FreeBSD'",  # noqa: E501
         "websockets==5.0.1",

--- a/tests/core/json-rpc/test_ipc.py
+++ b/tests/core/json-rpc/test_ipc.py
@@ -152,7 +152,7 @@ def uint256_to_bytes(uint):
 def mock_network_id(network_id):
     async def mock_event_bus_interaction(bus):
         async for req in bus.stream(NetworkIdRequest):
-            bus.broadcast(NetworkIdResponse(network_id), req.broadcast_config())
+            await bus.broadcast(NetworkIdResponse(network_id), req.broadcast_config())
             break
 
     return mock_event_bus_interaction
@@ -439,7 +439,7 @@ async def test_eth_call_with_contract_on_ipc(
 def mock_peer_count(count):
     async def mock_event_bus_interaction(bus):
         async for req in bus.stream(PeerCountRequest):
-            bus.broadcast(PeerCountResponse(count), req.broadcast_config())
+            await bus.broadcast(PeerCountResponse(count), req.broadcast_config())
             break
 
     return mock_event_bus_interaction
@@ -486,7 +486,7 @@ async def test_peer_pool_over_ipc(
 def mock_syncing(is_syncing, progress=None):
     async def mock_event_bus_interaction(bus):
         async for req in bus.stream(SyncingRequest):
-            bus.broadcast(SyncingResponse(is_syncing, progress), req.broadcast_config())
+            await bus.broadcast(SyncingResponse(is_syncing, progress), req.broadcast_config())
             break
 
     return mock_event_bus_interaction

--- a/tests/core/network-db/test_blacklist_connection_tracking.py
+++ b/tests/core/network-db/test_blacklist_connection_tracking.py
@@ -26,7 +26,7 @@ async def test_records_failures():
     node = NodeFactory()
     assert await connection_tracker.should_connect_to(node) is True
 
-    connection_tracker.record_failure(node, HandshakeFailure())
+    await connection_tracker.record_failure(node, HandshakeFailure())
 
     assert await connection_tracker.should_connect_to(node) is False
     assert connection_tracker._record_exists(node.uri())
@@ -38,7 +38,7 @@ async def test_memory_does_not_persist():
 
     connection_tracker_a = MemoryConnectionTracker()
     assert await connection_tracker_a.should_connect_to(node) is True
-    connection_tracker_a.record_failure(node, HandshakeFailure())
+    await connection_tracker_a.record_failure(node, HandshakeFailure())
     assert await connection_tracker_a.should_connect_to(node) is False
 
     # open a second instance
@@ -56,7 +56,7 @@ async def test_sql_does_persist(tmpdir):
 
     connection_tracker_a = SQLiteConnectionTracker(get_tracking_database(db_path))
     assert await connection_tracker_a.should_connect_to(node) is True
-    connection_tracker_a.record_failure(node, HandshakeFailure())
+    await connection_tracker_a.record_failure(node, HandshakeFailure())
     assert await connection_tracker_a.should_connect_to(node) is False
     del connection_tracker_a
 
@@ -73,7 +73,7 @@ async def test_timeout_works():
     connection_tracker = MemoryConnectionTracker()
     assert await connection_tracker.should_connect_to(node) is True
 
-    connection_tracker.record_failure(node, HandshakeFailure())
+    await connection_tracker.record_failure(node, HandshakeFailure())
     assert await connection_tracker.should_connect_to(node) is False
 
     record = connection_tracker._get_record(node.uri())

--- a/tests/core/network-db/test_connection_tracker_server.py
+++ b/tests/core/network-db/test_connection_tracker_server.py
@@ -19,7 +19,7 @@ from trinity.plugins.builtin.network_db.connection.tracker import (
 async def test_connection_tracker_server_and_client(event_loop, event_bus):
     tracker = MemoryConnectionTracker()
     remote_a = NodeFactory()
-    tracker.record_blacklist(remote_a, 60, "testing")
+    await tracker.record_blacklist(remote_a, 60, "testing")
 
     assert await tracker.should_connect_to(remote_a) is False
 
@@ -40,7 +40,7 @@ async def test_connection_tracker_server_and_client(event_loop, event_bus):
 
     assert await bus_tracker.should_connect_to(remote_b) is True
 
-    bus_tracker.record_blacklist(remote_b, 60, "testing")
+    await bus_tracker.record_blacklist(remote_b, 60, "testing")
 
     assert await bus_tracker.should_connect_to(remote_b) is False
     assert await tracker.should_connect_to(remote_b) is False

--- a/tests/core/p2p-proto/test_server.py
+++ b/tests/core/p2p-proto/test_server.py
@@ -180,7 +180,7 @@ async def test_peer_pool_answers_connect_commands(event_loop, event_bus, server)
 
     assert len(server.peer_pool.connected_nodes) == 0
 
-    event_bus.broadcast(
+    await event_bus.broadcast(
         ConnectToNodeCommand(RECEIVER_REMOTE),
         TO_NETWORKING_BROADCAST_CONFIG
     )

--- a/tests/plugins/eth2/beacon/test_validator.py
+++ b/tests/plugins/eth2/beacon/test_validator.py
@@ -265,7 +265,7 @@ async def test_validator_handle_new_slot(caplog, event_loop, event_bus, monkeypa
     # sleep for `event_bus` ready
     await asyncio.sleep(0.01)
 
-    event_bus.broadcast(
+    await event_bus.broadcast(
         NewSlotEvent(
             slot=1,
             elapsed_time=2,

--- a/trinity/endpoint.py
+++ b/trinity/endpoint.py
@@ -26,7 +26,7 @@ class TrinityEventBusEndpoint(Endpoint):
         """
         Perfom a graceful shutdown of Trinity. Can be called from any process.
         """
-        self.broadcast(
+        self.broadcast_nowait(
             ShutdownRequest(reason),
             BroadcastConfig(filter_endpoint=MAIN_EVENTBUS_ENDPOINT)
         )
@@ -58,7 +58,7 @@ class TrinityEventBusEndpoint(Endpoint):
         Announce this endpoint to the :class:`~trinity.endpoint.TrinityMainEventBusEndpoint` so
         that it will be further propagated to all other endpoints, allowing them to connect to us.
         """
-        self.broadcast(
+        self.broadcast_nowait(
             EventBusConnected(ConnectionConfig(name=self.name, path=self.ipc_path)),
             BroadcastConfig(filter_endpoint=MAIN_EVENTBUS_ENDPOINT)
         )
@@ -94,7 +94,7 @@ class TrinityMainEventBusEndpoint(TrinityEventBusEndpoint):
             self.logger.debug("New EventBus Endpoint connected %s", ev.connection_config.name)
             # Broadcast available endpoints to all connected endpoints, giving them
             # a chance to cross connect
-            self.broadcast(AvailableEndpointsUpdated(self.available_endpoints))
+            self.broadcast_nowait(AvailableEndpointsUpdated(self.available_endpoints))
             self.logger.debug("Connected EventBus Endpoints %s", self.available_endpoints)
 
         self.subscribe(EventBusConnected, handle_new_endpoints)

--- a/trinity/extensibility/plugin.py
+++ b/trinity/extensibility/plugin.py
@@ -215,7 +215,7 @@ class BasePlugin(ABC):
 
         self._status = PluginStatus.STARTED
         self.do_start()
-        self.event_bus.broadcast(
+        self.event_bus.broadcast_nowait(
             PluginStartedEvent(type(self))
         )
         self.logger.info("Plugin started: %s", self.name)
@@ -309,7 +309,7 @@ class BaseIsolatedPlugin(BasePlugin):
         # This makes the `main` process aware of this Endpoint which will then propagate the info
         # so that every other Endpoint can connect directly to the plugin Endpoint
         self.event_bus.announce_endpoint()
-        self.event_bus.broadcast(
+        self.event_bus.broadcast_nowait(
             PluginStartedEvent(type(self))
         )
 

--- a/trinity/plugins/builtin/light_peer_chain_bridge/light_peer_chain_bridge.py
+++ b/trinity/plugins/builtin/light_peer_chain_bridge/light_peer_chain_bridge.py
@@ -167,7 +167,7 @@ class LightPeerChainEventBusHandler(BaseService):
                 self.chain.coro_get_block_header_by_hash(event.block_hash)
             )
 
-            self.event_bus.broadcast(
+            await self.event_bus.broadcast(
                 event.expected_response_type()(val, error),
                 event.broadcast_config()
             )
@@ -179,7 +179,7 @@ class LightPeerChainEventBusHandler(BaseService):
                 self.chain.coro_get_block_body_by_hash(event.block_hash)
             )
 
-            self.event_bus.broadcast(
+            await self.event_bus.broadcast(
                 event.expected_response_type()(val, error),
                 event.broadcast_config()
             )
@@ -189,7 +189,7 @@ class LightPeerChainEventBusHandler(BaseService):
 
             val, error = await await_and_wrap_errors(self.chain.coro_get_receipts(event.block_hash))
 
-            self.event_bus.broadcast(
+            await self.event_bus.broadcast(
                 event.expected_response_type()(val, error),
                 event.broadcast_config()
             )
@@ -201,7 +201,7 @@ class LightPeerChainEventBusHandler(BaseService):
                 self.chain.coro_get_account(event.block_hash, event.address)
             )
 
-            self.event_bus.broadcast(
+            await self.event_bus.broadcast(
                 event.expected_response_type()(val, error),
                 event.broadcast_config()
             )
@@ -214,7 +214,7 @@ class LightPeerChainEventBusHandler(BaseService):
                 self.chain.coro_get_contract_code(event.block_hash, event.address)
             )
 
-            self.event_bus.broadcast(
+            await self.event_bus.broadcast(
                 event.expected_response_type()(val, error),
                 event.broadcast_config()
             )

--- a/trinity/plugins/builtin/network_db/connection/server.py
+++ b/trinity/plugins/builtin/network_db/connection/server.py
@@ -34,7 +34,7 @@ class ConnectionTrackerServer(BaseService):
         async for req in self.wait_iter(self.event_bus.stream(ShouldConnectToPeerRequest)):
             self.logger.debug2('Received should connect to request: %s', req.remote)
             should_connect = await self.tracker.should_connect_to(req.remote)
-            self.event_bus.broadcast(
+            await self.event_bus.broadcast(
                 ShouldConnectToPeerResponse(should_connect),
                 req.broadcast_config()
             )
@@ -47,7 +47,11 @@ class ConnectionTrackerServer(BaseService):
                 humanize_seconds(command.timeout_seconds),
                 command.reason,
             )
-            self.tracker.record_blacklist(command.remote, command.timeout_seconds, command.reason)
+            await self.tracker.record_blacklist(
+                command.remote,
+                command.timeout_seconds,
+                command.reason
+            )
 
     async def _run(self) -> None:
         self.logger.debug("Running ConnectionTrackerServer")

--- a/trinity/plugins/builtin/network_db/connection/tracker.py
+++ b/trinity/plugins/builtin/network_db/connection/tracker.py
@@ -56,7 +56,7 @@ class SQLiteConnectionTracker(BaseConnectionTracker):
     #
     # Core API
     #
-    def record_blacklist(self, remote: Node, timeout_seconds: int, reason: str) -> None:
+    async def record_blacklist(self, remote: Node, timeout_seconds: int, reason: str) -> None:
         if self._record_exists(remote.uri()):
             self._update_record(remote, timeout_seconds, reason)
         else:
@@ -150,8 +150,8 @@ class ConnectionTrackerClient(BaseConnectionTracker):
         self.event_bus = event_bus
         self.config = config
 
-    def record_blacklist(self, remote: Node, timeout_seconds: int, reason: str) -> None:
-        self.event_bus.broadcast(
+    async def record_blacklist(self, remote: Node, timeout_seconds: int, reason: str) -> None:
+        await self.event_bus.broadcast(
             BlacklistEvent(remote, timeout_seconds, reason=reason),
             self.config,
         )

--- a/trinity/plugins/eth2/beacon/slot_ticker.py
+++ b/trinity/plugins/eth2/beacon/slot_ticker.py
@@ -69,7 +69,7 @@ class SlotTicker(BaseService):
                         bold_green(f"New slot: {slot}\tElapsed time: {elapsed_time}")
                     )
                     self.latest_slot = slot
-                    self.event_bus.broadcast(
+                    await self.event_bus.broadcast(
                         NewSlotEvent(
                             slot=slot,
                             elapsed_time=elapsed_time,

--- a/trinity/protocol/common/peer_pool_event_bus.py
+++ b/trinity/protocol/common/peer_pool_event_bus.py
@@ -57,7 +57,7 @@ class PeerPoolEventServer(BaseService, Generic[TPeer]):
 
     async def handle_peer_count_requests(self) -> None:
         async for req in self.wait_iter(self.event_bus.stream(PeerCountRequest)):
-            self.event_bus.broadcast(
+            await self.event_bus.broadcast(
                 PeerCountResponse(len(self.peer_pool)),
                 req.broadcast_config()
             )

--- a/trinity/rpc/modules/admin.py
+++ b/trinity/rpc/modules/admin.py
@@ -15,7 +15,7 @@ class Admin(BaseRPCModule):
     async def addPeer(self, uri: str) -> None:
         validate_enode_uri(uri, require_ip=True)
 
-        self.event_bus.broadcast(
+        await self.event_bus.broadcast(
             ConnectToNodeCommand(Node.from_uri(uri)),
             TO_NETWORKING_BROADCAST_CONFIG
         )

--- a/trinity/rpc/modules/evm.py
+++ b/trinity/rpc/modules/evm.py
@@ -41,7 +41,7 @@ class EVM(Eth1ChainRPCModule):
         """
         chain = new_chain_from_fixture(chain_info, type(self.chain))
 
-        self.event_bus.broadcast(
+        await self.event_bus.broadcast(
             ChainReplacementEvent(chain),
             BroadcastConfig(internal=True)
         )


### PR DESCRIPTION
### What was wrong?

Draft of how big of a refactor it would be for `Endpoint.broadcast` to become async. I think that a lot of these `asyncio.ensure_future` calls are reasonable, but the plugin part might benefit from becoming more asyncio-aware.

(Integrates https://github.com/ethereum/lahja/pull/43)

TODO: 
- [ ] update `setup.py` with the right lahja version once it's been released.
- [x] This misses a call in `BaseIsolatedPlugin._prepare_start()`
- [x] I think that `record_blacklist` needs to become async

#### Cute Animal Picture

![cute-bird](https://user-images.githubusercontent.com/466333/56706340-7215c600-66c9-11e9-80ee-a3852f0bfc03.jpg)
