### PR TITLE
Migrate to mypy.ini and enable more checks

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -1,5 +1,4 @@
 [mypy]
-follow_imports = silent
 warn_unused_ignores = True
 ignore_missing_imports = True
 strict_optional = False
@@ -7,4 +6,4 @@ check_untyped_defs = True
 disallow_incomplete_defs = True
 disallow_untyped_defs = True
 disallow_any_generics = True
-
+warn_redundant_casts = True

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,0 +1,10 @@
+[mypy]
+follow_imports = silent
+warn_unused_ignores = True
+ignore_missing_imports = True
+strict_optional = False
+check_untyped_defs = True
+disallow_incomplete_defs = True
+disallow_untyped_defs = True
+disallow_any_generics = True
+

--- a/mypy.ini
+++ b/mypy.ini
@@ -6,5 +6,7 @@ check_untyped_defs = True
 disallow_incomplete_defs = True
 disallow_untyped_defs = True
 disallow_any_generics = True
+disallow_untyped_calls = True
 warn_redundant_casts = True
+warn_unused_configs = True
 strict_equality = True

--- a/mypy.ini
+++ b/mypy.ini
@@ -7,3 +7,4 @@ disallow_incomplete_defs = True
 disallow_untyped_defs = True
 disallow_any_generics = True
 warn_redundant_casts = True
+strict_equality = True

--- a/p2p/kademlia.py
+++ b/p2p/kademlia.py
@@ -333,7 +333,7 @@ class RoutingTable:
         # nodes and sort it by distance_to.
         for bucket in self.buckets_by_distance_to(node_id):
             for n in bucket.nodes_by_distance_to(node_id):
-                if n is not node_id:
+                if n.id is not node_id:
                     nodes.append(n)
                     if len(nodes) == k * 2:
                         break

--- a/p2p/kademlia.py
+++ b/p2p/kademlia.py
@@ -8,7 +8,6 @@ import struct
 import time
 from typing import (
     Any,
-    cast,
     Dict,
     Iterable,
     Iterator,
@@ -134,7 +133,6 @@ class Node:
     def __eq__(self, other: object) -> bool:
         if not isinstance(other, self.__class__):
             return super().__eq__(other)
-        other = cast(Node, other)
         return self.pubkey == other.pubkey
 
     def __ne__(self, other: object) -> bool:

--- a/tox.ini
+++ b/tox.ini
@@ -133,8 +133,7 @@ commands=
     flake8 {toxinidir}/scripts
     flake8 {toxinidir}/eth2
     flake8 --exclude={toxinidir}/libp2p/p2pclient/pb {toxinidir}/libp2p
-    # TODO: Drop --ignore-missing-imports once we have type annotations for eth_utils, coincurve and cytoolz
-    mypy --follow-imports=silent --warn-unused-ignores --ignore-missing-imports --no-strict-optional --check-untyped-defs --disallow-incomplete-defs --disallow-untyped-defs --disallow-any-generics -p p2p -p trinity -p eth2 -p libp2p
+    mypy -p p2p -p trinity -p eth2 -p libp2p --config-file {toxinidir}/mypy.ini
 
 
 [testenv:py36-lint]

--- a/trinity/_utils/percentile.py
+++ b/trinity/_utils/percentile.py
@@ -27,7 +27,7 @@ class Percentile:
             raise ValueError("No data for percentile calculation")
 
         idx = (len(self.window) - 1) * self.percentile
-        if int(idx) == idx:
+        if idx.is_integer():
             return self.window[int(idx)]
 
         left = int(math.floor(idx))

--- a/trinity/protocol/common/servers.py
+++ b/trinity/protocol/common/servers.py
@@ -2,7 +2,6 @@ from abc import abstractmethod
 from typing import (
     AsyncIterator,
     Tuple,
-    cast,
 )
 
 from cancel_token import CancelToken, OperationCancelled
@@ -12,7 +11,6 @@ from eth.exceptions import (
 )
 from eth_typing import (
     BlockNumber,
-    Hash32,
 )
 from eth.rlp.headers import BlockHeader
 from p2p import protocol
@@ -55,7 +53,7 @@ class BaseRequestServer(BaseService, PeerSubscriber):
     async def _handle_msg_loop(self) -> None:
         while self.is_operational:
             peer, cmd, msg = await self.wait(self.msg_queue.get())
-            self.run_task(self._quiet_handle_msg(cast(BasePeer, peer), cmd, msg))
+            self.run_task(self._quiet_handle_msg(peer, cmd, msg))
 
     async def _quiet_handle_msg(
             self,
@@ -113,7 +111,7 @@ class BasePeerRequestHandler(CancellableMixin, HasExtendedDebugLogger):
         """
         if isinstance(request.block_number_or_hash, bytes):
             header = await self.wait(
-                self.db.coro_get_block_header_by_hash(cast(Hash32, request.block_number_or_hash)))
+                self.db.coro_get_block_header_by_hash(request.block_number_or_hash))
             return request.generate_block_numbers(header.block_number)
         elif isinstance(request.block_number_or_hash, int):
             # We don't need to pass in the block number to

--- a/trinity/protocol/eth/commands.py
+++ b/trinity/protocol/eth/commands.py
@@ -1,5 +1,4 @@
 from typing import (
-    cast,
     Tuple,
 )
 
@@ -55,7 +54,7 @@ class BlockHeaders(BaseBlockHeaders):
     structure = sedes.CountableList(BlockHeader)
 
     def extract_headers(self, msg: _DecodedMsgType) -> Tuple[BlockHeader, ...]:
-        return cast(Tuple[BlockHeader, ...], tuple(msg))
+        return tuple(msg)
 
 
 class GetBlockBodies(Command):

--- a/trinity/protocol/les/commands.py
+++ b/trinity/protocol/les/commands.py
@@ -131,7 +131,7 @@ class BlockHeaders(BaseBlockHeaders):
 
     def extract_headers(self, msg: _DecodedMsgType) -> Tuple[BlockHeader, ...]:
         msg = cast(Dict[str, Any], msg)
-        return cast(Tuple[BlockHeader, ...], tuple(msg['headers']))
+        return tuple(msg['headers'])
 
 
 class GetBlockBodies(Command):


### PR DESCRIPTION
### What was wrong?

Our `mypy` invocation was getting rather lengthy and hence discouraged adding further checks which is bad as we all love to be punished and bow to our `mypy` master as often as we can.


### How was it fixed?

- migrated to `mypy.ini` file
- added more checks and fixed some issues in the process

[//]: # (For important changes, please add a new entry to the release notes file)
[//]: # (See: https://trinity-client.readthedocs.io/en/latest/contributing.html#pull-requests)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](http://i.imgur.com/YcoTtX7.jpg)
