### PR TITLE
Update to newer jsonschema lib to fix deprecation warning

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ deps = {
         "termcolor>=1.1.0,<2.0.0",
         "uvloop==0.11.2;platform_system=='Linux' or platform_system=='Darwin' or platform_system=='FreeBSD'",  # noqa: E501
         "websockets==5.0.1",
-        "jsonschema==2.6.0",
+        "jsonschema==3.0.1",
         "mypy_extensions>=0.4.1,<1.0.0",
         "typing_extensions>=3.7.2,<4.0.0",
     ],


### PR DESCRIPTION
### What was wrong?

When Trinity boots, it prints a deprecation warning caused by the `jsonschema` library.

>/home/cburgdorf/Documents/hacking/ef/trinity/venv/lib/python3.7/site-packages/jsonschema/compat.py:6: DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated, and in 3.8 it will stop working
  from collections import MutableMapping, Sequence  # noqa

### How was it fixed?

Upgraded to newer `jsonschema` library

[//]: # (For important changes, please add a new entry to the release notes file)
[//]: # (See: https://trinity-client.readthedocs.io/en/latest/contributing.html#pull-requests)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://www.bestfunnies.com/wp-content/uploads/2012/01/Funny-and-Cute-Kangaroos-Kangaroo-Picture-14-FunnyPica.com_.jpg)
