### PR TITLE
Increase timeout for backend peer candidate requests

### DIFF
--- a/p2p/constants.py
+++ b/p2p/constants.py
@@ -122,7 +122,7 @@ PEER_CONNECT_INTERVAL = 2
 MAX_SEQUENTIAL_PEER_CONNECT = 5
 
 # Timeout used when fetching peer candidates from discovery
-REQUEST_PEER_CANDIDATE_TIMEOUT = 0.5
+REQUEST_PEER_CANDIDATE_TIMEOUT = 1
 
 # The maximum number of concurrent attempts to establis new peer connections
 MAX_CONCURRENT_CONNECTION_ATTEMPTS = 10

--- a/tests/integration/test_trinity_cli.py
+++ b/tests/integration/test_trinity_cli.py
@@ -119,6 +119,9 @@ async def test_web3(command, async_process_runner):
         "Started DB server process",
         "Started networking process",
         "IPC started at",
+        # Ensure we do not start making requests that depend on the networking
+        # process, before it is connected to the JSON-RPC-API
+        "EventBus Endpoint networking connecting to other Endpoint bjson-rpc-api",
     })
 
     attached_trinity = pexpect.spawn('trinity', ['attach'], logfile=sys.stdout, encoding="utf-8")

--- a/trinity/tools/async_process_runner.py
+++ b/trinity/tools/async_process_runner.py
@@ -1,4 +1,5 @@
 import asyncio
+import logging
 import os
 import signal
 from typing import (
@@ -13,6 +14,7 @@ class AsyncProcessRunner():
 
     def __init__(self, debug_fn: Callable[[bytes], None] = None) -> None:
         self.debug_fn = debug_fn
+        self.logger = logging.getLogger("trinity.tools.async_process_runner.AsyncProcessRunner")
 
     @classmethod
     async def create_and_run(cls,
@@ -64,4 +66,7 @@ class AsyncProcessRunner():
         raise TimeoutError(f'Killed process after {timeout_sec} seconds')
 
     def kill(self) -> None:
-        os.killpg(os.getpgid(self.proc.pid), signal.SIGKILL)
+        try:
+            os.killpg(os.getpgid(self.proc.pid), signal.SIGKILL)
+        except ProcessLookupError:
+            self.logger.info("Process %s has already disappeared", self.proc.pid)

--- a/trinity/tools/async_process_runner.py
+++ b/trinity/tools/async_process_runner.py
@@ -11,10 +11,10 @@ from typing import (
 
 
 class AsyncProcessRunner():
+    logger = logging.getLogger("trinity.tools.async_process_runner.AsyncProcessRunner")
 
     def __init__(self, debug_fn: Callable[[bytes], None] = None) -> None:
         self.debug_fn = debug_fn
-        self.logger = logging.getLogger("trinity.tools.async_process_runner.AsyncProcessRunner")
 
     @classmethod
     async def create_and_run(cls,


### PR DESCRIPTION
### What was wrong?

The timeout for peer candidate requests seems like it may be too short.

https://github.com/ethereum/trinity/pull/517#issuecomment-484905167

### How was it fixed?

Increased it from 0.5 - > 1 to see if it makes CI happy.  Waiting a full second for these seems allowable. (could see increasing it further since this should have little effect on actual performance).

#### Cute Animal Picture


![goat goat goat](https://user-images.githubusercontent.com/824194/56752812-661c1980-6746-11e9-8e35-4a2b42e2a140.jpeg)

