### PR TITLE
remove legacy pypi markdown approach using pandoc

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -113,12 +113,18 @@ deps['dev'] = (
 
 install_requires = deps['trinity'] + deps['p2p'] + deps['eth2']
 
+
+with open('./README.md') as readme:
+    long_description = readme.read()
+
+
 setup(
     name='trinity',
     # *IMPORTANT*: Don't manually change the version here. Use the 'bumpversion' utility.
     version='0.1.0-alpha.23',
     description='The Trinity client for the Ethereum network',
-    long_description_markdown_filename='README.md',
+    long_description=long_description,
+    long_description_content_type='text/markdown',
     author='Ethereum Foundation',
     author_email='piper@pipermerriam.com',
     url='https://github.com/ethereum/trinity',
@@ -127,7 +133,6 @@ setup(
     python_requires=">=3.6,<4",
     install_requires=install_requires,
     extras_require=deps,
-    setup_requires=['setuptools-markdown'],
     license='MIT',
     zip_safe=False,
     keywords='ethereum blockchain evm trinity',

--- a/tox.ini
+++ b/tox.ini
@@ -132,6 +132,7 @@ commands=
     flake8 {toxinidir}/trinity
     flake8 {toxinidir}/scripts
     flake8 {toxinidir}/eth2
+    flake8 {toxinidir}/setup.py
     flake8 --exclude={toxinidir}/libp2p/p2pclient/pb {toxinidir}/libp2p
     # TODO: Drop --ignore-missing-imports once we have type annotations for eth_utils, coincurve and cytoolz
     mypy --follow-imports=silent --warn-unused-ignores --ignore-missing-imports --no-strict-optional --check-untyped-defs --disallow-incomplete-defs --disallow-untyped-defs --disallow-any-generics -p p2p -p trinity -p eth2 -p libp2p


### PR DESCRIPTION
### What was wrong?

A while back we used a 3rd party tool that required pandoc to make our markdown README render correctly on pypi.  Pypi now supports markdown natively.

### How was it fixed?

Specify the content type and include the readme information directly.

#### Cute Animal Picture

![c2c4ca1739ac6a218250b600cfd02b32](https://user-images.githubusercontent.com/824194/56753419-bb0c5f80-6747-11e9-9ec0-41af92926d8b.jpg)

