### PR TITLE
Track metadata abount peers on connection

### DIFF
--- a/p2p/peer.py
+++ b/p2p/peer.py
@@ -496,6 +496,7 @@ class BasePeer(BaseService):
                 f"Reason must be an item of DisconnectReason, got {reason}"
             )
 
+        self.disconnect_reason = reason
         if reason is DisconnectReason.bad_protocol:
             self.connection_tracker.record_blacklist(
                 self.remote,
@@ -505,7 +506,6 @@ class BasePeer(BaseService):
 
         self.logger.debug("Disconnecting from remote peer %s; reason: %s", self.remote, reason.name)
         self.base_protocol.send_disconnect(reason.value)
-        self.disconnect_reason = reason
         self.transport.close()
 
     async def disconnect(self, reason: DisconnectReason) -> None:

--- a/tests/core/p2p-proto/test_peer_metadata_tracker.py
+++ b/tests/core/p2p-proto/test_peer_metadata_tracker.py
@@ -1,0 +1,357 @@
+import datetime
+
+import pytest
+
+from p2p.tools.factories import NodeFactory
+
+from trinity.plugins.builtin.network_db.connection.tracker import (
+    SQLiteConnectionTracker,
+)
+from trinity.plugins.builtin.network_db.eth1_peer_db.tracker import (
+    MemoryEth1PeerTracker,
+)
+
+
+@pytest.fixture
+def remote():
+    return NodeFactory()
+
+
+ZERO_HASH = b'\x00' * 32
+ZERO_HASH_HEX = ZERO_HASH.hex()
+
+ZERO_ONE_HASH = b'\x01' * 32
+ZERO_ONE_HASH_HEX = ZERO_ONE_HASH.hex()
+
+
+# is_outbound, last_connected_at, genesis_hash, protocol, protocol_version, network_id
+TRACK_ARGS = (True, None, ZERO_HASH, 'eth', 61, 1)
+SIMPLE_META = TRACK_ARGS[2:]
+
+
+@pytest.mark.parametrize('is_outbound', (True, False))
+def test_track_peer_connection_persists(remote, is_outbound):
+    tracker = MemoryEth1PeerTracker()
+    assert not tracker._remote_exists(remote.uri())
+    tracker.track_peer_connection(remote, is_outbound, *TRACK_ARGS[1:])
+    assert tracker._remote_exists(remote.uri())
+
+    node = tracker._get_remote(remote.uri())
+    assert node.uri == remote.uri()
+    assert node.is_outbound is is_outbound
+
+
+@pytest.mark.parametrize('is_outbound', (True, False))
+def test_track_peer_connection_does_not_clobber_existing_record(remote, is_outbound):
+    tracker = MemoryEth1PeerTracker()
+    assert not tracker._remote_exists(remote.uri())
+    tracker.track_peer_connection(remote, is_outbound, *TRACK_ARGS[1:])
+
+    original = tracker._get_remote(remote.uri())
+    assert original.is_outbound is is_outbound
+
+    tracker.track_peer_connection(remote, not is_outbound, *TRACK_ARGS[1:])
+
+    updated = tracker._get_remote(remote.uri())
+    assert updated.is_outbound is is_outbound
+
+
+def test_track_peer_connection_metadata(remote, caplog):
+    tracker = MemoryEth1PeerTracker()
+    tracker.track_peer_connection(remote, *TRACK_ARGS)
+
+    node = tracker._get_remote(remote.uri())
+    node = tracker._get_remote(remote.uri())
+    assert node.genesis_hash == ZERO_HASH_HEX
+    assert node.protocol == 'eth'
+    assert node.protocol_version == 61
+    assert node.network_id == 1
+
+
+def test_track_peer_connection_metadata_updates(remote, caplog):
+    tracker = MemoryEth1PeerTracker()
+    tracker.track_peer_connection(remote, *TRACK_ARGS)
+
+    node = tracker._get_remote(remote.uri())
+    assert node.genesis_hash == ZERO_HASH_HEX
+    assert node.protocol == 'eth'
+    assert node.protocol_version == 61
+    assert node.network_id == 1
+
+    tracker.track_peer_connection(remote, True, None, ZERO_ONE_HASH, 'les', 60, 2)
+
+    updated_node = tracker._get_remote(remote.uri())
+    assert updated_node.genesis_hash == ZERO_ONE_HASH_HEX
+    assert updated_node.protocol == 'les'
+    assert updated_node.protocol_version == 60
+    assert updated_node.network_id == 2
+
+
+def test_track_peer_connection_tracks_last_connected(remote, caplog):
+    tracker = MemoryEth1PeerTracker()
+    now = datetime.datetime.utcnow()
+    tracker.track_peer_connection(remote, True, now, *SIMPLE_META)
+
+    node = tracker._get_remote(remote.uri())
+    assert node.last_connected_at == now
+
+
+def test_track_peer_connection_maintains_last_connected(remote, caplog):
+    tracker = MemoryEth1PeerTracker()
+    now = datetime.datetime.utcnow()
+    tracker.track_peer_connection(remote, True, now, *SIMPLE_META)
+
+    node = tracker._get_remote(remote.uri())
+    assert node.last_connected_at == now
+
+    tracker.track_peer_connection(remote, True, None, *SIMPLE_META)
+    updated_node = tracker._get_remote(remote.uri())
+    assert updated_node.last_connected_at == now
+
+
+def test_track_peer_connection_updates_last_connected(remote, caplog):
+    tracker = MemoryEth1PeerTracker()
+    now = datetime.datetime.utcnow()
+    tracker.track_peer_connection(remote, True, now, *SIMPLE_META)
+
+    node = tracker._get_remote(remote.uri())
+    assert node.last_connected_at == now
+
+    later = now + datetime.timedelta(seconds=300)
+    tracker.track_peer_connection(remote, True, later, *SIMPLE_META)
+    updated_node = tracker._get_remote(remote.uri())
+    assert updated_node.last_connected_at == later
+
+
+@pytest.mark.asyncio
+async def do_tracker_peer_query_test(tracker_params,
+                                     good_remotes,
+                                     bad_remotes,
+                                     blacklist_records=(),
+                                     connected_remotes=None):
+    tracker = MemoryEth1PeerTracker(**tracker_params)
+
+    for remote, is_outbound, meta_params in good_remotes:
+        tracker.track_peer_connection(remote, is_outbound, None, *meta_params)
+
+    for remote, is_outbound, meta_params in bad_remotes:
+        tracker.track_peer_connection(remote, is_outbound, None, *meta_params)
+
+    # use the same in-memory database
+    blacklist_tracker = SQLiteConnectionTracker(tracker.session)
+    for remote, delta_seconds in blacklist_records:
+        expires_at = datetime.datetime.utcnow() + datetime.timedelta(seconds=delta_seconds)
+        blacklist_tracker._create_record(remote, expires_at, 'test')
+
+    candidates = tuple(sorted(
+        await tracker.get_peer_candidates(
+            num_requested=10,
+            connected_remotes=connected_remotes or set(),
+        ),
+        key=lambda r: r.uri(),
+    ))
+    just_good_remotes = tuple(r[0] for r in sorted(good_remotes, key=lambda r: r[0].uri()))
+    just_bad_remotes = tuple(r[0] for r in sorted(bad_remotes, key=lambda r: r[0].uri()))
+    assert len(candidates) == len(just_good_remotes)
+    for remote in just_good_remotes:
+        assert remote in candidates
+    for remote in just_bad_remotes:
+        assert remote not in candidates
+
+
+@pytest.mark.asyncio
+async def test_getting_peer_candidates_no_filter():
+    await do_tracker_peer_query_test(
+        {},
+        (
+            (NodeFactory(), True, SIMPLE_META),
+            (NodeFactory(), True, SIMPLE_META),
+            (NodeFactory(), True, SIMPLE_META),
+        ),
+        (),
+    )
+
+
+@pytest.mark.asyncio
+async def test_getting_peer_candidates_excludes_non_outbound():
+    await do_tracker_peer_query_test(
+        {},
+        (
+            (NodeFactory(), True, SIMPLE_META),
+            (NodeFactory(), True, SIMPLE_META),
+        ),
+        (
+            (NodeFactory(), False, SIMPLE_META),
+        ),
+    )
+
+
+@pytest.mark.asyncio
+async def test_getting_peer_candidates_excludes_genesis_hash_mismatch():
+    await do_tracker_peer_query_test(
+        {'genesis_hash': ZERO_HASH},
+        (
+            (NodeFactory(), True, SIMPLE_META),
+            (NodeFactory(), True, SIMPLE_META),
+        ),
+        (
+            (NodeFactory(), True, (ZERO_ONE_HASH, 'eth', 61, 1)),
+        ),
+    )
+
+
+@pytest.mark.asyncio
+async def test_getting_peer_candidates_excludes_protocol_mismatch():
+    await do_tracker_peer_query_test(
+        {'protocols': ('eth',)},
+        (
+            (NodeFactory(), True, SIMPLE_META),
+            (NodeFactory(), True, SIMPLE_META),
+        ),
+        (
+            (NodeFactory(), True, (ZERO_HASH, 'les', 61, 1)),
+        ),
+    )
+
+
+@pytest.mark.asyncio
+async def test_getting_peer_candidates_matches_multiple_protocols():
+    await do_tracker_peer_query_test(
+        {'protocols': ('eth', 'les')},
+        (
+            (NodeFactory(), True, (ZERO_HASH, 'eth', 61, 1)),
+            (NodeFactory(), True, (ZERO_HASH, 'les', 61, 1)),
+        ),
+        (
+            (NodeFactory(), True, (ZERO_HASH, 'bcc', 61, 1)),
+        ),
+    )
+
+
+@pytest.mark.asyncio
+async def test_getting_peer_candidates_excludes_protocol_version_mismatch():
+    await do_tracker_peer_query_test(
+        {'protocol_versions': (60, 61)},
+        (
+            (NodeFactory(), True, (ZERO_HASH, 'eth', 60, 1)),
+            (NodeFactory(), True, (ZERO_HASH, 'eth', 61, 1)),
+        ),
+        (
+            (NodeFactory(), True, (ZERO_HASH, 'eth', 62, 1)),
+        ),
+    )
+
+
+@pytest.mark.asyncio
+async def test_getting_peer_candidates_excludes_network_id_mismatch():
+    await do_tracker_peer_query_test(
+        {'network_id': 1},
+        (
+            (NodeFactory(), True, SIMPLE_META),
+            (NodeFactory(), True, SIMPLE_META),
+        ),
+        (
+            (NodeFactory(), True, (ZERO_HASH, 'eth', 62, 2)),
+        ),
+    )
+
+
+@pytest.mark.asyncio
+async def test_getting_peer_candidates_complex_query():
+    await do_tracker_peer_query_test(
+        {
+            'genesis_hash': ZERO_HASH,
+            'protocols': ['eth'],
+            'protocol_versions': [61],
+            'network_id': 1,
+        },
+        (
+            (NodeFactory(), True, SIMPLE_META),
+            (NodeFactory(), True, SIMPLE_META),
+        ),
+        (
+            (NodeFactory(), False, SIMPLE_META),  # inbound peer
+            (NodeFactory(), True, (ZERO_HASH, 'les', 61, 1)),  # wrong protocol
+            (NodeFactory(), True, (ZERO_HASH, 'eth', 60, 1)),  # wrong protocol version
+            (NodeFactory(), True, (ZERO_HASH, 'eth', 61, 2)),  # wrong network_id
+        ),
+    )
+
+
+@pytest.mark.asyncio
+async def test_excludes_blacklisted_peers_from_candidates():
+    remote_b = NodeFactory()
+    await do_tracker_peer_query_test(
+        {},
+        (
+            (NodeFactory(), True, SIMPLE_META),
+            (NodeFactory(), True, SIMPLE_META),
+        ),
+        (
+            (remote_b, True, SIMPLE_META),
+        ),
+        (
+            (remote_b, 10),  # blacklisted for 10 seconds
+        )
+    )
+
+
+@pytest.mark.asyncio
+async def test_includes_expired_blacklisted_from_candidates():
+    remote_a = NodeFactory()
+    await do_tracker_peer_query_test(
+        {},
+        (
+            (remote_a, True, SIMPLE_META),
+            (NodeFactory(), True, SIMPLE_META),
+            (NodeFactory(), True, SIMPLE_META),
+        ),
+        (
+        ),
+        (
+            (remote_a, -10),  # expired blacklist record
+        )
+    )
+
+
+@pytest.mark.asyncio
+async def test_candidate_selection_with_mixed_blacklisted_remotes():
+    remote_a = NodeFactory()
+    remote_b = NodeFactory()
+    remote_c = NodeFactory()
+    remote_d = NodeFactory()
+    await do_tracker_peer_query_test(
+        {},
+        (
+            (remote_a, True, SIMPLE_META),
+            (NodeFactory(), True, SIMPLE_META),
+            (remote_c, True, SIMPLE_META),
+            (NodeFactory(), True, SIMPLE_META),
+        ),
+        (
+            (remote_b, True, SIMPLE_META),
+            (remote_d, True, SIMPLE_META),
+        ),
+        (
+            (remote_a, -5),  # expired blacklist record
+            (remote_b, 10),  # expired blacklist record
+            (remote_c, -20),  # expired blacklist record
+            (remote_d, 25),  # expired blacklist record
+        )
+    )
+
+
+@pytest.mark.asyncio
+async def test_getting_peer_candidates_excludes_already_connected():
+    remote_a = NodeFactory()
+    await do_tracker_peer_query_test(
+        {},
+        (
+            (NodeFactory(), True, SIMPLE_META),
+            (NodeFactory(), True, SIMPLE_META),
+        ),
+        (
+            (remote_a, True, SIMPLE_META),
+        ),
+        connected_remotes=(remote_a,),
+    )

--- a/trinity/db/orm.py
+++ b/trinity/db/orm.py
@@ -27,7 +27,7 @@ from trinity.exceptions import (
 Base = declarative_base()
 
 
-SCHEMA_VERSION = '2'
+SCHEMA_VERSION = '3'
 
 
 class SchemaVersion(Base):

--- a/trinity/plugins/builtin/network_db/eth1_peer_db/events.py
+++ b/trinity/plugins/builtin/network_db/eth1_peer_db/events.py
@@ -1,0 +1,48 @@
+import datetime
+from typing import Optional, Set, Type, Tuple
+
+from lahja import (
+    BaseEvent,
+    BaseRequestResponseEvent,
+)
+
+from eth_typing import Hash32
+
+from p2p.kademlia import Node
+
+
+class BasePeerDBEvent(BaseEvent):
+    pass
+
+
+class TrackPeerEvent(BasePeerDBEvent):
+    def __init__(self,
+                 remote: Node,
+                 is_outbound: bool,
+                 last_connected_at: Optional[datetime.datetime],
+                 genesis_hash: Hash32,
+                 protocol: str,
+                 protocol_version: int,
+                 network_id: int) -> None:
+        self.remote = remote
+        self.is_outbound = is_outbound
+        self.last_connected_at = last_connected_at
+        self.genesis_hash = genesis_hash
+        self.protocol = protocol
+        self.protocol_version = protocol_version
+        self.network_id = network_id
+
+
+class GetPeerCandidatesResponse(BasePeerDBEvent):
+    def __init__(self, candidates: Tuple[Node, ...]) -> None:
+        self.candidates = candidates
+
+
+class GetPeerCandidatesRequest(BaseRequestResponseEvent[GetPeerCandidatesResponse]):
+    def __init__(self, num_requested: int, connected_remotes: Set[Node]) -> None:
+        self.num_requested = num_requested
+        self.connected_remotes = connected_remotes
+
+    @staticmethod
+    def expected_response_type() -> Type[GetPeerCandidatesResponse]:
+        return GetPeerCandidatesResponse

--- a/trinity/plugins/builtin/network_db/eth1_peer_db/server.py
+++ b/trinity/plugins/builtin/network_db/eth1_peer_db/server.py
@@ -1,0 +1,61 @@
+from cancel_token import CancelToken
+
+from p2p.service import BaseService
+
+from trinity.endpoint import (
+    TrinityEventBusEndpoint,
+)
+
+from .tracker import (
+    BaseEth1PeerTracker,
+)
+from .events import (
+    TrackPeerEvent,
+    GetPeerCandidatesRequest,
+    GetPeerCandidatesResponse,
+)
+
+
+class PeerDBServer(BaseService):
+    """
+    Server to handle the event bus communication for PeerDB
+    """
+
+    def __init__(self,
+                 event_bus: TrinityEventBusEndpoint,
+                 tracker: BaseEth1PeerTracker,
+                 token: CancelToken = None) -> None:
+        super().__init__(token)
+        self.tracker = tracker
+        self.event_bus = event_bus
+
+    async def handle_track_peer_event(self) -> None:
+        async for command in self.wait_iter(self.event_bus.stream(TrackPeerEvent)):
+            self.tracker.track_peer_connection(
+                command.remote,
+                command.is_outbound,
+                command.last_connected_at,
+                command.genesis_hash,
+                command.protocol,
+                command.protocol_version,
+                command.network_id,
+            )
+
+    async def handle_get_peer_candidates_request(self) -> None:
+        async for req in self.wait_iter(self.event_bus.stream(GetPeerCandidatesRequest)):
+            candidates = tuple(await self.tracker.get_peer_candidates(
+                req.num_requested,
+                req.connected_remotes,
+            ))
+            await self.event_bus.broadcast(
+                GetPeerCandidatesResponse(candidates),
+                req.broadcast_config(),
+            )
+
+    async def _run(self) -> None:
+        self.logger.debug("Running PeerDBServer")
+
+        self.run_daemon_task(self.handle_track_peer_event())
+        self.run_daemon_task(self.handle_get_peer_candidates_request())
+
+        await self.cancel_token.wait()

--- a/trinity/plugins/builtin/network_db/eth1_peer_db/tracker.py
+++ b/trinity/plugins/builtin/network_db/eth1_peer_db/tracker.py
@@ -117,8 +117,8 @@ class BaseEth1PeerTracker(BasePeerBackend, PeerSubscriber):
 
     def deregister_peer(self, peer: BasePeer) -> None:
         """
-        This is likely the proper place to do record statistics about peer
-        performance.
+        At disconnection we check whether our session with the peer was long
+        enough to warrant recording statistics about them in our peer database.
         """
         # prevent circular import
         from trinity.protocol.common.peer import BaseChainPeer
@@ -308,7 +308,7 @@ class SQLiteEth1PeerTracker(BaseEth1PeerTracker):
         ).order_by(
             # We want the ones that we have recently connected to succesfully to be first.
             Remote.last_connected_at.desc(),  # type: ignore
-        ).all()
+        )
 
         # Return them as an iterator to allow the consuming process to
         # determine how many records it wants to fetch.

--- a/trinity/plugins/builtin/network_db/eth1_peer_db/tracker.py
+++ b/trinity/plugins/builtin/network_db/eth1_peer_db/tracker.py
@@ -1,0 +1,400 @@
+from abc import abstractmethod
+import datetime
+import logging
+from pathlib import Path
+from typing import (
+    Any,
+    cast,
+    FrozenSet,
+    Iterable,
+    Optional,
+    Set,
+    Type,
+    Tuple,
+)
+
+from sqlalchemy.orm import (
+    relationship,
+    Session as BaseSession,
+)
+from sqlalchemy import (
+    Column,
+    Boolean,
+    Integer,
+    DateTime,
+    String,
+)
+from sqlalchemy.orm.exc import NoResultFound
+
+from lahja import (
+    BroadcastConfig,
+    AsyncioEndpoint,
+)
+
+from eth_typing import Hash32
+
+from eth_utils import humanize_seconds, to_tuple
+
+from eth.tools.logging import ExtendedDebugLogger
+
+from p2p import protocol
+from p2p.peer_backend import BasePeerBackend
+from p2p.kademlia import Node
+from p2p.peer import (
+    BasePeer,
+    PeerSubscriber,
+)
+
+from trinity.constants import (
+    NETWORKDB_EVENTBUS_ENDPOINT,
+)
+from trinity.db.orm import (
+    get_tracking_database,
+    Base,
+)
+from trinity.plugins.builtin.network_db.connection.tracker import (
+    BlacklistRecord,
+)
+
+from .events import (
+    TrackPeerEvent,
+    GetPeerCandidatesRequest,
+)
+
+
+class Remote(Base):
+    __tablename__ = 'remotes'
+
+    id = Column(Integer, primary_key=True)
+
+    uri = Column(String, unique=True, nullable=False, index=True)
+    is_outbound = Column(Boolean, nullable=False, index=True)
+
+    created_at = Column(DateTime(timezone=True), nullable=False)
+    updated_at = Column(DateTime(timezone=True), nullable=False, index=True)
+
+    last_connected_at = Column(DateTime(timezone=True), nullable=True)
+
+    genesis_hash = Column(String, nullable=False, index=True)
+    protocol = Column(String, nullable=False, index=True)
+    protocol_version = Column(Integer, nullable=False, index=True)
+    network_id = Column(Integer, nullable=False, index=True)
+
+    blacklist = relationship(
+        "BlacklistRecord",
+        primaryjoin="Remote.uri==foreign(BlacklistRecord.uri)",
+        uselist=False,
+    )
+
+
+class BaseEth1PeerTracker(BasePeerBackend, PeerSubscriber):
+    logger = cast(
+        ExtendedDebugLogger,
+        logging.getLogger('trinity.protocol.common.connection.PeerTracker'),
+    )
+
+    msg_queue_maxsize = 100
+    subscription_msg_types: FrozenSet[Type[protocol.Command]] = frozenset()
+
+    def register_peer(self, peer: BasePeer) -> None:
+        # prevent circular import
+        from trinity.protocol.common.peer import BaseChainPeer
+        peer = cast(BaseChainPeer, peer)
+        self.logger.debug(
+            'tracking %s peer connection: %s',
+            'inbound' if peer.inbound else 'outbound',
+            peer,
+        )
+        self.track_peer_connection(
+            remote=peer.remote,
+            is_outbound=not peer.inbound,
+            last_connected_at=None,
+            genesis_hash=peer.genesis_hash,
+            protocol=peer.sub_proto.name,
+            protocol_version=peer.sub_proto.version,
+            network_id=peer.network_id,
+        )
+
+    def deregister_peer(self, peer: BasePeer) -> None:
+        """
+        This is likely the proper place to do record statistics about peer
+        performance.
+        """
+        # prevent circular import
+        from trinity.protocol.common.peer import BaseChainPeer
+        peer = cast(BaseChainPeer, peer)
+        if peer.disconnect_reason is None:
+            # we don't care about peers that don't properly disconnect
+            self.logger.debug(
+                'Not tracking disconnecting peer %s[%s] missing disconnect reason',
+                peer,
+                'inbound' if peer.inbound else 'outbound',
+            )
+            return
+        elif peer.uptime < MIN_QUALIFYING_UPTIME:
+            # we don't register a peer who connects for less than
+            # `MIN_QUALIFYING_UPTIME` as having been a successful connection.
+            self.logger.debug(
+                'Not tracking disconnecting peer %s[%s][%s] due to insufficient uptime (%s < %s)',
+                peer,
+                peer.disconnect_reason,
+                'inbound' if peer.inbound else 'outbound',
+                humanize_seconds(peer.uptime),
+                humanize_seconds(MIN_QUALIFYING_UPTIME),
+            )
+            return
+        else:
+            self.logger.debug(
+                'Tracking disconnecting peer %s[%s][%s] with uptime: %s',
+                peer,
+                'inbound' if peer.inbound else 'outbound',
+                peer.disconnect_reason,
+                humanize_seconds(peer.uptime),
+            )
+
+        self.track_peer_connection(
+            remote=peer.remote,
+            is_outbound=not peer.inbound,
+            last_connected_at=datetime.datetime.utcnow(),
+            genesis_hash=peer.genesis_hash,
+            protocol=peer.sub_proto.name,
+            protocol_version=peer.sub_proto.version,
+            network_id=peer.network_id,
+        )
+
+    @abstractmethod
+    def track_peer_connection(self,
+                              remote: Node,
+                              is_outbound: bool,
+                              last_connected_at: Optional[datetime.datetime],
+                              genesis_hash: Hash32,
+                              protocol: str,
+                              protocol_version: int,
+                              network_id: int) -> None:
+        pass
+
+    @abstractmethod
+    async def get_peer_candidates(self,
+                                  num_requested: int,
+                                  connected_remotes: Set[Node]) -> Tuple[Node, ...]:
+        pass
+
+
+class NoopEth1PeerTracker(BaseEth1PeerTracker):
+    def track_peer_connection(self,
+                              remote: Node,
+                              is_outbound: bool,
+                              last_connected_at: Optional[datetime.datetime],
+                              genesis_hash: Hash32,
+                              protocol: str,
+                              protocol_version: int,
+                              network_id: int) -> None:
+        pass
+
+    async def get_peer_candidates(self,
+                                  num_requested: int,
+                                  connected_remotes: Set[Node]) -> Tuple[Node, ...]:
+        return ()
+
+
+MIN_QUALIFYING_UPTIME = 60
+
+
+class SQLiteEth1PeerTracker(BaseEth1PeerTracker):
+    def __init__(self,
+                 session: BaseSession,
+                 genesis_hash: Hash32 = None,
+                 protocols: Tuple[str, ...] = None,
+                 protocol_versions: Tuple[int, ...] = None,
+                 network_id: int = None) -> None:
+        self.session = session
+        if genesis_hash is not None:
+            self.genesis_hash = genesis_hash.hex()
+        else:
+            self.genesis_hash = genesis_hash
+        self.protocols = protocols
+        self.protocol_versions = protocol_versions
+        self.network_id = network_id
+
+    def track_peer_connection(self,
+                              remote: Node,
+                              is_outbound: bool,
+                              last_connected_at: Optional[datetime.datetime],
+                              genesis_hash: Hash32,
+                              protocol: str,
+                              protocol_version: int,
+                              network_id: int) -> None:
+        uri = remote.uri()
+        now = datetime.datetime.utcnow()
+
+        if self._remote_exists(uri):
+            self.logger.debug2("Updated ETH1 peer record: %s", remote)
+            record = self._get_remote(uri)
+
+            record.updated_at = now
+
+            if last_connected_at is not None:
+                record.last_connected_at = last_connected_at
+
+            record.genesis_hash = genesis_hash.hex()
+            record.protocol = protocol
+            record.protocol_version = protocol_version
+            record.network_id = network_id
+        else:
+            self.logger.debug2("New ETH1 peer record: %s", remote)
+            record = Remote(
+                uri=uri,
+                is_outbound=is_outbound,
+                created_at=now,
+                updated_at=now,
+                last_connected_at=last_connected_at,
+                genesis_hash=genesis_hash.hex(),
+                protocol=protocol,
+                protocol_version=protocol_version,
+                network_id=network_id,
+            )
+
+        self.session.add(record)
+        self.session.commit()  # type: ignore
+
+    @to_tuple
+    def _get_candidate_filter_query(self) -> Iterable[Any]:
+        yield Remote.is_outbound.is_(True)  # type: ignore
+
+        if self.protocols is not None:
+            if len(self.protocols) == 1:
+                yield Remote.protocol == self.protocols[0]  # type: ignore
+            else:
+                yield Remote.protocol.in_(self.protocols)  # type: ignore
+
+        if self.protocol_versions is not None:
+            if len(self.protocol_versions) == 1:
+                yield Remote.protocol_version == self.protocol_versions[0]  # type: ignore
+            else:
+                yield Remote.protocol_version.in_(self.protocol_versions)  # type: ignore
+
+        if self.network_id is not None:
+            yield Remote.network_id == self.network_id  # type: ignore
+
+        if self.genesis_hash is not None:
+            yield Remote.genesis_hash == self.genesis_hash  # type: ignore
+
+    def _get_peer_candidates(self,
+                             num_requested: int,
+                             connected_remotes: Set[Node]) -> Iterable[Node]:
+        """
+        Return up to `num_requested` candidates sourced from peers whe have
+        historically connected to which match the following criteria:
+
+        * Matches all of: network_id, protocol, genesis_hash, protocol_version
+        * Either has no blacklist record or existing blacklist record is expired.
+        * Not in the set of remotes we are already connected to.
+        """
+        connected_uris = set(remote.uri() for remote in connected_remotes)
+        now = datetime.datetime.utcnow()
+        metadata_filters = self._get_candidate_filter_query()
+
+        # Query the database for peers that match our criteria.
+        candidates = self.session.query(Remote).outerjoin(  # type: ignore
+            # Join against the blacklist records with matching node URI
+            Remote.blacklist,
+        ).filter(
+            # Either they have no blacklist record or the record is expired.
+            ((Remote.blacklist == None) | (BlacklistRecord.expires_at <= now)),  # noqa: E711
+            # We are not currently connected to them
+            ~Remote.uri.in_(connected_uris),  # type: ignore
+            # They match our filters for network metadata
+            *metadata_filters,
+        ).order_by(
+            # We want the ones that we have recently connected to succesfully to be first.
+            Remote.last_connected_at.desc(),  # type: ignore
+        ).all()
+
+        # Return them as an iterator to allow the consuming process to
+        # determine how many records it wants to fetch.
+        for candidate in candidates:
+            yield Node.from_uri(candidate.uri)
+
+    async def get_peer_candidates(self,
+                                  num_requested: int,
+                                  connected_remotes: Set[Node]) -> Tuple[Node, ...]:
+        # For now we fully evaluate the response in order to print debug
+        # statistics.  Once this API is no longer experimental, this should be
+        # adjusted to only consume a maximum of `num_requested` from the
+        # returned iterable.
+        all_candidates = tuple(self._get_peer_candidates(num_requested, connected_remotes))
+        candidates = all_candidates[:num_requested]
+        total_in_database = self.session.query(Remote).count()  # type: ignore
+        self.logger.debug(
+            "Eth1 Peer Candidate Request: req=%d  ret=%d  avail=%d  total=%d",
+            num_requested,
+            len(candidates),
+            len(all_candidates),
+            total_in_database,
+        )
+        return candidates
+
+    #
+    # Helpers
+    #
+    def _get_remote(self, uri: str) -> Remote:
+        return self.session.query(Remote).filter_by(uri=uri).one()  # type: ignore
+
+    def _remote_exists(self, uri: str) -> bool:
+        try:
+            self._get_remote(uri)
+        except NoResultFound:
+            return False
+        else:
+            return True
+
+
+class MemoryEth1PeerTracker(SQLiteEth1PeerTracker):
+    def __init__(self,
+                 genesis_hash: Hash32 = None,
+                 protocols: Tuple[str, ...] = None,
+                 protocol_versions: Tuple[int, ...] = None,
+                 network_id: int = None) -> None:
+        session = get_tracking_database(Path(":memory:"))
+        super().__init__(session, genesis_hash, protocols, protocol_versions, network_id)
+
+
+TO_NETWORKDB_BROADCAST_CONFIG = BroadcastConfig(filter_endpoint=NETWORKDB_EVENTBUS_ENDPOINT)
+
+
+class EventBusEth1PeerTracker(BaseEth1PeerTracker):
+    def __init__(self,
+                 event_bus: AsyncioEndpoint,
+                 config: BroadcastConfig = TO_NETWORKDB_BROADCAST_CONFIG) -> None:
+        self.event_bus = event_bus
+        self.config = config
+
+    def track_peer_connection(self,
+                              remote: Node,
+                              is_outbound: bool,
+                              last_connected_at: Optional[datetime.datetime],
+                              genesis_hash: Hash32,
+                              protocol: str,
+                              protocol_version: int,
+                              network_id: int) -> None:
+        self.event_bus.broadcast_nowait(
+            TrackPeerEvent(
+                remote,
+                is_outbound,
+                last_connected_at,
+                genesis_hash,
+                protocol,
+                protocol_version,
+                network_id,
+            ),
+            self.config,
+        )
+
+    async def get_peer_candidates(self,
+                                  num_requested: int,
+                                  connected_remotes: Set[Node]) -> Tuple[Node, ...]:
+        response = await self.event_bus.request(
+            GetPeerCandidatesRequest(num_requested, connected_remotes),
+            self.config,
+        )
+        return response.candidates


### PR DESCRIPTION
fixes https://github.com/ethereum/trinity/issues/24

### What was wrong?

Every time the trinity client runs, it starts with zero knowledge about the network.  This means that it must bootstrap with the kademlia network and then find appropriate peers to connect to.  This process is time consuming and results in the node taking a long time to find appropriate peers and establish connections to start syncing.

### How was it fixed?

Now, each time we successfully connect to a peer, we keep a record of information about them.

- remote URI
- whether they were originally inbound or outbound
- when we first saw them
- when we last updated their record
- when we last established a connection with them that was at least X seconds long
- their genesis hash
- their network id
- the protocol name they were speaking
- the protocol version they were speaking

Now, when we start, the peer pool will query this database for nodes using the following rules.

- exclude nodes that have an active blacklist record.
- exclude nodes that were originally inbound
- exclude nodes who's network parameters do not match ours (genesis hash, network, etc)
- order nodes by the last time a good connection was established (most recent first)
- exclude nodes that we are already connected to

With this change, a node that goes offline and comes quickly back online will quickly re-establish many of their previous connections as they will be first in the queue.

[//]: # (For important changes, please add a new entry to the release notes file)
[//]: # (See: https://trinity-client.readthedocs.io/en/latest/contributing.html#pull-requests)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses]()
