### PR TITLE
Fix RANDAO message_hash

### DIFF
--- a/eth2/beacon/tools/builder/proposer.py
+++ b/eth2/beacon/tools/builder/proposer.py
@@ -6,8 +6,8 @@ from typing import (
 from eth_typing import (
     BLSPubkey,
     BLSSignature,
-    Hash32,
 )
+import ssz
 
 
 from eth2.configs import (
@@ -60,7 +60,7 @@ def _generate_randao_reveal(privkey: int,
     """
     epoch = slot_to_epoch(slot, config.SLOTS_PER_EPOCH)
 
-    message_hash = Hash32(epoch.to_bytes(32, byteorder='little'))
+    message_hash = ssz.hash_tree_root(epoch, sedes=ssz.sedes.uint64)
 
     randao_reveal = sign_transaction(
         message_hash=message_hash,


### PR DESCRIPTION
### What was wrong?

In spec [v0.5.1](https://github.com/ethereum/eth2.0-specs/blob/v0.5.1/specs/core/0_beacon-chain.md#randao), we use `hash_tree_root` to generate `message_hash`.

### How was it fixed?
Use `ssz.hash_tree_root(epoch, sedes=ssz.sedes.uint64)`

#### Cute Animal Picture

![barn-owl-1107397_640](https://user-images.githubusercontent.com/9263930/56863260-e660aa00-69e6-11e9-8834-b191e006a9c5.jpg)
