### PR TITLE
Rename and reorder `PendingAttestationRecord` fields

### DIFF
--- a/eth2/beacon/epoch_processing_helpers.py
+++ b/eth2/beacon/epoch_processing_helpers.py
@@ -279,11 +279,11 @@ def get_inclusion_infos(
         for index in participant_indices:
             should_update_inclusion_data = (
                 index not in inclusion_infos or
-                attestation.slot_included < inclusion_infos[index].inclusion_slot
+                attestation.inclusion_slot < inclusion_infos[index].inclusion_slot
             )
             if should_update_inclusion_data:
                 inclusion_infos[index] = InclusionInfo(
-                    attestation.slot_included,
+                    attestation.inclusion_slot,
                     attestation.data.slot
                 )
     return inclusion_infos

--- a/eth2/beacon/state_machines/forks/serenity/operation_processing.py
+++ b/eth2/beacon/state_machines/forks/serenity/operation_processing.py
@@ -147,8 +147,8 @@ def process_attestations(state: BeaconState,
         if slot_to_epoch(attestation.data.slot, config.SLOTS_PER_EPOCH) == current_epoch:
             new_current_epoch_pending_attestations.append(
                 PendingAttestationRecord(
-                    data=attestation.data,
                     aggregation_bitfield=attestation.aggregation_bitfield,
+                    data=attestation.data,
                     custody_bitfield=attestation.custody_bitfield,
                     inclusion_slot=state.slot,
                 )
@@ -156,8 +156,8 @@ def process_attestations(state: BeaconState,
         elif slot_to_epoch(attestation.data.slot, config.SLOTS_PER_EPOCH) == previous_epoch:
             new_previous_epoch_pending_attestations.append(
                 PendingAttestationRecord(
-                    data=attestation.data,
                     aggregation_bitfield=attestation.aggregation_bitfield,
+                    data=attestation.data,
                     custody_bitfield=attestation.custody_bitfield,
                     inclusion_slot=state.slot,
                 )

--- a/eth2/beacon/state_machines/forks/serenity/operation_processing.py
+++ b/eth2/beacon/state_machines/forks/serenity/operation_processing.py
@@ -150,7 +150,7 @@ def process_attestations(state: BeaconState,
                     data=attestation.data,
                     aggregation_bitfield=attestation.aggregation_bitfield,
                     custody_bitfield=attestation.custody_bitfield,
-                    slot_included=state.slot,
+                    inclusion_slot=state.slot,
                 )
             )
         elif slot_to_epoch(attestation.data.slot, config.SLOTS_PER_EPOCH) == previous_epoch:
@@ -159,7 +159,7 @@ def process_attestations(state: BeaconState,
                     data=attestation.data,
                     aggregation_bitfield=attestation.aggregation_bitfield,
                     custody_bitfield=attestation.custody_bitfield,
-                    slot_included=state.slot,
+                    inclusion_slot=state.slot,
                 )
             )
 

--- a/eth2/beacon/types/pending_attestation_records.py
+++ b/eth2/beacon/types/pending_attestation_records.py
@@ -24,17 +24,17 @@ class PendingAttestationRecord(ssz.Serializable):
         # Custody bitfield
         ('custody_bitfield', bytes_sedes),
         # Slot the attestation was included
-        ('slot_included', uint64),
+        ('inclusion_slot', uint64),
     ]
 
     def __init__(self,
                  data: AttestationData,
                  aggregation_bitfield: Bitfield,
                  custody_bitfield: Bitfield,
-                 slot_included: Slot) -> None:
+                 inclusion_slot: Slot) -> None:
         super().__init__(
             data=data,
             aggregation_bitfield=aggregation_bitfield,
             custody_bitfield=custody_bitfield,
-            slot_included=slot_included,
+            inclusion_slot=inclusion_slot,
         )

--- a/eth2/beacon/types/pending_attestation_records.py
+++ b/eth2/beacon/types/pending_attestation_records.py
@@ -17,24 +17,24 @@ from .attestation_data import (
 class PendingAttestationRecord(ssz.Serializable):
 
     fields = [
-        # Signed data
-        ('data', AttestationData),
         # Attester aggregation bitfield
         ('aggregation_bitfield', bytes_sedes),
+        # Attestation data
+        ('data', AttestationData),
         # Custody bitfield
         ('custody_bitfield', bytes_sedes),
-        # Slot the attestation was included
+        # Inclusion slot
         ('inclusion_slot', uint64),
     ]
 
     def __init__(self,
-                 data: AttestationData,
                  aggregation_bitfield: Bitfield,
+                 data: AttestationData,
                  custody_bitfield: Bitfield,
                  inclusion_slot: Slot) -> None:
         super().__init__(
-            data=data,
             aggregation_bitfield=aggregation_bitfield,
+            data=data,
             custody_bitfield=custody_bitfield,
             inclusion_slot=inclusion_slot,
         )

--- a/tests/eth2/beacon/conftest.py
+++ b/tests/eth2/beacon/conftest.py
@@ -267,8 +267,8 @@ def sample_fork_params():
 @pytest.fixture
 def sample_pending_attestation_record_params(sample_attestation_data_params):
     return {
-        'data': AttestationData(**sample_attestation_data_params),
         'aggregation_bitfield': b'\12' * 16,
+        'data': AttestationData(**sample_attestation_data_params),
         'custody_bitfield': b'\34' * 16,
         'inclusion_slot': 0,
     }

--- a/tests/eth2/beacon/conftest.py
+++ b/tests/eth2/beacon/conftest.py
@@ -270,7 +270,7 @@ def sample_pending_attestation_record_params(sample_attestation_data_params):
         'data': AttestationData(**sample_attestation_data_params),
         'aggregation_bitfield': b'\12' * 16,
         'custody_bitfield': b'\34' * 16,
-        'slot_included': 0,
+        'inclusion_slot': 0,
     }
 
 

--- a/tests/eth2/beacon/state_machines/forks/test_serenity_epoch_processing.py
+++ b/tests/eth2/beacon/state_machines/forks/test_serenity_epoch_processing.py
@@ -778,6 +778,7 @@ def test_process_rewards_and_penalties_for_finality(
                 participants_bitfield = set_voted(participants_bitfield, committee.index(index))
         prev_epoch_attestations.append(
             PendingAttestationRecord(**sample_pending_attestation_record_params).copy(
+                aggregation_bitfield=participants_bitfield,
                 data=AttestationData(**sample_attestation_data_params).copy(
                     slot=(prev_epoch_start_slot + i),
                     shard=shard,
@@ -792,7 +793,6 @@ def test_process_rewards_and_penalties_for_finality(
                         config.SLOTS_PER_HISTORICAL_ROOT,
                     ),
                 ),
-                aggregation_bitfield=participants_bitfield,
             )
         )
     state = state.copy(
@@ -896,6 +896,7 @@ def test_process_rewards_and_penalties_for_crosslinks(
         data_slot = i + previous_epoch * slots_per_epoch
         previous_epoch_attestations.append(
             PendingAttestationRecord(**sample_pending_attestation_record_params).copy(
+                aggregation_bitfield=participants_bitfield,
                 data=AttestationData(**sample_attestation_data_params).copy(
                     slot=data_slot,
                     shard=shard,
@@ -904,7 +905,6 @@ def test_process_rewards_and_penalties_for_crosslinks(
                         crosslink_data_root=ZERO_HASH32,
                     ),
                 ),
-                aggregation_bitfield=participants_bitfield,
                 inclusion_slot=(data_slot + min_attestation_inclusion_delay),
             )
         )

--- a/tests/eth2/beacon/state_machines/forks/test_serenity_epoch_processing.py
+++ b/tests/eth2/beacon/state_machines/forks/test_serenity_epoch_processing.py
@@ -905,7 +905,7 @@ def test_process_rewards_and_penalties_for_crosslinks(
                     ),
                 ),
                 aggregation_bitfield=participants_bitfield,
-                slot_included=(data_slot + min_attestation_inclusion_delay),
+                inclusion_slot=(data_slot + min_attestation_inclusion_delay),
             )
         )
     state = state.copy(

--- a/tests/eth2/beacon/test_epoch_processing_helpers.py
+++ b/tests/eth2/beacon/test_epoch_processing_helpers.py
@@ -553,7 +553,7 @@ def test_get_inclusion_infos(
                 shard=shard,
             ),
             aggregation_bitfield=aggregation_bitfield,
-            slot_included=attestation_1_inclusion_slot,
+            inclusion_slot=attestation_1_inclusion_slot,
         ),
         PendingAttestationRecord(**sample_pending_attestation_record_params).copy(
             data=AttestationData(**sample_attestation_data_params).copy(
@@ -561,7 +561,7 @@ def test_get_inclusion_infos(
                 shard=shard,
             ),
             aggregation_bitfield=aggregation_bitfield,
-            slot_included=attestation_2_inclusion_slot,
+            inclusion_slot=attestation_2_inclusion_slot,
         ),
     ]
 

--- a/tests/eth2/beacon/test_epoch_processing_helpers.py
+++ b/tests/eth2/beacon/test_epoch_processing_helpers.py
@@ -548,19 +548,19 @@ def test_get_inclusion_infos(
     )
     previous_epoch_attestations = [
         PendingAttestationRecord(**sample_pending_attestation_record_params).copy(
+            aggregation_bitfield=aggregation_bitfield,
             data=AttestationData(**sample_attestation_data_params).copy(
                 slot=attestation_1_data_slot,
                 shard=shard,
             ),
-            aggregation_bitfield=aggregation_bitfield,
             inclusion_slot=attestation_1_inclusion_slot,
         ),
         PendingAttestationRecord(**sample_pending_attestation_record_params).copy(
+            aggregation_bitfield=aggregation_bitfield,
             data=AttestationData(**sample_attestation_data_params).copy(
                 slot=attestation_2_data_slot,
                 shard=shard,
             ),
-            aggregation_bitfield=aggregation_bitfield,
             inclusion_slot=attestation_2_inclusion_slot,
         ),
     ]

--- a/tests/eth2/beacon/types/test_pending_attestation_record.py
+++ b/tests/eth2/beacon/types/test_pending_attestation_record.py
@@ -11,5 +11,5 @@ def test_defaults(sample_pending_attestation_record_params):
     assert pending_attestation.data == sample_pending_attestation_record_params['data']
     assert pending_attestation.aggregation_bitfield == sample_pending_attestation_record_params['aggregation_bitfield']  # noqa: E501
     assert pending_attestation.custody_bitfield == sample_pending_attestation_record_params['custody_bitfield']  # noqa: E501
-    assert pending_attestation.slot_included == sample_pending_attestation_record_params['slot_included']  # noqa: E501
+    assert pending_attestation.inclusion_slot == sample_pending_attestation_record_params['inclusion_slot']  # noqa: E501
     assert ssz.encode(pending_attestation)


### PR DESCRIPTION
### What was wrong?

Simple field name sync.

### How was it fixed?
- Rename `PendingAttestationRecord.slot_included` to `PendingAttestationRecord.inclusion_slot`
- Reorder `aggregation_bitfield` and `data` fields in `PendingAttestationRecord`

#### Cute Animal Picture

![owl-3340957_640](https://user-images.githubusercontent.com/9263930/56863300-4b1c0480-69e7-11e9-9969-c1fe7b06d298.jpg)
