### PR TITLE
v0.5.1 state tests

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "fixtures"]
 	path = fixtures
 	url = https://github.com/ethereum/tests.git
+[submodule "eth2-fixtures"]
+	path = eth2-fixtures
+	url = git@github.com:ethereum/eth2.0-tests.git

--- a/eth2/beacon/epoch_processing_helpers.py
+++ b/eth2/beacon/epoch_processing_helpers.py
@@ -94,6 +94,8 @@ def _filter_attestations_by_latest_crosslinks_and_shard(
         shard: Shard) -> Iterable[PendingAttestation]:
     for attestation in attestations:
         is_latest_crosslink_matched = attestation.data.previous_crosslink == latest_crosslink
+        # NOTE: v0.5.1 doesn't check is_shard_matched but it's fixed in v0.6.0
+        # We implemented ahead here.
         is_shard_matched = attestation.data.shard == shard
         if is_latest_crosslink_matched and is_shard_matched:
             yield attestation

--- a/eth2/beacon/state_machines/base.py
+++ b/eth2/beacon/state_machines/base.py
@@ -7,10 +7,6 @@ from typing import (
     Type,
 )
 
-from eth_typing import (
-    Hash32,
-)
-
 from eth._utils.datatypes import (
     Configurable,
 )

--- a/eth2/beacon/state_machines/base.py
+++ b/eth2/beacon/state_machines/base.py
@@ -45,7 +45,8 @@ class BaseBeaconStateMachine(Configurable, ABC):
     @abstractmethod
     def __init__(self,
                  chaindb: BaseBeaconChainDB,
-                 block_root: Hash32) -> None:
+                 block: BaseBeaconBlock,
+                 state: BeaconState=None) -> None:
         pass
 
     @classmethod
@@ -87,9 +88,13 @@ class BaseBeaconStateMachine(Configurable, ABC):
 class BeaconStateMachine(BaseBeaconStateMachine):
     def __init__(self,
                  chaindb: BaseBeaconChainDB,
-                 block: BaseBeaconBlock) -> None:
+                 block: BaseBeaconBlock,
+                 state: BeaconState=None) -> None:
         self.chaindb = chaindb
-        self.block = block
+        if state is not None:
+            self._state = state
+        else:
+            self.block = block
 
     @property
     def state(self) -> BeaconState:

--- a/eth2/beacon/state_machines/forks/serenity/block_processing.py
+++ b/eth2/beacon/state_machines/forks/serenity/block_processing.py
@@ -50,7 +50,6 @@ def process_block_header(state: BeaconState,
         validate_proposer_signature(
             state,
             block,
-            beacon_chain_shard_number=config.BEACON_CHAIN_SHARD_NUMBER,
             committee_config=CommitteeConfig(config),
         )
 

--- a/eth2/beacon/state_machines/forks/serenity/block_validation.py
+++ b/eth2/beacon/state_machines/forks/serenity/block_validation.py
@@ -60,7 +60,6 @@ from eth2.beacon.types.validators import Validator
 from eth2.beacon.typing import (
     Bitfield,
     Epoch,
-    Shard,
     Slot,
     ValidatorIndex,
 )

--- a/eth2/beacon/state_machines/forks/serenity/block_validation.py
+++ b/eth2/beacon/state_machines/forks/serenity/block_validation.py
@@ -101,7 +101,6 @@ def validate_block_previous_root(state: BeaconState,
 #
 def validate_proposer_signature(state: BeaconState,
                                 block: BaseBeaconBlock,
-                                beacon_chain_shard_number: Shard,
                                 committee_config: CommitteeConfig) -> None:
     message_hash = block.signing_root
 

--- a/eth2/beacon/state_machines/forks/serenity/configs.py
+++ b/eth2/beacon/state_machines/forks/serenity/configs.py
@@ -22,23 +22,19 @@ SERENITY_CONFIG = Eth2Config(
     # Misc
     SHARD_COUNT=2**10,  # (= 1,024) shards
     TARGET_COMMITTEE_SIZE=2**7,  # (= 128) validators
-    EJECTION_BALANCE=Gwei(2**4 * GWEI_PER_ETH),  # (= 16,000,000,000) Gwei
     MAX_BALANCE_CHURN_QUOTIENT=2**5,  # (= 32)
-    BEACON_CHAIN_SHARD_NUMBER=Shard(2**64 - 1),
     MAX_INDICES_PER_SLASHABLE_VOTE=2**12,  # (= 4,096) votes
     MAX_EXIT_DEQUEUES_PER_EPOCH=2**2,  # (= 4)
     SHUFFLE_ROUND_COUNT=90,
-    # State list lengths
-    SLOTS_PER_HISTORICAL_ROOT=2**13,  # (= 8,192) slots
-    LATEST_ACTIVE_INDEX_ROOTS_LENGTH=2**13,  # (= 8,192) epochs
-    LATEST_RANDAO_MIXES_LENGTH=2**13,  # (= 8,192) epochs
-    LATEST_SLASHED_EXIT_LENGTH=2**13,  # (= 8,192) epochs
     # Deposit contract
     DEPOSIT_CONTRACT_ADDRESS=ZERO_ADDRESS,  # TBD
     DEPOSIT_CONTRACT_TREE_DEPTH=2**5,  # (= 32)
+    # Gwei values
     MIN_DEPOSIT_AMOUNT=Gwei(2**0 * GWEI_PER_ETH),  # (= 1,000,000,000) Gwei
     MAX_DEPOSIT_AMOUNT=Gwei(2**5 * GWEI_PER_ETH),  # (= 32,000,000,00) Gwei
-    # Genesis values
+    FORK_CHOICE_BALANCE_INCREMENT=Gwei(2**0 * GWEI_PER_ETH),  # (= 1,000,000,000) Gwei
+    EJECTION_BALANCE=Gwei(2**4 * GWEI_PER_ETH),  # (= 16,000,000,000) Gwei
+    # Initial values
     GENESIS_FORK_VERSION=0,
     GENESIS_SLOT=GENESIS_SLOT,
     GENESIS_EPOCH=slot_to_epoch(GENESIS_SLOT, SLOTS_PER_EPOCH),
@@ -53,6 +49,11 @@ SERENITY_CONFIG = Eth2Config(
     EPOCHS_PER_ETH1_VOTING_PERIOD=2**4,  # (= 16) epochs
     MIN_VALIDATOR_WITHDRAWABILITY_DELAY=2**8,  # (= 256) epochs
     PERSISTENT_COMMITTEE_PERIOD=2**11,  # (= 2,048) epochs
+    # State list lengths
+    SLOTS_PER_HISTORICAL_ROOT=2**13,  # (= 8,192) slots
+    LATEST_ACTIVE_INDEX_ROOTS_LENGTH=2**13,  # (= 8,192) epochs
+    LATEST_RANDAO_MIXES_LENGTH=2**13,  # (= 8,192) epochs
+    LATEST_SLASHED_EXIT_LENGTH=2**13,  # (= 8,192) epochs
     # Reward and penalty quotients
     BASE_REWARD_QUOTIENT=2**10,  # (= 1,024)
     WHISTLEBLOWER_REWARD_QUOTIENT=2**9,  # (= 512)

--- a/eth2/beacon/state_machines/forks/serenity/state_transitions.py
+++ b/eth2/beacon/state_machines/forks/serenity/state_transitions.py
@@ -57,7 +57,7 @@ class SerenityStateTransition(BaseStateTransition):
         else:
             raise Exception(
                 f"Invariant: state.slot ({state.slot}) should be less "
-                "than block.slot ({block.slot}) so that state transition terminates"
+                f"than block.slot ({block.slot}) so that state transition terminates"
             )
         return state
 

--- a/eth2/configs.py
+++ b/eth2/configs.py
@@ -20,29 +20,25 @@ Eth2Config = NamedTuple(
         # Misc
         ('SHARD_COUNT', int),
         ('TARGET_COMMITTEE_SIZE', int),
-        ('EJECTION_BALANCE', Gwei),
         ('MAX_BALANCE_CHURN_QUOTIENT', int),
-        ('BEACON_CHAIN_SHARD_NUMBER', Shard),
         ('MAX_INDICES_PER_SLASHABLE_VOTE', int),
         ('MAX_EXIT_DEQUEUES_PER_EPOCH', int),
         ('SHUFFLE_ROUND_COUNT', int),
-        # State list lengths
-        ('SLOTS_PER_HISTORICAL_ROOT', int),
-        ('LATEST_ACTIVE_INDEX_ROOTS_LENGTH', int),
-        ('LATEST_RANDAO_MIXES_LENGTH', int),
-        ('LATEST_SLASHED_EXIT_LENGTH', int),
-        # EMPTY_SIGNATURE is defined in constants.py
         # Deposit contract
         ('DEPOSIT_CONTRACT_ADDRESS', Address),
         ('DEPOSIT_CONTRACT_TREE_DEPTH', int),
+        # Gwei values,
         ('MIN_DEPOSIT_AMOUNT', Gwei),
         ('MAX_DEPOSIT_AMOUNT', Gwei),
-        # ZERO_HASH (ZERO_HASH32) is defined in constants.py
-        # Genesis values
+        ('FORK_CHOICE_BALANCE_INCREMENT', Gwei),
+        ('EJECTION_BALANCE', Gwei),
+        # Initial values
         ('GENESIS_FORK_VERSION', int),
         ('GENESIS_SLOT', Slot),
         ('GENESIS_EPOCH', Epoch),
         ('GENESIS_START_SHARD', Shard),
+        # `FAR_FUTURE_EPOCH`, `EMPTY_SIGNATURE` `ZERO_HASH (ZERO_HASH32)`
+        # are defined in constants.py
         ('BLS_WITHDRAWAL_PREFIX_BYTE', bytes),
         # Time parameters
         ('SECONDS_PER_SLOT', Second),
@@ -53,6 +49,11 @@ Eth2Config = NamedTuple(
         ('EPOCHS_PER_ETH1_VOTING_PERIOD', int),
         ('MIN_VALIDATOR_WITHDRAWABILITY_DELAY', int),
         ('PERSISTENT_COMMITTEE_PERIOD', int),
+        # State list lengths
+        ('SLOTS_PER_HISTORICAL_ROOT', int),
+        ('LATEST_ACTIVE_INDEX_ROOTS_LENGTH', int),
+        ('LATEST_RANDAO_MIXES_LENGTH', int),
+        ('LATEST_SLASHED_EXIT_LENGTH', int),
         # Reward and penalty quotients
         ('BASE_REWARD_QUOTIENT', int),
         ('WHISTLEBLOWER_REWARD_QUOTIENT', int),

--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,7 @@ deps = {
         # only needed for p2p
         "pytest-asyncio-network-simulator==0.1.0a2;python_version>='3.6'",
         # only for eth2
-        "ruamel.yaml<=0.15",
+        "ruamel.yaml>=0.15.87,<0.16",
     ],
     'lint': [
         "flake8==3.5.0",

--- a/setup.py
+++ b/setup.py
@@ -47,6 +47,7 @@ deps = {
         "pytest-cov==2.5.1",
         "pytest-watch>=4.1.0,<5",
         "pytest-xdist==1.18.1",
+        "pytest-mock==1.10.4",
         # only needed for p2p
         "pytest-asyncio-network-simulator==0.1.0a2;python_version>='3.6'",
     ],

--- a/setup.py
+++ b/setup.py
@@ -50,6 +50,8 @@ deps = {
         "pytest-mock==1.10.4",
         # only needed for p2p
         "pytest-asyncio-network-simulator==0.1.0a2;python_version>='3.6'",
+        # only for eth2
+        "ruamel.yaml<=0.15",
     ],
     'lint': [
         "flake8==3.5.0",

--- a/tests/eth2/beacon/conftest.py
+++ b/tests/eth2/beacon/conftest.py
@@ -448,18 +448,8 @@ def target_committee_size():
 
 
 @pytest.fixture
-def ejection_balance():
-    return SERENITY_CONFIG.EJECTION_BALANCE
-
-
-@pytest.fixture
 def max_balance_churn_quotient():
     return SERENITY_CONFIG.MAX_BALANCE_CHURN_QUOTIENT
-
-
-@pytest.fixture
-def beacon_chain_shard_number():
-    return SERENITY_CONFIG.BEACON_CHAIN_SHARD_NUMBER
 
 
 @pytest.fixture
@@ -483,21 +473,6 @@ def slots_per_historical_root():
 
 
 @pytest.fixture
-def latest_active_index_roots_length():
-    return SERENITY_CONFIG.LATEST_ACTIVE_INDEX_ROOTS_LENGTH
-
-
-@pytest.fixture
-def latest_randao_mixes_length():
-    return SERENITY_CONFIG.LATEST_RANDAO_MIXES_LENGTH
-
-
-@pytest.fixture
-def latest_slashed_exit_length():
-    return SERENITY_CONFIG.LATEST_SLASHED_EXIT_LENGTH
-
-
-@pytest.fixture
 def deposit_contract_address():
     return SERENITY_CONFIG.DEPOSIT_CONTRACT_ADDRESS
 
@@ -515,6 +490,16 @@ def min_deposit_amount():
 @pytest.fixture
 def max_deposit_amount():
     return SERENITY_CONFIG.MAX_DEPOSIT_AMOUNT
+
+
+@pytest.fixture
+def fork_choice_balance_increment():
+    return SERENITY_CONFIG.FORK_CHOICE_BALANCE_INCREMENT
+
+
+@pytest.fixture
+def ejection_balance():
+    return SERENITY_CONFIG.EJECTION_BALANCE
 
 
 @pytest.fixture
@@ -580,6 +565,21 @@ def min_validator_withdrawability_delay():
 @pytest.fixture
 def persistent_committee_period():
     return SERENITY_CONFIG.PERSISTENT_COMMITTEE_PERIOD
+
+
+@pytest.fixture
+def latest_active_index_roots_length():
+    return SERENITY_CONFIG.LATEST_ACTIVE_INDEX_ROOTS_LENGTH
+
+
+@pytest.fixture
+def latest_randao_mixes_length():
+    return SERENITY_CONFIG.LATEST_RANDAO_MIXES_LENGTH
+
+
+@pytest.fixture
+def latest_slashed_exit_length():
+    return SERENITY_CONFIG.LATEST_SLASHED_EXIT_LENGTH
 
 
 @pytest.fixture
@@ -724,20 +724,17 @@ def genesis_balances(init_validator_pubkeys, max_deposit_amount):
 def config(
         shard_count,
         target_committee_size,
-        ejection_balance,
         max_balance_churn_quotient,
-        beacon_chain_shard_number,
         max_indices_per_slashable_vote,
         max_exit_dequeues_per_epoch,
         shuffle_round_count,
         slots_per_historical_root,
-        latest_active_index_roots_length,
-        latest_randao_mixes_length,
-        latest_slashed_exit_length,
         deposit_contract_address,
         deposit_contract_tree_depth,
         min_deposit_amount,
         max_deposit_amount,
+        fork_choice_balance_increment,
+        ejection_balance,
         genesis_fork_version,
         genesis_slot,
         genesis_epoch,
@@ -751,6 +748,9 @@ def config(
         epochs_per_eth1_voting_period,
         min_validator_withdrawability_delay,
         persistent_committee_period,
+        latest_active_index_roots_length,
+        latest_randao_mixes_length,
+        latest_slashed_exit_length,
         base_reward_quotient,
         whistleblower_reward_quotient,
         attestation_inclusion_reward_quotient,
@@ -766,20 +766,17 @@ def config(
     return Eth2Config(
         SHARD_COUNT=shard_count,
         TARGET_COMMITTEE_SIZE=target_committee_size,
-        EJECTION_BALANCE=ejection_balance,
         MAX_BALANCE_CHURN_QUOTIENT=max_balance_churn_quotient,
-        BEACON_CHAIN_SHARD_NUMBER=beacon_chain_shard_number,
         MAX_INDICES_PER_SLASHABLE_VOTE=max_indices_per_slashable_vote,
         MAX_EXIT_DEQUEUES_PER_EPOCH=max_exit_dequeues_per_epoch,
         SHUFFLE_ROUND_COUNT=shuffle_round_count,
         SLOTS_PER_HISTORICAL_ROOT=slots_per_historical_root,
-        LATEST_ACTIVE_INDEX_ROOTS_LENGTH=latest_active_index_roots_length,
-        LATEST_RANDAO_MIXES_LENGTH=latest_randao_mixes_length,
-        LATEST_SLASHED_EXIT_LENGTH=latest_slashed_exit_length,
         DEPOSIT_CONTRACT_ADDRESS=deposit_contract_address,
         DEPOSIT_CONTRACT_TREE_DEPTH=deposit_contract_tree_depth,
         MIN_DEPOSIT_AMOUNT=min_deposit_amount,
         MAX_DEPOSIT_AMOUNT=max_deposit_amount,
+        FORK_CHOICE_BALANCE_INCREMENT=fork_choice_balance_increment,
+        EJECTION_BALANCE=ejection_balance,
         GENESIS_FORK_VERSION=genesis_fork_version,
         GENESIS_SLOT=genesis_slot,
         GENESIS_EPOCH=genesis_epoch,
@@ -793,6 +790,9 @@ def config(
         EPOCHS_PER_ETH1_VOTING_PERIOD=epochs_per_eth1_voting_period,
         MIN_VALIDATOR_WITHDRAWABILITY_DELAY=min_validator_withdrawability_delay,
         PERSISTENT_COMMITTEE_PERIOD=persistent_committee_period,
+        LATEST_ACTIVE_INDEX_ROOTS_LENGTH=latest_active_index_roots_length,
+        LATEST_RANDAO_MIXES_LENGTH=latest_randao_mixes_length,
+        LATEST_SLASHED_EXIT_LENGTH=latest_slashed_exit_length,
         BASE_REWARD_QUOTIENT=base_reward_quotient,
         WHISTLEBLOWER_REWARD_QUOTIENT=whistleblower_reward_quotient,
         ATTESTATION_INCLUSION_REWARD_QUOTIENT=attestation_inclusion_reward_quotient,

--- a/tests/eth2/beacon/state-fixtures/test_minimal_state.py
+++ b/tests/eth2/beacon/state-fixtures/test_minimal_state.py
@@ -1,12 +1,20 @@
-import os
+from pathlib import Path
 import yaml
+try:
+    from yaml import CLoader as Loader
+except ImportError:
+    from yaml import Loader
 import pytest
 
-from py_ecc import bls
+from eth_utils import (
+    to_tuple,
+)
+from py_ecc import bls  # noqa: F401
 from ssz.tools import (
     from_formatted_dict,
     to_formatted_dict,
 )
+
 
 from eth2.configs import (
     Eth2Config,
@@ -22,21 +30,19 @@ from eth2.beacon.state_machines.forks.serenity import (
 )
 
 # Test files
-ROOT_PROJECT_DIR = os.path.dirname(os.path.dirname(os.path.dirname(__file__)))
+ROOT_PROJECT_DIR = Path(__file__).cwd()
 
-BASE_FIXTURE_PATH = os.path.join(ROOT_PROJECT_DIR, '../../', 'eth2-fixtures', 'state')
+BASE_FIXTURE_PATH = ROOT_PROJECT_DIR / 'eth2-fixtures' / 'state'
 
-FILE_NAMES = [
+FIXTURE_FILE_NAMES = [
     "sanity-check_small-config_32-vals.yaml",
-    "sanity-check_default-config_100-vals.yaml",
+    # "sanity-check_default-config_100-vals.yaml",
 ]
+
 
 #
 # Mock bls verification for these tests
 #
-bls = bls
-
-
 def mock_bls_verify(message_hash, pubkey, signature, domain):
     return True
 
@@ -50,51 +56,72 @@ def mock_bls_verify_multiple(pubkeys,
 
 @pytest.fixture(autouse=True)
 def mock_bls(mocker, request):
-    if 'noautofixt' in request.keywords:
+    if 'noautofixture' in request.keywords:
         return
 
     mocker.patch('py_ecc.bls.verify', side_effect=mock_bls_verify)
     mocker.patch('py_ecc.bls.verify_multiple', side_effect=mock_bls_verify_multiple)
 
 
-def get_test_case(file_names):
-    all_test_cases = []
+#
+# Helpers for generating test suite
+#
+def get_all_test_cases(file_names):
+    test_cases = []
     for file_name in file_names:
-        with open(BASE_FIXTURE_PATH + '/' + file_name, 'U') as f:
+        file_to_open = BASE_FIXTURE_PATH / file_name
+        with open(file_to_open, 'U') as f:
             # TODO: `proof_of_possession` is used in v0.5.1 spec and will be renamed to `signature`
             # Trinity renamed it ahead due to py-ssz signing_root requirements
             new_text = f.read().replace('proof_of_possession', 'signature')
             try:
-                data = yaml.load(new_text)
-                all_test_cases += data['test_cases']
+                data = yaml.load(new_text, Loader=Loader)
+                test_cases += data['test_cases']
             except yaml.YAMLError as exc:
                 print(exc)
-    return all_test_cases
+    return test_cases
 
 
-test_cases = get_test_case(FILE_NAMES)
-
-
-@pytest.mark.parametrize("test_case", test_cases)
-def test_state(base_db, test_case):
-    test_name = test_case['name']
-    if test_name == 'test_transfer':
-        print('skip')
+def state_fixture_mark_fn(fixture_name):
+    if fixture_name == 'test_transfer':
+        return pytest.mark.skip(reason="has not implemented")
     else:
-        execute_state_transtion(test_case, base_db)
+        return None
+
+
+@to_tuple
+def get_test_cases(fixture_file_names):
+    test_cases = get_all_test_cases(fixture_file_names)
+    for test_case in test_cases:
+        test_name = test_case['name']
+        mark = state_fixture_mark_fn(test_name)
+        if mark is not None:
+            yield pytest.param(test_case, id=test_name, marks=(mark,))
+        else:
+            yield pytest.param(test_case, id=test_name)
+
+
+all_test_cases = get_test_cases(FIXTURE_FILE_NAMES)
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    all_test_cases
+)
+def test_state(base_db, test_case):
+    execute_state_transtion(test_case, base_db)
 
 
 def generate_config_by_dict(dict_config):
     dict_config['DEPOSIT_CONTRACT_ADDRESS'] = b'\x00' * 20
     for key in list(dict_config):
-        if 'DOMAIN_' in key in key:
+        if 'DOMAIN_' in key:
             # DOMAIN is defined in SignatureDomain
             dict_config.pop(key, None)
     return Eth2Config(**dict_config)
 
 
 def execute_state_transtion(test_case, base_db):
-    test_name = test_case['name']
     dict_config = test_case['config']
     verify_signatures = test_case['verify_signatures']
     dict_initial_state = test_case['initial_state']
@@ -103,8 +130,6 @@ def execute_state_transtion(test_case, base_db):
 
     # TODO: make it case by case
     assert verify_signatures is False
-
-    print(f"[{test_name}]")
 
     # Set config
     config = generate_config_by_dict(dict_config)

--- a/tests/eth2/beacon/state-fixtures/test_minimal_state.py
+++ b/tests/eth2/beacon/state-fixtures/test_minimal_state.py
@@ -3,7 +3,10 @@ import yaml
 import pytest
 
 from py_ecc import bls
-import ssz
+from ssz.tools import (
+    from_formatted_dict,
+    to_formatted_dict,
+)
 
 from eth2.configs import (
     Eth2Config,
@@ -110,12 +113,12 @@ def execute_state_transtion(test_case, base_db):
     override_vector_lengths(config)
 
     # Set pre_state
-    pre_state = ssz.tools.from_formatted_dict(dict_initial_state, BeaconState)
+    pre_state = from_formatted_dict(dict_initial_state, BeaconState)
 
     # Set blocks
     blocks = ()
     for dict_block in dict_blocks:
-        block = ssz.tools.from_formatted_dict(dict_block, SerenityBeaconBlock)
+        block = from_formatted_dict(dict_block, SerenityBeaconBlock)
         blocks += (block,)
 
     sm_class = SerenityStateMachine.configure(
@@ -130,7 +133,7 @@ def execute_state_transtion(test_case, base_db):
         post_state, _ = sm.import_block(block)
 
     # Use dict diff, easier to see the diff
-    dict_post_state = ssz.tools.to_formatted_dict(post_state, BeaconState)
+    dict_post_state = to_formatted_dict(post_state, BeaconState)
 
     for key, value in dict_expected_state.items():
         if isinstance(value, list):

--- a/tests/eth2/beacon/state-fixtures/test_minimal_state.py
+++ b/tests/eth2/beacon/state-fixtures/test_minimal_state.py
@@ -151,7 +151,7 @@ def execute_state_transtion(test_case, base_db):
         __name__='SerenityStateMachineForTesting',
         config=config,
     )
-    chaindb = BeaconChainDB(base_db)
+    chaindb = BeaconChainDB(base_db, config)
 
     post_state = pre_state.copy()
     for block in blocks:

--- a/tests/eth2/beacon/state-fixtures/test_minimal_state.py
+++ b/tests/eth2/beacon/state-fixtures/test_minimal_state.py
@@ -1,0 +1,138 @@
+import os
+import yaml
+import pytest
+
+from py_ecc import bls
+import ssz
+
+from eth2.configs import (
+    Eth2Config,
+)
+from eth2.beacon.db.chain import BeaconChainDB
+from eth2.beacon.tools.misc.ssz_vector import (
+    override_vector_lengths,
+)
+from eth2.beacon.types.states import BeaconState
+from eth2.beacon.state_machines.forks.serenity.blocks import SerenityBeaconBlock
+from eth2.beacon.state_machines.forks.serenity import (
+    SerenityStateMachine,
+)
+
+# Test files
+ROOT_PROJECT_DIR = os.path.dirname(os.path.dirname(os.path.dirname(__file__)))
+
+BASE_FIXTURE_PATH = os.path.join(ROOT_PROJECT_DIR, '../../', 'eth2-fixtures', 'state')
+
+FILE_NAMES = [
+    "sanity-check_small-config_32-vals.yaml",
+    "sanity-check_default-config_100-vals.yaml",
+]
+
+#
+# Mock bls verification for these tests
+#
+bls = bls
+
+
+def mock_bls_verify(message_hash, pubkey, signature, domain):
+    return True
+
+
+def mock_bls_verify_multiple(pubkeys,
+                             message_hashes,
+                             signature,
+                             domain):
+    return True
+
+
+@pytest.fixture(autouse=True)
+def mock_bls(mocker, request):
+    if 'noautofixt' in request.keywords:
+        return
+
+    mocker.patch('py_ecc.bls.verify', side_effect=mock_bls_verify)
+    mocker.patch('py_ecc.bls.verify_multiple', side_effect=mock_bls_verify_multiple)
+
+
+def get_test_case(file_names):
+    all_test_cases = []
+    for file_name in file_names:
+        with open(BASE_FIXTURE_PATH + '/' + file_name, 'U') as f:
+            # TODO: `proof_of_possession` is used in v0.5.1 spec and will be renamed to `signature`
+            # Trinity renamed it ahead due to py-ssz signing_root requirements
+            new_text = f.read().replace('proof_of_possession', 'signature')
+            try:
+                data = yaml.load(new_text)
+                all_test_cases += data['test_cases']
+            except yaml.YAMLError as exc:
+                print(exc)
+    return all_test_cases
+
+
+test_cases = get_test_case(FILE_NAMES)
+
+
+@pytest.mark.parametrize("test_case", test_cases)
+def test_state(base_db, test_case):
+    test_name = test_case['name']
+    if test_name == 'test_transfer':
+        print('skip')
+    else:
+        execute_state_transtion(test_case, base_db)
+
+
+def generate_config_by_dict(dict_config):
+    dict_config['DEPOSIT_CONTRACT_ADDRESS'] = b'\x00' * 20
+    for key in list(dict_config):
+        if 'DOMAIN_' in key in key:
+            # DOMAIN is defined in SignatureDomain
+            dict_config.pop(key, None)
+    return Eth2Config(**dict_config)
+
+
+def execute_state_transtion(test_case, base_db):
+    test_name = test_case['name']
+    dict_config = test_case['config']
+    verify_signatures = test_case['verify_signatures']
+    dict_initial_state = test_case['initial_state']
+    dict_blocks = test_case['blocks']
+    dict_expected_state = test_case['expected_state']
+
+    # TODO: make it case by case
+    assert verify_signatures is False
+
+    print(f"[{test_name}]")
+
+    # Set config
+    config = generate_config_by_dict(dict_config)
+
+    # Set Vector fields
+    override_vector_lengths(config)
+
+    # Set pre_state
+    pre_state = ssz.tools.from_formatted_dict(dict_initial_state, BeaconState)
+
+    # Set blocks
+    blocks = ()
+    for dict_block in dict_blocks:
+        block = ssz.tools.from_formatted_dict(dict_block, SerenityBeaconBlock)
+        blocks += (block,)
+
+    sm_class = SerenityStateMachine.configure(
+        __name__='SerenityStateMachineForTesting',
+        config=config,
+    )
+    chaindb = BeaconChainDB(base_db)
+
+    post_state = pre_state.copy()
+    for block in blocks:
+        sm = sm_class(chaindb, None, post_state)
+        post_state, _ = sm.import_block(block)
+
+    # Use dict diff, easier to see the diff
+    dict_post_state = ssz.tools.to_formatted_dict(post_state, BeaconState)
+
+    for key, value in dict_expected_state.items():
+        if isinstance(value, list):
+            value = tuple(value)
+        assert dict_post_state[key] == value

--- a/tests/eth2/beacon/state_machines/forks/test_serenity_block_proposer_slashing_validation.py
+++ b/tests/eth2/beacon/state_machines/forks/test_serenity_block_proposer_slashing_validation.py
@@ -98,11 +98,7 @@ def test_validate_proposer_slashing_headers(genesis_state,
         (True, False),
     ],
 )
-def test_validate_proposer_slashing_is_slashed(slots_per_epoch,
-                                               genesis_state,
-                                               beacon_chain_shard_number,
-                                               keymap,
-                                               slashed,
+def test_validate_proposer_slashing_is_slashed(slashed,
                                                success):
     # Invalid
     if success:

--- a/tests/eth2/beacon/state_machines/forks/test_serenity_block_validation.py
+++ b/tests/eth2/beacon/state_machines/forks/test_serenity_block_validation.py
@@ -91,7 +91,6 @@ def test_validate_proposer_signature(
         is_valid_signature,
         sample_beacon_block_params,
         sample_beacon_state_params,
-        beacon_chain_shard_number,
         target_committee_size,
         max_deposit_amount,
         config):
@@ -127,7 +126,6 @@ def test_validate_proposer_signature(
         validate_proposer_signature(
             state,
             proposed_block,
-            beacon_chain_shard_number,
             CommitteeConfig(config),
         )
     else:
@@ -135,7 +133,6 @@ def test_validate_proposer_signature(
             validate_proposer_signature(
                 state,
                 proposed_block,
-                beacon_chain_shard_number,
                 CommitteeConfig(config),
             )
 


### PR DESCRIPTION
### What was wrong?

v0.5.1 state-tests: https://github.com/ethereum/eth2.0-tests/tree/master/state
Add tests/eth2/beacon/state-fixtures/test_minimal_state.py for testing it.

### How was it fixed?
1. Add submodule `ethereum/eth2.0-tests`
2. Add tests/eth2/beacon/state-fixtures/test_minimal_state.py
3. Update `BeaconStateMachine.__init__` for supporting setting `pre_state` in state machine.
4. Sync the spec constants
5. Simplify `validate_proposer_signature` interface

### How to test it:
```
pytest tests/eth2/beacon/state-fixtures/ -s
```

(And v0.6.0 tests are coming...)


#### Cute Animal Picture

![racoon-1414027_640](https://user-images.githubusercontent.com/9263930/56909873-c19a2e80-6adb-11e9-9292-6f23a46a3f61.jpg)