### PR TITLE
Update shutdown utils to accept multiple services

### DIFF
--- a/tests/core/test_service_and_endpoint_shutdown_utils.py
+++ b/tests/core/test_service_and_endpoint_shutdown_utils.py
@@ -1,0 +1,51 @@
+import asyncio
+import multiprocessing
+import os
+import signal
+
+import pytest
+
+from p2p.service import BaseService
+
+from trinity.endpoint import TrinityEventBusEndpoint
+from trinity._utils.shutdown import (
+    exit_with_endpoint_and_services,
+)
+
+
+class SimpleService(BaseService):
+    def __init__(self, ready_to_kill_event, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.ready_to_kill_event = ready_to_kill_event
+
+    async def _run(self):
+        self.ready_to_kill_event.set()
+        await self.cancellation()
+
+
+def run_service(ready_to_kill_event):
+    loop = asyncio.get_event_loop()
+
+    endpoint = TrinityEventBusEndpoint()
+    service = SimpleService(ready_to_kill_event, loop=loop)
+
+    asyncio.ensure_future(exit_with_endpoint_and_services(endpoint, service))
+    asyncio.ensure_future(service.run())
+
+    loop.run_forever()
+    loop.close()
+
+    assert service.is_cancelled
+    assert endpoint._running is False
+
+
+@pytest.mark.parametrize('sig', (signal.SIGINT, signal.SIGTERM))
+@pytest.mark.asyncio
+async def test_exit_with_endpoind_and_services_facilitates_clean_shutdown(sig):
+    ready_to_kill_event = multiprocessing.Event()
+    proc = multiprocessing.Process(target=run_service, args=(ready_to_kill_event,))
+    proc.start()
+
+    ready_to_kill_event.wait()
+    os.kill(proc.pid, sig)
+    proc.join(timeout=1)

--- a/trinity-external-plugins/examples/peer_count_reporter/peer_count_reporter_plugin/plugin.py
+++ b/trinity-external-plugins/examples/peer_count_reporter/peer_count_reporter_plugin/plugin.py
@@ -5,11 +5,10 @@ from argparse import ArgumentParser, _SubParsersAction
 import asyncio
 
 from p2p.service import BaseService
-from lahja import Endpoint
 from trinity.endpoint import TrinityEventBusEndpoint
 from trinity.extensibility import BaseIsolatedPlugin
 from trinity.protocol.common.events import PeerCountRequest
-from trinity._utils.shutdown import exit_with_service_and_endpoint
+from trinity._utils.shutdown import exit_with_endpoint_and_services
 
 
 class PeerCountReporter(BaseService):
@@ -57,7 +56,7 @@ class PeerCountReporterPlugin(BaseIsolatedPlugin):
     def do_start(self) -> None:
         loop = asyncio.get_event_loop()
         service = PeerCountReporter(self.event_bus)
-        asyncio.ensure_future(exit_with_service_and_endpoint(service, self.event_bus))
+        asyncio.ensure_future(exit_with_endpoint_and_services(self.event_bus, service))
         asyncio.ensure_future(service.run())
         loop.run_forever()
         loop.close()

--- a/trinity/main.py
+++ b/trinity/main.py
@@ -73,7 +73,7 @@ from trinity._utils.proxy import (
     serve_until_sigint,
 )
 from trinity._utils.shutdown import (
-    exit_signal_with_service,
+    exit_signal_with_services,
 )
 
 
@@ -212,7 +212,7 @@ async def handle_networking_exit(service: BaseService,
                                  plugin_manager: PluginManager,
                                  endpoint: TrinityEventBusEndpoint) -> None:
 
-    async with exit_signal_with_service(service):
+    async with exit_signal_with_services(service):
         await plugin_manager.shutdown()
         endpoint.stop()
         # Retrieve and shutdown the global executor that was created at startup

--- a/trinity/plugins/builtin/ethstats/plugin.py
+++ b/trinity/plugins/builtin/ethstats/plugin.py
@@ -18,7 +18,7 @@ from trinity.extensibility import (
     BaseIsolatedPlugin,
 )
 from trinity._utils.shutdown import (
-    exit_with_service_and_endpoint,
+    exit_with_endpoint_and_services,
 )
 
 from trinity.plugins.builtin.ethstats.ethstats_service import (
@@ -125,7 +125,7 @@ class EthstatsPlugin(BaseIsolatedPlugin):
 
         loop: asyncio.AbstractEventLoop = asyncio.get_event_loop()
 
-        asyncio.ensure_future(exit_with_service_and_endpoint(service, self.context.event_bus))
+        asyncio.ensure_future(exit_with_endpoint_and_services(self.context.event_bus, service))
         asyncio.ensure_future(service.run())
 
         loop.run_forever()

--- a/trinity/plugins/builtin/json_rpc/plugin.py
+++ b/trinity/plugins/builtin/json_rpc/plugin.py
@@ -38,7 +38,7 @@ from trinity.rpc.ipc import (
     IPCServer,
 )
 from trinity._utils.shutdown import (
-    exit_with_service_and_endpoint,
+    exit_with_endpoint_and_services,
 )
 
 
@@ -98,7 +98,7 @@ class JsonRpcServerPlugin(BaseIsolatedPlugin):
         ipc_server = IPCServer(rpc, self.context.trinity_config.jsonrpc_ipc_path)
 
         loop = asyncio.get_event_loop()
-        asyncio.ensure_future(exit_with_service_and_endpoint(ipc_server, self.context.event_bus))
+        asyncio.ensure_future(exit_with_endpoint_and_services(self.context.event_bus, ipc_server))
         asyncio.ensure_future(ipc_server.run())
         loop.run_forever()
         loop.close()

--- a/trinity/plugins/builtin/network_db/plugin.py
+++ b/trinity/plugins/builtin/network_db/plugin.py
@@ -14,7 +14,7 @@ from p2p.tracking.connection import (
 )
 
 from trinity._utils.shutdown import (
-    exit_with_service_and_endpoint,
+    exit_with_endpoint_and_services,
 )
 from trinity.config import (
     TrinityConfig,
@@ -154,7 +154,7 @@ class NetworkDBPlugin(BaseIsolatedPlugin):
 
             service = self._get_blacklist_service()
 
-            asyncio.ensure_future(exit_with_service_and_endpoint(service, self.event_bus))
+            asyncio.ensure_future(exit_with_endpoint_and_services(self.event_bus, service))
             asyncio.ensure_future(service.run())
 
             loop.run_forever()

--- a/trinity/plugins/builtin/peer_discovery/plugin.py
+++ b/trinity/plugins/builtin/peer_discovery/plugin.py
@@ -59,7 +59,7 @@ from trinity.protocol.les.proto import (
     LESProtocolV2,
 )
 from trinity._utils.shutdown import (
-    exit_with_service_and_endpoint,
+    exit_with_endpoint_and_services,
 )
 
 
@@ -176,7 +176,7 @@ class PeerDiscoveryPlugin(BaseIsolatedPlugin):
             self.event_bus,
             self.context.trinity_config
         )
-        asyncio.ensure_future(exit_with_service_and_endpoint(discovery_bootstrap, self.event_bus))
+        asyncio.ensure_future(exit_with_endpoint_and_services(self.event_bus, discovery_bootstrap))
         asyncio.ensure_future(discovery_bootstrap.run())
         loop.run_forever()
         loop.close()

--- a/trinity/plugins/eth2/beacon/plugin.py
+++ b/trinity/plugins/eth2/beacon/plugin.py
@@ -6,7 +6,7 @@ from argparse import (
 from p2p import ecies
 from p2p.constants import DEFAULT_MAX_PEERS
 from trinity._utils.shutdown import (
-    exit_with_service_and_endpoint,
+    exit_with_endpoint_and_services,
 )
 from trinity.config import BeaconAppConfig
 from trinity.endpoint import TrinityEventBusEndpoint
@@ -77,7 +77,7 @@ class BeaconNodePlugin(BaseIsolatedPlugin):
         )
 
         loop = asyncio.get_event_loop()
-        asyncio.ensure_future(exit_with_service_and_endpoint(server, self.context.event_bus))
+        asyncio.ensure_future(exit_with_endpoint_and_services(self.context.event_bus, server))
         asyncio.ensure_future(server.run())
         asyncio.ensure_future(syncer.run())
         loop.run_forever()


### PR DESCRIPTION
### What was wrong?

A plugin which runs multiple services will want to use the shutdown utilities to manage the clean shutdown of each of those services. These utilities however only support a single service.

### How was it fixed?

Extended the utilities in` trinity._utils.shutdown` to allow for many services to be passed in.

#### Cute Animal Picture

![Baby miniature goats](https://user-images.githubusercontent.com/824194/56916384-01c6c600-6a76-11e9-80c0-d6f303037faf.JPG)

