### PR TITLE
Update token bucket API

### DIFF
--- a/p2p/_utils.py
+++ b/p2p/_utils.py
@@ -1,14 +1,10 @@
-import asyncio
 from concurrent.futures import Executor, ProcessPoolExecutor
 import datetime
 import logging
 import os
 import signal
-import time
 from typing import (
-    AsyncGenerator,
     Tuple,
-    Union,
 )
 
 import rlp
@@ -112,31 +108,3 @@ def ensure_global_asyncio_executor(cpu_count: int=None) -> Executor:
         _executor._start_queue_management_thread()  # type: ignore
         signal.signal(signal.SIGINT, original_handler)
     return _executor
-
-
-async def token_bucket(rate: Union[int, float],
-                       capacity: Union[int, float],
-                       ) -> AsyncGenerator[None, None]:
-    """
-    rate: Number of token that can be consumed per second.
-    capacity: Maximum number of tokens
-
-    Each `await` call consumes a single token.
-    """
-    num_tokens = capacity
-    last_refill = time.perf_counter()
-    seconds_per_token = 1 / rate
-
-    while True:
-        now = time.perf_counter()
-        num_tokens = min(
-            capacity,
-            num_tokens + (rate * (now - last_refill)),
-        )
-        last_refill = now
-
-        if num_tokens >= 1:
-            num_tokens -= 1
-            yield
-        else:
-            await asyncio.sleep((1 - num_tokens) * seconds_per_token)

--- a/p2p/token_bucket.py
+++ b/p2p/token_bucket.py
@@ -1,0 +1,91 @@
+import asyncio
+import time
+from typing import (
+    Union,
+    AsyncGenerator,
+)
+
+
+class NotEnoughTokens(Exception):
+    """
+    Raised if the token bucket is empty when trying to take a token in blocking
+    mode.
+    """
+    pass
+
+
+class TokenBucket:
+    def __init__(self,
+                 rate: Union[int, float],
+                 capacity: Union[int, float]) -> None:
+        self._rate = rate
+        self._capacity = capacity
+        self._num_tokens = self._capacity
+        self._last_refill = time.perf_counter()
+        self._seconds_per_token = 1 / self._rate
+        self._take_lock = asyncio.Lock()
+
+    async def __aiter__(self) -> AsyncGenerator[None, None]:
+        """
+        Can be used as an async iterator to limit the rate at which a loop can
+        run.
+        """
+        while True:
+            await self.take()
+            yield
+
+    def get_num_tokens(self) -> float:
+        """
+        Return the number of tokens current in the bucke
+        """
+        return max(0, self._get_num_tokens(time.perf_counter()))
+
+    def _get_num_tokens(self, when: float) -> float:
+        return min(
+            self._capacity,
+            self._num_tokens + (self._rate * (when - self._last_refill)),
+        )
+
+    def _take(self, num: Union[int, float] = 1) -> None:
+        now = time.perf_counter()
+        if num < 0:
+            raise ValueError("Cannot take negative token quantity")
+
+        # refill the bucket
+        self._num_tokens = self._get_num_tokens(now)
+        self._last_refill = now
+
+        # deduct the requested tokens
+        self._num_tokens -= num
+
+    async def take(self, num: Union[int, float] = 1) -> None:
+        """
+        Take `num` tokens out of the bucket.  If the bucket does not have
+        enough tokens, blocks until the bucket will be full enough to fulfill
+        the request.
+        """
+        # the lock ensures that we don't have two processes take from the
+        # bucket at the same time while the inner sleep is happening
+        async with self._take_lock:
+            self._take(num)
+
+        # if the bucket balance is negative, wait an amount of seconds adequatet to fill it
+        if self._num_tokens < 0:
+            sleep_for = abs(self._num_tokens) * self._seconds_per_token
+            await asyncio.sleep(sleep_for)
+
+    def take_nowait(self, num: Union[int, float] = 1) -> None:
+        # we calculate this value locally to ensure that in the case of not
+        # having enough tokens the error message is accurate due to race
+        # condition between calculating capacity and raising the error message.
+        num_tokens = self.get_num_tokens()
+        if num_tokens >= num:
+            self._take(num)
+        else:
+            raise NotEnoughTokens(f"Insufficient capacity.  Needed {num} but only has {num_tokens}")
+
+    def can_take(self, num: Union[int, float] = 1) -> bool:
+        """
+        Return boolean whether the bucket has enough tokens to take `num` tokens.
+        """
+        return num <= self.get_num_tokens()

--- a/tests/p2p/test_token_bucket.py
+++ b/tests/p2p/test_token_bucket.py
@@ -2,13 +2,17 @@ import asyncio
 import pytest
 import time
 
-from p2p._utils import token_bucket
+from p2p.token_bucket import (
+    TokenBucket,
+    NotEnoughTokens,
+)
 
 
 async def measure_zero(iterations):
+    bucket = TokenBucket(1, iterations)
     start_at = time.perf_counter()
     for _ in range(iterations):
-        await asyncio.sleep(0)
+        await bucket.take()
     end_at = time.perf_counter()
     return end_at - start_at
 
@@ -19,11 +23,11 @@ def assert_fuzzy_equal(actual, expected, allowed_drift):
 
 @pytest.mark.asyncio
 async def test_token_bucket_initial_tokens():
-    limiter = token_bucket(1000, 10)
+    bucket = TokenBucket(1000, 10)
 
     start_at = time.perf_counter()
     for _ in range(10):
-        await limiter.__anext__()
+        await bucket.take()
 
     end_at = time.perf_counter()
     delta = end_at - start_at
@@ -38,31 +42,36 @@ async def test_token_bucket_initial_tokens():
 
 @pytest.mark.asyncio
 async def test_token_bucket_hits_limit():
-    limiter = token_bucket(1000, 10)
+    bucket = TokenBucket(1000, 10)
 
+    bucket.take_nowait(10)
     start_at = time.perf_counter()
     # first 10 tokens should be roughly instant
     # next 10 tokens should each take 1/1000th second each to generate.
-    for _ in range(20):
-        await limiter.__anext__()
+    while True:
+        if bucket.can_take(10):
+            break
+        else:
+            await asyncio.sleep(0)
 
     end_at = time.perf_counter()
 
     # we use a zero-measure of 20 to account for the loop overhead.
-    expected_delta = 10 / 1000 + await measure_zero(20)
+    zero = await measure_zero(10)
+    expected_delta = 10 / 1000 + zero
     delta = end_at - start_at
 
-    # allow up to 1% difference in expected time
-    assert_fuzzy_equal(delta, expected_delta, allowed_drift=0.01)
+    # allow up to 5% difference in expected time
+    assert_fuzzy_equal(delta, expected_delta, allowed_drift=0.05)
 
 
 @pytest.mark.asyncio
 async def test_token_bucket_refills_itself():
-    limiter = token_bucket(1000, 10)
+    bucket = TokenBucket(1000, 10)
 
     # consume all of the tokens
     for _ in range(10):
-        await limiter.__anext__()
+        await bucket.take()
 
     # enough time for the bucket to fully refill
     await asyncio.sleep(20 / 1000)
@@ -70,7 +79,7 @@ async def test_token_bucket_refills_itself():
     start_at = time.perf_counter()
 
     for _ in range(10):
-        await limiter.__anext__()
+        await bucket.take()
 
     end_at = time.perf_counter()
 
@@ -81,3 +90,41 @@ async def test_token_bucket_refills_itself():
     # drift is allowed to be up to 200% since we're working with very small
     # numbers.
     assert_fuzzy_equal(delta, expected, allowed_drift=2)
+
+
+@pytest.mark.asyncio
+async def test_token_bucket_can_take():
+    bucket = TokenBucket(1, 10)
+
+    assert bucket.can_take() is True  # can take 1
+    assert bucket.can_take(bucket.get_num_tokens()) is True  # can take full capacity
+
+    await bucket.take(10)  # empty the bucket
+
+    assert bucket.can_take() is False
+
+
+@pytest.mark.asyncio
+async def test_token_bucket_get_num_tokens():
+    bucket = TokenBucket(1, 10)
+
+    # starts at full capacity
+    assert bucket.get_num_tokens() == 10
+
+    await bucket.take(5)
+    assert 5 <= bucket.get_num_tokens() <= 5.1
+
+    await bucket.take(bucket.get_num_tokens())
+
+    assert 0 <= bucket.get_num_tokens() <= 0.1
+
+
+def test_token_bucket_take_nowait():
+    bucket = TokenBucket(1, 10)
+
+    assert bucket.can_take(10)
+    bucket.take_nowait(10)
+    assert not bucket.can_take(1)
+
+    with pytest.raises(NotEnoughTokens):
+        bucket.take_nowait(1)


### PR DESCRIPTION
### What was wrong?

The `token_bucket` API that was implemented in the `p2p` module was done so in `p2p._utils` which is private.  I'd like to use this API in `triinity` **and** I need some additional functionality too allow failures when taking tokens from the bucket.

### How was it fixed?

Converted from a pure async generator to a simple class that has a `take_nowait` method which can be used to force an immediate success or failure when taking from the bucket.

#### Cute Animal Picture

![miryah_kid_feb282012_00261](https://user-images.githubusercontent.com/824194/56924564-7277dd80-6a8a-11e9-9827-f7e871027018.jpg)

