### PR TITLE
Extend blacklisting to peer behavior to peer request timeouts.

### DIFF
--- a/p2p/constants.py
+++ b/p2p/constants.py
@@ -131,5 +131,5 @@ MAX_CONCURRENT_CONNECTION_ATTEMPTS = 10
 # `DisconnectReason.bad_protocol`
 BLACKLIST_SECONDS_BAD_PROTOCOL = 60 * 10  # 10 minutes
 
-# Amount of time a peer will be blacklisted when they timeout too freequently
+# Amount of time a peer will be blacklisted when they timeout too frequently
 BLACKLIST_SECONDS_TOO_MANY_TIMEOUTS = 60 * 5  # 5 minutes

--- a/p2p/constants.py
+++ b/p2p/constants.py
@@ -127,5 +127,9 @@ REQUEST_PEER_CANDIDATE_TIMEOUT = 1
 # The maximum number of concurrent attempts to establis new peer connections
 MAX_CONCURRENT_CONNECTION_ATTEMPTS = 10
 
-# Time values in seconds
-MINUTES_10 = 60 * 10
+# Amount of time a peer will be blacklisted when they are disconnected as
+# `DisconnectReason.bad_protocol`
+BLACKLIST_SECONDS_BAD_PROTOCOL = 60 * 10  # 10 minutes
+
+# Amount of time a peer will be blacklisted when they timeout too freequently
+BLACKLIST_SECONDS_TOO_MANY_TIMEOUTS = 60 * 5  # 5 minutes

--- a/p2p/peer.py
+++ b/p2p/peer.py
@@ -82,7 +82,7 @@ from .constants import (
     CONN_IDLE_TIMEOUT,
     HEADER_LEN,
     MAC_LEN,
-    MINUTES_10,
+    BLACKLIST_SECONDS_BAD_PROTOCOL,
     SNAPPY_PROTOCOL_VERSION,
 )
 
@@ -630,8 +630,8 @@ class BasePeer(BaseService):
         if reason is DisconnectReason.bad_protocol:
             self.connection_tracker.record_blacklist(
                 self.remote,
-                timeout_seconds=MINUTES_10,
-                reason=f"Bad protocol",
+                timeout_seconds=BLACKLIST_SECONDS_BAD_PROTOCOL,
+                reason="Bad protocol",
             )
 
         self.logger.debug("Disconnecting from remote peer %s; reason: %s", self.remote, reason.name)

--- a/trinity/protocol/common/constants.py
+++ b/trinity/protocol/common/constants.py
@@ -15,3 +15,9 @@ CHAIN_SPLIT_CHECK_TIMEOUT = 15
 # estimate the queue length is to determine how long a timeout to use when
 # waiting for the lock to send the next queued peer request.
 NUM_QUEUED_REQUESTS = 3
+
+
+# Parameters for the token bucket which manages whether a peer should be
+# disconnected from in the event of a TimeoutError during a request/response.
+TIMEOUT_BUCKET_RATE = 1 / 300  # refill 1 token every 5 minutes
+TIMEOUT_BUCKET_CAPACITY = 3  # max capacity of 3 tokens

--- a/trinity/protocol/common/managers.py
+++ b/trinity/protocol/common/managers.py
@@ -35,6 +35,8 @@ from trinity.exceptions import AlreadyWaiting
 from .constants import (
     ROUND_TRIP_TIMEOUT,
     NUM_QUEUED_REQUESTS,
+    TIMEOUT_BUCKET_CAPACITY,
+    TIMEOUT_BUCKET_RATE,
 )
 from .normalizers import BaseNormalizer
 from .trackers import BasePerformanceTracker
@@ -77,7 +79,7 @@ class ResponseCandidateStream(
         # token bucket for limiting timeouts.
         # - Refills at 1-token every 5 minutes
         # - Max capacity of 3 tokens
-        self.timeout_bucket = TokenBucket(1 / 300, 3)
+        self.timeout_bucket = TokenBucket(TIMEOUT_BUCKET_RATE, TIMEOUT_BUCKET_CAPACITY)
 
     async def payload_candidates(
             self,

--- a/trinity/protocol/common/managers.py
+++ b/trinity/protocol/common/managers.py
@@ -18,6 +18,7 @@ from eth_utils import (
 )
 
 from p2p._utils import ensure_global_asyncio_executor
+from p2p.constants import BLACKLIST_SECONDS_TOO_MANY_TIMEOUTS
 from p2p.exceptions import PeerConnectionLost
 from p2p.p2p_proto import DisconnectReason
 from p2p.peer import BasePeer, PeerSubscriber
@@ -125,11 +126,11 @@ class ResponseCandidateStream(
                         )
                         self._peer.connection_tracker.record_blacklist(
                             self._peer.remote,
-                            300,  # 5 minutes
+                            BLACKLIST_SECONDS_TOO_MANY_TIMEOUTS,
                             f"Too many timeouts: {err}",
                         )
                         self._peer.disconnect_nowait(DisconnectReason.timeout)
-                        await self.cancelation()
+                        await self.cancellation()
                     finally:
                         raise
         finally:


### PR DESCRIPTION
- Part of https://github.com/ethereum/trinity/issues/520
- Builds on https://github.com/ethereum/trinity/pull/557

### What was wrong?

When we encounter a timeout when interacting with the peer request/response API (**not** the core peer API for reading messages), we tend to simply log that the request timed out and continue on.  I.E. a peer that always times out (but that is not unresponsive) will remain in our peer pool indefinitely.

### How was it fixed?

The `Manager` class for the request/response API will now disconnect from a peer that times out too often.  This is measured using a token bucket which allows for "on average" one timeout every 5 minutes with a maximum burst of 5 timeouts.  Peers who hit this limit are disconnected and blacklisted for 5 minutes.

> **NOTE** the the internal API for connection tracker will scale this timeout up automatically as it happens more often.

This also removes the 99th percentile dynamic tuning of round trip timeouts as was discussed in another issue.   The reason is in the event that our network connection to a peer changes a little for the worse, they start timing out all of their requests.  This is most prone to happening to our most performant peers.  I believe we decided that without aggregate statistics about peer response times across the pool, any form of dynamic tuning of this value was likely to cause more problems than it solved.  (going to extract this to a separate PR tomorrow)

#### Cute Animal Picture

![goatbucklingadrenaline](https://user-images.githubusercontent.com/824194/56925204-04ccb100-6a8c-11e9-9f50-1f3fc1e251e7.jpg)

