### PR TITLE
Use lahja v0.12.0

### DIFF
--- a/docs/api/extensibility/api.extensibility.exceptions.rst
+++ b/docs/api/extensibility/api.extensibility.exceptions.rst
@@ -1,9 +1,6 @@
 Exceptions
 ==========
 
-.. autoclass:: trinity.extensibility.exceptions.EventBusNotReady
-  :members:
-
 .. autoclass:: trinity.extensibility.exceptions.UnsuitableShutdownError
   :members:
 

--- a/docs/api/extensibility/api.extensibility.plugin.rst
+++ b/docs/api/extensibility/api.extensibility.plugin.rst
@@ -2,12 +2,6 @@ Plugin
 ======
 
 
-PluginContext
--------------
-
-.. autoclass:: trinity.extensibility.plugin.PluginContext
-  :members:
-
 BasePlugin
 ----------
 

--- a/docs/guides/writing_plugins.rst
+++ b/docs/guides/writing_plugins.rst
@@ -134,13 +134,12 @@ was called which happens as soon as the core infrastructure of Trinity is ready.
 Plugin state: ``READY``
 -----------------------
 
-After Trinity has finished setting up the core infrastructure, every plugin has its
-:class:`~trinity.extensibility.plugin.PluginContext` set and
-:meth:`~trinity.extensibility.plugin.BasePlugin.on_ready` is called. At this point the plugin has
-access to important information such as the parsed arguments or the 
-:class:`~trinity.config.TrinityConfig`. It also has access to the central event bus via its
-:meth:`~trinity.extensibility.plugin.BasePlugin.event_bus` property which enables the plugin to
-communicate with other parts of the application including other plugins.
+After Trinity has finished setting up the core infrastructure,
+:meth:`~trinity.extensibility.plugin.BasePlugin.on_ready` is called on each plugin. At
+this point the plugin has access to important information such as the parsed arguments or
+the :class:`~trinity.config.TrinityConfig`. It also has access to the central event bus
+via its :meth:`~trinity.extensibility.plugin.BasePlugin.event_bus` property which enables
+the plugin to communicate with other parts of the application including other plugins.
 
 Plugin state: ``STARTED``
 -------------------------

--- a/docs/release_notes/trinity.rst
+++ b/docs/release_notes/trinity.rst
@@ -4,7 +4,8 @@ Trinity
 Unreleased (latest source)
 --------------------------
 
-- `#436 <https://github.com/ethereum/trinity/pull/436>`_: Feauture: connect to preferred nodes even when discovery is disabled
+- `#556 <https://github.com/ethereum/trinity/pull/556>`_: Performance: Upgrade to lahja 0.13.0 which performs less inter-process communication
+- `#436 <https://github.com/ethereum/trinity/pull/436>`_: Feature: connect to preferred nodes even when discovery is disabled
 - `#400 <https://github.com/ethereum/trinity/pull/400>`_: Bugfix: Respect configuration of individual logger (e.g -l p2p.discovery=ERROR)
 - `#386 <https://github.com/ethereum/trinity/pull/386>`_: Slightly reduce eventbus traffic that the peer pool causes
 - `#336 <https://github.com/ethereum/trinity/pull/336>`_: Bugfix: Ensure Trinity shuts down if the process pool dies (fatal error)

--- a/p2p/peer_pool.py
+++ b/p2p/peer_pool.py
@@ -253,7 +253,7 @@ class BasePeerPool(BaseService, AsyncIterable[BasePeer]):
             await peer.disconnect(DisconnectReason.timeout)
             return
         except HandshakeFailure as err:
-            self.connection_tracker.record_failure(peer.remote, err)
+            await self.connection_tracker.record_failure(peer.remote, err)
             raise
         else:
             if peer.is_operational:
@@ -348,7 +348,7 @@ class BasePeerPool(BaseService, AsyncIterable[BasePeer]):
             raise
         except HandshakeFailure as e:
             self.logger.debug("Could not complete handshake with %r: %s", remote, repr(e))
-            self.connection_tracker.record_failure(remote, e)
+            await self.connection_tracker.record_failure(remote, e)
             raise
         except COMMON_PEER_CONNECTION_EXCEPTIONS as e:
             self.logger.debug("Could not complete handshake with %r: %s", remote, repr(e))

--- a/p2p/tracking/connection.py
+++ b/p2p/tracking/connection.py
@@ -41,14 +41,14 @@ class BaseConnectionTracker(ABC):
     """
     logger = logging.getLogger('p2p.tracking.connection.ConnectionTracker')
 
-    def record_failure(self, remote: Node, failure: BaseP2PError) -> None:
+    async def record_failure(self, remote: Node, failure: BaseP2PError) -> None:
         timeout_seconds = get_timeout_for_failure(failure)
         failure_name = type(failure).__name__
 
-        return self.record_blacklist(remote, timeout_seconds, failure_name)
+        return await self.record_blacklist(remote, timeout_seconds, failure_name)
 
     @abstractmethod
-    def record_blacklist(self, remote: Node, timeout_seconds: int, reason: str) -> None:
+    async def record_blacklist(self, remote: Node, timeout_seconds: int, reason: str) -> None:
         pass
 
     @abstractmethod
@@ -57,7 +57,7 @@ class BaseConnectionTracker(ABC):
 
 
 class NoopConnectionTracker(BaseConnectionTracker):
-    def record_blacklist(self, remote: Node, timeout_seconds: int, reason: str) -> None:
+    async def record_blacklist(self, remote: Node, timeout_seconds: int, reason: str) -> None:
         pass
 
     async def should_connect_to(self, remote: Node) -> bool:

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ deps = {
         "plyvel==1.0.5",
         "py-evm==0.2.0a42",
         "web3==4.4.1",
-        "lahja==0.11.2",
+        "lahja==0.12.0",
         "termcolor>=1.1.0,<2.0.0",
         "uvloop==0.11.2;platform_system=='Linux' or platform_system=='Darwin' or platform_system=='FreeBSD'",  # noqa: E501
         "websockets==5.0.1",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -114,7 +114,7 @@ def event_loop():
 # This fixture provides a tear down to run after each test that uses it.
 # This ensures the AsyncProcessRunner will never leave a process behind
 @pytest.fixture(scope="function")
-def async_process_runner(event_loop):
+def async_process_runner():
     runner = AsyncProcessRunner(
         # This allows running pytest with -s and observing the output
         debug_fn=lambda line: print(line)
@@ -127,7 +127,7 @@ def async_process_runner(event_loop):
 
 
 @pytest.fixture(scope='module')
-async def event_bus(event_loop):
+async def event_bus():
     endpoint = TrinityEventBusEndpoint()
     # Tests run concurrently, therefore we need unique IPC paths
     ipc_path = Path(f"networking-{uuid.uuid4()}.ipc")
@@ -135,7 +135,7 @@ async def event_bus(event_loop):
         name=NETWORKING_EVENTBUS_ENDPOINT,
         path=ipc_path
     )
-    await endpoint.start_serving(networking_connection_config, event_loop)
+    await endpoint.start_serving(networking_connection_config)
     await endpoint.connect_to_endpoints(networking_connection_config)
     try:
         yield endpoint

--- a/tests/core/json-rpc/test_ipc.py
+++ b/tests/core/json-rpc/test_ipc.py
@@ -152,7 +152,7 @@ def uint256_to_bytes(uint):
 def mock_network_id(network_id):
     async def mock_event_bus_interaction(bus):
         async for req in bus.stream(NetworkIdRequest):
-            bus.broadcast(NetworkIdResponse(network_id), req.broadcast_config())
+            await bus.broadcast(NetworkIdResponse(network_id), req.broadcast_config())
             break
 
     return mock_event_bus_interaction
@@ -439,7 +439,7 @@ async def test_eth_call_with_contract_on_ipc(
 def mock_peer_count(count):
     async def mock_event_bus_interaction(bus):
         async for req in bus.stream(PeerCountRequest):
-            bus.broadcast(PeerCountResponse(count), req.broadcast_config())
+            await bus.broadcast(PeerCountResponse(count), req.broadcast_config())
             break
 
     return mock_event_bus_interaction
@@ -486,7 +486,7 @@ async def test_peer_pool_over_ipc(
 def mock_syncing(is_syncing, progress=None):
     async def mock_event_bus_interaction(bus):
         async for req in bus.stream(SyncingRequest):
-            bus.broadcast(SyncingResponse(is_syncing, progress), req.broadcast_config())
+            await bus.broadcast(SyncingResponse(is_syncing, progress), req.broadcast_config())
             break
 
     return mock_event_bus_interaction

--- a/tests/core/network-db/test_blacklist_connection_tracking.py
+++ b/tests/core/network-db/test_blacklist_connection_tracking.py
@@ -26,7 +26,7 @@ async def test_records_failures():
     node = NodeFactory()
     assert await connection_tracker.should_connect_to(node) is True
 
-    connection_tracker.record_failure(node, HandshakeFailure())
+    await connection_tracker.record_failure(node, HandshakeFailure())
 
     assert await connection_tracker.should_connect_to(node) is False
     assert connection_tracker._record_exists(node.uri())
@@ -38,7 +38,7 @@ async def test_memory_does_not_persist():
 
     connection_tracker_a = MemoryConnectionTracker()
     assert await connection_tracker_a.should_connect_to(node) is True
-    connection_tracker_a.record_failure(node, HandshakeFailure())
+    await connection_tracker_a.record_failure(node, HandshakeFailure())
     assert await connection_tracker_a.should_connect_to(node) is False
 
     # open a second instance
@@ -56,7 +56,7 @@ async def test_sql_does_persist(tmpdir):
 
     connection_tracker_a = SQLiteConnectionTracker(get_tracking_database(db_path))
     assert await connection_tracker_a.should_connect_to(node) is True
-    connection_tracker_a.record_failure(node, HandshakeFailure())
+    await connection_tracker_a.record_failure(node, HandshakeFailure())
     assert await connection_tracker_a.should_connect_to(node) is False
     del connection_tracker_a
 
@@ -73,7 +73,7 @@ async def test_timeout_works():
     connection_tracker = MemoryConnectionTracker()
     assert await connection_tracker.should_connect_to(node) is True
 
-    connection_tracker.record_failure(node, HandshakeFailure())
+    await connection_tracker.record_failure(node, HandshakeFailure())
     assert await connection_tracker.should_connect_to(node) is False
 
     record = connection_tracker._get_record(node.uri())

--- a/tests/core/network-db/test_connection_tracker_server.py
+++ b/tests/core/network-db/test_connection_tracker_server.py
@@ -19,7 +19,7 @@ from trinity.plugins.builtin.network_db.connection.tracker import (
 async def test_connection_tracker_server_and_client(event_loop, event_bus):
     tracker = MemoryConnectionTracker()
     remote_a = NodeFactory()
-    tracker.record_blacklist(remote_a, 60, "testing")
+    await tracker.record_blacklist(remote_a, 60, "testing")
 
     assert await tracker.should_connect_to(remote_a) is False
 
@@ -40,7 +40,7 @@ async def test_connection_tracker_server_and_client(event_loop, event_bus):
 
     assert await bus_tracker.should_connect_to(remote_b) is True
 
-    bus_tracker.record_blacklist(remote_b, 60, "testing")
+    await bus_tracker.record_blacklist(remote_b, 60, "testing")
 
     assert await bus_tracker.should_connect_to(remote_b) is False
     assert await tracker.should_connect_to(remote_b) is False

--- a/tests/core/p2p-proto/test_server.py
+++ b/tests/core/p2p-proto/test_server.py
@@ -181,7 +181,7 @@ async def test_peer_pool_answers_connect_commands(event_loop, event_bus, server)
 
     assert len(server.peer_pool.connected_nodes) == 0
 
-    event_bus.broadcast(
+    await event_bus.broadcast(
         ConnectToNodeCommand(RECEIVER_REMOTE),
         TO_NETWORKING_BROADCAST_CONFIG
     )

--- a/tests/integration/test_plugin_discovery.py
+++ b/tests/integration/test_plugin_discovery.py
@@ -13,5 +13,5 @@ def test_plugin_discovery():
     # pip install -e trinity-external-plugins/examples/peer_count_reporter
     from peer_count_reporter_plugin import PeerCountReporterPlugin
 
-    plugins = [type(plugin) for plugin in discover_plugins()]
+    plugins = discover_plugins()
     assert PeerCountReporterPlugin in plugins

--- a/tests/plugins/eth2/beacon/test_validator.py
+++ b/tests/plugins/eth2/beacon/test_validator.py
@@ -267,7 +267,7 @@ async def test_validator_handle_new_slot(caplog, event_loop, event_bus, monkeypa
     # sleep for `event_bus` ready
     await asyncio.sleep(0.01)
 
-    event_bus.broadcast(
+    await event_bus.broadcast(
         NewSlotEvent(
             slot=1,
             elapsed_time=2,

--- a/trinity-external-plugins/examples/peer_count_reporter/peer_count_reporter_plugin/plugin.py
+++ b/trinity-external-plugins/examples/peer_count_reporter/peer_count_reporter_plugin/plugin.py
@@ -40,7 +40,8 @@ class PeerCountReporterPlugin(BaseIsolatedPlugin):
     def name(self) -> str:
         return "Peer Count Reporter"
 
-    def configure_parser(self,
+    @classmethod
+    def configure_parser(cls,
                          arg_parser: ArgumentParser,
                          subparser: _SubParsersAction) -> None:
         arg_parser.add_argument(
@@ -50,7 +51,7 @@ class PeerCountReporterPlugin(BaseIsolatedPlugin):
         )
 
     def on_ready(self, manager_eventbus: TrinityEventBusEndpoint) -> None:
-        if self.context.args.report_peer_count:
+        if self.boot_info.args.report_peer_count:
             self.start()
 
     def do_start(self) -> None:

--- a/trinity-external-plugins/examples/peer_count_reporter/peer_count_reporter_plugin/plugin.py
+++ b/trinity-external-plugins/examples/peer_count_reporter/peer_count_reporter_plugin/plugin.py
@@ -54,9 +54,6 @@ class PeerCountReporterPlugin(BaseIsolatedPlugin):
             self.start()
 
     def do_start(self) -> None:
-        loop = asyncio.get_event_loop()
         service = PeerCountReporter(self.event_bus)
         asyncio.ensure_future(exit_with_endpoint_and_services(self.event_bus, service))
         asyncio.ensure_future(service.run())
-        loop.run_forever()
-        loop.close()

--- a/trinity/bootstrap.py
+++ b/trinity/bootstrap.py
@@ -43,7 +43,6 @@ from trinity.endpoint import (
 )
 from trinity.extensibility import (
     BasePlugin,
-    BaseManagerProcessScope,
     MainAndIsolatedProcessScope,
     PluginManager,
 )
@@ -106,12 +105,12 @@ BootFn = Callable[[
 
 def main_entry(trinity_boot: BootFn,
                app_identifier: str,
-               plugins: Iterable[BasePlugin],
+               plugins: Iterable[Type[BasePlugin]],
                sub_configs: Iterable[Type[BaseAppConfig]]) -> None:
 
     main_endpoint = TrinityMainEventBusEndpoint()
 
-    plugin_manager = setup_plugins(
+    plugin_manager = PluginManager(
         MainAndIsolatedProcessScope(main_endpoint),
         plugins
     )
@@ -259,13 +258,6 @@ async def trinity_boot_coro(kill_trinity, main_endpoint, trinity_config,  # type
     )
 
     plugin_manager.prepare(args, trinity_config, extra_kwargs)
-
-
-def setup_plugins(scope: BaseManagerProcessScope, plugins: Iterable[BasePlugin]) -> PluginManager:
-    plugin_manager = PluginManager(scope)
-    plugin_manager.register(plugins)
-
-    return plugin_manager
 
 
 def display_launch_logs(trinity_config: TrinityConfig) -> None:

--- a/trinity/endpoint.py
+++ b/trinity/endpoint.py
@@ -1,3 +1,4 @@
+import asyncio
 from typing import (
     Tuple,
 )
@@ -26,7 +27,7 @@ class TrinityEventBusEndpoint(Endpoint):
         """
         Perfom a graceful shutdown of Trinity. Can be called from any process.
         """
-        self.broadcast(
+        self.broadcast_nowait(
             ShutdownRequest(reason),
             BroadcastConfig(filter_endpoint=MAIN_EVENTBUS_ENDPOINT)
         )
@@ -53,12 +54,12 @@ class TrinityEventBusEndpoint(Endpoint):
         """
         self.subscribe(AvailableEndpointsUpdated, self.connect_to_other_endpoints)
 
-    def announce_endpoint(self) -> None:
+    async def announce_endpoint(self) -> None:
         """
         Announce this endpoint to the :class:`~trinity.endpoint.TrinityMainEventBusEndpoint` so
         that it will be further propagated to all other endpoints, allowing them to connect to us.
         """
-        self.broadcast(
+        await self.broadcast(
             EventBusConnected(ConnectionConfig(name=self.name, path=self.ipc_path)),
             BroadcastConfig(filter_endpoint=MAIN_EVENTBUS_ENDPOINT)
         )
@@ -78,7 +79,7 @@ class TrinityMainEventBusEndpoint(TrinityEventBusEndpoint):
         """
         self.available_endpoints = tuple()
 
-        def handle_new_endpoints(ev: EventBusConnected) -> None:
+        async def handle_new_endpoints(ev: EventBusConnected) -> None:
             # In a perfect world, we should only reach this code once for every endpoint.
             # However, we check `is_connected_to` here as a safe guard because theoretically
             # it could happen that a (buggy, malicious) plugin raises the `EventBusConnected`
@@ -88,13 +89,16 @@ class TrinityMainEventBusEndpoint(TrinityEventBusEndpoint):
                 self.logger.info(
                     "EventBus of main process connecting to EventBus %s", ev.connection_config.name
                 )
-                self.connect_to_endpoints_blocking(ev.connection_config)
+                await self.connect_to_endpoints(ev.connection_config)
 
             self.available_endpoints = self.available_endpoints + (ev.connection_config,)
             self.logger.debug("New EventBus Endpoint connected %s", ev.connection_config.name)
             # Broadcast available endpoints to all connected endpoints, giving them
             # a chance to cross connect
-            self.broadcast(AvailableEndpointsUpdated(self.available_endpoints))
+            await self.broadcast(AvailableEndpointsUpdated(self.available_endpoints))
             self.logger.debug("Connected EventBus Endpoints %s", self.available_endpoints)
 
-        self.subscribe(EventBusConnected, handle_new_endpoints)
+        def spawn_handle_new_endpoints(ev: EventBusConnected) -> None:
+            asyncio.ensure_future(handle_new_endpoints(ev))
+
+        self.subscribe(EventBusConnected, spawn_handle_new_endpoints)

--- a/trinity/extensibility/__init__.py
+++ b/trinity/extensibility/__init__.py
@@ -2,7 +2,6 @@ from trinity.extensibility.events import (  # noqa: F401
     BaseEvent
 )
 from trinity.extensibility.exceptions import (  # noqa: F401
-    EventBusNotReady,
     InvalidPluginStatus,
     UnsuitableShutdownError,
 )
@@ -12,7 +11,6 @@ from trinity.extensibility.plugin import (  # noqa: F401
     BaseIsolatedPlugin,
     BasePlugin,
     DebugPlugin,
-    PluginContext,
     PluginStatus,
     TrinityBootInfo,
 )

--- a/trinity/extensibility/exceptions.py
+++ b/trinity/extensibility/exceptions.py
@@ -3,14 +3,6 @@ from trinity.exceptions import (
 )
 
 
-class EventBusNotReady(BaseTrinityError):
-    """
-    Raised when a plugin tried to access the event bus before the plugin
-    had received its :meth:`~trinity.extensibility.plugin.BasePlugin.on_ready` call.
-    """
-    pass
-
-
 class InvalidPluginStatus(BaseTrinityError):
     """
     Raised when it was attempted to perform an action while the current

--- a/trinity/extensibility/plugin_manager.py
+++ b/trinity/extensibility/plugin_manager.py
@@ -99,7 +99,7 @@ class MainAndIsolatedProcessScope(BaseManagerProcessScope):
             # created here for API symmetry. Endpoints are pickleable *before* they are connected,
             # which means, this Endpoint will be pickled and transferred into the new process
             # together with the rest of the `PluginContext`.
-            plugin.set_context(PluginContext(TrinityEventBusEndpoint(), boot_info,))
+            plugin.set_context(PluginContext(None, boot_info,))
 
 
 class SharedProcessScope(BaseManagerProcessScope):

--- a/trinity/main.py
+++ b/trinity/main.py
@@ -22,7 +22,6 @@ from p2p._utils import ensure_global_asyncio_executor
 
 from trinity.bootstrap import (
     main_entry,
-    setup_plugins,
 )
 from trinity.config import (
     TrinityConfig,
@@ -74,7 +73,7 @@ from trinity._utils.shutdown import (
 )
 
 
-def get_all_plugins() -> Iterable[BasePlugin]:
+def get_all_plugins() -> Iterable[Type[BasePlugin]]:
     return BASE_PLUGINS + ETH1_NODE_PLUGINS + discover_plugins()
 
 
@@ -167,7 +166,7 @@ async def launch_node_coro(args: Namespace, trinity_config: TrinityConfig) -> No
     await endpoint.announce_endpoint()
 
     # This is a second PluginManager instance governing plugins in a shared process.
-    plugin_manager = setup_plugins(SharedProcessScope(endpoint), get_all_plugins())
+    plugin_manager = PluginManager(SharedProcessScope(endpoint), get_all_plugins())
     plugin_manager.prepare(args, trinity_config)
 
     asyncio.ensure_future(handle_networking_exit(node, plugin_manager, endpoint))

--- a/trinity/plugins/builtin/attach/plugin.py
+++ b/trinity/plugins/builtin/attach/plugin.py
@@ -3,6 +3,7 @@ from argparse import (
     Namespace,
     _SubParsersAction,
 )
+import pkg_resources
 import sys
 
 from trinity.config import (
@@ -19,56 +20,65 @@ from trinity.plugins.builtin.attach.console import (
 )
 
 
+def is_ipython_available() -> bool:
+    try:
+        pkg_resources.get_distribution('IPython')
+    except pkg_resources.DistributionNotFound:
+        return False
+    else:
+        return True
+
+
 class AttachPlugin(BaseMainProcessPlugin):
-
-    def __init__(self, use_ipython: bool = True) -> None:
-        super().__init__()
-        self.use_ipython = use_ipython
-
     @property
     def name(self) -> str:
         return "Attach"
 
-    def configure_parser(self, arg_parser: ArgumentParser, subparser: _SubParsersAction) -> None:
+    @classmethod
+    def configure_parser(cls,
+                         arg_parser: ArgumentParser,
+                         subparser: _SubParsersAction) -> None:
 
         attach_parser = subparser.add_parser(
             'attach',
             help='open an REPL attached to a currently running chain',
         )
 
-        attach_parser.set_defaults(func=self.run_console)
+        attach_parser.set_defaults(func=cls.run_console)
 
-    def run_console(self, args: Namespace, trinity_config: TrinityConfig) -> None:
+    @classmethod
+    def run_console(cls, args: Namespace, trinity_config: TrinityConfig) -> None:
         try:
-            console(trinity_config.jsonrpc_ipc_path, use_ipython=self.use_ipython)
+            console(trinity_config.jsonrpc_ipc_path, use_ipython=is_ipython_available())
         except FileNotFoundError as err:
-            self.logger.error(str(err))
+            cls.get_logger().error(str(err))
             sys.exit(1)
 
 
 class DbShellPlugin(BaseMainProcessPlugin):
-
-    def __init__(self, use_ipython: bool = True) -> None:
-        super().__init__()
-        self.use_ipython = use_ipython
-
     @property
     def name(self) -> str:
         return "DB Shell"
 
-    def configure_parser(self, arg_parser: ArgumentParser, subparser: _SubParsersAction) -> None:
+    @classmethod
+    def configure_parser(cls,
+                         arg_parser: ArgumentParser,
+                         subparser: _SubParsersAction) -> None:
 
         attach_parser = subparser.add_parser(
             'db-shell',
             help='open a REPL to inspect the db',
         )
 
-        attach_parser.set_defaults(func=self.run_shell)
+        attach_parser.set_defaults(func=cls.run_shell)
 
-    def run_shell(self, args: Namespace, trinity_config: TrinityConfig) -> None:
+    @classmethod
+    def run_shell(cls, args: Namespace, trinity_config: TrinityConfig) -> None:
 
         if trinity_config.has_app_config(Eth1AppConfig):
             config = trinity_config.get_app_config(Eth1AppConfig)
-            db_shell(self.use_ipython, config.database_dir, trinity_config)
+            db_shell(is_ipython_available(), config.database_dir, trinity_config)
         else:
-            self.logger.error("DB Shell does only support the Ethereum 1 node at this time")
+            cls.get_logger().error(
+                "DB Shell only supports the Ethereum 1 node at this time"
+            )

--- a/trinity/plugins/builtin/ethstats/plugin.py
+++ b/trinity/plugins/builtin/ethstats/plugin.py
@@ -123,10 +123,5 @@ class EthstatsPlugin(BaseIsolatedPlugin):
             self.stats_interval,
         )
 
-        loop: asyncio.AbstractEventLoop = asyncio.get_event_loop()
-
         asyncio.ensure_future(exit_with_endpoint_and_services(self.context.event_bus, service))
         asyncio.ensure_future(service.run())
-
-        loop.run_forever()
-        loop.close()

--- a/trinity/plugins/builtin/ethstats/plugin.py
+++ b/trinity/plugins/builtin/ethstats/plugin.py
@@ -43,9 +43,10 @@ class EthstatsPlugin(BaseIsolatedPlugin):
         return 'Ethstats'
 
     def get_default_server_url(self) -> str:
-        return DEFAULT_SERVERS_URLS.get(self.context.trinity_config.network_id, '')
+        return DEFAULT_SERVERS_URLS.get(self.boot_info.trinity_config.network_id, '')
 
-    def configure_parser(self, arg_parser: ArgumentParser, subparser: _SubParsersAction) -> None:
+    @classmethod
+    def configure_parser(cls, arg_parser: ArgumentParser, subparser: _SubParsersAction) -> None:
         ethstats_parser = arg_parser.add_argument_group('ethstats (experimental)')
 
         ethstats_parser.add_argument(
@@ -81,7 +82,7 @@ class EthstatsPlugin(BaseIsolatedPlugin):
         )
 
     def on_ready(self, manager_eventbus: TrinityEventBusEndpoint) -> None:
-        args = self.context.args
+        args = self.boot_info.args
 
         if not args.ethstats:
             return
@@ -115,7 +116,8 @@ class EthstatsPlugin(BaseIsolatedPlugin):
 
     def do_start(self) -> None:
         service = EthstatsService(
-            self.context,
+            self.boot_info,
+            self.event_bus,
             self.server_url,
             self.server_secret,
             self.node_id,
@@ -123,5 +125,5 @@ class EthstatsPlugin(BaseIsolatedPlugin):
             self.stats_interval,
         )
 
-        asyncio.ensure_future(exit_with_endpoint_and_services(self.context.event_bus, service))
+        asyncio.ensure_future(exit_with_endpoint_and_services(self.event_bus, service))
         asyncio.ensure_future(service.run())

--- a/trinity/plugins/builtin/fix_unclean_shutdown/plugin.py
+++ b/trinity/plugins/builtin/fix_unclean_shutdown/plugin.py
@@ -18,43 +18,47 @@ from trinity._utils.ipc import (
 
 
 class FixUncleanShutdownPlugin(BaseMainProcessPlugin):
-
     @property
     def name(self) -> str:
         return "Fix Unclean Shutdown"
 
-    def configure_parser(self, arg_parser: ArgumentParser, subparser: _SubParsersAction) -> None:
+    @classmethod
+    def configure_parser(cls,
+                         arg_parser: ArgumentParser,
+                         subparser: _SubParsersAction) -> None:
 
         attach_parser = subparser.add_parser(
             'fix-unclean-shutdown',
             help='close any dangling processes from a previous unclean shutdown',
         )
 
-        attach_parser.set_defaults(func=self.fix_unclean_shutdown)
+        attach_parser.set_defaults(func=cls.fix_unclean_shutdown)
 
-    def fix_unclean_shutdown(self, args: Namespace, trinity_config: TrinityConfig) -> None:
-        self.logger.info("Cleaning up unclean shutdown...")
+    @classmethod
+    def fix_unclean_shutdown(cls, args: Namespace, trinity_config: TrinityConfig) -> None:
+        logger = cls.get_logger()
+        logger.info("Cleaning up unclean shutdown...")
 
-        self.logger.info("Searching for process id files in %s..." % trinity_config.data_dir)
+        logger.info("Searching for process id files in %s..." % trinity_config.data_dir)
         pidfiles = tuple(trinity_config.pid_dir.glob('*.pid'))
         if len(pidfiles) > 1:
-            self.logger.info('Found %d processes from a previous run. Closing...' % len(pidfiles))
+            logger.info('Found %d processes from a previous run. Closing...' % len(pidfiles))
         elif len(pidfiles) == 1:
-            self.logger.info('Found 1 process from a previous run. Closing...')
+            logger.info('Found 1 process from a previous run. Closing...')
         else:
-            self.logger.info('Found 0 processes from a previous run. No processes to kill.')
+            logger.info('Found 0 processes from a previous run. No processes to kill.')
 
         for pidfile in pidfiles:
             process_id = int(pidfile.read_text())
-            kill_process_id_gracefully(process_id, time.sleep, self.logger)
+            kill_process_id_gracefully(process_id, time.sleep, logger)
             try:
                 pidfile.unlink()
-                self.logger.info(
+                logger.info(
                     'Manually removed %s after killing process id %d' % (pidfile, process_id)
                 )
             except FileNotFoundError:
-                self.logger.debug(
+                logger.debug(
                     'pidfile %s was gone after killing process id %d' % (pidfile, process_id)
                 )
 
-        remove_dangling_ipc_files(self.logger, trinity_config.ipc_dir)
+        remove_dangling_ipc_files(logger, trinity_config.ipc_dir)

--- a/trinity/plugins/builtin/json_rpc/plugin.py
+++ b/trinity/plugins/builtin/json_rpc/plugin.py
@@ -97,8 +97,5 @@ class JsonRpcServerPlugin(BaseIsolatedPlugin):
         rpc = RPCServer(modules, self.context.event_bus)
         ipc_server = IPCServer(rpc, self.context.trinity_config.jsonrpc_ipc_path)
 
-        loop = asyncio.get_event_loop()
         asyncio.ensure_future(exit_with_endpoint_and_services(self.context.event_bus, ipc_server))
         asyncio.ensure_future(ipc_server.run())
-        loop.run_forever()
-        loop.close()

--- a/trinity/plugins/builtin/light_peer_chain_bridge/light_peer_chain_bridge.py
+++ b/trinity/plugins/builtin/light_peer_chain_bridge/light_peer_chain_bridge.py
@@ -167,7 +167,7 @@ class LightPeerChainEventBusHandler(BaseService):
                 self.chain.coro_get_block_header_by_hash(event.block_hash)
             )
 
-            self.event_bus.broadcast(
+            await self.event_bus.broadcast(
                 event.expected_response_type()(val, error),
                 event.broadcast_config()
             )
@@ -179,7 +179,7 @@ class LightPeerChainEventBusHandler(BaseService):
                 self.chain.coro_get_block_body_by_hash(event.block_hash)
             )
 
-            self.event_bus.broadcast(
+            await self.event_bus.broadcast(
                 event.expected_response_type()(val, error),
                 event.broadcast_config()
             )
@@ -189,7 +189,7 @@ class LightPeerChainEventBusHandler(BaseService):
 
             val, error = await await_and_wrap_errors(self.chain.coro_get_receipts(event.block_hash))
 
-            self.event_bus.broadcast(
+            await self.event_bus.broadcast(
                 event.expected_response_type()(val, error),
                 event.broadcast_config()
             )
@@ -201,7 +201,7 @@ class LightPeerChainEventBusHandler(BaseService):
                 self.chain.coro_get_account(event.block_hash, event.address)
             )
 
-            self.event_bus.broadcast(
+            await self.event_bus.broadcast(
                 event.expected_response_type()(val, error),
                 event.broadcast_config()
             )
@@ -214,7 +214,7 @@ class LightPeerChainEventBusHandler(BaseService):
                 self.chain.coro_get_contract_code(event.block_hash, event.address)
             )
 
-            self.event_bus.broadcast(
+            await self.event_bus.broadcast(
                 event.expected_response_type()(val, error),
                 event.broadcast_config()
             )

--- a/trinity/plugins/builtin/light_peer_chain_bridge/plugin.py
+++ b/trinity/plugins/builtin/light_peer_chain_bridge/plugin.py
@@ -44,7 +44,7 @@ class LightPeerChainBridgePlugin(BaseAsyncStopPlugin):
         return "LightPeerChain Bridge"
 
     def on_ready(self, manager_eventbus: TrinityEventBusEndpoint) -> None:
-        if self.context.args.sync_mode != SYNC_LIGHT:
+        if self.boot_info.args.sync_mode != SYNC_LIGHT:
             return
 
         self.event_bus.subscribe(
@@ -59,7 +59,7 @@ class LightPeerChainBridgePlugin(BaseAsyncStopPlugin):
 
     def do_start(self) -> None:
         chain = cast(LightDispatchChain, self.chain)
-        self.handler = LightPeerChainEventBusHandler(chain._peer_chain, self.context.event_bus)
+        self.handler = LightPeerChainEventBusHandler(chain._peer_chain, self.event_bus)
         asyncio.ensure_future(self.handler.run())
 
     async def do_stop(self) -> None:

--- a/trinity/plugins/builtin/network_db/connection/server.py
+++ b/trinity/plugins/builtin/network_db/connection/server.py
@@ -34,7 +34,7 @@ class ConnectionTrackerServer(BaseService):
         async for req in self.wait_iter(self.event_bus.stream(ShouldConnectToPeerRequest)):
             self.logger.debug2('Received should connect to request: %s', req.remote)
             should_connect = await self.tracker.should_connect_to(req.remote)
-            self.event_bus.broadcast(
+            await self.event_bus.broadcast(
                 ShouldConnectToPeerResponse(should_connect),
                 req.broadcast_config()
             )
@@ -47,7 +47,11 @@ class ConnectionTrackerServer(BaseService):
                 humanize_seconds(command.timeout_seconds),
                 command.reason,
             )
-            self.tracker.record_blacklist(command.remote, command.timeout_seconds, command.reason)
+            await self.tracker.record_blacklist(
+                command.remote,
+                command.timeout_seconds,
+                command.reason
+            )
 
     async def _run(self) -> None:
         self.logger.debug("Running ConnectionTrackerServer")

--- a/trinity/plugins/builtin/network_db/connection/tracker.py
+++ b/trinity/plugins/builtin/network_db/connection/tracker.py
@@ -56,7 +56,7 @@ class SQLiteConnectionTracker(BaseConnectionTracker):
     #
     # Core API
     #
-    def record_blacklist(self, remote: Node, timeout_seconds: int, reason: str) -> None:
+    async def record_blacklist(self, remote: Node, timeout_seconds: int, reason: str) -> None:
         if self._record_exists(remote.uri()):
             self._update_record(remote, timeout_seconds, reason)
         else:
@@ -150,8 +150,8 @@ class ConnectionTrackerClient(BaseConnectionTracker):
         self.event_bus = event_bus
         self.config = config
 
-    def record_blacklist(self, remote: Node, timeout_seconds: int, reason: str) -> None:
-        self.event_bus.broadcast(
+    async def record_blacklist(self, remote: Node, timeout_seconds: int, reason: str) -> None:
+        await self.event_bus.broadcast(
             BlacklistEvent(remote, timeout_seconds, reason=reason),
             self.config,
         )

--- a/trinity/plugins/builtin/network_db/plugin.py
+++ b/trinity/plugins/builtin/network_db/plugin.py
@@ -150,12 +150,6 @@ class NetworkDBPlugin(BaseIsolatedPlugin):
             self.logger.warning("Blacklist Database disabled via CLI flag")
             return
         else:
-            loop = asyncio.get_event_loop()
-
             service = self._get_blacklist_service()
-
             asyncio.ensure_future(exit_with_endpoint_and_services(self.event_bus, service))
             asyncio.ensure_future(service.run())
-
-            loop.run_forever()
-            loop.close()

--- a/trinity/plugins/builtin/peer_discovery/plugin.py
+++ b/trinity/plugins/builtin/peer_discovery/plugin.py
@@ -162,7 +162,10 @@ class PeerDiscoveryPlugin(BaseIsolatedPlugin):
     def on_ready(self, manager_eventbus: TrinityEventBusEndpoint) -> None:
         self.start()
 
-    def configure_parser(self, arg_parser: ArgumentParser, subparser: _SubParsersAction) -> None:
+    @classmethod
+    def configure_parser(cls,
+                         arg_parser: ArgumentParser,
+                         subparser: _SubParsersAction) -> None:
         arg_parser.add_argument(
             "--disable-discovery",
             action="store_true",
@@ -171,9 +174,9 @@ class PeerDiscoveryPlugin(BaseIsolatedPlugin):
 
     def do_start(self) -> None:
         discovery_bootstrap = DiscoveryBootstrapService(
-            self.context.args.disable_discovery,
+            self.boot_info.args.disable_discovery,
             self.event_bus,
-            self.context.trinity_config
+            self.boot_info.trinity_config
         )
         asyncio.ensure_future(exit_with_endpoint_and_services(self.event_bus, discovery_bootstrap))
         asyncio.ensure_future(discovery_bootstrap.run())

--- a/trinity/plugins/builtin/peer_discovery/plugin.py
+++ b/trinity/plugins/builtin/peer_discovery/plugin.py
@@ -170,7 +170,6 @@ class PeerDiscoveryPlugin(BaseIsolatedPlugin):
         )
 
     def do_start(self) -> None:
-        loop = asyncio.get_event_loop()
         discovery_bootstrap = DiscoveryBootstrapService(
             self.context.args.disable_discovery,
             self.event_bus,
@@ -178,5 +177,3 @@ class PeerDiscoveryPlugin(BaseIsolatedPlugin):
         )
         asyncio.ensure_future(exit_with_endpoint_and_services(self.event_bus, discovery_bootstrap))
         asyncio.ensure_future(discovery_bootstrap.run())
-        loop.run_forever()
-        loop.close()

--- a/trinity/plugins/builtin/tx_pool/plugin.py
+++ b/trinity/plugins/builtin/tx_pool/plugin.py
@@ -50,7 +50,8 @@ class TxPlugin(BaseAsyncStopPlugin):
     def name(self) -> str:
         return "TxPlugin"
 
-    def configure_parser(self, arg_parser: ArgumentParser, subparser: _SubParsersAction) -> None:
+    @classmethod
+    def configure_parser(cls, arg_parser: ArgumentParser, subparser: _SubParsersAction) -> None:
         arg_parser.add_argument(
             "--tx-pool",
             action="store_true",
@@ -59,10 +60,10 @@ class TxPlugin(BaseAsyncStopPlugin):
 
     def on_ready(self, manager_eventbus: TrinityEventBusEndpoint) -> None:
 
-        light_mode = self.context.args.sync_mode == SYNC_LIGHT
-        self.is_enabled = self.context.args.tx_pool and not light_mode
+        light_mode = self.boot_info.args.sync_mode == SYNC_LIGHT
+        self.is_enabled = self.boot_info.args.tx_pool and not light_mode
 
-        unsupported = self.context.args.tx_pool and light_mode
+        unsupported = self.boot_info.args.tx_pool and light_mode
 
         if unsupported:
             unsupported_msg = "Transaction pool not available in light mode"
@@ -85,9 +86,9 @@ class TxPlugin(BaseAsyncStopPlugin):
             self.start()
 
     def do_start(self) -> None:
-        if self.context.trinity_config.network_id == MAINNET_NETWORK_ID:
+        if self.boot_info.trinity_config.network_id == MAINNET_NETWORK_ID:
             validator = DefaultTransactionValidator(self.chain, BYZANTIUM_MAINNET_BLOCK)
-        elif self.context.trinity_config.network_id == ROPSTEN_NETWORK_ID:
+        elif self.boot_info.trinity_config.network_id == ROPSTEN_NETWORK_ID:
             validator = DefaultTransactionValidator(self.chain, BYZANTIUM_ROPSTEN_BLOCK)
         else:
             # TODO: We could hint the user about e.g. a --tx-pool-no-validation flag to run the

--- a/trinity/plugins/eth2/beacon/plugin.py
+++ b/trinity/plugins/eth2/beacon/plugin.py
@@ -76,9 +76,6 @@ class BeaconNodePlugin(BaseIsolatedPlugin):
             server.cancel_token,
         )
 
-        loop = asyncio.get_event_loop()
         asyncio.ensure_future(exit_with_endpoint_and_services(self.context.event_bus, server))
         asyncio.ensure_future(server.run())
         asyncio.ensure_future(syncer.run())
-        loop.run_forever()
-        loop.close()

--- a/trinity/plugins/eth2/beacon/slot_ticker.py
+++ b/trinity/plugins/eth2/beacon/slot_ticker.py
@@ -69,7 +69,7 @@ class SlotTicker(BaseService):
                         bold_green(f"New slot: {slot}\tElapsed time: {elapsed_time}")
                     )
                     self.latest_slot = slot
-                    self.event_bus.broadcast(
+                    await self.event_bus.broadcast(
                         NewSlotEvent(
                             slot=slot,
                             elapsed_time=elapsed_time,

--- a/trinity/plugins/registry.py
+++ b/trinity/plugins/registry.py
@@ -1,6 +1,7 @@
 import pkg_resources
 from typing import (
     Tuple,
+    Type,
 )
 
 from trinity.extensibility import (
@@ -26,10 +27,6 @@ from trinity.plugins.builtin.peer_discovery.plugin import (
     PeerDiscoveryPlugin,
 )
 from trinity.plugins.builtin.syncer.plugin import (
-    FastThenFullSyncStrategy,
-    FullSyncStrategy,
-    LightSyncStrategy,
-    NoopSyncStrategy,
     SyncerPlugin,
 )
 from trinity.plugins.eth2.network_generator.plugin import NetworkGeneratorPlugin
@@ -42,44 +39,30 @@ from trinity.plugins.builtin.light_peer_chain_bridge.plugin import (
 )
 
 
-def is_ipython_available() -> bool:
-    try:
-        pkg_resources.get_distribution('IPython')
-    except pkg_resources.DistributionNotFound:
-        return False
-    else:
-        return True
-
-
-BASE_PLUGINS: Tuple[BasePlugin, ...] = (
-    AttachPlugin(use_ipython=is_ipython_available()),
-    NetworkGeneratorPlugin(),
-    FixUncleanShutdownPlugin(),
-    JsonRpcServerPlugin(),
-    NetworkDBPlugin(),
-    PeerDiscoveryPlugin(),
-    BeaconNodePlugin(),
+BASE_PLUGINS: Tuple[Type[BasePlugin], ...] = (
+    AttachPlugin,
+    NetworkGeneratorPlugin,
+    FixUncleanShutdownPlugin,
+    JsonRpcServerPlugin,
+    NetworkDBPlugin,
+    PeerDiscoveryPlugin,
+    BeaconNodePlugin,
 )
 
 
-ETH1_NODE_PLUGINS: Tuple[BasePlugin, ...] = (
-    DbShellPlugin(use_ipython=is_ipython_available()),
-    EthstatsPlugin(),
-    LightPeerChainBridgePlugin(),
-    SyncerPlugin((
-        FastThenFullSyncStrategy(),
-        FullSyncStrategy(),
-        LightSyncStrategy(),
-        NoopSyncStrategy(),
-    ), FastThenFullSyncStrategy),
-    TxPlugin(),
+ETH1_NODE_PLUGINS: Tuple[Type[BasePlugin], ...] = (
+    DbShellPlugin,
+    EthstatsPlugin,
+    LightPeerChainBridgePlugin,
+    SyncerPlugin,
+    TxPlugin,
 )
 
 
-def discover_plugins() -> Tuple[BasePlugin, ...]:
+def discover_plugins() -> Tuple[Type[BasePlugin], ...]:
     # Plugins need to define entrypoints at 'trinity.plugins' to automatically get loaded
     # https://packaging.python.org/guides/creating-and-discovering-plugins/#using-package-metadata
 
     return tuple(
-        entry_point.load()() for entry_point in pkg_resources.iter_entry_points('trinity.plugins')
+        entry_point.load() for entry_point in pkg_resources.iter_entry_points('trinity.plugins')
     )

--- a/trinity/protocol/common/peer_pool_event_bus.py
+++ b/trinity/protocol/common/peer_pool_event_bus.py
@@ -57,7 +57,7 @@ class PeerPoolEventServer(BaseService, Generic[TPeer]):
 
     async def handle_peer_count_requests(self) -> None:
         async for req in self.wait_iter(self.event_bus.stream(PeerCountRequest)):
-            self.event_bus.broadcast(
+            await self.event_bus.broadcast(
                 PeerCountResponse(len(self.peer_pool)),
                 req.broadcast_config()
             )

--- a/trinity/rpc/modules/admin.py
+++ b/trinity/rpc/modules/admin.py
@@ -15,7 +15,7 @@ class Admin(BaseRPCModule):
     async def addPeer(self, uri: str) -> None:
         validate_enode_uri(uri, require_ip=True)
 
-        self.event_bus.broadcast(
+        await self.event_bus.broadcast(
             ConnectToNodeCommand(Node.from_uri(uri)),
             TO_NETWORKING_BROADCAST_CONFIG
         )

--- a/trinity/rpc/modules/evm.py
+++ b/trinity/rpc/modules/evm.py
@@ -41,7 +41,7 @@ class EVM(Eth1ChainRPCModule):
         """
         chain = new_chain_from_fixture(chain_info, type(self.chain))
 
-        self.event_bus.broadcast(
+        await self.event_bus.broadcast(
             ChainReplacementEvent(chain),
             BroadcastConfig(internal=True)
         )


### PR DESCRIPTION
This is a version of trinity which uses the new asyncio-powered lahja (https://github.com/ethereum/lahja/pull/39). Previously the `*_nowait()` methods would block the main thread and do their work. Since most of them now call async methods they now schedule their work to be done in the future. This caused problems inside trinity, which for example assumes that it can call `broadcast_nowait` immediately after it calls `connect_to_endpoints_nowait`. To account for this a couple parts of trinity were turned into async methods so that the blocking versions of those `Endpoint` methods could be called.

#### Cute Animal Picture

![seal](https://user-images.githubusercontent.com/466333/56927696-adc5dc80-6a89-11e9-82b3-96e1b624ec6a.jpg)

