### PR TITLE
Piper/expose event bus on peer

### DIFF
--- a/p2p/_utils.py
+++ b/p2p/_utils.py
@@ -1,14 +1,10 @@
-import asyncio
 from concurrent.futures import Executor, ProcessPoolExecutor
 import datetime
 import logging
 import os
 import signal
-import time
 from typing import (
-    AsyncGenerator,
     Tuple,
-    Union,
 )
 
 import rlp
@@ -112,31 +108,3 @@ def ensure_global_asyncio_executor(cpu_count: int=None) -> Executor:
         _executor._start_queue_management_thread()  # type: ignore
         signal.signal(signal.SIGINT, original_handler)
     return _executor
-
-
-async def token_bucket(rate: Union[int, float],
-                       capacity: Union[int, float],
-                       ) -> AsyncGenerator[None, None]:
-    """
-    rate: Number of token that can be consumed per second.
-    capacity: Maximum number of tokens
-
-    Each `await` call consumes a single token.
-    """
-    num_tokens = capacity
-    last_refill = time.perf_counter()
-    seconds_per_token = 1 / rate
-
-    while True:
-        now = time.perf_counter()
-        num_tokens = min(
-            capacity,
-            num_tokens + (rate * (now - last_refill)),
-        )
-        last_refill = now
-
-        if num_tokens >= 1:
-            num_tokens -= 1
-            yield
-        else:
-            await asyncio.sleep((1 - num_tokens) * seconds_per_token)

--- a/p2p/peer.py
+++ b/p2p/peer.py
@@ -261,7 +261,7 @@ class BasePeer(BaseService):
 
     def get_event_bus(self) -> Endpoint:
         if self._event_bus is None:
-            raise AttributeError("No event bus configured for this peer pool")
+            raise AttributeError(f"No event bus configured for peer {self}")
         return self._event_bus
 
     def setup_connection_tracker(self) -> BaseConnectionTracker:

--- a/p2p/token_bucket.py
+++ b/p2p/token_bucket.py
@@ -1,0 +1,91 @@
+import asyncio
+import time
+from typing import (
+    Union,
+    AsyncGenerator,
+)
+
+
+class NotEnoughTokens(Exception):
+    """
+    Raised if the token bucket is empty when trying to take a token in blocking
+    mode.
+    """
+    pass
+
+
+class TokenBucket:
+    def __init__(self,
+                 rate: Union[int, float],
+                 capacity: Union[int, float]) -> None:
+        self._rate = rate
+        self._capacity = capacity
+        self._num_tokens = self._capacity
+        self._last_refill = time.perf_counter()
+        self._seconds_per_token = 1 / self._rate
+        self._take_lock = asyncio.Lock()
+
+    async def __aiter__(self) -> AsyncGenerator[None, None]:
+        """
+        Can be used as an async iterator to limit the rate at which a loop can
+        run.
+        """
+        while True:
+            await self.take()
+            yield
+
+    def get_num_tokens(self) -> float:
+        """
+        Return the number of tokens current in the bucke
+        """
+        return max(0, self._get_num_tokens(time.perf_counter()))
+
+    def _get_num_tokens(self, when: float) -> float:
+        return min(
+            self._capacity,
+            self._num_tokens + (self._rate * (when - self._last_refill)),
+        )
+
+    def _take(self, num: Union[int, float] = 1) -> None:
+        now = time.perf_counter()
+        if num < 0:
+            raise ValueError("Cannot take negative token quantity")
+
+        # refill the bucket
+        self._num_tokens = self._get_num_tokens(now)
+        self._last_refill = now
+
+        # deduct the requested tokens
+        self._num_tokens -= num
+
+    async def take(self, num: Union[int, float] = 1) -> None:
+        """
+        Take `num` tokens out of the bucket.  If the bucket does not have
+        enough tokens, blocks until the bucket will be full enough to fulfill
+        the request.
+        """
+        # the lock ensures that we don't have two processes take from the
+        # bucket at the same time while the inner sleep is happening
+        async with self._take_lock:
+            self._take(num)
+
+        # if the bucket balance is negative, wait an amount of seconds adequatet to fill it
+        if self._num_tokens < 0:
+            sleep_for = abs(self._num_tokens) * self._seconds_per_token
+            await asyncio.sleep(sleep_for)
+
+    def take_nowait(self, num: Union[int, float] = 1) -> None:
+        # we calculate this value locally to ensure that in the case of not
+        # having enough tokens the error message is accurate due to race
+        # condition between calculating capacity and raising the error message.
+        num_tokens = self.get_num_tokens()
+        if num_tokens >= num:
+            self._take(num)
+        else:
+            raise NotEnoughTokens(f"Insufficient capacity.  Needed {num} but only has {num_tokens}")
+
+    def can_take(self, num: Union[int, float] = 1) -> bool:
+        """
+        Return boolean whether the bucket has enough tokens to take `num` tokens.
+        """
+        return num <= self.get_num_tokens()

--- a/tests/p2p/test_token_bucket.py
+++ b/tests/p2p/test_token_bucket.py
@@ -2,13 +2,17 @@ import asyncio
 import pytest
 import time
 
-from p2p._utils import token_bucket
+from p2p.token_bucket import (
+    TokenBucket,
+    NotEnoughTokens,
+)
 
 
 async def measure_zero(iterations):
+    bucket = TokenBucket(1, iterations)
     start_at = time.perf_counter()
     for _ in range(iterations):
-        await asyncio.sleep(0)
+        await bucket.take()
     end_at = time.perf_counter()
     return end_at - start_at
 
@@ -19,11 +23,11 @@ def assert_fuzzy_equal(actual, expected, allowed_drift):
 
 @pytest.mark.asyncio
 async def test_token_bucket_initial_tokens():
-    limiter = token_bucket(1000, 10)
+    bucket = TokenBucket(1000, 10)
 
     start_at = time.perf_counter()
     for _ in range(10):
-        await limiter.__anext__()
+        await bucket.take()
 
     end_at = time.perf_counter()
     delta = end_at - start_at
@@ -38,31 +42,36 @@ async def test_token_bucket_initial_tokens():
 
 @pytest.mark.asyncio
 async def test_token_bucket_hits_limit():
-    limiter = token_bucket(1000, 10)
+    bucket = TokenBucket(1000, 10)
 
+    bucket.take_nowait(10)
     start_at = time.perf_counter()
     # first 10 tokens should be roughly instant
     # next 10 tokens should each take 1/1000th second each to generate.
-    for _ in range(20):
-        await limiter.__anext__()
+    while True:
+        if bucket.can_take(10):
+            break
+        else:
+            await asyncio.sleep(0)
 
     end_at = time.perf_counter()
 
     # we use a zero-measure of 20 to account for the loop overhead.
-    expected_delta = 10 / 1000 + await measure_zero(20)
+    zero = await measure_zero(10)
+    expected_delta = 10 / 1000 + zero
     delta = end_at - start_at
 
-    # allow up to 1% difference in expected time
-    assert_fuzzy_equal(delta, expected_delta, allowed_drift=0.01)
+    # allow up to 5% difference in expected time
+    assert_fuzzy_equal(delta, expected_delta, allowed_drift=0.05)
 
 
 @pytest.mark.asyncio
 async def test_token_bucket_refills_itself():
-    limiter = token_bucket(1000, 10)
+    bucket = TokenBucket(1000, 10)
 
     # consume all of the tokens
     for _ in range(10):
-        await limiter.__anext__()
+        await bucket.take()
 
     # enough time for the bucket to fully refill
     await asyncio.sleep(20 / 1000)
@@ -70,7 +79,7 @@ async def test_token_bucket_refills_itself():
     start_at = time.perf_counter()
 
     for _ in range(10):
-        await limiter.__anext__()
+        await bucket.take()
 
     end_at = time.perf_counter()
 
@@ -81,3 +90,41 @@ async def test_token_bucket_refills_itself():
     # drift is allowed to be up to 200% since we're working with very small
     # numbers.
     assert_fuzzy_equal(delta, expected, allowed_drift=2)
+
+
+@pytest.mark.asyncio
+async def test_token_bucket_can_take():
+    bucket = TokenBucket(1, 10)
+
+    assert bucket.can_take() is True  # can take 1
+    assert bucket.can_take(bucket.get_num_tokens()) is True  # can take full capacity
+
+    await bucket.take(10)  # empty the bucket
+
+    assert bucket.can_take() is False
+
+
+@pytest.mark.asyncio
+async def test_token_bucket_get_num_tokens():
+    bucket = TokenBucket(1, 10)
+
+    # starts at full capacity
+    assert bucket.get_num_tokens() == 10
+
+    await bucket.take(5)
+    assert 5 <= bucket.get_num_tokens() <= 5.1
+
+    await bucket.take(bucket.get_num_tokens())
+
+    assert 0 <= bucket.get_num_tokens() <= 0.1
+
+
+def test_token_bucket_take_nowait():
+    bucket = TokenBucket(1, 10)
+
+    assert bucket.can_take(10)
+    bucket.take_nowait(10)
+    assert not bucket.can_take(1)
+
+    with pytest.raises(NotEnoughTokens):
+        bucket.take_nowait(1)

--- a/trinity/db/network.py
+++ b/trinity/db/network.py
@@ -4,9 +4,11 @@ from trinity.config import (
     TrinityConfig,
 )
 
+from .orm import SCHEMA_VERSION
+
 
 def get_networkdb_path(config: TrinityConfig) -> Path:
     base_db_path = config.with_app_suffix(
         config.data_dir / "networkdb"
     )
-    return base_db_path.with_name(base_db_path.name + ".sqlite3")
+    return base_db_path.with_name(base_db_path.name + f".v{SCHEMA_VERSION}.sqlite3")

--- a/trinity/protocol/common/constants.py
+++ b/trinity/protocol/common/constants.py
@@ -1,4 +1,8 @@
 # The default timeout for a round trip API request and response from a peer.
+#
+# > NOTE: This value **MUST** be less than `p2p.constants.CONN_IDLE_TIMEOUT` for
+# it to be meaningful.  Otherwise, the actual reading of the p2p message from
+# the network will timeout before this timeout is ever hit.
 ROUND_TRIP_TIMEOUT = 20.0
 
 # Timeout used when performing the check to ensure peers are on the same side of chain splits as

--- a/trinity/protocol/common/peer.py
+++ b/trinity/protocol/common/peer.py
@@ -102,6 +102,16 @@ class BaseChainPeer(BasePeer):
             genesis_hash=genesis_hash,
         )
 
+    def setup_connection_tracker(self) -> BaseConnectionTracker:
+        if self.has_event_bus:
+            return ConnectionTrackerClient(self.get_event_bus())
+        else:
+            self.logger.warning(
+                "No event_bus set on peer.  Connection tracking falling back to "
+                "`NoopConnectionTracker`."
+            )
+            return NoopConnectionTracker()
+
 
 class BaseChainPeerFactory(BasePeerFactory):
     context: ChainContext
@@ -130,6 +140,6 @@ class BaseChainPeerPool(BasePeerPool):
 
     def setup_connection_tracker(self) -> BaseConnectionTracker:
         if self.has_event_bus:
-            return ConnectionTrackerClient(self.event_bus)
+            return ConnectionTrackerClient(self.get_event_bus())
         else:
             return NoopConnectionTracker()


### PR DESCRIPTION
- Part of https://github.com/ethereum/trinity/issues/520
- builds on https://github.com/ethereum/trinity/pull/554

### What was wrong?

In order to implement blacklisting for various peer interactions, we need access to the connection tracker from the peer instance.

### How was it fixed?

Adds a handle to the event bus to each peer.

Also includes these cleanups:

- Note about the round trip timeout
- Import ordering in `p2p.peer`
- rename `PeerPool.event_bus` to method `PeerPool.get_event_bus()` to make it a little clearer that something is going on under the hood.  (I don't like this API but it's simple and I figure we'll iterate on it)
- add version to the network-db sqlite database filename.  Makes for smoother upgrades and ease of development across different database versions.

#### Cute Animal Picture


![28d3ebe00d1c57f39fcb204020b29159](https://user-images.githubusercontent.com/824194/56931378-05217800-6a9d-11e9-8930-33af5eba6f02.jpg)
