### PR TITLE
Add test that scans Trinity shutdown for errors

### DIFF
--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -3,9 +3,17 @@ async def run_command_and_detect_errors(async_process_runner, command, time):
     Run the given ``command`` on the given ``async_process_runner`` for ``time`` seconds and
     throw an Exception in case any unresolved Exceptions are detected in the output of the command.
     """
-    lines_since_error = 0
     await async_process_runner.run(command, timeout_sec=time)
-    async for line in async_process_runner.stderr:
+    scan_for_errors(async_process_runner.stderr)
+
+
+async def scan_for_errors(async_iterable):
+    """
+    Consume the output produced by the async iterable and throw if it contains hints of an
+    uncaught exception.
+    """
+    lines_since_error = 0
+    async for line in async_iterable:
 
         # We detect errors by some string at the beginning of the Traceback and keep
         # counting lines from there to be able to read and report more valuable info

--- a/tests/integration/test_trinity_cli.py
+++ b/tests/integration/test_trinity_cli.py
@@ -1,4 +1,6 @@
+import signal
 import sys
+
 import pexpect
 import pytest
 
@@ -12,6 +14,7 @@ from eth.constants import (
 
 from tests.integration.helpers import (
     run_command_and_detect_errors,
+    scan_for_errors,
 )
 
 from trinity._utils.async_iter import (
@@ -176,3 +179,35 @@ async def test_logger(async_process_runner, command, expected_to_contain_log):
         "DiscoveryProtocol  >>> ping",
     })
     assert actually_contains_log == expected_to_contain_log
+
+
+@pytest.mark.parametrize(
+    'command',
+    (
+        ('trinity', ),
+    )
+)
+@pytest.mark.asyncio
+# Once we get Trinity to shutdown cleanly, we should remove the xfail so that the test ensures
+# ongoing clean exits.
+@pytest.mark.xfail
+async def test_shutdown(command, async_process_runner):
+
+    async def run_then_shutdown_and_yield_output():
+        await async_process_runner.run(command, timeout_sec=30)
+
+        # Somewhat arbitrary but we wait until the syncer starts before we trigger the shutdown.
+        # At this point, most of the internals should be set up, leaving us with more room for
+        # failure which is what we are looking for in this test.
+        trigger = "FastChainBodySyncer"
+        triggered = False
+        async for line in async_process_runner.stderr:
+            if trigger in line:
+                triggered = True
+                async_process_runner.kill(signal.SIGINT)
+
+            # We are only interested in the output that is created after we initiate the shutdown
+            if triggered:
+                yield line
+
+    await scan_for_errors(run_then_shutdown_and_yield_output())

--- a/trinity/tools/async_process_runner.py
+++ b/trinity/tools/async_process_runner.py
@@ -65,8 +65,8 @@ class AsyncProcessRunner():
         self.kill()
         raise TimeoutError(f'Killed process after {timeout_sec} seconds')
 
-    def kill(self) -> None:
+    def kill(self, sig: int = signal.SIGKILL) -> None:
         try:
-            os.killpg(os.getpgid(self.proc.pid), signal.SIGKILL)
+            os.killpg(os.getpgid(self.proc.pid), sig)
         except ProcessLookupError:
             self.logger.info("Process %s has already disappeared", self.proc.pid)


### PR DESCRIPTION
### What was wrong?

We currently do not have a test that ensures trinity exists cleanly.

### How was it fixed?

Added a test that does the following:

1. Run Trinity
2. Wait until the syncer starts its job
3. Send a `SIGINT`
4. Scan for errors in the following output

Notice that the test is currently marked as `xfail`. When we get rid of the failures, we'll remove the `xfail` so that the test can ensure ongoing clean exits.

[//]: # (For important changes, please add a new entry to the running release notes PR)
[//]: # (You can find the current one using: https://github.com/ethereum/trinity/pulls?q=is%3Aopen+is%3Apr+label%3A%22Release+Notes%22 )
[//]: # (See: https://trinity-client.readthedocs.io/en/latest/contributing.html#pull-requests)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](http://www.funkidslive.com/wp-content/uploads/2014/07/tiger-baby-1024x640.jpg)
