### PR TITLE
Remove mutable data structures from p2p.protocol classes

### DIFF
--- a/p2p/p2p_proto.py
+++ b/p2p/p2p_proto.py
@@ -28,13 +28,13 @@ if TYPE_CHECKING:
 class Hello(Command):
     _cmd_id = 0
     decode_strict = False
-    structure = [
+    structure = (
         ('version', sedes.big_endian_int),
         ('client_version_string', sedes.text),
         ('capabilities', sedes.CountableList(sedes.List([sedes.text, sedes.big_endian_int]))),
         ('listen_port', sedes.big_endian_int),
         ('remote_pubkey', sedes.binary)
-    ]
+    )
 
     def decompress_payload(self, raw_payload: bytes) -> bytes:
         # The `Hello` command doesn't support snappy compression
@@ -65,7 +65,7 @@ class DisconnectReason(enum.Enum):
 
 class Disconnect(Command):
     _cmd_id = 1
-    structure = [('reason', sedes.big_endian_int)]
+    structure = (('reason', sedes.big_endian_int),)
 
     def get_reason_name(self, reason_id: int) -> str:
         try:
@@ -93,7 +93,7 @@ class Pong(Command):
 class P2PProtocol(Protocol):
     name = 'p2p'
     version = 5
-    _commands = [Hello, Ping, Pong, Disconnect]
+    _commands = (Hello, Ping, Pong, Disconnect)
     cmd_length = 16
 
     def __init__(self, peer: 'BasePeer', snappy_support: bool) -> None:

--- a/p2p/p2p_proto.py
+++ b/p2p/p2p_proto.py
@@ -84,10 +84,12 @@ class Disconnect(Command):
 
 class Ping(Command):
     _cmd_id = 2
+    structure = ()
 
 
 class Pong(Command):
     _cmd_id = 3
+    structure = ()
 
 
 class P2PProtocol(Protocol):

--- a/p2p/protocol.py
+++ b/p2p/protocol.py
@@ -53,16 +53,15 @@ TRequestPayload = TypeVar('TRequestPayload', bound=PayloadType, covariant=True)
 _DecodedMsgType = PayloadType
 
 
-TStructure = Union[
+StructureType = Union[
     Tuple[Tuple[str, Any], ...],
-    sedes.CountableList,
 ]
 
 
 class Command:
     _cmd_id: int = None
     decode_strict = True
-    structure: TStructure
+    structure: StructureType
 
     _logger: logging.Logger = None
 
@@ -85,7 +84,7 @@ class Command:
         return f"{type(self).__name__} (cmd_id={self.cmd_id})"
 
     def encode_payload(self, data: Union[PayloadType, sedes.CountableList]) -> bytes:
-        if isinstance(data, dict):  # convert dict to ordered tuple
+        if isinstance(data, dict):
             if not isinstance(self.structure, tuple):
                 raise ValueError(
                     "Command.structure must be a list when data is a dict.  Got "
@@ -97,7 +96,8 @@ class Command:
                 raise ValueError(
                     f"Keys in data dict ({data_keys}) do not match expected keys ({expected_keys})"
                 )
-            data = [data[name] for name, _ in self.structure]
+            data = tuple(data[name] for name, _ in self.structure)
+
         if isinstance(self.structure, sedes.CountableList):
             encoder = self.structure
         else:

--- a/p2p/tools/paragon/commands.py
+++ b/p2p/tools/paragon/commands.py
@@ -7,21 +7,21 @@ from p2p.protocol import (
 
 class BroadcastData(Command):
     _cmd_id = 0
-    structure = [
+    structure = (
         ('data', sedes.binary),
-    ]
+    )
 
 
 class GetSum(Command):
     _cmd_id = 2
-    structure = [
+    structure = (
         ('a', sedes.big_endian_int),
         ('b', sedes.big_endian_int),
-    ]
+    )
 
 
 class Sum(Command):
     _cmd_id = 3
-    structure = [
+    structure = (
         ('result', sedes.big_endian_int),
-    ]
+    )

--- a/p2p/tools/paragon/proto.py
+++ b/p2p/tools/paragon/proto.py
@@ -19,10 +19,10 @@ from .commands import (
 class ParagonProtocol(Protocol):
     name = 'paragon'
     version = 1
-    _commands = [
+    _commands = (
         BroadcastData,
         GetSum, Sum,
-    ]
+    )
     cmd_length = 3
     logger = logging.getLogger("p2p.tools.paragon.proto.ParagonProtocol")
 

--- a/trinity/protocol/bcc/commands.py
+++ b/trinity/protocol/bcc/commands.py
@@ -92,6 +92,6 @@ class NewBeaconBlockMessage(TypedDict):
 
 class NewBeaconBlock(Command):
     _cmd_id = 4
-    structure = [
+    structure = (
         ('encoded_block', sedes.binary),
-    ]
+    )

--- a/trinity/protocol/bcc/commands.py
+++ b/trinity/protocol/bcc/commands.py
@@ -45,12 +45,12 @@ class StatusMessage(TypedDict):
 
 class Status(Command):
     _cmd_id = 0
-    structure = [
+    structure = (
         ('protocol_version', sedes.big_endian_int),
         ('network_id', sedes.big_endian_int),
         ('genesis_hash', sedes.binary),
         ('head_slot', sedes.big_endian_int),
-    ]
+    )
 
 
 class GetBeaconBlocksMessage(TypedDict):
@@ -61,11 +61,11 @@ class GetBeaconBlocksMessage(TypedDict):
 
 class GetBeaconBlocks(Command):
     _cmd_id = 1
-    structure = [
+    structure = (
         ('request_id', sedes.big_endian_int),
         ('block_slot_or_root', HashOrNumber()),
         ('max_blocks', sedes.big_endian_int),
-    ]
+    )
 
 
 class BeaconBlocksMessage(TypedDict):
@@ -75,10 +75,10 @@ class BeaconBlocksMessage(TypedDict):
 
 class BeaconBlocks(Command):
     _cmd_id = 2
-    structure = [
+    structure = (
         ('request_id', sedes.big_endian_int),
         ('encoded_blocks', sedes.CountableList(sedes.binary)),
-    ]
+    )
 
 
 class AttestationRecords(Command):

--- a/trinity/protocol/bcc/proto.py
+++ b/trinity/protocol/bcc/proto.py
@@ -40,7 +40,12 @@ if TYPE_CHECKING:
 class BCCProtocol(HasExtendedDebugLogger, Protocol):
     name = "bcc"
     version = 0
-    _commands = [Status, GetBeaconBlocks, BeaconBlocks, AttestationRecords, NewBeaconBlock]
+    _commands = (
+        Status,
+        GetBeaconBlocks, BeaconBlocks,
+        AttestationRecords,
+        NewBeaconBlock,
+    )
     cmd_length = 5
 
     peer: "BCCPeer"

--- a/trinity/protocol/eth/commands.py
+++ b/trinity/protocol/eth/commands.py
@@ -20,13 +20,13 @@ from trinity.rlp.sedes import HashOrNumber
 
 class Status(Command):
     _cmd_id = 0
-    structure = [
+    structure = (
         ('protocol_version', sedes.big_endian_int),
         ('network_id', sedes.big_endian_int),
         ('td', sedes.big_endian_int),
         ('best_hash', sedes.binary),
         ('genesis_hash', sedes.binary),
-    ]
+    )
 
 
 class NewBlockHashes(Command):
@@ -41,12 +41,12 @@ class Transactions(Command):
 
 class GetBlockHeaders(Command):
     _cmd_id = 3
-    structure = [
+    structure = (
         ('block_number_or_hash', HashOrNumber()),
         ('max_headers', sedes.big_endian_int),
         ('skip', sedes.big_endian_int),
         ('reverse', sedes.boolean),
-    ]
+    )
 
 
 class BlockHeaders(BaseBlockHeaders):
@@ -69,11 +69,12 @@ class BlockBodies(Command):
 
 class NewBlock(Command):
     _cmd_id = 7
-    structure = [
+    structure = (
         ('block', sedes.List([BlockHeader,
                               sedes.CountableList(BaseTransactionFields),
                               sedes.CountableList(BlockHeader)])),
-        ('total_difficulty', sedes.big_endian_int)]
+        ('total_difficulty', sedes.big_endian_int),
+    )
 
 
 class GetNodeData(Command):

--- a/trinity/protocol/eth/proto.py
+++ b/trinity/protocol/eth/proto.py
@@ -46,10 +46,16 @@ if TYPE_CHECKING:
 class ETHProtocol(HasExtendedDebugLogger, Protocol):
     name = 'eth'
     version = 63
-    _commands = [
-        Status, NewBlockHashes, Transactions, GetBlockHeaders, BlockHeaders,
-        GetBlockBodies, BlockBodies, NewBlock, GetNodeData, NodeData,
-        GetReceipts, Receipts]
+    _commands = (
+        Status,
+        NewBlockHashes,
+        Transactions,
+        GetBlockHeaders, BlockHeaders,
+        GetBlockBodies, BlockBodies,
+        NewBlock,
+        GetNodeData, NodeData,
+        GetReceipts, Receipts,
+    )
     cmd_length = 17
 
     peer: 'ETHPeer'

--- a/trinity/protocol/les/commands.py
+++ b/trinity/protocol/les/commands.py
@@ -93,7 +93,7 @@ class Status(Command):
 
 class Announce(Command):
     _cmd_id = 1
-    structure = [
+    structure = (
         ('head_hash', sedes.binary),
         ('head_number', sedes.big_endian_int),
         ('head_td', sedes.big_endian_int),
@@ -101,33 +101,33 @@ class Announce(Command):
         # TODO: The params CountableList may contain any of the values from the
         # Status msg.  Need to extend this command to process that too.
         ('params', sedes.CountableList(sedes.List([sedes.text, sedes.raw]))),
-    ]
+    )
 
 
 class GetBlockHeadersQuery(rlp.Serializable):
-    fields = [
+    fields = (
         ('block_number_or_hash', HashOrNumber()),
         ('max_headers', sedes.big_endian_int),
         ('skip', sedes.big_endian_int),
         ('reverse', sedes.boolean),
-    ]
+    )
 
 
 class GetBlockHeaders(Command):
     _cmd_id = 2
-    structure = [
+    structure = (
         ('request_id', sedes.big_endian_int),
         ('query', GetBlockHeadersQuery),
-    ]
+    )
 
 
 class BlockHeaders(BaseBlockHeaders):
     _cmd_id = 3
-    structure = [
+    structure = (
         ('request_id', sedes.big_endian_int),
         ('buffer_value', sedes.big_endian_int),
         ('headers', sedes.CountableList(BlockHeader)),
-    ]
+    )
 
     def extract_headers(self, msg: _DecodedMsgType) -> Tuple[BlockHeader, ...]:
         msg = cast(Dict[str, Any], msg)
@@ -136,62 +136,62 @@ class BlockHeaders(BaseBlockHeaders):
 
 class GetBlockBodies(Command):
     _cmd_id = 4
-    structure = [
+    structure = (
         ('request_id', sedes.big_endian_int),
         ('block_hashes', sedes.CountableList(sedes.binary)),
-    ]
+    )
 
 
 class BlockBodies(Command):
     _cmd_id = 5
-    structure = [
+    structure = (
         ('request_id', sedes.big_endian_int),
         ('buffer_value', sedes.big_endian_int),
         ('bodies', sedes.CountableList(BlockBody)),
-    ]
+    )
 
 
 class GetReceipts(Command):
     _cmd_id = 6
-    structure = [
+    structure = (
         ('request_id', sedes.big_endian_int),
         ('block_hashes', sedes.CountableList(sedes.binary)),
-    ]
+    )
 
 
 class Receipts(Command):
     _cmd_id = 7
-    structure = [
+    structure = (
         ('request_id', sedes.big_endian_int),
         ('buffer_value', sedes.big_endian_int),
         ('receipts', sedes.CountableList(sedes.CountableList(Receipt))),
-    ]
+    )
 
 
 class ProofRequest(rlp.Serializable):
-    fields = [
+    fields = (
         ('block_hash', sedes.binary),
         ('account_key', sedes.binary),
         ('key', sedes.binary),
         ('from_level', sedes.big_endian_int),
-    ]
+    )
 
 
 class GetProofs(Command):
     _cmd_id = 8
-    structure = [
+    structure = (
         ('request_id', sedes.big_endian_int),
         ('proof_requests', sedes.CountableList(ProofRequest)),
-    ]
+    )
 
 
 class Proofs(Command):
     _cmd_id = 9
-    structure = [
+    structure = (
         ('request_id', sedes.big_endian_int),
         ('buffer_value', sedes.big_endian_int),
         ('proofs', sedes.CountableList(sedes.CountableList(sedes.raw))),
-    ]
+    )
 
     def decode_payload(self, rlp_data: bytes) -> _DecodedMsgType:
         decoded = super().decode_payload(rlp_data)
@@ -207,27 +207,27 @@ class Proofs(Command):
 
 
 class ContractCodeRequest(rlp.Serializable):
-    fields = [
+    fields = (
         ('block_hash', sedes.binary),
         ('key', sedes.binary),
-    ]
+    )
 
 
 class GetContractCodes(Command):
     _cmd_id = 10
-    structure = [
+    structure = (
         ('request_id', sedes.big_endian_int),
         ('code_requests', sedes.CountableList(ContractCodeRequest)),
-    ]
+    )
 
 
 class ContractCodes(Command):
     _cmd_id = 11
-    structure = [
+    structure = (
         ('request_id', sedes.big_endian_int),
         ('buffer_value', sedes.big_endian_int),
         ('codes', sedes.CountableList(sedes.binary)),
-    ]
+    )
 
 
 class StatusV2(Status):
@@ -244,8 +244,8 @@ class GetProofsV2(GetProofs):
 
 class ProofsV2(Command):
     _cmd_id = 16
-    structure = [
+    structure = (
         ('request_id', sedes.big_endian_int),
         ('buffer_value', sedes.big_endian_int),
         ('proof', sedes.CountableList(sedes.raw)),
-    ]
+    )

--- a/trinity/protocol/les/proto.py
+++ b/trinity/protocol/les/proto.py
@@ -48,8 +48,15 @@ if TYPE_CHECKING:
 class LESProtocol(Protocol):
     name = 'les'
     version = 1
-    _commands = [Status, Announce, BlockHeaders, GetBlockHeaders, BlockBodies, Receipts, Proofs,
-                 ContractCodes]
+    _commands = (
+        Status,
+        Announce,
+        BlockHeaders, GetBlockHeaders,
+        BlockBodies,
+        Receipts,
+        Proofs,
+        ContractCodes,
+    )
     cmd_length = 15
     peer: 'LESPeer'
 
@@ -170,8 +177,15 @@ class LESProtocol(Protocol):
 
 class LESProtocolV2(LESProtocol):
     version = 2
-    _commands = [StatusV2, Announce, BlockHeaders, GetBlockHeaders, BlockBodies, Receipts,
-                 ProofsV2, ContractCodes]
+    _commands = (  # type: ignore  # mypy doesn't like us overriding this.
+        StatusV2,
+        Announce,
+        BlockHeaders, GetBlockHeaders,
+        BlockBodies,
+        Receipts,
+        ProofsV2,
+        ContractCodes,
+    )
     cmd_length = 21
 
     def send_handshake(self, chain_info: ChainInfo) -> None:


### PR DESCRIPTION
### What was wrong?

The `p2p.protocol.Command` and `p2p.protocol.Protocol` classes were defined with mutable data structures.

### How was it fixed?

Replaced them with immutable data structures.

#### Cute Animal Picture

![e99379dd8b2cc14ec34e75988feac46d](https://user-images.githubusercontent.com/824194/56982744-38b4de80-6b3f-11e9-87bf-8705d438a612.jpg)

