### PR TITLE
Extract low level peer networking into transport class

### DIFF
--- a/p2p/peer.py
+++ b/p2p/peer.py
@@ -88,7 +88,7 @@ async def handshake(remote: Node, factory: 'BasePeerFactory') -> 'BasePeer':
     handshake or if none of the sub-protocols supported by us is also
     supported by the remote.
     """
-    transport = await Transport.handshake(
+    transport = await Transport.connect(
         remote,
         factory.privkey,
         factory.cancel_token,

--- a/p2p/peer.py
+++ b/p2p/peer.py
@@ -75,7 +75,8 @@ if TYPE_CHECKING:
 
 
 async def handshake(remote: Node, factory: 'BasePeerFactory') -> 'BasePeer':
-    """Perform the auth and P2P handshakes with the given remote.
+    """
+    Perform the auth and P2P handshakes with the given remote.
 
     Return an instance of the given peer_class (must be a subclass of
     BasePeer) connected to that remote in case both handshakes are
@@ -87,7 +88,7 @@ async def handshake(remote: Node, factory: 'BasePeerFactory') -> 'BasePeer':
     handshake or if none of the sub-protocols supported by us is also
     supported by the remote.
     """
-    transport = await Transport.open_connection(
+    transport = await Transport.handshake(
         remote,
         factory.privkey,
         factory.cancel_token,
@@ -205,9 +206,6 @@ class BasePeer(BaseService):
 
     def __repr__(self) -> str:
         return f"{self.__class__.__name__} {self.remote!r}"
-
-    def __hash__(self) -> int:
-        return hash(self.remote)
 
     #
     # Proxy Transport attributes
@@ -357,7 +355,6 @@ class BasePeer(BaseService):
                 return
 
     async def read_msg(self) -> Tuple[Command, PayloadType]:
-        # TODO: Transport class needs a cancel token for proper cancellation
         msg = await self.transport.recv(self.cancel_token)
         cmd = self.get_protocol_command_for(msg)
         # NOTE: This used to be a bottleneck but it doesn't seem to be so anymore. If we notice

--- a/p2p/protocol.py
+++ b/p2p/protocol.py
@@ -4,6 +4,7 @@ import operator
 import struct
 from typing import (
     Any,
+    ClassVar,
     Dict,
     Generic,
     Iterable,
@@ -12,7 +13,6 @@ from typing import (
     Tuple,
     Type,
     TypeVar,
-    TYPE_CHECKING,
     Union,
 )
 
@@ -30,15 +30,11 @@ from rlp import sedes
 
 from eth.constants import NULL_BYTE
 
+from p2p._utils import get_devp2p_cmd_id
 from p2p.exceptions import (
     MalformedMessage,
 )
-from p2p._utils import get_devp2p_cmd_id
-
-# Workaround for import cycles caused by type annotations:
-# http://mypy.readthedocs.io/en/latest/common_issues.html#import-cycles
-if TYPE_CHECKING:
-    from p2p.peer import BasePeer  # noqa: F401
+from p2p.transport import Transport
 
 
 class TypedDictPayload(TypedDict):
@@ -193,18 +189,18 @@ class BaseRequest(ABC, Generic[TRequestPayload]):
 CapabilityType = Tuple[str, int]
 
 
-class Protocol:
-    peer: 'BasePeer'
-    name: str = None
-    version: int = None
+class Protocol(ABC):
+    transport: Transport
+    name: ClassVar[str]
+    version: ClassVar[int]
     cmd_length: int = None
     # Command classes that this protocol supports.
     _commands: Tuple[Type[Command], ...]
 
     _logger: logging.Logger = None
 
-    def __init__(self, peer: 'BasePeer', cmd_id_offset: int, snappy_support: bool) -> None:
-        self.peer = peer
+    def __init__(self, transport: Transport, cmd_id_offset: int, snappy_support: bool) -> None:
+        self.transport = transport
         self.cmd_id_offset = cmd_id_offset
         self.snappy_support = snappy_support
         self.commands = [cmd_class(cmd_id_offset, snappy_support) for cmd_class in self._commands]
@@ -217,13 +213,10 @@ class Protocol:
             self._logger = logging.getLogger(f"p2p.protocol.{type(self).__name__}")
         return self._logger
 
-    def send(self, header: bytes, body: bytes) -> None:
-        self.peer.send(header, body)
-
     def send_request(self, request: BaseRequest[PayloadType]) -> None:
         command = self.cmd_by_type[request.cmd_type]
         header, body = command.encode(request.command_payload)
-        self.send(header, body)
+        self.transport.send(header, body)
 
     def supports_command(self, cmd_type: Type[Command]) -> bool:
         return cmd_type in self.cmd_by_type

--- a/p2p/tools/paragon/helpers.py
+++ b/p2p/tools/paragon/helpers.py
@@ -29,11 +29,11 @@ from p2p.p2p_proto import (
 from p2p.peer import (
     BasePeer,
     BasePeerFactory,
-    PeerConnection,
 )
 from p2p.protocol import (
     match_protocols_with_capabilities,
 )
+from p2p.transport import Transport
 
 
 from .peer import (
@@ -131,7 +131,9 @@ async def get_directly_linked_peers_without_handshake(
         aes_secret, mac_secret, egress_mac, ingress_mac = await auth._handshake(
             initiator, alice_reader, alice_writer, cancel_token)
 
-        connection = PeerConnection(
+        transport = Transport(
+            remote=alice_remote,
+            private_key=alice_factory.privkey,
             reader=alice_reader,
             writer=alice_writer,
             aes_secret=aes_secret,
@@ -139,10 +141,7 @@ async def get_directly_linked_peers_without_handshake(
             egress_mac=egress_mac,
             ingress_mac=ingress_mac,
         )
-        alice = alice_factory.create_peer(
-            alice_remote,
-            connection,
-        )
+        alice = alice_factory.create_peer(transport)
 
         f_alice.set_result(alice)
         handshake_finished.set()
@@ -166,9 +165,11 @@ async def get_directly_linked_peers_without_handshake(
     aes_secret, mac_secret, egress_mac, ingress_mac = responder.derive_secrets(
         initiator_nonce, responder_nonce, initiator_ephemeral_pubkey,
         auth_cipher, auth_ack_ciphertext)
-    assert egress_mac.digest() == alice.ingress_mac.digest()
-    assert ingress_mac.digest() == alice.egress_mac.digest()
-    connection = PeerConnection(
+    assert egress_mac.digest() == alice.transport._ingress_mac.digest()
+    assert ingress_mac.digest() == alice.transport._egress_mac.digest()
+    transport = Transport(
+        remote=bob_remote,
+        private_key=bob_factory.privkey,
         reader=bob_reader,
         writer=bob_writer,
         aes_secret=aes_secret,
@@ -176,10 +177,7 @@ async def get_directly_linked_peers_without_handshake(
         egress_mac=egress_mac,
         ingress_mac=ingress_mac,
     )
-    bob = bob_factory.create_peer(
-        bob_remote,
-        connection,
-    )
+    bob = bob_factory.create_peer(transport)
 
     return alice, bob
 
@@ -256,7 +254,7 @@ async def process_v4_p2p_handshake(
     )
     if len(matched_proto_classes) == 1:
         self.sub_proto = matched_proto_classes[0](
-            self,
+            self.transport,
             self.base_protocol.cmd_length,
             snappy_support,
         )
@@ -292,9 +290,8 @@ async def get_directly_linked_v4_and_v5_peers(
     )
 
     # Tweaking the P2P Protocol Versions for Alice
-    alice.base_protocol.version = 4
-    # The below type ignore is because mypy still doesn't support method overwrites
-    alice.process_p2p_handshake = MethodType(process_v4_p2p_handshake, alice)  # type: ignore
+    alice.base_protocol.version = 4  # type: ignore  # mypy doesn't like us overwriting class variables  # noqa: E501
+    alice.process_p2p_handshake = MethodType(process_v4_p2p_handshake, alice)  # type: ignore  # mypy still support method overwrites  # noqa: E501
 
     # Perform the base protocol (P2P) handshake.
     await asyncio.gather(alice.do_p2p_handshake(), bob.do_p2p_handshake())

--- a/p2p/tools/paragon/proto.py
+++ b/p2p/tools/paragon/proto.py
@@ -33,7 +33,7 @@ class ParagonProtocol(Protocol):
         cmd = BroadcastData(self.cmd_id_offset, self.snappy_support)
         msg: Dict[str, Any] = {'data': data}
         header, body = cmd.encode(msg)
-        self.send(header, body)
+        self.transport.send(header, body)
 
     #
     # Sum
@@ -42,10 +42,10 @@ class ParagonProtocol(Protocol):
         cmd = GetSum(self.cmd_id_offset, self.snappy_support)
         msg: Dict[str, Any] = {'a': value_a, 'b': value_b}
         header, body = cmd.encode(msg)
-        self.send(header, body)
+        self.transport.send(header, body)
 
     def send_sum(self, result: int) -> None:
         cmd = GetSum(self.cmd_id_offset, self.snappy_support)
         msg: Dict[str, Any] = {'result': result}
         header, body = cmd.encode(msg)
-        self.send(header, body)
+        self.transport.send(header, body)

--- a/p2p/transport.py
+++ b/p2p/transport.py
@@ -74,10 +74,10 @@ class Transport:
         self._mac_enc = mac_cipher.encryptor().update
 
     @classmethod
-    async def handshake(cls,
-                        remote: Node,
-                        private_key: datatypes.PrivateKey,
-                        token: CancelToken) -> 'Transport':
+    async def connect(cls,
+                      remote: Node,
+                      private_key: datatypes.PrivateKey,
+                      token: CancelToken) -> 'Transport':
         """Perform the auth and P2P handshakes with the given remote.
 
         Return an instance of the given peer_class (must be a subclass of

--- a/p2p/transport.py
+++ b/p2p/transport.py
@@ -74,11 +74,10 @@ class Transport:
         self._mac_enc = mac_cipher.encryptor().update
 
     @classmethod
-    async def open_connection(cls,
-                              remote: Node,
-                              private_key: datatypes.PrivateKey,
-                              token: CancelToken) -> 'Transport':
-        # TODO: what do we name this method....
+    async def handshake(cls,
+                        remote: Node,
+                        private_key: datatypes.PrivateKey,
+                        token: CancelToken) -> 'Transport':
         """Perform the auth and P2P handshakes with the given remote.
 
         Return an instance of the given peer_class (must be a subclass of

--- a/p2p/transport.py
+++ b/p2p/transport.py
@@ -1,0 +1,244 @@
+import asyncio
+import hmac
+import logging
+import struct
+from typing import cast
+
+import sha3
+
+from cryptography.hazmat.backends import default_backend
+from cryptography.hazmat.primitives.ciphers import Cipher, algorithms, modes
+
+from cached_property import cached_property
+
+from cancel_token import CancelToken
+
+import rlp
+
+from eth_keys import datatypes
+
+from eth.tools.logging import ExtendedDebugLogger
+
+from p2p import auth
+from p2p._utils import (
+    roundup_16,
+    sxor,
+)
+from p2p.constants import (
+    CONN_IDLE_TIMEOUT,
+    HEADER_LEN,
+    MAC_LEN,
+)
+from p2p.exceptions import (
+    DecryptionError,
+    MalformedMessage,
+    PeerConnectionLost,
+    UnreachablePeer,
+)
+from p2p.kademlia import Node
+
+
+class Transport:
+    logger = cast(ExtendedDebugLogger, logging.getLogger('p2p.connection.Transport'))
+
+    def __init__(self,
+                 remote: Node,
+                 private_key: datatypes.PrivateKey,
+                 reader: asyncio.StreamReader,
+                 writer: asyncio.StreamWriter,
+                 aes_secret: bytes,
+                 mac_secret: bytes,
+                 egress_mac: sha3.keccak_256,
+                 ingress_mac: sha3.keccak_256) -> None:
+        self.remote = remote
+
+        self._private_key = private_key
+
+        # Encryption and Cryptography *stuff*
+        self._egress_mac = egress_mac
+        self._ingress_mac = ingress_mac
+
+        self._reader = reader
+        self._writer = writer
+
+        # FIXME: Insecure Encryption: https://github.com/ethereum/devp2p/issues/32
+        iv = b"\x00" * 16
+        aes_secret = aes_secret
+        mac_secret = mac_secret
+
+        aes_cipher = Cipher(algorithms.AES(aes_secret), modes.CTR(iv), default_backend())
+        self._aes_enc = aes_cipher.encryptor()
+        self._aes_dec = aes_cipher.decryptor()
+
+        mac_cipher = Cipher(algorithms.AES(mac_secret), modes.ECB(), default_backend())
+        self._mac_enc = mac_cipher.encryptor().update
+
+    @classmethod
+    async def open_connection(cls,
+                              remote: Node,
+                              private_key: datatypes.PrivateKey,
+                              token: CancelToken) -> 'Transport':
+        # TODO: what do we name this method....
+        """Perform the auth and P2P handshakes with the given remote.
+
+        Return an instance of the given peer_class (must be a subclass of
+        BasePeer) connected to that remote in case both handshakes are
+        successful and at least one of the sub-protocols supported by
+        peer_class is also supported by the remote.
+
+        Raises UnreachablePeer if we cannot connect to the peer or
+        HandshakeFailure if the remote disconnects before completing the
+        handshake or if none of the sub-protocols supported by us is also
+        supported by the remote.
+        """
+        try:
+            (aes_secret,
+             mac_secret,
+             egress_mac,
+             ingress_mac,
+             reader,
+             writer
+             ) = await auth.handshake(remote, private_key, token)
+        except (ConnectionRefusedError, OSError) as e:
+            raise UnreachablePeer(f"Can't reach {remote!r}") from e
+
+        return cls(
+            remote=remote,
+            private_key=private_key,
+            reader=reader,
+            writer=writer,
+            aes_secret=aes_secret,
+            mac_secret=mac_secret,
+            egress_mac=egress_mac,
+            ingress_mac=ingress_mac,
+        )
+
+    @cached_property
+    def public_key(self) -> datatypes.PublicKey:
+        return self._private_key.public_key
+
+    async def read(self, n: int, token: CancelToken) -> bytes:
+        self.logger.debug2("Waiting for %s bytes from %s", n, self.remote)
+        try:
+            return await token.cancellable_wait(
+                self._reader.readexactly(n),
+                timeout=CONN_IDLE_TIMEOUT,
+            )
+        except (asyncio.IncompleteReadError, ConnectionResetError, BrokenPipeError) as e:
+            raise PeerConnectionLost(repr(e))
+
+    def write(self, data: bytes) -> None:
+        self._writer.write(data)
+
+    async def recv(self, token: CancelToken) -> bytes:
+        header_data = await self.read(HEADER_LEN + MAC_LEN, token)
+        try:
+            header = self._decrypt_header(header_data)
+        except DecryptionError as err:
+            self.logger.debug(
+                "Bad message header from peer %s: Error: %r",
+                self, err,
+            )
+            raise MalformedMessage from err
+        frame_size = self._get_frame_size(header)
+        # The frame_size specified in the header does not include the padding to 16-byte boundary,
+        # so need to do this here to ensure we read all the frame's data.
+        read_size = roundup_16(frame_size)
+        frame_data = await self.read(read_size + MAC_LEN, token)
+        try:
+            msg = self._decrypt_body(frame_data, frame_size)
+        except DecryptionError as err:
+            self.logger.debug(
+                "Bad message body from peer %s: Error: %r",
+                self, err,
+            )
+            raise MalformedMessage from err
+        return msg
+
+    def send(self, header: bytes, body: bytes) -> None:
+        cmd_id = rlp.decode(body[:1], sedes=rlp.sedes.big_endian_int)
+        self.logger.debug2("Sending msg with cmd id %d to %s", cmd_id, self)
+        if self.is_closing:
+            self.logger.error(
+                "Attempted to send msg with cmd id %d to disconnected peer %s", cmd_id, self)
+            return
+        self.write(self._encrypt(header, body))
+
+    def close(self) -> None:
+        """Close this peer's reader/writer streams.
+
+        This will cause the peer to stop in case it is running.
+
+        If the streams have already been closed, do nothing.
+        """
+        if not self._reader.at_eof():
+            self._reader.feed_eof()
+        self._writer.close()
+
+    @property
+    def is_closing(self) -> bool:
+        return self._writer.transport.is_closing()
+
+    def _encrypt(self, header: bytes, frame: bytes) -> bytes:
+        if len(header) != HEADER_LEN:
+            raise ValueError(f"Unexpected header length: {len(header)}")
+
+        header_ciphertext = self._aes_enc.update(header)
+        mac_secret = self._egress_mac.digest()[:HEADER_LEN]
+        self._egress_mac.update(sxor(self._mac_enc(mac_secret), header_ciphertext))
+        header_mac = self._egress_mac.digest()[:HEADER_LEN]
+
+        frame_ciphertext = self._aes_enc.update(frame)
+        self._egress_mac.update(frame_ciphertext)
+        fmac_seed = self._egress_mac.digest()[:HEADER_LEN]
+
+        mac_secret = self._egress_mac.digest()[:HEADER_LEN]
+        self._egress_mac.update(sxor(self._mac_enc(mac_secret), fmac_seed))
+        frame_mac = self._egress_mac.digest()[:HEADER_LEN]
+
+        return header_ciphertext + header_mac + frame_ciphertext + frame_mac
+
+    def _decrypt_header(self, data: bytes) -> bytes:
+        if len(data) != HEADER_LEN + MAC_LEN:
+            raise ValueError(
+                f"Unexpected header length: {len(data)}, expected {HEADER_LEN} + {MAC_LEN}"
+            )
+
+        header_ciphertext = data[:HEADER_LEN]
+        header_mac = data[HEADER_LEN:]
+        mac_secret = self._ingress_mac.digest()[:HEADER_LEN]
+        aes = self._mac_enc(mac_secret)[:HEADER_LEN]
+        self._ingress_mac.update(sxor(aes, header_ciphertext))
+        expected_header_mac = self._ingress_mac.digest()[:HEADER_LEN]
+        if not hmac.compare_digest(expected_header_mac, header_mac):
+            raise DecryptionError(
+                f'Invalid header mac: expected {expected_header_mac}, got {header_mac}'
+            )
+        return self._aes_dec.update(header_ciphertext)
+
+    def _decrypt_body(self, data: bytes, body_size: int) -> bytes:
+        read_size = roundup_16(body_size)
+        if len(data) < read_size + MAC_LEN:
+            raise ValueError(
+                f'Insufficient body length; Got {len(data)}, wanted {read_size} + {MAC_LEN}'
+            )
+
+        frame_ciphertext = data[:read_size]
+        frame_mac = data[read_size:read_size + MAC_LEN]
+
+        self._ingress_mac.update(frame_ciphertext)
+        fmac_seed = self._ingress_mac.digest()[:MAC_LEN]
+        self._ingress_mac.update(sxor(self._mac_enc(fmac_seed), fmac_seed))
+        expected_frame_mac = self._ingress_mac.digest()[:MAC_LEN]
+        if not hmac.compare_digest(expected_frame_mac, frame_mac):
+            raise DecryptionError(
+                f'Invalid frame mac: expected {expected_frame_mac}, got {frame_mac}'
+            )
+        return self._aes_dec.update(frame_ciphertext)[:body_size]
+
+    def _get_frame_size(self, header: bytes) -> int:
+        # The frame size is encoded in the header as a 3-byte int, so before we unpack we need
+        # to prefix it with an extra byte.
+        encoded_size = b'\x00' + header[:3]
+        (size,) = struct.unpack(b'>I', encoded_size)
+        return size

--- a/setup.py
+++ b/setup.py
@@ -8,6 +8,7 @@ deps = {
     'p2p': [
         "asyncio-cancel-token==0.1.0a2",
         "async_lru>=0.1.0,<1.0.0",
+        "cached-property>=1.5.1,<2",
         # cryptography does not use semver and allows breaking changes within `0.3` version bumps.
         "cryptography>=2.5,<2.7",
         "eth-hash>=0.1.4,<1",

--- a/tests/core/p2p-proto/bcc/helpers.py
+++ b/tests/core/p2p-proto/bcc/helpers.py
@@ -180,8 +180,8 @@ async def get_directly_linked_peers_in_peer_pools(request,
         alice_chain_db=alice_chain_db,
         bob_chain_db=bob_chain_db,
     )
-    alice_peer_pool = BCCPeerPool(alice.privkey, alice.context)
-    bob_peer_pool = BCCPeerPool(bob.privkey, bob.context)
+    alice_peer_pool = BCCPeerPool(alice.transport._private_key, alice.context)
+    bob_peer_pool = BCCPeerPool(bob.transport._private_key, bob.context)
 
     asyncio.ensure_future(alice_peer_pool.run())
     asyncio.ensure_future(bob_peer_pool.run())

--- a/tests/p2p/test_auth.py
+++ b/tests/p2p/test_auth.py
@@ -10,18 +10,18 @@ from cancel_token import CancelToken
 
 from p2p import ecies
 from p2p import kademlia
-from p2p.p2p_proto import Hello
 from p2p.auth import (
     HandshakeInitiator,
     HandshakeResponder,
 )
 from p2p.auth import decode_authentication
-from p2p.peer import PeerConnection
+from p2p.p2p_proto import Hello
 from p2p.tools.paragon import (
     ParagonPeer,
     ParagonContext,
     get_directly_connected_streams,
 )
+from p2p.transport import Transport
 
 
 from tests.p2p.auth_constants import (
@@ -110,7 +110,9 @@ async def test_handshake():
         (initiator_reader, initiator_writer),
     ) = get_directly_connected_streams()
 
-    initiator_connection = PeerConnection(
+    initiator_transport = Transport(
+        remote=initiator_remote,
+        private_key=initiator.privkey,
         reader=initiator_reader,
         writer=initiator_writer,
         aes_secret=initiator_aes_secret,
@@ -119,13 +121,13 @@ async def test_handshake():
         ingress_mac=initiator_ingress_mac
     )
     initiator_peer = ParagonPeer(
-        remote=initiator.remote,
-        privkey=initiator.privkey,
-        connection=initiator_connection,
+        transport=initiator_transport,
         context=ParagonContext(),
     )
     initiator_peer.base_protocol.send_handshake()
-    responder_connection = PeerConnection(
+    responder_transport = Transport(
+        remote=responder_remote,
+        private_key=responder.privkey,
         reader=responder_reader,
         writer=responder_writer,
         aes_secret=aes_secret,
@@ -134,9 +136,7 @@ async def test_handshake():
         ingress_mac=ingress_mac,
     )
     responder_peer = ParagonPeer(
-        remote=responder.remote,
-        privkey=responder.privkey,
-        connection=responder_connection,
+        transport=responder_transport,
         context=ParagonContext(),
     )
     responder_peer.base_protocol.send_handshake()
@@ -220,7 +220,9 @@ async def test_handshake_eip8():
         (initiator_reader, initiator_writer),
     ) = get_directly_connected_streams()
 
-    initiator_connection = PeerConnection(
+    initiator_transport = Transport(
+        remote=initiator_remote,
+        private_key=initiator.privkey,
         reader=initiator_reader,
         writer=initiator_writer,
         aes_secret=initiator_aes_secret,
@@ -229,13 +231,13 @@ async def test_handshake_eip8():
         ingress_mac=initiator_ingress_mac
     )
     initiator_peer = ParagonPeer(
-        remote=initiator.remote,
-        privkey=initiator.privkey,
-        connection=initiator_connection,
+        transport=initiator_transport,
         context=ParagonContext(),
     )
     initiator_peer.base_protocol.send_handshake()
-    responder_connection = PeerConnection(
+    responder_transport = Transport(
+        remote=responder_remote,
+        private_key=responder.privkey,
         reader=responder_reader,
         writer=responder_writer,
         aes_secret=aes_secret,
@@ -244,9 +246,7 @@ async def test_handshake_eip8():
         ingress_mac=ingress_mac,
     )
     responder_peer = ParagonPeer(
-        remote=responder.remote,
-        privkey=responder.privkey,
-        connection=responder_connection,
+        transport=responder_transport,
         context=ParagonContext(),
     )
     responder_peer.base_protocol.send_handshake()

--- a/trinity/protocol/bcc/peer.py
+++ b/trinity/protocol/bcc/peer.py
@@ -59,7 +59,7 @@ class BCCPeer(BasePeer):
             BeaconBlock,
         )
         head = await self.chain_db.coro_get_canonical_head(BeaconBlock)
-        self.sub_proto.send_handshake(genesis.signing_root, head.slot)
+        self.sub_proto.send_handshake(genesis.signing_root, head.slot, self.network_id)
 
     async def process_sub_proto_handshake(self, cmd: Command, msg: _DecodedMsgType) -> None:
         if not isinstance(cmd, Status):

--- a/trinity/protocol/common/peer.py
+++ b/trinity/protocol/common/peer.py
@@ -48,6 +48,8 @@ class ChainInfo(NamedTuple):
     total_difficulty: int
     genesis_hash: Hash32
 
+    network_id: int
+
 
 class BaseChainPeer(BasePeer):
     boot_manager_class = DAOCheckBootManager
@@ -100,6 +102,7 @@ class BaseChainPeer(BasePeer):
             block_hash=head.hash,
             total_difficulty=total_difficulty,
             genesis_hash=genesis_hash,
+            network_id=self.local_network_id,
         )
 
     def setup_connection_tracker(self) -> BaseConnectionTracker:

--- a/trinity/protocol/common/validators.py
+++ b/trinity/protocol/common/validators.py
@@ -108,10 +108,21 @@ class BaseBlockHeadersValidator(BaseValidator[Tuple[BlockHeader, ...]]):
     def _is_numbered(self) -> bool:
         return isinstance(self.block_number_or_hash, int)
 
+    @property
+    def block_identifier(self) -> str:
+        if isinstance(self.block_number_or_hash, int):
+            return str(self.block_number_or_hash)
+        elif isinstance(self.block_number_or_hash, bytes):
+            return humanize_hash(self.block_number_or_hash)
+        else:
+            raise Exception(
+                f"Unexpected type for block identifier: "
+                f"{type(self.block_number_or_hash)}"
+            )
+
     def _get_formatted_params(self) -> str:
-        identifier = self.block_number_or_hash
         return (
-            f'ident: {identifier if self._is_numbered else humanize_hash(identifier)}  '  # type: ignore  # mypy doesn't know `identifier` is a Hash32  # noqa: E501
+            f'ident: {self.block_identifier}  '
             f'max={self.max_headers}  '
             f'skip={self.skip}  '
             f'reverse={self.reverse}'

--- a/trinity/protocol/common/validators.py
+++ b/trinity/protocol/common/validators.py
@@ -111,7 +111,7 @@ class BaseBlockHeadersValidator(BaseValidator[Tuple[BlockHeader, ...]]):
     def _get_formatted_params(self) -> str:
         identifier = self.block_number_or_hash
         return (
-            f'ident: {identifier if self._is_numbered else humanize_hash(identifier)}  '  # type: ignore  # mypy doesn't know that identifier is of the right type  # noqa: E501
+            f'ident: {identifier if self._is_numbered else humanize_hash(identifier)}  '  # type: ignore  # mypy doesn't know `identifier` is a Hash32  # noqa: E501
             f'max={self.max_headers}  '
             f'skip={self.skip}  '
             f'reverse={self.reverse}'

--- a/trinity/protocol/eth/proto.py
+++ b/trinity/protocol/eth/proto.py
@@ -63,14 +63,14 @@ class ETHProtocol(HasExtendedDebugLogger, Protocol):
     def send_handshake(self, chain_info: ChainInfo) -> None:
         resp = {
             'protocol_version': self.version,
-            'network_id': self.peer.local_network_id,
+            'network_id': chain_info.network_id,
             'td': chain_info.total_difficulty,
             'best_hash': chain_info.block_hash,
             'genesis_hash': chain_info.genesis_hash,
         }
         cmd = Status(self.cmd_id_offset, self.snappy_support)
         self.logger.debug2("Sending ETH/Status msg: %s", resp)
-        self.send(*cmd.encode(resp))
+        self.transport.send(*cmd.encode(resp))
 
     #
     # Node Data
@@ -78,12 +78,12 @@ class ETHProtocol(HasExtendedDebugLogger, Protocol):
     def send_get_node_data(self, node_hashes: Tuple[Hash32, ...]) -> None:
         cmd = GetNodeData(self.cmd_id_offset, self.snappy_support)
         header, body = cmd.encode(node_hashes)
-        self.send(header, body)
+        self.transport.send(header, body)
 
     def send_node_data(self, nodes: Tuple[bytes, ...]) -> None:
         cmd = NodeData(self.cmd_id_offset, self.snappy_support)
         header, body = cmd.encode(nodes)
-        self.send(header, body)
+        self.transport.send(header, body)
 
     #
     # Block Headers
@@ -108,12 +108,12 @@ class ETHProtocol(HasExtendedDebugLogger, Protocol):
             'reverse': reverse
         }
         header, body = cmd.encode(data)
-        self.send(header, body)
+        self.transport.send(header, body)
 
     def send_block_headers(self, headers: Tuple[BlockHeader, ...]) -> None:
         cmd = BlockHeaders(self.cmd_id_offset, self.snappy_support)
         header, body = cmd.encode(headers)
-        self.send(header, body)
+        self.transport.send(header, body)
 
     #
     # Block Bodies
@@ -121,12 +121,12 @@ class ETHProtocol(HasExtendedDebugLogger, Protocol):
     def send_get_block_bodies(self, block_hashes: Tuple[Hash32, ...]) -> None:
         cmd = GetBlockBodies(self.cmd_id_offset, self.snappy_support)
         header, body = cmd.encode(block_hashes)
-        self.send(header, body)
+        self.transport.send(header, body)
 
     def send_block_bodies(self, blocks: List[BlockBody]) -> None:
         cmd = BlockBodies(self.cmd_id_offset, self.snappy_support)
         header, body = cmd.encode(blocks)
-        self.send(header, body)
+        self.transport.send(header, body)
 
     #
     # Receipts
@@ -134,12 +134,12 @@ class ETHProtocol(HasExtendedDebugLogger, Protocol):
     def send_get_receipts(self, block_hashes: Tuple[Hash32, ...]) -> None:
         cmd = GetReceipts(self.cmd_id_offset, self.snappy_support)
         header, body = cmd.encode(block_hashes)
-        self.send(header, body)
+        self.transport.send(header, body)
 
     def send_receipts(self, receipts: List[List[Receipt]]) -> None:
         cmd = Receipts(self.cmd_id_offset, self.snappy_support)
         header, body = cmd.encode(receipts)
-        self.send(header, body)
+        self.transport.send(header, body)
 
     #
     # Transactions
@@ -147,4 +147,4 @@ class ETHProtocol(HasExtendedDebugLogger, Protocol):
     def send_transactions(self, transactions: List[BaseTransactionFields]) -> None:
         cmd = Transactions(self.cmd_id_offset, self.snappy_support)
         header, body = cmd.encode(transactions)
-        self.send(header, body)
+        self.transport.send(header, body)

--- a/trinity/protocol/les/proto.py
+++ b/trinity/protocol/les/proto.py
@@ -63,7 +63,7 @@ class LESProtocol(Protocol):
     def send_handshake(self, chain_info: ChainInfo) -> None:
         resp = {
             'protocolVersion': self.version,
-            'networkId': self.peer.local_network_id,
+            'networkId': chain_info.network_id,
             'headTd': chain_info.total_difficulty,
             'headHash': chain_info.block_hash,
             'headNum': chain_info.block_number,
@@ -74,7 +74,7 @@ class LESProtocol(Protocol):
             # 'txRelay': None,
         }
         cmd = Status(self.cmd_id_offset, self.snappy_support)
-        self.send(*cmd.encode(resp))
+        self.transport.send(*cmd.encode(resp))
         self.logger.debug("Sending LES/Status msg: %s", resp)
 
     def send_get_block_bodies(self, block_hashes: List[bytes], request_id: int=None) -> int:
@@ -89,7 +89,7 @@ class LESProtocol(Protocol):
             'block_hashes': block_hashes,
         }
         header, body = GetBlockBodies(self.cmd_id_offset, self.snappy_support).encode(data)
-        self.send(header, body)
+        self.transport.send(header, body)
 
         return request_id
 
@@ -119,7 +119,7 @@ class LESProtocol(Protocol):
             ),
         }
         header, body = cmd.encode(data)
-        self.send(header, body)
+        self.transport.send(header, body)
 
         return request_id
 
@@ -133,7 +133,7 @@ class LESProtocol(Protocol):
             'buffer_value': buffer_value,
         }
         header, body = BlockHeaders(self.cmd_id_offset, self.snappy_support).encode(data)
-        self.send(header, body)
+        self.transport.send(header, body)
 
         return request_id
 
@@ -145,7 +145,7 @@ class LESProtocol(Protocol):
             'block_hashes': [block_hash],
         }
         header, body = GetReceipts(self.cmd_id_offset, self.snappy_support).encode(data)
-        self.send(header, body)
+        self.transport.send(header, body)
 
         return request_id
 
@@ -158,7 +158,7 @@ class LESProtocol(Protocol):
             'proof_requests': [ProofRequest(block_hash, account_key, key, from_level)],
         }
         header, body = GetProofs(self.cmd_id_offset, self.snappy_support).encode(data)
-        self.send(header, body)
+        self.transport.send(header, body)
 
         return request_id
 
@@ -170,7 +170,7 @@ class LESProtocol(Protocol):
             'code_requests': [ContractCodeRequest(block_hash, key)],
         }
         header, body = GetContractCodes(self.cmd_id_offset, self.snappy_support).encode(data)
-        self.send(header, body)
+        self.transport.send(header, body)
 
         return request_id
 
@@ -192,7 +192,7 @@ class LESProtocolV2(LESProtocol):
         resp = {
             'announceType': constants.LES_ANNOUNCE_SIMPLE,
             'protocolVersion': self.version,
-            'networkId': self.peer.local_network_id,
+            'networkId': chain_info.network_id,
             'headTd': chain_info.total_difficulty,
             'headHash': chain_info.block_hash,
             'headNum': chain_info.block_number,
@@ -203,7 +203,7 @@ class LESProtocolV2(LESProtocol):
         }
         cmd = StatusV2(self.cmd_id_offset, self.snappy_support)
         self.logger.debug("Sending LES/Status msg: %s", resp)
-        self.send(*cmd.encode(resp))
+        self.transport.send(*cmd.encode(resp))
 
     def send_get_proof(self,
                        block_hash: bytes,
@@ -218,6 +218,6 @@ class LESProtocolV2(LESProtocol):
             'proof_requests': [ProofRequest(block_hash, account_key, key, from_level)],
         }
         header, body = GetProofsV2(self.cmd_id_offset, self.snappy_support).encode(data)
-        self.send(header, body)
+        self.transport.send(header, body)
 
         return request_id

--- a/trinity/server.py
+++ b/trinity/server.py
@@ -41,8 +41,9 @@ from p2p.nat import UPnPService
 from p2p.p2p_proto import (
     DisconnectReason,
 )
-from p2p.peer import BasePeer, PeerConnection
+from p2p.peer import BasePeer
 from p2p.service import BaseService
+from p2p.transport import Transport
 
 from eth2.beacon.chains.base import BeaconChain
 
@@ -249,7 +250,10 @@ class BaseServer(BaseService, Generic[TPeerPool]):
             auth_init_ciphertext=msg,
             auth_ack_ciphertext=auth_ack_ciphertext
         )
-        connection = PeerConnection(
+
+        transport = Transport(
+            remote=initiator_remote,
+            private_key=self.privkey,
             reader=reader,
             writer=writer,
             aes_secret=aes_secret,
@@ -260,8 +264,7 @@ class BaseServer(BaseService, Generic[TPeerPool]):
 
         # Create and register peer in peer_pool
         peer = self.peer_pool.get_peer_factory().create_peer(
-            remote=initiator_remote,
-            connection=connection,
+            transport=transport,
             inbound=True,
         )
 


### PR DESCRIPTION
Replaces https://github.com/ethereum/trinity/pull/546

fixes #90

Based on: #563 #564 #565 which all must be merged first


### What was wrong?

The `p2p.BasePeer` class has been shown to contain *too much logic*.  This has had many resulting difficulties such as:

- harder to test
- harder to type
- unable to support multiple protocols

### How was it fixed?

This PR extracts the lowest level networking components from the `BasePeer` class out into a `Transport` class which has well constrained responsibilities

- reading and writing to the streams
- encryption and decryption

#### Cute Animal Picture

![Gusbypail jpg w560h702](https://user-images.githubusercontent.com/824194/56983566-2b98ef00-6b41-11e9-8c02-72f65adc38d4.jpg)

