### PR TITLE
Piper/better messaging on header validation failure

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -126,7 +126,7 @@ modindex_common_prefix = ['eth.']
 # -- Options for HTMLHelp output ------------------------------------------
 
 # Output file base name for HTML help builder.
-htmlhelp_basename = 'py-evmdoc'
+htmlhelp_basename = 'trinitydoc'
 
 
 # -- Options for LaTeX output ---------------------------------------------
@@ -153,7 +153,7 @@ latex_elements = {
 # (source start file, target name, title,
 #  author, documentclass [howto, manual, or own class]).
 latex_documents = [
-    (master_doc, 'py-evm.tex', 'py-evm Documentation',
+    (master_doc, 'trinity.tex', 'Trinity Documentation',
      about['__author__'], 'manual'),
 ]
 
@@ -163,7 +163,7 @@ latex_documents = [
 # One entry per manual page. List of tuples
 # (source start file, name, description, authors, manual section).
 man_pages = [
-    (master_doc, about['__name__'], 'py-evm Documentation',
+    (master_doc, about['__name__'], 'Trinity Documentation',
      about['__author__'], 1)
 ]
 
@@ -174,7 +174,7 @@ man_pages = [
 # (source start file, target name, title, author,
 #  dir menu entry, description, category)
 texinfo_documents = [
-    (master_doc, about['__name__'], 'py-evm Documentation',
+    (master_doc, about['__name__'], 'Trinity Documentation',
      about['__author__'], about['__name__'], about['__description__'],
      'Miscellaneous'),
 ]

--- a/tests/core/test_humanize_integer_sequence.py
+++ b/tests/core/test_humanize_integer_sequence.py
@@ -1,0 +1,23 @@
+import pytest
+
+from trinity._utils.humanize import humanize_integer_sequence
+
+
+@pytest.mark.parametrize(
+    'seq,expected',
+    (
+        ((), '(empty)'),
+        ((1,), '1'),
+        ((2,), '2'),
+        ((10,), '10'),
+        ((1, 2, 3), '1-3'),
+        (range(6), '0-5'),
+        ((1, 2, 3, 7, 8, 9), '1-3|7-9'),
+        ((1, 2, 3, 5, 7, 8, 9), '1-3|5|7-9'),
+        ((1, 3, 4, 5, 7, 8, 9), '1|3-5|7-9'),
+        ((1, 3, 4, 5, 9), '1|3-5|9'),
+    ),
+)
+def test_humanize_integer_sequence(seq, expected):
+    actual = humanize_integer_sequence(seq)
+    assert actual == expected

--- a/trinity/_utils/humanize.py
+++ b/trinity/_utils/humanize.py
@@ -15,8 +15,8 @@ def _find_breakpoints(*values: int) -> Iterable[int]:
 
 def _extract_integer_ranges(*values: int) -> Iterable[Tuple[int, int]]:
     """
-    Takes a sequence of integers which is expected to be ordered and returns
-    the most concise definition of the sequence in terms of integer ranges.
+    Take a sequence of integers which is expected to be ordered and return the
+    most concise definition of the sequence in terms of integer ranges.
 
     - fn(1, 2, 3) -> ((1, 3),)
     - fn(1, 2, 3, 7, 8, 9) -> ((1, 3), (7, 9))
@@ -40,9 +40,10 @@ def humanize_integer_sequence(values: Sequence[int]) -> str:
     Return a human readable string that attempts to concisely define a sequence
     of integers.
 
-    - fn((1, 2, 3)) -> '1 - 3'
-    - fn((1, 2, 3, 7, 8, 9)) -> '1-3, 7-9'
-    - fn((1, 7, 8, 9)) -> '1, 7-9'
+    - fn((1, 2, 3)) -> '1-3'
+    - fn((1, 2, 3, 7, 8, 9)) -> '1-3|7-9'
+    - fn((1, 2, 3, 5, 7, 8, 9)) -> '1-3|5|7-9'
+    - fn((1, 7, 8, 9)) -> '1|7-9'
     """
     if not values:
         return "(empty)"

--- a/trinity/_utils/humanize.py
+++ b/trinity/_utils/humanize.py
@@ -1,0 +1,50 @@
+from typing import Iterable, Sequence, Tuple
+
+from eth_utils.toolz import sliding_window
+
+
+def _find_breakpoints(*values: int) -> Iterable[int]:
+    yield 0
+    for index, (left, right) in enumerate(sliding_window(2, values), 1):
+        if left + 1 == right:
+            continue
+        else:
+            yield index
+    yield len(values)
+
+
+def _extract_integer_ranges(*values: int) -> Iterable[Tuple[int, int]]:
+    """
+    Takes a sequence of integers which is expected to be ordered and returns
+    the most concise definition of the sequence in terms of integer ranges.
+
+    - fn(1, 2, 3) -> ((1, 3),)
+    - fn(1, 2, 3, 7, 8, 9) -> ((1, 3), (7, 9))
+    - fn(1, 7, 8, 9) -> ((1, 1), (7, 9))
+    """
+    for left, right in sliding_window(2, _find_breakpoints(*values)):
+        chunk = values[left:right]
+        yield chunk[0], chunk[-1]
+
+
+def _humanize_range(bounds: Tuple[int, int]) -> str:
+    left, right = bounds
+    if left == right:
+        return str(left)
+    else:
+        return f'{left}-{right}'
+
+
+def humanize_integer_sequence(values: Sequence[int]) -> str:
+    """
+    Return a human readable string that attempts to concisely define a sequence
+    of integers.
+
+    - fn((1, 2, 3)) -> '1 - 3'
+    - fn((1, 2, 3, 7, 8, 9)) -> '1-3, 7-9'
+    - fn((1, 7, 8, 9)) -> '1, 7-9'
+    """
+    if not values:
+        return "(empty)"
+    else:
+        return '|'.join(map(_humanize_range, _extract_integer_ranges(*values)))


### PR DESCRIPTION
### What was wrong?

When header validation fails, it can output messages like this:

```
   DEBUG  04-30 13:04:21  ResponseCandidateStream  Response validation failed for pending BlockHeaders request from peer ETHPeer <Node(0x1784@82.221.106.165)>: Unexpected numbers: {2213376, 2213377, 2213378, 2213379, 2213380, 2213381, 2213382, 2213383, 2213384, 2213385, 2213386, 2213387, 2213388, 2213389, 2213390, 2213391, 2213392, 2213393, 2213394, 2213395, 2213396, 2213397, 2213398, 2213399, 2213400, 2213401, 2213402, 2213403, 2213404, 2213405, 2213406, 2213407, 2213408, 2213409, 2213410, 2213411, 2213412, 2213413, 2213414, 2213415, 2213416, 2213417, 2213418, 2213419, 2213420, 2213421, 2213422, 2213423, 2213424, 2213425, 2213426, 2213427, 2213428, 2213429, 2213430, 2213431, 2213432, 2213433, 2213434, 2213435, 2213436, 2213437, 2213438, 2213439, 2213440, 2213441, 2213442, 2213443, 2213444, 2213445, 2213446, 2213447, 2213448, 2213449, 2213450, 2213451, 2213452, 2213453, 2213454, 2213455, 2213456, 2213457, 2213458, 2213459, 2213460, 2213461, 2213462, 2213463, 2213464, 2213465, 2213466, 2213467, 2213468, 2213469, 2213470, 2213471, 2213472, 2213473, 2213474, 2213475, 2213476, 2213477, 2213478, 2213479, 2213480, 2213481, 2213482, 2213483, 2213484, 2213485, 2213486, 2213487, 2213488, 2213489, 2213490, 2213491, 2213492, 2213301, 2213302, 2213303, 2213304, 2213305, 2213306, 2213307, 2213308, 2213309, 2213310, 2213311, 2213312, 2213313, 2213314, 2213315, 2213316, 2213317, 2213318, 2213319, 2213320, 2213321, 2213322, 2213323, 2213324, 2213325, 2213326, 2213327, 2213328, 2213329, 2213330, 2213331, 2213332, 2213333, 2213334, 2213335, 2213336, 2213337, 2213338, 2213339, 2213340, 2213341, 2213342, 2213343, 2213344, 2213345, 2213346, 2213347, 2213348, 2213349, 2213350, 2213351, 2213352, 2213353, 2213354, 2213355, 2213356, 2213357, 2213358, 2213359, 2213360, 2213361, 2213362, 2213363, 2213364, 2213365, 2213366, 2213367, 2213368, 2213369, 2213370, 2213371, 2213372, 2213373, 2213374, 2213375}
```

This message both fails to tell me what numbers I should have expected as well as presents the information in an unreadable format.


### How was it fixed?

I wrote up a new utility that takes a sequence of integers and tries to condense it into the most concise representation.  The above giant string of numbers becomes: `2213376-2213492|2213301-2213375`.

I also updated each of the error messages to include metadata about the request and any contextual information that might be useful.  And last, I optimized the validation checks as I believe one of them was kind-of broken.

#### Cute Animal Picture

![tumblr_lu5vxyPjpq1qcd504o7_1280](https://user-images.githubusercontent.com/824194/56996992-8ba08d00-6b63-11e9-8017-3362423c3a42.jpg)

