### PR TITLE
Move uptime tracking to base service class

### DIFF
--- a/p2p/_utils.py
+++ b/p2p/_utils.py
@@ -1,11 +1,7 @@
 from concurrent.futures import Executor, ProcessPoolExecutor
-import datetime
 import logging
 import os
 import signal
-from typing import (
-    Tuple,
-)
 
 import rlp
 
@@ -40,13 +36,6 @@ def get_devp2p_cmd_id(msg: bytes) -> int:
     as an integer.
     """
     return rlp.decode(msg[:1], sedes=rlp.sedes.big_endian_int)
-
-
-def time_since(start_time: datetime.datetime) -> Tuple[int, int, int, int]:
-    delta = datetime.datetime.now() - start_time
-    hours, remainder = divmod(delta.seconds, 3600)
-    minutes, seconds = divmod(remainder, 60)
-    return delta.days, hours, minutes, seconds
 
 
 CPU_EMPTY_VALUES = {None, 0}

--- a/p2p/peer.py
+++ b/p2p/peer.py
@@ -2,7 +2,6 @@ from abc import ABC, abstractmethod
 import asyncio
 import collections
 import contextlib
-import datetime
 import functools
 import logging
 import operator
@@ -44,7 +43,6 @@ from p2p._utils import (
     get_devp2p_cmd_id,
     roundup_16,
     sxor,
-    time_since,
 )
 from p2p.protocol import (
     Command,
@@ -235,11 +233,6 @@ class BasePeer(BaseService):
         self.inbound = inbound
         self._subscribers: List[PeerSubscriber] = []
 
-        # Uptime tracker for how long the peer has been running.
-        # TODO: this should move to begin within the `_run` method (or maybe as
-        # part of the `BaseService` API)
-        self.start_time = datetime.datetime.now()
-
         # A counter of the number of messages this peer has received for each
         # message type.
         self.received_msgs: Dict[Command, int] = collections.defaultdict(int)
@@ -311,10 +304,6 @@ class BasePeer(BaseService):
     @property
     def received_msgs_count(self) -> int:
         return sum(self.received_msgs.values())
-
-    @property
-    def uptime(self) -> str:
-        return '%d:%02d:%02d:%02d' % time_since(self.start_time)
 
     def add_subscriber(self, subscriber: 'PeerSubscriber') -> None:
         self._subscribers.append(subscriber)

--- a/p2p/peer_pool.py
+++ b/p2p/peer_pool.py
@@ -471,7 +471,7 @@ class BasePeerPool(BaseService, AsyncIterable[BasePeer]):
                     peer.received_msgs.items(), key=operator.itemgetter(1))
                 self.logger.debug(
                     "%s: uptime=%s, received_msgs=%d, most_received=%s(%d)",
-                    peer, humanize_seconds(peer.uptime.total_seconds()), peer.received_msgs_count,
+                    peer, humanize_seconds(peer.uptime), peer.received_msgs_count,
                     most_received_type, count)
                 self.logger.debug("client_version_string='%s'", peer.client_version_string)
                 for line in peer.get_extra_stats():

--- a/p2p/peer_pool.py
+++ b/p2p/peer_pool.py
@@ -21,6 +21,9 @@ from cancel_token import (
 from eth_keys import (
     datatypes,
 )
+from eth_utils import (
+    humanize_seconds,
+)
 from eth_utils.toolz import (
     groupby,
     take,
@@ -468,7 +471,7 @@ class BasePeerPool(BaseService, AsyncIterable[BasePeer]):
                     peer.received_msgs.items(), key=operator.itemgetter(1))
                 self.logger.debug(
                     "%s: uptime=%s, received_msgs=%d, most_received=%s(%d)",
-                    peer, peer.uptime, peer.received_msgs_count,
+                    peer, humanize_seconds(peer.uptime.total_seconds()), peer.received_msgs_count,
                     most_received_type, count)
                 self.logger.debug("client_version_string='%s'", peer.client_version_string)
                 for line in peer.get_extra_stats():

--- a/p2p/service.py
+++ b/p2p/service.py
@@ -1,6 +1,7 @@
 from abc import ABC, abstractmethod
 import asyncio
 import concurrent
+import datetime
 import functools
 import logging
 from typing import (
@@ -73,6 +74,10 @@ class BaseService(ABC, CancellableMixin):
             )
         return self._logger
 
+    @property
+    def uptime(self) -> datetime.timedelta:
+        return datetime.datetime.utcnow() - self.start_time
+
     def get_event_loop(self) -> asyncio.AbstractEventLoop:
         if self._loop is None:
             return asyncio.get_event_loop()
@@ -98,6 +103,7 @@ class BaseService(ABC, CancellableMixin):
         try:
             async with self._run_lock:
                 self.events.started.set()
+                self.start_time = datetime.datetime.utcnow()
                 await self._run()
         except OperationCancelled as e:
             self.logger.debug("%s finished: %s", self, e)


### PR DESCRIPTION
### What was wrong?

The peer class implemented an `uptime` property.  It was somewhat awkwardly implemented to return a string since it was only used for logging purposes.

### How was it fixed?

Maybe YAGNI but this felt cleaner, moving this onto `BaseService.uptime` and converting it to be a `datetime.timedelta`, then leveraging the `humanize_seconds` utility in the actual logging statement.

#### Cute Animal Picture

![0b16cc1c64e61433e5d351c34ca94c81](https://user-images.githubusercontent.com/824194/56998979-96aaeb80-6b6a-11e9-95ba-e288bcc4f265.jpg)

