### PR TITLE
Upgrade cachetools to fix deprecation warnings

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ deps = {
     'trinity': [
         "async-generator==1.10",
         "bloom-filter==1.3",
-        "cachetools>=2.1.0,<3.0.0",
+        "cachetools>=3.1.0,<4.0.0",
         "coincurve>=10.0.0,<11.0.0",
         "eth-utils>=1.5.1,<2",
         "ipython>=6.2.1,<7.0.0",


### PR DESCRIPTION
### What was wrong?

Trinity issues the following warning.

```
'  from collections import Iterable, Sequence\n'
"/home/cburgdorf/Documents/hacking/ef/trinity/venv/lib/python3.7/site-packages/cachetools/abc.py:7: DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated, and in 3.8 it will stop working\n"
'  class DefaultMapping(collections.MutableMapping):\n'

```

### How was it fixed?

Use `cachetools` version `>3.1` which has a fix for that.

[//]: # (For important changes, please add a new entry to the running release notes PR)
[//]: # (You can find the current one using: https://github.com/ethereum/trinity/pulls?q=is%3Aopen+is%3Apr+label%3A%22Release+Notes%22 )
[//]: # (See: https://trinity-client.readthedocs.io/en/latest/contributing.html#pull-requests)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://wp.nathabblog.com/wp-content/uploads/2013/05/Galapago-Sea-Lion-Pup1.jpg)
