### PR TITLE
Add receive server for validator service

### DIFF
--- a/tests/core/p2p-proto/bcc/test_receive_server.py
+++ b/tests/core/p2p-proto/bcc/test_receive_server.py
@@ -1,6 +1,5 @@
 import asyncio
 import functools
-import time
 
 from typing import (
     Tuple,
@@ -21,7 +20,6 @@ from p2p.peer import (
 from eth.exceptions import (
     BlockNotFound,
 )
-from eth2.beacon.chains.base import BeaconChain
 from eth2.beacon.chains.testnet import TestnetChain
 from eth2.beacon.types.blocks import (
     BaseBeaconBlock,
@@ -197,12 +195,14 @@ async def test_bcc_receive_server_try_import_or_handle_orphan(request, event_loo
     assert block_2 not in bob_recv_server.orphan_block_pool._pool
     assert bob_recv_server._is_block_root_in_db(block_3.signed_root)
     assert block_3 not in bob_recv_server.orphan_block_pool._pool
-    # TODO: test for requests
 
 
 @pytest.mark.asyncio
 async def test_bcc_receive_server_handle_beacon_blocks_checks(request, event_loop, monkeypatch):
-    alice, _, bob_recv_server, bob_msg_queue = await get_peer_and_receive_server(request, event_loop)
+    alice, _, bob_recv_server, bob_msg_queue = await get_peer_and_receive_server(
+        request,
+        event_loop,
+    )
     bob_chain = bob_recv_server.chain
     head = bob_chain.get_canonical_head()
     block_0 = bob_chain.create_block_from_parent(
@@ -333,7 +333,7 @@ async def test_bcc_receive_request_block_by_root(request, event_loop):
 
 
 @pytest.mark.asyncio
-async def test_bcc_receive_server_interleaving_operations(request, event_loop, monkeypatch):
+async def test_bcc_receive_server_with_request_server(request, event_loop):
     alice, alice_req_server, bob_recv_server, bob_msg_queue = await get_peer_and_receive_server(
         request,
         event_loop,

--- a/tests/core/p2p-proto/bcc/test_receive_server.py
+++ b/tests/core/p2p-proto/bcc/test_receive_server.py
@@ -36,20 +36,13 @@ from trinity.protocol.bcc.peer import (
 )
 from trinity.protocol.bcc.servers import (
     BCCReceiveServer,
+    BCCRequestServer,
     OrphanBlockPool,
 )
-from trinity.protocol.bcc.commands import (
-    BeaconBlocks,
-)
-
-# from tests.plugins.eth2.beacon.test_validator import (
-#     get_chain,
-# )
 
 from .helpers import (
     FakeAsyncBeaconChainDB,
     get_genesis_chain_db,
-    get_chain_db,
     create_test_block,
     get_directly_linked_peers_in_peer_pools,
 )
@@ -57,15 +50,6 @@ from .helpers import (
 
 class FakeChain(TestnetChain):
     chaindb_class = FakeAsyncBeaconChainDB
-
-    timeout = 2
-    fake_db = None
-
-    def __init__(self, base_db):
-        super().__init__(base_db)
-        self.fake_db = {}
-        head = self.get_canonical_head()
-        self.fake_db[head.signed_root] = head
 
     def import_block(
             self,
@@ -76,29 +60,15 @@ class FakeChain(TestnetChain):
         Remove the logics about `state`, because we only need to check a block's parent in
         `ReceiveServer`.
         """
-        if block.previous_block_root not in self.fake_db:
-            raise ValidationError
         try:
             self.get_block_by_root(block.previous_block_root)
         except BlockNotFound:
             raise ValidationError
-
-        self.fake_db[block.signed_root] = block
-
         (
             new_canonical_blocks,
             old_canonical_blocks,
         ) = self.chaindb.persist_block(block, block.__class__)
         return block, new_canonical_blocks, old_canonical_blocks
-
-    # helper
-    def is_block_existing(self, block_root) -> bool:
-        return block_root in self.fake_db
-        # try:
-        #     self.get_block_by_root(block_root)
-        #     return True
-        # except BlockNotFound:
-        #     return False
 
 
 async def get_fake_chain() -> FakeChain:
@@ -118,7 +88,8 @@ async def get_peer_and_receive_server(request, event_loop) -> Tuple[
         bob_chain_db=bob_chain.chaindb,
     )
 
-    # add a queue to put message after every msg handler finishes
+    # Add a queue to ensure messages put after every msg handler finishes.
+    # This is crucial to synchronize the test with the BCCReceiveServer.
     msg_queue = asyncio.Queue()
     orig_handle_msg = BCCReceiveServer._handle_msg
 
@@ -127,21 +98,28 @@ async def get_peer_and_receive_server(request, event_loop) -> Tuple[
 
         def enqueue_msg(future, msg):
             msg_queue.put_nowait(msg)
-        task.add_done_callback(functools.partial(enqueue_msg, msg))
+        task.add_done_callback(functools.partial(enqueue_msg, msg=msg))
         await task
     BCCReceiveServer._handle_msg = _handle_msg
 
-    bob_receive_server = BCCReceiveServer(chain=bob_chain, peer_pool=bob_peer_pool)
+    alice_req_server = BCCRequestServer(
+        db=alice_chain.chaindb,
+        peer_pool=alice_peer_pool,
+    )
+    bob_recv_server = BCCReceiveServer(chain=bob_chain, peer_pool=bob_peer_pool)
 
-    asyncio.ensure_future(bob_receive_server.run())
-    await bob_receive_server.events.started.wait()
+    asyncio.ensure_future(alice_req_server.run())
+    asyncio.ensure_future(bob_recv_server.run())
+    await alice_req_server.events.started.wait()
+    await bob_recv_server.events.started.wait()
 
     def finalizer():
-        event_loop.run_until_complete(bob_receive_server.cancel())
+        event_loop.run_until_complete(alice_req_server.cancel())
+        event_loop.run_until_complete(bob_recv_server.cancel())
 
     request.addfinalizer(finalizer)
 
-    return alice, bob_receive_server, msg_queue
+    return alice, alice_req_server, bob_recv_server, msg_queue
 
 
 def test_orphan_block_pool():
@@ -168,18 +146,18 @@ def test_orphan_block_pool():
 
 @pytest.mark.asyncio
 async def test_bcc_receive_server_try_import_or_handle_orphan(request, event_loop, monkeypatch):
-    alice, bob_receive_server, _ = await get_peer_and_receive_server(request, event_loop)
+    _, _, bob_recv_server, _ = await get_peer_and_receive_server(request, event_loop)
 
     def _request_block_by_root(block_root):
         pass
 
     monkeypatch.setattr(
-        bob_receive_server,
+        bob_recv_server,
         '_request_block_by_root',
         _request_block_by_root,
     )
 
-    bob_chain = bob_receive_server.chain
+    bob_chain = bob_recv_server.chain
     head = bob_chain.get_canonical_head()
     block_0 = bob_chain.create_block_from_parent(
         parent_block=head,
@@ -198,96 +176,215 @@ async def test_bcc_receive_server_try_import_or_handle_orphan(request, event_loo
         block_params=FromBlockParams(),
     )
     # test: block should not be in the db before imported.
-    assert not bob_chain.is_block_existing(block_0.signed_root)
+    assert not bob_recv_server._is_block_root_in_db(block_0.signed_root)
     # test: block with its parent in db should be imported successfully.
-    bob_receive_server._try_import_or_handle_orphan(block_0)
+    bob_recv_server._try_import_or_handle_orphan(block_0)
 
-    assert bob_chain.is_block_existing(block_0.signed_root)
+    assert bob_recv_server._is_block_root_in_db(block_0.signed_root)
     # test: block without its parent in db should not be imported, and it should be put in the
     #   `orphan_block_pool`.
-    bob_receive_server._try_import_or_handle_orphan(block_2)
-    assert not bob_chain.is_block_existing(block_2.signed_root)
-    assert block_2 in bob_receive_server.orphan_block_pool._pool
-    bob_receive_server._try_import_or_handle_orphan(block_3)
-    assert not bob_chain.is_block_existing(block_3.signed_root)
-    assert block_3 in bob_receive_server.orphan_block_pool._pool
+    bob_recv_server._try_import_or_handle_orphan(block_2)
+    assert not bob_recv_server._is_block_root_in_db(block_2.signed_root)
+    assert bob_recv_server._is_block_root_in_orphan_block_pool(block_2.signed_root)
+    bob_recv_server._try_import_or_handle_orphan(block_3)
+    assert not bob_recv_server._is_block_root_in_db(block_3.signed_root)
+    assert block_3 in bob_recv_server.orphan_block_pool._pool
     # test: a successfully imported parent is present, its children should be processed
     #   recursively.
-    bob_receive_server._try_import_or_handle_orphan(block_1)
-    assert bob_chain.is_block_existing(block_1.signed_root)
-    assert bob_chain.is_block_existing(block_2.signed_root)
-    assert block_2 not in bob_receive_server.orphan_block_pool._pool
-    assert bob_chain.is_block_existing(block_3.signed_root)
-    assert block_3 not in bob_receive_server.orphan_block_pool._pool
+    bob_recv_server._try_import_or_handle_orphan(block_1)
+    assert bob_recv_server._is_block_root_in_db(block_1.signed_root)
+    assert bob_recv_server._is_block_root_in_db(block_2.signed_root)
+    assert block_2 not in bob_recv_server.orphan_block_pool._pool
+    assert bob_recv_server._is_block_root_in_db(block_3.signed_root)
+    assert block_3 not in bob_recv_server.orphan_block_pool._pool
     # TODO: test for requests
 
 
 @pytest.mark.asyncio
-async def test_bcc_receive_server_handle_beacon_blocks(request, event_loop, monkeypatch):
-    alice, bob_receive_server, msg_queue = await get_peer_and_receive_server(request, event_loop)
-    bob_chain = bob_receive_server.chain
+async def test_bcc_receive_server_handle_beacon_blocks_checks(request, event_loop, monkeypatch):
+    alice, _, bob_recv_server, bob_msg_queue = await get_peer_and_receive_server(request, event_loop)
+    bob_chain = bob_recv_server.chain
     head = bob_chain.get_canonical_head()
     block_0 = bob_chain.create_block_from_parent(
         parent_block=head,
         block_params=FromBlockParams(),
+    )
+
+    event = asyncio.Event()
+
+    def _try_import_or_handle_orphan(block):
+        event.set()
+
+    monkeypatch.setattr(
+        bob_recv_server,
+        '_try_import_or_handle_orphan',
+        _try_import_or_handle_orphan,
     )
 
     # test: `request_id` not found, it should be rejected
     inexistent_request_id = 5566
-    assert inexistent_request_id not in bob_receive_server.map_requested_id_block_root
+    assert inexistent_request_id not in bob_recv_server.map_requested_id_block_root
     alice.sub_proto.send_blocks(blocks=(block_0,), request_id=inexistent_request_id)
-    await msg_queue.get()
-    await asyncio.sleep(0)
-    assert not bob_chain.is_block_existing(block_0.signed_root)
+    await bob_msg_queue.get()
+    assert not event.is_set()
+
     # test: >= 1 blocks are sent, the request should be rejected.
+    event.clear()
     existing_request_id = 1
-    bob_receive_server.map_requested_id_block_root[existing_request_id] = block_0.signed_root
+    bob_recv_server.map_requested_id_block_root[existing_request_id] = block_0.signed_root
     alice.sub_proto.send_blocks(blocks=(block_0, block_0), request_id=existing_request_id)
-    await msg_queue.get()
-    assert not bob_chain.is_block_existing(block_0.signed_root)
+    await bob_msg_queue.get()
+    assert not event.is_set()
+
     # test: `request_id` is found but `block.signed_root` does not correspond to the request
+    event.clear()
     existing_request_id = 2
-    bob_receive_server.map_requested_id_block_root[existing_request_id] = b'\x12' * 32
+    bob_recv_server.map_requested_id_block_root[existing_request_id] = b'\x12' * 32
     alice.sub_proto.send_blocks(blocks=(block_0,), request_id=existing_request_id)
-    await msg_queue.get()
-    assert not bob_chain.is_block_existing(block_0.signed_root)
+    await bob_msg_queue.get()
+    assert not event.is_set()
+
     # test: `request_id` is found and the block is valid. It should be imported.
+    event.clear()
     existing_request_id = 3
-    bob_receive_server.map_requested_id_block_root[existing_request_id] = block_0.signed_root
+    bob_recv_server.map_requested_id_block_root[existing_request_id] = block_0.signed_root
     alice.sub_proto.send_blocks(blocks=(block_0,), request_id=existing_request_id)
-    await msg_queue.get()
-    assert bob_chain.is_block_existing(block_0.signed_root)
-    assert existing_request_id not in bob_receive_server.map_requested_id_block_root
+    await bob_msg_queue.get()
+    assert event.is_set()
+    # ensure `request_id` is cleared after successful response
+    assert existing_request_id not in bob_recv_server.map_requested_id_block_root
 
 
 @pytest.mark.asyncio
 async def test_bcc_receive_server_handle_new_beacon_block_checks(request, event_loop, monkeypatch):
-    alice, bob_receive_server, msg_queue = await get_peer_and_receive_server(request, event_loop)
-    bob_chain = bob_receive_server.chain
+    alice, _, bob_recv_server, bob_msg_queue = await get_peer_and_receive_server(
+        request,
+        event_loop,
+    )
+    bob_chain = bob_recv_server.chain
     head = bob_chain.get_canonical_head()
     block_0 = bob_chain.create_block_from_parent(
         parent_block=head,
         block_params=FromBlockParams(),
     )
-    is_called = False
+
+    event = asyncio.Event()
 
     def _try_import_or_handle_orphan(block):
-        nonlocal is_called
-        is_called = True
+        event.set()
 
     monkeypatch.setattr(
-        bob_receive_server,
+        bob_recv_server,
         '_try_import_or_handle_orphan',
         _try_import_or_handle_orphan,
     )
 
     alice.sub_proto.send_new_block(block=block_0)
-    await msg_queue.get()
-    assert is_called
-    is_called = False
+    await bob_msg_queue.get()
+    assert event.is_set()
 
     # test: seen blocks should be rejected
-    bob_receive_server.orphan_block_pool.add(block_0)
+    event.clear()
+    bob_recv_server.orphan_block_pool.add(block_0)
     alice.sub_proto.send_new_block(block=block_0)
-    await msg_queue.get()
-    assert not is_called
+    await bob_msg_queue.get()
+    assert not event.is_set()
+
+
+def parse_new_block_msg(msg):
+    key = "encoded_block"
+    assert key in msg
+    return ssz.decode(msg[key], BeaconBlock)
+
+
+def parse_resp_block_msg(msg):
+    key = "encoded_blocks"
+    assert len(msg[key]) == 1
+    return ssz.decode(msg[key][0], BeaconBlock)
+
+
+@pytest.mark.asyncio
+async def test_bcc_receive_request_block_by_root(request, event_loop):
+    alice, alice_req_server, bob_recv_server, bob_msg_queue = await get_peer_and_receive_server(
+        request,
+        event_loop,
+    )
+    alice_msg_buffer = MsgBuffer()
+    alice.add_subscriber(alice_msg_buffer)
+    bob_chain = bob_recv_server.chain
+    head = bob_chain.get_canonical_head()
+    block_0 = bob_chain.create_block_from_parent(
+        parent_block=head,
+        block_params=FromBlockParams(),
+    )
+
+    # test: request from bob is issued and received by alice
+    bob_recv_server._request_block_by_root(block_0.signed_root)
+    req = await alice_msg_buffer.msg_queue.get()
+    assert req.payload['block_slot_or_root'] == block_0.signed_root
+
+    # test: alice responds to the bob's request
+    await alice_req_server.db.coro_persist_block(
+        block_0,
+        BeaconBlock,
+    )
+    bob_recv_server._request_block_by_root(block_0.signed_root)
+    assert block_0 == parse_resp_block_msg(await bob_msg_queue.get())
+
+
+@pytest.mark.asyncio
+async def test_bcc_receive_server_interleaving_operations(request, event_loop, monkeypatch):
+    alice, alice_req_server, bob_recv_server, bob_msg_queue = await get_peer_and_receive_server(
+        request,
+        event_loop,
+    )
+    alice_msg_buffer = MsgBuffer()
+    alice.add_subscriber(alice_msg_buffer)
+    bob_chain = bob_recv_server.chain
+    head = bob_chain.get_canonical_head()
+    block_0 = bob_chain.create_block_from_parent(
+        parent_block=head,
+        block_params=FromBlockParams(),
+    )
+    block_1 = bob_chain.create_block_from_parent(
+        parent_block=block_0,
+        block_params=FromBlockParams(),
+    )
+    block_2 = bob_chain.create_block_from_parent(
+        parent_block=block_1,
+        block_params=FromBlockParams(),
+    )
+    await alice_req_server.db.coro_persist_block(
+        block_0,
+        BeaconBlock,
+    )
+    await alice_req_server.db.coro_persist_block(
+        block_1,
+        BeaconBlock,
+    )
+    await alice_req_server.db.coro_persist_block(
+        block_2,
+        BeaconBlock,
+    )
+
+    # test: alice send `block_2` to bob, and bob should be able to get `block_1` and `block_0`
+    #   later through the requests.
+    assert not bob_recv_server._is_block_seen(block_0)
+    assert not bob_recv_server._is_block_seen(block_1)
+    assert not bob_recv_server._is_block_seen(block_2)
+    alice.sub_proto.send_new_block(block=block_2)
+    # bob receives new block `block_2`
+    assert block_2 == parse_new_block_msg(await bob_msg_queue.get())
+    # bob requests for `block_1`, and alice receives the request
+    req_1 = await alice_msg_buffer.msg_queue.get()
+    assert req_1.payload['block_slot_or_root'] == block_1.signed_root
+    # bob receives the response block `block_1`
+    assert block_1 == parse_resp_block_msg(await bob_msg_queue.get())
+    # bob requests for `block_0`, and alice receives the request
+    req_0 = await alice_msg_buffer.msg_queue.get()
+    assert req_0.payload['block_slot_or_root'] == block_0.signed_root
+    # bob receives the response block `block_0`
+    assert block_0 == parse_resp_block_msg(await bob_msg_queue.get())
+    assert bob_recv_server._is_block_root_in_db(block_0.signed_root)
+    assert bob_recv_server._is_block_root_in_db(block_1.signed_root)
+    assert bob_recv_server._is_block_root_in_db(block_2.signed_root)

--- a/tests/core/p2p-proto/bcc/test_receive_server.py
+++ b/tests/core/p2p-proto/bcc/test_receive_server.py
@@ -1,4 +1,5 @@
 import asyncio
+import time
 
 from typing import (
     Tuple,
@@ -8,15 +9,25 @@ import pytest
 
 import ssz
 
+from eth_utils import (
+    ValidationError,
+)
+
 from p2p.peer import (
     MsgBuffer,
 )
 
-from eth2.beacon.chains.base import (
-    BeaconChain,
+from eth.exceptions import (
+    BlockNotFound,
 )
+from eth2.beacon.chains.base import BeaconChain
+from eth2.beacon.chains.testnet import TestnetChain
 from eth2.beacon.types.blocks import (
+    BaseBeaconBlock,
     BeaconBlock,
+)
+from eth2.beacon.typing import (
+    FromBlockParams,
 )
 
 from trinity.protocol.bcc.peer import (
@@ -24,205 +35,246 @@ from trinity.protocol.bcc.peer import (
 )
 from trinity.protocol.bcc.servers import (
     BCCReceiveServer,
+    OrphanBlockPool,
 )
 from trinity.protocol.bcc.commands import (
     BeaconBlocks,
 )
 
+# from tests.plugins.eth2.beacon.test_validator import (
+#     get_chain,
+# )
+
 from .helpers import (
+    FakeAsyncBeaconChainDB,
     get_genesis_chain_db,
+    get_chain_db,
     create_test_block,
     get_directly_linked_peers_in_peer_pools,
 )
 
 
-async def get_peer_and_receive_server(request, event_loop) -> Tuple[BCCPeer, BCCReceiveServer]:
-    alice_chain_db = await get_genesis_chain_db()
-    bob_chain_db = await get_genesis_chain_db()
+class FakeChain(TestnetChain):
+    chaindb_class = FakeAsyncBeaconChainDB
+
+    timeout = 2
+    fake_db = None
+
+    def __init__(self, base_db):
+        super().__init__(base_db)
+        self.fake_db = {}
+
+    def import_block(
+            self,
+            block: BaseBeaconBlock,
+            perform_validation: bool=True) -> Tuple[
+                BaseBeaconBlock, Tuple[BaseBeaconBlock, ...], Tuple[BaseBeaconBlock, ...]]:
+        """
+        Remove the logics about `state`, because we only need to check a block's parent in
+        `ReceiveServer`.
+        """
+        try:
+            self.get_block_by_root(block.previous_block_root)
+        except BlockNotFound:
+            raise ValidationError
+
+        self.fake_db[block.signed_root] = block
+
+        (
+            new_canonical_blocks,
+            old_canonical_blocks,
+        ) = self.chaindb.persist_block(block, block.__class__)
+        return block, new_canonical_blocks, old_canonical_blocks
+
+    # helper
+    def is_block_existing(self, block_root) -> bool:
+        return block_root in self.fake_db
+        # try:
+        #     self.get_block_by_root(block_root)
+        #     return True
+        # except BlockNotFound:
+        #     return False
+
+
+async def get_fake_chain() -> FakeChain:
+    chain_db = await get_genesis_chain_db()
+    return FakeChain(chain_db.db)
+
+
+async def get_peer_and_receive_server(request, event_loop) -> Tuple[
+        BCCPeer, BCCReceiveServer]:
+    alice_chain = await get_fake_chain()
+    bob_chain = await get_fake_chain()
+
     alice, alice_peer_pool, bob, bob_peer_pool = await get_directly_linked_peers_in_peer_pools(
         request,
         event_loop,
-        alice_chain_db=alice_chain_db,
-        bob_chain_db=bob_chain_db,
+        alice_chain_db=alice_chain.chaindb,
+        bob_chain_db=bob_chain.chaindb,
     )
 
-    chain = BeaconChain(bob_chain_db.db)
-    bob_receive_server = BCCReceiveServer(chain=chain, peer_pool=bob_peer_pool)
+    msg_buffer = MsgBuffer()
+    bob.add_subscriber(msg_buffer)
+    bob_receive_server = BCCReceiveServer(chain=bob_chain, peer_pool=bob_peer_pool)
+
     asyncio.ensure_future(bob_receive_server.run())
+    await bob_receive_server.events.started.wait()
 
     def finalizer():
         event_loop.run_until_complete(bob_receive_server.cancel())
 
     request.addfinalizer(finalizer)
 
-    return alice, bob_receive_server
+    return alice, bob_receive_server, msg_buffer
+
+
+def test_orphan_block_pool():
+    pool = OrphanBlockPool()
+    b0 = create_test_block()
+    b1 = create_test_block(parent=b0)
+    b2 = create_test_block(parent=b0, state_root=b"\x11" * 32)
+    # test: add
+    pool.add(b1)
+    assert b1 in pool._pool
+    # test: add: no side effect for adding twice
+    pool.add(b1)
+    # test: add: two blocks
+    pool.add(b2)
+    # test: get
+    assert pool.get(b1.signed_root) == b1
+    assert pool.get(b2.signed_root) == b2
+    # test: pop_children
+    b2_children = pool.pop_children(b2)
+    assert len(b2_children) == 0
+    b0_children = pool.pop_children(b0)
+    assert len(b0_children) == 2 and (b1 in b0_children) and (b2 in b0_children)
 
 
 @pytest.mark.asyncio
-async def test_send_block(request, event_loop):
-    alice, bob_receive_server = await get_peer_and_receive_server(request, event_loop)
+async def test_bcc_receive_server_try_import_or_handle_orphan(request, event_loop, monkeypatch):
+    alice, bob_receive_server, msg_buffer = await get_peer_and_receive_server(request, event_loop)
+
+    def _request_block_by_root(block_root):
+        pass
+
+    monkeypatch.setattr(
+        bob_receive_server,
+        '_request_block_by_root',
+        _request_block_by_root,
+    )
+
+    bob_chain = bob_receive_server.chain
+    head = bob_chain.get_canonical_head()
+    block_0 = bob_chain.create_block_from_parent(
+        parent_block=head,
+        block_params=FromBlockParams(),
+    )
+    block_1 = bob_chain.create_block_from_parent(
+        parent_block=block_0,
+        block_params=FromBlockParams(),
+    )
+    block_2 = bob_chain.create_block_from_parent(
+        parent_block=block_1,
+        block_params=FromBlockParams(),
+    )
+    block_3 = bob_chain.create_block_from_parent(
+        parent_block=block_2,
+        block_params=FromBlockParams(),
+    )
+    # test: block should not be in the db before imported.
+    assert not bob_chain.is_block_existing(block_0.signed_root)
+    # test: block with its parent in db should be imported successfully.
+    bob_receive_server._try_import_or_handle_orphan(block_0)
+
+    assert bob_chain.is_block_existing(block_0.signed_root)
+    # test: block without its parent in db should not be imported, and it should be put in the
+    #   `orphan_block_pool`.
+    bob_receive_server._try_import_or_handle_orphan(block_2)
+    await asyncio.sleep(0)
+    assert not bob_chain.is_block_existing(block_2.signed_root)
+    assert block_2 in bob_receive_server.orphan_block_pool._pool
+    bob_receive_server._try_import_or_handle_orphan(block_3)
+    assert not bob_chain.is_block_existing(block_3.signed_root)
+    assert block_3 in bob_receive_server.orphan_block_pool._pool
+    # test: a successfully imported parent is present, its children should be processed
+    #   recursively.
+    bob_receive_server._try_import_or_handle_orphan(block_1)
+    await asyncio.sleep(0)
+    assert bob_chain.is_block_existing(block_1.signed_root)
+    assert bob_chain.is_block_existing(block_2.signed_root)
+    assert block_2 not in bob_receive_server.orphan_block_pool._pool
+    assert bob_chain.is_block_existing(block_3.signed_root)
+    assert block_3 not in bob_receive_server.orphan_block_pool._pool
+    # TODO: test for requests
 
 
-# @pytest.mark.asyncio
-# async def test_get_single_block_by_root(request, event_loop):
-#     block = create_test_block()
-#     chain_db = await get_chain_db((block,))
-#     alice, response_buffer = await get_request_server_setup(request, event_loop, chain_db)
+@pytest.mark.asyncio
+async def test_bcc_receive_server_handle_beacon_blocks(request, event_loop, monkeypatch):
+    alice, bob_receive_server, msg_buffer = await get_peer_and_receive_server(request, event_loop)
+    bob_chain = bob_receive_server.chain
+    head = bob_chain.get_canonical_head()
+    block_0 = bob_chain.create_block_from_parent(
+        parent_block=head,
+        block_params=FromBlockParams(),
+    )
 
-#     alice.sub_proto.send_get_blocks(block.slot, 1, request_id=5)
-#     response = await response_buffer.msg_queue.get()
-
-#     assert isinstance(response.command, BeaconBlocks)
-#     assert response.payload == {
-#         "request_id": 5,
-#         "encoded_blocks": (ssz.encode(block),),
-#     }
-
-
-# @pytest.mark.asyncio
-# async def test_get_no_blocks(request, event_loop):
-#     block = create_test_block()
-#     chain_db = await get_chain_db((block,))
-#     alice, response_buffer = await get_request_server_setup(request, event_loop, chain_db)
-
-#     alice.sub_proto.send_get_blocks(block.slot, 0, request_id=5)
-#     response = await response_buffer.msg_queue.get()
-
-#     assert isinstance(response.command, BeaconBlocks)
-#     assert response.payload == {
-#         "request_id": 5,
-#         "encoded_blocks": (),
-#     }
-
-
-# @pytest.mark.asyncio
-# async def test_get_unknown_block_by_slot(request, event_loop):
-#     block = create_test_block()
-#     chain_db = await get_chain_db((block,))
-#     alice, response_buffer = await get_request_server_setup(request, event_loop, chain_db)
-
-#     alice.sub_proto.send_get_blocks(block.slot + 100, 1, request_id=5)
-#     response = await response_buffer.msg_queue.get()
-
-#     assert isinstance(response.command, BeaconBlocks)
-#     assert response.payload == {
-#         "request_id": 5,
-#         "encoded_blocks": (),
-#     }
+    # test: `request_id` not found, it should be rejected
+    inexistent_request_id = 5566
+    assert inexistent_request_id not in bob_receive_server.map_requested_id_block_root
+    alice.sub_proto.send_blocks(blocks=(block_0,), request_id=inexistent_request_id)
+    await msg_buffer.msg_queue.get()
+    await asyncio.sleep(0)
+    assert not bob_chain.is_block_existing(block_0.signed_root)
+    # test: >= 1 blocks are sent, the request should be rejected.
+    existing_request_id = 1
+    bob_receive_server.map_requested_id_block_root[existing_request_id] = block_0.signed_root
+    alice.sub_proto.send_blocks(blocks=(block_0, block_0), request_id=existing_request_id)
+    await msg_buffer.msg_queue.get()
+    assert not bob_chain.is_block_existing(block_0.signed_root)
+    # test: `request_id` is found but `block.signed_root` does not correspond to the request
+    existing_request_id = 2
+    bob_receive_server.map_requested_id_block_root[existing_request_id] = b'\x12' * 32
+    alice.sub_proto.send_blocks(blocks=(block_0,), request_id=existing_request_id)
+    await msg_buffer.msg_queue.get()
+    assert not bob_chain.is_block_existing(block_0.signed_root)
+    # test: `request_id` is found and the block is valid. It should be imported.
+    existing_request_id = 3
+    bob_receive_server.map_requested_id_block_root[existing_request_id] = block_0.signed_root
+    alice.sub_proto.send_blocks(blocks=(block_0,), request_id=existing_request_id)
+    await msg_buffer.msg_queue.get()
+    await asyncio.sleep(0.01)
+    assert bob_chain.is_block_existing(block_0.signed_root)
+    assert existing_request_id not in bob_receive_server.map_requested_id_block_root
 
 
-# @pytest.mark.asyncio
-# async def test_get_unknown_block_by_root(request, event_loop):
-#     block = create_test_block()
-#     chain_db = await get_chain_db((block,))
-#     alice, response_buffer = await get_request_server_setup(request, event_loop, chain_db)
+@pytest.mark.asyncio
+async def test_bcc_receive_server_handle_new_beacon_block_checks(request, event_loop, monkeypatch):
+    alice, bob_receive_server, msg_buffer = await get_peer_and_receive_server(request, event_loop)
+    bob_chain = bob_receive_server.chain
+    head = bob_chain.get_canonical_head()
+    block_0 = bob_chain.create_block_from_parent(
+        parent_block=head,
+        block_params=FromBlockParams(),
+    )
+    is_called = False
 
-#     alice.sub_proto.send_get_blocks(b"\x00" * 32, 1, request_id=5)
-#     response = await response_buffer.msg_queue.get()
+    def _try_import_or_handle_orphan(block):
+        nonlocal is_called
+        is_called = True
 
-#     assert isinstance(response.command, BeaconBlocks)
-#     assert response.payload == {
-#         "request_id": 5,
-#         "encoded_blocks": (),
-#     }
+    monkeypatch.setattr(
+        bob_receive_server,
+        '_try_import_or_handle_orphan',
+        _try_import_or_handle_orphan,
+    )
 
+    alice.sub_proto.send_new_block(block=block_0)
+    await asyncio.sleep(0.01)
+    assert is_called
+    is_called = False
 
-# @pytest.mark.asyncio
-# async def test_get_canonical_block_range_by_slot(request, event_loop):
-#     chain_db = await get_chain_db()
-
-#     genesis = create_test_block()
-#     base_branch = create_branch(3, root=genesis)
-#     non_canonical_branch = create_branch(3, root=base_branch[-1], state_root=b"\x00" * 32)
-
-#     canonical_branch = create_branch(4, root=base_branch[-1], state_root=b"\x11" * 32)
-
-#     for branch in [[genesis], base_branch, non_canonical_branch, canonical_branch]:
-#         await chain_db.coro_persist_block_chain(branch, BeaconBlock)
-
-#     alice, response_buffer = await get_request_server_setup(request, event_loop, chain_db)
-
-#     alice.sub_proto.send_get_blocks(genesis.slot + 2, 4, request_id=5)
-#     response = await response_buffer.msg_queue.get()
-
-#     assert isinstance(response.command, BeaconBlocks)
-#     assert response.payload["request_id"] == 5
-#     blocks = tuple(ssz.decode(block, BeaconBlock) for block in response.payload["encoded_blocks"])
-#     assert len(blocks) == 4
-#     assert [block.slot for block in blocks] == [genesis.slot + s for s in [2, 3, 4, 5]]
-#     assert blocks == base_branch[1:] + canonical_branch[:2]
-
-
-# @pytest.mark.asyncio
-# async def test_get_canonical_block_range_by_root(request, event_loop):
-#     chain_db = await get_chain_db()
-
-#     genesis = create_test_block()
-#     base_branch = create_branch(3, root=genesis)
-#     non_canonical_branch = create_branch(3, root=base_branch[-1], state_root=b"\x00" * 32)
-#     canonical_branch = create_branch(4, root=base_branch[-1], state_root=b"\x11" * 32)
-
-#     for branch in [[genesis], base_branch, non_canonical_branch, canonical_branch]:
-#         await chain_db.coro_persist_block_chain(branch, BeaconBlock)
-
-#     alice, response_buffer = await get_request_server_setup(request, event_loop, chain_db)
-
-#     alice.sub_proto.send_get_blocks(base_branch[1].root, 4, request_id=5)
-#     response = await response_buffer.msg_queue.get()
-
-#     assert isinstance(response.command, BeaconBlocks)
-#     assert response.payload["request_id"] == 5
-#     blocks = tuple(ssz.decode(block, BeaconBlock) for block in response.payload["encoded_blocks"])
-#     assert len(blocks) == 4
-#     assert [block.slot for block in blocks] == [genesis.slot + s for s in [2, 3, 4, 5]]
-#     assert blocks == base_branch[1:] + canonical_branch[:2]
-
-
-# @pytest.mark.asyncio
-# async def test_get_incomplete_canonical_block_range(request, event_loop):
-#     chain_db = await get_chain_db()
-
-#     genesis = create_test_block()
-#     base_branch = create_branch(3, root=genesis)
-#     non_canonical_branch = create_branch(3, root=base_branch[-1], state_root=b"\x00" * 32)
-#     canonical_branch = create_branch(4, root=base_branch[-1], state_root=b"\x11" * 32)
-
-#     for branch in [[genesis], base_branch, non_canonical_branch, canonical_branch]:
-#         await chain_db.coro_persist_block_chain(branch, BeaconBlock)
-
-#     alice, response_buffer = await get_request_server_setup(request, event_loop, chain_db)
-
-#     alice.sub_proto.send_get_blocks(genesis.slot + 3, 10, request_id=5)
-#     response = await response_buffer.msg_queue.get()
-
-#     assert isinstance(response.command, BeaconBlocks)
-#     assert response.payload["request_id"] == 5
-#     blocks = tuple(ssz.decode(block, BeaconBlock) for block in response.payload["encoded_blocks"])
-#     assert len(blocks) == 5
-#     assert [block.slot for block in blocks] == [genesis.slot + s for s in [3, 4, 5, 6, 7]]
-#     assert blocks == base_branch[-1:] + canonical_branch
-
-
-# @pytest.mark.asyncio
-# async def test_get_non_canonical_branch(request, event_loop):
-#     chain_db = await get_chain_db()
-
-#     genesis = create_test_block()
-#     base_branch = create_branch(3, root=genesis)
-#     non_canonical_branch = create_branch(3, root=base_branch[-1], state_root=b"\x00" * 32)
-#     canonical_branch = create_branch(4, root=base_branch[-1], state_root=b"\x11" * 32)
-
-#     for branch in [[genesis], base_branch, non_canonical_branch, canonical_branch]:
-#         await chain_db.coro_persist_block_chain(branch, BeaconBlock)
-
-#     alice, response_buffer = await get_request_server_setup(request, event_loop, chain_db)
-
-#     alice.sub_proto.send_get_blocks(non_canonical_branch[1].root, 3, request_id=5)
-#     response = await response_buffer.msg_queue.get()
-
-#     assert isinstance(response.command, BeaconBlocks)
-#     assert response.payload["request_id"] == 5
-#     blocks = tuple(ssz.decode(block, BeaconBlock) for block in response.payload["encoded_blocks"])
-#     assert len(blocks) == 1
-#     assert blocks[0].slot == genesis.slot + 5
-#     assert blocks[0] == non_canonical_branch[1]
+    # test: seen blocks should be rejected
+    bob_receive_server.orphan_block_pool.add(block_0)
+    alice.sub_proto.send_new_block(block=block_0)
+    await asyncio.sleep(0.01)
+    assert not is_called

--- a/tests/core/p2p-proto/bcc/test_receive_server.py
+++ b/tests/core/p2p-proto/bcc/test_receive_server.py
@@ -1,0 +1,228 @@
+import asyncio
+
+from typing import (
+    Tuple,
+)
+
+import pytest
+
+import ssz
+
+from p2p.peer import (
+    MsgBuffer,
+)
+
+from eth2.beacon.chains.base import (
+    BeaconChain,
+)
+from eth2.beacon.types.blocks import (
+    BeaconBlock,
+)
+
+from trinity.protocol.bcc.peer import (
+    BCCPeer,
+)
+from trinity.protocol.bcc.servers import (
+    BCCReceiveServer,
+)
+from trinity.protocol.bcc.commands import (
+    BeaconBlocks,
+)
+
+from .helpers import (
+    get_genesis_chain_db,
+    create_test_block,
+    get_directly_linked_peers_in_peer_pools,
+)
+
+
+async def get_peer_and_receive_server(request, event_loop) -> Tuple[BCCPeer, BCCReceiveServer]:
+    alice_chain_db = await get_genesis_chain_db()
+    bob_chain_db = await get_genesis_chain_db()
+    alice, alice_peer_pool, bob, bob_peer_pool = await get_directly_linked_peers_in_peer_pools(
+        request,
+        event_loop,
+        alice_chain_db=alice_chain_db,
+        bob_chain_db=bob_chain_db,
+    )
+
+    chain = BeaconChain(bob_chain_db.db)
+    bob_receive_server = BCCReceiveServer(chain=chain, peer_pool=bob_peer_pool)
+    asyncio.ensure_future(bob_receive_server.run())
+
+    def finalizer():
+        event_loop.run_until_complete(bob_receive_server.cancel())
+
+    request.addfinalizer(finalizer)
+
+    return alice, bob_receive_server
+
+
+@pytest.mark.asyncio
+async def test_send_block(request, event_loop):
+    alice, bob_receive_server = await get_peer_and_receive_server(request, event_loop)
+
+
+# @pytest.mark.asyncio
+# async def test_get_single_block_by_root(request, event_loop):
+#     block = create_test_block()
+#     chain_db = await get_chain_db((block,))
+#     alice, response_buffer = await get_request_server_setup(request, event_loop, chain_db)
+
+#     alice.sub_proto.send_get_blocks(block.slot, 1, request_id=5)
+#     response = await response_buffer.msg_queue.get()
+
+#     assert isinstance(response.command, BeaconBlocks)
+#     assert response.payload == {
+#         "request_id": 5,
+#         "encoded_blocks": (ssz.encode(block),),
+#     }
+
+
+# @pytest.mark.asyncio
+# async def test_get_no_blocks(request, event_loop):
+#     block = create_test_block()
+#     chain_db = await get_chain_db((block,))
+#     alice, response_buffer = await get_request_server_setup(request, event_loop, chain_db)
+
+#     alice.sub_proto.send_get_blocks(block.slot, 0, request_id=5)
+#     response = await response_buffer.msg_queue.get()
+
+#     assert isinstance(response.command, BeaconBlocks)
+#     assert response.payload == {
+#         "request_id": 5,
+#         "encoded_blocks": (),
+#     }
+
+
+# @pytest.mark.asyncio
+# async def test_get_unknown_block_by_slot(request, event_loop):
+#     block = create_test_block()
+#     chain_db = await get_chain_db((block,))
+#     alice, response_buffer = await get_request_server_setup(request, event_loop, chain_db)
+
+#     alice.sub_proto.send_get_blocks(block.slot + 100, 1, request_id=5)
+#     response = await response_buffer.msg_queue.get()
+
+#     assert isinstance(response.command, BeaconBlocks)
+#     assert response.payload == {
+#         "request_id": 5,
+#         "encoded_blocks": (),
+#     }
+
+
+# @pytest.mark.asyncio
+# async def test_get_unknown_block_by_root(request, event_loop):
+#     block = create_test_block()
+#     chain_db = await get_chain_db((block,))
+#     alice, response_buffer = await get_request_server_setup(request, event_loop, chain_db)
+
+#     alice.sub_proto.send_get_blocks(b"\x00" * 32, 1, request_id=5)
+#     response = await response_buffer.msg_queue.get()
+
+#     assert isinstance(response.command, BeaconBlocks)
+#     assert response.payload == {
+#         "request_id": 5,
+#         "encoded_blocks": (),
+#     }
+
+
+# @pytest.mark.asyncio
+# async def test_get_canonical_block_range_by_slot(request, event_loop):
+#     chain_db = await get_chain_db()
+
+#     genesis = create_test_block()
+#     base_branch = create_branch(3, root=genesis)
+#     non_canonical_branch = create_branch(3, root=base_branch[-1], state_root=b"\x00" * 32)
+
+#     canonical_branch = create_branch(4, root=base_branch[-1], state_root=b"\x11" * 32)
+
+#     for branch in [[genesis], base_branch, non_canonical_branch, canonical_branch]:
+#         await chain_db.coro_persist_block_chain(branch, BeaconBlock)
+
+#     alice, response_buffer = await get_request_server_setup(request, event_loop, chain_db)
+
+#     alice.sub_proto.send_get_blocks(genesis.slot + 2, 4, request_id=5)
+#     response = await response_buffer.msg_queue.get()
+
+#     assert isinstance(response.command, BeaconBlocks)
+#     assert response.payload["request_id"] == 5
+#     blocks = tuple(ssz.decode(block, BeaconBlock) for block in response.payload["encoded_blocks"])
+#     assert len(blocks) == 4
+#     assert [block.slot for block in blocks] == [genesis.slot + s for s in [2, 3, 4, 5]]
+#     assert blocks == base_branch[1:] + canonical_branch[:2]
+
+
+# @pytest.mark.asyncio
+# async def test_get_canonical_block_range_by_root(request, event_loop):
+#     chain_db = await get_chain_db()
+
+#     genesis = create_test_block()
+#     base_branch = create_branch(3, root=genesis)
+#     non_canonical_branch = create_branch(3, root=base_branch[-1], state_root=b"\x00" * 32)
+#     canonical_branch = create_branch(4, root=base_branch[-1], state_root=b"\x11" * 32)
+
+#     for branch in [[genesis], base_branch, non_canonical_branch, canonical_branch]:
+#         await chain_db.coro_persist_block_chain(branch, BeaconBlock)
+
+#     alice, response_buffer = await get_request_server_setup(request, event_loop, chain_db)
+
+#     alice.sub_proto.send_get_blocks(base_branch[1].root, 4, request_id=5)
+#     response = await response_buffer.msg_queue.get()
+
+#     assert isinstance(response.command, BeaconBlocks)
+#     assert response.payload["request_id"] == 5
+#     blocks = tuple(ssz.decode(block, BeaconBlock) for block in response.payload["encoded_blocks"])
+#     assert len(blocks) == 4
+#     assert [block.slot for block in blocks] == [genesis.slot + s for s in [2, 3, 4, 5]]
+#     assert blocks == base_branch[1:] + canonical_branch[:2]
+
+
+# @pytest.mark.asyncio
+# async def test_get_incomplete_canonical_block_range(request, event_loop):
+#     chain_db = await get_chain_db()
+
+#     genesis = create_test_block()
+#     base_branch = create_branch(3, root=genesis)
+#     non_canonical_branch = create_branch(3, root=base_branch[-1], state_root=b"\x00" * 32)
+#     canonical_branch = create_branch(4, root=base_branch[-1], state_root=b"\x11" * 32)
+
+#     for branch in [[genesis], base_branch, non_canonical_branch, canonical_branch]:
+#         await chain_db.coro_persist_block_chain(branch, BeaconBlock)
+
+#     alice, response_buffer = await get_request_server_setup(request, event_loop, chain_db)
+
+#     alice.sub_proto.send_get_blocks(genesis.slot + 3, 10, request_id=5)
+#     response = await response_buffer.msg_queue.get()
+
+#     assert isinstance(response.command, BeaconBlocks)
+#     assert response.payload["request_id"] == 5
+#     blocks = tuple(ssz.decode(block, BeaconBlock) for block in response.payload["encoded_blocks"])
+#     assert len(blocks) == 5
+#     assert [block.slot for block in blocks] == [genesis.slot + s for s in [3, 4, 5, 6, 7]]
+#     assert blocks == base_branch[-1:] + canonical_branch
+
+
+# @pytest.mark.asyncio
+# async def test_get_non_canonical_branch(request, event_loop):
+#     chain_db = await get_chain_db()
+
+#     genesis = create_test_block()
+#     base_branch = create_branch(3, root=genesis)
+#     non_canonical_branch = create_branch(3, root=base_branch[-1], state_root=b"\x00" * 32)
+#     canonical_branch = create_branch(4, root=base_branch[-1], state_root=b"\x11" * 32)
+
+#     for branch in [[genesis], base_branch, non_canonical_branch, canonical_branch]:
+#         await chain_db.coro_persist_block_chain(branch, BeaconBlock)
+
+#     alice, response_buffer = await get_request_server_setup(request, event_loop, chain_db)
+
+#     alice.sub_proto.send_get_blocks(non_canonical_branch[1].root, 3, request_id=5)
+#     response = await response_buffer.msg_queue.get()
+
+#     assert isinstance(response.command, BeaconBlocks)
+#     assert response.payload["request_id"] == 5
+#     blocks = tuple(ssz.decode(block, BeaconBlock) for block in response.payload["encoded_blocks"])
+#     assert len(blocks) == 1
+#     assert blocks[0].slot == genesis.slot + 5
+#     assert blocks[0] == non_canonical_branch[1]

--- a/tests/libp2p/p2pclient/test_p2pclient_integration.py
+++ b/tests/libp2p/p2pclient/test_p2pclient_integration.py
@@ -417,7 +417,7 @@ async def test_control_client_list_peers(p2pds):
     (True,),
 )
 @pytest.mark.asyncio
-async def test_controle_client_disconnect(peer_id_random, p2pds):
+async def test_control_client_disconnect(peer_id_random, p2pds):
     c0, c1 = p2pds[0].control, p2pds[1].control
     # test case: disconnect a peer without connections
     await c1.disconnect(peer_id_random)

--- a/trinity/protocol/bcc/servers.py
+++ b/trinity/protocol/bcc/servers.py
@@ -1,23 +1,37 @@
+from abc import abstractmethod
+import random
 from typing import (
     cast,
     AsyncIterator,
     FrozenSet,
+    MutableSet,
+    List,
     Type,
 )
 
 from eth_typing import (
     Hash32,
 )
+from eth_utils import (
+    ValidationError,
+)
 
-from cancel_token import CancelToken
+from cancel_token import CancelToken, OperationCancelled
+
+import ssz
 
 from p2p import protocol
-from p2p.peer import BasePeer
+from p2p.peer import (
+    BasePeer,
+    PeerSubscriber,
+)
 from p2p.protocol import Command
+from p2p.service import BaseService
 
 from eth.exceptions import BlockNotFound
 
-from trinity.db.beacon.chain import BaseAsyncBeaconChainDB
+from eth2.beacon.chains.base import BeaconChain
+
 from eth2.beacon.types.blocks import (
     BaseBeaconBlock,
     BeaconBlock,
@@ -26,10 +40,19 @@ from eth2.beacon.typing import (
     Slot,
 )
 
+from trinity._utils.shellart import (
+    bold_red,
+)
+from trinity.db.beacon.chain import BaseAsyncBeaconChainDB
 from trinity.protocol.common.servers import BaseRequestServer
+from trinity.protocol.common.peer import BasePeerPool
 from trinity.protocol.bcc.commands import (
+    BeaconBlocks,
+    BeaconBlocksMessage,
     GetBeaconBlocks,
     GetBeaconBlocksMessage,
+    NewBeaconBlock,
+    NewBeaconBlockMessage,
 )
 from trinity.protocol.bcc.peer import (
     BCCPeer,
@@ -52,11 +75,11 @@ class BCCRequestServer(BaseRequestServer):
     async def _handle_msg(self, base_peer: BasePeer, cmd: Command,
                           msg: protocol._DecodedMsgType) -> None:
         peer = cast(BCCPeer, base_peer)
-
+        self.logger.debug("cmd %s" % cmd)
         if isinstance(cmd, GetBeaconBlocks):
             await self._handle_get_beacon_blocks(peer, cast(GetBeaconBlocksMessage, msg))
         else:
-            raise Exception("Invariant: Only subscribed to GetBeaconBlocks")
+            raise Exception(f"Invariant: Only subscribed to {self.subscription_msg_types}")
 
     async def _handle_get_beacon_blocks(self, peer: BCCPeer, msg: GetBeaconBlocksMessage) -> None:
         if not peer.is_operational:
@@ -133,3 +156,115 @@ class BCCRequestServer(BaseRequestServer):
                 parent = block
         except BlockNotFound:
             return
+
+
+# FIXME: `BaseReceiveServer` is the same as `BaseRequestServer`.
+# Since it's not settled that a `BaseReceiveServer` is needed and so
+# in order not to pollute /trinity/protocol/common/servers.py,
+# add the `BaseReceiveServer` here instead.
+class BaseReceiveServer(BaseRequestServer):
+    pass
+
+
+class BCCReceiveServer(BaseReceiveServer):
+    subscription_msg_types: FrozenSet[Type[Command]] = frozenset({
+        NewBeaconBlock,
+        BeaconBlocks,
+    })
+
+    requested_ids: MutableSet[int]
+    # TODO: probably use lru-cache or other cache in the future?
+    #   map from `block.parent_root` to `block`
+    orphan_block_pool: List[BeaconBlock]
+
+    def __init__(
+            self,
+            chain: BeaconChain,
+            peer_pool: BCCPeerPool,
+            token: CancelToken = None) -> None:
+        super().__init__(peer_pool, token)
+        self.chain = chain
+        self.orphan_block_pool = []
+        self.requested_ids = set()
+
+    async def _handle_msg(self, base_peer: BasePeer, cmd: Command,
+                          msg: protocol._DecodedMsgType) -> None:
+        peer = cast(BCCPeer, base_peer)
+        self.logger.debug("cmd %s" % cmd)
+        if isinstance(cmd, NewBeaconBlock):
+            await self._handle_new_beacon_block(peer, cast(NewBeaconBlockMessage, msg))
+        elif isinstance(cmd, BeaconBlocks):
+            await self._handle_beacon_blocks(peer, cast(BeaconBlocksMessage, msg))
+        else:
+            raise Exception(f"Invariant: Only subscribed to {self.subscription_msg_types}")
+
+    async def _handle_beacon_blocks(self, peer: BCCPeer, msg: NewBeaconBlockMessage) -> None:
+        if not peer.is_operational:
+            return
+        request_id = msg["request_id"]
+        if request_id not in self.requested_ids:
+            return
+        encoded_blocks = msg["encoded_blocks"]
+        if len(encoded_blocks) != 1:
+            raise Exception("should only receive 1 block from our requests")
+        resp_block = ssz.decode(encoded_blocks[0], BeaconBlock)
+        self.logger.debug(f"received request_id={request_id}, resp_block={resp_block}")  # noqa: E501
+        self._try_import_or_handle_orphan(resp_block)
+        self.requested_ids.remove(request_id)
+
+    async def _handle_new_beacon_block(self, peer: BCCPeer, msg: NewBeaconBlockMessage) -> None:
+        if not peer.is_operational:
+            return
+        encoded_block = msg["encoded_block"]
+        # TODO: Catch ssz decode error.
+        block = ssz.decode(encoded_block, BeaconBlock)
+        self.logger.debug(f"received block={block}")  # noqa: E501
+        self._try_import_or_handle_orphan(block)
+
+    def _try_import_or_handle_orphan(self, block: BeaconBlock) -> None:
+        blocks_to_be_imported: List[BeaconBlock] = []
+        blocks_failed_to_be_imported: List[BeaconBlock] = []
+
+        blocks_to_be_imported.append(block)
+        while len(blocks_to_be_imported) != 0:
+            block = blocks_to_be_imported.pop()
+            # try to import the block
+            try:
+                self.logger.debug(f"try to import block={block}")
+                self.chain.import_block(block)
+                self.logger.debug(f"successfully imported block={block}")
+            except ValidationError:
+                self.logger.debug(f"failed to import block={block}, add to the orphan pool")
+                # if failed, add the block and the rest of the queue back to the pool
+                blocks_failed_to_be_imported.append(block)
+                #   and send request for their parents
+                self._request_block_by_root(block_root=block.parent_root)
+            # if succeeded, handle the orphan blocks which depend on this block.
+            matched_orphan_blocks = tuple(
+                orphan_block
+                for orphan_block in self.orphan_block_pool
+                if orphan_block.parent_root == block.root
+            )
+            if len(matched_orphan_blocks) > 0:
+                self.logger.debug(
+                    f"blocks {matched_orphan_blocks} match their parent {block}"
+                )
+                blocks_to_be_imported.extend(matched_orphan_blocks)
+                self.orphan_block_pool = list(
+                    set(self.orphan_block_pool).difference(matched_orphan_blocks)
+                )
+        # add the blocks-failed-to-import back
+        self.orphan_block_pool.extend(blocks_failed_to_be_imported)
+
+    def _request_block_by_root(self, block_root: Hash32) -> None:
+        for i, peer in enumerate(self._peer_pool.connected_nodes.values()):
+            self.logger.debug(
+                bold_red(f"send block request to: request_id={i}, peer={peer}")
+            )
+            req_request_id = random.randint(0, 32768)
+            self.requested_ids.add(req_request_id)
+            peer.sub_proto.send_get_blocks(
+                block_root,
+                max_blocks=1,
+                request_id=req_request_id,
+            )

--- a/trinity/protocol/bcc/servers.py
+++ b/trinity/protocol/bcc/servers.py
@@ -168,8 +168,8 @@ class BaseReceiveServer(BaseRequestServer):
 
 class BCCReceiveServer(BaseReceiveServer):
     subscription_msg_types: FrozenSet[Type[Command]] = frozenset({
-        NewBeaconBlock,
         BeaconBlocks,
+        NewBeaconBlock,
     })
 
     requested_ids: MutableSet[int]
@@ -253,7 +253,7 @@ class BCCReceiveServer(BaseReceiveServer):
                 self.orphan_block_pool = list(
                     set(self.orphan_block_pool).difference(matched_orphan_blocks)
                 )
-        # add the blocks-failed-to-import back
+        # add the failed-to-be-imported blocks back
         self.orphan_block_pool.extend(blocks_failed_to_be_imported)
 
     def _request_block_by_root(self, block_root: Hash32) -> None:

--- a/trinity/protocol/bcc/servers.py
+++ b/trinity/protocol/bcc/servers.py
@@ -164,8 +164,7 @@ class BaseReceiveServer(BaseRequestServer):
 
 
 class OrphanBlockPool:
-    # TODO: probably use lru-cache or other cache in the future?
-    #   map from `block.previous_block_root` to `block`
+    # TODO: can probably use lru-cache or even database
     _pool: Set[BaseBeaconBlock]
 
     def __init__(self) -> None:

--- a/trinity/protocol/bcc/servers.py
+++ b/trinity/protocol/bcc/servers.py
@@ -1,4 +1,3 @@
-from abc import abstractmethod
 import random
 from typing import (
     cast,
@@ -9,27 +8,21 @@ from typing import (
     MutableSet,
     Tuple,
     Type,
-    Union,
 )
 
 from eth_typing import (
     Hash32,
 )
-from eth_utils import (
-    ValidationError,
-)
 
-from cancel_token import CancelToken, OperationCancelled
+from cancel_token import CancelToken
 
 import ssz
 
 from p2p import protocol
 from p2p.peer import (
     BasePeer,
-    PeerSubscriber,
 )
 from p2p.protocol import Command
-from p2p.service import BaseService
 
 from eth.exceptions import BlockNotFound
 
@@ -48,7 +41,6 @@ from trinity._utils.shellart import (
 )
 from trinity.db.beacon.chain import BaseAsyncBeaconChainDB
 from trinity.protocol.common.servers import BaseRequestServer
-from trinity.protocol.common.peer import BasePeerPool
 from trinity.protocol.bcc.commands import (
     BeaconBlocks,
     BeaconBlocksMessage,

--- a/trinity/protocol/bcc/servers.py
+++ b/trinity/protocol/bcc/servers.py
@@ -5,7 +5,7 @@ from typing import (
     Dict,
     FrozenSet,
     List,
-    MutableSet,
+    Set,
     Tuple,
     Type,
 )
@@ -164,7 +164,7 @@ class BaseReceiveServer(BaseRequestServer):
 class OrphanBlockPool:
     # TODO: probably use lru-cache or other cache in the future?
     #   map from `block.previous_block_root` to `block`
-    _pool: MutableSet[BaseBeaconBlock]
+    _pool: Set[BaseBeaconBlock]
 
     def __init__(self) -> None:
         self._pool = set()
@@ -220,7 +220,7 @@ class BCCReceiveServer(BaseReceiveServer):
         else:
             raise Exception(f"Invariant: Only subscribed to {self.subscription_msg_types}")
 
-    async def _handle_beacon_blocks(self, peer: BCCPeer, msg: NewBeaconBlockMessage) -> None:
+    async def _handle_beacon_blocks(self, peer: BCCPeer, msg: BeaconBlocksMessage) -> None:
         if not peer.is_operational:
             return
         request_id = msg["request_id"]
@@ -277,6 +277,7 @@ class BCCReceiveServer(BaseReceiveServer):
 
     def _request_block_by_root(self, block_root: Hash32) -> None:
         for i, peer in enumerate(self._peer_pool.connected_nodes.values()):
+            peer = cast(BCCPeer, peer)
             self.logger.debug(
                 bold_red(f"send block request to: request_id={i}, peer={peer}")
             )

--- a/trinity/server.py
+++ b/trinity/server.py
@@ -349,7 +349,6 @@ class BCCServer(BaseServer[BCCPeerPool]):
                  headerdb: BaseAsyncHeaderDB,
                  base_db: BaseAsyncDB,
                  network_id: int,
-                 peer_info: BasePeerInfo = None,
                  max_peers: int = DEFAULT_MAX_PEERS,
                  bootstrap_nodes: Tuple[Node, ...] = None,
                  preferred_nodes: Sequence[Node] = None,

--- a/trinity/server.py
+++ b/trinity/server.py
@@ -363,7 +363,6 @@ class BCCServer(BaseServer[BCCPeerPool]):
             headerdb,
             base_db,
             network_id,
-            peer_info,
             max_peers,
             bootstrap_nodes,
             preferred_nodes,


### PR DESCRIPTION
### What was wrong?
Our validator service has no corresponding handler for the command `NewBeaconBlock`.

### How was it fixed?
Based on `BCCReceiveServer`, the work of @NIC619 from https://github.com/ethereum/trinity/pull/465.
- Add `BCCReceiveServer` to define the handler for `NewBeaconBlock`.
- Add method `BCCReceiveServer._try_import_or_handle_orphan` to check and maintain orphan blocks in `BCCReceiveServer.orphan_block_pool`. Currently, it is a in-memory set. We can further optimize it for purposes through changing `orphan_block_pool._pool`.
- Add method `BCCReceiveServer._request_block_by_root` used by `BCCReceiveServer._try_import_or_handle_orphan` to request the parents of the orphans from peers.
- Add a handler for `BeaconBlocks` to handle the response of our sent requests.

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://i.imgur.com/chSkTmP.jpg)
