### PR TITLE
Ensure BaseAsyncHeaderDB derives from ABC

### DIFF
--- a/tests/core/integration_test_helpers.py
+++ b/tests/core/integration_test_helpers.py
@@ -83,6 +83,7 @@ class FakeAsyncHeaderDB(BaseAsyncHeaderDB, HeaderDB):
 
 
 class FakeAsyncChainDB(BaseAsyncChainDB, FakeAsyncHeaderDB, ChainDB):
+    coro_exists = async_passthrough('exists')
     coro_persist_block = async_passthrough('persist_block')
     coro_persist_uncles = async_passthrough('persist_uncles')
     coro_persist_trie_data_dict = async_passthrough('persist_trie_data_dict')

--- a/trinity/db/eth1/chain.py
+++ b/trinity/db/eth1/chain.py
@@ -87,6 +87,7 @@ class AsyncChainDBPreProxy(BaseAsyncChainDB):
     coro_get_canonical_block_header_by_number = async_method('get_canonical_block_header_by_number')
     coro_persist_header = async_method('persist_header')
     coro_persist_block = async_method('persist_block')
+    coro_persist_header_chain = async_method('persist_header_chain')
     coro_persist_uncles = async_method('persist_uncles')
     coro_persist_trie_data_dict = async_method('persist_trie_data_dict')
     coro_get_block_transactions = async_method('get_block_transactions')

--- a/trinity/db/eth1/header.py
+++ b/trinity/db/eth1/header.py
@@ -1,4 +1,7 @@
-from abc import abstractmethod
+from abc import (
+    ABC,
+    abstractmethod,
+)
 # Typeshed definitions for multiprocessing.managers is incomplete, so ignore them for now:
 # https://github.com/python/typeshed/blob/85a788dbcaa5e9e9a62e55f15d44530cd28ba830/stdlib/3/multiprocessing/managers.pyi#L3
 from multiprocessing.managers import (  # type: ignore
@@ -24,7 +27,7 @@ from trinity._utils.mp import (
 )
 
 
-class BaseAsyncHeaderDB:
+class BaseAsyncHeaderDB(ABC):
     """
     Abstract base class for the async counterpart to ``BaseHeaderDB``.
     """


### PR DESCRIPTION
### What was wrong?

The `BaseAsyncHeaderDB` class did not derive from `ABC` which meant that nothing enforces the implementation of the `abstractmethod`'s.

### How was it fixed?

- Derive from `ABC` 
- Implement missing `coro_persist_header_chain` that was now rightfully caught by tests.
- Implement missing `coro_exists` that was now rightfully caught by tests.

[//]: # (For important changes, please add a new entry to the running release notes PR)
[//]: # (You can find the current one using: https://github.com/ethereum/trinity/pulls?q=is%3Aopen+is%3Apr+label%3A%22Release+Notes%22 )
[//]: # (See: https://trinity-client.readthedocs.io/en/latest/contributing.html#pull-requests)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://www.brazilrocket.com/images/1427660110_411976/web.jpg)
