### PR TITLE
Fix CI failure: Add config to `FakeAsyncBeaconChainDB.__init__`

### DIFF
--- a/tests/core/p2p-proto/bcc/helpers.py
+++ b/tests/core/p2p-proto/bcc/helpers.py
@@ -14,13 +14,14 @@ from eth.constants import (
 )
 from eth.db.atomic import AtomicDB
 
+from eth2.configs import Eth2Config
 from eth2.beacon.db.chain import BeaconChainDB
-from trinity.db.beacon.chain import BaseAsyncBeaconChainDB
 from eth2.beacon.types.blocks import (
     BeaconBlock,
     BeaconBlockBody,
 )
 
+from trinity.db.beacon.chain import BaseAsyncBeaconChainDB
 from trinity.protocol.bcc.context import BeaconContext
 from trinity.protocol.bcc.peer import (
     BCCPeerFactory,
@@ -46,8 +47,9 @@ from eth2.beacon.state_machines.forks.serenity import SERENITY_CONFIG
 
 class FakeAsyncBeaconChainDB(BaseAsyncBeaconChainDB, BeaconChainDB):
 
-    def __init__(self, db: BaseAtomicDB) -> None:
+    def __init__(self, db: BaseAtomicDB, config: Eth2Config) -> None:
         self.db = db
+        self.config = config
 
     coro_persist_block = async_passthrough('persist_block')
     coro_get_canonical_block_root = async_passthrough('get_canonical_block_root')
@@ -101,7 +103,7 @@ def create_branch(length, root=None, **start_kwargs):
 
 async def get_chain_db(blocks=()):
     db = AtomicDB()
-    chain_db = FakeAsyncBeaconChainDB(db)
+    chain_db = FakeAsyncBeaconChainDB(db=db, config=SERENITY_CONFIG)
     await chain_db.coro_persist_block_chain(blocks, BeaconBlock)
     return chain_db
 

--- a/tests/core/p2p-proto/bcc/helpers.py
+++ b/tests/core/p2p-proto/bcc/helpers.py
@@ -101,16 +101,16 @@ def create_branch(length, root=None, **start_kwargs):
         parent = child
 
 
-async def get_chain_db(blocks=()):
+async def get_chain_db(blocks=(), config=SERENITY_CONFIG):
     db = AtomicDB()
-    chain_db = FakeAsyncBeaconChainDB(db=db, config=SERENITY_CONFIG)
+    chain_db = FakeAsyncBeaconChainDB(db=db, config=config)
     await chain_db.coro_persist_block_chain(blocks, BeaconBlock)
     return chain_db
 
 
-async def get_genesis_chain_db():
+async def get_genesis_chain_db(config=SERENITY_CONFIG):
     genesis = create_test_block()
-    return await get_chain_db((genesis,))
+    return await get_chain_db((genesis,), config=config)
 
 
 async def _setup_alice_and_bob_factories(alice_chain_db, bob_chain_db):

--- a/tests/core/p2p-proto/bcc/test_receive_server.py
+++ b/tests/core/p2p-proto/bcc/test_receive_server.py
@@ -31,6 +31,9 @@ from eth2.beacon.typing import (
 from eth2.beacon.state_machines.forks.serenity.blocks import (
     SerenityBeaconBlock,
 )
+from eth2.beacon.state_machines.forks.xiao_long_bao.configs import (
+    XIAO_LONG_BAO_CONFIG,
+)
 
 from trinity.protocol.bcc.peer import (
     BCCPeer,
@@ -74,7 +77,7 @@ class FakeChain(TestnetChain):
 
 async def get_fake_chain() -> FakeChain:
     chain_db = await get_genesis_chain_db()
-    return FakeChain(chain_db.db)
+    return FakeChain(base_db=chain_db.db, config=XIAO_LONG_BAO_CONFIG)
 
 
 def get_blocks(

--- a/tests/core/p2p-proto/bcc/test_receive_server.py
+++ b/tests/core/p2p-proto/bcc/test_receive_server.py
@@ -76,7 +76,7 @@ class FakeChain(TestnetChain):
 
 
 async def get_fake_chain() -> FakeChain:
-    chain_db = await get_genesis_chain_db()
+    chain_db = await get_genesis_chain_db(config=XIAO_LONG_BAO_CONFIG)
     return FakeChain(base_db=chain_db.db, config=XIAO_LONG_BAO_CONFIG)
 
 


### PR DESCRIPTION
### What was wrong?
`config` is added in `BaseBeaconChainDB`. Sorry I made the CI [fail](https://circleci.com/gh/ethereum/trinity/33433) because I didn't rebase before merging my PR.

### How was it fixed?
Add config in `FakeAsyncBeaconChainDB`, and pass the corresponding configs in the tests.

[//]: # (For important changes, please add a new entry to the running release notes PR)
[//]: # (You can find the current one using: https://github.com/ethereum/trinity/pulls?q=is%3Aopen+is%3Apr+label%3A%22Release+Notes%22 )
[//]: # (See: https://trinity-client.readthedocs.io/en/latest/contributing.html#pull-requests)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://i.imgur.com/3ucc3nV.jpg)
