### PR TITLE
Add plugin that helps with performance benchmarking

### DIFF
--- a/docs/guides/index.rst
+++ b/docs/guides/index.rst
@@ -10,3 +10,4 @@ This section aims to provide hands-on guides to demonstrate how to use Trinity. 
    quickstart
    architecture
    writing_plugins
+   measuring_runtime_sync_performance

--- a/docs/guides/measuring_runtime_sync_performance.rst
+++ b/docs/guides/measuring_runtime_sync_performance.rst
@@ -1,0 +1,93 @@
+Measuring runtime sync performance
+==================================
+
+Trinity comes with a built-in plugin that allows us to measure its runtime performance.
+The plugin is currently limited to a single use case which is measuring the time it takes to
+sync from a blank slate to some target block.
+
+
+Measuring runtime performance
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+To start performance testing with default settings simply run ``trinity track-perf``. This will
+kick off a series of tasks:
+
+1. Boot the performance runner
+2. Rename Trinity's currently used database with a timestamp suffix
+3. Run ``trinity`` and monitor its performance until block ``100000`` is hit
+4. Append (create if it doesn't exist) performance stats to the ``performance_report.txt`` file
+5. Repeat steps 2 - 4 until ``3`` runs are completed.
+
+
+When the performance tracking has finished we can look at the ``performance_report.txt`` to
+find out about the:
+
+- names of all archived databases
+- reached block numbers
+- total duration (including pre-sync time)
+- actual syncing duration
+- synced blocks per second
+
+
+We can also customize the target block number as well as the number of individual runs. Here is
+how we can start ``10`` runs, each syncing up until block ``20000``.
+
+.. code-block:: shell
+
+  trinity track-perf --track-perf-target-block 20000 --track-perf-run-count 10
+
+
+Passing parameters to trinity
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Chances are that we would like to pass certain parameters to trinity for each run. For instance,
+we may want to enable/disable certain plugins or ensure to only connect to a specific peer.
+The performance runner allows this by using the ``--track-perf-trinity-arg`` parameter as seen in
+the following example.
+
+.. code-block:: shell
+
+  trinity track-perf --track-perf-trinity-args='--disable-discovery --preferred-node="enode://a979fb575495b8d6db44f750317d0f4622bf4c2aa3365d6af7c284339968eef29b69ad0dce72a4d8db5ebb4968de0e3bec910127f134779fbcb0cb6d3331163c@52.16.188.185:30303" --max-peers 1'
+
+
+A/B testing different branches
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+If we would like to profile two different versions against each other, we can do so by continously
+toggling between different branches. The runner doesn't support this specifically but it allows us
+to run any command in between the individual runs using the ``--track-perf-pre-exec-cmd`` parmeter.
+
+We can rely on git toggling between branches if we configure `--track-perf-pre-exec-cmd` as
+follows:
+
+.. code-block:: shell
+
+  trinity track-perf --track-perf-pre-exec-cmd 'git checkout -'
+
+This feature can also come handy if we are profiling branches that may not shut down cleanly as we
+can arbitrary chain commands e.g.
+
+.. code-block:: shell
+
+  trinity track-perf --track-perf-pre-exec-cmd 'trinity fix-unclean-shutdown && git checkout -'
+
+Notice that any output that this command may generate will end up in the ``performance_report.txt``
+which also means that the output of ``git checkout -`` ensures we'll be able to identify the branches
+of each run.
+
+Special cases
+~~~~~~~~~~~~~
+
+The performance runner lets us configure the path to the actual trinity executable which may be
+useful if the host system does not support a global ``trinity`` command.
+
+.. code-block:: shell
+
+  trinity track-perf --track-perf-trinity-exec '/home/ubuntu/trinity/venv/bin/trinity'
+
+Similarly, the path to the ``performance_report.txt`` can be set, too.
+
+.. code-block:: shell
+
+  trinity track-perf --track-perf-report-path '/home/ubuntu/trinity/performance_report.txt'
+

--- a/trinity/plugins/builtin/performance_tracker/plugin.py
+++ b/trinity/plugins/builtin/performance_tracker/plugin.py
@@ -1,0 +1,210 @@
+from argparse import (
+    ArgumentParser,
+    Namespace,
+    _ArgumentGroup,
+    _SubParsersAction,
+)
+import asyncio
+import logging
+import subprocess
+import time
+from typing import (
+    Union,
+)
+
+from trinity.config import (
+    Eth1AppConfig,
+    TrinityConfig,
+)
+from trinity.db.eth1.manager import (
+    create_db_consumer_manager
+)
+from trinity.endpoint import (
+    TrinityEventBusEndpoint,
+)
+from trinity.extensibility import (
+    AsyncioIsolatedPlugin,
+    BaseMainProcessPlugin,
+)
+from trinity._utils.shutdown import (
+    exit_with_endpoint_and_services,
+)
+from .tracker import (
+    PerformanceTracker
+)
+
+
+DEFAULT_TARGET_BLOCK = 100000
+DEFAULT_INTERVAL = 1
+DEFAULT_LABEL = f"Unnamed run ({time.time()})"
+DEFAULT_REPORT_PATH = "performance_report.txt"
+DEFAULT_RUN_COUNT = 3
+DEFAULT_TRINITY_EXEC = "trinity"
+
+
+def add_shared_cli_args(parser: Union[ArgumentParser, _ArgumentGroup]) -> None:
+        parser.add_argument(
+            '--track-perf-target-block',
+            type=int,
+            default=DEFAULT_TARGET_BLOCK,
+            help='Target block number at which a run is finished',
+        )
+
+        parser.add_argument(
+            '--track-perf-label',
+            help='Label that identifies the current run',
+            default=DEFAULT_LABEL,
+        )
+
+        parser.add_argument(
+            '--track-perf-report-path',
+            help='Report file path',
+            default=DEFAULT_REPORT_PATH,
+        )
+
+        parser.add_argument(
+            '--track-perf-interval',
+            help='Interval at which current block is looked up',
+            type=int,
+            default=DEFAULT_INTERVAL,
+        )
+
+
+class TrackerRunnerPlugin(BaseMainProcessPlugin):
+    """
+    Run Trinity a specified number of times to take performance measures.
+    Performance stats for each run are written to a single file and Trinity's
+    database is archived before every run.
+    """
+
+    @property
+    def name(self) -> str:
+        return "Tracker Runner"
+
+    @classmethod
+    def configure_parser(cls, arg_parser: ArgumentParser, subparser: _SubParsersAction) -> None:
+
+        track_perf_parser = subparser.add_parser(
+            'track-perf',
+            help='Repeatedly sync up to target block and track performance',
+        )
+
+        track_perf_parser.add_argument(
+            '--track-perf-run-count',
+            type=int,
+            default=DEFAULT_RUN_COUNT,
+            help='Number of times to run Trinity',
+        )
+
+        track_perf_parser.add_argument(
+            '--track-perf-pre-exec-cmd',
+            help='Command hook executed before every run',
+        )
+
+        track_perf_parser.add_argument(
+            '--track-perf-trinity-exec',
+            default=DEFAULT_TRINITY_EXEC,
+            help='Command or path to Trinity executable',
+        )
+
+        track_perf_parser.add_argument(
+            '--track-perf-trinity-args',
+            help='Pass additional arguments to Trinity',
+        )
+
+        add_shared_cli_args(track_perf_parser)
+
+        track_perf_parser.set_defaults(func=cls.start_tracking)
+
+    @classmethod
+    def start_tracking(cls, args: Namespace, trinity_config: TrinityConfig) -> None:
+        logger = cls.get_logger()
+        file_handler = logging.handlers.RotatingFileHandler(args.track_perf_report_path)
+        logger.addHandler(file_handler)
+
+        logger.info(
+            "Performance Tracking (%s runs up to block #%s)",
+            args.track_perf_run_count,
+            args.track_perf_target_block
+        )
+        logger.info('=============================================')
+
+        for run_number in range(1, args.track_perf_run_count + 1):
+            db_path = trinity_config.get_app_config(Eth1AppConfig).database_dir
+            db_new_name = f"{db_path.name}_{time.time()}"
+            if db_path.exists():
+                db_path.rename(db_path.with_name(db_new_name))
+
+            logger.info("Run %s out of %s", run_number, args.track_perf_run_count)
+
+            if args.track_perf_pre_exec_cmd:
+                logger.info("Runing pre exec command hook: %s ", args.track_perf_pre_exec_cmd)
+                pre_hook = subprocess.run(
+                    args.track_perf_pre_exec_cmd,
+                    shell=True,
+                    stdout=subprocess.PIPE,
+                    stderr=subprocess.PIPE,
+                )
+                # A common hook would be something like `git checkout -` to toggle between branches
+                # This output allows us to identify the branch in the report
+                logger.info(pre_hook.stdout.decode())
+                logger.info(pre_hook.stderr.decode())
+
+            logger.info("Archived previous database to %s", db_new_name)
+
+            cmd = (
+                f"{args.track_perf_trinity_exec} --track-perf"
+                f" --track-perf-label '{args.track_perf_label} #{run_number}'"
+                f" --track-perf-target-block {args.track_perf_target_block}"
+                f" --track-perf-interval {args.track_perf_interval}"
+                f" --track-perf-report-path '{args.track_perf_report_path}'"
+            )
+
+            # Pass any additional params on to Trinity
+            # (e.g. --track-perf-trininty-args='--disable-discovery')
+            if args.track_perf_trinity_args is not None:
+                cmd += f" {args.track_perf_trinity_args}"
+
+            logger.info("Running cmd=%s", cmd)
+            subprocess.run(cmd, shell=True)
+
+
+class PerformanceTrackerPlugin(AsyncioIsolatedPlugin):
+    """
+    Track the time from syncing the first block to some specified target block.
+    """
+
+    @property
+    def name(self) -> str:
+        return "Performance Tracker"
+
+    def on_ready(self, manager_eventbus: TrinityEventBusEndpoint) -> None:
+        if self.boot_info.args.track_perf:
+            self.start()
+
+    @classmethod
+    def configure_parser(cls, arg_parser: ArgumentParser, subparser: _SubParsersAction) -> None:
+        perf_parser = arg_parser.add_argument_group('Performance Tracker')
+
+        perf_parser.add_argument(
+            '--track-perf',
+            action='store_true',
+            help='Enable performance tracking',
+        )
+
+        add_shared_cli_args(perf_parser)
+
+    def do_start(self) -> None:
+        db_manager = create_db_consumer_manager(self.boot_info.trinity_config.database_ipc_path)
+        chain_db = db_manager.get_chaindb()  # type: ignore
+
+        perf_tracker = PerformanceTracker(
+            chain_db,
+            self.event_bus,
+            self.boot_info.args.track_perf_label,
+            self.boot_info.args.track_perf_target_block,
+            self.boot_info.args.track_perf_interval,
+            self.boot_info.args.track_perf_report_path,
+        )
+        asyncio.ensure_future(exit_with_endpoint_and_services(self.event_bus, perf_tracker))
+        asyncio.ensure_future(perf_tracker.run())

--- a/trinity/plugins/builtin/performance_tracker/tracker.py
+++ b/trinity/plugins/builtin/performance_tracker/tracker.py
@@ -1,0 +1,80 @@
+import asyncio
+import logging
+import time
+
+from eth_utils import (
+    humanize_seconds,
+)
+from p2p.service import (
+    BaseService,
+)
+
+from trinity.db.eth1.header import (
+    BaseAsyncHeaderDB,
+)
+from trinity.endpoint import (
+    TrinityEventBusEndpoint,
+)
+
+
+class PerformanceTracker(BaseService):
+    """
+    Continously track and report performance.
+    """
+
+    _tracking_startet_at: float = 0.0
+    _first_block_started_at: float = 0.0
+    _target_hit_at: float = 0.0
+
+    def __init__(self,
+                 header_db: BaseAsyncHeaderDB,
+                 event_bus: TrinityEventBusEndpoint,
+                 label: str,
+                 target_block_number: int,
+                 reporting_interval: int,
+                 report_path: str) -> None:
+        super().__init__()
+        self.header_db = header_db
+        self.event_bus = event_bus
+        self.label = label
+        self.target_block_number = target_block_number
+        self.reporting_interval = reporting_interval
+        file_handler = logging.handlers.RotatingFileHandler(report_path)
+        file_handler.setLevel(logging.INFO)
+        self.logger.addHandler(file_handler)
+
+    async def _run(self) -> None:
+        self._tracking_startet_at = time.perf_counter()
+        while self.is_operational:
+            await self._check()
+            await asyncio.sleep(self.reporting_interval)
+
+    async def _check(self) -> None:
+        current_head = await self.header_db.coro_get_canonical_head()
+        block_number = current_head.block_number
+
+        self.logger.debug("Current block: %s, target: %s", block_number, self.target_block_number)
+
+        if block_number > 0 and self._first_block_started_at == 0.0:
+            self._first_block_started_at = time.perf_counter()
+
+        if block_number >= self.target_block_number:
+            self._target_hit_at = time.perf_counter()
+            self.report(block_number)
+            self.event_bus.request_shutdown("Performance tracking ended")
+
+    def report(self, last_block_number: int) -> None:
+        total_duration = int(self._target_hit_at - self._tracking_startet_at)
+        actual_duration = 0
+
+        if self._first_block_started_at > 0.0:
+            actual_duration = int(self._target_hit_at - self._first_block_started_at)
+
+        blocks_per_second = 0 if actual_duration == 0 else last_block_number / actual_duration
+
+        self.logger.info(f"Performance tracking finished run: {self.label}")
+        self.logger.info(f"Hit target block {self.target_block_number} ({last_block_number})")
+        self.logger.info(f"Total duration: {humanize_seconds(total_duration)}")
+        self.logger.info(f"Actual duration: {humanize_seconds(actual_duration)}")
+        self.logger.info(f"Blocks per second: {blocks_per_second}")
+        self.logger.info("#####################")

--- a/trinity/plugins/registry.py
+++ b/trinity/plugins/registry.py
@@ -32,6 +32,10 @@ from trinity.plugins.builtin.peer_discovery.plugin import (
 from trinity.plugins.builtin.request_server.plugin import (
     RequestServerPlugin,
 )
+from trinity.plugins.builtin.performance_tracker.plugin import (
+    TrackerRunnerPlugin,
+    PerformanceTrackerPlugin,
+)
 from trinity.plugins.builtin.syncer.plugin import (
     SyncerPlugin,
 )
@@ -69,7 +73,9 @@ ETH1_NODE_PLUGINS: Tuple[Type[BasePlugin], ...] = (
     DbShellPlugin,
     EthstatsPlugin,
     LightPeerChainBridgePlugin,
+    PerformanceTrackerPlugin,
     SyncerPlugin,
+    TrackerRunnerPlugin,
     TxPlugin,
 )
 


### PR DESCRIPTION
### What was wrong?

We don't have good tooling to measure Trinitys run time performance. For things that aren't easily quantifiable in isolation (e.g. with `timeit`), our best option so far is to just run Trinity and manually take some numbers. This PR tries to improve that a little.

### How was it fixed?

1. The `PerformanceTrackerPlugin` roughly does the following:
1.1 Measure the sync time from boot up to some target block
1.2 Also measure the time from the start of sync up to the target block (in other words don't include the upfront time until syncing has startet)
1.3 Write report to log and append it to the `performance_report.txt` file
1.4 Shutdown Trinity

2. The `TrackerRunnerPlugin` plugin is a `BaseMainProcessPlugin` plugin is a minimal viable runner that runs Trinity up to `n` runs with performance tracking enabled.
2.1 E.g. `trinity track-perf --track-perf-target-block 100000 --trag-perf-run-count 5`
2.2 After all runs are finished one can look at the results in `performance_report.txt` which should look like this:

```
Performance tracking finished run: Unnamed run #1
Hit target block 100
Total duration: 15s
Actual duration: 0s
#####################
Performance tracking finished run: Unnamed run #2
Hit target block 100
Total duration: 15s
Actual duration: 5s
#####################
Performance tracking finished run: Unnamed run #3
Hit target block 100
Total duration: 20s
Actual duration: 5s
#####################
```

With the default configuration, the tracker looks up the current head every 5 seconds which means that it won't be accurate to the very second. However, the general idea is that this should make it very easy to e.g. run Trinity ten times in a row up to block `1m` or something and hence give one a rough measure about its performance.

-  [ ] add changelog entry

[//]: # (For important changes, please add a new entry to the running release notes PR)
[//]: # (You can find the current one using: https://github.com/ethereum/trinity/pulls?q=is%3Aopen+is%3Apr+label%3A%22Release+Notes%22 )
[//]: # (See: https://trinity-client.readthedocs.io/en/latest/contributing.html#pull-requests)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://static.independent.co.uk/s3fs-public/thumbnails/image/2016/09/05/10/cubs9.jpg?w968h681)
