### PR TITLE
Refactor Plugin management

### DIFF
--- a/docs/api/extensibility/api.extensibility.exceptions.rst
+++ b/docs/api/extensibility/api.extensibility.exceptions.rst
@@ -1,9 +1,6 @@
 Exceptions
 ==========
 
-.. autoclass:: trinity.extensibility.exceptions.EventBusNotReady
-  :members:
-
 .. autoclass:: trinity.extensibility.exceptions.UnsuitableShutdownError
   :members:
 

--- a/docs/api/extensibility/api.extensibility.plugin.rst
+++ b/docs/api/extensibility/api.extensibility.plugin.rst
@@ -2,12 +2,6 @@ Plugin
 ======
 
 
-PluginContext
--------------
-
-.. autoclass:: trinity.extensibility.plugin.PluginContext
-  :members:
-
 BasePlugin
 ----------
 

--- a/docs/guides/writing_plugins.rst
+++ b/docs/guides/writing_plugins.rst
@@ -134,13 +134,12 @@ was called which happens as soon as the core infrastructure of Trinity is ready.
 Plugin state: ``READY``
 -----------------------
 
-After Trinity has finished setting up the core infrastructure, every plugin has its
-:class:`~trinity.extensibility.plugin.PluginContext` set and
-:meth:`~trinity.extensibility.plugin.BasePlugin.on_ready` is called. At this point the plugin has
-access to important information such as the parsed arguments or the 
-:class:`~trinity.config.TrinityConfig`. It also has access to the central event bus via its
-:meth:`~trinity.extensibility.plugin.BasePlugin.event_bus` property which enables the plugin to
-communicate with other parts of the application including other plugins.
+After Trinity has finished setting up the core infrastructure,
+:meth:`~trinity.extensibility.plugin.BasePlugin.on_ready` is called on each plugin. At
+this point the plugin has access to important information such as the parsed arguments or
+the :class:`~trinity.config.TrinityConfig`. It also has access to the central event bus
+via its :meth:`~trinity.extensibility.plugin.BasePlugin.event_bus` property which enables
+the plugin to communicate with other parts of the application including other plugins.
 
 Plugin state: ``STARTED``
 -------------------------

--- a/tests/integration/test_plugin_discovery.py
+++ b/tests/integration/test_plugin_discovery.py
@@ -13,5 +13,5 @@ def test_plugin_discovery():
     # pip install -e trinity-external-plugins/examples/peer_count_reporter
     from peer_count_reporter_plugin import PeerCountReporterPlugin
 
-    plugins = [type(plugin) for plugin in discover_plugins()]
+    plugins = discover_plugins()
     assert PeerCountReporterPlugin in plugins

--- a/trinity-external-plugins/examples/peer_count_reporter/peer_count_reporter_plugin/plugin.py
+++ b/trinity-external-plugins/examples/peer_count_reporter/peer_count_reporter_plugin/plugin.py
@@ -40,7 +40,8 @@ class PeerCountReporterPlugin(BaseIsolatedPlugin):
     def name(self) -> str:
         return "Peer Count Reporter"
 
-    def configure_parser(self,
+    @classmethod
+    def configure_parser(cls,
                          arg_parser: ArgumentParser,
                          subparser: _SubParsersAction) -> None:
         arg_parser.add_argument(
@@ -50,7 +51,7 @@ class PeerCountReporterPlugin(BaseIsolatedPlugin):
         )
 
     def on_ready(self, manager_eventbus: TrinityEventBusEndpoint) -> None:
-        if self.context.args.report_peer_count:
+        if self.boot_info.args.report_peer_count:
             self.start()
 
     def do_start(self) -> None:

--- a/trinity/bootstrap.py
+++ b/trinity/bootstrap.py
@@ -43,7 +43,6 @@ from trinity.endpoint import (
 )
 from trinity.extensibility import (
     BasePlugin,
-    BaseManagerProcessScope,
     MainAndIsolatedProcessScope,
     PluginManager,
 )
@@ -106,12 +105,12 @@ BootFn = Callable[[
 
 def main_entry(trinity_boot: BootFn,
                app_identifier: str,
-               plugins: Iterable[BasePlugin],
+               plugins: Iterable[Type[BasePlugin]],
                sub_configs: Iterable[Type[BaseAppConfig]]) -> None:
 
     main_endpoint = TrinityMainEventBusEndpoint()
 
-    plugin_manager = setup_plugins(
+    plugin_manager = PluginManager(
         MainAndIsolatedProcessScope(main_endpoint),
         plugins
     )
@@ -259,13 +258,6 @@ async def trinity_boot_coro(kill_trinity, main_endpoint, trinity_config,  # type
     )
 
     plugin_manager.prepare(args, trinity_config, extra_kwargs)
-
-
-def setup_plugins(scope: BaseManagerProcessScope, plugins: Iterable[BasePlugin]) -> PluginManager:
-    plugin_manager = PluginManager(scope)
-    plugin_manager.register(plugins)
-
-    return plugin_manager
 
 
 def display_launch_logs(trinity_config: TrinityConfig) -> None:

--- a/trinity/extensibility/__init__.py
+++ b/trinity/extensibility/__init__.py
@@ -2,7 +2,6 @@ from trinity.extensibility.events import (  # noqa: F401
     BaseEvent
 )
 from trinity.extensibility.exceptions import (  # noqa: F401
-    EventBusNotReady,
     InvalidPluginStatus,
     UnsuitableShutdownError,
 )
@@ -12,7 +11,6 @@ from trinity.extensibility.plugin import (  # noqa: F401
     BaseIsolatedPlugin,
     BasePlugin,
     DebugPlugin,
-    PluginContext,
     PluginStatus,
     TrinityBootInfo,
 )

--- a/trinity/extensibility/exceptions.py
+++ b/trinity/extensibility/exceptions.py
@@ -3,14 +3,6 @@ from trinity.exceptions import (
 )
 
 
-class EventBusNotReady(BaseTrinityError):
-    """
-    Raised when a plugin tried to access the event bus before the plugin
-    had received its :meth:`~trinity.extensibility.plugin.BasePlugin.on_ready` call.
-    """
-    pass
-
-
 class InvalidPluginStatus(BaseTrinityError):
     """
     Raised when it was attempted to perform an action while the current

--- a/trinity/main.py
+++ b/trinity/main.py
@@ -22,7 +22,6 @@ from p2p._utils import ensure_global_asyncio_executor
 
 from trinity.bootstrap import (
     main_entry,
-    setup_plugins,
 )
 from trinity.config import (
     TrinityConfig,
@@ -74,7 +73,7 @@ from trinity._utils.shutdown import (
 )
 
 
-def get_all_plugins() -> Iterable[BasePlugin]:
+def get_all_plugins() -> Iterable[Type[BasePlugin]]:
     return BASE_PLUGINS + ETH1_NODE_PLUGINS + discover_plugins()
 
 
@@ -167,7 +166,7 @@ async def launch_node_coro(args: Namespace, trinity_config: TrinityConfig) -> No
     await endpoint.announce_endpoint()
 
     # This is a second PluginManager instance governing plugins in a shared process.
-    plugin_manager = setup_plugins(SharedProcessScope(endpoint), get_all_plugins())
+    plugin_manager = PluginManager(SharedProcessScope(endpoint), get_all_plugins())
     plugin_manager.prepare(args, trinity_config)
 
     asyncio.ensure_future(handle_networking_exit(node, plugin_manager, endpoint))

--- a/trinity/plugins/builtin/attach/plugin.py
+++ b/trinity/plugins/builtin/attach/plugin.py
@@ -3,6 +3,7 @@ from argparse import (
     Namespace,
     _SubParsersAction,
 )
+import pkg_resources
 import sys
 
 from trinity.config import (
@@ -19,56 +20,65 @@ from trinity.plugins.builtin.attach.console import (
 )
 
 
+def is_ipython_available() -> bool:
+    try:
+        pkg_resources.get_distribution('IPython')
+    except pkg_resources.DistributionNotFound:
+        return False
+    else:
+        return True
+
+
 class AttachPlugin(BaseMainProcessPlugin):
-
-    def __init__(self, use_ipython: bool = True) -> None:
-        super().__init__()
-        self.use_ipython = use_ipython
-
     @property
     def name(self) -> str:
         return "Attach"
 
-    def configure_parser(self, arg_parser: ArgumentParser, subparser: _SubParsersAction) -> None:
+    @classmethod
+    def configure_parser(cls,
+                         arg_parser: ArgumentParser,
+                         subparser: _SubParsersAction) -> None:
 
         attach_parser = subparser.add_parser(
             'attach',
             help='open an REPL attached to a currently running chain',
         )
 
-        attach_parser.set_defaults(func=self.run_console)
+        attach_parser.set_defaults(func=cls.run_console)
 
-    def run_console(self, args: Namespace, trinity_config: TrinityConfig) -> None:
+    @classmethod
+    def run_console(cls, args: Namespace, trinity_config: TrinityConfig) -> None:
         try:
-            console(trinity_config.jsonrpc_ipc_path, use_ipython=self.use_ipython)
+            console(trinity_config.jsonrpc_ipc_path, use_ipython=is_ipython_available())
         except FileNotFoundError as err:
-            self.logger.error(str(err))
+            cls.get_logger().error(str(err))
             sys.exit(1)
 
 
 class DbShellPlugin(BaseMainProcessPlugin):
-
-    def __init__(self, use_ipython: bool = True) -> None:
-        super().__init__()
-        self.use_ipython = use_ipython
-
     @property
     def name(self) -> str:
         return "DB Shell"
 
-    def configure_parser(self, arg_parser: ArgumentParser, subparser: _SubParsersAction) -> None:
+    @classmethod
+    def configure_parser(cls,
+                         arg_parser: ArgumentParser,
+                         subparser: _SubParsersAction) -> None:
 
         attach_parser = subparser.add_parser(
             'db-shell',
             help='open a REPL to inspect the db',
         )
 
-        attach_parser.set_defaults(func=self.run_shell)
+        attach_parser.set_defaults(func=cls.run_shell)
 
-    def run_shell(self, args: Namespace, trinity_config: TrinityConfig) -> None:
+    @classmethod
+    def run_shell(cls, args: Namespace, trinity_config: TrinityConfig) -> None:
 
         if trinity_config.has_app_config(Eth1AppConfig):
             config = trinity_config.get_app_config(Eth1AppConfig)
-            db_shell(self.use_ipython, config.database_dir, trinity_config)
+            db_shell(is_ipython_available(), config.database_dir, trinity_config)
         else:
-            self.logger.error("DB Shell does only support the Ethereum 1 node at this time")
+            cls.get_logger().error(
+                "DB Shell only supports the Ethereum 1 node at this time"
+            )

--- a/trinity/plugins/builtin/ethstats/plugin.py
+++ b/trinity/plugins/builtin/ethstats/plugin.py
@@ -43,9 +43,10 @@ class EthstatsPlugin(BaseIsolatedPlugin):
         return 'Ethstats'
 
     def get_default_server_url(self) -> str:
-        return DEFAULT_SERVERS_URLS.get(self.context.trinity_config.network_id, '')
+        return DEFAULT_SERVERS_URLS.get(self.boot_info.trinity_config.network_id, '')
 
-    def configure_parser(self, arg_parser: ArgumentParser, subparser: _SubParsersAction) -> None:
+    @classmethod
+    def configure_parser(cls, arg_parser: ArgumentParser, subparser: _SubParsersAction) -> None:
         ethstats_parser = arg_parser.add_argument_group('ethstats (experimental)')
 
         ethstats_parser.add_argument(
@@ -81,7 +82,7 @@ class EthstatsPlugin(BaseIsolatedPlugin):
         )
 
     def on_ready(self, manager_eventbus: TrinityEventBusEndpoint) -> None:
-        args = self.context.args
+        args = self.boot_info.args
 
         if not args.ethstats:
             return
@@ -115,7 +116,8 @@ class EthstatsPlugin(BaseIsolatedPlugin):
 
     def do_start(self) -> None:
         service = EthstatsService(
-            self.context,
+            self.boot_info,
+            self.event_bus,
             self.server_url,
             self.server_secret,
             self.node_id,
@@ -123,5 +125,5 @@ class EthstatsPlugin(BaseIsolatedPlugin):
             self.stats_interval,
         )
 
-        asyncio.ensure_future(exit_with_endpoint_and_services(self.context.event_bus, service))
+        asyncio.ensure_future(exit_with_endpoint_and_services(self.event_bus, service))
         asyncio.ensure_future(service.run())

--- a/trinity/plugins/builtin/fix_unclean_shutdown/plugin.py
+++ b/trinity/plugins/builtin/fix_unclean_shutdown/plugin.py
@@ -18,43 +18,47 @@ from trinity._utils.ipc import (
 
 
 class FixUncleanShutdownPlugin(BaseMainProcessPlugin):
-
     @property
     def name(self) -> str:
         return "Fix Unclean Shutdown"
 
-    def configure_parser(self, arg_parser: ArgumentParser, subparser: _SubParsersAction) -> None:
+    @classmethod
+    def configure_parser(cls,
+                         arg_parser: ArgumentParser,
+                         subparser: _SubParsersAction) -> None:
 
         attach_parser = subparser.add_parser(
             'fix-unclean-shutdown',
             help='close any dangling processes from a previous unclean shutdown',
         )
 
-        attach_parser.set_defaults(func=self.fix_unclean_shutdown)
+        attach_parser.set_defaults(func=cls.fix_unclean_shutdown)
 
-    def fix_unclean_shutdown(self, args: Namespace, trinity_config: TrinityConfig) -> None:
-        self.logger.info("Cleaning up unclean shutdown...")
+    @classmethod
+    def fix_unclean_shutdown(cls, args: Namespace, trinity_config: TrinityConfig) -> None:
+        logger = cls.get_logger()
+        logger.info("Cleaning up unclean shutdown...")
 
-        self.logger.info("Searching for process id files in %s..." % trinity_config.data_dir)
+        logger.info("Searching for process id files in %s..." % trinity_config.data_dir)
         pidfiles = tuple(trinity_config.pid_dir.glob('*.pid'))
         if len(pidfiles) > 1:
-            self.logger.info('Found %d processes from a previous run. Closing...' % len(pidfiles))
+            logger.info('Found %d processes from a previous run. Closing...' % len(pidfiles))
         elif len(pidfiles) == 1:
-            self.logger.info('Found 1 process from a previous run. Closing...')
+            logger.info('Found 1 process from a previous run. Closing...')
         else:
-            self.logger.info('Found 0 processes from a previous run. No processes to kill.')
+            logger.info('Found 0 processes from a previous run. No processes to kill.')
 
         for pidfile in pidfiles:
             process_id = int(pidfile.read_text())
-            kill_process_id_gracefully(process_id, time.sleep, self.logger)
+            kill_process_id_gracefully(process_id, time.sleep, logger)
             try:
                 pidfile.unlink()
-                self.logger.info(
+                logger.info(
                     'Manually removed %s after killing process id %d' % (pidfile, process_id)
                 )
             except FileNotFoundError:
-                self.logger.debug(
+                logger.debug(
                     'pidfile %s was gone after killing process id %d' % (pidfile, process_id)
                 )
 
-        remove_dangling_ipc_files(self.logger, trinity_config.ipc_dir)
+        remove_dangling_ipc_files(logger, trinity_config.ipc_dir)

--- a/trinity/plugins/builtin/light_peer_chain_bridge/plugin.py
+++ b/trinity/plugins/builtin/light_peer_chain_bridge/plugin.py
@@ -44,7 +44,7 @@ class LightPeerChainBridgePlugin(BaseAsyncStopPlugin):
         return "LightPeerChain Bridge"
 
     def on_ready(self, manager_eventbus: TrinityEventBusEndpoint) -> None:
-        if self.context.args.sync_mode != SYNC_LIGHT:
+        if self.boot_info.args.sync_mode != SYNC_LIGHT:
             return
 
         self.event_bus.subscribe(
@@ -59,7 +59,7 @@ class LightPeerChainBridgePlugin(BaseAsyncStopPlugin):
 
     def do_start(self) -> None:
         chain = cast(LightDispatchChain, self.chain)
-        self.handler = LightPeerChainEventBusHandler(chain._peer_chain, self.context.event_bus)
+        self.handler = LightPeerChainEventBusHandler(chain._peer_chain, self.event_bus)
         asyncio.ensure_future(self.handler.run())
 
     async def do_stop(self) -> None:

--- a/trinity/plugins/builtin/peer_discovery/plugin.py
+++ b/trinity/plugins/builtin/peer_discovery/plugin.py
@@ -162,7 +162,10 @@ class PeerDiscoveryPlugin(BaseIsolatedPlugin):
     def on_ready(self, manager_eventbus: TrinityEventBusEndpoint) -> None:
         self.start()
 
-    def configure_parser(self, arg_parser: ArgumentParser, subparser: _SubParsersAction) -> None:
+    @classmethod
+    def configure_parser(cls,
+                         arg_parser: ArgumentParser,
+                         subparser: _SubParsersAction) -> None:
         arg_parser.add_argument(
             "--disable-discovery",
             action="store_true",
@@ -171,9 +174,9 @@ class PeerDiscoveryPlugin(BaseIsolatedPlugin):
 
     def do_start(self) -> None:
         discovery_bootstrap = DiscoveryBootstrapService(
-            self.context.args.disable_discovery,
+            self.boot_info.args.disable_discovery,
             self.event_bus,
-            self.context.trinity_config
+            self.boot_info.trinity_config
         )
         asyncio.ensure_future(exit_with_endpoint_and_services(self.event_bus, discovery_bootstrap))
         asyncio.ensure_future(discovery_bootstrap.run())

--- a/trinity/plugins/builtin/tx_pool/plugin.py
+++ b/trinity/plugins/builtin/tx_pool/plugin.py
@@ -50,7 +50,8 @@ class TxPlugin(BaseAsyncStopPlugin):
     def name(self) -> str:
         return "TxPlugin"
 
-    def configure_parser(self, arg_parser: ArgumentParser, subparser: _SubParsersAction) -> None:
+    @classmethod
+    def configure_parser(cls, arg_parser: ArgumentParser, subparser: _SubParsersAction) -> None:
         arg_parser.add_argument(
             "--tx-pool",
             action="store_true",
@@ -59,10 +60,10 @@ class TxPlugin(BaseAsyncStopPlugin):
 
     def on_ready(self, manager_eventbus: TrinityEventBusEndpoint) -> None:
 
-        light_mode = self.context.args.sync_mode == SYNC_LIGHT
-        self.is_enabled = self.context.args.tx_pool and not light_mode
+        light_mode = self.boot_info.args.sync_mode == SYNC_LIGHT
+        self.is_enabled = self.boot_info.args.tx_pool and not light_mode
 
-        unsupported = self.context.args.tx_pool and light_mode
+        unsupported = self.boot_info.args.tx_pool and light_mode
 
         if unsupported:
             unsupported_msg = "Transaction pool not available in light mode"
@@ -85,9 +86,9 @@ class TxPlugin(BaseAsyncStopPlugin):
             self.start()
 
     def do_start(self) -> None:
-        if self.context.trinity_config.network_id == MAINNET_NETWORK_ID:
+        if self.boot_info.trinity_config.network_id == MAINNET_NETWORK_ID:
             validator = DefaultTransactionValidator(self.chain, BYZANTIUM_MAINNET_BLOCK)
-        elif self.context.trinity_config.network_id == ROPSTEN_NETWORK_ID:
+        elif self.boot_info.trinity_config.network_id == ROPSTEN_NETWORK_ID:
             validator = DefaultTransactionValidator(self.chain, BYZANTIUM_ROPSTEN_BLOCK)
         else:
             # TODO: We could hint the user about e.g. a --tx-pool-no-validation flag to run the

--- a/trinity/plugins/eth2/network_generator/plugin.py
+++ b/trinity/plugins/eth2/network_generator/plugin.py
@@ -3,13 +3,17 @@ from argparse import (
     Namespace,
     _SubParsersAction,
 )
-import asyncio
 import os
 from pathlib import (
     Path,
 )
 import sys
 import time
+from typing import (
+    Any,
+    Dict,
+    Tuple,
+)
 
 from ruamel.yaml import (
     YAML,
@@ -107,61 +111,64 @@ class NetworkGeneratorPlugin(BaseMainProcessPlugin):
 
     @classmethod
     def run_generate_testnet_dir(cls, args: Namespace, trinity_config: TrinityConfig) -> None:
-        loop = asyncio.get_event_loop()
-        loop.run_until_complete(cls._run_generate_testnet_dir(args))
-        loop.close()
-
-    @classmethod
-    async def _run_generate_testnet_dir(cls, args: Namespace) -> None:
         logger = cls.get_logger()
         logger.info("Generating testnet")
-        cls.network_dir = args.network_dir
-        if len(os.listdir(cls.network_dir)) > 0:
+        network_dir = args.network_dir
+        if len(os.listdir(network_dir)) > 0:
             logger.error("This directory is not empty, won't create network files here.")
             sys.exit(1)
 
-        cls.generate_trinity_root_dirs()
-        cls.generate_keys(args.num)
-        cls.generate_genesis_state(args.genesis_delay)
+        clients = cls.generate_trinity_root_dirs(network_dir)
+        keymap = cls.generate_keys(args.num, network_dir, clients)
+        cls.generate_genesis_state(args.genesis_delay, network_dir, keymap, clients)
 
         logger.info(bold_green("Network generation completed"))
 
     @classmethod
-    def generate_keys(cls, num: int) -> None:
+    def generate_keys(cls,
+                      num: int,
+                      network_dir: Path,
+                      clients: Tuple[Client, ...]) -> Dict[Any, Any]:
         logger = cls.get_logger()
         logger.info(f"Creating {num} validators' keys")
-        cls.keys_dir = cls.network_dir / KEYS_DIR
-        cls.keys_dir.mkdir()
+        keys_dir = network_dir / KEYS_DIR
+        keys_dir.mkdir()
 
         privkeys = tuple(int.from_bytes(
             hash_eth2(str(i).encode('utf-8'))[:4], 'big')
             for i in range(num)
         )
-        cls.keymap = {bls.privtopub(key): key for key in privkeys}
+        keymap = {bls.privtopub(key): key for key in privkeys}
 
-        num_of_clients = len(cls.clients)
+        num_of_clients = len(clients)
         for validator_index, key in enumerate(privkeys):
             file_name = f"v{validator_index:07d}.privkey"
-            private_key_path = cls.keys_dir / file_name
+            private_key_path = keys_dir / file_name
             with open(private_key_path, "w") as f:
                 f.write(str(key))
 
             # Distribute keys to clients
-            client = cls.clients[validator_index % num_of_clients]
+            client = clients[validator_index % num_of_clients]
             with open(client.validator_keys_dir / file_name, "w") as f:
                 f.write(str(key))
 
+        return keymap
+
     @classmethod
-    def generate_genesis_state(cls, genesis_delay: Second) -> None:
+    def generate_genesis_state(cls,
+                               genesis_delay: Second,
+                               network_dir: Path,
+                               keymap: Dict[Any, Any],
+                               clients: Tuple[Client, ...]) -> None:
         logger = cls.get_logger()
         state_machine_class = XiaoLongBaoStateMachine
 
         # Since create_mock_genesis takes a long time, update the real genesis_time later
         dummy_time = Timestamp(int(time.time()))
         state, _ = create_mock_genesis(
-            num_validators=len(cls.keymap.keys()),
+            num_validators=len(keymap.keys()),
             config=state_machine_class.config,
-            keymap=cls.keymap,
+            keymap=keymap,
             genesis_block_class=state_machine_class.block_class,
             genesis_time=dummy_time,
         )
@@ -171,19 +178,20 @@ class NetworkGeneratorPlugin(BaseMainProcessPlugin):
             genesis_time=genesis_time,
         )
         yaml = YAML()
-        with open(cls.network_dir / GENESIS_FILE, "w") as f:
+        with open(network_dir / GENESIS_FILE, "w") as f:
             yaml.dump(to_formatted_dict(state), f)
 
         # Distribute genesis file to clients
-        for client in cls.clients:
+        for client in clients:
             with open(client.client_dir / GENESIS_FILE, "w") as f:
                 yaml.dump(to_formatted_dict(state), f)
 
     @classmethod
-    def generate_trinity_root_dirs(cls) -> None:
+    def generate_trinity_root_dirs(cls, network_dir: Path) -> Tuple[Client, ...]:
         logger = cls.get_logger()
         logger.info("Generating root directories for clients")
-        cls.clients = tuple(Client(name, cls.network_dir) for name in ("alice", "bob"))
-        for client in cls.clients:
+        clients = tuple(Client(name, network_dir) for name in ("alice", "bob"))
+        for client in clients:
             client.client_dir.mkdir()
             client.validator_keys_dir.mkdir()
+        return clients

--- a/trinity/plugins/eth2/network_generator/plugin.py
+++ b/trinity/plugins/eth2/network_generator/plugin.py
@@ -77,7 +77,8 @@ class NetworkGeneratorPlugin(BaseMainProcessPlugin):
     def name(self) -> str:
         return "NetworkGenerator"
 
-    def configure_parser(self, arg_parser: ArgumentParser, subparser: _SubParsersAction) -> None:
+    @classmethod
+    def configure_parser(cls, arg_parser: ArgumentParser, subparser: _SubParsersAction) -> None:
 
         testnet_generator_parser = subparser.add_parser(
             'testnet',
@@ -102,78 +103,87 @@ class NetworkGeneratorPlugin(BaseMainProcessPlugin):
             default=60,
         )
 
-        testnet_generator_parser.set_defaults(func=self.run_generate_testnet_dir)
+        testnet_generator_parser.set_defaults(func=cls.run_generate_testnet_dir)
 
-    def run_generate_testnet_dir(self, args: Namespace, trinity_config: TrinityConfig) -> None:
+    @classmethod
+    def run_generate_testnet_dir(cls, args: Namespace, trinity_config: TrinityConfig) -> None:
         loop = asyncio.get_event_loop()
-        loop.run_until_complete(self._run_generate_testnet_dir(args))
+        loop.run_until_complete(cls._run_generate_testnet_dir(args))
         loop.close()
 
-    async def _run_generate_testnet_dir(self, args: Namespace) -> None:
-        self.logger.info("Generating testnet")
-        self.network_dir = args.network_dir
-        if len(os.listdir(self.network_dir)) > 0:
-            self.logger.error("This directory is not empty, won't create network files here.")
+    @classmethod
+    async def _run_generate_testnet_dir(cls, args: Namespace) -> None:
+        logger = cls.get_logger()
+        logger.info("Generating testnet")
+        cls.network_dir = args.network_dir
+        if len(os.listdir(cls.network_dir)) > 0:
+            logger.error("This directory is not empty, won't create network files here.")
             sys.exit(1)
 
-        self.generate_trinity_root_dirs()
-        self.generate_keys(args.num)
-        self.generate_genesis_state(args.genesis_delay)
+        cls.generate_trinity_root_dirs()
+        cls.generate_keys(args.num)
+        cls.generate_genesis_state(args.genesis_delay)
 
-        self.logger.info(bold_green("Network generation completed"))
+        logger.info(bold_green("Network generation completed"))
 
-    def generate_keys(self, num: int) -> None:
-        self.logger.info(f"Creating {num} validators' keys")
-        self.keys_dir = self.network_dir / KEYS_DIR
-        self.keys_dir.mkdir()
+    @classmethod
+    def generate_keys(cls, num: int) -> None:
+        logger = cls.get_logger()
+        logger.info(f"Creating {num} validators' keys")
+        cls.keys_dir = cls.network_dir / KEYS_DIR
+        cls.keys_dir.mkdir()
 
         privkeys = tuple(int.from_bytes(
             hash_eth2(str(i).encode('utf-8'))[:4], 'big')
             for i in range(num)
         )
-        self.keymap = {bls.privtopub(key): key for key in privkeys}
+        cls.keymap = {bls.privtopub(key): key for key in privkeys}
 
-        num_of_clients = len(self.clients)
+        num_of_clients = len(cls.clients)
         for validator_index, key in enumerate(privkeys):
             file_name = f"v{validator_index:07d}.privkey"
-            private_key_path = self.keys_dir / file_name
+            private_key_path = cls.keys_dir / file_name
             with open(private_key_path, "w") as f:
                 f.write(str(key))
 
             # Distribute keys to clients
-            client = self.clients[validator_index % num_of_clients]
+            client = cls.clients[validator_index % num_of_clients]
             with open(client.validator_keys_dir / file_name, "w") as f:
                 f.write(str(key))
 
-    def generate_genesis_state(self, genesis_delay: Second) -> None:
+    @classmethod
+    def generate_genesis_state(cls, genesis_delay: Second) -> None:
+        logger = cls.get_logger()
         state_machine_class = XiaoLongBaoStateMachine
 
         # Since create_mock_genesis takes a long time, update the real genesis_time later
         dummy_time = Timestamp(int(time.time()))
         state, _ = create_mock_genesis(
-            num_validators=len(self.keymap.keys()),
+            num_validators=len(cls.keymap.keys()),
             config=state_machine_class.config,
-            keymap=self.keymap,
+            keymap=cls.keymap,
             genesis_block_class=state_machine_class.block_class,
             genesis_time=dummy_time,
         )
-        self.logger.info(f"Genesis time will be {genesis_delay} seconds from now")
+        logger.info(f"Genesis time will be {genesis_delay} seconds from now")
         genesis_time = Timestamp(int(time.time()) + genesis_delay)
         state = state.copy(
             genesis_time=genesis_time,
         )
         yaml = YAML()
-        with open(self.network_dir / GENESIS_FILE, "w") as f:
+        with open(cls.network_dir / GENESIS_FILE, "w") as f:
             yaml.dump(to_formatted_dict(state), f)
 
         # Distribute genesis file to clients
-        for client in self.clients:
+        for client in cls.clients:
             with open(client.client_dir / GENESIS_FILE, "w") as f:
                 yaml.dump(to_formatted_dict(state), f)
 
-    def generate_trinity_root_dirs(self) -> None:
-        self.logger.info("Generating root directories for clients")
-        self.clients = tuple(Client(name, self.network_dir) for name in ("alice", "bob"))
-        for client in self.clients:
+    @classmethod
+    def generate_trinity_root_dirs(cls) -> None:
+        logger = cls.get_logger()
+        logger.info("Generating root directories for clients")
+        cls.clients = tuple(Client(name, cls.network_dir) for name in ("alice", "bob"))
+        for client in cls.clients:
             client.client_dir.mkdir()
             client.validator_keys_dir.mkdir()

--- a/trinity/plugins/registry.py
+++ b/trinity/plugins/registry.py
@@ -1,6 +1,7 @@
 import pkg_resources
 from typing import (
     Tuple,
+    Type,
 )
 
 from trinity.extensibility import (
@@ -26,10 +27,6 @@ from trinity.plugins.builtin.peer_discovery.plugin import (
     PeerDiscoveryPlugin,
 )
 from trinity.plugins.builtin.syncer.plugin import (
-    FastThenFullSyncStrategy,
-    FullSyncStrategy,
-    LightSyncStrategy,
-    NoopSyncStrategy,
     SyncerPlugin,
 )
 from trinity.plugins.eth2.network_generator.plugin import NetworkGeneratorPlugin
@@ -42,44 +39,30 @@ from trinity.plugins.builtin.light_peer_chain_bridge.plugin import (
 )
 
 
-def is_ipython_available() -> bool:
-    try:
-        pkg_resources.get_distribution('IPython')
-    except pkg_resources.DistributionNotFound:
-        return False
-    else:
-        return True
-
-
-BASE_PLUGINS: Tuple[BasePlugin, ...] = (
-    AttachPlugin(use_ipython=is_ipython_available()),
-    NetworkGeneratorPlugin(),
-    FixUncleanShutdownPlugin(),
-    JsonRpcServerPlugin(),
-    NetworkDBPlugin(),
-    PeerDiscoveryPlugin(),
-    BeaconNodePlugin(),
+BASE_PLUGINS: Tuple[Type[BasePlugin], ...] = (
+    AttachPlugin,
+    NetworkGeneratorPlugin,
+    FixUncleanShutdownPlugin,
+    JsonRpcServerPlugin,
+    NetworkDBPlugin,
+    PeerDiscoveryPlugin,
+    BeaconNodePlugin,
 )
 
 
-ETH1_NODE_PLUGINS: Tuple[BasePlugin, ...] = (
-    DbShellPlugin(use_ipython=is_ipython_available()),
-    EthstatsPlugin(),
-    LightPeerChainBridgePlugin(),
-    SyncerPlugin((
-        FastThenFullSyncStrategy(),
-        FullSyncStrategy(),
-        LightSyncStrategy(),
-        NoopSyncStrategy(),
-    ), FastThenFullSyncStrategy),
-    TxPlugin(),
+ETH1_NODE_PLUGINS: Tuple[Type[BasePlugin], ...] = (
+    DbShellPlugin,
+    EthstatsPlugin,
+    LightPeerChainBridgePlugin,
+    SyncerPlugin,
+    TxPlugin,
 )
 
 
-def discover_plugins() -> Tuple[BasePlugin, ...]:
+def discover_plugins() -> Tuple[Type[BasePlugin], ...]:
     # Plugins need to define entrypoints at 'trinity.plugins' to automatically get loaded
     # https://packaging.python.org/guides/creating-and-discovering-plugins/#using-package-metadata
 
     return tuple(
-        entry_point.load()() for entry_point in pkg_resources.iter_entry_points('trinity.plugins')
+        entry_point.load() for entry_point in pkg_resources.iter_entry_points('trinity.plugins')
     )


### PR DESCRIPTION
This PR started out as an attempt to address [this comment](https://github.com/ethereum/trinity/pull/556#discussion_r281092960). In short: as of #556, `BaseIsolatedPlugin`s receive a context where `context.event_bus == None`. This caused problems: some plugins directly accessed `self.context.event_bus` (which did not exist) instead of accessing `self.event_bus` (which does exist). The simple fix would have been to fix those accesses, but this PR is the result of an experiment where I tried to make that bug impossible.

This resulted in me pulling at a thread for a while, after each change another small change appeared. For example: First I removed `event_bus` from `PluginContext`, but that left `PluginContext` holding nothing but `TrinityBootInfo`, so the next step was to remove `PluginContext`. I'm not married to any of these changes, I'm happy to walk out one that you disagree with! But I *think* that most of these help a little with clarity, and it's nice that this ends up removing 64 lines in exchange for almost no functionality.

Changes:

- Plugins are no longer instantiated during import, before any startup.
- `BasePlugin.configure_parser` is now a classmethod, because the parser is configured before plugin instantiation.
- `BasePlugin.__init__()` accepts a `TrinityBootInfo`, `BaseAsyncStopPlugin.__init__()` accepts an additional event_bus parameter. Previously plugins started in an uninitialized state until `set_context` had been called on them. They now accept their context during construction, such that it's now impossible to create an uninitialized Plugin.

    This required changes to a few of the plugins:
    - `AttachPlugin` and `DbShellPlugin` now always use ipython, when it's available.
    - `SyncerPlugin` now hard-codes the strategies which it uses, although a subclass could easily change them.
   - In general, it's no longer possible to configure plugins by passing information into their constructor.

- `PluginContext` no longer exists. It was a wrapper around `(boot_info, endpoint)`, now each of those parameters are passed in separately. This is done because `BaseAsyncStopPlugin` is the only subclass which uses an event bus so it can now be the only subclass which accepts one.
- `PluginManager.register()` was dropped. Previously `PluginManager()` returned an object that was uninitialized until `.register(Iterable[BasePlugin])` was called. Now those plugins are passed into the constructor and it's impossible to create an uninitialized `PluginManager`.
- `BaseManagerProcessScope.create_plugin_context` is now `create_plugin`. Now that the implementation is so simple there's probably room to simplify this class further, but I think this PR might be at a good checkpoint and that can be saved for later.

#### Cute Animal Picture

![bird-stick](https://user-images.githubusercontent.com/466333/57396299-fd3d9400-717e-11e9-86d7-bbaf14810c9f.jpg)