### PR TITLE
Add To-Do list to PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -5,9 +5,15 @@
 ### How was it fixed?
 
 
+### To-Do
+
+[//]: # (Stay ahead of things, add list items here!)
+- [ ] Clean up commit history
+
 [//]: # (For important changes, please add a new entry to the running release notes PR)
 [//]: # (You can find the current one using: https://github.com/ethereum/trinity/pulls?q=is%3Aopen+is%3Apr+label%3A%22Release+Notes%22 )
 [//]: # (See: https://trinity-client.readthedocs.io/en/latest/contributing.html#pull-requests)
+- [ ] Add entry to the [release notes PR](https://github.com/ethereum/trinity/pulls?q=is%3Aopen+is%3Apr+label%3A%22Release+Notes%22)
 
 #### Cute Animal Picture
 


### PR DESCRIPTION
### What was wrong?

I find myself creating todo list items in PR usually to not forget about the release notes entry. Maybe changing the PR template to include such a todo list isn't a bad idea?

### How was it fixed?

Added To-Do list section to PR template.

[//]: # (For important changes, please add a new entry to the running release notes PR)
[//]: # (You can find the current one using: https://github.com/ethereum/trinity/pulls?q=is%3Aopen+is%3Apr+label%3A%22Release+Notes%22 )
[//]: # (See: https://trinity-client.readthedocs.io/en/latest/contributing.html#pull-requests)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://i.ytimg.com/vi/SB-qEYVdvXA/hqdefault.jpg)
