### PR TITLE
Handle corrupt snappy data

### DIFF
--- a/p2p/peer.py
+++ b/p2p/peer.py
@@ -292,8 +292,12 @@ class BasePeer(BaseService):
 
         try:
             cmd, msg = await self.read_msg()
-        except rlp.DecodingError:
-            raise HandshakeFailure("Got invalid rlp data during handshake")
+        except rlp.DecodingError as err:
+            # We dump the exception trace here to ensure that when/if this
+            # happens we have enough information to better diagnose if this is
+            # an error in our handshake code or just a broken peer.
+            self.logger.debug("Got RLP decoding error during P2P handshake", exc_info=True)
+            raise MalformedMessage(f"Got invalid rlp data during handshake: {err}") from err
 
         if isinstance(cmd, Disconnect):
             msg = cast(Dict[str, Any], msg)

--- a/p2p/peer.py
+++ b/p2p/peer.py
@@ -294,8 +294,6 @@ class BasePeer(BaseService):
             cmd, msg = await self.read_msg()
         except rlp.DecodingError:
             raise HandshakeFailure("Got invalid rlp data during handshake")
-        except MalformedMessage as e:
-            raise HandshakeFailure("Got malformed message during handshake") from e
 
         if isinstance(cmd, Disconnect):
             msg = cast(Dict[str, Any], msg)

--- a/p2p/peer.py
+++ b/p2p/peer.py
@@ -21,8 +21,6 @@ from lahja import Endpoint
 
 from cached_property import cached_property
 
-import rlp
-
 from eth_utils import (
     to_tuple,
 )
@@ -290,14 +288,7 @@ class BasePeer(BaseService):
         """
         self.base_protocol.send_handshake()
 
-        try:
-            cmd, msg = await self.read_msg()
-        except rlp.DecodingError as err:
-            # We dump the exception trace here to ensure that when/if this
-            # happens we have enough information to better diagnose if this is
-            # an error in our handshake code or just a broken peer.
-            self.logger.debug("Got RLP decoding error during P2P handshake", exc_info=True)
-            raise MalformedMessage(f"Got invalid rlp data during handshake: {err}") from err
+        cmd, msg = await self.read_msg()
 
         if isinstance(cmd, Disconnect):
             msg = cast(Dict[str, Any], msg)

--- a/p2p/protocol.py
+++ b/p2p/protocol.py
@@ -138,7 +138,12 @@ class Command:
     def decompress_payload(self, raw_payload: bytes) -> bytes:
         # Do the Snappy Decompression only if Snappy Compression is supported by the protocol
         if self.snappy_support:
-            return snappy.decompress(raw_payload)
+            try:
+                return snappy.decompress(raw_payload)
+            except Exception as err:
+                # log this just in case it's a library error of some kind on valid messages.
+                self.logger.debug("Snappy decompression error on payload: %s", raw_payload.hex())
+                raise MalformedMessage from err
         else:
             return raw_payload
 


### PR DESCRIPTION
Fixes https://github.com/ethereum/trinity/issues/292

### What was wrong?

If a peer sends us a data payload that snappy can't decode, it blows the whole node up.

### How was it fixed?

The actual exception being raised is being raised from C code so it doesn't appear we can properly catch it.   This code catches any error out of `snappy.descompress`, logs enough info for us to know what happened, and then raises a `MalformedMessage` exception in it's place.

This also updates the logic of the handshake to not treat `MalformedMessage` as a simple `HandshakeError` since we want to distinguish between *soft* handshake errors like mismatched network id's and hard ones where a peer is sending us bad messages.  The blacklisting code treats malformed messages more severely which I think is what we want here.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history

[//]: # (For important changes, please add a new entry to the running release notes PR)
[//]: # (You can find the current one using: https://github.com/ethereum/trinity/pulls?q=is%3Aopen+is%3Apr+label%3A%22Release+Notes%22 )
[//]: # (See: https://trinity-client.readthedocs.io/en/latest/contributing.html#pull-requests)
- [x] Add entry to the [release notes PR](https://github.com/ethereum/trinity/pulls?q=is%3Aopen+is%3Apr+label%3A%22Release+Notes%22)

#### Cute Animal Picture


![7c5df7d2cd45e5ff9c70d6105dfc3986](https://user-images.githubusercontent.com/824194/57489257-b0d38080-7272-11e9-8e05-4dba512695a8.jpg)
