### PR TITLE
Use existing utility function in test

### DIFF
--- a/tests/core/database/test_database_over_ipc_manager.py
+++ b/tests/core/database/test_database_over_ipc_manager.py
@@ -1,8 +1,5 @@
 import logging
 import multiprocessing
-from multiprocessing.managers import (
-    BaseManager,
-)
 import tempfile
 
 import pytest
@@ -16,6 +13,7 @@ from eth.db.chain import (
 )
 
 from trinity.db.eth1.manager import (
+    create_db_consumer_manager,
     create_db_server_manager,
 )
 from trinity.config import (
@@ -25,8 +23,6 @@ from trinity.initialization import (
     initialize_data_dir,
 )
 from trinity.constants import ROPSTEN_NETWORK_ID
-from trinity.db.eth1.chain import AsyncChainDBProxy
-from trinity.db.base import AsyncDBProxy
 from trinity._utils.ipc import (
     wait_for_ipc,
     kill_process_gracefully,
@@ -71,15 +67,7 @@ def database_server_ipc_path():
 
 @pytest.fixture
 def manager(database_server_ipc_path):
-    class DBManager(BaseManager):
-        pass
-
-    DBManager.register('get_db', proxytype=AsyncDBProxy)
-    DBManager.register('get_chaindb', proxytype=AsyncChainDBProxy)
-
-    _manager = DBManager(address=str(database_server_ipc_path))
-    _manager.connect()
-    return _manager
+    return create_db_consumer_manager(database_server_ipc_path, connect=True)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
### What was wrong?

The test had some custom code that we have an existing utility function for

### How was it fixed?

Removed custom code in favor of utility function

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history

[//]: # (For important changes, please add a new entry to the running release notes PR)
[//]: # (You can find the current one using: https://github.com/ethereum/trinity/pulls?q=is%3Aopen+is%3Apr+label%3A%22Release+Notes%22 )
[//]: # (See: https://trinity-client.readthedocs.io/en/latest/contributing.html#pull-requests)
- [x] No changelog entry needed

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://yesbiscuit.files.wordpress.com/2012/12/squirrel.jpg)
