### PR TITLE
Make CLI tests more strict in respect to error scanning

### DIFF
--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -12,12 +12,15 @@ async def scan_for_errors(async_iterable):
     Consume the output produced by the async iterable and throw if it contains hints of an
     uncaught exception.
     """
+
+    error_trigger = ("exception was never retrieved", "Traceback (most recent call last)")
+
     lines_since_error = 0
     async for line in async_iterable:
 
         # We detect errors by some string at the beginning of the Traceback and keep
         # counting lines from there to be able to read and report more valuable info
-        if "Traceback (most recent call last)" in line and lines_since_error == 0:
+        if any(trigger in line for trigger in error_trigger) and lines_since_error == 0:
             lines_since_error = 1
         elif lines_since_error > 0:
             lines_since_error += 1


### PR DESCRIPTION
### What was wrong?

The test that ensures Trinity shuts down cleanly (which it currently doesn't hence the `xfail`) was sometimes flaky.

### How was it fixed?

Sometimes Trinity did in fact shut down less bad than usual. To be more precise, there were still exceptions thrown but only hidden in async code which out error scanning did not catch yet. This PR makes the scanner sensitive for these errors as well and hence makes the test suite less flaky.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history

[//]: # (For important changes, please add a new entry to the running release notes PR)
[//]: # (You can find the current one using: https://github.com/ethereum/trinity/pulls?q=is%3Aopen+is%3Apr+label%3A%22Release+Notes%22 )
[//]: # (See: https://trinity-client.readthedocs.io/en/latest/contributing.html#pull-requests)
- [x]  No release notes entry needed

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcRrP-n3PQaz3OR1Tdau1bkbyiqA3-AhwJBHT0FwRTwUl8QPGonY)
