### PR TITLE
hotfix: import `get_merkle_proof`

### DIFF
--- a/eth2/_utils/merkle/normal.py
+++ b/eth2/_utils/merkle/normal.py
@@ -29,6 +29,7 @@ from .common import (  # noqa: F401
     _calc_parent_hash,
     _hash_layer,
     get_branch_indices,
+    get_merkle_proof,
     get_root,
     MerkleTree,
     MerkleProof,


### PR DESCRIPTION
### What was wrong?

It turns out #600 CI green light was a lie when I merged it...

### How was it fixed?

#### Cute Animal Picture

![cat-1165112_640](https://user-images.githubusercontent.com/9263930/57615793-2317ce00-75af-11e9-9153-129ed83baa1a.jpg)
