### PR TITLE
NamedTuple for `CommitteeConfig`

### DIFF
--- a/eth2/beacon/epoch_processing_helpers.py
+++ b/eth2/beacon/epoch_processing_helpers.py
@@ -156,7 +156,7 @@ def get_attesting_indices(state: 'BeaconState',
             state,
             a.data,
             a.aggregation_bitfield,
-            CommitteeConfig(config),
+            CommitteeConfig.from_eth2_config(config),
         )
         output = output.union(participants)
     for result in sorted(output):

--- a/eth2/beacon/genesis.py
+++ b/eth2/beacon/genesis.py
@@ -163,7 +163,7 @@ def get_genesis_beacon_state(*,
     current_shuffling_seed = generate_seed(
         state=state,
         epoch=config.GENESIS_EPOCH,
-        committee_config=CommitteeConfig(config),
+        committee_config=CommitteeConfig.from_eth2_config(config),
     )
     state = state.copy(
         current_shuffling_seed=current_shuffling_seed,

--- a/eth2/beacon/state_machines/forks/serenity/block_processing.py
+++ b/eth2/beacon/state_machines/forks/serenity/block_processing.py
@@ -50,7 +50,7 @@ def process_block_header(state: BeaconState,
         validate_proposer_signature(
             state,
             block,
-            committee_config=CommitteeConfig(config),
+            committee_config=CommitteeConfig.from_eth2_config(config),
         )
 
     return state
@@ -89,7 +89,7 @@ def process_randao(state: BeaconState,
     proposer_index = get_beacon_proposer_index(
         state=state,
         slot=state.slot,
-        committee_config=CommitteeConfig(config),
+        committee_config=CommitteeConfig.from_eth2_config(config),
     )
     proposer = state.validator_registry[proposer_index]
 

--- a/eth2/beacon/state_machines/forks/serenity/epoch_processing.py
+++ b/eth2/beacon/state_machines/forks/serenity/epoch_processing.py
@@ -297,14 +297,14 @@ def process_crosslinks(state: BeaconState, config: Eth2Config) -> BeaconState:
         crosslink_committees_at_slot = get_crosslink_committees_at_slot(
             state,
             slot,
-            CommitteeConfig(config),
+            CommitteeConfig.from_eth2_config(config),
         )
         for crosslink_committee, shard in crosslink_committees_at_slot:
             winning_root, attesting_validator_indices = get_winning_root_and_participants(
                 state=state,
                 shard=shard,
                 effective_balances=effective_balances,
-                committee_config=CommitteeConfig(config),
+                committee_config=CommitteeConfig.from_eth2_config(config),
             )
             if len(attesting_validator_indices) > 0:
                 total_attesting_balance = get_total_balance(
@@ -432,7 +432,7 @@ def _compute_normal_justification_and_finalization_deltas(
             proposer_index = get_beacon_proposer_index(
                 state,
                 inclusion_infos[index].inclusion_slot,
-                CommitteeConfig(config),
+                CommitteeConfig.from_eth2_config(config),
             )
             rewards_received = _update_rewards_or_penalies(
                 proposer_index,
@@ -539,7 +539,7 @@ def _process_rewards_and_penalties_for_finality(
     previous_epoch_boundary_attester_indices = get_attester_indices_from_attestations(
         state=state,
         attestations=previous_epoch_boundary_attestations,
-        committee_config=CommitteeConfig(config),
+        committee_config=CommitteeConfig.from_eth2_config(config),
     )
 
     previous_epoch_head_attestations = get_previous_epoch_matching_head_attestations(
@@ -550,7 +550,7 @@ def _process_rewards_and_penalties_for_finality(
     previous_epoch_head_attester_indices = get_attester_indices_from_attestations(
         state=state,
         attestations=previous_epoch_head_attestations,
-        committee_config=CommitteeConfig(config),
+        committee_config=CommitteeConfig.from_eth2_config(config),
     )
 
     epochs_since_finality = state.next_epoch(config.SLOTS_PER_EPOCH) - state.finalized_epoch
@@ -607,14 +607,14 @@ def _process_rewards_and_penalties_for_crosslinks(
         crosslink_committees_at_slot = get_crosslink_committees_at_slot(
             state,
             slot,
-            CommitteeConfig(config),
+            CommitteeConfig.from_eth2_config(config),
         )
         for crosslink_committee, shard in crosslink_committees_at_slot:
             winning_root, attesting_validator_indices = get_winning_root_and_participants(
                 state=state,
                 shard=shard,
                 effective_balances=effective_balances,
-                committee_config=CommitteeConfig(config),
+                committee_config=CommitteeConfig.from_eth2_config(config),
             )
             total_attesting_balance = get_total_balance(
                 state.validator_balances,
@@ -661,14 +661,14 @@ def process_rewards_and_penalties(state: BeaconState, config: Eth2Config) -> Bea
     previous_epoch_attester_indices = get_attester_indices_from_attestations(
         state=state,
         attestations=previous_epoch_attestations,
-        committee_config=CommitteeConfig(config),
+        committee_config=CommitteeConfig.from_eth2_config(config),
     )
 
     # Compute inclusion slot/distance of previous attestations for later use.
     inclusion_infos = get_inclusion_infos(
         state=state,
         attestations=previous_epoch_attestations,
-        committee_config=CommitteeConfig(config),
+        committee_config=CommitteeConfig.from_eth2_config(config),
     )
 
     # Compute effective balance of each previous epoch active validator for later use
@@ -956,7 +956,7 @@ def _process_validator_registry_with_update(current_epoch_committee_count: int,
 
     state = _update_shuffling_epoch(state, config.SLOTS_PER_EPOCH)
 
-    state = _update_shuffling_seed(state, CommitteeConfig(config))
+    state = _update_shuffling_seed(state, CommitteeConfig.from_eth2_config(config))
 
     return state
 
@@ -979,7 +979,7 @@ def _process_validator_registry_without_update(state: BeaconState,
         # produced a full set of new crosslinks; validators should have a chance to
         # complete this goal in future epochs.
 
-        state = _update_shuffling_seed(state, CommitteeConfig(config))
+        state = _update_shuffling_seed(state, CommitteeConfig.from_eth2_config(config))
 
     return state
 
@@ -1178,7 +1178,7 @@ def process_final_updates(state: BeaconState,
     current_epoch = state.current_epoch(config.SLOTS_PER_EPOCH)
     next_epoch = state.next_epoch(config.SLOTS_PER_EPOCH)
 
-    state = _update_latest_active_index_roots(state, CommitteeConfig(config))
+    state = _update_latest_active_index_roots(state, CommitteeConfig.from_eth2_config(config))
 
     state = state.copy(
         latest_slashed_balances=update_tuple_item(

--- a/eth2/beacon/state_machines/forks/serenity/operation_processing.py
+++ b/eth2/beacon/state_machines/forks/serenity/operation_processing.py
@@ -56,7 +56,7 @@ def process_proposer_slashings(state: BeaconState,
             latest_slashed_exit_length=config.LATEST_SLASHED_EXIT_LENGTH,
             whistleblower_reward_quotient=config.WHISTLEBLOWER_REWARD_QUOTIENT,
             max_deposit_amount=config.MAX_DEPOSIT_AMOUNT,
-            committee_config=CommitteeConfig(config),
+            committee_config=CommitteeConfig.from_eth2_config(config),
         )
 
     return state
@@ -103,7 +103,7 @@ def process_attester_slashings(state: BeaconState,
                 latest_slashed_exit_length=config.LATEST_SLASHED_EXIT_LENGTH,
                 whistleblower_reward_quotient=config.WHISTLEBLOWER_REWARD_QUOTIENT,
                 max_deposit_amount=config.MAX_DEPOSIT_AMOUNT,
-                committee_config=CommitteeConfig(config),
+                committee_config=CommitteeConfig.from_eth2_config(config),
             )
 
     return state
@@ -135,7 +135,7 @@ def process_attestations(state: BeaconState,
             attestation,
             config.MIN_ATTESTATION_INCLUSION_DELAY,
             config.SLOTS_PER_HISTORICAL_ROOT,
-            CommitteeConfig(config),
+            CommitteeConfig.from_eth2_config(config),
         )
 
     # update attestations

--- a/eth2/beacon/tools/builder/proposer.py
+++ b/eth2/beacon/tools/builder/proposer.py
@@ -82,7 +82,7 @@ def validate_proposer_index(state: BeaconState,
             slot=slot,
         ),
         slot,
-        CommitteeConfig(config),
+        CommitteeConfig.from_eth2_config(config),
     )
 
     if validator_index != beacon_proposer_index:
@@ -162,7 +162,7 @@ def _get_proposer_index(state: BeaconState,
     proposer_index = get_beacon_proposer_index(
         state,
         slot,
-        CommitteeConfig(config),
+        CommitteeConfig.from_eth2_config(config),
     )
     return proposer_index
 

--- a/eth2/beacon/tools/builder/validator.py
+++ b/eth2/beacon/tools/builder/validator.py
@@ -498,7 +498,7 @@ def create_mock_signed_attestations_at_slot(
     crosslink_committees_at_slot = get_crosslink_committees_at_slot(
         state,
         attestation_slot,
-        CommitteeConfig(config),
+        CommitteeConfig.from_eth2_config(config),
     )
 
     # Get `target_root`
@@ -647,7 +647,7 @@ def get_committee_assignment(
 
     epoch_start_slot = get_epoch_start_slot(epoch, config.SLOTS_PER_EPOCH)
 
-    committee_config = CommitteeConfig(config)
+    committee_config = CommitteeConfig.from_eth2_config(config)
 
     for slot in range(epoch_start_slot, epoch_start_slot + config.SLOTS_PER_EPOCH):
         crosslink_committees = get_crosslink_committees_at_slot(

--- a/eth2/configs.py
+++ b/eth2/configs.py
@@ -14,75 +14,85 @@ from eth2.beacon.typing import (
 )
 
 
-Eth2Config = NamedTuple(
-    'Eth2Config',
-    (
-        # Misc
-        ('SHARD_COUNT', int),
-        ('TARGET_COMMITTEE_SIZE', int),
-        ('MAX_BALANCE_CHURN_QUOTIENT', int),
-        ('MAX_INDICES_PER_SLASHABLE_VOTE', int),
-        ('MAX_EXIT_DEQUEUES_PER_EPOCH', int),
-        ('SHUFFLE_ROUND_COUNT', int),
-        # Deposit contract
-        ('DEPOSIT_CONTRACT_ADDRESS', Address),
-        ('DEPOSIT_CONTRACT_TREE_DEPTH', int),
-        # Gwei values,
-        ('MIN_DEPOSIT_AMOUNT', Gwei),
-        ('MAX_DEPOSIT_AMOUNT', Gwei),
-        ('FORK_CHOICE_BALANCE_INCREMENT', Gwei),
-        ('EJECTION_BALANCE', Gwei),
-        # Initial values
-        ('GENESIS_FORK_VERSION', int),
-        ('GENESIS_SLOT', Slot),
-        ('GENESIS_EPOCH', Epoch),
-        ('GENESIS_START_SHARD', Shard),
-        # `FAR_FUTURE_EPOCH`, `EMPTY_SIGNATURE` `ZERO_HASH (ZERO_HASH32)`
-        # are defined in constants.py
-        ('BLS_WITHDRAWAL_PREFIX_BYTE', bytes),
-        # Time parameters
-        ('SECONDS_PER_SLOT', Second),
-        ('MIN_ATTESTATION_INCLUSION_DELAY', int),
-        ('SLOTS_PER_EPOCH', int),
-        ('MIN_SEED_LOOKAHEAD', int),
-        ('ACTIVATION_EXIT_DELAY', int),
-        ('EPOCHS_PER_ETH1_VOTING_PERIOD', int),
-        ('MIN_VALIDATOR_WITHDRAWABILITY_DELAY', int),
-        ('PERSISTENT_COMMITTEE_PERIOD', int),
-        # State list lengths
-        ('SLOTS_PER_HISTORICAL_ROOT', int),
-        ('LATEST_ACTIVE_INDEX_ROOTS_LENGTH', int),
-        ('LATEST_RANDAO_MIXES_LENGTH', int),
-        ('LATEST_SLASHED_EXIT_LENGTH', int),
-        # Reward and penalty quotients
-        ('BASE_REWARD_QUOTIENT', int),
-        ('WHISTLEBLOWER_REWARD_QUOTIENT', int),
-        ('ATTESTATION_INCLUSION_REWARD_QUOTIENT', int),
-        ('INACTIVITY_PENALTY_QUOTIENT', int),
-        ('MIN_PENALTY_QUOTIENT', int),
-        # Max operations per block
-        ('MAX_PROPOSER_SLASHINGS', int),
-        ('MAX_ATTESTER_SLASHINGS', int),
-        ('MAX_ATTESTATIONS', int),
-        ('MAX_DEPOSITS', int),
-        ('MAX_VOLUNTARY_EXITS', int),
-        ('MAX_TRANSFERS', int),
-    )
-)
+class Eth2Config(NamedTuple):
+    # Misc
+    SHARD_COUNT: int
+    TARGET_COMMITTEE_SIZE: int
+    MAX_BALANCE_CHURN_QUOTIENT: int
+    MAX_INDICES_PER_SLASHABLE_VOTE: int
+    MAX_EXIT_DEQUEUES_PER_EPOCH: int
+    SHUFFLE_ROUND_COUNT: int
+    # Deposit contract
+    DEPOSIT_CONTRACT_ADDRESS: Address
+    DEPOSIT_CONTRACT_TREE_DEPTH: int
+    # Gwei values,
+    MIN_DEPOSIT_AMOUNT: Gwei
+    MAX_DEPOSIT_AMOUNT: Gwei
+    FORK_CHOICE_BALANCE_INCREMENT: Gwei
+    EJECTION_BALANCE: Gwei
+    # Initial values
+    GENESIS_FORK_VERSION: int
+    GENESIS_SLOT: Slot
+    GENESIS_EPOCH: Epoch
+    GENESIS_START_SHARD: Shard
+    # `FAR_FUTURE_EPOCH`, `EMPTY_SIGNATURE` `ZERO_HASH (ZERO_HASH32)`
+    # are defined in constants.py
+    BLS_WITHDRAWAL_PREFIX_BYTE: bytes
+    # Time parameters
+    SECONDS_PER_SLOT: Second
+    MIN_ATTESTATION_INCLUSION_DELAY: int
+    SLOTS_PER_EPOCH: int
+    MIN_SEED_LOOKAHEAD: int
+    ACTIVATION_EXIT_DELAY: int
+    EPOCHS_PER_ETH1_VOTING_PERIOD: int
+    MIN_VALIDATOR_WITHDRAWABILITY_DELAY: int
+    PERSISTENT_COMMITTEE_PERIOD: int
+    # State list lengths
+    SLOTS_PER_HISTORICAL_ROOT: int
+    LATEST_ACTIVE_INDEX_ROOTS_LENGTH: int
+    LATEST_RANDAO_MIXES_LENGTH: int
+    LATEST_SLASHED_EXIT_LENGTH: int
+    # Reward and penalty quotients
+    BASE_REWARD_QUOTIENT: int
+    WHISTLEBLOWER_REWARD_QUOTIENT: int
+    ATTESTATION_INCLUSION_REWARD_QUOTIENT: int
+    INACTIVITY_PENALTY_QUOTIENT: int
+    MIN_PENALTY_QUOTIENT: int
+    # Max operations per block
+    MAX_PROPOSER_SLASHINGS: int
+    MAX_ATTESTER_SLASHINGS: int
+    MAX_ATTESTATIONS: int
+    MAX_DEPOSITS: int
+    MAX_VOLUNTARY_EXITS: int
+    MAX_TRANSFERS: int
 
 
-class CommitteeConfig:
-    def __init__(self, config: Eth2Config):
-        # Basic
-        self.GENESIS_SLOT = config.GENESIS_SLOT
-        self.GENESIS_EPOCH = config.GENESIS_EPOCH
-        self.SHARD_COUNT = config.SHARD_COUNT
-        self.SLOTS_PER_EPOCH = config.SLOTS_PER_EPOCH
-        self.TARGET_COMMITTEE_SIZE = config.TARGET_COMMITTEE_SIZE
-        self.SHUFFLE_ROUND_COUNT = config.SHUFFLE_ROUND_COUNT
+class CommitteeConfig(NamedTuple):
+    GENESIS_SLOT: Slot
+    GENESIS_EPOCH: Epoch
+    SHARD_COUNT: Shard
+    SLOTS_PER_EPOCH: int
+    TARGET_COMMITTEE_SIZE: int
+    SHUFFLE_ROUND_COUNT: int
 
-        # For seed
-        self.MIN_SEED_LOOKAHEAD = config.MIN_SEED_LOOKAHEAD
-        self.ACTIVATION_EXIT_DELAY = config.ACTIVATION_EXIT_DELAY
-        self.LATEST_ACTIVE_INDEX_ROOTS_LENGTH = config.LATEST_ACTIVE_INDEX_ROOTS_LENGTH
-        self.LATEST_RANDAO_MIXES_LENGTH = config.LATEST_RANDAO_MIXES_LENGTH
+    MIN_SEED_LOOKAHEAD: int
+    ACTIVATION_EXIT_DELAY: int
+    LATEST_ACTIVE_INDEX_ROOTS_LENGTH: int
+    LATEST_RANDAO_MIXES_LENGTH: int
+
+    @classmethod
+    def from_eth2_config(cls, config: Eth2Config) -> 'CommitteeConfig':
+        return cls(
+            # Basic
+            GENESIS_SLOT=config.GENESIS_SLOT,
+            GENESIS_EPOCH=config.GENESIS_EPOCH,
+            SHARD_COUNT=config.SHARD_COUNT,
+            SLOTS_PER_EPOCH=config.SLOTS_PER_EPOCH,
+            TARGET_COMMITTEE_SIZE=config.TARGET_COMMITTEE_SIZE,
+            SHUFFLE_ROUND_COUNT=config.SHUFFLE_ROUND_COUNT,
+            # For seed
+            MIN_SEED_LOOKAHEAD=config.MIN_SEED_LOOKAHEAD,
+            ACTIVATION_EXIT_DELAY=config.ACTIVATION_EXIT_DELAY,
+            LATEST_ACTIVE_INDEX_ROOTS_LENGTH=config.LATEST_ACTIVE_INDEX_ROOTS_LENGTH,
+            LATEST_RANDAO_MIXES_LENGTH=config.LATEST_RANDAO_MIXES_LENGTH,
+        )

--- a/tests/eth2/core/beacon/conftest.py
+++ b/tests/eth2/core/beacon/conftest.py
@@ -796,4 +796,4 @@ def fixture_sm_class(config):
 #
 @pytest.fixture
 def committee_config(config):
-    return CommitteeConfig(config)
+    return CommitteeConfig.from_eth2_config(config)

--- a/tests/eth2/core/beacon/state_machines/forks/test_serenity_block_validation.py
+++ b/tests/eth2/core/beacon/state_machines/forks/test_serenity_block_validation.py
@@ -126,14 +126,14 @@ def test_validate_proposer_signature(
         validate_proposer_signature(
             state,
             proposed_block,
-            CommitteeConfig(config),
+            CommitteeConfig.from_eth2_config(config),
         )
     else:
         with pytest.raises(ValidationError):
             validate_proposer_signature(
                 state,
                 proposed_block,
-                CommitteeConfig(config),
+                CommitteeConfig.from_eth2_config(config),
             )
 
 

--- a/tests/eth2/core/beacon/state_machines/forks/test_serenity_epoch_processing.py
+++ b/tests/eth2/core/beacon/state_machines/forks/test_serenity_epoch_processing.py
@@ -488,7 +488,7 @@ def test_process_crosslinks(
         for committee, _shard in get_crosslink_committees_at_slot(
             state,
             slot_in_previous_epoch,
-            CommitteeConfig(config),
+            CommitteeConfig.from_eth2_config(config),
         ):
             if _shard == shard:
                 # Sample validators attesting to this shard.
@@ -527,7 +527,7 @@ def test_process_crosslinks(
         for committee, _shard in get_crosslink_committees_at_slot(
             state,
             slot_in_current_epoch,
-            CommitteeConfig(config),
+            CommitteeConfig.from_eth2_config(config),
         ):
             if _shard == shard:
                 # Sample validators attesting to this shard.
@@ -766,7 +766,7 @@ def test_process_rewards_and_penalties_for_finality(
         get_crosslink_committees_at_slot(
             state,
             slot,
-            CommitteeConfig(config),
+            CommitteeConfig.from_eth2_config(config),
         )[0] for slot in range(prev_epoch_start_slot, prev_epoch_start_slot + slots_per_epoch)
     ]
 
@@ -874,7 +874,7 @@ def test_process_rewards_and_penalties_for_crosslinks(
         get_crosslink_committees_at_slot(
             state,
             slot,
-            CommitteeConfig(config),
+            CommitteeConfig.from_eth2_config(config),
         )[0] for slot in range(prev_epoch_start_slot, prev_epoch_start_slot + slots_per_epoch)
     ]
 

--- a/tests/eth2/core/beacon/state_machines/forks/test_serenity_operation_processing.py
+++ b/tests/eth2/core/beacon/state_machines/forks/test_serenity_operation_processing.py
@@ -110,7 +110,7 @@ def test_process_proposer_slashings(genesis_state,
     whistleblower_index = get_beacon_proposer_index(
         state,
         state.slot,
-        CommitteeConfig(config),
+        CommitteeConfig.from_eth2_config(config),
     )
     slashing_proposer_index = (whistleblower_index + 1) % len(state.validator_registry)
     proposer_slashing = create_mock_proposer_slashing_at_block(

--- a/tests/eth2/core/beacon/test_epoch_processing_helpers.py
+++ b/tests/eth2/core/beacon/test_epoch_processing_helpers.py
@@ -568,7 +568,7 @@ def test_get_inclusion_infos(
     result = get_inclusion_infos(
         state=n_validators_state,
         attestations=previous_epoch_attestations,
-        committee_config=CommitteeConfig(config),
+        committee_config=CommitteeConfig.from_eth2_config(config),
     )
     assert result[participating_validator_index].inclusion_slot == expected_inclusion_slot
     assert result[participating_validator_index].inclusion_distance == expected_inclusion_distance


### PR DESCRIPTION
### What was wrong?
Using simple `class CommitteeConfig()` created unnecessary hashing overhead.  


### How was it fixed?
1. Use `NamedTuple` in `CommitteeConfig`
2. New NamedTuple writing style for Eth2Config

#### Cute Animal Picture

![PIXNIO-2104830-600x400](https://user-images.githubusercontent.com/9263930/57692686-f7154f00-7679-11e9-89e7-0066c5001465.jpg)
