### PR TITLE
Remove lru cache for performance

### DIFF
--- a/eth2/beacon/committee_helpers.py
+++ b/eth2/beacon/committee_helpers.py
@@ -271,7 +271,6 @@ def _get_shuffling_contextis_next_epoch_no_registry_change_no_reseed(
     )
 
 
-@functools.lru_cache(maxsize=128)
 @to_tuple
 def get_crosslink_committees_at_slot(
         state: 'BeaconState',


### PR DESCRIPTION
### What was wrong?

The lru cache of get_crosslink_committees_at_slot requires computing the hash of the function arguments, which results in expensive computation of tree-hash of the state. The removal of lru cache improve the performance of test_demo.py, reducing running time from 155 seconds to 105.08.

### some supporting data

- cache_info before this PR

```
# cache_info at the end of test_demo.py
get_shuffling CacheInfo(hits=585, misses=890, maxsize=128, currsize=128)
get_crosslink_committees_at_slot CacheInfo(hits=636, misses=1475, maxsize=128, currsize=128)
```

- [Before this PR] The profile shows that `__hash__` of serializable was called by functions that do not explicitly call it.
  - ![](https://user-images.githubusercontent.com/3391420/57693610-33e24580-767c-11e9-8a6f-b0f1513b60a6.png)
  - Full picture: https://drive.google.com/file/d/1bDhwP4vNhRfz6aiZleU0BAO_B8AljPwD/view

- [After this PR] The profile shows `__hash__` as cool as everybody else 😎🏖
  - ![](https://user-images.githubusercontent.com/3391420/57704179-fe495680-7693-11e9-90bd-411e692e3c90.png)
  - Full picture: https://drive.google.com/file/d/13mIOkyZWAJvZ3cVx_xBgIAag_4iwLr6d/view

### How was it fixed?

Remove lru cache decorator.


#### Cute Animal Picture

![image](https://user-images.githubusercontent.com/3391420/57693505-f7aee500-767b-11e9-8437-0e66278a1fd5.png)
