### PR TITLE
tests: update to match `py-evm`: don't skip Constantinople, add Petersburg, use `--fork`; break out long-running categories

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -234,6 +234,18 @@ jobs:
       - image: circleci/python:3.6
         environment:
           TOXENV: py36-rpc-state-quadratic
+  py36-rpc-state-sstore:
+    <<: *common
+    docker:
+      - image: circleci/python:3.6
+        environment:
+          TOXENV: py36-rpc-state-sstore
+  py36-rpc-state-zero_knowledge:
+    <<: *common
+    docker:
+      - image: circleci/python:3.6
+        environment:
+          TOXENV: py36-rpc-state-zero_knowledge
   py36-eth2-core:
     <<: *common
     docker:
@@ -358,6 +370,8 @@ workflows:
       - py36-rpc-state-tangerine_whistle
       - py36-rpc-state-spurious_dragon
       - py36-rpc-state-quadratic
+      - py36-rpc-state-sstore
+      - py36-rpc-state-zero_knowledge
       - py36-rpc-blockchain
 
       - py36-core

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -171,6 +171,13 @@ jobs:
       - image: circleci/python:3.6
         environment:
           TOXENV: py36-rpc-state-homestead
+  py36-rpc-state-petersburg:
+    <<: *common
+    docker:
+      - image: circleci/python:3.6
+        environment:
+          TOXENV: py36-rpc-state-petersburg
+
   py36-rpc-state-tangerine_whistle:
     <<: *common
     docker:
@@ -347,6 +354,7 @@ workflows:
       - py36-rpc-state-constantinople
       - py36-rpc-state-frontier
       - py36-rpc-state-homestead
+      - py36-rpc-state-petersburg
       - py36-rpc-state-tangerine_whistle
       - py36-rpc-state-spurious_dragon
       - py36-rpc-state-quadratic

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -131,14 +131,12 @@ jobs:
       - image: circleci/python:3.6
         environment:
           TOXENV: py36-lint
-
   py37-lint:
     <<: *common
     docker:
       - image: circleci/python:3.7
         environment:
           TOXENV: py37-lint
-
 
   py36-docs:
     <<: *common
@@ -228,24 +226,6 @@ jobs:
       - image: circleci/python:3.6
         environment:
           TOXENV: py36-p2p
-  py36-rpc-state-quadratic:
-    <<: *common
-    docker:
-      - image: circleci/python:3.6
-        environment:
-          TOXENV: py36-rpc-state-quadratic
-  py36-rpc-state-sstore:
-    <<: *common
-    docker:
-      - image: circleci/python:3.6
-        environment:
-          TOXENV: py36-rpc-state-sstore
-  py36-rpc-state-zero_knowledge:
-    <<: *common
-    docker:
-      - image: circleci/python:3.6
-        environment:
-          TOXENV: py36-rpc-state-zero_knowledge
   py36-eth2-core:
     <<: *common
     docker:
@@ -283,6 +263,24 @@ jobs:
         environment:
           TOXENV: py36-plugins
 
+  py37-rpc-state-quadratic:
+    <<: *common
+    docker:
+      - image: circleci/python:3.7
+        environment:
+          TOXENV: py37-rpc-state-quadratic
+  py37-rpc-state-sstore:
+    <<: *common
+    docker:
+      - image: circleci/python:3.7
+        environment:
+          TOXENV: py37-rpc-state-sstore
+  py37-rpc-state-zero_knowledge:
+    <<: *common
+    docker:
+      - image: circleci/python:3.7
+        environment:
+          TOXENV: py37-rpc-state-zero_knowledge
 
   py37-core:
     <<: *common
@@ -339,7 +337,6 @@ jobs:
         environment:
           TOXENV: py37-plugins
 
-
   docker-image-build-test:
     machine: true
     steps:
@@ -362,16 +359,17 @@ workflows:
       # - py37-libp2p
       - py37-plugins
 
+      - py37-rpc-state-quadratic
+      - py37-rpc-state-sstore
+      - py37-rpc-state-zero_knowledge
+
       - py36-rpc-state-byzantium
       - py36-rpc-state-constantinople
       - py36-rpc-state-frontier
       - py36-rpc-state-homestead
       - py36-rpc-state-petersburg
-      - py36-rpc-state-tangerine_whistle
       - py36-rpc-state-spurious_dragon
-      - py36-rpc-state-quadratic
-      - py36-rpc-state-sstore
-      - py36-rpc-state-zero_knowledge
+      - py36-rpc-state-tangerine_whistle
       - py36-rpc-blockchain
 
       - py36-core

--- a/tests/json-fixtures-over-rpc/test_rpc_fixtures.py
+++ b/tests/json-fixtures-over-rpc/test_rpc_fixtures.py
@@ -105,6 +105,7 @@ SLOW_TESTS = (
 # at the commit currently checked out in submodule `fixtures`.
 # Ideally, this list should be empty.
 # WHEN ADDING ENTRIES, ALWAYS PROVIDE AN EXPLANATION!
+# TODO: import from `py-evm` if possible
 INCORRECT_UPSTREAM_TESTS = {
     # The test considers a "synthetic" scenario (the state described there can't
     # be arrived at using regular consensus rules).
@@ -112,6 +113,28 @@ INCORRECT_UPSTREAM_TESTS = {
     # The result is in conflict with the yellow-paper:
     # * https://github.com/ethereum/py-evm/pull/1224#issuecomment-418800369
     ('GeneralStateTests/stRevertTest/RevertInCreateInInit_d0g0v0.json', 'RevertInCreateInInit_d0g0v0_Byzantium'),  # noqa: E501
+    ('GeneralStateTests/stRevertTest/RevertInCreateInInit_d0g0v0.json', 'RevertInCreateInInit_d0g0v0_Constantinople'),  # noqa: E501
+    ('GeneralStateTests/stRevertTest/RevertInCreateInInit_d0g0v0.json', 'RevertInCreateInInit_d0g0v0_ConstantinopleFix'),  # noqa: E501
+
+    # The CREATE2 variant seems to have been derived from the one above - it, too,
+    # has a "synthetic" state, on which py-evm flips.
+    # * https://github.com/ethereum/py-evm/pull/1181#issuecomment-446330609
+    ('GeneralStateTests/stCreate2/RevertInCreateInInitCreate2_d0g0v0.json', 'RevertInCreateInInitCreate2_d0g0v0_Constantinople'),  # noqa: E501
+    ('GeneralStateTests/stCreate2/RevertInCreateInInitCreate2_d0g0v0.json', 'RevertInCreateInInitCreate2_d0g0v0_ConstantinopleFix'),  # noqa: E501
+
+    # Four variants have been specifically added to test a collision type
+    # like the above; therefore, they fail in the same manner.
+    # * https://github.com/ethereum/py-evm/pull/1579#issuecomment-446591118
+    # Interestingly, d2 passes in Constantinople after a py-evm refactor of storage handling,
+    # the same test is already passing in ConstantinopleFix. Since the situation is synthetic,
+    # not much research went into why, yet.
+    ('GeneralStateTests/stSStoreTest/InitCollision_d0g0v0.json', 'InitCollision_d0g0v0_Constantinople'),  # noqa: E501
+    ('GeneralStateTests/stSStoreTest/InitCollision_d1g0v0.json', 'InitCollision_d1g0v0_Constantinople'),  # noqa: E501
+    ('GeneralStateTests/stSStoreTest/InitCollision_d2g0v0.json', 'InitCollision_d2g0v0_Constantinople'),  # noqa: E501
+    ('GeneralStateTests/stSStoreTest/InitCollision_d3g0v0.json', 'InitCollision_d3g0v0_Constantinople'),  # noqa: E501
+    ('GeneralStateTests/stSStoreTest/InitCollision_d0g0v0.json', 'InitCollision_d0g0v0_ConstantinopleFix'),  # noqa: E501
+    ('GeneralStateTests/stSStoreTest/InitCollision_d1g0v0.json', 'InitCollision_d1g0v0_ConstantinopleFix'),  # noqa: E501
+    ('GeneralStateTests/stSStoreTest/InitCollision_d3g0v0.json', 'InitCollision_d3g0v0_ConstantinopleFix'),  # noqa: E501
 }
 
 RPC_STATE_NORMALIZERS = {
@@ -376,8 +399,8 @@ async def validate_uncles(rpc, block_fixture, at_block):
 @pytest.fixture
 def chain_fixture(fixture_data):
     fixture = load_fixture(*fixture_data)
-    if fixture['network'] == 'Constantinople':
-        pytest.skip('Constantinople VM rules not yet supported')
+    if fixture['network'] == 'Istanbul':
+        pytest.skip('Istanbul VM rules not yet supported')
     return fixture
 
 

--- a/tests/json-fixtures-over-rpc/test_rpc_fixtures.py
+++ b/tests/json-fixtures-over-rpc/test_rpc_fixtures.py
@@ -207,10 +207,10 @@ def blockchain_fixture_mark_fn(fixture_path, fixture_name, fixture_fork):
 
 def generate_ignore_fn_for_fork(passed_fork):
     if passed_fork:
-        passed_fork = passed_fork.lower()
+        normalized_fork = passed_fork.lower()
 
         def ignore_fn(fixture_path, fixture_key, fixture_fork):
-            return fixture_fork.lower() != passed_fork
+            return fixture_fork.lower() != normalized_fork
 
         return ignore_fn
 

--- a/tests/json-fixtures-over-rpc/test_rpc_fixtures.py
+++ b/tests/json-fixtures-over-rpc/test_rpc_fixtures.py
@@ -48,16 +48,12 @@ ROOT_PROJECT_DIR = Path(__file__).parent.parent.parent
 BASE_FIXTURE_PATH = os.path.join(ROOT_PROJECT_DIR, 'fixtures', 'BlockchainTests')
 
 SLOW_TESTS = (
-    'Call1024PreCalls_d0g0v0_Byzantium',
-    'Call1024PreCalls_d0g0v0_EIP150',
-    'Call1024PreCalls_d0g0v0_EIP158',
+    'Call1024PreCalls_d0g0v0',
     'ContractCreationSpam_d0g0v0_Homestead',
     'ContractCreationSpam_d0g0v0_Frontier',
-    'ForkStressTest_EIP150',
-    'ForkStressTest_EIP158',
-    'ForkStressTest_Homestead',
-    'ForkStressTest_Frontier',
-    'ForkStressTest_Byzantium',
+    'Create2Recursive_d0g0v0',
+    'Create2Recursive_d0g1v0',
+    'ForkStressTest',
     'stQuadraticComplexityTest/Call50000_d0g1v0.json',
     'stQuadraticComplexityTest/QuadraticComplexitySolidity_CallDataCopy_d0g1v0.json',
     'stQuadraticComplexityTest/Return50000_2_d0g1v0.json',
@@ -67,46 +63,43 @@ SLOW_TESTS = (
     'stQuadraticComplexityTest/Call50000_ecrec_d0g1v0.json',
     'walletReorganizeOwners',
     'bcExploitTest/SuicideIssue.json',
-    'DelegateCallSpam_Homestead',
-    'static_Call50000_sha256_d0g0v0_Byzantium',
-    'static_Call50000_rip160_d0g0v0_Byzantium',
-    'static_Call50000_rip160_d1g0v0_Byzantium',
-    'static_Call50000_sha256_d1g0v0_Byzantium',
-    'static_Call50000_ecrec_d1g0v0_Byzantium',
-    'static_Call50000_d1g0v0_Byzantium',
-    'static_Call50000_d0g0v0_Byzantium',
-    'static_Call50000_ecrec_d0g0v0_Byzantium',
-    'static_Call50000_identity2_d0g0v0_Byzantium',
-    'static_Call50000_identity2_d1g0v0_Byzantium',
-    'static_Call50000_identity_d1g0v0_Byzantium',
-    'static_Call50000_identity_d0g0v0_Byzantium',
-    'static_Call50000bytesContract50_1_d1g0v0_Byzantium',
-    'static_Call50000bytesContract50_2_d1g0v0_Byzantium',
-    'static_LoopCallsThenRevert_d0g0v0_Byzantium',
-    'static_LoopCallsThenRevert_d0g1v0_Byzantium',
-    'Call1024PreCalls_d0g0v0_Byzantium',
-    'Call1024PreCalls_d0g0v0_EIP158',
-    'Call1024PreCalls_d0g0v0_EIP150',
-    'Call1024PreCalls_d0g0v0_Byzantium',
-    'Call1024PreCalls_d0g0v0_EIP150',
-    'Call1024PreCalls_d0g0v0_EIP158',
+    'static_Call1024PreCalls_d1g0v0',
+    'static_Call1024PreCalls2_d0g0v0',
+    'static_Call1024PreCalls2_d1g0v0',
+    'static_Call1024PreCalls3_d1g0v0',
+    'static_Call50000bytesContract50_1_d0g0v0',
+    'static_Call50000_ecrec_d0g0v0',
+    'static_Call50000_ecrec_d1g0v0',
+    'static_Call50000_rip160_d0g0v0',
+    'static_Call50000_rip160_d1g0v0',
+    'static_Call50000_sha256_d0g0v0',
+    'static_Call50000_sha256_d1g0v0',
+    'static_Call50000_d0g0v0',
+    'static_Call50000_d1g0v0',
+    'static_Call50000_identity2_d0g0v0',
+    'static_Call50000_identity2_d1g0v0',
+    'static_Call50000_identity_d0g0v0',
+    'static_Call50000_identity_d1g0v0',
+    'static_Call50000bytesContract50_1_d1g0v0',
+    'static_Call50000bytesContract50_2_d1g0v0',
+    'static_LoopCallsThenRevert_d0g0v0',
+    'static_LoopCallsThenRevert_d0g1v0',
+    'static_Return50000_2_d0g0v0',
     'stQuadraticComplexityTest/Call50000_identity2_d0g1v0.json',
     'stQuadraticComplexityTest/Call50000_identity_d0g1v0.json',
     'stQuadraticComplexityTest/Call50000_rip160_d0g1v0.json',
     'stQuadraticComplexityTest/Call50000bytesContract50_1_d0g1v0.json',
+    'stQuadraticComplexityTest/Call50000bytesContract50_2_d0g1v0.json',
     'stQuadraticComplexityTest/Create1000_d0g1v0.json',
     'ShanghaiLove_Homestead',
     'ShanghaiLove_Frontier',
-    'DelegateCallSpam_EIP158',
-    'DelegateCallSpam_Byzantium',
-    'DelegateCallSpam_EIP150',
+    'DelegateCallSpam',
 )
 
 # These are tests that are thought to be incorrect or buggy upstream,
 # at the commit currently checked out in submodule `fixtures`.
 # Ideally, this list should be empty.
 # WHEN ADDING ENTRIES, ALWAYS PROVIDE AN EXPLANATION!
-# TODO: import from `py-evm` if possible
 INCORRECT_UPSTREAM_TESTS = {
     # The test considers a "synthetic" scenario (the state described there can't
     # be arrived at using regular consensus rules).
@@ -212,7 +205,6 @@ def blockchain_fixture_mark_fn(fixture_path, fixture_name, fixture_fork):
         return pytest.mark.xfail(reason="Listed in INCORRECT_UPSTREAM_TESTS.")
 
 
-# TODO: import from `py-evm` if possible?..
 def generate_ignore_fn_for_fork(passed_fork):
     if passed_fork:
         passed_fork = passed_fork.lower()
@@ -223,7 +215,6 @@ def generate_ignore_fn_for_fork(passed_fork):
         return ignore_fn
 
 
-# TODO: import from `py-evm` if possible?..
 @to_tuple
 def expand_fixtures_forks(all_fixtures):
     for fixture_path, fixture_key in all_fixtures:

--- a/tox.ini
+++ b/tox.ini
@@ -1,9 +1,10 @@
 [tox]
 envlist=
     py{36,37}-{core,p2p,integration,lightchain_integration,eth2-core,eth2-fixtures,eth2-integration,plugins}
-    py{36}-long_run_integration
-    py{36}-rpc-state-{frontier,homestead,tangerine_whistle,spurious_dragon,byzantium,constantinople,petersburg,quadratic,sstore,zero_knowledge}
-    py{36}-rpc-blockchain
+    py36-long_run_integration
+    py36-rpc-blockchain
+    py36-rpc-state-{frontier,homestead,tangerine_whistle,spurious_dragon,byzantium,constantinople,petersburg}
+    py37-rpc-state-{quadratic,sstore,zero_knowledge}
     py{36,37}-libp2p
     py{36,37}-lint
     py{36,37}-wheel-cli

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,7 @@
 envlist=
     py{36,37}-{core,p2p,integration,lightchain_integration,eth2-core,eth2-fixtures,eth2-integration,plugins}
     py{36}-long_run_integration
-    py{36}-rpc-state-{frontier,homestead,tangerine_whistle,spurious_dragon,byzantium,constantinople,petersburg,quadratic}
+    py{36}-rpc-state-{frontier,homestead,tangerine_whistle,spurious_dragon,byzantium,constantinople,petersburg,quadratic,sstore,zero_knowledge}
     py{36}-rpc-blockchain
     py{36,37}-libp2p
     py{36,37}-lint
@@ -26,15 +26,19 @@ commands=
     p2p: pytest -n 4 {posargs:tests/p2p}
     plugins: pytest -n 4 {posargs:tests/plugins/}
     rpc-blockchain: pytest -n 4 {posargs:tests/json-fixtures-over-rpc/test_rpc_fixtures.py -k 'not GeneralStateTests'}
-    rpc-state-frontier: pytest -n 4 {posargs:tests/json-fixtures-over-rpc/test_rpc_fixtures.py --fork Frontier -k 'GeneralStateTests and not stQuadraticComplexityTest'}
-    rpc-state-homestead: pytest -n 4 {posargs:tests/json-fixtures-over-rpc/test_rpc_fixtures.py --fork Homestead -k 'GeneralStateTests and not stQuadraticComplexityTest'}
-    rpc-state-tangerine_whistle: pytest -n 4 {posargs:tests/json-fixtures-over-rpc/test_rpc_fixtures.py --fork EIP150 -k 'GeneralStateTests and not stQuadraticComplexityTest'}
-    rpc-state-spurious_dragon: pytest -n 4 {posargs:tests/json-fixtures-over-rpc/test_rpc_fixtures.py --fork EIP158 -k 'GeneralStateTests and not stQuadraticComplexityTest'}
+    # Fork/VM-specific state transition tests; long-running categories run separately!
+    rpc-state-frontier: pytest -n 4 {posargs:tests/json-fixtures-over-rpc/test_rpc_fixtures.py --fork Frontier -k 'GeneralStateTests and not stQuadraticComplexityTest and not stSStoreTest and not stZeroKnowledge'}
+    rpc-state-homestead: pytest -n 4 {posargs:tests/json-fixtures-over-rpc/test_rpc_fixtures.py --fork Homestead -k 'GeneralStateTests and not stQuadraticComplexityTest and not stSStoreTest and not stZeroKnowledge'}
+    rpc-state-tangerine_whistle: pytest -n 4 {posargs:tests/json-fixtures-over-rpc/test_rpc_fixtures.py --fork EIP150 -k 'GeneralStateTests and not stQuadraticComplexityTest and not stSStoreTest and not stZeroKnowledge'}
+    rpc-state-spurious_dragon: pytest -n 4 {posargs:tests/json-fixtures-over-rpc/test_rpc_fixtures.py --fork EIP158 -k 'GeneralStateTests and not stQuadraticComplexityTest and not stSStoreTest and not stZeroKnowledge'}
     # The following test seems to consume a lot of memory. Restricting to 3 processes reduces crashes
-    rpc-state-byzantium: pytest -n 3 {posargs:tests/json-fixtures-over-rpc/test_rpc_fixtures.py --fork Byzantium -k 'GeneralStateTests and not stQuadraticComplexityTest'}
-    rpc-state-constantinople: pytest -n 3 {posargs:tests/json-fixtures-over-rpc/test_rpc_fixtures.py --fork Constantinople -k 'GeneralStateTests and not stQuadraticComplexityTest'}
-    rpc-state-petersburg: pytest -n 3 {posargs:tests/json-fixtures-over-rpc/test_rpc_fixtures.py --fork ConstantinopleFix -k 'GeneralStateTests and not stQuadraticComplexityTest'}
+    rpc-state-byzantium: pytest -n 3 {posargs:tests/json-fixtures-over-rpc/test_rpc_fixtures.py --fork Byzantium -k 'GeneralStateTests and not stQuadraticComplexityTest and not stSStoreTest and not stZeroKnowledge'}
+    rpc-state-constantinople: pytest -n 3 {posargs:tests/json-fixtures-over-rpc/test_rpc_fixtures.py --fork Constantinople -k 'GeneralStateTests and not stQuadraticComplexityTest and not stSStoreTest and not stZeroKnowledge'}
+    rpc-state-petersburg: pytest -n 3 {posargs:tests/json-fixtures-over-rpc/test_rpc_fixtures.py --fork ConstantinopleFix -k 'GeneralStateTests and not stQuadraticComplexityTest and not stSStoreTest and not stZeroKnowledge'}
+    # Long-running categories.
     rpc-state-quadratic: pytest -n 4 {posargs:tests/json-fixtures-over-rpc/test_rpc_fixtures.py -k 'GeneralStateTests and stQuadraticComplexityTest'}
+    rpc-state-sstore: pytest -n 4 {posargs:tests/json-fixtures-over-rpc/test_rpc_fixtures.py -k 'GeneralStateTests and stSStoreTest'}
+    rpc-state-zero_knowledge: pytest -n 4 {posargs:tests/json-fixtures-over-rpc/test_rpc_fixtures.py -k 'GeneralStateTests and stZeroKnowledge'}
     lightchain_integration: pytest --integration {posargs:tests/integration/test_lightchain_integration.py}
 
 deps = .[p2p,trinity,eth2,test]

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,7 @@
 envlist=
     py{36,37}-{core,p2p,integration,lightchain_integration,eth2-core,eth2-fixtures,eth2-integration,plugins}
     py{36}-long_run_integration
-    py{36}-rpc-state-{frontier,homestead,tangerine_whistle,spurious_dragon,byzantium,constantinople,quadratic}
+    py{36}-rpc-state-{frontier,homestead,tangerine_whistle,spurious_dragon,byzantium,constantinople,petersburg,quadratic}
     py{36}-rpc-blockchain
     py{36,37}-libp2p
     py{36,37}-lint
@@ -32,7 +32,9 @@ commands=
     rpc-state-spurious_dragon: pytest -n 4 {posargs:tests/json-fixtures-over-rpc/test_rpc_fixtures.py -k 'GeneralStateTests and not stQuadraticComplexityTest and EIP158'}
     # The following test seems to consume a lot of memory. Restricting to 3 processes reduces crashes
     rpc-state-byzantium: pytest -n 3 {posargs:tests/json-fixtures-over-rpc/test_rpc_fixtures.py -k 'GeneralStateTests and not stQuadraticComplexityTest and Byzantium'}
-    rpc-state-constantinople: pytest -n 3 {posargs:tests/json-fixtures-over-rpc/test_rpc_fixtures.py -k 'GeneralStateTests and not stQuadraticComplexityTest and Constantinople'}
+    # Must match Constantinople but not ConstantinopleFix!
+    rpc-state-constantinople: pytest -n 3 {posargs:tests/json-fixtures-over-rpc/test_rpc_fixtures.py -k 'GeneralStateTests and not stQuadraticComplexityTest and not ConstantinopleFix and Constantinople'}
+    rpc-state-petersburg: pytest -n 3 {posargs:tests/json-fixtures-over-rpc/test_rpc_fixtures.py -k 'GeneralStateTests and not stQuadraticComplexityTest and ConstantinopleFix'}
     rpc-state-quadratic: pytest -n 4 {posargs:tests/json-fixtures-over-rpc/test_rpc_fixtures.py -k 'GeneralStateTests and stQuadraticComplexityTest'}
     lightchain_integration: pytest --integration {posargs:tests/integration/test_lightchain_integration.py}
 

--- a/tox.ini
+++ b/tox.ini
@@ -26,15 +26,14 @@ commands=
     p2p: pytest -n 4 {posargs:tests/p2p}
     plugins: pytest -n 4 {posargs:tests/plugins/}
     rpc-blockchain: pytest -n 4 {posargs:tests/json-fixtures-over-rpc/test_rpc_fixtures.py -k 'not GeneralStateTests'}
-    rpc-state-frontier: pytest -n 4 {posargs:tests/json-fixtures-over-rpc/test_rpc_fixtures.py -k 'GeneralStateTests and not stQuadraticComplexityTest and Frontier'}
-    rpc-state-homestead: pytest -n 4 {posargs:tests/json-fixtures-over-rpc/test_rpc_fixtures.py -k 'GeneralStateTests and not stQuadraticComplexityTest and Homestead'}
-    rpc-state-tangerine_whistle: pytest -n 4 {posargs:tests/json-fixtures-over-rpc/test_rpc_fixtures.py -k 'GeneralStateTests and not stQuadraticComplexityTest and EIP150'}
-    rpc-state-spurious_dragon: pytest -n 4 {posargs:tests/json-fixtures-over-rpc/test_rpc_fixtures.py -k 'GeneralStateTests and not stQuadraticComplexityTest and EIP158'}
+    rpc-state-frontier: pytest -n 4 {posargs:tests/json-fixtures-over-rpc/test_rpc_fixtures.py --fork Frontier -k 'GeneralStateTests and not stQuadraticComplexityTest'}
+    rpc-state-homestead: pytest -n 4 {posargs:tests/json-fixtures-over-rpc/test_rpc_fixtures.py --fork Homestead -k 'GeneralStateTests and not stQuadraticComplexityTest'}
+    rpc-state-tangerine_whistle: pytest -n 4 {posargs:tests/json-fixtures-over-rpc/test_rpc_fixtures.py --fork EIP150 -k 'GeneralStateTests and not stQuadraticComplexityTest'}
+    rpc-state-spurious_dragon: pytest -n 4 {posargs:tests/json-fixtures-over-rpc/test_rpc_fixtures.py --fork EIP158 -k 'GeneralStateTests and not stQuadraticComplexityTest'}
     # The following test seems to consume a lot of memory. Restricting to 3 processes reduces crashes
-    rpc-state-byzantium: pytest -n 3 {posargs:tests/json-fixtures-over-rpc/test_rpc_fixtures.py -k 'GeneralStateTests and not stQuadraticComplexityTest and Byzantium'}
-    # Must match Constantinople but not ConstantinopleFix!
-    rpc-state-constantinople: pytest -n 3 {posargs:tests/json-fixtures-over-rpc/test_rpc_fixtures.py -k 'GeneralStateTests and not stQuadraticComplexityTest and not ConstantinopleFix and Constantinople'}
-    rpc-state-petersburg: pytest -n 3 {posargs:tests/json-fixtures-over-rpc/test_rpc_fixtures.py -k 'GeneralStateTests and not stQuadraticComplexityTest and ConstantinopleFix'}
+    rpc-state-byzantium: pytest -n 3 {posargs:tests/json-fixtures-over-rpc/test_rpc_fixtures.py --fork Byzantium -k 'GeneralStateTests and not stQuadraticComplexityTest'}
+    rpc-state-constantinople: pytest -n 3 {posargs:tests/json-fixtures-over-rpc/test_rpc_fixtures.py --fork Constantinople -k 'GeneralStateTests and not stQuadraticComplexityTest'}
+    rpc-state-petersburg: pytest -n 3 {posargs:tests/json-fixtures-over-rpc/test_rpc_fixtures.py --fork ConstantinopleFix -k 'GeneralStateTests and not stQuadraticComplexityTest'}
     rpc-state-quadratic: pytest -n 4 {posargs:tests/json-fixtures-over-rpc/test_rpc_fixtures.py -k 'GeneralStateTests and stQuadraticComplexityTest'}
     lightchain_integration: pytest --integration {posargs:tests/integration/test_lightchain_integration.py}
 


### PR DESCRIPTION
### What was wrong?

Tests for `network=='Constantinople'` are being skipped.

The pinned git submodule is for https://github.com/ethereum/tests/tree/420f443477caa8516f1f9ee8122fafc3415c0f34 (same as tag `v6.0.0-beta.2`, which is not even latest), whereas `py-evm` has https://github.com/ethereum/tests/tree/6b85703b568f4456582a00665d8a3e5c3b20b484 (untagged commit slightly after `v6.0.0-beta.3`, which itself does not include `ConstantinopleFix` - which why we're using something "slightly after").

### How was it fixed?

- [x] Skip `network=='Istanbul'` (leave placeholder).
- [x] Use same `fixtures` commit as `py-evm`.
- [x] Add `petersburg` jobs to CI.
- [x] Use `pytest --fork` arg (copy-paste! from `py-evm`).
- [x] Address test failures (the usual disparity on "synthetic state").
- [x] Address long CI run times:
  * break out categories into their own CI jobs:
    * zero-knowledge;
    * `SSTORE`;
  * switch these break-out categories to use Python 3.7 (a tiny bit more performant than 3.6).

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history

[//]: # (For important changes, please add a new entry to the running release notes PR)
[//]: # (You can find the current one using: https://github.com/ethereum/trinity/pulls?q=is%3Aopen+is%3Apr+label%3A%22Release+Notes%22 )
[//]: # (See: https://trinity-client.readthedocs.io/en/latest/contributing.html#pull-requests)
- [x] Add entry to the [release notes PR](https://github.com/ethereum/trinity/pulls?q=is%3Aopen+is%3Apr+label%3A%22Release+Notes%22): https://github.com/ethereum/trinity/pull/445#issuecomment-493034038

### Cute Animal Picture

![Felicia the ferret slides out of a wave guide](https://assets.atlasobscura.com/article_images/64091/image.jpg)

Source: Felicia the ferret of [Fermilab; via Atlas Obscura](https://www.atlasobscura.com/articles/felicia-ferret-particle-accelerator-fermilab)