### PR TITLE
Upgrade docker release to use Python 3.7

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.6
+FROM python:3.7
 # Set up code directory
 RUN mkdir -p /usr/src/app
 WORKDIR /usr/src/app


### PR DESCRIPTION
### What was wrong?

Our docker image generation currently fails due to a [bug](https://github.com/debuerreotype/docker-debian-artifacts/issues/66) with the docker debian jessie image.

### How was it fixed?

The easiest way to solve this is to just build on the `python:3.7` package which happens to be on debian stretch already and hence not suffer from this bug.

Since Trinity supports Python 3.7 out of the box and there's no good reason to stick to Python 3.6 for the docker images, this seems to be the simplest fix (confirmed that it works).

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history

[//]: # (For important changes, please add a new entry to the running release notes PR)
[//]: # (You can find the current one using: https://github.com/ethereum/trinity/pulls?q=is%3Aopen+is%3Apr+label%3A%22Release+Notes%22 )
[//]: # (See: https://trinity-client.readthedocs.io/en/latest/contributing.html#pull-requests)
- [x] Add entry to the [release notes PR](https://github.com/ethereum/trinity/pulls?q=is%3Aopen+is%3Apr+label%3A%22Release+Notes%22)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://www.gannett-cdn.com/presto/2018/09/26/PBAC/a7246ced-4869-4912-9b58-77164fd80617-oolongredpanda.jpg)
