### PR TITLE
Avoid catching of RuntimeError during handshake

### DIFF
--- a/p2p/auth.py
+++ b/p2p/auth.py
@@ -86,10 +86,10 @@ async def _handshake(initiator: 'HandshakeInitiator', reader: asyncio.StreamRead
     auth_msg = initiator.create_auth_message(initiator_nonce)
     auth_init = initiator.encrypt_auth_message(auth_msg)
 
-    try:
-        writer.write(auth_init)
-    except RuntimeError as err:
-        raise HandshakeFailure("Error during handshake with {initiator.remote!r}: {err}") from err
+    if writer.transport.is_closing():
+        raise HandshakeFailure("Error during handshake with {initiator.remote!r}. Writer closed.")
+
+    writer.write(auth_init)
 
     auth_ack = await token.cancellable_wait(
         reader.read(ENCRYPTED_AUTH_ACK_LEN),


### PR DESCRIPTION
### What was wrong?

Catching a `RuntimeError` on a `StreamWriter` might hide a whole bunch of errors that we would rather like go through.

### How was it fixed?

Only raise a `HandshakeError` if the writer is closed and let all other `RuntimeError` go through so that we (or the Trinity user) can decide on a case by case basis what to do.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history

[//]: # (For important changes, please add a new entry to the running release notes PR)
[//]: # (You can find the current one using: https://github.com/ethereum/trinity/pulls?q=is%3Aopen+is%3Apr+label%3A%22Release+Notes%22 )
[//]: # (See: https://trinity-client.readthedocs.io/en/latest/contributing.html#pull-requests)
- [x] No changelog entry needed 

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://wallpaper-gallery.net/images/wild-animals-wallpapers-high-resolution/wild-animals-wallpapers-high-resolution-22.jpg)
