### PR TITLE
Clean up chain db

### DIFF
--- a/eth2/beacon/db/chain.py
+++ b/eth2/beacon/db/chain.py
@@ -302,8 +302,8 @@ class BeaconChainDB(BaseBeaconChainDB):
         finalized_head_root = cls._get_finalized_head_root(db)
         return cls._get_block_by_root(db, Hash32(finalized_head_root), block_class)
 
-    @classmethod
-    def _get_finalized_head_root(cls, db: BaseDB) -> Hash32:
+    @staticmethod
+    def _get_finalized_head_root(db: BaseDB) -> Hash32:
         try:
             finalized_head_root = db[SchemaV1.make_finalized_head_root_lookup_key()]
         except KeyError:
@@ -323,8 +323,8 @@ class BeaconChainDB(BaseBeaconChainDB):
         justified_head_root = cls._get_justified_head_root(db)
         return cls._get_block_by_root(db, Hash32(justified_head_root), block_class)
 
-    @classmethod
-    def _get_justified_head_root(cls, db: BaseDB) -> Hash32:
+    @staticmethod
+    def _get_justified_head_root(db: BaseDB) -> Hash32:
         try:
             justified_head_root = db[SchemaV1.make_justified_head_root_lookup_key()]
         except KeyError:
@@ -405,9 +405,8 @@ class BeaconChainDB(BaseBeaconChainDB):
         with self.db.atomic_batch() as db:
             return self._persist_block_chain(db, blocks, block_class)
 
-    @classmethod
+    @staticmethod
     def _set_block_scores_to_db(
-            cls,
             db: BaseDB,
             block: BaseBeaconBlock
     ) -> int:

--- a/eth2/beacon/db/chain.py
+++ b/eth2/beacon/db/chain.py
@@ -93,10 +93,6 @@ class BaseBeaconChainDB(ABC):
         pass
 
     @abstractmethod
-    def get_canonical_block_root_by_slot(self, slot: int) -> Hash32:
-        pass
-
-    @abstractmethod
     def get_canonical_head(self, block_class: Type[BaseBeaconBlock]) -> BaseBeaconBlock:
         pass
 
@@ -263,25 +259,8 @@ class BeaconChainDB(BaseBeaconChainDB):
             db: BaseDB,
             slot: int,
             block_class: Type[BaseBeaconBlock]) -> BaseBeaconBlock:
-        canonical_block_root = cls._get_canonical_block_root_by_slot(db, slot)
+        canonical_block_root = cls._get_canonical_block_root(db, slot)
         return cls._get_block_by_root(db, canonical_block_root, block_class)
-
-    def get_canonical_block_root_by_slot(self, slot: int) -> Hash32:
-        """
-        Return the block root with the given slot in the canonical chain.
-
-        Raise BlockNotFound if there's no block with the given slot in the
-        canonical chain.
-        """
-        return self._get_canonical_block_root_by_slot(self.db, slot)
-
-    @classmethod
-    def _get_canonical_block_root_by_slot(
-            cls,
-            db: BaseDB,
-            slot: int) -> Hash32:
-        validate_slot(slot)
-        return cls._get_canonical_block_root(db, slot)
 
     def get_canonical_head(self, block_class: Type[BaseBeaconBlock]) -> BaseBeaconBlock:
         """

--- a/tests/core/p2p-proto/bcc/helpers.py
+++ b/tests/core/p2p-proto/bcc/helpers.py
@@ -46,7 +46,6 @@ class FakeAsyncBeaconChainDB(BaseAsyncBeaconChainDB, BeaconChainDB):
     coro_persist_block = async_passthrough('persist_block')
     coro_get_canonical_block_root = async_passthrough('get_canonical_block_root')
     coro_get_canonical_block_by_slot = async_passthrough('get_canonical_block_by_slot')
-    coro_get_canonical_block_root_by_slot = async_passthrough('get_canonical_block_root_by_slot')
     coro_get_canonical_head = async_passthrough('get_canonical_head')
     coro_get_canonical_head_root = async_passthrough('get_canonical_head_root')
     coro_get_finalized_head = async_passthrough('get_finalized_head')

--- a/trinity/db/beacon/chain.py
+++ b/trinity/db/beacon/chain.py
@@ -56,10 +56,6 @@ class BaseAsyncBeaconChainDB(ABC):
         pass
 
     @abstractmethod
-    async def coro_get_canonical_block_root_by_slot(self, slot: int) -> Hash32:
-        pass
-
-    @abstractmethod
     async def coro_get_canonical_head(self, block_class: Type[BaseBeaconBlock]) -> BaseBeaconBlock:
         pass
 
@@ -126,7 +122,6 @@ class AsyncBeaconChainDBPreProxy(BaseAsyncBeaconChainDB):
     coro_persist_block = async_method('persist_block')
     coro_get_canonical_block_root = async_method('get_canonical_block_root')
     coro_get_canonical_block_by_slot = async_method('get_canonical_block_by_slot')
-    coro_get_canonical_block_root_by_slot = async_method('get_canonical_block_root_by_slot')
     coro_get_canonical_head = async_method('get_canonical_head')
     coro_get_canonical_head_root = async_method('get_canonical_head_root')
     coro_get_finalized_head = async_method('get_finalized_head')


### PR DESCRIPTION
### What was wrong?

- `get_canonical_block_root_by_slot` is equivalent to `get_canonical_block_root`
- some functions can be changed from classmethod to staticmethods.

### How was it fixed?

- Removed `get_canonical_block_root_by_slot`
- update some methods to `staticmethods`. I left the functions added in #547 unchanged for the time being since they involved in caching object properties.

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://i.redd.it/zma3v167tiy21.jpg)
