### PR TITLE
Header skipping unification

### DIFF
--- a/trinity/_utils/headers.py
+++ b/trinity/_utils/headers.py
@@ -75,13 +75,28 @@ async def _skip_complete_headers_iterator(
     the remaining headers.
     """
     iter_headers = iter(headers)
+    # for logging:
+    first_discarded = None
+    last_discarded = None
+    num_discarded = 0
     for header in iter_headers:
         is_present = await completion_check(header)
         if is_present:
-            logger.debug("Discarding header that we already have: %s", header)
+            if first_discarded is None:
+                first_discarded = header
+            else:
+                last_discarded = header
+            num_discarded += 1
         else:
             yield header
             break
+
+    logger.debug(
+        "Discarding %d headers that we already have: %s...%s",
+        num_discarded,
+        first_discarded,
+        last_discarded,
+    )
 
     for header in iter_headers:
         yield header


### PR DESCRIPTION
### What was wrong?

Two issues:
1. The header skipping log was *very* noisy, spitting out a line for every skipped header
2. The full syncer was using the `skip_complete_headers` utility, but not header sync, so fixing ^ didn't apply everywhere

### How was it fixed?

1. Combine the skipped headers, then log a single line about all skipped headers
2. Use `skip_complete_headers()` in the header syncer

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcTrinlxEfXNWExyK-Qx_QbaAeuOm7S-lgyYdK45e6_b7lbXaIYM)
