### PR TITLE
Fix test that does not catch error

### DIFF
--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -4,7 +4,7 @@ async def run_command_and_detect_errors(async_process_runner, command, time):
     throw an Exception in case any unresolved Exceptions are detected in the output of the command.
     """
     await async_process_runner.run(command, timeout_sec=time)
-    scan_for_errors(async_process_runner.stderr)
+    await scan_for_errors(async_process_runner.stderr)
 
 
 async def scan_for_errors(async_iterable):


### PR DESCRIPTION
### What was wrong?

There was an `await` missing in one test (I think I recently broke that) which had the effect that the test would always go green (not cover what it was supposed to cover)

### How was it fixed?

Add missing `await`

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history

[//]: # (For important changes, please add a new entry to the running release notes PR)
[//]: # (You can find the current one using: https://github.com/ethereum/trinity/pulls?q=is%3Aopen+is%3Apr+label%3A%22Release+Notes%22 )
[//]: # (See: https://trinity-client.readthedocs.io/en/latest/contributing.html#pull-requests)
- [x] No changelog entry needed

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://www.cbreptile.com/wp-content/uploads/2017/08/ambilobe-panther-chameleon-breeder.jpg)
