### PR TITLE
tests: Don't consider `MiningChain` in tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -14,10 +14,7 @@ from eth_utils import (
 from eth_keys import keys
 
 from eth import constants as eth_constants
-from eth.chains.base import (
-    Chain,
-    MiningChain,
-)
+from eth.chains.base import Chain
 from eth.db.atomic import AtomicDB
 # TODO: tests should not be locked into one set of VM rules.  Look at expanding
 # to all mainnet vms.
@@ -251,7 +248,7 @@ def genesis_state(base_genesis_state):
     return base_genesis_state
 
 
-@pytest.fixture(params=[Chain, MiningChain])
+@pytest.fixture
 def chain_without_block_validation(
         request,
         base_db,
@@ -271,8 +268,7 @@ def chain_without_block_validation(
         'validate_block': lambda self, block: None,
     }
     SpuriousDragonVMForTesting = SpuriousDragonVM.configure(validate_seal=lambda block: None)
-    chain_class = request.param
-    klass = chain_class.configure(
+    klass = Chain.configure(
         __name__='TestChainWithoutBlockValidation',
         vm_configuration=(
             (eth_constants.GENESIS_BLOCK_NUMBER, SpuriousDragonVMForTesting),

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -250,7 +250,6 @@ def genesis_state(base_genesis_state):
 
 @pytest.fixture
 def chain_without_block_validation(
-        request,
         base_db,
         genesis_state):
     """

--- a/tests/json-fixtures-over-rpc/test_rpc_fixtures.py
+++ b/tests/json-fixtures-over-rpc/test_rpc_fixtures.py
@@ -18,9 +18,6 @@ from eth_utils import (
     is_string,
 )
 
-from eth.chains.base import (
-    MiningChain,
-)
 from eth.chains.mainnet import (
     MainnetChain,
 )
@@ -384,21 +381,12 @@ def chain_fixture(fixture_data):
     return fixture
 
 
-@pytest.fixture
-def chain(chain_without_block_validation):
-    if isinstance(chain_without_block_validation, MiningChain):
-        # These tests are long. For RPC state tests, there shouldn't be any
-        # significant difference between a mining chain and a basic chain.
-        pytest.skip("I'm only here to make your life miserable.")
-        return
-
-
 class MainnetFullChain(FullChain):
     vm_configuration = MainnetChain.vm_configuration
 
 
 @pytest.mark.asyncio
-async def test_rpc_against_fixtures(chain, event_bus, ipc_server, chain_fixture, fixture_data):
+async def test_rpc_against_fixtures(event_bus, chain_fixture, fixture_data):
     rpc = RPCServer(
         initialize_eth1_modules(MainnetFullChain(None), event_bus)
     )

--- a/tests/json-fixtures-over-rpc/test_rpc_fixtures.py
+++ b/tests/json-fixtures-over-rpc/test_rpc_fixtures.py
@@ -389,7 +389,7 @@ def chain(chain_without_block_validation):
     if isinstance(chain_without_block_validation, MiningChain):
         # These tests are long. For RPC state tests, there shouldn't be any
         # significant difference between a mining chain and a basic chain.
-        pytest.skip("Only need to test basic chain")
+        pytest.skip("I'm only here to make your life miserable.")
         return
 
 


### PR DESCRIPTION
### What was wrong?

Tests were being parametrised for both `[Chain, MiningChain]`, only for `MiningChain` to be marked `skip`. `pytest` has to set up the fixtures (and therefore tear them down afterwards) so that they can be marked.

Identified in PR comment https://github.com/ethereum/trinity/pull/608#issuecomment-493433855.

~~TBH, I don't know why there's a distinction, or if `MiningChain` is used somewhere. @carver, do you?..~~

EDIT: Looks like `MiningChain` is used in integration tests and plugin `txpool` tests; these use the class directly AFAIU, they don't need the parametrised `chain` fixture.

In fact, the `pytest` fixture `chain` only checked if a different `pytest` fixture, `chain_without_block_validation`, was parametrised to use `Chain` or `MiningChain`. AFAIU, both were tested for `py-evm`, but it was OK to skip `MiningChain` when running `trinity` RPC tests with `ethereum/tests` JSON fixtures.

With `trinity` out of `py-evm`'s codebase, there should no longer be need for the contraption.

### How was it fixed?

Don't bother parametrising the `chain_without_block_validation` fixture: use class `Chain` always. Therefore, drop the `chain` fixture - don't pass it to `test_rpc_against_fixtures()`.

Before PR, for Byzantium jobs [2142](https://circleci.com/gh/veox/trinity/2142), [2177](https://circleci.com/gh/veox/trinity/2177), [2342](https://circleci.com/gh/veox/trinity/2342), [2533](https://circleci.com/gh/veox/trinity/2533):

```
============ 4691 passed, 4732 skipped, 1 xfailed in 372.96 seconds ============
============ 4691 passed, 4732 skipped, 1 xfailed in 387.18 seconds ============
============ 4691 passed, 4732 skipped, 1 xfailed in 335.39 seconds ============
============ 4691 passed, 4732 skipped, 1 xfailed in 339.63 seconds ============
```

With PR (at various commits!), for Byzantium jobs [2209](https://circleci.com/gh/veox/trinity/2209), [2229](https://circleci.com/gh/veox/trinity/2229), [2275](https://circleci.com/gh/veox/trinity/2275), [2351](https://circleci.com/gh/veox/trinity/2351):

```
============= 4691 passed, 20 skipped, 1 xfailed in 241.98 seconds =============
============= 4691 passed, 20 skipped, 1 xfailed in 227.80 seconds =============
============= 4691 passed, 20 skipped, 1 xfailed in 299.59 seconds =============
============= 4691 passed, 20 skipped, 1 xfailed in 200.57 seconds =============
```

There is, of course, much variance.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history

[//]: # (For important changes, please add a new entry to the running release notes PR)
[//]: # (You can find the current one using: https://github.com/ethereum/trinity/pulls?q=is%3Aopen+is%3Apr+label%3A%22Release+Notes%22 )
[//]: # (See: https://trinity-client.readthedocs.io/en/latest/contributing.html#pull-requests)
- [x] Add entry to the [release notes PR](https://github.com/ethereum/trinity/pulls?q=is%3Aopen+is%3Apr+label%3A%22Release+Notes%22): https://github.com/ethereum/trinity/pull/445#issuecomment-493744809

### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://www.efoto.lt/files/images/62062/vovasEF.preview.jpg)

Source: [Tomas Ivašauskas @ efoto.lt](https://www.efoto.lt/node/1262612)