### PR TITLE
Disconnect reason handling and tracking

### DIFF
--- a/p2p/peer.py
+++ b/p2p/peer.py
@@ -277,7 +277,7 @@ class BasePeer(BaseService):
             try:
                 reason = DisconnectReason(msg['reason'])
             except TypeError:
-                self.logger.info('Unrecognized disconnect reason: %s', msg['reason'])
+                self.logger.warning('Unrecognized disconnect reason: %s', msg['reason'])
             else:
                 self.disconnect_reason = reason
                 # Peers sometimes send a disconnect msg before they send the sub-proto handshake.

--- a/p2p/peer_pool.py
+++ b/p2p/peer_pool.py
@@ -427,7 +427,7 @@ class BasePeerPool(BaseService, AsyncIterable[BasePeer]):
         """
         peer = cast(BasePeer, peer)
         if peer.remote in self.connected_nodes:
-            self.logger.info("%s finished, removing from pool", peer)
+            self.logger.info("%s finished[%s], removing from pool", peer, peer.disconnect_reason)
             self.connected_nodes.pop(peer.remote)
         else:
             self.logger.warning(


### PR DESCRIPTION
### What was wrong?

It's useful to know why a peer disconnected.

### How was it fixed?

Ensure that when a peer disconnects due to a `Disconnect` message we keep track of it.  Also better error messaging.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history

[//]: # (For important changes, please add a new entry to the running release notes PR)
[//]: # (You can find the current one using: https://github.com/ethereum/trinity/pulls?q=is%3Aopen+is%3Apr+label%3A%22Release+Notes%22 )
[//]: # (See: https://trinity-client.readthedocs.io/en/latest/contributing.html#pull-requests)
- [ ] Add entry to the [release notes PR](https://github.com/ethereum/trinity/pulls?q=is%3Aopen+is%3Apr+label%3A%22Release+Notes%22)

#### Cute Animal Picture

![e8407f03d49d16127dd8cf35b902667d--mini-goats-baby-goats](https://user-images.githubusercontent.com/824194/57941705-e7218900-788c-11e9-96e9-83a04936c2fe.jpg)

