### PR TITLE
Candidate backend API now provides all connected remotes

### DIFF
--- a/p2p/peer_pool.py
+++ b/p2p/peer_pool.py
@@ -161,10 +161,13 @@ class BasePeerPool(BaseService, AsyncIterable[BasePeer]):
         available_slots = self.max_peers - len(self)
 
         try:
+            connected_remotes = {
+                peer.remote for peer in self.connected_nodes.values()
+            }
             candidates = await self.wait(
                 backend.get_peer_candidates(
                     num_requested=available_slots,
-                    num_connected_peers=len(self),
+                    connected_remotes=connected_remotes,
                 ),
                 timeout=REQUEST_PEER_CANDIDATE_TIMEOUT,
             )


### PR DESCRIPTION
### What was wrong?

The peer backend API was only getting a count of currently connected peers.  This doesn't allow the backends to exclude peers that we are already connected to.

### How was it fixed?

The request now comes with a full list of the remotes that we are currently connected to.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history

[//]: # (For important changes, please add a new entry to the running release notes PR)
[//]: # (You can find the current one using: https://github.com/ethereum/trinity/pulls?q=is%3Aopen+is%3Apr+label%3A%22Release+Notes%22 )
[//]: # (See: https://trinity-client.readthedocs.io/en/latest/contributing.html#pull-requests)
- [ ] Add entry to the [release notes PR](https://github.com/ethereum/trinity/pulls?q=is%3Aopen+is%3Apr+label%3A%22Release+Notes%22)

#### Cute Animal Picture

![alpaca04](https://user-images.githubusercontent.com/824194/57941844-39fb4080-788d-11e9-891f-0b99a91ec664.jpg)

