### PR TITLE
relocate WrongGenesis and WrongNetwork to trinity

### DIFF
--- a/p2p/exceptions.py
+++ b/p2p/exceptions.py
@@ -38,20 +38,6 @@ class HandshakeFailure(BaseP2PError):
     pass
 
 
-class WrongNetworkFailure(HandshakeFailure):
-    """
-    Disconnected from the peer because it's on a different network than we're on
-    """
-    pass
-
-
-class WrongGenesisFailure(HandshakeFailure):
-    """
-    Disconnected from the peer because it has a different genesis than we do
-    """
-    pass
-
-
 class TooManyPeersFailure(HandshakeFailure):
     """
     The remote disconnected from us because it has too many peers

--- a/trinity/constants.py
+++ b/trinity/constants.py
@@ -82,3 +82,6 @@ DEFAULT_PREFERRED_NODES: Dict[int, Tuple[Node, ...]] = {
              Address("34.198.237.7", 30303, 30303)),
     ),
 }
+
+# Amount of time a peer will be blacklisted if their network or genesis hash does not match
+BLACKLIST_SECONDS_WRONG_NETWORK_OR_GENESIS = 600

--- a/trinity/exceptions.py
+++ b/trinity/exceptions.py
@@ -1,5 +1,10 @@
 import pathlib
 
+from p2p.exceptions import HandshakeFailure
+from p2p.tracking.connection import register_error
+
+from trinity.constants import BLACKLIST_SECONDS_WRONG_NETWORK_OR_GENESIS
+
 
 class BaseTrinityError(Exception):
     """
@@ -61,3 +66,23 @@ class BadDatabaseError(BaseTrinityError):
      - missing tables
     """
     pass
+
+
+class WrongNetworkFailure(HandshakeFailure):
+    """
+    Disconnected from the peer because it's on a different network than we're on
+    """
+    pass
+
+
+register_error(WrongNetworkFailure, BLACKLIST_SECONDS_WRONG_NETWORK_OR_GENESIS)
+
+
+class WrongGenesisFailure(HandshakeFailure):
+    """
+    Disconnected from the peer because it has a different genesis than we do
+    """
+    pass
+
+
+register_error(WrongGenesisFailure, BLACKLIST_SECONDS_WRONG_NETWORK_OR_GENESIS)

--- a/trinity/protocol/eth/peer.py
+++ b/trinity/protocol/eth/peer.py
@@ -9,8 +9,6 @@ from eth_utils import encode_hex
 
 from p2p.exceptions import (
     HandshakeFailure,
-    WrongNetworkFailure,
-    WrongGenesisFailure,
 )
 from p2p.p2p_proto import DisconnectReason
 from p2p.protocol import (
@@ -18,6 +16,10 @@ from p2p.protocol import (
     _DecodedMsgType,
 )
 
+from trinity.exceptions import (
+    WrongNetworkFailure,
+    WrongGenesisFailure,
+)
 from trinity.protocol.common.peer import (
     BaseChainPeer,
     BaseChainPeerFactory,

--- a/trinity/protocol/les/peer.py
+++ b/trinity/protocol/les/peer.py
@@ -15,8 +15,6 @@ from eth_utils import encode_hex
 
 from p2p.exceptions import (
     HandshakeFailure,
-    WrongGenesisFailure,
-    WrongNetworkFailure,
 )
 from p2p.p2p_proto import DisconnectReason
 from p2p.protocol import (
@@ -24,6 +22,10 @@ from p2p.protocol import (
     _DecodedMsgType,
 )
 
+from trinity.exceptions import (
+    WrongNetworkFailure,
+    WrongGenesisFailure,
+)
 from trinity.protocol.common.peer import (
     BaseChainPeer,
     BaseChainPeerFactory,


### PR DESCRIPTION
### What was wrong?

The `p2p` module shouldn't know anything about the ETH network but the `WrongGenesis` and `WrongNetwork` exceptions lived inside `p2p.exceptions`

### How was it fixed?

Moved them to `trinity.exceptions`

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history

[//]: # (For important changes, please add a new entry to the running release notes PR)
[//]: # (You can find the current one using: https://github.com/ethereum/trinity/pulls?q=is%3Aopen+is%3Apr+label%3A%22Release+Notes%22 )
[//]: # (See: https://trinity-client.readthedocs.io/en/latest/contributing.html#pull-requests)
- [ ] Add entry to the [release notes PR](https://github.com/ethereum/trinity/pulls?q=is%3Aopen+is%3Apr+label%3A%22Release+Notes%22)

#### Cute Animal Picture

![Frappachino](https://user-images.githubusercontent.com/824194/57953311-f57f9d00-78ac-11e9-85a3-b225fb6f7dd6.jpg)

