### PR TITLE
remove async from blacklist tracker methods

### DIFF
--- a/p2p/peer_pool.py
+++ b/p2p/peer_pool.py
@@ -253,7 +253,7 @@ class BasePeerPool(BaseService, AsyncIterable[BasePeer]):
             await peer.disconnect(DisconnectReason.timeout)
             return
         except HandshakeFailure as err:
-            await self.connection_tracker.record_failure(peer.remote, err)
+            self.connection_tracker.record_failure(peer.remote, err)
             raise
         else:
             if peer.is_operational:
@@ -348,7 +348,7 @@ class BasePeerPool(BaseService, AsyncIterable[BasePeer]):
             raise
         except HandshakeFailure as e:
             self.logger.debug("Could not complete handshake with %r: %s", remote, repr(e))
-            await self.connection_tracker.record_failure(remote, e)
+            self.connection_tracker.record_failure(remote, e)
             raise
         except COMMON_PEER_CONNECTION_EXCEPTIONS as e:
             self.logger.debug("Could not complete handshake with %r: %s", remote, repr(e))

--- a/p2p/tracking/connection.py
+++ b/p2p/tracking/connection.py
@@ -41,14 +41,14 @@ class BaseConnectionTracker(ABC):
     """
     logger = logging.getLogger('p2p.tracking.connection.ConnectionTracker')
 
-    async def record_failure(self, remote: Node, failure: BaseP2PError) -> None:
+    def record_failure(self, remote: Node, failure: BaseP2PError) -> None:
         timeout_seconds = get_timeout_for_failure(failure)
         failure_name = type(failure).__name__
 
-        return await self.record_blacklist(remote, timeout_seconds, failure_name)
+        return self.record_blacklist(remote, timeout_seconds, failure_name)
 
     @abstractmethod
-    async def record_blacklist(self, remote: Node, timeout_seconds: int, reason: str) -> None:
+    def record_blacklist(self, remote: Node, timeout_seconds: int, reason: str) -> None:
         pass
 
     @abstractmethod
@@ -57,7 +57,7 @@ class BaseConnectionTracker(ABC):
 
 
 class NoopConnectionTracker(BaseConnectionTracker):
-    async def record_blacklist(self, remote: Node, timeout_seconds: int, reason: str) -> None:
+    def record_blacklist(self, remote: Node, timeout_seconds: int, reason: str) -> None:
         pass
 
     async def should_connect_to(self, remote: Node) -> bool:

--- a/tests/core/network-db/test_blacklist_connection_tracking.py
+++ b/tests/core/network-db/test_blacklist_connection_tracking.py
@@ -26,7 +26,7 @@ async def test_records_failures():
     node = NodeFactory()
     assert await connection_tracker.should_connect_to(node) is True
 
-    await connection_tracker.record_failure(node, HandshakeFailure())
+    connection_tracker.record_failure(node, HandshakeFailure())
 
     assert await connection_tracker.should_connect_to(node) is False
     assert connection_tracker._record_exists(node.uri())
@@ -38,7 +38,7 @@ async def test_memory_does_not_persist():
 
     connection_tracker_a = MemoryConnectionTracker()
     assert await connection_tracker_a.should_connect_to(node) is True
-    await connection_tracker_a.record_failure(node, HandshakeFailure())
+    connection_tracker_a.record_failure(node, HandshakeFailure())
     assert await connection_tracker_a.should_connect_to(node) is False
 
     # open a second instance
@@ -56,7 +56,7 @@ async def test_sql_does_persist(tmpdir):
 
     connection_tracker_a = SQLiteConnectionTracker(get_tracking_database(db_path))
     assert await connection_tracker_a.should_connect_to(node) is True
-    await connection_tracker_a.record_failure(node, HandshakeFailure())
+    connection_tracker_a.record_failure(node, HandshakeFailure())
     assert await connection_tracker_a.should_connect_to(node) is False
     del connection_tracker_a
 
@@ -73,7 +73,7 @@ async def test_timeout_works():
     connection_tracker = MemoryConnectionTracker()
     assert await connection_tracker.should_connect_to(node) is True
 
-    await connection_tracker.record_failure(node, HandshakeFailure())
+    connection_tracker.record_failure(node, HandshakeFailure())
     assert await connection_tracker.should_connect_to(node) is False
 
     record = connection_tracker._get_record(node.uri())

--- a/tests/core/network-db/test_connection_tracker_server.py
+++ b/tests/core/network-db/test_connection_tracker_server.py
@@ -19,7 +19,7 @@ from trinity.plugins.builtin.network_db.connection.tracker import (
 async def test_connection_tracker_server_and_client(event_loop, event_bus):
     tracker = MemoryConnectionTracker()
     remote_a = NodeFactory()
-    await tracker.record_blacklist(remote_a, 60, "testing")
+    tracker.record_blacklist(remote_a, 60, "testing")
 
     assert await tracker.should_connect_to(remote_a) is False
 
@@ -40,7 +40,9 @@ async def test_connection_tracker_server_and_client(event_loop, event_bus):
 
     assert await bus_tracker.should_connect_to(remote_b) is True
 
-    await bus_tracker.record_blacklist(remote_b, 60, "testing")
+    bus_tracker.record_blacklist(remote_b, 60, "testing")
+    # let the underlying broadcast_nowait execute
+    await asyncio.sleep(0.01)
 
     assert await bus_tracker.should_connect_to(remote_b) is False
     assert await tracker.should_connect_to(remote_b) is False

--- a/trinity/plugins/builtin/network_db/connection/server.py
+++ b/trinity/plugins/builtin/network_db/connection/server.py
@@ -47,7 +47,7 @@ class ConnectionTrackerServer(BaseService):
                 humanize_seconds(command.timeout_seconds),
                 command.reason,
             )
-            await self.tracker.record_blacklist(
+            self.tracker.record_blacklist(
                 command.remote,
                 command.timeout_seconds,
                 command.reason

--- a/trinity/plugins/builtin/network_db/connection/tracker.py
+++ b/trinity/plugins/builtin/network_db/connection/tracker.py
@@ -56,7 +56,7 @@ class SQLiteConnectionTracker(BaseConnectionTracker):
     #
     # Core API
     #
-    async def record_blacklist(self, remote: Node, timeout_seconds: int, reason: str) -> None:
+    def record_blacklist(self, remote: Node, timeout_seconds: int, reason: str) -> None:
         if self._record_exists(remote.uri()):
             self._update_record(remote, timeout_seconds, reason)
         else:
@@ -150,8 +150,8 @@ class ConnectionTrackerClient(BaseConnectionTracker):
         self.event_bus = event_bus
         self.config = config
 
-    async def record_blacklist(self, remote: Node, timeout_seconds: int, reason: str) -> None:
-        await self.event_bus.broadcast(
+    def record_blacklist(self, remote: Node, timeout_seconds: int, reason: str) -> None:
+        self.event_bus.broadcast_nowait(
             BlacklistEvent(remote, timeout_seconds, reason=reason),
             self.config,
         )


### PR DESCRIPTION
### What was wrong?

When we disconnect from a peer we *may* want to also blacklist them.  The `tracker.record_blacklist` method is `async` which means that it can only be used from `async` methods.

When we are within something like the `BootManager` or `RequestManager` for a peer and we want to disconnect we **must** use `Peer.disconnect_nowait` because using `await Peer.disconnect` throws a cancellation error because of the inner call to `Peer.cancel()`.

This means we **must** be able to issue a blacklist from a sync method.

### How was it fixed?

Changed to using `broadcast_nowait` and removed the `async` nature of the methods on the blacklist tracker.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history

[//]: # (For important changes, please add a new entry to the running release notes PR)
[//]: # (You can find the current one using: https://github.com/ethereum/trinity/pulls?q=is%3Aopen+is%3Apr+label%3A%22Release+Notes%22 )
[//]: # (See: https://trinity-client.readthedocs.io/en/latest/contributing.html#pull-requests)
- [ ] Add entry to the [release notes PR](https://github.com/ethereum/trinity/pulls?q=is%3Aopen+is%3Apr+label%3A%22Release+Notes%22)

#### Cute Animal Picture

![12-06-19 Sugar (9)C750](https://user-images.githubusercontent.com/824194/57953539-94a49480-78ad-11e9-94b8-4e200909f093.JPG)

