### PR TITLE
refactor blacklist tracking API to allow explicit expiration

### DIFF
--- a/p2p/peer.py
+++ b/p2p/peer.py
@@ -355,7 +355,7 @@ class BasePeer(BaseService):
                 self.process_msg(cmd, msg)
             except RemoteDisconnected as e:
                 if self.uptime < BLACKLIST_SECONDS_QUICK_DISCONNECT:
-                    await self.connection_tracker.record_blacklist(
+                    self.connection_tracker.record_blacklist(
                         self.remote,
                         BLACKLIST_SECONDS_QUICK_DISCONNECT,
                         "Quick disconnect",

--- a/trinity/plugins/builtin/network_db/connection/tracker.py
+++ b/trinity/plugins/builtin/network_db/connection/tracker.py
@@ -57,10 +57,16 @@ class SQLiteConnectionTracker(BaseConnectionTracker):
     # Core API
     #
     def record_blacklist(self, remote: Node, timeout_seconds: int, reason: str) -> None:
-        if self._record_exists(remote.uri()):
-            self._update_record(remote, timeout_seconds, reason)
+        try:
+            record = self._get_record(remote.uri())
+        except NoResultFound:
+            expires_at = datetime.datetime.utcnow() + datetime.timedelta(seconds=timeout_seconds)
+            self._create_record(remote, expires_at, reason)
         else:
-            self._create_record(remote, timeout_seconds, reason)
+            adjusted_timeout_seconds = int(timeout_seconds * math.sqrt(record.error_count + 1))
+            delta = datetime.timedelta(seconds=adjusted_timeout_seconds)
+            scaled_expires_at = datetime.datetime.utcnow() + delta
+            self._update_record(remote, scaled_expires_at, reason)
 
     async def should_connect_to(self, remote: Node) -> bool:
         try:
@@ -96,29 +102,29 @@ class SQLiteConnectionTracker(BaseConnectionTracker):
         else:
             return True
 
-    def _create_record(self, remote: Node, timeout_seconds: int, reason: str) -> None:
+    def _create_record(self, remote: Node, expires_at: datetime.datetime, reason: str) -> None:
         uri = remote.uri()
-        expires_at = datetime.datetime.utcnow() + datetime.timedelta(seconds=timeout_seconds)
 
         record = BlacklistRecord(uri=uri, expires_at=expires_at, reason=reason)
         self.session.add(record)
         # mypy doesn't know about the type of the `commit()` function
         self.session.commit()  # type: ignore
 
+        usable_delta = expires_at - datetime.datetime.utcnow()
         self.logger.debug(
             '%s will not be retried for %s because %s',
             remote,
-            humanize_seconds(timeout_seconds),
+            humanize_seconds(usable_delta.total_seconds()),
             reason,
         )
 
-    def _update_record(self, remote: Node, timeout_seconds: int, reason: str) -> None:
+    def _update_record(self, remote: Node, expires_at: datetime.datetime, reason: str) -> None:
         uri = remote.uri()
         record = self._get_record(uri)
-        record.error_count += 1
 
-        adjusted_timeout_seconds = int(timeout_seconds * math.sqrt(record.error_count))
-        record.expires_at += datetime.timedelta(seconds=adjusted_timeout_seconds)
+        if expires_at > record.expires_at:
+            # only update expiration if it is further in the future than the existing expiration
+            record.expires_at = expires_at
         record.reason = reason
         record.error_count += 1
 
@@ -126,10 +132,11 @@ class SQLiteConnectionTracker(BaseConnectionTracker):
         # mypy doesn't know about the type of the `commit()` function
         self.session.commit()  # type: ignore
 
+        usable_delta = expires_at - datetime.datetime.utcnow()
         self.logger.debug(
             '%s will not be retried for %s because %s',
             remote,
-            humanize_seconds(adjusted_timeout_seconds),
+            humanize_seconds(usable_delta.total_seconds()),
             reason,
         )
 


### PR DESCRIPTION
### What was wrong?

The business logic for adjusting the total timeout based on how many times a peer has errored out was at the wrong level, not allowing us to do explicit setting of the expiration via the core API.  This made testing harder in #543

### How was it fixed?

Moved the business logic up a level into the `record_blacklist` method.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history

[//]: # (For important changes, please add a new entry to the running release notes PR)
[//]: # (You can find the current one using: https://github.com/ethereum/trinity/pulls?q=is%3Aopen+is%3Apr+label%3A%22Release+Notes%22 )
[//]: # (See: https://trinity-client.readthedocs.io/en/latest/contributing.html#pull-requests)
- [ ] Add entry to the [release notes PR](https://github.com/ethereum/trinity/pulls?q=is%3Aopen+is%3Apr+label%3A%22Release+Notes%22)

#### Cute Animal Picture

![16-05-28 Honeysuckle Rose (7)C1000](https://user-images.githubusercontent.com/824194/57953700-1694bd80-78ae-11e9-97b4-fbcdbfcb3af8.JPG)

