### PR TITLE
Blacklist peers who disconnect too quickly

### DIFF
--- a/p2p/constants.py
+++ b/p2p/constants.py
@@ -133,3 +133,8 @@ BLACKLIST_SECONDS_BAD_PROTOCOL = 60 * 10  # 10 minutes
 
 # Amount of time a peer will be blacklisted when they timeout too frequently
 BLACKLIST_SECONDS_TOO_MANY_TIMEOUTS = 60 * 5  # 5 minutes
+
+# Both the amount of time that we consider to be a peer disconnecting from us
+# too quickly as well as the amount of time they will be blacklisted for doing
+# so.
+BLACKLIST_SECONDS_QUICK_DISCONNECT = 60

--- a/p2p/peer.py
+++ b/p2p/peer.py
@@ -67,6 +67,7 @@ from p2p.tracking.connection import (
 
 from .constants import (
     BLACKLIST_SECONDS_BAD_PROTOCOL,
+    BLACKLIST_SECONDS_QUICK_DISCONNECT,
     SNAPPY_PROTOCOL_VERSION,
 )
 
@@ -351,6 +352,12 @@ class BasePeer(BaseService):
             try:
                 self.process_msg(cmd, msg)
             except RemoteDisconnected as e:
+                if self.uptime < BLACKLIST_SECONDS_QUICK_DISCONNECT:
+                    await self.connection_tracker.record_blacklist(
+                        self.remote,
+                        BLACKLIST_SECONDS_QUICK_DISCONNECT,
+                        "Quick disconnect",
+                    )
                 self.logger.debug("%r disconnected: %s", self, e)
                 return
 


### PR DESCRIPTION
### What was wrong?

While working on #543 I ran into a problem.  When looking at a set of historical peer connections we choose peers that are not currently blacklisted, and then order them by how recently we successfully connected to them.

Under this rule, a peer could allow our connection for a short duration, and then disconnect, claiming they are shutting down.  They would still be very close to the front of the queue when we query our database, which would result in us attempting to connect to them again.  They could repeat this for a very long time, constantly disrupting our sync but always being very close to the front of the line for peers we choose to connect to.

### How was it fixed?

If a peer disconnects from us after too short a duration (currently set to 60 seconds but I think 2-5 minutes might be better), we put them on the blacklist for some duration, allowing other peers to make their way to the front of the line.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history

[//]: # (For important changes, please add a new entry to the running release notes PR)
[//]: # (You can find the current one using: https://github.com/ethereum/trinity/pulls?q=is%3Aopen+is%3Apr+label%3A%22Release+Notes%22 )
[//]: # (See: https://trinity-client.readthedocs.io/en/latest/contributing.html#pull-requests)
- [ ] Add entry to the [release notes PR](https://github.com/ethereum/trinity/pulls?q=is%3Aopen+is%3Apr+label%3A%22Release+Notes%22)

#### Cute Animal Picture

![13-09-28 Breeze Boy Cria (34)C750](https://user-images.githubusercontent.com/824194/57954018-ff0a0480-78ae-11e9-8b8f-80d089de323a.JPG)

