### PR TITLE
Shutdown networkdb plugin on bad database

### DIFF
--- a/trinity/plugins/builtin/network_db/plugin.py
+++ b/trinity/plugins/builtin/network_db/plugin.py
@@ -28,6 +28,9 @@ from trinity.db.network import (
 from trinity.endpoint import (
     TrinityEventBusEndpoint,
 )
+from trinity.exceptions import (
+    BadDatabaseError,
+)
 
 from .connection.server import ConnectionTrackerServer
 from .connection.tracker import (
@@ -99,7 +102,15 @@ class NetworkDBPlugin(BaseIsolatedPlugin):
             # user swapping in an equivalent experimental version.
             return
         else:
-            self.start()
+            try:
+                get_tracking_database(get_networkdb_path(self.boot_info.trinity_config))
+            except BadDatabaseError as err:
+                manager_eventbus.request_shutdown(
+                    "Error loading network database.  Trying removing database "
+                    f"with `remove-network-db` command:\n{err}"
+                )
+            else:
+                self.start()
 
     @classmethod
     def clear_node_db(cls, args: Namespace, trinity_config: TrinityConfig) -> None:


### PR DESCRIPTION
### What was wrong?

The current `Network DB Plugin` doesn't properly kill the main process if it encounters a corrupt database.

### How was it fixed?

Used @cburgdorf suggestion from [here](https://github.com/ethereum/trinity/pull/543#discussion_r283268330) and moved the shutdown logic to the `on_ready` which is still running in the main process.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history

[//]: # (For important changes, please add a new entry to the running release notes PR)
[//]: # (You can find the current one using: https://github.com/ethereum/trinity/pulls?q=is%3Aopen+is%3Apr+label%3A%22Release+Notes%22 )
[//]: # (See: https://trinity-client.readthedocs.io/en/latest/contributing.html#pull-requests)
- [ ] Add entry to the [release notes PR](https://github.com/ethereum/trinity/pulls?q=is%3Aopen+is%3Apr+label%3A%22Release+Notes%22)

#### Cute Animal Picture

![a8c3bf673ee3ed86f06499c66170a786](https://user-images.githubusercontent.com/824194/57954142-5ad48d80-78af-11e9-8289-bbcf0b449b5d.jpg)

