### PR TITLE
Avoid logging in skip_complete_headers() utility

### DIFF
--- a/tests/core/utils/test_headers.py
+++ b/tests/core/utils/test_headers.py
@@ -28,6 +28,12 @@ async def is_odd(header):
         ((2, 3), return_true, (2, 3), ()),
         ((2, 3), return_false, (), (2, 3)),
         ((5, 6), is_odd, (5,), (6,)),
+        # should accept a generator
+        ((_ for _ in range(0)), return_false, (), ()),
+        ((_ for _ in range(0)), return_true, (), ()),
+        ((i for i in range(3)), return_true, (0, 1, 2), ()),
+        ((i for i in range(3)), return_false, (), (0, 1, 2)),
+        ((i for i in range(1, 4)), is_odd, (1,), (2, 3)),
     ),
 )
 async def test_skip_complete_headers(headers, check, expected_completed, expected_remaining):

--- a/tests/core/utils/test_headers.py
+++ b/tests/core/utils/test_headers.py
@@ -1,0 +1,38 @@
+import pytest
+
+from trinity._utils.headers import (
+    skip_complete_headers,
+)
+
+
+async def return_true(header):
+    return True
+
+
+async def return_false(header):
+    return False
+
+
+async def is_odd(header):
+    return header % 2
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "headers, check, expected_completed, expected_remaining",
+    (
+        ((), return_true, (), ()),
+        ((), return_false, (), ()),
+        ((1,), return_true, (1,), ()),
+        ((1,), return_false, (), (1,)),
+        ((2, 3), return_true, (2, 3), ()),
+        ((2, 3), return_false, (), (2, 3)),
+        ((5, 6), is_odd, (5,), (6,)),
+    ),
+)
+async def test_skip_complete_headers(headers, check, expected_completed, expected_remaining):
+    # Nothing about skip_complete_headers actually depends on having a header, so
+    # we use integers for easy testing.
+    completed, remaining = await skip_complete_headers(headers, check)
+    assert completed == expected_completed
+    assert remaining == expected_remaining

--- a/tests/core/utils/test_humanize_integer_sequence.py
+++ b/tests/core/utils/test_humanize_integer_sequence.py
@@ -16,6 +16,9 @@ from trinity._utils.humanize import humanize_integer_sequence
         ((1, 2, 3, 5, 7, 8, 9), '1-3|5|7-9'),
         ((1, 3, 4, 5, 7, 8, 9), '1|3-5|7-9'),
         ((1, 3, 4, 5, 9), '1|3-5|9'),
+        # should accept a generator
+        ((_ for _ in range(0)), '(empty)'),
+        ((i for i in (1, 2, 3, 7, 8, 10)), '1-3|7-8|10'),
     ),
 )
 def test_humanize_integer_sequence(seq, expected):

--- a/trinity/_utils/headers.py
+++ b/trinity/_utils/headers.py
@@ -2,7 +2,7 @@ from typing import (
     Awaitable,
     Callable,
     cast,
-    Sequence,
+    Iterable,
     Tuple,
     TypeVar,
 )
@@ -45,7 +45,7 @@ def sequence_builder(start_number: T,
 
 
 async def skip_complete_headers(
-        headers: Sequence[BlockHeader],
+        headers_iter: Iterable[BlockHeader],
         completion_check: Callable[[BlockHeader], Awaitable[bool]]) -> Tuple[BlockHeader, ...]:
     """
     Collect all completed headers into a tuple, and the remaining headers into a second tuple,
@@ -56,6 +56,7 @@ async def skip_complete_headers(
 
     Services should call self.wait() when using this method.
     """
+    headers = tuple(headers_iter)
     for index, header in enumerate(headers):
         if not await completion_check(header):
             # index of first header that is not complete

--- a/trinity/_utils/headers.py
+++ b/trinity/_utils/headers.py
@@ -1,16 +1,14 @@
 from typing import (
-    AsyncIterator,
     Awaitable,
     Callable,
     cast,
-    Iterable,
+    Sequence,
     Tuple,
     TypeVar,
 )
 
 from eth.constants import UINT_256_MAX
 from eth.rlp.headers import BlockHeader
-from eth.tools.logging import ExtendedDebugLogger
 
 from trinity.exceptions import OversizeObject
 
@@ -47,56 +45,23 @@ def sequence_builder(start_number: T,
 
 
 async def skip_complete_headers(
-        headers: Iterable[BlockHeader],
-        logger: ExtendedDebugLogger,
+        headers: Sequence[BlockHeader],
         completion_check: Callable[[BlockHeader], Awaitable[bool]]) -> Tuple[BlockHeader, ...]:
     """
-    Skip any headers where `completion_check(header)` returns False
-    After finding the first header that returns True, return all remaining headers.
-    This is useful when importing headers in sequence, after writing them to DB in sequence.
+    Collect all completed headers into a tuple, and the remaining headers into a second tuple,
+    using `completion_check(header)` to decide on completion.
 
-    Services should call self.wait() when using this method
-    """
-    skip_headers_coro = _skip_complete_headers_iterator(headers, logger, completion_check)
-    return tuple(
-        # The inner list comprehension is needed because async_generators
-        # cannot be cast to a tuple.
-        [header async for header in skip_headers_coro]
-    )
+    Note that `completion_check` is *not* run on the remaining headers after the first time
+    that it returns ``False``.
 
-
-async def _skip_complete_headers_iterator(
-        headers: Iterable[BlockHeader],
-        logger: ExtendedDebugLogger,
-        completion_check: Callable[[BlockHeader], Awaitable[bool]]) -> AsyncIterator[BlockHeader]:
+    Services should call self.wait() when using this method.
     """
-    We only want headers that are missing, so we iterate over the list
-    until we find the first missing header, after which we return all of
-    the remaining headers.
-    """
-    iter_headers = iter(headers)
-    # for logging:
-    first_discarded = None
-    last_discarded = None
-    num_discarded = 0
-    for header in iter_headers:
-        is_present = await completion_check(header)
-        if is_present:
-            if first_discarded is None:
-                first_discarded = header
-            else:
-                last_discarded = header
-            num_discarded += 1
-        else:
-            yield header
+    for index, header in enumerate(headers):
+        if not await completion_check(header):
+            # index of first header that is not complete
+            first_incomplete_index = index
             break
+    else:
+        first_incomplete_index = len(headers)
 
-    logger.debug(
-        "Discarding %d headers that we already have: %s...%s",
-        num_discarded,
-        first_discarded,
-        last_discarded,
-    )
-
-    for header in iter_headers:
-        yield header
+    return tuple(headers[:first_incomplete_index]), tuple(headers[first_incomplete_index:])

--- a/trinity/_utils/humanize.py
+++ b/trinity/_utils/humanize.py
@@ -1,4 +1,4 @@
-from typing import Iterable, Sequence, Tuple
+from typing import Iterable, Tuple
 
 from eth_utils.toolz import sliding_window
 
@@ -35,7 +35,7 @@ def _humanize_range(bounds: Tuple[int, int]) -> str:
         return f'{left}-{right}'
 
 
-def humanize_integer_sequence(values: Sequence[int]) -> str:
+def humanize_integer_sequence(values: Iterable[int]) -> str:
     """
     Return a human readable string that attempts to concisely define a sequence
     of integers.

--- a/trinity/_utils/humanize.py
+++ b/trinity/_utils/humanize.py
@@ -35,7 +35,7 @@ def _humanize_range(bounds: Tuple[int, int]) -> str:
         return f'{left}-{right}'
 
 
-def humanize_integer_sequence(values: Iterable[int]) -> str:
+def humanize_integer_sequence(values_iter: Iterable[int]) -> str:
     """
     Return a human readable string that attempts to concisely define a sequence
     of integers.
@@ -45,6 +45,7 @@ def humanize_integer_sequence(values: Iterable[int]) -> str:
     - fn((1, 2, 3, 5, 7, 8, 9)) -> '1-3|5|7-9'
     - fn((1, 7, 8, 9)) -> '1|7-9'
     """
+    values = tuple(values_iter)
     if not values:
         return "(empty)"
     else:

--- a/trinity/sync/common/headers.py
+++ b/trinity/sync/common/headers.py
@@ -66,6 +66,9 @@ from trinity._utils.datastructures import (
 from trinity._utils.headers import (
     skip_complete_headers,
 )
+from trinity._utils.humanize import (
+    humanize_integer_sequence,
+)
 
 
 class SkeletonSyncer(BaseService, Generic[TChainPeer]):
@@ -286,9 +289,18 @@ class SkeletonSyncer(BaseService, Generic[TChainPeer]):
             )
 
         # identify headers that are not already stored locally
-        new_headers = await self.wait(
-            skip_complete_headers(launch_headers, self.logger, self._should_skip_header)
+        completed_headers, new_headers = await self.wait(
+            skip_complete_headers(launch_headers, self._should_skip_header)
         )
+
+        if completed_headers:
+            self.logger.debug(
+                "During header sync launch, skipping over (%d) already stored headers %s: %s..%s",
+                len(completed_headers),
+                humanize_integer_sequence(h.block_number for h in completed_headers),
+                completed_headers[0],
+                completed_headers[-1],
+            )
 
         if len(new_headers) == 0:
             self.logger.debug(


### PR DESCRIPTION
Suggested in https://github.com/ethereum/trinity/pull/619#discussion_r285304221

By changing the result from "return incomplete headers" to "return tuple of completed and tuple of incompleted headers". Added some tests as a gut-check.

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://www.sharesloth.com/wp-content/uploads/2014/07/cute-baby-goat-7.jpg)
