### PR TITLE
Add attestation handling to validator and receive server

### DIFF
--- a/eth2/beacon/tools/builder/validator.py
+++ b/eth2/beacon/tools/builder/validator.py
@@ -599,7 +599,7 @@ def create_signed_attestation_at_slot(
     return Attestation(
         aggregation_bitfield=aggregation_bitfield,
         data=attestation_data,
-        custody_bitfield=Bitfield(b'\x00' * len(aggregation_bitfield)),
+        custody_bitfield=Bitfield(get_empty_bitfield(len(aggregation_bitfield))),
         aggregate_signature=aggregate_signature,
     )
 

--- a/tests/core/p2p-proto/bcc/test_commands.py
+++ b/tests/core/p2p-proto/bcc/test_commands.py
@@ -148,7 +148,9 @@ async def test_send_no_attestations(request, event_loop):
 
     message = await msg_buffer.msg_queue.get()
     assert isinstance(message.command, Attestations)
-    assert message.payload == ()
+    assert message.payload == {
+        "encoded_attestations": (),
+    }
 
 
 @pytest.mark.asyncio
@@ -174,7 +176,7 @@ async def test_send_single_attestation(request, event_loop):
 
     message = await msg_buffer.msg_queue.get()
     assert isinstance(message.command, Attestations)
-    assert message.payload == (ssz.encode(attestation),)
+    assert message.payload["encoded_attestations"] == (ssz.encode(attestation),)
 
 
 @pytest.mark.asyncio
@@ -202,4 +204,5 @@ async def test_send_multiple_attestations(request, event_loop):
 
     message = await msg_buffer.msg_queue.get()
     assert isinstance(message.command, Attestations)
-    assert message.payload == tuple(ssz.encode(attestation) for attestation in attestations)
+    assert message.payload["encoded_attestations"] == tuple(
+        ssz.encode(attestation) for attestation in attestations)

--- a/tests/plugins/eth2/beacon/test_validator.py
+++ b/tests/plugins/eth2/beacon/test_validator.py
@@ -11,11 +11,12 @@ from lahja import (
 )
 import pytest
 
-from eth.exceptions import BlockNotFound
-
-from eth2.configs import CommitteeConfig
 from eth2.beacon.helpers import (
     slot_to_epoch,
+)
+from eth2.beacon.state_machines.forks.serenity.block_validation import validate_attestation
+from eth2.beacon.state_machines.forks.xiao_long_bao.configs import (
+    XIAO_LONG_BAO_CONFIG,
 )
 from eth2.beacon.tools.builder.proposer import (
     _get_proposer_index,
@@ -23,10 +24,7 @@ from eth2.beacon.tools.builder.proposer import (
 from eth2.beacon.tools.misc.ssz_vector import (
     override_vector_lengths,
 )
-from eth2.beacon.state_machines.forks.serenity.block_validation import validate_attestation
-from eth2.beacon.state_machines.forks.xiao_long_bao.configs import (
-    XIAO_LONG_BAO_CONFIG,
-)
+from eth2.configs import CommitteeConfig
 
 from trinity.config import (
     BeaconChainConfig,

--- a/tests/plugins/eth2/beacon/test_validator.py
+++ b/tests/plugins/eth2/beacon/test_validator.py
@@ -13,12 +13,9 @@ import pytest
 
 from eth.exceptions import BlockNotFound
 
+from eth2.configs import CommitteeConfig
 from eth2.beacon.helpers import (
     slot_to_epoch,
-)
-from eth2.beacon.state_machines.forks.serenity.block_validation import validate_attestation
-from eth2.beacon.state_machines.forks.xiao_long_bao.configs import (
-    XIAO_LONG_BAO_CONFIG,
 )
 from eth2.beacon.tools.builder.proposer import (
     _get_proposer_index,
@@ -26,7 +23,10 @@ from eth2.beacon.tools.builder.proposer import (
 from eth2.beacon.tools.misc.ssz_vector import (
     override_vector_lengths,
 )
-from eth2.configs import CommitteeConfig
+from eth2.beacon.state_machines.forks.serenity.block_validation import validate_attestation
+from eth2.beacon.state_machines.forks.xiao_long_bao.configs import (
+    XIAO_LONG_BAO_CONFIG,
+)
 
 from trinity.config import (
     BeaconChainConfig,

--- a/tests/plugins/eth2/beacon/test_validator.py
+++ b/tests/plugins/eth2/beacon/test_validator.py
@@ -96,7 +96,6 @@ async def get_validator(event_loop, event_bus, index) -> Validator:
         chain=chain,
         peer_pool=peer_pool,
         validator_privkeys=validator_privkeys,
-        genesis_config=Eth2GenesisConfig(XIAO_LONG_BAO_CONFIG),
         event_bus=event_bus,
     )
     asyncio.ensure_future(v.run(), loop=event_loop)

--- a/trinity/plugins/eth2/beacon/plugin.py
+++ b/trinity/plugins/eth2/beacon/plugin.py
@@ -124,7 +124,6 @@ class BeaconNodePlugin(BaseIsolatedPlugin):
             chain=chain,
             peer_pool=server.peer_pool,
             validator_privkeys=validator_privkeys,
-            genesis_config=chain_config.genesis_config,
             event_bus=self.event_bus,
             token=server.cancel_token,
         )

--- a/trinity/plugins/eth2/beacon/validator.py
+++ b/trinity/plugins/eth2/beacon/validator.py
@@ -96,7 +96,10 @@ class Validator(BaseService):
         for validator_index in validator_privkeys:
             self.latest_proposed_epoch[validator_index] = Epoch(-1)
             self.latest_attested_epoch[validator_index] = Epoch(-1)
-            self.this_epoch_assignment[validator_index] = (Epoch(-1),)  # type: ignore
+            self.this_epoch_assignment[validator_index] = (
+                Epoch(-1),
+                CommitteeAssignment((), Shard(-1), Slot(-1), False),
+            )
 
     async def _run(self) -> None:
         await self.event_bus.wait_until_serving()
@@ -247,10 +250,7 @@ class Validator(BaseService):
                       slot: Slot,
                       epoch: Epoch) -> bool:
         has_attested = epoch <= self.latest_attested_epoch[validator_index]
-        if not has_attested and slot == assignment.slot:
-            return True
-        else:
-            return False
+        return not has_attested and slot == assignment.slot
 
     @to_tuple
     def _get_attesting_validator_and_shard(self,

--- a/trinity/plugins/eth2/beacon/validator.py
+++ b/trinity/plugins/eth2/beacon/validator.py
@@ -60,9 +60,6 @@ from trinity.protocol.bcc.peer import (
 from trinity.plugins.eth2.beacon.slot_ticker import (
     SlotTickEvent,
 )
-from eth2.configs import (
-    Eth2GenesisConfig,
-)
 
 
 class Validator(BaseService):

--- a/trinity/plugins/eth2/beacon/validator.py
+++ b/trinity/plugins/eth2/beacon/validator.py
@@ -307,7 +307,7 @@ class Validator(BaseService):
             self.logger.debug(
                 bold_green(
                     f"validator index={attesting_validators_indices} attest to block, "
-                    "block={head}, attestation={attestation}"
+                    f"block={head}, attestation={attestation}"
                 )
             )
             for validator_index in attesting_validators_indices:

--- a/trinity/plugins/eth2/beacon/validator.py
+++ b/trinity/plugins/eth2/beacon/validator.py
@@ -1,4 +1,6 @@
+from itertools import groupby
 import logging
+from operator import itemgetter
 from typing import (
     Dict,
     Iterable,
@@ -273,13 +275,12 @@ class Validator(BaseService):
         # Sort the attesting validators by shard
         sorted_attesting_validators = sorted(
             attesting_validators,
-            key=lambda attesting_data: attesting_data[1],
+            key=itemgetter(1),
         )
         # Group the attesting validators by shard
-        from itertools import groupby
         attesting_validators_groups = groupby(
             sorted_attesting_validators,
-            lambda attesting_data: attesting_data[1],
+            key=itemgetter(1),
         )
         for shard, group in attesting_validators_groups:
             # Get the validator_index -> privkey map of the attesting validators

--- a/trinity/protocol/bcc/commands.py
+++ b/trinity/protocol/bcc/commands.py
@@ -16,6 +16,8 @@ from eth_typing import (
 from eth2.beacon.typing import (
     Slot,
 )
+from eth2.beacon.types.attestations import Attestation
+from eth2.beacon.types.blocks import BeaconBlock
 
 from p2p.protocol import (
     Command,
@@ -24,8 +26,6 @@ from p2p.protocol import (
 from trinity.rlp.sedes import (
     HashOrNumber,
 )
-
-from eth2.beacon.types.blocks import BeaconBlock
 
 
 class RequestMessage(TypedDict):
@@ -81,9 +81,15 @@ class BeaconBlocks(Command):
     )
 
 
+class AttestationsMessage(TypedDict):
+    encoded_attestations: Tuple[Attestation, ...]
+
+
 class Attestations(Command):
     _cmd_id = 3
-    structure = sedes.CountableList(sedes.binary)
+    structure = (
+        ('encoded_attestations', sedes.CountableList(sedes.binary)),
+    )
 
 
 class NewBeaconBlockMessage(TypedDict):

--- a/trinity/protocol/bcc/proto.py
+++ b/trinity/protocol/bcc/proto.py
@@ -28,6 +28,7 @@ from trinity.protocol.bcc.commands import (
     NewBeaconBlock,
     NewBeaconBlockMessage,
     Attestations,
+    AttestationsMessage,
 )
 
 from trinity._utils.logging import HasExtendedDebugLogger
@@ -86,7 +87,9 @@ class BCCProtocol(HasExtendedDebugLogger, Protocol):
 
     def send_attestation_records(self, attestations: Tuple[Attestation, ...]) -> None:
         cmd = Attestations(self.cmd_id_offset, self.snappy_support)
-        header, body = cmd.encode(tuple(ssz.encode(attestation) for attestation in attestations))
+        header, body = cmd.encode(AttestationsMessage(
+            encoded_attestations=tuple(ssz.encode(attestation) for attestation in attestations)),
+        )
         self.transport.send(header, body)
 
     def send_new_block(self, block: BaseBeaconBlock) -> None:

--- a/trinity/protocol/bcc/servers.py
+++ b/trinity/protocol/bcc/servers.py
@@ -258,7 +258,7 @@ class BCCReceiveServer(BaseReceiveServer):
         if not peer.is_operational:
             return
         encoded_attestations = msg["encoded_attestations"]
-        attestations = (
+        attestations = tuple(
             ssz.decode(encoded_attestation, Attestation)
             for encoded_attestation in encoded_attestations
         )


### PR DESCRIPTION
### How was it fixed?
- `Validator` plugin:
    - [x] add `Validator.this_epoch_assignment`: cache the validators' assignment of this epoch
    - [x] add `Validator.attest`: when slot ticked, validators check if they are supposed to attest during this slot and attest if they are
    - [x] broadcast the attestation
- `ReceiveServer`:
    - [x] add `_handle_attestations`
        - [x] validate the received attestations
        - [x] check if the received attestations are already in database or attestation pool
            - currently make this a stub
        - [x] broadcast the new and valid attestations
- [x] Update p2p proto `Attestation` command and `AttestationMessage`

- TODOs in later PRs:
    - store included-in-block attestations reference into database
    - attestation pool
        - store not yet included-in-block attestations in attestation pool
        - when receiving a valid block, remove the included-in-block attestations from attestation pool 
        - `Validator` request ready-to-be-included attestations from `ReceiveServer` when proposing 
### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] Clean up commit history

[//]: # (For important changes, please add a new entry to the running release notes PR)
[//]: # (You can find the current one using: https://github.com/ethereum/trinity/pulls?q=is%3Aopen+is%3Apr+label%3A%22Release+Notes%22 )
[//]: # (See: https://trinity-client.readthedocs.io/en/latest/contributing.html#pull-requests)
- [ ] Add entry to the [release notes PR](https://github.com/ethereum/trinity/pulls?q=is%3Aopen+is%3Apr+label%3A%22Release+Notes%22)

#### Cute Animal Picture


![](https://www.maxpixel.net/static/photo/2x/Pet-Animal-Wallpaper-Canine-Background-Dog-Cute-4165141.jpg)