### PR TITLE
Add TaskQueue.num_pending()

### DIFF
--- a/tests/core/task-queue-utils/test_task_queue.py
+++ b/tests/core/task-queue-utils/test_task_queue.py
@@ -163,18 +163,22 @@ async def test_queue_contains_task_until_complete(tasks):
     first_task = tasks[0]
 
     assert first_task not in q
+    assert q.num_pending() == 0
 
     await wait(q.add(tasks))
 
     assert first_task in q
+    assert q.num_pending() == 2
 
     batch, pending_tasks = await wait(q.get())
 
     assert first_task in q
+    assert q.num_pending() == 0
 
     q.complete(batch, pending_tasks)
 
     assert first_task not in q
+    assert q.num_pending() == 0
 
 
 @pytest.mark.asyncio
@@ -259,13 +263,20 @@ async def test_unfinished_tasks_readded():
     q = TaskQueue()
     await wait(q.add((2, 1, 3)))
 
+    assert q.num_pending() == 3
+
     batch, tasks = await wait(q.get())
 
+    assert q.num_pending() == 0
+
     q.complete(batch, (2, ))
+
+    assert q.num_pending() == 2
 
     batch, tasks = await wait(q.get())
 
     assert tasks == (1, 3)
+    assert q.num_pending() == 0
 
 
 @pytest.mark.asyncio

--- a/trinity/_utils/datastructures.py
+++ b/trinity/_utils/datastructures.py
@@ -269,6 +269,10 @@ class TaskQueue(Generic[TTask]):
         """How many tasks are retrieved, but not completed"""
         return len(self._tasks) - self._open_queue.qsize()
 
+    def num_pending(self) -> int:
+        """How many tasks are pending, not retrieved nor completed"""
+        return self._open_queue.qsize()
+
     def __len__(self) -> int:
         """How many tasks are queued for completion"""
         return len(self._tasks)


### PR DESCRIPTION
### What was wrong?

Needed to know how many pending items there are in the queue for a Beam Sync prototype.

### How was it fixed?

Add `TaskQueue.num_pending()`

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://am23.akamaized.net/tms/cnt/uploads/2012/02/goat-pile.png)
