### PR TITLE
Shorter p2p message log line

### DIFF
--- a/p2p/_utils.py
+++ b/p2p/_utils.py
@@ -97,3 +97,25 @@ def ensure_global_asyncio_executor(cpu_count: int=None) -> Executor:
         _executor._start_queue_management_thread()  # type: ignore
         signal.signal(signal.SIGINT, original_handler)
     return _executor
+
+
+def trim_middle(arbitrary_string: str, max_length: int) -> str:
+    """
+    Trim down strings to max_length by cutting out the middle.
+    This assumes that the most "interesting" bits are toward
+    the beginning and the end.
+
+    Adds a highly unusual '✂✂✂' in the middle where characters
+    were stripped out, to avoid not realizing about the stripped
+    info.
+    """
+    # candidate for moving to eth-utils, if we like it
+    size = len(arbitrary_string)
+    if size <= max_length:
+        return arbitrary_string
+    else:
+        half_len, is_odd = divmod(max_length, 2)
+        first_half = arbitrary_string[:half_len - 1]
+        last_half_len = half_len - 2 + is_odd
+        last_half = arbitrary_string[last_half_len * -1:]
+        return f"{first_half}✂✂✂{last_half}"

--- a/p2p/peer.py
+++ b/p2p/peer.py
@@ -29,7 +29,10 @@ from eth_keys import datatypes
 
 from cancel_token import CancelToken
 
-from p2p._utils import get_devp2p_cmd_id
+from p2p._utils import (
+    get_devp2p_cmd_id,
+    trim_middle,
+)
 from p2p.exceptions import (
     DecryptionError,
     HandshakeFailure,
@@ -376,7 +379,11 @@ class BasePeer(BaseService):
             )
             raise
         else:
-            self.logger.debug2("Successfully decoded %s msg: %s", cmd, decoded_msg)
+            self.logger.debug2(
+                "Successfully decoded %s msg: %s",
+                cmd,
+                trim_middle(str(decoded_msg), 500),
+            )
             self.received_msgs[cmd] += 1
             return cmd, decoded_msg
 

--- a/tests/p2p/test_utils.py
+++ b/tests/p2p/test_utils.py
@@ -1,0 +1,37 @@
+import pytest
+
+from hypothesis import (
+    given,
+    strategies as st,
+)
+
+from p2p._utils import trim_middle
+
+
+@pytest.mark.parametrize(
+    "in_str, max_length, expected",
+    (
+        ("notcut", 6, "notcut"),
+        ("tobecut", 6, "to✂✂✂t"),
+        ("tobecut", 5, "t✂✂✂t"),
+        ("really long thing with a bunch of garbage", 20, "really lo✂✂✂ garbage"),
+    )
+)
+def test_trim_middle(in_str, max_length, expected):
+    actual = trim_middle(in_str, max_length)
+    assert actual == expected
+
+
+@given(st.text(), st.integers(min_value=3))
+def test_trim_middle_length(in_str, max_length):
+    result = trim_middle(in_str, max_length)
+
+    # should never be longer than max length
+    assert len(result) <= max_length
+
+    if len(in_str) <= max_length:
+        # should never be modified if the input is within max length
+        assert in_str == result
+    else:
+        # should always have the trim marker if the input was too long
+        assert "✂✂✂" in result


### PR DESCRIPTION
### What was wrong?

Fixes #638 

Sometimes very long lines (like 10s of kb of characters) can cause problems, like when we search the logs for results during tests.

### How was it fixed?

- Add a utility to strip out the middle of a very long string
- Strip out the middle of the p2p decoded message log that (probably) caused the problem.

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://www.sharesloth.com/wp-content/uploads/2014/07/cute-baby-goat-3.jpg)
