### PR TITLE
fix genesis config

### DIFF
--- a/eth2/beacon/db/chain.py
+++ b/eth2/beacon/db/chain.py
@@ -89,6 +89,10 @@ class BaseBeaconChainDB(ABC):
         pass
 
     @abstractmethod
+    def get_genesis_block_root(self) -> Hash32:
+        pass
+
+    @abstractmethod
     def get_canonical_block_by_slot(self,
                                     slot: int,
                                     block_class: Type[BaseBeaconBlock]) -> BaseBeaconBlock:
@@ -230,6 +234,9 @@ class BeaconChainDB(BaseBeaconChainDB):
         canonical chain.
         """
         return self._get_canonical_block_root(self.db, slot)
+
+    def get_genesis_block_root(self) -> Hash32:
+        return self._get_canonical_block_root(self.db, self.genesis_config.GENESIS_SLOT)
 
     @staticmethod
     def _get_canonical_block_root(db: BaseDB, slot: int) -> Hash32:

--- a/tests/core/p2p-proto/bcc/helpers.py
+++ b/tests/core/p2p-proto/bcc/helpers.py
@@ -50,6 +50,7 @@ class FakeAsyncBeaconChainDB(BaseAsyncBeaconChainDB, BeaconChainDB):
 
     coro_persist_block = async_passthrough('persist_block')
     coro_get_canonical_block_root = async_passthrough('get_canonical_block_root')
+    coro_get_genesis_block_root = async_passthrough('get_genesis_block_root')
     coro_get_canonical_block_by_slot = async_passthrough('get_canonical_block_by_slot')
     coro_get_canonical_head = async_passthrough('get_canonical_head')
     coro_get_canonical_head_root = async_passthrough('get_canonical_head_root')

--- a/tests/core/p2p-proto/bcc/test_full_sync.py
+++ b/tests/core/p2p-proto/bcc/test_full_sync.py
@@ -9,6 +9,7 @@ from trinity.protocol.bcc.servers import BCCRequestServer
 from trinity.sync.beacon.chain import BeaconChainSyncer
 
 from .helpers import (
+    SERENITY_GENESIS_CONFIG,
     get_directly_linked_peers_in_peer_pools,
     get_chain_db,
     create_test_block,
@@ -20,11 +21,17 @@ class NoopBlockImporter:
     """
     Do nothing, to override the block validation in ``SyncBlockImporter``.
     """
+
     def import_block(self, block):
         return None, tuple(), tuple()
 
 
-async def get_sync_setup(request, event_loop, alice_chain_db, bob_chain_db):
+async def get_sync_setup(
+        request,
+        event_loop,
+        alice_chain_db,
+        bob_chain_db,
+        genesis_config=SERENITY_GENESIS_CONFIG):
     alice, alice_peer_pool, bob, bob_peer_pool = await get_directly_linked_peers_in_peer_pools(
         request,
         event_loop,
@@ -33,7 +40,12 @@ async def get_sync_setup(request, event_loop, alice_chain_db, bob_chain_db):
     )
 
     bob_request_server = BCCRequestServer(bob.context.chain_db, bob_peer_pool)
-    alice_syncer = BeaconChainSyncer(alice_chain_db, alice_peer_pool, NoopBlockImporter())
+    alice_syncer = BeaconChainSyncer(
+        alice_chain_db,
+        alice_peer_pool,
+        NoopBlockImporter(),
+        genesis_config,
+    )
 
     asyncio.ensure_future(bob_request_server.run())
     asyncio.ensure_future(alice_syncer.run())

--- a/tests/eth2/core/beacon/db/test_beacon_chaindb.py
+++ b/tests/eth2/core/beacon/db/test_beacon_chaindb.py
@@ -121,6 +121,12 @@ def test_chaindb_get_canonical_block_root(chaindb, block):
     assert block_root == block.signing_root
 
 
+def test_chaindb_get_genesis_block_root(chaindb, genesis_block):
+    chaindb.persist_block(genesis_block, genesis_block.__class__)
+    block_root = chaindb.get_genesis_block_root()
+    assert block_root == genesis_block.signing_root
+
+
 def test_chaindb_state(chaindb, state):
     chaindb.persist_state(state)
     state_class = BeaconState

--- a/trinity/db/beacon/chain.py
+++ b/trinity/db/beacon/chain.py
@@ -25,16 +25,12 @@ from eth2.beacon.types.blocks import (  # noqa: F401
 from trinity._utils.mp import (
     async_method,
 )
-from eth2.configs import (
-    Eth2Config,
-)
 
 
 class BaseAsyncBeaconChainDB(ABC):
     """
     Abstract base class defines async counterparts of the sync ``BaseBeaconChainDB`` APIs.
     """
-    genesis_config: Eth2Config
 
     @abstractmethod
     async def coro_persist_block(
@@ -50,6 +46,10 @@ class BaseAsyncBeaconChainDB(ABC):
 
     @abstractmethod
     async def coro_get_canonical_block_root(self, slot: int) -> Hash32:
+        pass
+
+    @abstractmethod
+    async def coro_get_genesis_block_root(self) -> Hash32:
         pass
 
     @abstractmethod
@@ -125,6 +125,7 @@ class AsyncBeaconChainDBPreProxy(BaseAsyncBeaconChainDB):
 
     coro_persist_block = async_method('persist_block')
     coro_get_canonical_block_root = async_method('get_canonical_block_root')
+    coro_get_genesis_block_root = async_method('get_genesis_block_root')
     coro_get_canonical_block_by_slot = async_method('get_canonical_block_by_slot')
     coro_get_canonical_head = async_method('get_canonical_head')
     coro_get_canonical_head_root = async_method('get_canonical_head_root')

--- a/trinity/plugins/eth2/beacon/plugin.py
+++ b/trinity/plugins/eth2/beacon/plugin.py
@@ -107,6 +107,7 @@ class BeaconNodePlugin(BaseIsolatedPlugin):
             chain_db=chain_db,
             peer_pool=server.peer_pool,
             block_importer=SyncBlockImporter(chain),
+            genesis_config=chain_config.genesis_config,
             token=server.cancel_token,
         )
 

--- a/trinity/protocol/bcc/peer.py
+++ b/trinity/protocol/bcc/peer.py
@@ -87,9 +87,7 @@ class BCCPeer(BasePeer):
 
     async def get_genesis_root(self) -> Hash32:
         if self._genesis_root is None:
-            self._genesis_root = await self.chain_db.coro_get_canonical_block_root(
-                self.chain_db.genesis_config.GENESIS_SLOT,
-            )
+            self._genesis_root = await self.chain_db.coro_get_genesis_block_root()
         return self._genesis_root
 
     @property

--- a/trinity/sync/beacon/chain.py
+++ b/trinity/sync/beacon/chain.py
@@ -45,6 +45,9 @@ from trinity.sync.beacon.constants import (
 from trinity.sync.common.chain import (
     SyncBlockImporter,
 )
+from eth2.configs import (
+    Eth2GenesisConfig,
+)
 
 
 class BeaconChainSyncer(BaseService):
@@ -54,12 +57,14 @@ class BeaconChainSyncer(BaseService):
                  chain_db: BaseAsyncBeaconChainDB,
                  peer_pool: BCCPeerPool,
                  block_importer: SyncBlockImporter,
+                 genesis_config: Eth2GenesisConfig,
                  token: CancelToken = None) -> None:
         super().__init__(token)
 
         self.chain_db = chain_db
         self.peer_pool = peer_pool
         self.block_importer = block_importer
+        self.genesis_config = genesis_config
 
         self.sync_peer: BCCPeer = None
 
@@ -125,7 +130,7 @@ class BeaconChainSyncer(BaseService):
             finalized_slot = finalized_head.slot
         # TODO(ralexstokes) look at better way to handle once we have fork choice in place
         except FinalizedHeadNotFound:
-            finalized_slot = self.chain_db.genesis_config.GENESIS_SLOT
+            finalized_slot = self.genesis_config.GENESIS_SLOT
 
         self.logger.info(
             "Syncing with %s (their head slot: %d, our finalized slot: %d)",


### PR DESCRIPTION
### What was wrong?

Can't access chain_db.genesis_config from AsyncBeaconChainDBProxy

### How was it fixed?

- For BeaconChainSyncer, pass a genesis_config as an `__init__`  parameter.
- For BCCPeer, add `get_genesis_block_root` at chaindb, since passing genesis_config requires massive diffs in BCCPeerContext, BCCServer, and Server.

#### Cute Animal Picture

🦐