### PR TITLE
Fix eth2 debug msg

### DIFF
--- a/eth2/beacon/scripts/run_beacon_nodes.py
+++ b/eth2/beacon/scripts/run_beacon_nodes.py
@@ -180,7 +180,7 @@ class Node:
     def _record_happenning_logs(self, from_stream: str, line: str) -> None:
         for log in self.logs_expected[from_stream]:
             if log.pattern in line:
-                self.logger.debug(f"log \"log.name\" occurred in {from_stream}")
+                self.logger.debug('log "log.name" occurred in %s', from_stream)
                 self.has_log_happened[log] = True
 
 

--- a/eth2/beacon/types/attestation_data.py
+++ b/eth2/beacon/types/attestation_data.py
@@ -14,6 +14,9 @@ from eth2.beacon.typing import (
     Shard,
 )
 from eth2.beacon.types.crosslinks import Crosslink
+from eth_utils import (
+    humanize_hash,
+)
 
 
 class AttestationData(ssz.Serializable):
@@ -52,4 +55,13 @@ class AttestationData(ssz.Serializable):
             shard=shard,
             previous_crosslink=previous_crosslink,
             crosslink_data_root=crosslink_data_root,
+        )
+
+    def __str__(self):
+        return (
+            f"LMD slot={self.slot} root={humanize_hash(self.beacon_block_root)} | "
+            f"FFG epoch={self.source_epoch} "
+            f"{humanize_hash(self.source_root)}<-{humanize_hash(self.target_root)} | "
+            f"CL shard={self.shard} previous={humanize_hash(self.previous_crosslink)} "
+            f"data_root={humanize_hash(self.crosslink_data_root)}"
         )

--- a/eth2/beacon/types/attestation_data.py
+++ b/eth2/beacon/types/attestation_data.py
@@ -57,11 +57,11 @@ class AttestationData(ssz.Serializable):
             crosslink_data_root=crosslink_data_root,
         )
 
-    def __str__(self):
+    def __str__(self) -> str:
         return (
             f"LMD slot={self.slot} root={humanize_hash(self.beacon_block_root)} | "
             f"FFG epoch={self.source_epoch} "
             f"{humanize_hash(self.source_root)}<-{humanize_hash(self.target_root)} | "
-            f"CL shard={self.shard} previous={humanize_hash(self.previous_crosslink)} "
+            f"CL shard={self.shard} previous={str(self.previous_crosslink)} "
             f"data_root={humanize_hash(self.crosslink_data_root)}"
         )

--- a/eth2/beacon/types/attestation_data.py
+++ b/eth2/beacon/types/attestation_data.py
@@ -59,9 +59,9 @@ class AttestationData(ssz.Serializable):
 
     def __str__(self) -> str:
         return (
-            f"LMD slot={self.slot} root={humanize_hash(self.beacon_block_root)} | "
-            f"FFG epoch={self.source_epoch} "
+            f"LMD  slot={self.slot} root={humanize_hash(self.beacon_block_root)} | "
+            f"FFG  epoch={self.source_epoch} "
             f"{humanize_hash(self.source_root)}<-{humanize_hash(self.target_root)} | "
-            f"CL shard={self.shard} previous={str(self.previous_crosslink)} "
-            f"data_root={humanize_hash(self.crosslink_data_root)}"
+            f"CL  shard={self.shard} {humanize_hash(self.previous_crosslink.root)}"
+            f"<-{humanize_hash(self.crosslink_data_root)}"
         )

--- a/eth2/beacon/types/attestations.py
+++ b/eth2/beacon/types/attestations.py
@@ -42,5 +42,5 @@ class Attestation(ssz.Serializable):
             aggregate_signature,
         )
 
-    def __repr__(self):
-        return "<Attestation %s >".format(self.data)
+    def __repr__(self) -> str:
+        return f"<Attestation {self.data} >"

--- a/eth2/beacon/types/attestations.py
+++ b/eth2/beacon/types/attestations.py
@@ -41,3 +41,6 @@ class Attestation(ssz.Serializable):
             custody_bitfield,
             aggregate_signature,
         )
+
+    def __repr__(self):
+        return "<Attestation %s >".format(self.data)

--- a/eth2/beacon/types/crosslinks.py
+++ b/eth2/beacon/types/crosslinks.py
@@ -9,6 +9,10 @@ from ssz.sedes import (
 )
 
 from eth2.beacon.typing import Epoch
+from eth_utils import (
+    encode_hex,
+    humanize_hash,
+)
 
 
 class Crosslink(ssz.Serializable):
@@ -28,3 +32,9 @@ class Crosslink(ssz.Serializable):
             epoch=epoch,
             crosslink_data_root=crosslink_data_root,
         )
+
+    def __str__(self) -> str:
+        return f"CL:{self.epoch} data_root={humanize_hash(self.crosslink_data_root)}"
+
+    def __repr__(self) -> str:
+        return f"<Crosslink epoch={self.epoch} data_root={encode_hex(self.crosslink_data_root)}>"

--- a/trinity/plugins/eth2/beacon/slot_ticker.py
+++ b/trinity/plugins/eth2/beacon/slot_ticker.py
@@ -80,7 +80,7 @@ class SlotTicker(BaseService):
                 # Case 1: new slot
                 if slot > self.latest_slot:
                     self.logger.debug(
-                        bold_green(f"New slot: {slot}\tElapsed time: {elapsed_time}")
+                        bold_green(f"Tick, new slot={slot} Elapsed time: {elapsed_time}")
                     )
                     self.latest_slot = slot
                     await self.event_bus.broadcast(
@@ -95,7 +95,7 @@ class SlotTicker(BaseService):
                 # Case 2: second half of an already ticked slot and it hasn't tick yet
                 elif is_second_tick and not has_sent_second_half_slot_tick:
                     self.logger.debug(
-                        bold_green(f"Second half of slot: {slot}")
+                        bold_green(f"Tick 2, this slot={slot}")
                     )
                     await self.event_bus.broadcast(
                         SlotTickEvent(

--- a/trinity/plugins/eth2/beacon/slot_ticker.py
+++ b/trinity/plugins/eth2/beacon/slot_ticker.py
@@ -80,7 +80,9 @@ class SlotTicker(BaseService):
                 # Case 1: new slot
                 if slot > self.latest_slot:
                     self.logger.debug(
-                        bold_green(f"Tick, new slot={slot} Elapsed time: {elapsed_time}")
+                        bold_green("Tick  this_slot=%s elapsed=%s"),
+                        slot,
+                        elapsed_time,
                     )
                     self.latest_slot = slot
                     await self.event_bus.broadcast(
@@ -94,9 +96,7 @@ class SlotTicker(BaseService):
                     has_sent_second_half_slot_tick = is_second_tick
                 # Case 2: second half of an already ticked slot and it hasn't tick yet
                 elif is_second_tick and not has_sent_second_half_slot_tick:
-                    self.logger.debug(
-                        bold_green(f"Tick 2, this slot={slot}")
-                    )
+                    self.logger.debug(bold_green("Tick  this_slot=%s (second-tick)"), slot)
                     await self.event_bus.broadcast(
                         SlotTickEvent(
                             slot=slot,

--- a/trinity/plugins/eth2/beacon/validator.py
+++ b/trinity/plugins/eth2/beacon/validator.py
@@ -166,8 +166,8 @@ class Validator(BaseService):
         self.logger.debug(
             # Align with debug log below
             bold_green("Head       epoch=%s slot=%s state_root=%s"),
-            head.slot,
             state.current_epoch(self.slots_per_epoch),
+            head.slot,
             encode_hex(head.state_root),
         )
         self.logger.debug(
@@ -269,7 +269,7 @@ class Validator(BaseService):
             cast(Slot, slot + 1),
         )
         self.logger.debug(
-            bold_green("Skip block at slot=%s  post_state=%s"),
+            bold_green("Skip block at slot=%s  post_state_root=%s"),
             slot,
             encode_hex(post_state.root),
         )

--- a/trinity/protocol/bcc/servers.py
+++ b/trinity/protocol/bcc/servers.py
@@ -306,7 +306,7 @@ class BCCReceiveServer(BaseReceiveServer):
         block = ssz.decode(encoded_block, BeaconBlock)
         if self._is_block_seen(block):
             raise Exception(f"block {block} is seen before")
-        self.logger.debug(f"received block={block}")
+        self.logger.debug(f"Received block={block}")
         # TODO: check the proposer signature before importing the block
         if self._process_received_block(block):
             self._broadcast_block(block, from_peer=peer)

--- a/trinity/protocol/bcc/servers.py
+++ b/trinity/protocol/bcc/servers.py
@@ -1,5 +1,4 @@
 from typing import (
-    cast,
     AsyncIterator,
     Dict,
     FrozenSet,
@@ -9,51 +8,62 @@ from typing import (
     Tuple,
     Type,
     Union,
+    cast,
 )
 
-from eth_typing import (
-    Hash32,
+from cancel_token import (
+    CancelToken,
 )
-
-from eth_utils import (
-    to_tuple,
-    ValidationError,
-)
-
-from cancel_token import CancelToken
-
-import ssz
-
-from p2p import protocol
-from p2p.peer import (
-    BasePeer,
-)
-from p2p.protocol import Command
-
 from eth.exceptions import (
     BlockNotFound,
 )
-
-from eth2.configs import CommitteeConfig
-from eth2.beacon.typing import (
-    Slot,
+from eth_typing import (
+    Hash32,
 )
-from eth2.beacon.chains.base import BaseBeaconChain
-from eth2.beacon.types.attestations import Attestation
+from eth_utils import (
+    ValidationError,
+    encode_hex,
+    to_tuple,
+)
+import ssz
+
+from eth2.beacon.chains.base import (
+    BaseBeaconChain,
+)
+from eth2.beacon.state_machines.forks.serenity.block_validation import (
+    validate_attestation,
+)
+from eth2.beacon.types.attestations import (
+    Attestation,
+)
 from eth2.beacon.types.blocks import (
     BaseBeaconBlock,
     BeaconBlock,
 )
-from eth2.beacon.state_machines.forks.serenity.block_validation import validate_attestation
-
-from trinity._utils.shellart import (
-    bold_red,
+from eth2.beacon.typing import (
+    Slot,
+)
+from eth2.configs import (
+    CommitteeConfig,
+)
+from p2p import (
+    protocol,
+)
+from p2p.peer import (
+    BasePeer,
+)
+from p2p.protocol import (
+    Command,
 )
 from trinity._utils.les import (
     gen_request_id,
 )
-from trinity.db.beacon.chain import BaseAsyncBeaconChainDB
-from trinity.protocol.common.servers import BaseRequestServer
+from trinity._utils.shellart import (
+    bold_red,
+)
+from trinity.db.beacon.chain import (
+    BaseAsyncBeaconChainDB,
+)
 from trinity.protocol.bcc.commands import (
     Attestations,
     AttestationsMessage,
@@ -67,6 +77,9 @@ from trinity.protocol.bcc.commands import (
 from trinity.protocol.bcc.peer import (
     BCCPeer,
     BCCPeerPool,
+)
+from trinity.protocol.common.servers import (
+    BaseRequestServer,
 )
 
 
@@ -85,7 +98,7 @@ class BCCRequestServer(BaseRequestServer):
     async def _handle_msg(self, base_peer: BasePeer, cmd: Command,
                           msg: protocol._DecodedMsgType) -> None:
         peer = cast(BCCPeer, base_peer)
-        self.logger.debug("cmd %s" % cmd)
+        self.logger.debug("cmd %s", cmd)
         if isinstance(cmd, GetBeaconBlocks):
             await self._handle_get_beacon_blocks(peer, cast(GetBeaconBlocksMessage, msg))
         else:
@@ -262,7 +275,7 @@ class BCCReceiveServer(BaseReceiveServer):
             ssz.decode(encoded_attestation, Attestation)
             for encoded_attestation in encoded_attestations
         )
-        self.logger.debug(f"received attestations={attestations}")
+        self.logger.debug("Received attestations=%s", attestations)
 
         # Validate attestations
         valid_attestations = self._validate_attestations(attestations)
@@ -295,7 +308,7 @@ class BCCReceiveServer(BaseReceiveServer):
                 f"block signing_root {block.signing_root} does not correpond to"
                 "the one we requested"
             )
-        self.logger.debug(f"received request_id={request_id}, block={block}")
+        self.logger.debug("Received request_id=%s, block=%s", request_id, block)
         self._process_received_block(block)
         del self.map_request_id_block_root[request_id]
 
@@ -306,7 +319,7 @@ class BCCReceiveServer(BaseReceiveServer):
         block = ssz.decode(encoded_block, BeaconBlock)
         if self._is_block_seen(block):
             raise Exception(f"block {block} is seen before")
-        self.logger.debug(f"Received block={block}")
+        self.logger.debug("Received block=%s", block)
         # TODO: check the proposer signature before importing the block
         if self._process_received_block(block):
             self._broadcast_block(block, from_peer=peer)
@@ -354,9 +367,7 @@ class BCCReceiveServer(BaseReceiveServer):
             # skip the peer who send the attestations to us
             if from_peer is not None and peer == from_peer:
                 continue
-            self.logger.debug(
-                bold_red(f"send attestations to peer={peer}")
-            )
+            self.logger.debug(bold_red("Send attestations=%s to peer=%s"), attestations, peer)
             peer.sub_proto.send_attestation_records(attestations)
 
     def _process_received_block(self, block: BaseBeaconBlock) -> bool:
@@ -367,7 +378,7 @@ class BCCReceiveServer(BaseReceiveServer):
         # If the block is an orphan, put it directly to the pool and request for its parent.
         if not self._is_block_root_in_db(block.previous_block_root):
             if block not in self.orphan_block_pool:
-                self.logger.debug(f"found orphan block={block}")
+                self.logger.debug("Found orphan_block=%s", block)
                 self.orphan_block_pool.add(block)
                 self._request_block_from_peers(block_root=block.previous_block_root)
             return False
@@ -405,13 +416,15 @@ class BCCReceiveServer(BaseReceiveServer):
             children = self.orphan_block_pool.pop_children(current_parent_root)
             if len(children) > 0:
                 self.logger.debug(
-                    f"blocks {children} match their parent block, block.root={current_parent_root}"
+                    "Blocks=%s match their parent block, parent_root=%s",
+                    children,
+                    current_parent_root,
                 )
             for block in children:
-                self.logger.debug(f"try to import block={block}")
+                self.logger.debug("Try to import block=%s", block)
                 try:
                     self.chain.import_block(block)
-                    self.logger.debug(f"successfully imported block={block}")
+                    self.logger.debug("Successfully imported block=%s", block)
                     imported_roots.append(block.signing_root)
                 except ValidationError:
                     # TODO: Possibly drop all of its descendants in `self.orphan_block_pool`?
@@ -422,8 +435,12 @@ class BCCReceiveServer(BaseReceiveServer):
             peer = cast(BCCPeer, peer)
             request_id = gen_request_id()
             self.logger.debug(
-                bold_red(f"send block request to: request_id={request_id}, peer={peer}")
+                bold_red("Send block=%s request to request_id=%s peer=%s"),
+                encode_hex(block_root),
+                request_id,
+                peer,
             )
+
             self.map_request_id_block_root[request_id] = block_root
             peer.sub_proto.send_get_blocks(
                 block_root,
@@ -440,9 +457,7 @@ class BCCReceiveServer(BaseReceiveServer):
             # skip the peer who send the block to us
             if from_peer is not None and peer == from_peer:
                 continue
-            self.logger.debug(
-                bold_red(f"send block to peer={peer}")
-            )
+            self.logger.debug(bold_red("Send block=%s to peer=%s"), block, peer)
             peer.sub_proto.send_new_block(block=block)
 
     def _is_block_root_in_orphan_block_pool(self, block_root: Hash32) -> bool:


### PR DESCRIPTION
### What was wrong?

Debug messages for eth2 are messy somehow.

### How was it fixed?

- Proper case them
- For hashes: humanize_hash those in __str__ , encode_hex those in __repr__ and in logging.debug.
- Connect name and value with `=`, so it's visually consistent and easier to parse them later  
- Add __repr__ for Attestation, AttestationData, and Crosslink.

Should merge after #643

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://preview.redd.it/6938iqplcgz21.jpg?width=640&crop=smart&auto=webp&s=2d39147bfecd3713066742cbe874de9091418ca8)
