### PR TITLE
Rate limit the full sync import logs

### DIFF
--- a/tests/p2p/test_peer_collect_sub_proto_msgs.py
+++ b/tests/p2p/test_peer_collect_sub_proto_msgs.py
@@ -27,6 +27,7 @@ async def test_peer_subscriber_filters_messages(request, event_loop):
     assert collector not in peer._subscribers
 
     # yield to let remote and peer transmit.
+    await asyncio.sleep(0.01)
 
     all_messages = collector.get_messages()
     assert len(all_messages) == 4


### PR DESCRIPTION
### What was wrong?

Usually regular sync can just spam all the import block logs to `INFO`, because they're only coming once every 12s. But if you run regular sync from block 0, you get a screen full of block import logs relatively quickly.

### How was it fixed?

Added a token bucket to rate-limit the number of logs spit out to screen. If there's been a gap, show up to 5 in a row. Otherwise, only show one every 3s.

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://i.ytimg.com/vi/YsM1QwjpUpc/maxresdefault.jpg)
