### PR TITLE
Drop git dependency for pypi release

### DIFF
--- a/p2p/_utils.py
+++ b/p2p/_utils.py
@@ -117,5 +117,8 @@ def trim_middle(arbitrary_string: str, max_length: int) -> str:
         half_len, is_odd = divmod(max_length, 2)
         first_half = arbitrary_string[:half_len - 1]
         last_half_len = half_len - 2 + is_odd
-        last_half = arbitrary_string[last_half_len * -1:]
+        if last_half_len > 0:
+            last_half = arbitrary_string[last_half_len * -1:]
+        else:
+            last_half = ''
         return f"{first_half}✂✂✂{last_half}"

--- a/setup.py
+++ b/setup.py
@@ -96,7 +96,7 @@ deps = {
     'libp2p': [
         "base58>=1.0.3",
         # use the forked multiaddr temporarily until the fixing changes are released
-        "multiaddr @ git+https://git@github.com/mhchia/py-multiaddr@feature/add-unix-proto",
+        "multiaddr>=0.0.7,<0.1.0",
         "protobuf>=3.6.1",
         "pymultihash>=0.8.2",
     ],

--- a/tests/p2p/test_utils.py
+++ b/tests/p2p/test_utils.py
@@ -14,6 +14,7 @@ from p2p._utils import trim_middle
         ("notcut", 6, "notcut"),
         ("tobecut", 6, "to✂✂✂t"),
         ("tobecut", 5, "t✂✂✂t"),
+        ("0000", 3, "✂✂✂"),
         ("really long thing with a bunch of garbage", 20, "really lo✂✂✂ garbage"),
     )
 )


### PR DESCRIPTION
### What was wrong?

pypi (reasonably) would not allow deployment with an `@git` dependency in `libp2p`

### How was it fixed?

Switched back to the standard release (0.0.7 was released in May, and the `@git` dependency was added in March, so maybe the feature made it upstream?)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://i.pinimg.com/originals/96/83/46/96834680d03a1438d1ec8de3c65a2df9.jpg)
