### PR TITLE
Drop usage of connect_to_endpoints_nowait API

### DIFF
--- a/trinity/endpoint.py
+++ b/trinity/endpoint.py
@@ -32,8 +32,8 @@ class TrinityEventBusEndpoint(Endpoint):
             BroadcastConfig(filter_endpoint=MAIN_EVENTBUS_ENDPOINT)
         )
 
-    def connect_to_other_endpoints(self,
-                                   ev: AvailableEndpointsUpdated) -> None:
+    async def connect_to_other_endpoints(self,
+                                         ev: AvailableEndpointsUpdated) -> None:
 
         for connection_config in ev.available_endpoints:
             if connection_config.name == self.name:
@@ -46,13 +46,14 @@ class TrinityEventBusEndpoint(Endpoint):
                     self.name,
                     connection_config.name
                 )
-                self.connect_to_endpoints_nowait(connection_config)
+                await self.connect_to_endpoints(connection_config)
 
-    def auto_connect_new_announced_endpoints(self) -> None:
+    async def auto_connect_new_announced_endpoints(self) -> None:
         """
         Connect this endpoint to all new endpoints that are announced
         """
-        self.subscribe(AvailableEndpointsUpdated, self.connect_to_other_endpoints)
+        async for event in self.stream(AvailableEndpointsUpdated):
+            await self.connect_to_other_endpoints(event)
 
     async def announce_endpoint(self) -> None:
         """

--- a/trinity/extensibility/plugin.py
+++ b/trinity/extensibility/plugin.py
@@ -291,7 +291,7 @@ class BaseIsolatedPlugin(BasePlugin):
 
         # Whenever new EventBus Endpoints come up the `main` process broadcasts this event
         # and we connect to every Endpoint directly
-        self.event_bus.auto_connect_new_announced_endpoints()
+        asyncio.ensure_future(self.event_bus.auto_connect_new_announced_endpoints())
 
         self.do_start()
 

--- a/trinity/main.py
+++ b/trinity/main.py
@@ -156,7 +156,7 @@ async def launch_node_coro(args: Namespace, trinity_config: TrinityConfig) -> No
     )
 
     await endpoint.start_serving(networking_connection_config)
-    endpoint.auto_connect_new_announced_endpoints()
+    asyncio.ensure_future(endpoint.auto_connect_new_announced_endpoints())
     await endpoint.connect_to_endpoints(
         ConnectionConfig.from_name(MAIN_EVENTBUS_ENDPOINT, trinity_config.ipc_dir),
         # Plugins that run within the networking process broadcast and receive on the


### PR DESCRIPTION
### What was wrong?

Looks like we want to drop the `connect_to_endpoints_nowait` API soon so I removed the usage.

### How was it fixed?

Migrated to async API and used `asyncio.ensure_future`. Two alternatives that I considered:

- move the `asyncio.ensure_future`  into the `auto_connect_new_announced_endpoints` method
- keep using the `subscribe` API but with an `async` handler.

The latter isn't available yet but will be possible with a future lahja version. The former would mean to introduce yet another (maybe nested) function to feed into the `asyncio.ensure_future`.

In the end, I thought pushing the `asyncio.ensure_future` to the actual usage level is inline with the rest of the code and also more explicit. 

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] Clean up commit history

[//]: # (For important changes, please add a new entry to the running release notes PR)
[//]: # (You can find the current one using: https://github.com/ethereum/trinity/pulls?q=is%3Aopen+is%3Apr+label%3A%22Release+Notes%22 )
[//]: # (See: https://trinity-client.readthedocs.io/en/latest/contributing.html#pull-requests)
- [ ] Add entry to the [release notes PR](https://github.com/ethereum/trinity/pulls?q=is%3Aopen+is%3Apr+label%3A%22Release+Notes%22)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://i1.wp.com/www.healththoroughfare.com/wp-content/uploads/2017/09/Cute-Wombat-Playing-Unusual-Animal-Friendship-Wombat-Wombat-Video.jpg?fit=640%2C360&ssl=1)
