### PR TITLE
Change hexlified-bytes to raw-bytes

### DIFF
--- a/libp2p/p2pclient/datastructures.py
+++ b/libp2p/p2pclient/datastructures.py
@@ -1,4 +1,3 @@
-import binascii
 from typing import (
     Any,
     List,

--- a/libp2p/p2pclient/datastructures.py
+++ b/libp2p/p2pclient/datastructures.py
@@ -58,7 +58,7 @@ class StreamInfo:
     def to_pb(self) -> p2pd_pb2.StreamInfo:
         pb_msg = p2pd_pb2.StreamInfo(
             peer=self.peer_id.to_bytes(),
-            addr=binascii.unhexlify(self.addr.to_bytes()),
+            addr=self.addr.to_bytes(),
             proto=self.proto,
         )
         return pb_msg
@@ -67,7 +67,7 @@ class StreamInfo:
     def from_pb(cls, pb_msg: p2pd_pb2.StreamInfo) -> 'StreamInfo':
         stream_info = cls(
             peer_id=PeerID(pb_msg.peer),
-            addr=Multiaddr(binascii.hexlify(pb_msg.addr)),
+            addr=Multiaddr(pb_msg.addr),
             proto=pb_msg.proto,
         )
         return stream_info
@@ -87,5 +87,5 @@ class PeerInfo:
     @classmethod
     def from_pb(cls, peer_info_pb: p2pd_pb2.PeerInfo) -> 'PeerInfo':
         peer_id = PeerID(peer_info_pb.id)
-        addrs = [Multiaddr(binascii.hexlify(addr)) for addr in peer_info_pb.addrs]
+        addrs = [Multiaddr(addr) for addr in peer_info_pb.addrs]
         return cls(peer_id, addrs)

--- a/libp2p/p2pclient/p2pclient.py
+++ b/libp2p/p2pclient/p2pclient.py
@@ -1,5 +1,4 @@
 import asyncio
-import binascii
 import logging
 from typing import (
     AsyncGenerator,

--- a/libp2p/p2pclient/p2pclient.py
+++ b/libp2p/p2pclient/p2pclient.py
@@ -175,7 +175,7 @@ class ControlClient:
         maddrs_bytes = resp.identify.addrs
 
         maddrs = tuple(
-            Multiaddr(binascii.hexlify(maddr_bytes))
+            Multiaddr(maddr_bytes)
             for maddr_bytes in maddrs_bytes
         )
         peer_id = PeerID(peer_id_bytes)
@@ -185,7 +185,7 @@ class ControlClient:
     async def connect(self, peer_id: PeerID, maddrs: Iterable[Multiaddr]) -> None:
         reader, writer = await self.client.open_connection()
 
-        maddrs_bytes = [binascii.unhexlify(i.to_bytes()) for i in maddrs]
+        maddrs_bytes = [i.to_bytes() for i in maddrs]
         connect_req = p2pd_pb.ConnectRequest(
             peer=peer_id.to_bytes(),
             addrs=maddrs_bytes,
@@ -259,7 +259,7 @@ class ControlClient:
     async def stream_handler(self, proto: str, handler_cb: StreamHandler) -> None:
         reader, writer = await self.client.open_connection()
 
-        listen_path_maddr_bytes = binascii.unhexlify(self.listen_maddr.to_bytes())
+        listen_path_maddr_bytes = self.listen_maddr.to_bytes()
         stream_handler_req = p2pd_pb.StreamHandlerRequest(
             addr=listen_path_maddr_bytes,
             proto=[proto],

--- a/setup.py
+++ b/setup.py
@@ -95,7 +95,7 @@ deps = {
     ],
     'libp2p': [
         "base58>=1.0.3",
-        "multiaddr>=0.0.7,<0.1.0",
+        "multiaddr>=0.0.8,<0.1.0",
         "protobuf>=3.6.1",
         "pymultihash>=0.8.2",
     ],

--- a/setup.py
+++ b/setup.py
@@ -95,7 +95,6 @@ deps = {
     ],
     'libp2p': [
         "base58>=1.0.3",
-        # use the forked multiaddr temporarily until the fixing changes are released
         "multiaddr>=0.0.7,<0.1.0",
         "protobuf>=3.6.1",
         "pymultihash>=0.8.2",

--- a/tests/libp2p/p2pclient/test_datastructures.py
+++ b/tests/libp2p/p2pclient/test_datastructures.py
@@ -1,5 +1,3 @@
-import binascii
-
 import pytest
 
 from multiaddr import (

--- a/tests/libp2p/p2pclient/test_datastructures.py
+++ b/tests/libp2p/p2pclient/test_datastructures.py
@@ -60,7 +60,7 @@ def test_stream_info(peer_id, maddr):
     # test case: `StreamInfo.to_pb`
     pb_si = si.to_pb()
     assert pb_si.peer == peer_id.to_bytes()
-    assert pb_si.addr == binascii.unhexlify(maddr.to_bytes())
+    assert pb_si.addr == maddr.to_bytes()
     assert pb_si.proto == si.proto
     # test case: `StreamInfo.from_pb`
     si_1 = StreamInfo.from_pb(pb_si)
@@ -77,7 +77,7 @@ def test_peer_info(peer_id, maddr):
     # test case: `PeerInfo.from_pb`
     pi_pb = p2pd_pb.PeerInfo(
         id=peer_id.to_bytes(),
-        addrs=[binascii.unhexlify(maddr.to_bytes())],
+        addrs=[maddr.to_bytes()],
     )
     pi_1 = PeerInfo.from_pb(pi_pb)
     assert pi.peer_id == pi_1.peer_id


### PR DESCRIPTION
### What was wrong?
A breaking change in `multiaddr==0.0.5` from https://github.com/multiformats/py-multiaddr/pull/37.


### How was it fixed?
Remove `binascii.hexlify` and `binascii.unhexlify`.

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://images-cdn.9gag.com/photo/an9yLoz_460swp.webp)
