### PR TITLE
Reactivate error scan test with increased sensitivity

### DIFF
--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -13,7 +13,11 @@ async def scan_for_errors(async_iterable):
     uncaught exception.
     """
 
-    error_trigger = ("exception was never retrieved", "Traceback (most recent call last)")
+    error_trigger = (
+        "exception was never retrieved",
+        "Task was destroyed but it is pending",
+        "Traceback (most recent call last)",
+    )
 
     lines_since_error = 0
     async for line in async_iterable:

--- a/tests/integration/test_trinity_cli.py
+++ b/tests/integration/test_trinity_cli.py
@@ -190,7 +190,7 @@ async def test_logger(async_process_runner, command, expected_to_contain_log):
 @pytest.mark.asyncio
 # Once we get Trinity to shutdown cleanly, we should remove the xfail so that the test ensures
 # ongoing clean exits.
-@pytest.mark.skip(reason="Needs to be made more sensitive to be less flaky")
+@pytest.mark.xfail
 async def test_shutdown(command, async_process_runner):
 
     async def run_then_shutdown_and_yield_output():


### PR DESCRIPTION
### What was wrong?

Yesterday, I rage removed the test that scans the Trinity shutdown for errors with the promise to re-activate it today.

A quick recap about this test, why it became flaky and why that is a good thing: The test runs trinity, shuts it down and scans the log for errors. In an ideal world, this test would guarantee that we never let changes in that cause Trinity to log some errors on shutdown.

In our world however, we **do have errors** on shutdown and so the test is marked `xFail` because this ensures that if we got to a point where we **don't see errors** on shutdown, we can just remove the `xFail` and have then successfully moved into our idealistic world of milk and honey. Credits to @pipermerriam who came up with that idea!

Now why did the test become more flaky? Guess what: There's milk and honey just in reach of us! With the recent Lahja updated (and realistically a bunch of other improvements that have happened) we are seeing more and more test runs without any errors being reported. That's exactly what we want but it does mean that if there's a 50 % chance that Trinity will just shutdown cleanly, we have a 50 % chance of this test failing.

### How was it fixed?

I've increased the sensitivity of this test so that it also counts `Task was destroyed but it is pending` as errors. I've ran the test several times and this does seem to catch more  errors and hence make the test less flaky. 

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] Clean up commit history

[//]: # (For important changes, please add a new entry to the running release notes PR)
[//]: # (You can find the current one using: https://github.com/ethereum/trinity/pulls?q=is%3Aopen+is%3Apr+label%3A%22Release+Notes%22 )
[//]: # (See: https://trinity-client.readthedocs.io/en/latest/contributing.html#pull-requests)
- [ ] Add entry to the [release notes PR](https://github.com/ethereum/trinity/pulls?q=is%3Aopen+is%3Apr+label%3A%22Release+Notes%22)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](http://en.bcdn.biz/Images/2016/5/6/a8b88aa3-2cd0-4af3-bca6-20893189f5f4.jpg)
