### PR TITLE
Reduce some duration of sleep(n) in tests

### DIFF
--- a/tests/core/p2p-proto/test_server.py
+++ b/tests/core/p2p-proto/test_server.py
@@ -182,7 +182,7 @@ async def test_peer_pool_answers_connect_commands(event_loop, event_bus, server)
             TO_NETWORKING_BROADCAST_CONFIG
         )
 
-        await asyncio.sleep(0.5)
+        await asyncio.sleep(0.1)
 
         assert len(server.peer_pool.connected_nodes) == 1
 

--- a/tests/p2p/test_service.py
+++ b/tests/p2p/test_service.py
@@ -55,7 +55,7 @@ async def test_cancel_exits_async_generator():
 
     async def async_iterator():
         yield 1
-        await asyncio.sleep(0.5)
+        await asyncio.sleep(0.05)
         assert False, "iterator should have been cancelled by now"
 
     try:


### PR DESCRIPTION
### What was wrong?

Timeout of `0.5` in tests is often more than what is actually needed.

### How was it fixed?

Reduced to `0.1`.

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://i.pinimg.com/originals/e1/74/79/e17479b261980d8cdf5b49bef14f84c2.jpg)
