### PR TITLE
Clarify log level usage

### DIFF
--- a/docs/api/api.cli.rst
+++ b/docs/api/api.cli.rst
@@ -1,5 +1,5 @@
 Command Line Interface (CLI)
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+============================
 
 .. code-block:: shell
 
@@ -43,3 +43,61 @@ Command Line Interface (CLI)
     --nodekey-path NODEKEY_PATH
                             The filesystem path to the file which contains the
                             nodekey
+
+
+
+Per-module logging
+~~~~~~~~~~~~~~~~~~
+
+Trinity provides rich logging output that can be of tremendous help during debugging. By default,
+Trinity prints only logs of level ``INFO`` or higher to ``stderr`` and only logs of level ``DEBUG``
+or higher to the log file.
+
+This can be adjusted to other log level such as ``ERROR`` or ``DEBUG2`` and independently for both
+the ``stderr`` and the file log.
+
+Starting Trinity with ``trinity --log-level DEBUG2`` (shorthand: ``trinity -l DEBUG2``) yields the
+absolute maximum of available logging output. However, running Trinity with maximum logging output
+might be too overwhelming when we are only interested in logging output for a specific
+module (e.g. ``p2p.discovery``).
+
+Fortunately, Trinity allows us to configure logging on a per-module basis by using the
+``--log-level`` flag in combination with specific modules and log levels such as in:
+``trinity --log-level DEBUG2 --log-level p2p.discovery=ERROR``.
+
+The following table shows various combinations of how to use logging in Trinity effectively.
+
+
++---------------------------------------------------------------------+--------------------------------+------------------------------+
+| Command                                                             | Stderr log [1]_                | File log [1]_                |
++=====================================================================+================================+==============================+
+| ``trinity``                                                         | ``INFO`` [2]_                  | ``DEBUG`` [2]_               |
++---------------------------------------------------------------------+--------------------------------+------------------------------+
+| ``trinity --stderr-log-level ERROR``                                | ``ERROR``                      | ``DEBUG``                    |
++---------------------------------------------------------------------+--------------------------------+------------------------------+
+| ``trinity --file-log-level INFO``                                   | ``INFO``                       | ``INFO``                     |
++---------------------------------------------------------------------+--------------------------------+------------------------------+
+| | ``trinity --file-log-level ERROR``                                | ``ERROR``                      | ``ERROR``                    |
+| | ``--stderr-log-level ERROR``                                      |                                |                              |
++---------------------------------------------------------------------+--------------------------------+------------------------------+
+| ``trinity --log-level ERROR`` (``trinity -l ERROR``) [3]_           | ``ERROR``                      | ``ERROR``                    |
++---------------------------------------------------------------------+--------------------------------+------------------------------+
+| ``trinity --l DEBUG2 -l 'p2p.discovery=ERROR'`` [4]_                | | ``DEBUG2`` but **only**      | | ``DEBUG2`` but **only**    |
+|                                                                     | | ``ERROR`` for                | | ``ERROR`` for              |
+|                                                                     | | ``p2p.discovery``            | | ``p2p.discovery``          |
++---------------------------------------------------------------------+--------------------------------+------------------------------+
+| ``trinity --l ERROR -l 'p2p.discovery=DEBUG2'`` [4]_                | | ``ERROR`` but **also**       | ``ERROR`` [5]_               |
+|                                                                     | | ``DEBUG2`` for               |                              |
+|                                                                     | | ``p2p.discovery``            |                              |
++---------------------------------------------------------------------+--------------------------------+------------------------------+
+
+.. [1] A stated level e.g. ``DEBUG2`` **always means** that log level **or higher** (e.g. ``INFO``)
+
+.. [2] ``INFO`` is the default log level for the ``stderr`` log, ``DEBUG`` the default log level for the file log.
+
+.. [3] Equivalent to the previous line
+
+.. [4] For per-module configuration, the equal sign (``=``) needs to be used.
+
+.. [5] **Increasing** the per-module log level above the general ``--file-log-level`` is not yet supported
+       (See `issue 689 <https://github.com/ethereum/trinity/issues/689>`_ )


### PR DESCRIPTION
### What was wrong?

Log level usage isn't explained anywhere.

### How was it fixed?

Tada!

![image](https://user-images.githubusercontent.com/521109/59021639-78609b80-884c-11e9-9af2-0649b3fcb5e6.png)

Notice that the 5th footnote is missing on the screenshot but it is actually there (not enough space) :)

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] Clean up commit history

[//]: # (For important changes, please add a new entry to the running release notes PR)
[//]: # (You can find the current one using: https://github.com/ethereum/trinity/pulls?q=is%3Aopen+is%3Apr+label%3A%22Release+Notes%22 )
[//]: # (See: https://trinity-client.readthedocs.io/en/latest/contributing.html#pull-requests)
- [ ] Add entry to the [release notes PR](https://github.com/ethereum/trinity/pulls?q=is%3Aopen+is%3Apr+label%3A%22Release+Notes%22)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](http://www.thatcutesite.com/uploads/2010/04/birds_in_hand.jpg)
