### PR TITLE
Pin `py-ecc==1.6.0`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -88,7 +88,7 @@ deps = {
         "eth-typing>=2.1.0,<3.0.0",
         "eth-utils>=1.3.0b0,<2.0.0",
         "lru-dict>=1.1.6",
-        "py-ecc>=1.6.0,<2.0.0",
+        "py-ecc==1.6.0",
         "rlp>=1.1.0,<2.0.0",
         PYEVM_DEPENDENCY,
         "ssz==0.1.0a8",


### PR DESCRIPTION
### What was wrong?

Add a protection from the https://github.com/ethereum/py_ecc/pull/70 breaking changes. Currently, Trinity's `hash_eth2` function is still Keccak256 for testing with spec-v0.5.1 Yaml tests.

### How was it fixed?
Pin `py-ecc==1.6.0`. We will modify it to `py-ecc>=1.7.0,<2.0.0` in the PR of `eth2._utils.hash.hash_eth2` updates in the `v06` branch.


#### Cute Animal Picture

🐴