### PR TITLE
Free the fork choice

### DIFF
--- a/eth2/beacon/chains/base.py
+++ b/eth2/beacon/chains/base.py
@@ -396,7 +396,10 @@ class BeaconChain(BaseBeaconChain):
             parent_block,
             FromBlockParams(),
         )
-        state, imported_block = self.get_state_machine(base_block_for_import).import_block(block)
+
+        state_machine = self.get_state_machine(base_block_for_import)
+
+        state, imported_block = state_machine.import_block(block)
 
         # Validate the imported block.
         if perform_validation:
@@ -405,10 +408,17 @@ class BeaconChain(BaseBeaconChain):
         # TODO: Now it just persists all state. Should design how to clean up the old state.
         self.chaindb.persist_state(state)
 
+        self.chaindb.persist_block_without_scoring(imported_block, imported_block.__class__)
+
+        fork_choice_scoring = state_machine.fork_choice_scoring
+        score = fork_choice_scoring(imported_block)
+
+        self.chaindb.set_score(imported_block, score)
+
         (
             new_canonical_blocks,
             old_canonical_blocks,
-        ) = self.chaindb.persist_block(imported_block, imported_block.__class__)
+        ) = self.chaindb.update_canonical_head_if_needed(imported_block, imported_block.__class__)
 
         self.logger.debug(
             'IMPORTED_BLOCK: slot %s | signed root %s',

--- a/eth2/beacon/chains/base.py
+++ b/eth2/beacon/chains/base.py
@@ -410,7 +410,7 @@ class BeaconChain(BaseBeaconChain):
 
         self.chaindb.persist_block_without_scoring(imported_block, imported_block.__class__)
 
-        fork_choice_scoring = state_machine.fork_choice_scoring
+        fork_choice_scoring = state_machine.get_fork_choice_scoring()
         score = fork_choice_scoring(imported_block)
 
         self.chaindb.set_score(imported_block, score)

--- a/eth2/beacon/db/chain.py
+++ b/eth2/beacon/db/chain.py
@@ -434,7 +434,7 @@ class BeaconChainDB(BaseBeaconChainDB):
             return self._persist_block_chain(db, blocks, block_class)
 
     @staticmethod
-    def _set_block_scores_to_db(
+    def _set_block_score_to_db(
             db: BaseDB,
             block: BaseBeaconBlock
     ) -> int:
@@ -486,7 +486,7 @@ class BeaconChainDB(BaseBeaconChainDB):
             ssz.encode(curr_block_head),
         )
         cls._add_block_root_to_slot_lookup(db, curr_block_head)
-        cls._set_block_scores_to_db(db, curr_block_head)
+        cls._set_block_score_to_db(db, curr_block_head)
         cls._add_attestations_root_to_block_lookup(db, curr_block_head)
 
         orig_blocks_seq = concat([(first_block,), blocks_iterator])
@@ -507,7 +507,7 @@ class BeaconChainDB(BaseBeaconChainDB):
                 ssz.encode(curr_block_head),
             )
             cls._add_block_root_to_slot_lookup(db, curr_block_head)
-            score = cls._set_block_scores_to_db(db, curr_block_head)
+            score = cls._set_block_score_to_db(db, curr_block_head)
             cls._add_attestations_root_to_block_lookup(db, curr_block_head)
 
         if no_canonical_head:

--- a/eth2/beacon/db/chain.py
+++ b/eth2/beacon/db/chain.py
@@ -39,6 +39,9 @@ from eth.exceptions import (
 from eth.validation import (
     validate_word,
 )
+from eth2.beacon.fork_choice import (
+    ForkChoiceScoring,
+)
 from eth2.beacon.helpers import (
     slot_to_epoch,
 )
@@ -59,6 +62,7 @@ from eth2.beacon.db.exceptions import (
     AttestationRootNotFound,
     FinalizedHeadNotFound,
     JustifiedHeadNotFound,
+    MissingForkChoiceScorings,
 )
 from eth2.beacon.db.schema import SchemaV1
 
@@ -88,7 +92,8 @@ class BaseBeaconChainDB(ABC):
     def persist_block(
             self,
             block: BaseBeaconBlock,
-            block_class: Type[BaseBeaconBlock]
+            block_class: Type[BaseBeaconBlock],
+            fork_choice_scoring: ForkChoiceScoring,
     ) -> Tuple[Tuple[BaseBeaconBlock, ...], Tuple[BaseBeaconBlock, ...]]:
         pass
 
@@ -145,7 +150,8 @@ class BaseBeaconChainDB(ABC):
     def persist_block_chain(
             self,
             blocks: Iterable[BaseBeaconBlock],
-            block_class: Type[BaseBeaconBlock]
+            block_class: Type[BaseBeaconBlock],
+            fork_choice_scoring: Iterable[ForkChoiceScoring],
     ) -> Tuple[Tuple[BaseBeaconBlock, ...], Tuple[BaseBeaconBlock, ...]]:
         pass
 
@@ -213,7 +219,8 @@ class BeaconChainDB(BaseBeaconChainDB):
     def persist_block(
             self,
             block: BaseBeaconBlock,
-            block_class: Type[BaseBeaconBlock]
+            block_class: Type[BaseBeaconBlock],
+            fork_choice_scoring: ForkChoiceScoring,
     ) -> Tuple[Tuple[BaseBeaconBlock, ...], Tuple[BaseBeaconBlock, ...]]:
         """
         Persist the given block.
@@ -222,20 +229,23 @@ class BeaconChainDB(BaseBeaconChainDB):
             if block.is_genesis:
                 self._handle_exceptional_justification_and_finality(db, block)
 
-            return self._persist_block(db, block, block_class)
+            return self._persist_block(db, block, block_class, fork_choice_scoring)
 
     @classmethod
     def _persist_block(
             cls,
             db: 'BaseDB',
             block: BaseBeaconBlock,
-            block_class: Type[BaseBeaconBlock]
+            block_class: Type[BaseBeaconBlock],
+            fork_choice_scoring: ForkChoiceScoring,
     ) -> Tuple[Tuple[BaseBeaconBlock, ...], Tuple[BaseBeaconBlock, ...]]:
         block_chain = (block, )
+        scorings = (fork_choice_scoring, )
         new_canonical_blocks, old_canonical_blocks = cls._persist_block_chain(
             db,
             block_chain,
             block_class,
+            scorings,
         )
 
         return new_canonical_blocks, old_canonical_blocks
@@ -428,23 +438,22 @@ class BeaconChainDB(BaseBeaconChainDB):
     def persist_block_chain(
             self,
             blocks: Iterable[BaseBeaconBlock],
-            block_class: Type[BaseBeaconBlock]
+            block_class: Type[BaseBeaconBlock],
+            fork_choice_scorings: Iterable[ForkChoiceScoring],
     ) -> Tuple[Tuple[BaseBeaconBlock, ...], Tuple[BaseBeaconBlock, ...]]:
         """
         Return two iterable of blocks, the first containing the new canonical blocks,
         the second containing the old canonical headers
         """
         with self.db.atomic_batch() as db:
-            return self._persist_block_chain(db, blocks, block_class)
+            return self._persist_block_chain(db, blocks, block_class, fork_choice_scorings)
 
     @staticmethod
     def _set_block_score_to_db(
             db: BaseDB,
-            block: BaseBeaconBlock
+            block: BaseBeaconBlock,
+            score: int,
     ) -> int:
-        # TODO: It's a stub before we implement fork choice rule
-        score = block.slot
-
         db.set(
             SchemaV1.make_block_root_to_score_lookup_key(block.signing_root),
             ssz.encode(score, sedes=ssz.sedes.uint64),
@@ -462,12 +471,15 @@ class BeaconChainDB(BaseBeaconChainDB):
             cls,
             db: BaseDB,
             blocks: Iterable[BaseBeaconBlock],
-            block_class: Type[BaseBeaconBlock]
+            block_class: Type[BaseBeaconBlock],
+            fork_choice_scorings: Iterable[ForkChoiceScoring],
     ) -> Tuple[Tuple[BaseBeaconBlock, ...], Tuple[BaseBeaconBlock, ...]]:
         blocks_iterator = iter(blocks)
+        scorings_iterator = iter(fork_choice_scorings)
 
         try:
             first_block = first(blocks_iterator)
+            first_scoring = first(scorings_iterator)
         except StopIteration:
             return tuple(), tuple()
 
@@ -488,7 +500,7 @@ class BeaconChainDB(BaseBeaconChainDB):
                 )
             )
 
-        score = first_block.slot
+        score = first_scoring(first_block)
 
         curr_block_head = first_block
         db.set(
@@ -496,7 +508,7 @@ class BeaconChainDB(BaseBeaconChainDB):
             ssz.encode(curr_block_head),
         )
         cls._add_block_root_to_slot_lookup(db, curr_block_head)
-        cls._set_block_score_to_db(db, curr_block_head)
+        cls._set_block_score_to_db(db, curr_block_head, score)
         cls._add_attestations_root_to_block_lookup(db, curr_block_head)
 
         orig_blocks_seq = concat([(first_block,), blocks_iterator])
@@ -517,8 +529,16 @@ class BeaconChainDB(BaseBeaconChainDB):
                 ssz.encode(curr_block_head),
             )
             cls._add_block_root_to_slot_lookup(db, curr_block_head)
-            score = cls._set_block_score_to_db(db, curr_block_head)
             cls._add_attestations_root_to_block_lookup(db, curr_block_head)
+
+            # NOTE: len(scorings_iterator) should equal len(blocks_iterator)
+            try:
+                next_scoring = next(scorings_iterator)
+            except StopIteration:
+                raise MissingForkChoiceScorings
+
+            score = next_scoring(curr_block_head)
+            cls._set_block_score_to_db(db, curr_block_head, score)
 
         if no_canonical_head:
             return cls._set_as_canonical_chain_head(db, curr_block_head.signing_root, block_class)

--- a/eth2/beacon/db/chain.py
+++ b/eth2/beacon/db/chain.py
@@ -93,6 +93,14 @@ class BaseBeaconChainDB(ABC):
         pass
 
     @abstractmethod
+    def persist_block_without_scoring(
+            self,
+            block: BaseBeaconBlock,
+            block_class: Type[BaseBeaconBlock]
+    ) -> None:
+        pass
+
+    @abstractmethod
     def get_canonical_block_root(self, slot: int) -> Hash32:
         pass
 
@@ -147,6 +155,18 @@ class BaseBeaconChainDB(ABC):
             blocks: Iterable[BaseBeaconBlock],
             block_class: Type[BaseBeaconBlock]
     ) -> Tuple[Tuple[BaseBeaconBlock, ...], Tuple[BaseBeaconBlock, ...]]:
+        pass
+
+    @abstractmethod
+    def update_canonical_head_if_needed(
+            self,
+            block: BaseBeaconBlock,
+            block_class: Type[BaseBeaconBlock]
+    )-> Tuple[Tuple[BaseBeaconBlock, ...], Tuple[BaseBeaconBlock, ...]]:
+        pass
+
+    @abstractmethod
+    def set_score(self, block: BaseBeaconBlock, score: int)-> None:
         pass
 
     #
@@ -235,6 +255,34 @@ class BeaconChainDB(BaseBeaconChainDB):
         )
 
         return new_canonical_blocks, old_canonical_blocks
+
+    def persist_block_without_scoring(
+            self,
+            block: BaseBeaconBlock,
+            block_class: Type[BaseBeaconBlock]
+    ) -> None:
+        """
+        Persist the given block. Does not score the block or try to run the fork choice.
+        """
+        with self.db.atomic_batch() as db:
+            if block.is_genesis:
+                self._handle_exceptional_justification_and_finality(db, block)
+
+            self._persist_block_without_scoring(db, block, block_class)
+
+    @classmethod
+    def _persist_block_without_scoring(
+            cls,
+            db: 'BaseDB',
+            block: BaseBeaconBlock,
+            block_class: Type[BaseBeaconBlock]
+    ) -> None:
+        block_chain = (block, )
+        cls._persist_block_chain_without_scoring(
+            db,
+            block_chain,
+            block_class,
+        )
 
     #
     #
@@ -447,6 +495,12 @@ class BeaconChainDB(BaseBeaconChainDB):
         )
         return score
 
+    def set_score(self, block: BaseBeaconBlock, score: int) -> None:
+        self.db.set(
+            SchemaV1.make_block_root_to_score_lookup_key(block.signing_root),
+            ssz.encode(score, sedes=ssz.sedes.uint64),
+        )
+
     @classmethod
     def _persist_block_chain(
             cls,
@@ -596,6 +650,55 @@ class BeaconChainDB(BaseBeaconChainDB):
             else:
                 block = cls._get_block_by_root(db, block.previous_block_root, block_class)
 
+    @classmethod
+    def _persist_block_chain_without_scoring(
+            cls,
+            db: BaseDB,
+            blocks: Iterable[BaseBeaconBlock],
+            block_class: Type[BaseBeaconBlock]
+    ) -> None:
+        blocks_iterator = iter(blocks)
+
+        try:
+            first_block = first(blocks_iterator)
+        except StopIteration:
+            return
+
+        is_genesis = first_block.is_genesis
+        if not is_genesis and not cls._block_exists(db, first_block.previous_block_root):
+            raise ParentNotFound(
+                "Cannot persist block ({}) with unknown parent ({})".format(
+                    encode_hex(first_block.signing_root),
+                    encode_hex(first_block.previous_block_root),
+                )
+            )
+
+        curr_block_head = first_block
+        db.set(
+            curr_block_head.signing_root,
+            ssz.encode(curr_block_head),
+        )
+        cls._add_block_root_to_slot_lookup(db, curr_block_head)
+
+        orig_blocks_seq = concat([(first_block,), blocks_iterator])
+
+        for parent, child in sliding_window(2, orig_blocks_seq):
+            if parent.signing_root != child.previous_block_root:
+                raise ValidationError(
+                    "Non-contiguous chain. Expected {} to have {} as parent but was {}".format(
+                        encode_hex(child.signing_root),
+                        encode_hex(parent.signing_root),
+                        encode_hex(child.previous_block_root),
+                    )
+                )
+
+            curr_block_head = child
+            db.set(
+                curr_block_head.signing_root,
+                ssz.encode(curr_block_head),
+            )
+            cls._add_block_root_to_slot_lookup(db, curr_block_head)
+
     @staticmethod
     def _add_block_slot_to_root_lookup(db: BaseDB, block: BaseBeaconBlock) -> None:
         """
@@ -623,6 +726,24 @@ class BeaconChainDB(BaseBeaconChainDB):
             block_root_to_slot_key,
             ssz.encode(block.slot, sedes=ssz.sedes.uint64),
         )
+
+    def update_canonical_head_if_needed(
+        self,
+        block: BaseBeaconBlock,
+        block_class: Type[BaseBeaconBlock]
+    ) -> Tuple[Tuple[BaseBeaconBlock, ...], Tuple[BaseBeaconBlock, ...]]:
+        try:
+            previous_canonical_head = self.get_canonical_head(block_class).signing_root
+            head_score = self.get_score(previous_canonical_head)
+        except CanonicalHeadNotFound:
+            return self._set_as_canonical_chain_head(self.db, block.signing_root, block_class)
+
+        score = self.get_score(block.signing_root)
+
+        if score > head_score:
+            return self._set_as_canonical_chain_head(self.db, block.signing_root, block_class)
+        else:
+            return tuple(), tuple()
 
     #
     # Beacon State API

--- a/eth2/beacon/db/exceptions.py
+++ b/eth2/beacon/db/exceptions.py
@@ -24,3 +24,11 @@ class AttestationRootNotFound(BeaconDBException):
     Exception raised if no attestation root is set in this database.
     """
     pass
+
+
+class MissingForkChoiceScorings(BeaconDBException):
+    """
+    Exception raised if a client tries to score a block without providing
+    the ability to generate a score via a ``scoring``.
+    """
+    pass

--- a/eth2/beacon/fork_choice/__init__.py
+++ b/eth2/beacon/fork_choice/__init__.py
@@ -1,0 +1,17 @@
+"""
+A blockchain has a way to pick a canonical chain from the block tree called a fork choice.
+A fork choice works by using a scoring rule to attach a scalar quantity to a particular block
+given our local view of the network.
+
+The fork choice provides a "canonical" path through the block tree by recursively selecting the
+highest scoring child of a given block until we terminate at the tip of the chain.
+
+This module provides a variety of fork choice rules. Clients can introduce new rules here to
+experiment with alternative fork choice methods.
+"""
+
+from .higher_slot import (  # noqa: F401
+    higher_slot_scoring,
+)
+
+from .fork_choice_scoring import ForkChoiceScoring  # noqa: F401

--- a/eth2/beacon/fork_choice/fork_choice_scoring.py
+++ b/eth2/beacon/fork_choice/fork_choice_scoring.py
@@ -1,0 +1,5 @@
+from typing import Callable
+
+from eth2.beacon.types.blocks import BaseBeaconBlock
+
+ForkChoiceScoring = Callable[[BaseBeaconBlock], int]

--- a/eth2/beacon/fork_choice/higher_slot.py
+++ b/eth2/beacon/fork_choice/higher_slot.py
@@ -1,0 +1,8 @@
+from eth2.beacon.types.blocks import BaseBeaconBlock
+
+
+def higher_slot_scoring(block: BaseBeaconBlock) -> int:
+    """
+    A ``block`` with a higher slot has a higher score.
+    """
+    return block.slot

--- a/eth2/beacon/state_machines/base.py
+++ b/eth2/beacon/state_machines/base.py
@@ -15,6 +15,7 @@ from eth2.configs import (  # noqa: F401
     Eth2Config,
 )
 from eth2.beacon.db.chain import BaseBeaconChainDB
+from eth2.beacon.fork_choice import ForkChoiceScoring
 from eth2.beacon.types.blocks import BaseBeaconBlock
 from eth2.beacon.types.states import BeaconState
 from eth2.beacon.typing import (
@@ -37,6 +38,7 @@ class BaseBeaconStateMachine(Configurable, ABC):
     block_class = None  # type: Type[BaseBeaconBlock]
     state_class = None  # type: Type[BeaconState]
     state_transition_class = None  # type: Type[BaseStateTransition]
+    fork_choice_scoring = None  # type: ForkChoiceScoring
 
     @abstractmethod
     def __init__(self,
@@ -63,6 +65,11 @@ class BaseBeaconStateMachine(Configurable, ABC):
     @property
     @abstractmethod
     def state_transition(self) -> BaseStateTransition:
+        pass
+
+    @property
+    @abstractmethod
+    def fork_choice_scoring(self) -> ForkChoiceScoring:
         pass
 
     #
@@ -137,6 +144,10 @@ class BeaconStateMachine(BaseBeaconStateMachine):
     @property
     def state_transition(self) -> BaseStateTransition:
         return self.get_state_transiton_class()(self.config)
+
+    @property
+    def fork_choice_scoring(self) -> ForkChoiceScoring:
+        return self.fork_choice_scoring
 
     #
     # Import block API

--- a/eth2/beacon/state_machines/base.py
+++ b/eth2/beacon/state_machines/base.py
@@ -38,7 +38,6 @@ class BaseBeaconStateMachine(Configurable, ABC):
     block_class = None  # type: Type[BaseBeaconBlock]
     state_class = None  # type: Type[BeaconState]
     state_transition_class = None  # type: Type[BaseStateTransition]
-    fork_choice_scoring = None  # type: ForkChoiceScoring
 
     @abstractmethod
     def __init__(self,
@@ -67,9 +66,8 @@ class BaseBeaconStateMachine(Configurable, ABC):
     def state_transition(self) -> BaseStateTransition:
         pass
 
-    @property
     @abstractmethod
-    def fork_choice_scoring(self) -> ForkChoiceScoring:
+    def get_fork_choice_scoring(self) -> ForkChoiceScoring:
         pass
 
     #
@@ -144,10 +142,6 @@ class BeaconStateMachine(BaseBeaconStateMachine):
     @property
     def state_transition(self) -> BaseStateTransition:
         return self.get_state_transiton_class()(self.config)
-
-    @property
-    def fork_choice_scoring(self) -> ForkChoiceScoring:
-        return self.fork_choice_scoring
 
     #
     # Import block API

--- a/eth2/beacon/state_machines/forks/serenity/__init__.py
+++ b/eth2/beacon/state_machines/forks/serenity/__init__.py
@@ -22,12 +22,12 @@ from .state_transitions import SerenityStateTransition
 class SerenityStateMachine(BeaconStateMachine):
     # fork name
     fork = 'serenity'  # type: str
+    config = SERENITY_CONFIG
 
     # classes
     block_class = SerenityBeaconBlock  # type: Type[BaseBeaconBlock]
     state_class = SerenityBeaconState  # type: Type[BeaconState]
     state_transition_class = SerenityStateTransition  # type: Type[BaseStateTransition]
-    config = SERENITY_CONFIG
 
     # methods
     @staticmethod

--- a/eth2/beacon/state_machines/forks/serenity/__init__.py
+++ b/eth2/beacon/state_machines/forks/serenity/__init__.py
@@ -1,6 +1,9 @@
 from typing import Type  # noqa: F401
 
-from eth2.beacon.fork_choice import higher_slot_scoring
+from eth2.beacon.fork_choice import (
+    ForkChoiceScoring,
+    higher_slot_scoring,
+)
 from eth2.beacon.typing import (
     FromBlockParams,
 )
@@ -29,10 +32,12 @@ class SerenityStateMachine(BeaconStateMachine):
     block_class = SerenityBeaconBlock  # type: Type[BaseBeaconBlock]
     state_class = SerenityBeaconState  # type: Type[BeaconState]
     state_transition_class = SerenityStateTransition  # type: Type[BaseStateTransition]
-    fork_choice_scoring = staticmethod(higher_slot_scoring)
 
     # methods
     @staticmethod
     def create_block_from_parent(parent_block: BaseBeaconBlock,
                                  block_params: FromBlockParams) -> BaseBeaconBlock:
         return create_serenity_block_from_parent(parent_block, block_params)
+
+    def get_fork_choice_scoring(self) -> ForkChoiceScoring:
+        return higher_slot_scoring

--- a/eth2/beacon/state_machines/forks/serenity/__init__.py
+++ b/eth2/beacon/state_machines/forks/serenity/__init__.py
@@ -1,5 +1,6 @@
 from typing import Type  # noqa: F401
 
+from eth2.beacon.fork_choice import higher_slot_scoring
 from eth2.beacon.typing import (
     FromBlockParams,
 )
@@ -28,6 +29,7 @@ class SerenityStateMachine(BeaconStateMachine):
     block_class = SerenityBeaconBlock  # type: Type[BaseBeaconBlock]
     state_class = SerenityBeaconState  # type: Type[BeaconState]
     state_transition_class = SerenityStateTransition  # type: Type[BaseStateTransition]
+    fork_choice_scoring = higher_slot_scoring
 
     # methods
     @staticmethod

--- a/eth2/beacon/state_machines/forks/serenity/__init__.py
+++ b/eth2/beacon/state_machines/forks/serenity/__init__.py
@@ -29,7 +29,7 @@ class SerenityStateMachine(BeaconStateMachine):
     block_class = SerenityBeaconBlock  # type: Type[BaseBeaconBlock]
     state_class = SerenityBeaconState  # type: Type[BeaconState]
     state_transition_class = SerenityStateTransition  # type: Type[BaseStateTransition]
-    fork_choice_scoring = higher_slot_scoring
+    fork_choice_scoring = staticmethod(higher_slot_scoring)
 
     # methods
     @staticmethod

--- a/eth2/beacon/state_machines/forks/xiao_long_bao/__init__.py
+++ b/eth2/beacon/state_machines/forks/xiao_long_bao/__init__.py
@@ -26,12 +26,12 @@ from .configs import (
 class XiaoLongBaoStateMachine(BeaconStateMachine):
     # fork name
     fork = 'xiao_long_bao'
+    config = XIAO_LONG_BAO_CONFIG
 
     # classes
     block_class = SerenityBeaconBlock
     state_class = SerenityBeaconState
     state_transition_class = SerenityStateTransition
-    config = XIAO_LONG_BAO_CONFIG
 
     # methods
     @staticmethod

--- a/eth2/beacon/state_machines/forks/xiao_long_bao/__init__.py
+++ b/eth2/beacon/state_machines/forks/xiao_long_bao/__init__.py
@@ -33,7 +33,7 @@ class XiaoLongBaoStateMachine(BeaconStateMachine):
     block_class = SerenityBeaconBlock
     state_class = SerenityBeaconState
     state_transition_class = SerenityStateTransition
-    fork_choice_scoring = higher_slot_scoring
+    fork_choice_scoring = staticmethod(higher_slot_scoring)
 
     # methods
     @staticmethod

--- a/eth2/beacon/state_machines/forks/xiao_long_bao/__init__.py
+++ b/eth2/beacon/state_machines/forks/xiao_long_bao/__init__.py
@@ -1,4 +1,7 @@
-from eth2.beacon.fork_choice import higher_slot_scoring
+from eth2.beacon.fork_choice import (
+    ForkChoiceScoring,
+    higher_slot_scoring,
+)
 from eth2.beacon.state_machines.base import (
     BeaconStateMachine,
 )
@@ -33,10 +36,12 @@ class XiaoLongBaoStateMachine(BeaconStateMachine):
     block_class = SerenityBeaconBlock
     state_class = SerenityBeaconState
     state_transition_class = SerenityStateTransition
-    fork_choice_scoring = staticmethod(higher_slot_scoring)
 
     # methods
     @staticmethod
     def create_block_from_parent(parent_block: BaseBeaconBlock,
                                  block_params: FromBlockParams) -> BaseBeaconBlock:
         return create_serenity_block_from_parent(parent_block, block_params)
+
+    def get_fork_choice_scoring(self) -> ForkChoiceScoring:
+        return higher_slot_scoring

--- a/eth2/beacon/state_machines/forks/xiao_long_bao/__init__.py
+++ b/eth2/beacon/state_machines/forks/xiao_long_bao/__init__.py
@@ -1,3 +1,4 @@
+from eth2.beacon.fork_choice import higher_slot_scoring
 from eth2.beacon.state_machines.base import (
     BeaconStateMachine,
 )
@@ -32,6 +33,7 @@ class XiaoLongBaoStateMachine(BeaconStateMachine):
     block_class = SerenityBeaconBlock
     state_class = SerenityBeaconState
     state_transition_class = SerenityStateTransition
+    fork_choice_scoring = higher_slot_scoring
 
     # methods
     @staticmethod

--- a/tests/core/p2p-proto/bcc/helpers.py
+++ b/tests/core/p2p-proto/bcc/helpers.py
@@ -38,6 +38,7 @@ from eth2.beacon.constants import (
 from tests.core.integration_test_helpers import (
     async_passthrough,
 )
+from eth2.beacon.fork_choice import higher_slot_scoring
 from eth2.beacon.state_machines.forks.serenity import SERENITY_CONFIG
 from eth2.configs import (
     Eth2GenesisConfig,
@@ -100,10 +101,18 @@ def create_branch(length, root=None, **start_kwargs):
         parent = child
 
 
-async def get_chain_db(blocks=(), genesis_config=SERENITY_GENESIS_CONFIG):
+async def get_chain_db(blocks=(),
+                       genesis_config=SERENITY_GENESIS_CONFIG,
+                       fork_choice_scoring=higher_slot_scoring):
     db = AtomicDB()
     chain_db = FakeAsyncBeaconChainDB(db=db, genesis_config=genesis_config)
-    await chain_db.coro_persist_block_chain(blocks, BeaconBlock)
+    await chain_db.coro_persist_block_chain(
+        blocks,
+        BeaconBlock,
+        (
+            higher_slot_scoring for block in blocks
+        ),
+    )
     return chain_db
 
 

--- a/tests/core/p2p-proto/bcc/helpers.py
+++ b/tests/core/p2p-proto/bcc/helpers.py
@@ -20,6 +20,10 @@ from eth2.beacon.types.blocks import (
     BeaconBlockBody,
 )
 
+from tests.core.integration_test_helpers import (
+    async_passthrough,
+)
+
 from trinity.db.beacon.chain import BaseAsyncBeaconChainDB
 from trinity.protocol.bcc.context import BeaconContext
 from trinity.protocol.bcc.peer import (
@@ -34,9 +38,6 @@ from p2p.tools.paragon.helpers import (
 )
 from eth2.beacon.constants import (
     EMPTY_SIGNATURE,
-)
-from tests.core.integration_test_helpers import (
-    async_passthrough,
 )
 from eth2.beacon.fork_choice import higher_slot_scoring
 from eth2.beacon.state_machines.forks.serenity import SERENITY_CONFIG

--- a/tests/core/p2p-proto/bcc/test_requests.py
+++ b/tests/core/p2p-proto/bcc/test_requests.py
@@ -32,6 +32,7 @@ from .helpers import (
     create_branch,
     get_directly_linked_peers_in_peer_pools,
 )
+from eth2.beacon.fork_choice import higher_slot_scoring
 from eth2.beacon.state_machines.forks.serenity import SERENITY_CONFIG
 
 
@@ -172,7 +173,8 @@ async def test_get_canonical_block_range_by_slot(request, event_loop, event_bus)
     canonical_branch = create_branch(4, root=base_branch[-1], state_root=b"\x11" * 32)
 
     for branch in [[genesis], base_branch, non_canonical_branch, canonical_branch]:
-        await chain_db.coro_persist_block_chain(branch, BeaconBlock)
+        scorings = (higher_slot_scoring for block in branch)
+        await chain_db.coro_persist_block_chain(branch, BeaconBlock, scorings)
 
     async with get_request_server_setup(
         request, event_loop, event_bus, chain_db
@@ -200,7 +202,8 @@ async def test_get_canonical_block_range_by_root(request, event_loop, event_bus)
     canonical_branch = create_branch(4, root=base_branch[-1], state_root=b"\x11" * 32)
 
     for branch in [[genesis], base_branch, non_canonical_branch, canonical_branch]:
-        await chain_db.coro_persist_block_chain(branch, BeaconBlock)
+        scorings = (higher_slot_scoring for block in branch)
+        await chain_db.coro_persist_block_chain(branch, BeaconBlock, scorings)
 
     async with get_request_server_setup(
         request, event_loop, event_bus, chain_db
@@ -228,7 +231,8 @@ async def test_get_incomplete_canonical_block_range(request, event_loop, event_b
     canonical_branch = create_branch(4, root=base_branch[-1], state_root=b"\x11" * 32)
 
     for branch in [[genesis], base_branch, non_canonical_branch, canonical_branch]:
-        await chain_db.coro_persist_block_chain(branch, BeaconBlock)
+        scorings = (higher_slot_scoring for block in branch)
+        await chain_db.coro_persist_block_chain(branch, BeaconBlock, scorings)
 
     async with get_request_server_setup(
         request, event_loop, event_bus, chain_db
@@ -256,7 +260,8 @@ async def test_get_non_canonical_branch(request, event_loop, event_bus):
     canonical_branch = create_branch(4, root=base_branch[-1], state_root=b"\x11" * 32)
 
     for branch in [[genesis], base_branch, non_canonical_branch, canonical_branch]:
-        await chain_db.coro_persist_block_chain(branch, BeaconBlock)
+        scorings = (higher_slot_scoring for block in branch)
+        await chain_db.coro_persist_block_chain(branch, BeaconBlock, scorings)
 
     async with get_request_server_setup(
         request, event_loop, event_bus, chain_db

--- a/tests/eth2/core/beacon/chains/test_beacon_chain.py
+++ b/tests/eth2/core/beacon/chains/test_beacon_chain.py
@@ -42,7 +42,7 @@ def valid_chain(beacon_chain_with_block_validation):
         (100, 20, 10, 10),
     ]
 )
-def test_canonical_chain(valid_chain, genesis_slot):
+def test_canonical_chain(valid_chain, genesis_slot, fork_choice_scoring):
     genesis_block = valid_chain.get_canonical_block_by_slot(genesis_slot)
 
     # Our chain fixture is created with only the genesis header, so initially that's the head of
@@ -53,7 +53,7 @@ def test_canonical_chain(valid_chain, genesis_slot):
         slot=genesis_block.slot + 1,
         previous_block_root=genesis_block.signing_root,
     )
-    valid_chain.chaindb.persist_block(block, block.__class__)
+    valid_chain.chaindb.persist_block(block, block.__class__, fork_choice_scoring)
 
     assert valid_chain.get_canonical_head() == block
 

--- a/tests/eth2/core/beacon/conftest.py
+++ b/tests/eth2/core/beacon/conftest.py
@@ -16,6 +16,9 @@ from eth2.configs import (
 from eth2.beacon.constants import (
     FAR_FUTURE_EPOCH,
 )
+from eth2.beacon.fork_choice import (
+    higher_slot_scoring,
+)
 from eth2.beacon.helpers import (
     slot_to_epoch,
 )
@@ -801,6 +804,11 @@ def fixture_sm_class(config):
         __name__='SerenityStateMachineForTesting',
         config=config,
     )
+
+
+@pytest.fixture
+def fork_choice_scoring():
+    return higher_slot_scoring
 
 
 @pytest.fixture

--- a/tests/eth2/core/beacon/db/test_beacon_chaindb.py
+++ b/tests/eth2/core/beacon/db/test_beacon_chaindb.py
@@ -36,9 +36,9 @@ from eth2.beacon.types.states import BeaconState
 
 
 @pytest.fixture
-def chaindb_at_genesis(chaindb, genesis_state, genesis_block):
+def chaindb_at_genesis(chaindb, genesis_state, genesis_block, fork_choice_scoring):
     chaindb.persist_state(genesis_state)
-    chaindb.persist_block(genesis_block, BeaconBlock)
+    chaindb.persist_block(genesis_block, BeaconBlock, fork_choice_scoring)
     return chaindb
 
 
@@ -56,9 +56,9 @@ def state(sample_beacon_state_params):
 
 
 @pytest.fixture()
-def block_with_attestation(chaindb, sample_block, sample_attestation):
+def block_with_attestation(chaindb, sample_block, sample_attestation, fork_choice_scoring):
     genesis = sample_block
-    chaindb.persist_block(genesis, genesis.__class__)
+    chaindb.persist_block(genesis, genesis.__class__, fork_choice_scoring)
     block1 = genesis.copy(
         previous_block_root=genesis.signing_root,
         slot=genesis.slot + 1,
@@ -74,45 +74,45 @@ def maximum_score_value():
     return 2**64 - 1
 
 
-def test_chaindb_add_block_number_to_root_lookup(chaindb, block):
+def test_chaindb_add_block_number_to_root_lookup(chaindb, block, fork_choice_scoring):
     block_slot_to_root_key = SchemaV1.make_block_slot_to_root_lookup_key(block.slot)
     assert not chaindb.exists(block_slot_to_root_key)
-    chaindb.persist_block(block, block.__class__)
+    chaindb.persist_block(block, block.__class__, fork_choice_scoring)
     assert chaindb.exists(block_slot_to_root_key)
 
 
-def test_chaindb_persist_block_and_slot_to_root(chaindb, block):
+def test_chaindb_persist_block_and_slot_to_root(chaindb, block, fork_choice_scoring):
     with pytest.raises(BlockNotFound):
         chaindb.get_block_by_root(block.signing_root, block.__class__)
     slot_to_root_key = SchemaV1.make_block_root_to_score_lookup_key(block.signing_root)
     assert not chaindb.exists(slot_to_root_key)
 
-    chaindb.persist_block(block, block.__class__)
+    chaindb.persist_block(block, block.__class__, fork_choice_scoring)
 
     assert chaindb.get_block_by_root(block.signing_root, block.__class__) == block
     assert chaindb.exists(slot_to_root_key)
 
 
 @given(seed=st.binary(min_size=32, max_size=32))
-def test_chaindb_persist_block_and_unknown_parent(chaindb, block, seed):
+def test_chaindb_persist_block_and_unknown_parent(chaindb, block, fork_choice_scoring, seed):
     n_block = block.copy(previous_block_root=hash_eth2(seed))
     with pytest.raises(ParentNotFound):
-        chaindb.persist_block(n_block, n_block.__class__)
+        chaindb.persist_block(n_block, n_block.__class__, fork_choice_scoring)
 
 
-def test_chaindb_persist_block_and_block_to_root(chaindb, block):
+def test_chaindb_persist_block_and_block_to_root(chaindb, block, fork_choice_scoring):
     block_to_root_key = SchemaV1.make_block_root_to_score_lookup_key(block.signing_root)
     assert not chaindb.exists(block_to_root_key)
-    chaindb.persist_block(block, block.__class__)
+    chaindb.persist_block(block, block.__class__, fork_choice_scoring)
     assert chaindb.exists(block_to_root_key)
 
 
-def test_chaindb_get_score(chaindb, sample_beacon_block_params):
+def test_chaindb_get_score(chaindb, sample_beacon_block_params, fork_choice_scoring):
     genesis = BeaconBlock(**sample_beacon_block_params).copy(
         previous_block_root=GENESIS_PARENT_HASH,
         slot=0,
     )
-    chaindb.persist_block(genesis, genesis.__class__)
+    chaindb.persist_block(genesis, genesis.__class__, fork_choice_scoring)
 
     genesis_score_key = SchemaV1.make_block_root_to_score_lookup_key(genesis.signing_root)
     genesis_score = ssz.decode(chaindb.db.get(genesis_score_key), sedes=ssz.sedes.uint64)
@@ -123,7 +123,7 @@ def test_chaindb_get_score(chaindb, sample_beacon_block_params):
         previous_block_root=genesis.signing_root,
         slot=1,
     )
-    chaindb.persist_block(block1, block1.__class__)
+    chaindb.persist_block(block1, block1.__class__, fork_choice_scoring)
 
     block1_score_key = SchemaV1.make_block_root_to_score_lookup_key(block1.signing_root)
     block1_score = ssz.decode(chaindb.db.get(block1_score_key), sedes=ssz.sedes.uint64)
@@ -140,20 +140,20 @@ def test_chaindb_set_score(chaindb, block, maximum_score_value):
     assert block_score == score
 
 
-def test_chaindb_get_block_by_root(chaindb, block):
-    chaindb.persist_block(block, block.__class__)
+def test_chaindb_get_block_by_root(chaindb, block, fork_choice_scoring):
+    chaindb.persist_block(block, block.__class__, fork_choice_scoring)
     result_block = chaindb.get_block_by_root(block.signing_root, block.__class__)
     validate_ssz_equal(result_block, block)
 
 
-def test_chaindb_get_canonical_block_root(chaindb, block):
-    chaindb.persist_block(block, block.__class__)
+def test_chaindb_get_canonical_block_root(chaindb, block, fork_choice_scoring):
+    chaindb.persist_block(block, block.__class__, fork_choice_scoring)
     block_root = chaindb.get_canonical_block_root(block.slot)
     assert block_root == block.signing_root
 
 
-def test_chaindb_get_genesis_block_root(chaindb, genesis_block):
-    chaindb.persist_block(genesis_block, genesis_block.__class__)
+def test_chaindb_get_genesis_block_root(chaindb, genesis_block, fork_choice_scoring):
+    chaindb.persist_block(genesis_block, genesis_block.__class__, fork_choice_scoring)
     block_root = chaindb.get_genesis_block_root()
     assert block_root == genesis_block.signing_root
 
@@ -176,7 +176,8 @@ def test_chaindb_get_justified_head_at_genesis(chaindb_at_genesis, genesis_block
 def test_chaindb_get_finalized_head(chaindb_at_genesis,
                                     genesis_block,
                                     genesis_state,
-                                    sample_beacon_block_params):
+                                    sample_beacon_block_params,
+                                    fork_choice_scoring):
     chaindb = chaindb_at_genesis
     block = BeaconBlock(**sample_beacon_block_params).copy(
         previous_block_root=genesis_block.signing_root,
@@ -189,7 +190,7 @@ def test_chaindb_get_finalized_head(chaindb_at_genesis,
         finalized_root=block.signing_root,
     )
     chaindb.persist_state(state_with_finalized_block)
-    chaindb.persist_block(block, BeaconBlock)
+    chaindb.persist_block(block, BeaconBlock, fork_choice_scoring)
 
     assert chaindb.get_finalized_head(BeaconBlock).signing_root == block.signing_root
     assert chaindb.get_justified_head(genesis_block.__class__) == genesis_block
@@ -199,6 +200,7 @@ def test_chaindb_get_justified_head(chaindb_at_genesis,
                                     genesis_block,
                                     genesis_state,
                                     sample_beacon_block_params,
+                                    fork_choice_scoring,
                                     config):
     chaindb = chaindb_at_genesis
     block = BeaconBlock(**sample_beacon_block_params).copy(
@@ -214,7 +216,7 @@ def test_chaindb_get_justified_head(chaindb_at_genesis,
         current_justified_epoch=config.GENESIS_EPOCH,
     )
     chaindb.persist_state(state_with_bad_epoch)
-    chaindb.persist_block(block, BeaconBlock)
+    chaindb.persist_block(block, BeaconBlock, fork_choice_scoring)
 
     assert chaindb.get_finalized_head(genesis_block.__class__) == genesis_block
     assert chaindb.get_justified_head(genesis_block.__class__) == genesis_block
@@ -240,8 +242,8 @@ def test_chaindb_get_justified_head_at_init_time(chaindb):
         chaindb.get_justified_head(BeaconBlock)
 
 
-def test_chaindb_get_canonical_head(chaindb, block):
-    chaindb.persist_block(block, block.__class__)
+def test_chaindb_get_canonical_head(chaindb, block, fork_choice_scoring):
+    chaindb.persist_block(block, block.__class__, fork_choice_scoring)
 
     canonical_head_root = chaindb.get_canonical_head_root()
     assert canonical_head_root == block.signing_root
@@ -253,7 +255,7 @@ def test_chaindb_get_canonical_head(chaindb, block):
         slot=block.slot + 1,
         previous_block_root=block.signing_root,
     )
-    chaindb.persist_block(block_2, block_2.__class__)
+    chaindb.persist_block(block_2, block_2.__class__, fork_choice_scoring)
     result_block = chaindb.get_canonical_head(block.__class__)
     assert result_block == block_2
 
@@ -261,28 +263,30 @@ def test_chaindb_get_canonical_head(chaindb, block):
         slot=block_2.slot + 1,
         previous_block_root=block_2.signing_root,
     )
-    chaindb.persist_block(block_3, block_3.__class__)
+    chaindb.persist_block(block_3, block_3.__class__, fork_choice_scoring)
     result_block = chaindb.get_canonical_head(block.__class__)
     assert result_block == block_3
 
 
-def test_get_slot_by_root(chaindb, block):
-    chaindb.persist_block(block, block.__class__)
+def test_get_slot_by_root(chaindb, block, fork_choice_scoring):
+    chaindb.persist_block(block, block.__class__, fork_choice_scoring)
     block_slot = block.slot
     result_slot = chaindb.get_slot_by_root(block.signing_root)
     assert result_slot == block_slot
 
 
-def test_chaindb_add_attestations_root_to_block_lookup(chaindb, block_with_attestation):
+def test_chaindb_add_attestations_root_to_block_lookup(chaindb,
+                                                       block_with_attestation,
+                                                       fork_choice_scoring):
     block, attestation = block_with_attestation
     assert not chaindb.attestation_exists(attestation.root)
-    chaindb.persist_block(block, block.__class__)
+    chaindb.persist_block(block, block.__class__, fork_choice_scoring)
     assert chaindb.attestation_exists(attestation.root)
 
 
-def test_chaindb_get_attestation_key_by_root(chaindb, block_with_attestation):
+def test_chaindb_get_attestation_key_by_root(chaindb, block_with_attestation, fork_choice_scoring):
     block, attestation = block_with_attestation
     with pytest.raises(AttestationRootNotFound):
         chaindb.get_attestation_key_by_root(attestation.root)
-    chaindb.persist_block(block, block.__class__)
+    chaindb.persist_block(block, block.__class__, fork_choice_scoring)
     assert chaindb.get_attestation_key_by_root(attestation.root) == (block.signing_root, 0)

--- a/tests/eth2/core/beacon/fork_choice/test_higher_slot.py
+++ b/tests/eth2/core/beacon/fork_choice/test_higher_slot.py
@@ -13,4 +13,8 @@ def test_fork_choice_scoring(sample_beacon_block_params, slot):
         slot=slot,
     )
 
-    assert higher_slot_scoring(block) == slot
+    expected_score = slot
+
+    score = higher_slot_scoring(block)
+
+    assert score == expected_score

--- a/tests/eth2/core/beacon/fork_choice/test_higher_slot.py
+++ b/tests/eth2/core/beacon/fork_choice/test_higher_slot.py
@@ -1,0 +1,16 @@
+import pytest
+
+from eth2.beacon.fork_choice import higher_slot_scoring
+from eth2.beacon.types.blocks import BeaconBlock
+
+
+@pytest.mark.parametrize(
+    "slot",
+    (i for i in range(10)),
+)
+def test_fork_choice_scoring(sample_beacon_block_params, slot):
+    block = BeaconBlock(**sample_beacon_block_params).copy(
+        slot=slot,
+    )
+
+    assert higher_slot_scoring(block) == slot

--- a/tests/eth2/core/beacon/state_machines/test_state_transition.py
+++ b/tests/eth2/core/beacon/state_machines/test_state_transition.py
@@ -51,8 +51,9 @@ def test_per_slot_transition(chaindb,
                              fixture_sm_class,
                              config,
                              state_slot,
+                             fork_choice_scoring,
                              keymap):
-    chaindb.persist_block(genesis_block, SerenityBeaconBlock)
+    chaindb.persist_block(genesis_block, SerenityBeaconBlock, fork_choice_scoring)
     chaindb.persist_state(genesis_state)
 
     state = genesis_state
@@ -72,7 +73,7 @@ def test_per_slot_transition(chaindb,
     )
 
     # Store in chaindb
-    chaindb.persist_block(block, SerenityBeaconBlock)
+    chaindb.persist_block(block, SerenityBeaconBlock, fork_choice_scoring)
 
     # Get state machine instance
     sm = fixture_sm_class(

--- a/tests/plugins/eth2/beacon/test_receive_server.py
+++ b/tests/plugins/eth2/beacon/test_receive_server.py
@@ -31,6 +31,7 @@ from eth2.beacon.typing import (
     FromBlockParams,
 )
 from eth2.beacon.chains.testnet import TestnetChain
+from eth2.beacon.fork_choice import higher_slot_scoring
 from eth2.beacon.types.attestations import Attestation
 from eth2.beacon.types.attestation_data import AttestationData
 from eth2.beacon.types.blocks import (
@@ -85,7 +86,7 @@ class FakeChain(TestnetChain):
         (
             new_canonical_blocks,
             old_canonical_blocks,
-        ) = self.chaindb.persist_block(block, block.__class__)
+        ) = self.chaindb.persist_block(block, block.__class__, higher_slot_scoring)
         return block, new_canonical_blocks, old_canonical_blocks
 
 
@@ -368,6 +369,7 @@ async def test_bcc_receive_request_block_by_root(request, event_loop, event_bus)
         await alice_req_server.db.coro_persist_block(
             blocks[0],
             SerenityBeaconBlock,
+            higher_slot_scoring,
         )
         bob_recv_server._request_block_from_peers(blocks[0].signing_root)
         msg_block = await bob_msg_queue.get()
@@ -482,14 +484,17 @@ async def test_bcc_receive_server_with_request_server(request, event_loop, event
         await alice_req_server.db.coro_persist_block(
             blocks[0],
             SerenityBeaconBlock,
+            higher_slot_scoring,
         )
         await alice_req_server.db.coro_persist_block(
             blocks[1],
             SerenityBeaconBlock,
+            higher_slot_scoring,
         )
         await alice_req_server.db.coro_persist_block(
             blocks[2],
             SerenityBeaconBlock,
+            higher_slot_scoring,
         )
 
         # test: alice send `blocks[2]` to bob, and bob should be able to

--- a/trinity/db/beacon/chain.py
+++ b/trinity/db/beacon/chain.py
@@ -15,6 +15,7 @@ from typing import (
 
 from eth_typing import Hash32
 
+from eth2.beacon.fork_choice import ForkChoiceScoring
 from eth2.beacon.types.states import (
     BeaconState,
 )
@@ -36,7 +37,8 @@ class BaseAsyncBeaconChainDB(ABC):
     async def coro_persist_block(
             self,
             block: BaseBeaconBlock,
-            block_class: Type[BaseBeaconBlock]
+            block_class: Type[BaseBeaconBlock],
+            fork_choice_scoring: ForkChoiceScoring,
     ) -> Tuple[Tuple[bytes, ...], Tuple[bytes, ...]]:
         pass
 
@@ -89,7 +91,8 @@ class BaseAsyncBeaconChainDB(ABC):
     async def coro_persist_block_chain(
             self,
             blocks: Iterable[BaseBeaconBlock],
-            block_class: Type[BaseBeaconBlock]
+            block_class: Type[BaseBeaconBlock],
+            fork_choice_scorings: Iterable[ForkChoiceScoring],
     ) -> Tuple[Tuple[BaseBeaconBlock, ...], Tuple[BaseBeaconBlock, ...]]:
         pass
 


### PR DESCRIPTION
**EDIT: update description to reflect current state of PR, may be helpful to start w/ `Summary of changes` below**

### What was wrong?

Big part of implementing LMG GHOST fork choice.

Pulling this out of #532 as it is substantial enough to stand on its own.

In Eth1, the fork scoring function is just a function of the block header. This fact makes it easy to calculate the score as we import new headers, adjusting the canonical head along the way.

In Eth2, the fork scoring function is more complex (a function of the block, the state, and off-chain attestations); moreover, we want to run the fork choice in more situations than just importing a new valid block.

The current design of the fork choice calculation does not readily facilitate these tasks.

### How was it fixed?

Summary of changes:
- Extend API of `persist_block` to allow arbitrary scoring
- Add `set_score` API (not technically required for this PR but will need for future fork choice work. easier to include here than patch up the git history... forgive me for the lack of precision :) )
- Update the tests!

To address these limitations, we allow the caller of `persist_block` to provide their own scoring logic.
~The DB class now exposes methods to persist the fork choice but does not actively compute it (at least via the new API `persist_block_without_scoring`). The particular fork choice lives to a particular variation of the `StateMachine`. For example, the `SerenityStateMachine` will have the `lmd_ghost_fork_scoring` rule after it lands in a subsequent PR. For now, they just use the existing `higher_slot_scoring` rule.~

### Rationale for putting the fork choice scoring in the StateMachine and using it in the Chain class

The Chain class is what ultimately orchestrates validating incoming data, persisting valid data, running the fork choice (based on the current state machine's scoring rule) and persisting the results of this fork choice (i.e. writing the new block's score and updating the canonical head if necessary).

This configuration is more flexible, exposing a direct path to inject the AttestationPool necessary for LMD GHOST, and avoids the situation where the DB knows about every other object in the system (single responsibility and all that).

~I have some concerns mainly around the new API(s). It might be dangerous to expose something like `set_score` for anyone to call and `update_canonical_head_if_needed` feels a little clunky still... I would suggest we merge this in and as we gain confidence w/ the new stuff, we can look at deprecating the old stuff (namely, `persist_block` and its callers).~


### Other comments

We could make the argument to pull the actual process of selecting which fork to follow (given a "score chain") but this seems low value given that we can map any fork choice to "follow the monotonically increasing score" by warping the fork choice scoring function).

There is another concern around "overloading" the state machine w/ the fork choice -- it seems like the best place to put it for now but readers should note that the state machine is no longer just a transformation from block to block. To justify this change, let's answer the question: if we change the fork choice (at some slot), does that imply a new state machine?

### To-Do

I'll add more tests but given there are some design questions up in the air, I'll get this up so you can make a pass at reviewing it if you want...

- [x] Add more tests to cover new APIs


#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://proxy.duckduckgo.com/iu/?u=https%3A%2F%2Fs-media-cache-ak0.pinimg.com%2Foriginals%2Fe2%2Fdd%2Ff2%2Fe2ddf29dc77bbd842147cfb77039cd51.jpg&f=1)
