### PR TITLE
Add attestation pool in beacon node `ReceiveServer`

### DIFF
--- a/eth2/beacon/chains/base.py
+++ b/eth2/beacon/chains/base.py
@@ -425,3 +425,6 @@ class BeaconChain(BaseBeaconChain):
         block_root, index = self.chaindb.get_attestation_key_by_root(attestation_root)
         block = self.get_block_by_root(block_root)
         return block.body.attestations[index]
+
+    def attestation_exists(self, attestation_root: Hash32) -> bool:
+        return self.chaindb.attestation_exists(attestation_root)

--- a/eth2/beacon/chains/base.py
+++ b/eth2/beacon/chains/base.py
@@ -170,6 +170,17 @@ class BaseBeaconChain(Configurable, ABC):
     ) -> Tuple[BaseBeaconBlock, Tuple[BaseBeaconBlock, ...], Tuple[BaseBeaconBlock, ...]]:
         pass
 
+    #
+    # Attestation API
+    #
+    @abstractmethod
+    def get_attestation_by_root(self, attestation_root: Hash32)-> Attestation:
+        pass
+
+    @abstractmethod
+    def attestation_exists(self, attestation_root: Hash32) -> bool:
+        pass
+
 
 class BeaconChain(BaseBeaconChain):
     """

--- a/tests/eth2/core/beacon/chains/test_beacon_chain.py
+++ b/tests/eth2/core/beacon/chains/test_beacon_chain.py
@@ -3,14 +3,17 @@ import copy
 import pytest
 
 
-from eth2.beacon.chains.base import (
-    BeaconChain,
-)
 from eth2.beacon.exceptions import (
     BlockClassError,
 )
-from eth2.beacon.state_machines.forks.serenity.blocks import (
-    SerenityBeaconBlock,
+from eth2.beacon.chains.base import (
+    BeaconChain,
+)
+from eth2.beacon.db.exceptions import (
+    AttestationRootNotFound,
+)
+from eth2.beacon.types.blocks import (
+    BeaconBlock,
 )
 from eth2.beacon.tools.builder.proposer import (
     create_mock_block,
@@ -19,8 +22,8 @@ from eth2.beacon.tools.builder.proposer import (
 from eth2.beacon.tools.builder.validator import (
     create_mock_signed_attestations_at_slot,
 )
-from eth2.beacon.types.blocks import (
-    BeaconBlock,
+from eth2.beacon.state_machines.forks.serenity.blocks import (
+    SerenityBeaconBlock,
 )
 
 
@@ -189,3 +192,9 @@ def test_get_attestation_root(valid_chain,
     a0 = attestations[0]
     assert valid_chain.get_attestation_by_root(a0.root) == a0
     assert valid_chain.attestation_exists(a0.root)
+    fake_attestation = a0.copy(
+        aggregate_signature=b'\x78' * 96,
+    )
+    with pytest.raises(AttestationRootNotFound):
+        valid_chain.get_attestation_by_root(fake_attestation.root)
+    assert not valid_chain.attestation_exists(fake_attestation.root)

--- a/tests/eth2/core/beacon/chains/test_beacon_chain.py
+++ b/tests/eth2/core/beacon/chains/test_beacon_chain.py
@@ -188,3 +188,4 @@ def test_get_attestation_root(valid_chain,
     # Only one attestation in attestations, so just check that one
     a0 = attestations[0]
     assert valid_chain.get_attestation_by_root(a0.root) == a0
+    assert valid_chain.attestation_exists(a0.root)

--- a/tests/plugins/eth2/beacon/test_receive_server.py
+++ b/tests/plugins/eth2/beacon/test_receive_server.py
@@ -632,3 +632,8 @@ async def test_bcc_receive_server_get_ready_attestations(
             attesting_slot + XIAO_LONG_BAO_CONFIG.MIN_ATTESTATION_INCLUSION_DELAY + 1,
         )
         assert set([a1, a2, a3]) == set(ready_attestations)
+
+        ready_attestations = bob_recv_server.get_ready_attestations(
+            attesting_slot + XIAO_LONG_BAO_CONFIG.SLOTS_PER_EPOCH + 1,
+        )
+        assert set([a3]) == set(ready_attestations)

--- a/tests/plugins/eth2/beacon/test_receive_server.py
+++ b/tests/plugins/eth2/beacon/test_receive_server.py
@@ -560,19 +560,19 @@ def test_attestation_pool(mock_attestation):
     )
 
     # test: add
-    pool.add([a1])
+    pool.add(a1)
     assert a1 in pool._pool
     assert len(pool._pool) == 1
     # test: add: no side effect for adding twice
-    pool.add([a1])
+    pool.add(a1)
     assert len(pool._pool) == 1
     # test: `__contains__`
     assert a1.root in pool
     assert a1 in pool
     assert a2.root not in pool
     assert a2 not in pool
-    # test: add: two blocks
-    pool.add([a2])
+    # test: batch_add: two attestations
+    pool.batch_add([a1, a2])
     assert len(pool._pool) == 2
     # test: get
     with pytest.raises(AttestationNotFound):
@@ -582,9 +582,9 @@ def test_attestation_pool(mock_attestation):
     # test: get_all
     assert set([a1, a2]) == set(pool.get_all())
     # test: remove
-    pool.remove([a3])
+    pool.remove(a3)
     assert len(pool._pool) == 2
-    pool.remove([a2, a1])
+    pool.batch_remove([a2, a1])
     assert len(pool._pool) == 0
 
 

--- a/tests/plugins/eth2/beacon/test_receive_server.py
+++ b/tests/plugins/eth2/beacon/test_receive_server.py
@@ -616,7 +616,7 @@ async def test_bcc_receive_server_get_ready_attestations(
                 slot=attesting_slot + 1,
             ),
         )
-        bob_recv_server.attestation_pool.add([a1, a2, a3])
+        bob_recv_server.attestation_pool.batch_add([a1, a2, a3])
 
         ready_attestations = bob_recv_server.get_ready_attestations(
             attesting_slot + XIAO_LONG_BAO_CONFIG.MIN_ATTESTATION_INCLUSION_DELAY - 1,

--- a/tests/plugins/eth2/beacon/test_receive_server.py
+++ b/tests/plugins/eth2/beacon/test_receive_server.py
@@ -581,6 +581,8 @@ def test_attestation_pool(mock_attestation):
         pass
     assert pool.get(a1.root) == a1
     assert pool.get(a2.root) == a2
+    # test: get_all
+    assert a1 in pool.get_all() and a2 in pool.get_all()
     # test: remove
     pool.remove([a3])
     assert len(pool._pool) == 2

--- a/tests/plugins/eth2/conftest.py
+++ b/tests/plugins/eth2/conftest.py
@@ -1,5 +1,12 @@
 import pytest
 
+from eth.constants import (
+    ZERO_HASH32,
+)
+
+from eth2.beacon.types.attestations import Attestation
+from eth2.beacon.types.attestation_data import AttestationData
+from eth2.beacon.types.crosslinks import Crosslink
 from eth2.beacon.tools.misc.ssz_vector import (
     override_vector_lengths,
 )
@@ -12,3 +19,25 @@ from eth2.beacon.state_machines.forks.xiao_long_bao.configs import (
 @pytest.fixture(scope="function", autouse=True)
 def override_lengths():
     override_vector_lengths(XIAO_LONG_BAO_CONFIG)
+
+
+@pytest.fixture
+def mock_attestation():
+    return Attestation(
+        aggregation_bitfield=b'\x12' * 16,
+        data=AttestationData(
+            slot=XIAO_LONG_BAO_CONFIG.GENESIS_SLOT + 1,
+            beacon_block_root=ZERO_HASH32,
+            source_epoch=XIAO_LONG_BAO_CONFIG.GENESIS_EPOCH,
+            source_root=ZERO_HASH32,
+            target_root=ZERO_HASH32,
+            shard=0,
+            previous_crosslink=Crosslink(
+                epoch=XIAO_LONG_BAO_CONFIG.GENESIS_EPOCH,
+                crosslink_data_root=ZERO_HASH32,
+            ),
+            crosslink_data_root=ZERO_HASH32,
+        ),
+        custody_bitfield=b'\x34' * 16,
+        aggregate_signature=b'\x56' * 96,
+    )

--- a/trinity/exceptions.py
+++ b/trinity/exceptions.py
@@ -68,6 +68,13 @@ class BadDatabaseError(BaseTrinityError):
     pass
 
 
+class AttestationNotFound(BaseTrinityError):
+    """
+    Raised when attestion with given attestation root does not exist.
+    """
+    pass
+
+
 class WrongNetworkFailure(HandshakeFailure):
     """
     Disconnected from the peer because it's on a different network than we're on

--- a/trinity/plugins/eth2/beacon/plugin.py
+++ b/trinity/plugins/eth2/beacon/plugin.py
@@ -127,6 +127,7 @@ class BeaconNodePlugin(BaseIsolatedPlugin):
             validator_privkeys=validator_privkeys,
             event_bus=self.event_bus,
             token=server.cancel_token,
+            get_ready_attestations_fn=server.receive_server.get_ready_attestations,
         )
 
         slot_ticker = SlotTicker(

--- a/trinity/plugins/eth2/beacon/validator.py
+++ b/trinity/plugins/eth2/beacon/validator.py
@@ -321,6 +321,8 @@ class Validator(BaseService):
             slot,
             epoch,
         )
+        if len(attesting_validators) == 0:
+            return ()
 
         # Sort the attesting validators by shard
         sorted_attesting_validators = sorted(

--- a/trinity/plugins/eth2/beacon/validator.py
+++ b/trinity/plugins/eth2/beacon/validator.py
@@ -82,6 +82,9 @@ from trinity.protocol.bcc.peer import (
 )
 
 
+GetReadyAttestationsFn = Callable[[Slot], Sequence[Attestation]]
+
+
 class Validator(BaseService):
     chain: BeaconChain
     peer_pool: BCCPeerPool
@@ -100,7 +103,7 @@ class Validator(BaseService):
             peer_pool: BCCPeerPool,
             validator_privkeys: Dict[ValidatorIndex, int],
             event_bus: TrinityEventBusEndpoint,
-            get_ready_attestations_fn: Callable[[Slot], Sequence[Attestation]],
+            get_ready_attestations_fn: GetReadyAttestationsFn,
             token: CancelToken = None) -> None:
         super().__init__(token)
         self.chain = chain
@@ -121,7 +124,7 @@ class Validator(BaseService):
                 Epoch(-1),
                 CommitteeAssignment((), Shard(-1), Slot(-1), False),
             )
-        self.get_ready_attestations = get_ready_attestations_fn
+        self.get_ready_attestations: GetReadyAttestationsFn = get_ready_attestations_fn
 
     async def _run(self) -> None:
         await self.event_bus.wait_until_serving()

--- a/trinity/plugins/eth2/beacon/validator.py
+++ b/trinity/plugins/eth2/beacon/validator.py
@@ -209,8 +209,6 @@ class Validator(BaseService):
                 )
                 self.latest_proposed_epoch[proposer_index] = epoch
 
-        await self.attest(slot)
-
     async def handle_second_tick(self, slot: Slot) -> None:
         state_machine = self.chain.get_state_machine()
         state = state_machine.state
@@ -220,6 +218,8 @@ class Validator(BaseService):
                 state=state,
                 state_machine=state_machine,
             )
+
+        await self.attest(slot)
 
     def propose_block(self,
                       proposer_index: ValidatorIndex,

--- a/trinity/protocol/bcc/servers.py
+++ b/trinity/protocol/bcc/servers.py
@@ -474,6 +474,8 @@ class BCCReceiveServer(BaseReceiveServer):
             # depends on it. If there are, try to import them.
             # TODO: should be done asynchronously?
             self._try_import_orphan_blocks(block.signing_root)
+            # Remove attestations in block that are also in the attestation pool.
+            self.attestation_pool.remove(block.body.attestations)
             return True
 
     def _try_import_orphan_blocks(self, parent_root: Hash32) -> None:

--- a/trinity/protocol/bcc/servers.py
+++ b/trinity/protocol/bcc/servers.py
@@ -252,12 +252,7 @@ class AttestationPool:
                 return
             self._pool.add(attestation)
 
-    def remove(self, attestation_roots: Iterable[Hash32]) -> None:
-        attestations = tuple(
-            self.get(root)
-            for root in attestation_roots
-            if root in self._pool
-        )
+    def remove(self, attestations: Iterable[Attestation]) -> None:
         self._pool.difference_update(attestations)
 
 

--- a/trinity/protocol/bcc/servers.py
+++ b/trinity/protocol/bcc/servers.py
@@ -236,7 +236,10 @@ class AttestationPool:
         elif isinstance(attestation_or_root, bytes):
             attestation_root = attestation_or_root
         else:
-            raise TypeError(f"`attestation_or_root` should be `Attestation` or `Hash32`, got {type(attestation_or_root)}")
+            raise TypeError(
+                f"`attestation_or_root` should be `Attestation` or `Hash32`,"
+                f" got {type(attestation_or_root)}"
+            )
         try:
             self.get(attestation_root)
             return True
@@ -254,10 +257,7 @@ class AttestationPool:
         return tuple(self._pool)
 
     def add(self, attestations: Iterable[Attestation]) -> None:
-        for attestation in attestations:
-            if attestation in self._pool:
-                continue
-            self._pool.add(attestation)
+        self._pool.union(set(attestations))
 
     def remove(self, attestations: Iterable[Attestation]) -> None:
         self._pool.difference_update(attestations)

--- a/trinity/protocol/bcc/servers.py
+++ b/trinity/protocol/bcc/servers.py
@@ -226,7 +226,14 @@ class AttestationPool:
     def __init__(self) -> None:
         self._pool = set()
 
-    def __contains__(self, attestation_root: Hash32) -> bool:
+    def __contains__(self, attestation_or_root: Union[Attestation, Hash32]) -> bool:
+        attestation_root: Hash32
+        if isinstance(attestation_or_root, Attestation):
+            attestation_root = attestation_or_root.root
+        elif isinstance(attestation_or_root, bytes):
+            attestation_root = attestation_or_root
+        else:
+            raise TypeError("`attestation_or_root` should be `Attestation` or `Hash32`")
         try:
             self.get(attestation_root)
             return True

--- a/trinity/protocol/bcc/servers.py
+++ b/trinity/protocol/bcc/servers.py
@@ -516,6 +516,8 @@ class BCCReceiveServer(BaseReceiveServer):
                 except ValidationError as e:
                     # TODO: Possibly drop all of its descendants in `self.orphan_block_pool`?
                     self.logger.debug("Fail to import invalid block=%s  reason=%s", block, e)
+                    # Remove attestations in block that are also in the attestation pool.
+                    self.attestation_pool.remove(block.body.attestations)
                     pass
 
     def _request_block_from_peers(self, block_root: Hash32) -> None:

--- a/trinity/protocol/bcc/servers.py
+++ b/trinity/protocol/bcc/servers.py
@@ -525,7 +525,6 @@ class BCCReceiveServer(BaseReceiveServer):
                     self.logger.debug("Fail to import invalid block=%s  reason=%s", block, e)
                     # Remove attestations in block that are also in the attestation pool.
                     self.attestation_pool.remove(block.body.attestations)
-                    pass
 
     def _request_block_from_peers(self, block_root: Hash32) -> None:
         for peer in self._peer_pool.connected_nodes.values():

--- a/trinity/protocol/bcc/servers.py
+++ b/trinity/protocol/bcc/servers.py
@@ -246,6 +246,9 @@ class AttestationPool:
                 return attestation
         raise AttestationNotFound(f"No attestation with root {attestation_root} is found.")
 
+    def get_all(self) -> Tuple[Attestation, ...]:
+        return tuple(self._pool)
+
     def add(self, attestations: Iterable[Attestation]) -> None:
         for attestation in attestations:
             if attestation in self._pool:

--- a/trinity/protocol/bcc/servers.py
+++ b/trinity/protocol/bcc/servers.py
@@ -399,8 +399,11 @@ class BCCReceiveServer(BaseReceiveServer):
         """
         Check if the attestation is already in the database or the attestion pool.
         """
-        # stub
-        return False
+        try:
+            self.attestation_pool.get(attestation.root)
+            return True
+        except AttestationNotFound:
+            return False
 
     @to_tuple
     def _validate_attestations(self,

--- a/trinity/protocol/bcc/servers.py
+++ b/trinity/protocol/bcc/servers.py
@@ -46,6 +46,9 @@ from p2p.protocol import (
 from eth2.beacon.chains.base import (
     BaseBeaconChain,
 )
+from eth2.beacon.db.exceptions import (
+    AttestationRootNotFound,
+)
 from eth2.beacon.state_machines.forks.serenity.block_validation import (
     validate_attestation,
 )
@@ -404,8 +407,8 @@ class BCCReceiveServer(BaseReceiveServer):
         """
         try:
             self.attestation_pool.get(attestation.root)
-            return True
-        except AttestationNotFound:
+            return self.chain.attestation_exists(attestation.root)
+        except (AttestationNotFound, AttestationRootNotFound):
             return False
 
     @to_tuple

--- a/trinity/protocol/bcc/servers.py
+++ b/trinity/protocol/bcc/servers.py
@@ -257,7 +257,7 @@ class AttestationPool:
         return tuple(self._pool)
 
     def add(self, attestations: Iterable[Attestation]) -> None:
-        self._pool.union(set(attestations))
+        self._pool = self._pool.union(set(attestations))
 
     def remove(self, attestations: Iterable[Attestation]) -> None:
         self._pool.difference_update(attestations)

--- a/trinity/protocol/bcc/servers.py
+++ b/trinity/protocol/bcc/servers.py
@@ -554,3 +554,10 @@ class BCCReceiveServer(BaseReceiveServer):
 
     def _is_block_seen(self, block: BaseBeaconBlock) -> bool:
         return self._is_block_root_seen(block_root=block.signing_root)
+
+    @to_tuple
+    def get_ready_attestations(self, inclusion_slot: Slot) -> Iterable[Attestation]:
+        config = self.chain.get_state_machine().config
+        for attestation in self.attestation_pool.get_all():
+            if attestation.data.slot + config.MIN_ATTESTATION_INCLUSION_DELAY <= inclusion_slot:
+                yield attestation

--- a/trinity/protocol/bcc/servers.py
+++ b/trinity/protocol/bcc/servers.py
@@ -363,6 +363,8 @@ class BCCReceiveServer(BaseReceiveServer):
             self._is_attestation_new,
             valid_attestations,
         )
+        if len(valid_new_attestations) == 0:
+            return
         # Add the valid and new attestations to attestation pool.
         self.attestation_pool.add(valid_new_attestations)
         # Broadcast the valid and new attestations.
@@ -407,9 +409,9 @@ class BCCReceiveServer(BaseReceiveServer):
         """
         try:
             self.attestation_pool.get(attestation.root)
-            return self.chain.attestation_exists(attestation.root)
+            return not self.chain.attestation_exists(attestation.root)
         except (AttestationNotFound, AttestationRootNotFound):
-            return False
+            return True
 
     @to_tuple
     def _validate_attestations(self,

--- a/trinity/protocol/bcc/servers.py
+++ b/trinity/protocol/bcc/servers.py
@@ -52,9 +52,6 @@ from eth2.beacon.typing import (
 from eth2.beacon.chains.base import (
     BaseBeaconChain,
 )
-from eth2.beacon.db.exceptions import (
-    AttestationRootNotFound,
-)
 from eth2.beacon.types.attestations import (
     Attestation,
 )
@@ -413,9 +410,8 @@ class BCCReceiveServer(BaseReceiveServer):
         """
         try:
             self.attestation_pool.get(attestation.root)
-            attestation_exists = self.chain.attestation_exists(attestation.root)
-            return not attestation_exists
-        except (AttestationNotFound, AttestationRootNotFound):
+            return not self.chain.attestation_exists(attestation.root)
+        except AttestationNotFound:
             return True
 
     @to_tuple

--- a/trinity/protocol/bcc/servers.py
+++ b/trinity/protocol/bcc/servers.py
@@ -236,7 +236,7 @@ class AttestationPool:
         elif isinstance(attestation_or_root, bytes):
             attestation_root = attestation_or_root
         else:
-            raise TypeError("`attestation_or_root` should be `Attestation` or `Hash32`")
+            raise TypeError(f"`attestation_or_root` should be `Attestation` or `Hash32`, got {type(attestation_or_root)}")
         try:
             self.get(attestation_root)
             return True


### PR DESCRIPTION
### How was it fixed?
- [x] Add `AttestationPool`
    - `get`/`get_all`/`add`/`remove`
- [x] Add `ReceiveServer.get_ready_attestations`
    - which return attestations that are ready to be included in block
- [x] Expose `ReceiveServer.get_ready_attestations` to `Validator`
    - validator would get ready attestations from receive server when proposing
- [x] Fix: validator should `attest` at second slot tick
- [x] When receiving new not-yet-included attestation, check if it's already in the database
    - pending on #660 
- [x] Remove attestations from attestation pool when identical attestations are included in an imported block

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] Clean up commit history

[//]: # (For important changes, please add a new entry to the running release notes PR)
[//]: # (You can find the current one using: https://github.com/ethereum/trinity/pulls?q=is%3Aopen+is%3Apr+label%3A%22Release+Notes%22 )
[//]: # (See: https://trinity-client.readthedocs.io/en/latest/contributing.html#pull-requests)
- [ ] Add entry to the [release notes PR](https://github.com/ethereum/trinity/pulls?q=is%3Aopen+is%3Apr+label%3A%22Release+Notes%22)

#### Cute Animal Picture


![](https://pixnio.com/free-images/2018/07/10/2018-07-10-21-27-44-1200x716.jpg)
