### PR TITLE
Combine issubclass checks in plugin scope

### DIFF
--- a/trinity/extensibility/plugin_manager.py
+++ b/trinity/extensibility/plugin_manager.py
@@ -85,7 +85,7 @@ class MainAndIsolatedProcessScope(BaseManagerProcessScope):
         :class:`~trinity.extensibility.plugin.BaseIsolatedPlugin` or
         :class:`~trinity.extensibility.plugin.BaseMainProcessPlugin`
         """
-        return issubclass(plugin, BaseIsolatedPlugin) or issubclass(plugin, BaseMainProcessPlugin)
+        return issubclass(plugin, (BaseIsolatedPlugin, BaseMainProcessPlugin))
 
     def create_plugin(self,
                       plugin_type: Type[TPlugin],


### PR DESCRIPTION
### What was wrong?

The plugin scope was doing two `issubclass` checks when it could be doing one.

### How was it fixed?

Combined the two checks to use the proper syntax as in a single check.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history

[//]: # (For important changes, please add a new entry to the running release notes PR)
[//]: # (You can find the current one using: https://github.com/ethereum/trinity/pulls?q=is%3Aopen+is%3Apr+label%3A%22Release+Notes%22 )
[//]: # (See: https://trinity-client.readthedocs.io/en/latest/contributing.html#pull-requests)
- [ ] Add entry to the [release notes PR](https://github.com/ethereum/trinity/pulls?q=is%3Aopen+is%3Apr+label%3A%22Release+Notes%22)

#### Cute Animal Picture

![Cute Baby Hippo (12)](https://user-images.githubusercontent.com/824194/58386418-d70c5680-7fbc-11e9-80b2-1c31de50490d.jpg)

