### PR TITLE
Split isolated plugin base into agnostic async base

### DIFF
--- a/docs/api/extensibility/api.extensibility.plugin.rst
+++ b/docs/api/extensibility/api.extensibility.plugin.rst
@@ -20,8 +20,8 @@ BaseMainProcessPlugin
 .. autoclass:: trinity.extensibility.plugin.BaseMainProcessPlugin
   :members:
 
-BaseIsolatedPlugin
-------------------
+AsyncioIsolatedPlugin
+---------------------
 
-.. autoclass:: trinity.extensibility.plugin.BaseIsolatedPlugin
+.. autoclass:: trinity.extensibility.asyncio.AsyncioIsolatedPlugin
   :members:

--- a/docs/guides/writing_plugins.rst
+++ b/docs/guides/writing_plugins.rst
@@ -79,7 +79,7 @@ This is the default type of plugin we want to build if:
   runtime (as opposed to e.g. just reading things from the database)
 
 We build this kind of plugin subclassing from
-:class:`~trinity.extensibility.plugin.BaseIsolatedPlugin`.  A detailed example will follow soon.
+:class:`~trinity.extensibility.asyncio.AsyncioIsolatedPlugin`.  A detailed example will follow soon.
 
 
 Plugins that run inside the networking process
@@ -96,7 +96,7 @@ same process as the rest of the networking code.
   chance this type of plugin will become obsolete at some point and may eventually be removed.
 
   We should only choose this type of plugin category if what we are trying to build cannot be built
-  with a :class:`~trinity.extensibility.plugin.BaseIsolatedPlugin`.
+  with a :class:`~trinity.extensibility.asyncio.AsyncioIsolatedPlugin`.
 
 We build this kind of plugin subclassing from
 :class:`~trinity.extensibility.plugin.BaseAsyncStopPlugin`.  A detailed example will follow soon.
@@ -166,9 +166,9 @@ Defining plugins
 
 We define a plugin by deriving from either
 :class:`~trinity.extensibility.plugin.BaseMainProcessPlugin`,
-:class:`~trinity.extensibility.plugin.BaseIsolatedPlugin` or 
+:class:`~trinity.extensibility.asyncio.AsyncioIsolatedPlugin` or 
 :class:`~trinity.extensibility.plugin.BaseAsyncStopPlugin` depending on the kind of plugin that we
-intend to write. For now, we'll stick to :class:`~trinity.extensibility.plugin.BaseIsolatedPlugin`
+intend to write. For now, we'll stick to :class:`~trinity.extensibility.asyncio.AsyncioIsolatedPlugin`
 which is the most commonly used plugin category.
 
 Every plugin needs to overwrite ``name`` so voilà, here's our first plugin!
@@ -239,7 +239,7 @@ service.
    :language: python
    :pyobject: PeerCountReporter
 
-Then, the implementation of :meth:`~trinity.extensibility.plugin.BaseIsolatedPlugin.do_start` is
+Then, the implementation of :meth:`~trinity.extensibility.asyncio.AsyncioIsolatedPlugin.do_start` is
 only concerned about running the service on a fresh event loop.
 
 .. literalinclude:: ../../trinity-external-plugins/examples/peer_count_reporter/peer_count_reporter_plugin/plugin.py
@@ -273,10 +273,10 @@ is started with the ``--report-peer-count`` flag.
    :language: python
    :pyobject: PeerCountReporterPlugin.on_ready
 
-In case of a :class:`~trinity.extensibility.plugin.BaseIsolatedPlugin`, this will cause the
-:meth:`~trinity.extensibility.plugin.BaseIsolatedPlugin.do_start` method to run on an entirely
+In case of a :class:`~trinity.extensibility.asyncio.AsyncioIsolatedPlugin`, this will cause the
+:meth:`~trinity.extensibility.asyncio.AsyncioIsolatedPlugin.do_start` method to run on an entirely
 separated, new process. In other cases
-:meth:`~trinity.extensibility.plugin.BaseIsolatedPlugin.do_start` will simply run in the same
+:meth:`~trinity.extensibility.asyncio.AsyncioIsolatedPlugin.do_start` will simply run in the same
 process as the plugin manager that the plugin is controlled by.
 
 

--- a/trinity-external-plugins/examples/peer_count_reporter/peer_count_reporter_plugin/plugin.py
+++ b/trinity-external-plugins/examples/peer_count_reporter/peer_count_reporter_plugin/plugin.py
@@ -6,7 +6,7 @@ import asyncio
 
 from p2p.service import BaseService
 from trinity.endpoint import TrinityEventBusEndpoint
-from trinity.extensibility import BaseIsolatedPlugin
+from trinity.extensibility import AsyncioIsolatedPlugin
 from trinity.protocol.common.events import PeerCountRequest
 from trinity._utils.shutdown import exit_with_endpoint_and_services
 
@@ -34,7 +34,7 @@ class PeerCountReporter(BaseService):
             await asyncio.sleep(5)
 
 
-class PeerCountReporterPlugin(BaseIsolatedPlugin):
+class PeerCountReporterPlugin(AsyncioIsolatedPlugin):
 
     @property
     def name(self) -> str:

--- a/trinity/extensibility/__init__.py
+++ b/trinity/extensibility/__init__.py
@@ -1,3 +1,6 @@
+from trinity.extensibility.asyncio import (  # noqa: F401
+    AsyncioIsolatedPlugin,
+)
 from trinity.extensibility.events import (  # noqa: F401
     BaseEvent
 )
@@ -8,7 +11,6 @@ from trinity.extensibility.exceptions import (  # noqa: F401
 from trinity.extensibility.plugin import (  # noqa: F401
     BaseAsyncStopPlugin,
     BaseMainProcessPlugin,
-    BaseIsolatedPlugin,
     BasePlugin,
     DebugPlugin,
     PluginStatus,

--- a/trinity/extensibility/asyncio.py
+++ b/trinity/extensibility/asyncio.py
@@ -1,0 +1,52 @@
+import asyncio
+
+from lahja import ConnectionConfig
+
+from trinity.constants import MAIN_EVENTBUS_ENDPOINT
+from trinity.extensibility.events import PluginStartedEvent
+from trinity.endpoint import TrinityEventBusEndpoint
+
+from .plugin import BaseIsolatedPlugin
+
+
+class AsyncioIsolatedPlugin(BaseIsolatedPlugin):
+    _event_bus: TrinityEventBusEndpoint = None
+
+    @property
+    def event_bus(self) -> TrinityEventBusEndpoint:
+        if self._event_bus is None:
+            self._event_bus = TrinityEventBusEndpoint()
+        return self._event_bus
+
+    def _spawn_start(self) -> None:
+        self._setup_logging()
+
+        with self.boot_info.trinity_config.process_id_file(self.normalized_name):
+            loop = asyncio.get_event_loop()
+            asyncio.ensure_future(self._prepare_start())
+            loop.run_forever()
+            loop.close()
+
+    async def _prepare_start(self) -> None:
+        connection_config = ConnectionConfig.from_name(
+            self.normalized_name,
+            self.boot_info.trinity_config.ipc_dir,
+        )
+        await self.event_bus.start_serving(connection_config)
+        await self.event_bus.connect_to_endpoints(
+            ConnectionConfig.from_name(
+                MAIN_EVENTBUS_ENDPOINT, self.boot_info.trinity_config.ipc_dir
+            )
+        )
+        # This makes the `main` process aware of this Endpoint which will then propagate the info
+        # so that every other Endpoint can connect directly to the plugin Endpoint
+        await self.event_bus.announce_endpoint()
+        await self.event_bus.broadcast(
+            PluginStartedEvent(type(self))
+        )
+
+        # Whenever new EventBus Endpoints come up the `main` process broadcasts this event
+        # and we connect to every Endpoint directly
+        asyncio.ensure_future(self.event_bus.auto_connect_new_announced_endpoints())
+
+        self.do_start()

--- a/trinity/plugins/builtin/ethstats/plugin.py
+++ b/trinity/plugins/builtin/ethstats/plugin.py
@@ -15,7 +15,7 @@ from trinity.endpoint import (
     TrinityEventBusEndpoint,
 )
 from trinity.extensibility import (
-    BaseIsolatedPlugin,
+    AsyncioIsolatedPlugin,
 )
 from trinity._utils.shutdown import (
     exit_with_endpoint_and_services,
@@ -31,7 +31,7 @@ DEFAULT_SERVERS_URLS = {
 }
 
 
-class EthstatsPlugin(BaseIsolatedPlugin):
+class EthstatsPlugin(AsyncioIsolatedPlugin):
     server_url: str
     server_secret: str
     stats_interval: int

--- a/trinity/plugins/builtin/json_rpc/plugin.py
+++ b/trinity/plugins/builtin/json_rpc/plugin.py
@@ -18,7 +18,7 @@ from trinity.db.eth1.manager import (
     create_db_consumer_manager
 )
 from trinity.extensibility import (
-    BaseIsolatedPlugin,
+    AsyncioIsolatedPlugin,
 )
 from trinity.endpoint import (
     TrinityEventBusEndpoint,
@@ -42,7 +42,7 @@ from trinity._utils.shutdown import (
 )
 
 
-class JsonRpcServerPlugin(BaseIsolatedPlugin):
+class JsonRpcServerPlugin(AsyncioIsolatedPlugin):
 
     @property
     def name(self) -> str:

--- a/trinity/plugins/builtin/network_db/plugin.py
+++ b/trinity/plugins/builtin/network_db/plugin.py
@@ -23,8 +23,8 @@ from trinity.config import (
     TrinityConfig,
 )
 from trinity.db.orm import get_tracking_database
-from trinity.extensibility.plugin import (
-    BaseIsolatedPlugin,
+from trinity.extensibility import (
+    AsyncioIsolatedPlugin,
 )
 from trinity.db.network import (
     get_networkdb_path,
@@ -52,7 +52,7 @@ from .eth1_peer_db.tracker import (
 )
 
 
-class NetworkDBPlugin(BaseIsolatedPlugin):
+class NetworkDBPlugin(AsyncioIsolatedPlugin):
     @property
     def name(self) -> str:
         return "Network Database"

--- a/trinity/plugins/builtin/peer_discovery/plugin.py
+++ b/trinity/plugins/builtin/peer_discovery/plugin.py
@@ -47,7 +47,7 @@ from trinity.endpoint import (
     TrinityEventBusEndpoint,
 )
 from trinity.extensibility import (
-    BaseIsolatedPlugin,
+    AsyncioIsolatedPlugin,
 )
 from trinity.protocol.bcc.proto import (
     BCCProtocol,
@@ -146,7 +146,7 @@ class DiscoveryBootstrapService(BaseService):
             self.event_bus.request_shutdown("Discovery ended unexpectedly")
 
 
-class PeerDiscoveryPlugin(BaseIsolatedPlugin):
+class PeerDiscoveryPlugin(AsyncioIsolatedPlugin):
     """
     Continously discover other Ethereum nodes.
     """

--- a/trinity/plugins/builtin/request_server/plugin.py
+++ b/trinity/plugins/builtin/request_server/plugin.py
@@ -26,7 +26,7 @@ from trinity.endpoint import (
     TrinityEventBusEndpoint,
 )
 from trinity.extensibility import (
-    BaseIsolatedPlugin,
+    AsyncioIsolatedPlugin,
 )
 from trinity.protocol.bcc.servers import (
     BCCRequestServer,
@@ -42,7 +42,7 @@ from trinity._utils.shutdown import (
 )
 
 
-class RequestServerPlugin(BaseIsolatedPlugin):
+class RequestServerPlugin(AsyncioIsolatedPlugin):
 
     @property
     def name(self) -> str:

--- a/trinity/plugins/builtin/upnp/plugin.py
+++ b/trinity/plugins/builtin/upnp/plugin.py
@@ -8,7 +8,7 @@ from trinity.endpoint import (
     TrinityEventBusEndpoint,
 )
 from trinity.extensibility import (
-    BaseIsolatedPlugin,
+    AsyncioIsolatedPlugin,
 )
 from trinity._utils.shutdown import (
     exit_with_endpoint_and_services,
@@ -18,7 +18,7 @@ from .nat import (
 )
 
 
-class UpnpPlugin(BaseIsolatedPlugin):
+class UpnpPlugin(AsyncioIsolatedPlugin):
     """
     Continously try to map external to internal ip address/port using the
     Universal Plug 'n' Play (upnp) standard.

--- a/trinity/plugins/eth2/beacon/plugin.py
+++ b/trinity/plugins/eth2/beacon/plugin.py
@@ -23,24 +23,14 @@ from p2p.constants import (
 from trinity._utils.shutdown import (
     exit_with_endpoint_and_services,
 )
-from trinity.config import (
-    BeaconAppConfig,
-)
 from trinity.db.beacon.manager import (
     create_db_consumer_manager,
 )
-from trinity.endpoint import (
-    TrinityEventBusEndpoint,
-)
-from trinity.extensibility import (
-    BaseIsolatedPlugin,
-)
-from trinity.server import (
-    BCCServer,
-)
-from trinity.sync.beacon.chain import (
-    BeaconChainSyncer,
-)
+from trinity.config import BeaconAppConfig
+from trinity.endpoint import TrinityEventBusEndpoint
+from trinity.extensibility import AsyncioIsolatedPlugin
+from trinity.server import BCCServer
+from trinity.sync.beacon.chain import BeaconChainSyncer
 from trinity.sync.common.chain import (
     SyncBlockImporter,
 )
@@ -53,7 +43,7 @@ from .validator import (
 )
 
 
-class BeaconNodePlugin(BaseIsolatedPlugin):
+class BeaconNodePlugin(AsyncioIsolatedPlugin):
 
     @property
     def name(self) -> str:


### PR DESCRIPTION
### What was wrong?

With `trio` coming, we need the `BaseIsolatedPlugin` to not have any `asyncio` specific components.

### How was it fixed?

Made `BaseIsolatedPlugin` a proper abstract base class and implemented `AynscioIsolatedPlugin` which contains all of the `asyncio` specific stuff.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history

[//]: # (For important changes, please add a new entry to the running release notes PR)
[//]: # (You can find the current one using: https://github.com/ethereum/trinity/pulls?q=is%3Aopen+is%3Apr+label%3A%22Release+Notes%22 )
[//]: # (See: https://trinity-client.readthedocs.io/en/latest/contributing.html#pull-requests)
- [ ] Add entry to the [release notes PR](https://github.com/ethereum/trinity/pulls?q=is%3Aopen+is%3Apr+label%3A%22Release+Notes%22)

#### Cute Animal Picture


![Cute Baby Hippo (11)](https://user-images.githubusercontent.com/824194/58386430-0f139980-7fbd-11e9-960d-fde0d8ecca1b.jpg)
