### PR TITLE
Ewwww, lists....

### DIFF
--- a/p2p/kademlia.py
+++ b/p2p/kademlia.py
@@ -388,5 +388,5 @@ def _compute_shared_prefix_bits(nodes: List[Node]) -> int:
     raise AssertionError("Unable to calculate number of shared prefix bits")
 
 
-def sort_by_distance(nodes: List[Node], target_id: int) -> List[Node]:
-    return sorted(nodes, key=operator.methodcaller('distance_to', target_id))
+def sort_by_distance(nodes: Tuple[Node, ...], target_id: int) -> Tuple[Node, ...]:
+    return tuple(sorted(nodes, key=operator.methodcaller('distance_to', target_id)))


### PR DESCRIPTION
### What was wrong?

A bunch of the `p2p.discovery` code uses lists.  I don't like it...

### How was it fixed?

Convert to tuples.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] Clean up commit history

[//]: # (For important changes, please add a new entry to the running release notes PR)
[//]: # (You can find the current one using: https://github.com/ethereum/trinity/pulls?q=is%3Aopen+is%3Apr+label%3A%22Release+Notes%22 )
[//]: # (See: https://trinity-client.readthedocs.io/en/latest/contributing.html#pull-requests)
- [ ] Add entry to the [release notes PR](https://github.com/ethereum/trinity/pulls?q=is%3Aopen+is%3Apr+label%3A%22Release+Notes%22)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses]()
