### PR TITLE
tests: increase timeout for all integration tests

### DIFF
--- a/tests/integration/test_trinity_cli.py
+++ b/tests/integration/test_trinity_cli.py
@@ -47,7 +47,7 @@ from trinity._utils.async_iter import (
 )
 @pytest.mark.asyncio
 async def test_full_boot(async_process_runner, command):
-    await async_process_runner.run(command, timeout_sec=30)
+    await async_process_runner.run(command, timeout_sec=40)
     assert await contains_all(async_process_runner.stderr, {
         "Started DB server process",
         "Started networking process",
@@ -65,7 +65,7 @@ async def test_full_boot(async_process_runner, command):
 )
 @pytest.mark.asyncio
 async def test_txpool_full_boot(async_process_runner, command):
-    await async_process_runner.run(command, timeout_sec=30)
+    await async_process_runner.run(command, timeout_sec=40)
     assert await contains_all(async_process_runner.stderr, {
         "Started DB server process",
         "Started networking process",
@@ -84,7 +84,7 @@ async def test_txpool_full_boot(async_process_runner, command):
 )
 @pytest.mark.asyncio
 async def test_txpool_deactivated(async_process_runner, command):
-    await async_process_runner.run(command, timeout_sec=30)
+    await async_process_runner.run(command, timeout_sec=40)
     assert await contains_all(async_process_runner.stderr, {
         "Started DB server process",
         "Started networking process",
@@ -101,7 +101,7 @@ async def test_txpool_deactivated(async_process_runner, command):
 )
 @pytest.mark.asyncio
 async def test_light_boot(async_process_runner, command):
-    await async_process_runner.run(command, timeout_sec=30)
+    await async_process_runner.run(command, timeout_sec=40)
     assert await contains_all(async_process_runner.stderr, {
         "Started DB server process",
         "Started networking process",
@@ -117,7 +117,7 @@ async def test_light_boot(async_process_runner, command):
 )
 @pytest.mark.asyncio
 async def test_web3(command, async_process_runner):
-    await async_process_runner.run(command, timeout_sec=30)
+    await async_process_runner.run(command, timeout_sec=40)
     assert await contains_all(async_process_runner.stderr, {
         "Started DB server process",
         "Started networking process",
@@ -174,7 +174,7 @@ async def test_does_not_throw(async_process_runner, command):
 )
 @pytest.mark.asyncio
 async def test_logger(async_process_runner, command, expected_to_contain_log):
-    await async_process_runner.run(command, timeout_sec=30)
+    await async_process_runner.run(command, timeout_sec=40)
     actually_contains_log = await contains_all(async_process_runner.stderr, {
         "DiscoveryProtocol  >>> ping",
     })
@@ -196,7 +196,7 @@ async def test_shutdown(command, async_process_runner):
     async def run_then_shutdown_and_yield_output():
         # This test spins up Trinity, waits until it has started syncing, sends a SIGINT and then
         # tries to scan the entire shutdown process for errors. It needs a little bit more time.
-        await async_process_runner.run(command, timeout_sec=40)
+        await async_process_runner.run(command, timeout_sec=50)
 
         # Somewhat arbitrary but we wait until the syncer starts before we trigger the shutdown.
         # At this point, most of the internals should be set up, leaving us with more room for


### PR DESCRIPTION
### What was wrong?

CircleCI tests have started to have sporadic failures when running `py3{6,7}-wheel-cli`. Reason unknown: could be some change in our codebase, CircleCI having less resources to spare, or Ethereum network conditions (happens on main-net only, it seems).

Reported by @jannikluhn in PR #652, where these failures seem unrelated. I've observed the CI runs fail on `master` (corroborating).

### How was it fixed?

Increase time-out. :drum:

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history

[//]: # (For important changes, please add a new entry to the running release notes PR)
[//]: # (You can find the current one using: https://github.com/ethereum/trinity/pulls?q=is%3Aopen+is%3Apr+label%3A%22Release+Notes%22 )
[//]: # (See: https://trinity-client.readthedocs.io/en/latest/contributing.html#pull-requests)
- [x] Add entry to the [release notes PR](https://github.com/ethereum/trinity/pulls?q=is%3Aopen+is%3Apr+label%3A%22Release+Notes%22): not needed, maintenance meta.

### Cute Animal Picture

One sec...

![put a cute animal picture link inside the parentheses]()
