### PR TITLE
Improve ergonomics, flexibility and consistency of logging

### DIFF
--- a/trinity/bootstrap.py
+++ b/trinity/bootstrap.py
@@ -125,25 +125,36 @@ def main_entry(trinity_boot: BootFn,
             "directory with `--data-dir path/to/data/directory`"
         )
 
-    has_ambigous_logging_config = (
-        args.log_levels is not None and
-        None in args.log_levels and
+    # The `common_log_level` is derived from `--log-level <Level>` / `-l <Level>` without
+    # specifying any module. If present, it is used for both `stderr` and `file` logging.
+    common_log_level = args.log_levels and args.log_levels.get(None)
+    has_ambigous_logging_config = ((
+        common_log_level is not None and
         args.stderr_log_level is not None
-    )
+    ) or (
+        common_log_level is not None and
+        args.file_log_level is not None
+    ))
+
     if has_ambigous_logging_config:
         parser.error(
-            "\n"
-            "Ambiguous logging configuration: The logging level for stderr was "
-            "configured with both `--stderr-log-level` and `--log-level`. "
-            "Please remove one of these flags",
+            f"""\n
+            Ambiguous logging configuration: The `--log-level (-l)` flag sets the
+            log level for both file and stderr logging.
+            To configure different log level for file and stderr logging,
+            remove the `--log-level` flag and use `--stderr-log-level` and/or
+            `--file-log-level` separately.
+            Alternatively, remove the `--stderr-log-level` and/or `--file-log-level`
+            flags to share one single log level across both handlers.
+            """
         )
 
     if is_prerelease():
         # this modifies the asyncio logger, but will be overridden by any custom settings below
         enable_warnings_by_default()
 
-    stderr_logger, formatter, handler_stream = setup_trinity_stderr_logging(
-        args.stderr_log_level or (args.log_levels and args.log_levels.get(None))
+    stderr_logger, handler_stream = setup_trinity_stderr_logging(
+        args.stderr_log_level or common_log_level
     )
 
     if args.log_levels:
@@ -173,10 +184,9 @@ def main_entry(trinity_boot: BootFn,
 
     file_logger, log_queue, listener = setup_trinity_file_and_queue_logging(
         stderr_logger,
-        formatter,
         handler_stream,
         trinity_config.logfile_path,
-        args.file_log_level,
+        args.file_log_level or common_log_level,
     )
 
     display_launch_logs(trinity_config)


### PR DESCRIPTION
### What was wrong?

Configuring the individual loggers is cumbersome (see https://github.com/ethereum/trinity/pull/659#discussion_r287093201)

### How was it fixed?

Let's go though a bunch of examples:

1. Run `trinity` -> stderr prints exactly the same logging output as current master (`INFO` to stderr, `DEBUG` to file as `DEBUG` is the default for file logging) 

2. Run `trinity -l p2p.discovery=DEBUG2` -> stderr + file log print only `INFO` logs except for `p2p.discovery` where `DEBUG2` or higher is shown

3. Run `trinity -l ERROR -l p2p.discovery=DEBUG2` -> stderr + file log print only `ERROR` logs except for `p2p.discovery` where `DEBUG2` or higher is shown

4. Run `trinity --file-log-level DEBUG2 --stderr-log-level INFO` -> stderr + file log print only `INFO` logs but file log prints `DEBUG2` or higher logs

5. Run `trinity --stderr-log-level DEBUG2 --file-log-level INFO` -> stderr prints `DEBUG2` or higher logs but file log prints only `INFO` logs

(The reverse of 4)

Notice that previously the usage of `--log-level` (or `-l`)  without any specified module was a bit inconsistent so that it was taken as default for `--stderr-log-level` but not as default for `--file-log-level`. 

This also meant that previously only the combination of `--log-level` with `--stderr-log-level` was illegal while the combination of `--log-level` with `--file-log-level` was perfectly fine. This was now changed so that both are treated equally and the user showing error message was improved (hopefully!)

One side effect of this is that the behavior for something like `trinity -l ERROR` is now slightly different. Previously this would cause only the stderr logging to reduce to level ERROR but keep file logging on level DEBUG (default). Now, it causes both stderr and file logging to use level ERROR. To get the previous behavior where ERROR is only used for stderr logging while file logging sticks to its default use `trinity --stderr-log-level ERROR` instead.

There were also some minor cleanups and refactoring.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history
- [x] write tests to proof all the claims this PR makes 

[//]: # (For important changes, please add a new entry to the running release notes PR)
[//]: # (You can find the current one using: https://github.com/ethereum/trinity/pulls?q=is%3Aopen+is%3Apr+label%3A%22Release+Notes%22 )
[//]: # (See: https://trinity-client.readthedocs.io/en/latest/contributing.html#pull-requests)
- [ ] Add entry to the [release notes PR](https://github.com/ethereum/trinity/pulls?q=is%3Aopen+is%3Apr+label%3A%22Release+Notes%22)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://i.pinimg.com/originals/3e/21/a6/3e21a6be3636ea03ff2c4f176fd93c72.jpg)
