### PR TITLE
Add arg to take Unix integer as genesis time

### DIFF
--- a/eth2/beacon/scripts/run_beacon_nodes.py
+++ b/eth2/beacon/scripts/run_beacon_nodes.py
@@ -118,7 +118,7 @@ class Node:
             "trinity-beacon",
             f"--port={self.port}",
             f"--trinity-root-dir={self.root_dir}",
-            f" --beacon-nodekey={remove_0x_prefix(self.node_privkey.to_hex())}",
+            f"--beacon-nodekey={remove_0x_prefix(self.node_privkey.to_hex())}",
             "-l debug",
         ]
         if len(self.bootstrap_nodes) != 0:
@@ -187,6 +187,7 @@ class Node:
 async def main():
     num_validators = 5
     time_bob_wait_for_alice = 15
+    genesis_delay = time_bob_wait_for_alice * 3
 
     proc = await run(
         f"rm -rf {Node.dir_root}"
@@ -198,7 +199,13 @@ async def main():
     await proc.wait()
 
     proc = await run(
-        f"trinity-beacon testnet --num={num_validators} --network-dir={Node.dir_root}"
+        " ".join((
+            "trinity-beacon",
+            "testnet",
+            f"--num={num_validators}",
+            f"--network-dir={Node.dir_root}",
+            f"--genesis-delay={genesis_delay}",
+        ))
     )
     await proc.wait()
 

--- a/tests/plugins/eth2/network_generator/test_network_generator.py
+++ b/tests/plugins/eth2/network_generator/test_network_generator.py
@@ -7,7 +7,8 @@ from trinity._utils.async_iter import (
 @pytest.mark.parametrize(
     'command',
     (
-        ('trinity-beacon', 'testnet', "--num=5"),
+        ('trinity-beacon', 'testnet', "--num=1", "--genesis-delay=10"),
+        ('trinity-beacon', 'testnet', "--num=1", "--genesis-time=1559315137"),
     )
 )
 @pytest.mark.asyncio

--- a/tests/plugins/eth2/network_generator/test_network_generator.py
+++ b/tests/plugins/eth2/network_generator/test_network_generator.py
@@ -20,3 +20,17 @@ async def test_directory_generation(async_process_runner, command, tmpdir):
     assert await contains_all(async_process_runner.stderr, {
         "Network generation completed",
     })
+
+
+@pytest.mark.parametrize(
+    'command',
+    (
+        ('trinity-beacon', 'testnet', "--num=1",),
+    )
+)
+@pytest.mark.asyncio
+async def test_missing_genesis_time_arg(async_process_runner, command):
+    await async_process_runner.run(command, timeout_sec=30)
+    assert await contains_all(async_process_runner.stderr, {
+        "one of the arguments --genesis-delay --genesis-time is required",
+    })

--- a/trinity/plugins/eth2/network_generator/plugin.py
+++ b/trinity/plugins/eth2/network_generator/plugin.py
@@ -139,7 +139,7 @@ class NetworkGeneratorPlugin(BaseMainProcessPlugin):
         logger.info("Generating testnet")
         network_dir = args.network_dir
         if len(os.listdir(network_dir)) > 0:
-            logger.error("This directory is not empty, won't create network files here.")
+            logger.error("This directory is not empty, won't create network files here")
             sys.exit(1)
 
         clients = cls.generate_trinity_root_dirs(network_dir)
@@ -161,7 +161,7 @@ class NetworkGeneratorPlugin(BaseMainProcessPlugin):
                       network_dir: Path,
                       clients: Tuple[Client, ...]) -> Dict[Any, Any]:
         logger = cls.get_logger()
-        logger.info(f"Creating {num} validators' keys")
+        logger.info("Creating %s validators' keys", num)
         keys_dir = network_dir / KEYS_DIR
         keys_dir.mkdir()
 
@@ -206,7 +206,8 @@ class NetworkGeneratorPlugin(BaseMainProcessPlugin):
         genesis_time = get_genesis_time()
         print(genesis_time)
         logger.info(
-            f"Genesis time will be {humanize_seconds(genesis_time-int(time.time()))} from now"
+            "Genesis time will be %s from now",
+            humanize_seconds(genesis_time - int(time.time())),
         )
         state = state.copy(
             genesis_time=genesis_time,

--- a/trinity/plugins/eth2/network_generator/plugin.py
+++ b/trinity/plugins/eth2/network_generator/plugin.py
@@ -122,7 +122,7 @@ class NetworkGeneratorPlugin(BaseMainProcessPlugin):
         )
         genesis_time_group.add_argument(
             "--genesis-delay",
-            help="Seconds before genesis time from now",
+            help="Set seconds delay after the genesis state is created as genesis time",
             type=int,
         )
         genesis_time_group.add_argument(
@@ -204,7 +204,6 @@ class NetworkGeneratorPlugin(BaseMainProcessPlugin):
             genesis_time=dummy_time,
         )
         genesis_time = get_genesis_time()
-        print(genesis_time)
         logger.info(
             "Genesis time will be %s from now",
             humanize_seconds(genesis_time - int(time.time())),

--- a/trinity/plugins/eth2/network_generator/plugin.py
+++ b/trinity/plugins/eth2/network_generator/plugin.py
@@ -11,10 +11,14 @@ import sys
 import time
 from typing import (
     Any,
+    Callable,
     Dict,
     Tuple,
 )
 
+from eth_utils import (
+    humanize_seconds,
+)
 from ruamel.yaml import (
     YAML,
 )
@@ -76,6 +80,18 @@ class Client:
         self.validator_keys_dir = self.client_dir / VALIDATOR_KEY_DIR
 
 
+def get_genesis_time_from_constant(genesis_time: Timestamp) -> Callable[[], Timestamp]:
+    def get_genesis_time() -> Timestamp:
+        return genesis_time
+    return get_genesis_time
+
+
+def get_genesis_time_from_delay(genesis_delay: Second)-> Callable[[], Timestamp]:
+    def get_genesis_time() -> Timestamp:
+        return Timestamp(int(time.time()) + genesis_delay)
+    return get_genesis_time
+
+
 class NetworkGeneratorPlugin(BaseMainProcessPlugin):
     @property
     def name(self) -> str:
@@ -100,11 +116,19 @@ class NetworkGeneratorPlugin(BaseMainProcessPlugin):
             type=int,
             default=100,
         )
-        testnet_generator_parser.add_argument(
+
+        genesis_time_group = testnet_generator_parser.add_mutually_exclusive_group(
+            required=True,
+        )
+        genesis_time_group.add_argument(
             "--genesis-delay",
             help="Seconds before genesis time from now",
             type=int,
-            default=60,
+        )
+        genesis_time_group.add_argument(
+            "--genesis-time",
+            help="Set a genesis time as Unix int, e.g. 1559292765",
+            type=int,
         )
 
         testnet_generator_parser.set_defaults(func=cls.run_generate_testnet_dir)
@@ -120,7 +144,14 @@ class NetworkGeneratorPlugin(BaseMainProcessPlugin):
 
         clients = cls.generate_trinity_root_dirs(network_dir)
         keymap = cls.generate_keys(args.num, network_dir, clients)
-        cls.generate_genesis_state(args.genesis_delay, network_dir, keymap, clients)
+
+        get_genesis_time = (
+            get_genesis_time_from_constant(args.genesis_time)
+            if args.genesis_time is not None
+            else get_genesis_time_from_delay(args.genesis_delay)
+        )
+
+        cls.generate_genesis_state(get_genesis_time, network_dir, keymap, clients)
 
         logger.info(bold_green("Network generation completed"))
 
@@ -156,7 +187,7 @@ class NetworkGeneratorPlugin(BaseMainProcessPlugin):
 
     @classmethod
     def generate_genesis_state(cls,
-                               genesis_delay: Second,
+                               get_genesis_time: Callable[[], Timestamp],
                                network_dir: Path,
                                keymap: Dict[Any, Any],
                                clients: Tuple[Client, ...]) -> None:
@@ -172,8 +203,11 @@ class NetworkGeneratorPlugin(BaseMainProcessPlugin):
             genesis_block_class=state_machine_class.block_class,
             genesis_time=dummy_time,
         )
-        logger.info(f"Genesis time will be {genesis_delay} seconds from now")
-        genesis_time = Timestamp(int(time.time()) + genesis_delay)
+        genesis_time = get_genesis_time()
+        print(genesis_time)
+        logger.info(
+            f"Genesis time will be {humanize_seconds(genesis_time-int(time.time()))} from now"
+        )
         state = state.copy(
             genesis_time=genesis_time,
         )


### PR DESCRIPTION
### What was wrong?

Now Eth2 network generator only takes seconds delay as the genesis time.

### How was it fixed?

Add a parser argument to take Unix integer as genesis time

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://preview.redd.it/rww8wyqm5k131.jpg?width=960&crop=smart&auto=webp&s=6d6eadafd5d7d4f4094c9b6f6b8b112fea293eeb)
