### PR TITLE
Prepare Lahja upgrade

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ deps = {
         "plyvel==1.0.5",
         PYEVM_DEPENDENCY,
         "web3==4.4.1",
-        "lahja@git+https://github.com/ethereum/lahja.git@22396a8fe79809357438e917e66a7101e6e3ac01",  # noqa: E501
+        "lahja>=0.14.0,<0.15.0",
         "termcolor>=1.1.0,<2.0.0",
         "uvloop==0.11.2;platform_system=='Linux' or platform_system=='Darwin' or platform_system=='FreeBSD'",  # noqa: E501
         "websockets==5.0.1",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -125,19 +125,14 @@ def async_process_runner():
 
 @pytest.fixture
 async def event_bus():
-    endpoint = TrinityEventBusEndpoint()
     # Tests run concurrently, therefore we need unique IPC paths
     ipc_path = Path(f"networking-{uuid.uuid4()}.ipc")
     networking_connection_config = ConnectionConfig(
         name=NETWORKING_EVENTBUS_ENDPOINT,
         path=ipc_path
     )
-    await endpoint.start_serving(networking_connection_config)
-    await endpoint.connect_to_endpoints(networking_connection_config)
-    try:
+    async with TrinityEventBusEndpoint.serve(networking_connection_config) as endpoint:
         yield endpoint
-    finally:
-        endpoint.stop()
 
 
 @pytest.fixture(scope='session')

--- a/tests/core/network-db/test_connection_tracker_server.py
+++ b/tests/core/network-db/test_connection_tracker_server.py
@@ -34,7 +34,7 @@ async def test_connection_tracker_server_and_client(event_loop, event_bus):
     bus_tracker = ConnectionTrackerClient(event_bus, config=config)
 
     # Give `bus_tracker` a moment to setup subscriptions
-    await event_bus.wait_until_all_connections_subscribed_to(ShouldConnectToPeerRequest)
+    await event_bus.wait_until_all_endpoints_subscribed_to(ShouldConnectToPeerRequest)
     # ensure we can read from the tracker over the event bus
     assert await bus_tracker.should_connect_to(remote_a) is False
 

--- a/tests/core/p2p-proto/bcc/test_requests.py
+++ b/tests/core/p2p-proto/bcc/test_requests.py
@@ -62,7 +62,7 @@ async def get_request_server_setup(request, event_loop, event_bus, chain_db):
             event_bus, TO_NETWORKING_BROADCAST_CONFIG, bob.context.chain_db)
         asyncio.ensure_future(bob_request_server.run())
 
-        await event_bus.wait_until_all_connections_subscribed_to(GetBeaconBlocksEvent)
+        await event_bus.wait_until_all_endpoints_subscribed_to(GetBeaconBlocksEvent)
 
         def finalizer():
             event_loop.run_until_complete(bob_request_server.cancel())

--- a/tests/core/p2p-proto/test_server.py
+++ b/tests/core/p2p-proto/test_server.py
@@ -176,7 +176,7 @@ async def test_peer_pool_answers_connect_commands(event_loop, event_bus, server)
 
         assert len(server.peer_pool.connected_nodes) == 0
 
-        await event_bus.wait_until_any_connection_subscribed_to(ConnectToNodeCommand)
+        await event_bus.wait_until_any_endpoint_subscribed_to(ConnectToNodeCommand)
         await event_bus.broadcast(
             ConnectToNodeCommand(RECEIVER_REMOTE),
             TO_NETWORKING_BROADCAST_CONFIG

--- a/tests/core/test_service_and_endpoint_shutdown_utils.py
+++ b/tests/core/test_service_and_endpoint_shutdown_utils.py
@@ -26,7 +26,7 @@ class SimpleService(BaseService):
 def run_service(ready_to_kill_event):
     loop = asyncio.get_event_loop()
 
-    endpoint = TrinityEventBusEndpoint()
+    endpoint = TrinityEventBusEndpoint("dummy")
     service = SimpleService(ready_to_kill_event, loop=loop)
 
     asyncio.ensure_future(exit_with_endpoint_and_services(endpoint, service))

--- a/tests/integration/test_trinity_cli.py
+++ b/tests/integration/test_trinity_cli.py
@@ -131,9 +131,9 @@ async def test_web3(command, async_process_runner):
         "Started DB server process",
         "Started networking process",
         "IPC started at",
-        # Ensure we do not start making requests that depend on the networking
-        # process, before it is connected to the JSON-RPC-API
-        "EventBus Endpoint networking connecting to other Endpoint bjson-rpc-api",
+        # Ensure we do not start making requests before Trinity is ready.
+        # Waiting for fast-sync to start gives us a reliable starting point
+        "Starting fast-sync",
     })
 
     attached_trinity = pexpect.spawn('trinity', ['attach'], logfile=sys.stdout, encoding="utf-8")

--- a/tests/p2p/test_peer_pool_event_server.py
+++ b/tests/p2p/test_peer_pool_event_server.py
@@ -19,7 +19,7 @@ async def test_event_bus_requests_against_peer_pool(request, event_loop, event_b
     peer_pool = ParagonMockPeerPoolWithConnectedPeers([alice, bob])
     async with run_peer_pool_event_server(event_bus, peer_pool):
 
-        await event_bus.wait_until_any_connection_subscribed_to(PeerCountRequest)
+        await event_bus.wait_until_any_endpoint_subscribed_to(PeerCountRequest)
 
         res = await event_bus.request(PeerCountRequest())
 

--- a/trinity/bootstrap.py
+++ b/trinity/bootstrap.py
@@ -108,7 +108,7 @@ def main_entry(trinity_boot: BootFn,
                plugins: Iterable[Type[BasePlugin]],
                sub_configs: Iterable[Type[BaseAppConfig]]) -> None:
 
-    main_endpoint = TrinityMainEventBusEndpoint()
+    main_endpoint = TrinityMainEventBusEndpoint(name=MAIN_EVENTBUS_ENDPOINT)
 
     plugin_manager = PluginManager(
         MainAndIsolatedProcessScope(main_endpoint),
@@ -255,12 +255,10 @@ async def trinity_boot_coro(kill_trinity, main_endpoint, trinity_config,  # type
         MAIN_EVENTBUS_ENDPOINT,
         trinity_config.ipc_dir
     )
-    await main_endpoint.start_serving(main_connection_config)
-    main_endpoint.track_and_propagate_available_endpoints()
+    await main_endpoint.start()
+    await main_endpoint.start_server(main_connection_config.path)
 
-    # We listen on events such as `ShutdownRequested` which may or may not originate on
-    # the `main_endpoint` which is why we connect to our own endpoint here
-    await main_endpoint.connect_to_endpoints(main_connection_config)
+    main_endpoint.track_and_propagate_available_endpoints()
 
     main_endpoint.subscribe(
         ShutdownRequest,

--- a/trinity/extensibility/asyncio.py
+++ b/trinity/extensibility/asyncio.py
@@ -15,7 +15,7 @@ class AsyncioIsolatedPlugin(BaseIsolatedPlugin):
     @property
     def event_bus(self) -> TrinityEventBusEndpoint:
         if self._event_bus is None:
-            self._event_bus = TrinityEventBusEndpoint()
+            self._event_bus = TrinityEventBusEndpoint(self.normalized_name)
         return self._event_bus
 
     def _spawn_start(self) -> None:
@@ -32,7 +32,8 @@ class AsyncioIsolatedPlugin(BaseIsolatedPlugin):
             self.normalized_name,
             self.boot_info.trinity_config.ipc_dir,
         )
-        await self.event_bus.start_serving(connection_config)
+        await self.event_bus.start()
+        await self.event_bus.start_server(connection_config.path)
         await self.event_bus.connect_to_endpoints(
             ConnectionConfig.from_name(
                 MAIN_EVENTBUS_ENDPOINT, self.boot_info.trinity_config.ipc_dir

--- a/trinity/nodes/base.py
+++ b/trinity/nodes/base.py
@@ -149,7 +149,6 @@ class Node(BaseService):
         )
 
     async def _run(self) -> None:
-        await self.event_bus.wait_until_serving()
         await self.notify_resource_available()
         self.run_daemon_task(self.handle_network_id_requests())
         self.run_daemon(self.get_p2p_server())

--- a/trinity/plugins/eth2/beacon/validator.py
+++ b/trinity/plugins/eth2/beacon/validator.py
@@ -124,7 +124,6 @@ class Validator(BaseService):
         self.get_ready_attestations: GetReadyAttestationsFn = get_ready_attestations_fn
 
     async def _run(self) -> None:
-        await self.event_bus.wait_until_serving()
         self.logger.info(
             bold_green("Validator service up  Handle indices=%s"),
             tuple(self.validator_privkeys.keys())


### PR DESCRIPTION
### What was wrong?

Trinity is on a git ref for `lahja` and needs to upgrade to `0.14.0` 

### How was it fixed?

1. In previous lahja versions connections where only one-way and we had to manually connect both ways. Lahja now handles the reverse connection on its own which leads to fewer manual connections.

2. It also leads to a new announcement scheme in general where every endpoint only connects to every other endpoint that appears *after* its own position in the centrally planned and maintained endpoint set. This ensures that no duplicate connection attempts can happen.

3. Upgraded to new APIs that let us wait on subscriptions

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] Clean up commit history

[//]: # (For important changes, please add a new entry to the running release notes PR)
[//]: # (You can find the current one using: https://github.com/ethereum/trinity/pulls?q=is%3Aopen+is%3Apr+label%3A%22Release+Notes%22 )
[//]: # (See: https://trinity-client.readthedocs.io/en/latest/contributing.html#pull-requests)
- [ ] Add entry to the [release notes PR](https://github.com/ethereum/trinity/pulls?q=is%3Aopen+is%3Apr+label%3A%22Release+Notes%22)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](http://www.thatcutesite.com/uploads/2010/04/birds_in_hand.jpg)
