### PR TITLE
Update sync tests to latest VM, where possible

### DIFF
--- a/tests/core/integration_test_helpers.py
+++ b/tests/core/integration_test_helpers.py
@@ -27,6 +27,7 @@ from eth.tools.builder.chain import (
 )
 from eth.db.header import HeaderDB
 from eth.vm.forks.byzantium import ByzantiumVM
+from eth.vm.forks.petersburg import PetersburgVM
 
 from trinity.constants import TO_NETWORKING_BROADCAST_CONFIG
 from trinity.db.base import BaseAsyncDB
@@ -128,6 +129,15 @@ class FakeAsyncChain(MiningChain):
     coro_validate_chain = async_passthrough('validate_chain')
     coro_validate_receipt = async_passthrough('validate_receipt')
     chaindb_class = FakeAsyncChainDB
+
+
+class LatestTestChain(FakeAsyncChain):
+    """
+    A test chain that uses the most recent mainnet VM from block 0.
+    That means the VM will explicitly change when a new network upgrade is locked in.
+    """
+    vm_configuration = ((0, PetersburgVM),)
+    network_id = 999
 
 
 class ByzantiumTestChain(FakeAsyncChain):

--- a/tests/core/integration_test_helpers.py
+++ b/tests/core/integration_test_helpers.py
@@ -21,9 +21,9 @@ from eth.db.atomic import AtomicDB
 from eth.db.chain import ChainDB
 from eth.tools.builder.chain import (
     build,
-    byzantium_at,
     enable_pow_mining,
     genesis,
+    latest_mainnet_at,
 )
 from eth.db.header import HeaderDB
 from eth.vm.forks.byzantium import ByzantiumVM
@@ -165,7 +165,7 @@ def load_mining_chain(db):
 
     return build(
         FakeAsyncChain,
-        byzantium_at(0),
+        latest_mainnet_at(0),
         enable_pow_mining(),
         genesis(db=db, params=GENESIS_PARAMS, state=GENESIS_STATE),
     )

--- a/tests/core/p2p-proto/test_server.py
+++ b/tests/core/p2p-proto/test_server.py
@@ -182,7 +182,8 @@ async def test_peer_pool_answers_connect_commands(event_loop, event_bus, server)
             TO_NETWORKING_BROADCAST_CONFIG
         )
 
-        await asyncio.sleep(0.1)
+        # This test was maybe 30% flaky at 0.1 sleep
+        await asyncio.sleep(0.2)
 
         assert len(server.peer_pool.connected_nodes) == 1
 

--- a/tests/core/p2p-proto/test_sync.py
+++ b/tests/core/p2p-proto/test_sync.py
@@ -26,6 +26,7 @@ from tests.core.integration_test_helpers import (
     FakeAsyncAtomicDB,
     FakeAsyncChainDB,
     FakeAsyncHeaderDB,
+    LatestTestChain,
     load_fixture_db,
     load_mining_chain,
     run_peer_pool_event_server,
@@ -58,7 +59,7 @@ async def test_fast_syncer(request,
         alice_headerdb=FakeAsyncHeaderDB(chaindb_fresh.db),
         bob_headerdb=FakeAsyncHeaderDB(chaindb_20.db))
     client_peer_pool = MockPeerPoolWithConnectedPeers([client_peer])
-    client = FastChainSyncer(ByzantiumTestChain(chaindb_fresh.db), chaindb_fresh, client_peer_pool)
+    client = FastChainSyncer(LatestTestChain(chaindb_fresh.db), chaindb_fresh, client_peer_pool)
     server_peer_pool = MockPeerPoolWithConnectedPeers([server_peer], event_bus=event_bus)
 
     async with run_peer_pool_event_server(
@@ -94,7 +95,7 @@ async def test_skeleton_syncer(request, event_loop, event_bus, chaindb_fresh, ch
         alice_headerdb=FakeAsyncHeaderDB(chaindb_fresh.db),
         bob_headerdb=FakeAsyncHeaderDB(chaindb_1000.db))
     client_peer_pool = MockPeerPoolWithConnectedPeers([client_peer])
-    client = FastChainSyncer(ByzantiumTestChain(chaindb_fresh.db), chaindb_fresh, client_peer_pool)
+    client = FastChainSyncer(LatestTestChain(chaindb_fresh.db), chaindb_fresh, client_peer_pool)
     server_peer_pool = MockPeerPoolWithConnectedPeers([server_peer], event_bus=event_bus)
 
     async with run_peer_pool_event_server(
@@ -279,7 +280,7 @@ async def test_light_syncer(request,
         alice_headerdb=FakeAsyncHeaderDB(chaindb_fresh.db),
         bob_headerdb=FakeAsyncHeaderDB(chaindb_20.db))
     client = LightChainSyncer(
-        ByzantiumTestChain(chaindb_fresh.db),
+        LatestTestChain(chaindb_fresh.db),
         chaindb_fresh,
         MockPeerPoolWithConnectedPeers([client_peer]))
     server_peer_pool = MockPeerPoolWithConnectedPeers([server_peer], event_bus=event_bus)


### PR DESCRIPTION
### What was wrong?

Was testing sync against Byzantium.

### How was it fixed?

- Update most of the sync tests to run against Petersburg
- Created a new test chain that will be easier to update to the latest VM

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://66.media.tumblr.com/2b4d16b4ec6558ba1f17225ffdf898a9/tumblr_inline_p3rlglw2BJ1u1ax71_500.jpg)