### PR TITLE
An in memory Transport for use in testing

### DIFF
--- a/p2p/tools/asyncio_streams.py
+++ b/p2p/tools/asyncio_streams.py
@@ -1,0 +1,44 @@
+import asyncio
+from typing import cast, Any, Callable, Tuple
+
+
+class MockTransport:
+    def __init__(self) -> None:
+        self._is_closing = False
+
+    def close(self) -> None:
+        self._is_closing = True
+
+    def is_closing(self) -> bool:
+        return self._is_closing
+
+
+class MockStreamWriter:
+    def __init__(self, write_target: Callable[..., None]) -> None:
+        self._target = write_target
+        self.transport = MockTransport()
+
+    def write(self, *args: Any, **kwargs: Any) -> None:
+        self._target(*args, **kwargs)
+
+    def close(self) -> None:
+        self.transport.close()
+
+
+TConnectedStreams = Tuple[
+    Tuple[asyncio.StreamReader, asyncio.StreamWriter],
+    Tuple[asyncio.StreamReader, asyncio.StreamWriter],
+]
+
+
+def get_directly_connected_streams() -> TConnectedStreams:
+    bob_reader = asyncio.StreamReader()
+    alice_reader = asyncio.StreamReader()
+    # Link the alice's writer to the bob's reader, and the bob's writer to the
+    # alice's reader.
+    bob_writer = MockStreamWriter(alice_reader.feed_data)
+    alice_writer = MockStreamWriter(bob_reader.feed_data)
+    return (
+        (alice_reader, cast(asyncio.StreamWriter, alice_writer)),
+        (bob_reader, cast(asyncio.StreamWriter, bob_writer)),
+    )

--- a/p2p/tools/memory_transport.py
+++ b/p2p/tools/memory_transport.py
@@ -1,0 +1,94 @@
+import asyncio
+import struct
+from typing import Tuple
+
+from cached_property import cached_property
+
+from eth_keys import datatypes
+
+from cancel_token import CancelToken
+
+from p2p.kademlia import Node
+from p2p.tools.asyncio_streams import get_directly_connected_streams
+from p2p.exceptions import PeerConnectionLost
+
+
+class MemoryTransport:
+    def __init__(self,
+                 remote: Node,
+                 private_key: datatypes.PrivateKey,
+                 reader: asyncio.StreamReader,
+                 writer: asyncio.StreamWriter,
+                 token: CancelToken = None) -> None:
+        self.remote = remote
+        self._private_key = private_key
+        self._reader = reader
+        self._writer = writer
+
+        if token is None:
+            token = CancelToken('MemoryTransport')
+        self._token = token
+
+    @classmethod
+    def connected_pair(cls,
+                       alice: Tuple[Node, datatypes.PrivateKey, CancelToken],
+                       bob: Tuple[Node, datatypes.PrivateKey, CancelToken],
+                       ) -> Tuple['MemoryTransport', 'MemoryTransport']:
+        (
+            (alice_reader, alice_writer),
+            (bob_reader, bob_writer),
+        ) = get_directly_connected_streams()
+        alice_remote, alice_private_key, alice_token = alice
+        bob_remote, bob_private_key, bob_token = bob
+        alice_transport = cls(
+            alice_remote,
+            alice_private_key,
+            alice_reader,
+            alice_writer,
+            alice_token,
+        )
+        bob_transport = cls(bob_remote, bob_private_key, bob_reader, bob_writer, bob_token)
+        return alice_transport, bob_transport
+
+    @cached_property
+    def public_key(self) -> datatypes.PublicKey:
+        return self._private_key.public_key
+
+    async def read(self, n: int, token: CancelToken) -> bytes:
+        try:
+            return await token.cancellable_wait(
+                self._reader.readexactly(n),
+                timeout=2,
+            )
+        except (asyncio.IncompleteReadError, ConnectionResetError, BrokenPipeError) as err:
+            raise PeerConnectionLost from err
+
+    def write(self, data: bytes) -> None:
+        self._writer.write(data)
+
+    async def recv(self, token: CancelToken) -> bytes:
+        encoded_size = await self.read(3, token)
+        (size,) = struct.unpack(b'>I', b'\x00' + encoded_size)
+        data = await self.read(size, token)
+        return data
+
+    def send(self, header: bytes, body: bytes) -> None:
+        (size,) = struct.unpack(b'>I', b'\x00' + header[:3])
+        if self.is_closing:
+            raise PeerConnectionLost("transport closed")
+        self.write(header[:3] + body[:size])
+
+    def close(self) -> None:
+        """Close this peer's reader/writer streams.
+
+        This will cause the peer to stop in case it is running.
+
+        If the streams have already been closed, do nothing.
+        """
+        if not self._reader.at_eof():
+            self._reader.feed_eof()
+        self._writer.close()
+
+    @property
+    def is_closing(self) -> bool:
+        return self._writer.transport.is_closing()

--- a/p2p/tools/paragon/helpers.py
+++ b/p2p/tools/paragon/helpers.py
@@ -3,7 +3,6 @@ import os
 from types import MethodType
 from typing import (
     Any,
-    Callable,
     cast,
     Dict,
     Tuple,
@@ -40,48 +39,7 @@ from .peer import (
     ParagonPeerFactory,
     ParagonContext,
 )
-
-
-class MockTransport:
-    def __init__(self) -> None:
-        self._is_closing = False
-
-    def close(self) -> None:
-        self._is_closing = True
-
-    def is_closing(self) -> bool:
-        return self._is_closing
-
-
-class MockStreamWriter:
-    def __init__(self, write_target: Callable[..., None]) -> None:
-        self._target = write_target
-        self.transport = MockTransport()
-
-    def write(self, *args: Any, **kwargs: Any) -> None:
-        self._target(*args, **kwargs)
-
-    def close(self) -> None:
-        self.transport.close()
-
-
-TConnectedStreams = Tuple[
-    Tuple[asyncio.StreamReader, asyncio.StreamWriter],
-    Tuple[asyncio.StreamReader, asyncio.StreamWriter],
-]
-
-
-def get_directly_connected_streams() -> TConnectedStreams:
-    bob_reader = asyncio.StreamReader()
-    alice_reader = asyncio.StreamReader()
-    # Link the alice's writer to the bob's reader, and the bob's writer to the
-    # alice's reader.
-    bob_writer = MockStreamWriter(alice_reader.feed_data)
-    alice_writer = MockStreamWriter(bob_reader.feed_data)
-    return (
-        (alice_reader, cast(asyncio.StreamWriter, alice_writer)),
-        (bob_reader, cast(asyncio.StreamWriter, bob_writer)),
-    )
+from p2p.tools.asyncio_streams import get_directly_connected_streams
 
 
 async def get_directly_linked_peers_without_handshake(

--- a/tests/p2p/test_memory_transport.py
+++ b/tests/p2p/test_memory_transport.py
@@ -1,0 +1,51 @@
+import asyncio
+import pytest
+
+import rlp
+from rlp import sedes
+
+from p2p.tools.factories import (
+    MemoryTransportPairFactory,
+    CancelTokenFactory,
+)
+from p2p.protocol import Command
+
+
+class CommandForTest(Command):
+    _cmd_id = 0
+    structure = (
+        ('data', sedes.binary),
+    )
+
+
+@pytest.mark.asyncio
+async def test_memory_transport_tool():
+    token = CancelTokenFactory()
+    alice_transport, bob_transport = MemoryTransportPairFactory()
+
+    done = asyncio.Event()
+
+    async def manage_bob(expected):
+        for msg in expected:
+            data = await bob_transport.recv(token)
+            assert msg == data
+        done.set()
+
+    messages = (
+        b'unicorns',
+        b'rainbows',
+        b'',
+        b'\x00' * 256,
+        b'\x00' * 65536,
+    )
+    cmd = CommandForTest(5, False)
+    rlp_messages = tuple(
+        rlp.encode(cmd.cmd_id, sedes.big_endian_int) + rlp.encode((msg,))
+        for msg in messages
+    )
+    asyncio.ensure_future(manage_bob(rlp_messages))
+    for message in messages:
+        header, body = cmd.encode({'data': message})
+        alice_transport.send(header, body)
+
+    await asyncio.wait_for(done.wait(), timeout=0.1)


### PR DESCRIPTION
### What was wrong?

For testing, it is convenient to be able to bypass the encryption overhead of the `p2p.transport.Transport`

### How was it fixed?

Added `p2p.tools.memory_transport.MemoryTransport` and a corresponding factory for easy setup that produces a pair of transports that are directly connected, bypassing the encryption and networking.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history

[//]: # (For important changes, please add a new entry to the running release notes PR)
[//]: # (You can find the current one using: https://github.com/ethereum/trinity/pulls?q=is%3Aopen+is%3Apr+label%3A%22Release+Notes%22 )
[//]: # (See: https://trinity-client.readthedocs.io/en/latest/contributing.html#pull-requests)
- [ ] Add entry to the [release notes PR](https://github.com/ethereum/trinity/pulls?q=is%3Aopen+is%3Apr+label%3A%22Release+Notes%22)

#### Cute Animal Picture

![pygmy-hippo-baby-cute](https://user-images.githubusercontent.com/824194/58914866-d7070780-86dc-11e9-89c3-125b7c941dfa.jpg)

