### PR TITLE
Expose peer cmds for new block hashes and transactions on event bus

### DIFF
--- a/trinity/protocol/eth/events.py
+++ b/trinity/protocol/eth/events.py
@@ -16,6 +16,8 @@ from trinity.protocol.common.events import (
 )
 
 
+# Events flowing from PeerPool to Proxy
+
 class GetBlockHeadersEvent(PeerPoolMessageEvent):
     """
     Event to carry a ``GetBlockHeaders`` command from the peer pool to any process that
@@ -46,6 +48,24 @@ class GetNodeDataEvent(PeerPoolMessageEvent):
     subscribes the event through the event bus.
     """
     pass
+
+
+class TransactionsEvent(PeerPoolMessageEvent):
+    """
+    Event to carry a ``Transactions`` command from the peer pool to any process that
+    subscribes the event through the event bus.
+    """
+    pass
+
+
+class NewBlockHashesEvent(PeerPoolMessageEvent):
+    """
+    Event to carry a ``Transactions`` command from the peer pool to any process that
+    subscribes the event through the event bus.
+    """
+    pass
+
+# Events flowing from Proxy to PeerPool
 
 
 class SendBlockHeadersEvent(HasRemoteEvent):

--- a/trinity/protocol/eth/peer.py
+++ b/trinity/protocol/eth/peer.py
@@ -54,10 +54,12 @@ from .events import (
     GetBlockBodiesEvent,
     GetReceiptsEvent,
     GetNodeDataEvent,
+    NewBlockHashesEvent,
     SendBlockBodiesEvent,
     SendBlockHeadersEvent,
     SendNodeDataEvent,
     SendReceiptsEvent,
+    TransactionsEvent,
 )
 from .proto import ETHProtocol, ProxyETHProtocol
 from .handlers import ETHExchangeHandler
@@ -157,8 +159,6 @@ class ETHPeerPoolEventServer(PeerPoolEventServer[ETHPeer]):
         GetBlockBodies,
         GetReceipts,
         GetNodeData,
-        # TODO: all of the following are here to quiet warning logging output
-        # until the messages are properly handled.
         Transactions,
         NewBlockHashes,
     })
@@ -181,14 +181,7 @@ class ETHPeerPoolEventServer(PeerPoolEventServer[ETHPeer]):
                                          cmd: Command,
                                          msg: PayloadType) -> None:
 
-        ignored_commands = (
-            Transactions,
-            NewBlockHashes,
-        )
-
-        if isinstance(cmd, ignored_commands):
-            pass
-        elif isinstance(cmd, GetBlockHeaders):
+        if isinstance(cmd, GetBlockHeaders):
             await self.event_bus.broadcast(GetBlockHeadersEvent(remote, cmd, msg))
         elif isinstance(cmd, GetBlockBodies):
             await self.event_bus.broadcast(GetBlockBodiesEvent(remote, cmd, msg))
@@ -196,6 +189,10 @@ class ETHPeerPoolEventServer(PeerPoolEventServer[ETHPeer]):
             await self.event_bus.broadcast(GetReceiptsEvent(remote, cmd, msg))
         elif isinstance(cmd, GetNodeData):
             await self.event_bus.broadcast(GetNodeDataEvent(remote, cmd, msg))
+        elif isinstance(cmd, NewBlockHashes):
+            await self.event_bus.broadcast(NewBlockHashesEvent(remote, cmd, msg))
+        elif isinstance(cmd, Transactions):
+            await self.event_bus.broadcast(TransactionsEvent(remote, cmd, msg))
         else:
             raise Exception(f"Command {cmd} is not broadcasted")
 


### PR DESCRIPTION
### What was wrong?

We currently do not expose peer commands for new block hashes and transactions on the event bus.
These commands need to be exposed on the event bus to become available to isolated plugins and hence allow things like the transaction pool to be moved into an isolated plugin.

Notice that exposing these events does **not** cause extra traffic on the event bus per se. They are only send to those endpoints that are actually listening for these events (none so far).

Notice that this also obsoletes the current hack of suppressing warnings for these commands not being handled.

### How was it fixed?

- Created `TransactionsEvent` and `NewBlockHashesEvent`
- Forwarded events in `PeerPoolEventServer

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] Clean up commit history

[//]: # (For important changes, please add a new entry to the running release notes PR)
[//]: # (You can find the current one using: https://github.com/ethereum/trinity/pulls?q=is%3Aopen+is%3Apr+label%3A%22Release+Notes%22 )
[//]: # (See: https://trinity-client.readthedocs.io/en/latest/contributing.html#pull-requests)
- [ ] Add entry to the [release notes PR](https://github.com/ethereum/trinity/pulls?q=is%3Aopen+is%3Apr+label%3A%22Release+Notes%22)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://static.boredpanda.com/blog/wp-content/uploads/2015/02/zao-fox-village-japan-29.jpg)
