### PR TITLE
Patch release of alpha.25, to merge in so that it's on master

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.1.0-alpha.24
+current_version = 0.1.0-alpha.25
 commit = True
 tag = True
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(-(?P<stage>[^.]*)\.(?P<devnum>\d+))?

--- a/docs/release_notes/trinity.rst
+++ b/docs/release_notes/trinity.rst
@@ -1,8 +1,13 @@
 Trinity 
 =======
 
-Unreleased (latest source)
+v0.1.0-alpha.25
 --------------------------
+
+Released 2019-06-05
+
+- Upgraded py-evm to deal with eth-keys v0.3.0 dependency issue --
+  `see commit <https://github.com/ethereum/trinity/commit/55d70bafb6e8d6918fee91ad54da721bdc5ed185>`_
 
 v0.1.0-alpha.24
 --------------------------

--- a/setup.py
+++ b/setup.py
@@ -130,7 +130,7 @@ with open('./README.md') as readme:
 setup(
     name='trinity',
     # *IMPORTANT*: Don't manually change the version here. Use the 'bumpversion' utility.
-    version='0.1.0-alpha.24',
+    version='0.1.0-alpha.25',
     description='The Trinity client for the Ethereum network',
     long_description=long_description,
     long_description_content_type='text/markdown',

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 import os
 from setuptools import setup, find_packages
 
-PYEVM_DEPENDENCY = "py-evm==0.2.0a43"
+PYEVM_DEPENDENCY = "py-evm==0.3.0a1"
 
 
 deps = {


### PR DESCRIPTION
bump py-evm, for eth-keys dependency patch