### PR TITLE
Fix skip block

### DIFF
--- a/eth2/beacon/types/states.py
+++ b/eth2/beacon/types/states.py
@@ -181,9 +181,7 @@ class BeaconState(ssz.Serializable):
         )
 
     def __repr__(self) -> str:
-        return '<BeaconState #{0}>'.format(
-            encode_hex(self.root)[2:10],
-        )
+        return f"<BeaconState #{self.slot} {encode_hex(self.root)[2:10]}>"
 
     @property
     def num_validators(self) -> int:

--- a/tests/plugins/eth2/beacon/test_validator.py
+++ b/tests/plugins/eth2/beacon/test_validator.py
@@ -219,7 +219,7 @@ async def test_validator_skip_block(event_loop, event_bus):
     state_machine = alice.chain.get_state_machine()
     state = state_machine.state
     slot = state.slot + 1
-    root_post_state = alice.skip_block(
+    post_state = alice.skip_block(
         slot=slot,
         state=state,
         state_machine=state_machine,
@@ -228,8 +228,8 @@ async def test_validator_skip_block(event_loop, event_bus):
     with pytest.raises(BlockNotFound):
         alice.chain.get_canonical_block_by_slot(slot)
     # test: the state root should change after skipping the block
-    assert state.root != root_post_state
-    # TODO: more tests
+    assert state.root != post_state.root
+    assert state.slot + 1 == post_state.slot
 
 
 @pytest.mark.asyncio

--- a/trinity/plugins/eth2/beacon/validator.py
+++ b/trinity/plugins/eth2/beacon/validator.py
@@ -273,20 +273,17 @@ class Validator(BaseService):
                    state_machine: BaseBeaconStateMachine) -> Hash32:
         post_state = state_machine.state_transition.apply_state_transition_without_block(
             state,
-            # TODO: Change back to `slot` instead of `slot + 1`.
-            # Currently `apply_state_transition_without_block` only returns the post state
-            # of `slot - 1`, so we increment it by one to get the post state of `slot`.
-            cast(Slot, slot + 1),
+            slot,
         )
         self.logger.debug(
-            bold_green("Skip block at slot=%s  post_state_root=%s"),
+            bold_green("Skip block at slot=%s  post_state=%s"),
             slot,
-            encode_hex(post_state.root),
+            post_state,
         )
         # FIXME: We might not need to persist state for skip slots since `create_block_on_state`
         # will run the state transition which also includes the state transition for skipped slots.
         self.chain.chaindb.persist_state(post_state)
-        return post_state.root
+        return post_state
 
     def _is_attesting(self,
                       validator_index: ValidatorIndex,

--- a/trinity/plugins/eth2/beacon/validator.py
+++ b/trinity/plugins/eth2/beacon/validator.py
@@ -17,9 +17,6 @@ from typing import (
 from cancel_token import (
     CancelToken,
 )
-from eth_typing import (
-    Hash32,
-)
 from eth_utils import (
     encode_hex,
     to_tuple,
@@ -270,7 +267,7 @@ class Validator(BaseService):
     def skip_block(self,
                    slot: Slot,
                    state: BeaconState,
-                   state_machine: BaseBeaconStateMachine) -> Hash32:
+                   state_machine: BaseBeaconStateMachine) -> BeaconState:
         post_state = state_machine.state_transition.apply_state_transition_without_block(
             state,
             slot,


### PR DESCRIPTION
### What was wrong?

`python eth2/beacon/scripts/run_beacon_nodes.py` reported state mismatch error in chain.import_block.

### How was it fixed?

- The cause is the skip_block skips too much. Say, state now at slot 0, skip slot 1 the post state is expected to be slot 1 but actually slot 2.
- Fix skip_block

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://preview.redd.it/18udg7gtct231.jpg?width=640&crop=smart&auto=webp&s=8d006efd96f6295f1d518eb73eb15e54225443ae)
