### PR TITLE
Add a maximum batch size for regular sync imports

### DIFF
--- a/trinity/sync/full/constants.py
+++ b/trinity/sync/full/constants.py
@@ -16,3 +16,10 @@ HEADER_QUEUE_SIZE_TARGET = 6000
 # How many blocks to persist at a time
 # Only need a few seconds of buffer on the DB write side.
 BLOCK_QUEUE_SIZE_TARGET = 1000
+
+# How many blocks to import at a time
+# Only need a few seconds of buffer on the DB side
+# This is specifically for blocks where execution happens locally.
+# So each block might have a pretty significant execution time, on
+#   the order of seconds.
+BLOCK_IMPORT_QUEUE_SIZE_TARGET = 10


### PR DESCRIPTION
Without this maximum batch size, when the first batch takes a long time
to execute, the second batch will be enormous. Perhaps most importantly,
the back-pressure set by `_db_buffer_capacity` is never triggered if the
batch is unlimited size. So the header downloader races ahead unimpeded.

I think this was something that @veox noticed.

Note that beam sync uses the regular syncer updated in this PR, which is why it was originally bundled in #641 .

### To-Do

[//]: # (For important changes, please add a new entry to the running release notes PR)
[//]: # (You can find the current one using: https://github.com/ethereum/trinity/pulls?q=is%3Aopen+is%3Apr+label%3A%22Release+Notes%22 )
[//]: # (See: https://trinity-client.readthedocs.io/en/latest/contributing.html#pull-requests)
- [ ] Add entry to the [release notes PR](https://github.com/ethereum/trinity/pulls?q=is%3Aopen+is%3Apr+label%3A%22Release+Notes%22)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcReCN36Po0E5pCUD8ibU2ruv08pZ8S6aVQciw6b55tZW1JPiVEWjw)