### PR TITLE
Fix the documentation to contribute from py-evm to trinity

### DIFF
--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -10,7 +10,7 @@ First we need to clone the Py-EVM repository. Py-EVM depends on a submodule of t
 
 .. code:: sh
 
-    $ git clone --recursive https://github.com/ethereum/py-evm.git
+    $ git clone --recursive https://github.com/ethereum/trinity.git
 
 
 


### PR DESCRIPTION
### What was wrong?

Issue Reference: https://github.com/ethereum/trinity/issues/711

Documentation of getting started to contribute still using `py-evm.git` reference

https://trinity-client.readthedocs.io/en/latest/contributing.html

### How was it fixed?

Change `py-evm.git` to `trinity.git`

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://cdn.kicksdigital.com/barkefellers.com/2018/07/barkefellers-doggie-day-care-5.jpg)
