### PR TITLE
Move Eth2 plugins out of base plugins

### DIFF
--- a/trinity/main_beacon.py
+++ b/trinity/main_beacon.py
@@ -41,7 +41,7 @@ from trinity.initialization import (
     ensure_beacon_dirs,
 )
 from trinity.plugins.registry import (
-    BASE_PLUGINS,
+    get_plugins_for_beacon_client,
 )
 from trinity._utils.ipc import (
     wait_for_ipc,
@@ -62,7 +62,12 @@ from trinity._utils.proxy import (
 
 
 def main_beacon() -> None:
-    main_entry(trinity_boot, APP_IDENTIFIER_BEACON, BASE_PLUGINS, (BeaconAppConfig,))
+    main_entry(
+        trinity_boot,
+        APP_IDENTIFIER_BEACON,
+        get_plugins_for_beacon_client(),
+        (BeaconAppConfig,)
+    )
 
 
 def trinity_boot(args: Namespace,

--- a/trinity/plugins/registry.py
+++ b/trinity/plugins/registry.py
@@ -47,14 +47,17 @@ from trinity.plugins.builtin.light_peer_chain_bridge.plugin import (
 
 BASE_PLUGINS: Tuple[Type[BasePlugin], ...] = (
     AttachPlugin,
-    NetworkGeneratorPlugin,
     FixUncleanShutdownPlugin,
     JsonRpcServerPlugin,
     NetworkDBPlugin,
     PeerDiscoveryPlugin,
     RequestServerPlugin,
-    BeaconNodePlugin,
     UpnpPlugin,
+)
+
+BEACON_NODE_PLUGINS: Tuple[Type[BasePlugin], ...] = (
+    NetworkGeneratorPlugin,
+    BeaconNodePlugin,
 )
 
 
@@ -74,3 +77,15 @@ def discover_plugins() -> Tuple[Type[BasePlugin], ...]:
     return tuple(
         entry_point.load() for entry_point in pkg_resources.iter_entry_points('trinity.plugins')
     )
+
+
+def get_all_plugins(*extra_plugins: Type[BasePlugin]) -> Tuple[Type[BasePlugin], ...]:
+    return BASE_PLUGINS + extra_plugins + discover_plugins()
+
+
+def get_plugins_for_eth1_client() -> Tuple[Type[BasePlugin], ...]:
+    return get_all_plugins(*ETH1_NODE_PLUGINS)
+
+
+def get_plugins_for_beacon_client() -> Tuple[Type[BasePlugin], ...]:
+    return get_all_plugins(*BEACON_NODE_PLUGINS)


### PR DESCRIPTION
### What was wrong?

The Two existing ETH2 plugins where in the set of *base*  plugins which includes them for the Eth1 client and all other possible clients.

### How was it fixed?

- Moved them into its own set so that we have: base plugins, eth1 plugins, eth2 plugins
- cleaned up imports a bit

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] Clean up commit history

[//]: # (For important changes, please add a new entry to the running release notes PR)
[//]: # (You can find the current one using: https://github.com/ethereum/trinity/pulls?q=is%3Aopen+is%3Apr+label%3A%22Release+Notes%22 )
[//]: # (See: https://trinity-client.readthedocs.io/en/latest/contributing.html#pull-requests)
- [ ] Add entry to the [release notes PR](https://github.com/ethereum/trinity/pulls?q=is%3Aopen+is%3Apr+label%3A%22Release+Notes%22)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](http://www.allaboutandalucia.com/wp-content/uploads/2018/04/lynx-4.jpg)
