### PR TITLE
Split PeerPool and Sync into two isolated processes

### DIFF
--- a/tests/integration/test_trinity_cli.py
+++ b/tests/integration/test_trinity_cli.py
@@ -56,7 +56,8 @@ async def test_full_boot(async_process_runner, command):
     await async_process_runner.run(command, timeout_sec=120)
     assert await contains_all(async_process_runner.stderr, {
         "Started DB server process",
-        "Plugin started: Sync / PeerPool",
+        "Plugin started: Sync",
+        "Plugin started: PeerPool",
         "Running server",
         "IPC started at",
     })
@@ -76,7 +77,8 @@ async def test_txpool_full_boot(async_process_runner, command):
     await async_process_runner.run(command, timeout_sec=120)
     assert await contains_all(async_process_runner.stderr, {
         "Started DB server process",
-        "Plugin started: Sync / PeerPool",
+        "Plugin started: Sync",
+        "Plugin started: PeerPool",
         "Running Tx Pool",
         "Running server",
         "IPC started at",
@@ -97,7 +99,8 @@ async def test_txpool_deactivated(async_process_runner, command):
     await async_process_runner.run(command, timeout_sec=120)
     assert await contains_all(async_process_runner.stderr, {
         "Started DB server process",
-        "Plugin started: Sync / PeerPool",
+        "Plugin started: Sync",
+        "Plugin started: PeerPool",
         "Transaction pool not available in light mode",
     })
 
@@ -114,7 +117,8 @@ async def test_light_boot(async_process_runner, command):
     await async_process_runner.run(command, timeout_sec=40)
     assert await contains_all(async_process_runner.stderr, {
         "Started DB server process",
-        "Plugin started: Sync / PeerPool",
+        "Plugin started: Sync",
+        "Plugin started: PeerPool",
         "IPC started at",
     })
 
@@ -130,7 +134,8 @@ async def test_web3(command, async_process_runner):
     await async_process_runner.run(command, timeout_sec=40)
     assert await contains_all(async_process_runner.stderr, {
         "Started DB server process",
-        "Plugin started: Sync / PeerPool",
+        "Plugin started: Sync",
+        "Plugin started: PeerPool",
         "IPC started at",
         "Plugin started: JSON-RPC API",
         # Ensure we do not start making requests before Trinity is ready.

--- a/trinity/plugins/builtin/peer_pool/plugin.py
+++ b/trinity/plugins/builtin/peer_pool/plugin.py
@@ -1,0 +1,67 @@
+from argparse import (
+    ArgumentParser,
+    _SubParsersAction,
+)
+import asyncio
+
+from lahja import EndpointAPI
+
+from trinity.config import (
+    Eth1AppConfig,
+)
+from trinity.constants import (
+    NETWORKING_EVENTBUS_ENDPOINT,
+)
+from trinity.extensibility.asyncio import (
+    AsyncioIsolatedPlugin
+)
+from trinity._utils.shutdown import (
+    exit_with_services,
+)
+
+
+class PeerPoolPlugin(AsyncioIsolatedPlugin):
+
+    @property
+    def name(self) -> str:
+        return "PeerPool"
+
+    @property
+    def normalized_name(self) -> str:
+        return NETWORKING_EVENTBUS_ENDPOINT
+
+    @classmethod
+    def configure_parser(cls,
+                         arg_parser: ArgumentParser,
+                         subparser: _SubParsersAction) -> None:
+        peer_pool_parser = arg_parser.add_argument_group('peer pool')
+
+        peer_pool_parser.add_argument(
+            '--disable-peer-pool',
+            help=(
+                "Disables the builtin 'Peer Pool' plugin. "
+                "**WARNING**: disabling this API without a proper replacement "
+                "will cause your trinity node to crash."
+            ),
+            action='store_true',
+        )
+
+    def on_ready(self, manager_eventbus: EndpointAPI) -> None:
+        if self.boot_info.args.disable_peer_pool:
+            self.logger.warning("Peer Pool disabled via CLI flag")
+            # Allow this plugin to be disabled for extreme cases such as the
+            # user swapping in an equivalent experimental version.
+            return
+        self.start()
+
+    def do_start(self) -> None:
+
+        trinity_config = self.boot_info.trinity_config
+
+        # TODO: Eventually, we can probably get rid of the NodeClass entirely and run
+        # the PeerPool directly
+        NodeClass = trinity_config.get_app_config(Eth1AppConfig).node_class
+        node = NodeClass(self.event_bus, trinity_config)
+
+        asyncio.ensure_future(exit_with_services(self._event_bus_service, node))
+        asyncio.ensure_future(node.run())

--- a/trinity/plugins/registry.py
+++ b/trinity/plugins/registry.py
@@ -14,6 +14,9 @@ from trinity.plugins.builtin.attach.plugin import (
 from trinity.plugins.builtin.beam_exec.plugin import (
     BeamChainExecutionPlugin,
 )
+from trinity.plugins.builtin.peer_pool.plugin import (
+    PeerPoolPlugin,
+)
 from trinity.plugins.builtin.ethstats.plugin import (
     EthstatsPlugin,
 )
@@ -65,6 +68,7 @@ BEACON_NODE_PLUGINS: Tuple[Type[BasePlugin], ...] = (
 ETH1_NODE_PLUGINS: Tuple[Type[BasePlugin], ...] = (
     BeamChainExecutionPlugin,
     EthstatsPlugin,
+    PeerPoolPlugin,
     SyncerPlugin,
     TxPlugin,
 )

--- a/trinity/protocol/common/events.py
+++ b/trinity/protocol/common/events.py
@@ -2,8 +2,15 @@ from dataclasses import (
     dataclass,
 )
 from typing import (
+    Dict,
+    NamedTuple,
     Tuple,
     Type,
+)
+
+from eth_typing import (
+    BlockNumber,
+    Hash32,
 )
 
 from lahja import (
@@ -66,6 +73,64 @@ class PeerLeftEvent(BaseEvent):
     Event broadcasted when a peer left the pool.
     """
     remote: NodeAPI
+
+
+class ChainPeerMetaData(NamedTuple):
+    head_td: int
+    head_hash: Hash32
+    head_number: BlockNumber
+    max_headers_fetch: int
+
+
+@dataclass
+class GetPeerMetaDataResponse(BaseEvent):
+
+    meta_data: ChainPeerMetaData
+    error: Exception = None
+
+
+@dataclass
+class GetPeerMetaDataRequest(BaseRequestResponseEvent[GetPeerMetaDataResponse]):
+
+    remote: NodeAPI
+
+    @staticmethod
+    def expected_response_type() -> Type[GetPeerMetaDataResponse]:
+        return GetPeerMetaDataResponse
+
+
+@dataclass
+class GetPeerPerfMetricsResponse(BaseEvent):
+
+    metrics: Dict[Type[CommandAPI], float]
+    error: Exception = None
+
+
+@dataclass
+class GetPeerPerfMetricsRequest(BaseRequestResponseEvent[GetPeerPerfMetricsResponse]):
+
+    remote: NodeAPI
+
+    @staticmethod
+    def expected_response_type() -> Type[GetPeerPerfMetricsResponse]:
+        return GetPeerPerfMetricsResponse
+
+
+@dataclass
+class GetHighestTDPeerResponse(BaseEvent):
+
+    remote: NodeAPI
+    error: Exception = None
+
+
+@dataclass
+class GetHighestTDPeerRequest(BaseRequestResponseEvent[GetHighestTDPeerResponse]):
+
+    timeout: float
+
+    @staticmethod
+    def expected_response_type() -> Type[GetHighestTDPeerResponse]:
+        return GetHighestTDPeerResponse
 
 
 @dataclass

--- a/trinity/protocol/common/monitors.py
+++ b/trinity/protocol/common/monitors.py
@@ -2,21 +2,29 @@ import asyncio
 from contextlib import contextmanager
 from typing import (
     AsyncIterator,
+    Generic,
     Iterator,
     Set,
+    Type,
+    TypeVar,
 )
 
 from cancel_token import CancelToken
 from eth_utils import ValidationError
+from lahja import BaseEvent
 
 from p2p.exceptions import NoConnectedPeers
-from p2p.peer import BasePeer, PeerSubscriber
 from p2p.service import BaseService
 
-from trinity.protocol.common.peer import BaseChainPeer, BaseChainPeerPool
+from trinity.protocol.common.events import PeerJoinedEvent
+from trinity.protocol.common.peer import BaseChainProxyPeer
+from trinity.protocol.eth.peer import BaseProxyPeerPool
 
 
-class BaseChainTipMonitor(BaseService, PeerSubscriber):
+TProxyPeer = TypeVar('TProxyPeer', bound=BaseChainProxyPeer)
+
+
+class BaseChainTipMonitor(BaseService, Generic[TProxyPeer]):
     """
     Monitor for potential changes to the tip of the chain: a new peer or a new block
 
@@ -27,16 +35,18 @@ class BaseChainTipMonitor(BaseService, PeerSubscriber):
     # now.
     msg_queue_maxsize = 2000
 
+    monitor_event_type: Type[BaseEvent]
+
     def __init__(
             self,
-            peer_pool: BaseChainPeerPool,
+            proxy_peer_pool: BaseProxyPeerPool[TProxyPeer],
             token: CancelToken = None) -> None:
         super().__init__(token)
-        self._peer_pool = peer_pool
+        self._proxy_peer_pool = proxy_peer_pool
         # There is one event for each subscriber, each one gets set any time new tip info arrives
         self._subscriber_notices: Set[asyncio.Event] = set()
 
-    async def wait_tip_info(self) -> AsyncIterator[BaseChainPeer]:
+    async def wait_tip_info(self) -> AsyncIterator[TProxyPeer]:
         """
         This iterator waits until there is potentially new tip information.
         New tip information means a new peer connected or a new block arrived.
@@ -51,7 +61,10 @@ class BaseChainTipMonitor(BaseService, PeerSubscriber):
         with self._subscriber() as new_tip_event:
             while self.is_operational:
                 try:
-                    highest_td_peer = self._peer_pool.highest_td_peer
+                    highest_td_peer = await self.wait(self._proxy_peer_pool.get_highest_td_peer())
+                except TimeoutError:
+                    self.logger.warning("Timed out waiting on peer with highest td")
+                    pass
                 except NoConnectedPeers:
                     # no peers are available right now, skip the new tip info yield
                     pass
@@ -61,24 +74,23 @@ class BaseChainTipMonitor(BaseService, PeerSubscriber):
                 await self.wait(new_tip_event.wait())
                 new_tip_event.clear()
 
-    def register_peer(self, peer: BasePeer) -> None:
-        self._notify_tip()
-
-    async def _handle_msg_loop(self) -> None:
-        new_tip_types = tuple(self.subscription_msg_types)
-        while self.is_operational:
-            peer, cmd, msg = await self.wait(self.msg_queue.get())
-            if isinstance(cmd, new_tip_types):
-                self._notify_tip()
-
     def _notify_tip(self) -> None:
         for new_tip_event in self._subscriber_notices:
             new_tip_event.set()
 
     async def _run(self) -> None:
-        self.run_daemon_task(self._handle_msg_loop())
-        with self.subscribe(self._peer_pool):
-            await self.cancellation()
+        monitor_subscription = self._proxy_peer_pool.event_bus.subscribe(
+            self.monitor_event_type,
+            lambda ev: self._notify_tip()
+        )
+        joined_subscription = self._proxy_peer_pool.event_bus.subscribe(
+            PeerJoinedEvent,
+            lambda ev: self._notify_tip()
+        )
+
+        await self.cancellation()
+        monitor_subscription.unsubscribe()
+        joined_subscription.unsubscribe()
 
     @contextmanager
     def _subscriber(self) -> Iterator[asyncio.Event]:

--- a/trinity/protocol/eth/handlers.py
+++ b/trinity/protocol/eth/handlers.py
@@ -91,7 +91,6 @@ class ProxyETHExchangeHandler:
                                 skip: int = 0,
                                 reverse: bool = True,
                                 timeout: float = None) -> Tuple[BlockHeader, ...]:
-
         response = await self._event_bus.request(
             GetBlockHeadersRequest(
                 self.remote,

--- a/trinity/protocol/eth/monitors.py
+++ b/trinity/protocol/eth/monitors.py
@@ -1,6 +1,8 @@
 from trinity.protocol.common.monitors import BaseChainTipMonitor
-from trinity.protocol.eth import commands
+from trinity.protocol.eth.peer import ETHProxyPeer
+from trinity.protocol.eth.events import NewBlockEvent
 
 
-class ETHChainTipMonitor(BaseChainTipMonitor):
-    subscription_msg_types = frozenset({commands.NewBlock})
+class ETHChainTipMonitor(BaseChainTipMonitor[ETHProxyPeer]):
+
+    monitor_event_type = NewBlockEvent

--- a/trinity/protocol/eth/sync.py
+++ b/trinity/protocol/eth/sync.py
@@ -1,7 +1,7 @@
 from trinity.protocol.eth.monitors import ETHChainTipMonitor
-from trinity.protocol.eth.peer import ETHPeer
+from trinity.protocol.eth.peer import ETHProxyPeer
 from trinity.sync.common.headers import BaseHeaderChainSyncer
 
 
-class ETHHeaderChainSyncer(BaseHeaderChainSyncer[ETHPeer]):
+class ETHHeaderChainSyncer(BaseHeaderChainSyncer[ETHProxyPeer]):
     tip_monitor_class = ETHChainTipMonitor

--- a/trinity/protocol/les/events.py
+++ b/trinity/protocol/les/events.py
@@ -12,6 +12,7 @@ from eth.rlp.headers import BlockHeader
 from eth.rlp.receipts import Receipt
 from eth_typing import (
     Address,
+    BlockIdentifier,
     Hash32,
 )
 
@@ -25,6 +26,14 @@ from trinity.protocol.common.events import (
     PeerPoolMessageEvent,
 )
 from trinity.rlp.block_body import BlockBody
+
+
+class AnnounceEvent(PeerPoolMessageEvent):
+    """
+    Event to carry an ``Announce`` command from the peer pool to any process that
+    subscribes the event through the event bus.
+    """
+    pass
 
 
 @dataclass
@@ -132,3 +141,25 @@ class SendBlockHeadersEvent(BaseEvent):
     headers: Tuple[BlockHeader, ...]
     buffer_value: int
     request_id: int
+
+
+@dataclass
+class GetBlockHeadersResponse(BaseEvent):
+
+    headers: Tuple[BlockHeader, ...]
+    error: Exception = None
+
+
+@dataclass
+class GetBlockHeadersRequest(BaseRequestResponseEvent[GetBlockHeadersResponse]):
+
+    remote: NodeAPI
+    block_number_or_hash: BlockIdentifier
+    max_headers: int
+    skip: int
+    reverse: bool
+    timeout: float
+
+    @staticmethod
+    def expected_response_type() -> Type[GetBlockHeadersResponse]:
+        return GetBlockHeadersResponse

--- a/trinity/protocol/les/handlers.py
+++ b/trinity/protocol/les/handlers.py
@@ -1,5 +1,31 @@
+import logging
+from typing import (
+    cast,
+    Tuple,
+)
+
+from lahja import (
+    BroadcastConfig,
+    EndpointAPI,
+)
+
+from eth_typing import BlockIdentifier
+
+from eth.rlp.headers import BlockHeader
+from eth.tools.logging import (
+    ExtendedDebugLogger,
+)
+
+from p2p.abc import NodeAPI
+
 from trinity.protocol.common.handlers import (
     BaseChainExchangeHandler,
+)
+from trinity.protocol.les.events import (
+    GetBlockHeadersRequest,
+)
+from trinity._utils.errors import (
+    SupportsError,
 )
 
 from .exchanges import GetBlockHeadersExchange
@@ -9,3 +35,57 @@ class LESExchangeHandler(BaseChainExchangeHandler):
     _exchange_config = {
         'get_block_headers': GetBlockHeadersExchange,
     }
+
+
+class ProxyLESExchangeHandler:
+    """
+    An ``LESExchangeHandler`` that can be used outside of the process that runs the peer pool. Any
+    action performed on this class is delegated to the process that runs the peer pool.
+    """
+
+    def __init__(self,
+                 remote: NodeAPI,
+                 event_bus: EndpointAPI,
+                 broadcast_config: BroadcastConfig):
+        self.remote = remote
+        self._event_bus = event_bus
+        self._broadcast_config = broadcast_config
+        self.logger = cast(
+            ExtendedDebugLogger,
+            logging.getLogger('trinity.protocol.les.handlers.ProxyLESExchangeHandler')
+        )
+
+    def raise_if_needed(self, value: SupportsError) -> None:
+        if value.error is not None:
+            self.logger.warning(
+                "Raised %s while fetching from peer %s", value.error, self.remote.uri
+            )
+            raise value.error
+
+    async def get_block_headers(self,
+                                block_number_or_hash: BlockIdentifier,
+                                max_headers: int = None,
+                                skip: int = 0,
+                                reverse: bool = True,
+                                timeout: float = None) -> Tuple[BlockHeader, ...]:
+        response = await self._event_bus.request(
+            GetBlockHeadersRequest(
+                self.remote,
+                block_number_or_hash,
+                max_headers,
+                skip,
+                reverse,
+                timeout,
+            ),
+            self._broadcast_config
+        )
+
+        self.raise_if_needed(response)
+
+        self.logger.debug2(
+            "ProxyETHExchangeHandler returning %s block headers from %s",
+            len(response.headers),
+            self.remote
+        )
+
+        return response.headers

--- a/trinity/protocol/les/monitors.py
+++ b/trinity/protocol/les/monitors.py
@@ -1,6 +1,7 @@
 from trinity.protocol.common.monitors import BaseChainTipMonitor
-from trinity.protocol.les import commands
+from trinity.protocol.les.events import AnnounceEvent
+from trinity.protocol.les.peer import LESProxyPeer
 
 
-class LightChainTipMonitor(BaseChainTipMonitor):
-    subscription_msg_types = frozenset({commands.Announce})
+class LightChainTipMonitor(BaseChainTipMonitor[LESProxyPeer]):
+    monitor_event_type = AnnounceEvent

--- a/trinity/protocol/les/sync.py
+++ b/trinity/protocol/les/sync.py
@@ -1,7 +1,7 @@
 from trinity.protocol.les.monitors import LightChainTipMonitor
-from trinity.protocol.les.peer import LESPeer
+from trinity.protocol.les.peer import LESProxyPeer
 from trinity.sync.common.headers import BaseHeaderChainSyncer
 
 
-class LightHeaderChainSyncer(BaseHeaderChainSyncer[LESPeer]):
+class LightHeaderChainSyncer(BaseHeaderChainSyncer[LESProxyPeer]):
     tip_monitor_class = LightChainTipMonitor

--- a/trinity/sync/beam/chain.py
+++ b/trinity/sync/beam/chain.py
@@ -28,7 +28,7 @@ from trinity.chains.base import BaseAsyncChain
 from trinity.db.base import BaseAsyncDB
 from trinity.db.eth1.chain import BaseAsyncChainDB
 from trinity.db.eth1.header import BaseAsyncHeaderDB
-from trinity.protocol.eth.peer import ETHPeerPool
+from trinity.protocol.eth.peer import ETHProxyPeerPool
 from trinity.protocol.eth.sync import ETHHeaderChainSyncer
 from trinity.sync.common.chain import (
     BaseBlockImporter,
@@ -85,7 +85,7 @@ class BeamSyncer(BaseService):
             chain: BaseAsyncChain,
             db: BaseAsyncDB,
             chain_db: BaseAsyncChainDB,
-            peer_pool: ETHPeerPool,
+            peer_pool: ETHProxyPeerPool,
             event_bus: EndpointAPI,
             force_beam_block_number: int = None,
             token: CancelToken = None) -> None:

--- a/trinity/sync/beam/service.py
+++ b/trinity/sync/beam/service.py
@@ -7,7 +7,7 @@ from p2p.service import BaseService
 from trinity.chains.base import BaseAsyncChain
 from trinity.db.base import BaseAsyncDB
 from trinity.db.eth1.chain import BaseAsyncChainDB
-from trinity.protocol.eth.peer import ETHPeerPool
+from trinity.protocol.eth.peer import ETHProxyPeerPool
 
 from .chain import BeamSyncer
 
@@ -19,7 +19,7 @@ class BeamSyncService(BaseService):
             chain: BaseAsyncChain,
             chaindb: BaseAsyncChainDB,
             base_db: BaseAsyncDB,
-            peer_pool: ETHPeerPool,
+            peer_pool: ETHProxyPeerPool,
             event_bus: EndpointAPI,
             token: CancelToken = None) -> None:
         super().__init__(token)

--- a/trinity/sync/common/headers.py
+++ b/trinity/sync/common/headers.py
@@ -44,7 +44,6 @@ from p2p.abc import CommandAPI
 from p2p.constants import SEAL_CHECK_RANDOM_SAMPLE_RATE
 from p2p.disconnect import DisconnectReason
 from p2p.exceptions import BaseP2PError, PeerConnectionLost
-from p2p.peer import BasePeer, PeerSubscriber
 from p2p.service import BaseService
 
 from trinity.chains.base import BaseAsyncChain
@@ -52,8 +51,11 @@ from trinity.db.eth1.header import BaseAsyncHeaderDB
 from trinity.protocol.common.commands import (
     BaseBlockHeaders,
 )
+from trinity.protocol.common.events import (
+    ChainPeerMetaData,
+)
 from trinity.protocol.common.monitors import BaseChainTipMonitor
-from trinity.protocol.common.peer import BaseChainPeer, BaseChainPeerPool
+from trinity.protocol.common.peer_pool_event_bus import BaseProxyPeerPool
 from trinity.protocol.eth.constants import (
     MAX_HEADERS_FETCH,
 )
@@ -87,12 +89,14 @@ class SkeletonSyncer(BaseService, Generic[TChainPeer]):
                  chain: BaseAsyncChain,
                  db: BaseAsyncHeaderDB,
                  peer: TChainPeer,
+                 peer_meta_data: ChainPeerMetaData,
                  token: CancelToken) -> None:
         super().__init__(token=token)
         self._chain = chain
         self._db = db
         self.peer = peer
-        max_pending_headers = peer.max_headers_fetch * 8
+        self.peer_meta_data = peer_meta_data
+        max_pending_headers = peer_meta_data.max_headers_fetch * 8
         self._fetched_headers = asyncio.Queue(max_pending_headers)
 
     async def next_skeleton_segment(self) -> AsyncIterator[Tuple[BlockHeader, ...]]:
@@ -431,9 +435,9 @@ class SkeletonSyncer(BaseService, Generic[TChainPeer]):
             derived_skip = self._skip_length
 
         if max_headers is None:
-            header_limit = peer.max_headers_fetch
+            header_limit = self.peer_meta_data.max_headers_fetch
         else:
-            header_limit = min(max_headers, peer.max_headers_fetch)
+            header_limit = min(max_headers, self.peer_meta_data.max_headers_fetch)
 
         try:
             self.logger.debug("Requsting chain of headers from %s starting at #%d", peer, start_at)
@@ -448,6 +452,9 @@ class SkeletonSyncer(BaseService, Generic[TChainPeer]):
             self.logger.debug2('sync received new headers: %s', headers)
         except OperationCancelled:
             self.logger.info("Skeleteon sync with %s cancelled", peer)
+            return tuple()
+        except PeerConnectionLost:
+            self.logger.debug("Peer went away, cancelling the headers request and moving on...")
             return tuple()
         except TimeoutError:
             self.logger.warning("Timeout waiting for header batch from %s, aborting sync", peer)
@@ -538,7 +545,7 @@ class _PeerBehind(Exception):
 HeaderStitcher = OrderedTaskPreparation[BlockHeader, Hash32, OrderedTaskPreparation.NoPrerequisites]
 
 
-class HeaderMeatSyncer(BaseService, PeerSubscriber, Generic[TChainPeer]):
+class HeaderMeatSyncer(BaseService, Generic[TChainPeer]):
     # We are only interested in peers entering or leaving the pool
     subscription_msg_types: FrozenSet[Type[CommandAPI]] = frozenset()
     msg_queue_maxsize = 2000
@@ -548,12 +555,13 @@ class HeaderMeatSyncer(BaseService, PeerSubscriber, Generic[TChainPeer]):
     def __init__(
             self,
             chain: BaseAsyncChain,
-            peer_pool: BaseChainPeerPool,
+            proxy_peer_pool: BaseProxyPeerPool[TChainPeer],
             stitcher: HeaderStitcher,
             token: CancelToken) -> None:
         super().__init__(token=token)
         self._chain = chain
         self._stitcher = stitcher
+        self._proxy_peer_pool = proxy_peer_pool
         max_pending_fillers = 50
         self._filler_header_tasks = TaskQueue(
             max_pending_fillers,
@@ -563,12 +571,6 @@ class HeaderMeatSyncer(BaseService, PeerSubscriber, Generic[TChainPeer]):
 
         # queue up idle peers, ordered by speed that they return block bodies
         self._waiting_peers: WaitingPeers[TChainPeer] = WaitingPeers(BaseBlockHeaders)
-        self._peer_pool = peer_pool
-
-    def register_peer(self, peer: BasePeer) -> None:
-        super().register_peer(peer)
-        # when a new peer is added to the pool, add it to the idle peer list
-        self._waiting_peers.put_nowait(peer)  # type: ignore
 
     async def schedule_segment(
             self,
@@ -586,8 +588,13 @@ class HeaderMeatSyncer(BaseService, PeerSubscriber, Generic[TChainPeer]):
 
     async def _run(self) -> None:
         self.run_daemon_task(self._display_stats())
-        with self.subscribe(self._peer_pool):
-            await self.wait(self._match_header_dls_to_peers())
+        self.run_daemon_task(self._watch_new_peers())
+
+        await self.wait(self._match_header_dls_to_peers())
+
+    async def _watch_new_peers(self) -> None:
+        async for peer in self.wait_iter(self._proxy_peer_pool.stream_existing_and_joining_peers()):
+            await self._waiting_peers.put(peer)
 
     async def _display_stats(self) -> None:
         q = self._filler_header_tasks
@@ -605,7 +612,6 @@ class HeaderMeatSyncer(BaseService, PeerSubscriber, Generic[TChainPeer]):
             batch_id, (
                 (parent_header, gap, skeleton_peer),
             ) = await self._filler_header_tasks.get(1)
-
             await self._match_dl_to_peer(batch_id, parent_header, gap, skeleton_peer)
 
     async def _match_dl_to_peer(
@@ -633,7 +639,7 @@ class HeaderMeatSyncer(BaseService, PeerSubscriber, Generic[TChainPeer]):
             complete_task_fn: Callable[[], None],
             fail_task_fn: Callable[[], None]) -> None:
         try:
-            completed_headers = await peer.wait(self._fetch_segment(peer, parent_header, length))
+            completed_headers = await self.wait(self._fetch_segment(peer, parent_header, length))
         except BaseP2PError as exc:
             self.logger.info("Unexpected p2p err while downloading headers from %s: %s", peer, exc)
             self.logger.debug("Problem downloading headers from peer, dropping...", exc_info=True)
@@ -653,7 +659,7 @@ class HeaderMeatSyncer(BaseService, PeerSubscriber, Generic[TChainPeer]):
         else:
             if len(completed_headers) == length:
                 # peer completed successfully, so have it get back in line for processing
-                self._waiting_peers.put_nowait(peer)
+                await self._waiting_peers.put(peer)
                 complete_task_fn()
             else:
                 # peer didn't return enough results, wait a while before trying again
@@ -664,7 +670,7 @@ class HeaderMeatSyncer(BaseService, PeerSubscriber, Generic[TChainPeer]):
                     delay,
                     len(completed_headers),
                 )
-                self.call_later(delay, self._waiting_peers.put_nowait, peer)
+                self.call_later(delay, self._waiting_peers.put, peer)
                 fail_task_fn()
 
     async def _fetch_segment(
@@ -672,9 +678,10 @@ class HeaderMeatSyncer(BaseService, PeerSubscriber, Generic[TChainPeer]):
             peer: TChainPeer,
             parent_header: BlockHeader,
             length: int) -> Tuple[BlockHeader, ...]:
-        if length > peer.max_headers_fetch:
+        peer_max_headers_fetch = (await peer.get_meta_data()).max_headers_fetch
+        if length > peer_max_headers_fetch:
             raise ValidationError(
-                f"Can't request {length} headers, because peer maximum is {peer.max_headers_fetch}"
+                f"Can't request {length} headers, because peer maximum is {peer_max_headers_fetch}"
             )
         headers = await self._request_headers(peer, parent_header.block_number + 1, length)
         if not headers:
@@ -765,14 +772,14 @@ class BaseHeaderChainSyncer(BaseService, HeaderSyncerAPI, Generic[TChainPeer]):
     def __init__(self,
                  chain: BaseAsyncChain,
                  db: BaseAsyncHeaderDB,
-                 peer_pool: BaseChainPeerPool,
+                 proxy_peer_pool: BaseProxyPeerPool[TChainPeer],
                  token: CancelToken = None) -> None:
         super().__init__(token)
         self._db = db
         self._chain = chain
-        self._peer_pool = peer_pool
-        self._tip_monitor = self.tip_monitor_class(peer_pool, token=self.cancel_token)
         self._last_target_header_hash: Hash32 = None
+        self._proxy_peer_pool = proxy_peer_pool
+        self._tip_monitor = self.tip_monitor_class(proxy_peer_pool, token=self.cancel_token)
         self._skeleton: SkeletonSyncer[TChainPeer] = None
 
         # Track if there is capacity for syncing more headers
@@ -794,11 +801,7 @@ class BaseHeaderChainSyncer(BaseService, HeaderSyncerAPI, Generic[TChainPeer]):
         # When downloading the headers into the gaps left by the syncer, they must be linearized
         # by the stitcher
         self._meat = HeaderMeatSyncer(
-            self._chain,
-            self._peer_pool,
-            self._stitcher,
-            self.cancel_token,
-        )
+            self._chain, self._proxy_peer_pool, self._stitcher, self.cancel_token)
 
         # Queue has reset, so always start with capacity
         self._buffer_capacity.set()
@@ -830,13 +833,13 @@ class BaseHeaderChainSyncer(BaseService, HeaderSyncerAPI, Generic[TChainPeer]):
         if not self._is_syncing_skeleton and self._last_target_header_hash is None:
             raise ValidationError("Cannot check the target hash before the first sync has started")
         elif self._is_syncing_skeleton:
-            return self._skeleton.peer.head_hash
+            return self._skeleton.peer_meta_data.head_hash
         else:
             return self._last_target_header_hash
 
     @property
     @abstractmethod
-    def tip_monitor_class(self) -> Type[BaseChainTipMonitor]:
+    def tip_monitor_class(self) -> Type[BaseChainTipMonitor[TChainPeer]]:
         ...
 
     async def _run(self) -> None:
@@ -864,10 +867,12 @@ class BaseHeaderChainSyncer(BaseService, HeaderSyncerAPI, Generic[TChainPeer]):
         if self._is_syncing_skeleton:
             raise ValidationError("Cannot sync skeleton headers from two peers at the same time")
 
+        peer_meta_data = await peer.get_meta_data()
         self._skeleton = SkeletonSyncer(
             self._chain,
             self._db,
             peer,
+            peer_meta_data,
             self.cancel_token,
         )
         self.run_child_service(self._skeleton)
@@ -881,7 +886,7 @@ class BaseHeaderChainSyncer(BaseService, HeaderSyncerAPI, Generic[TChainPeer]):
                 self._skeleton.cancel_nowait()
         finally:
             self.logger.debug("Skeleton sync with %s ended", peer)
-            self._last_target_header_hash = peer.head_hash
+            self._last_target_header_hash = peer_meta_data.head_hash
             self._skeleton = None
 
     @property
@@ -943,16 +948,17 @@ class BaseHeaderChainSyncer(BaseService, HeaderSyncerAPI, Generic[TChainPeer]):
             # Don't race ahead if the consumer is lagging
             await self._buffer_capacity.wait()
 
-    async def _validate_peer_is_ahead(self, peer: BaseChainPeer) -> None:
+    async def _validate_peer_is_ahead(self, peer: TChainPeer) -> None:
         head = await self.wait(self._db.coro_get_canonical_head())
         head_td = await self.wait(self._db.coro_get_score(head.hash))
-        if peer.head_td <= head_td:
+        peer_meta_data = await self.wait(peer.get_meta_data(use_cache=False))
+        if peer_meta_data.head_td <= head_td:
             self.logger.info(
                 "Head TD (%d) announced by %s not higher than ours (%d), not syncing",
-                peer.head_td, peer, head_td)
+                peer_meta_data.head_td, peer, head_td)
             raise _PeerBehind(f"{peer} is behind us, not a valid target for sync")
         else:
             self.logger.debug(
                 "%s announced Head TD %d, which is higher than ours (%d), starting sync",
-                peer, peer.head_td, head_td)
+                peer, peer_meta_data.head_td, head_td)
             pass

--- a/trinity/sync/full/service.py
+++ b/trinity/sync/full/service.py
@@ -11,7 +11,7 @@ from p2p.service import BaseService
 from trinity.chains.base import BaseAsyncChain
 from trinity.db.base import BaseAsyncDB
 from trinity.db.eth1.chain import BaseAsyncChainDB
-from trinity.protocol.eth.peer import ETHPeerPool
+from trinity.protocol.eth.peer import ETHProxyPeerPool
 
 from .chain import FastChainSyncer, RegularChainSyncer
 from .constants import FAST_SYNC_CUTOFF
@@ -23,7 +23,7 @@ async def ensure_state_then_sync_full(logger: logging.Logger,
                                       base_db: BaseAsyncDB,
                                       chaindb: BaseAsyncChainDB,
                                       chain: BaseAsyncChain,
-                                      peer_pool: ETHPeerPool,
+                                      peer_pool: ETHProxyPeerPool,
                                       cancel_token: CancelToken) -> None:
     # Ensure we have the state for our current head.
     if head.state_root != BLANK_ROOT_HASH and head.state_root not in base_db:
@@ -50,7 +50,7 @@ class FullChainSyncer(BaseService):
                  chain: BaseAsyncChain,
                  chaindb: BaseAsyncChainDB,
                  base_db: BaseAsyncDB,
-                 peer_pool: ETHPeerPool,
+                 peer_pool: ETHProxyPeerPool,
                  token: CancelToken = None) -> None:
         super().__init__(token)
         self.chain = chain
@@ -81,7 +81,7 @@ class FastThenFullChainSyncer(BaseService):
                  chain: BaseAsyncChain,
                  chaindb: BaseAsyncChainDB,
                  base_db: BaseAsyncDB,
-                 peer_pool: ETHPeerPool,
+                 peer_pool: ETHProxyPeerPool,
                  token: CancelToken = None) -> None:
         super().__init__(token)
         self.chain = chain

--- a/trinity/sync/light/chain.py
+++ b/trinity/sync/light/chain.py
@@ -5,7 +5,7 @@ from p2p.service import BaseService
 
 from trinity.chains.base import BaseAsyncChain
 from trinity.db.eth1.header import BaseAsyncHeaderDB
-from trinity.protocol.les.peer import LESPeerPool
+from trinity.protocol.les.peer import LESProxyPeerPool
 from trinity.protocol.les.sync import LightHeaderChainSyncer
 from trinity._utils.timer import Timer
 
@@ -14,11 +14,12 @@ class LightChainSyncer(BaseService):
     def __init__(self,
                  chain: BaseAsyncChain,
                  db: BaseAsyncHeaderDB,
-                 peer_pool: LESPeerPool,
+                 proxy_peer_pool: LESProxyPeerPool,
                  token: CancelToken = None) -> None:
         super().__init__(token=token)
         self._db = db
-        self._header_syncer = LightHeaderChainSyncer(chain, db, peer_pool, self.cancel_token)
+        self._header_syncer = LightHeaderChainSyncer(
+            chain, db, proxy_peer_pool, self.cancel_token)
 
     async def _run(self) -> None:
         self.run_daemon(self._header_syncer)


### PR DESCRIPTION
### What was wrong?

We want `PeerPool` and sync to run in their own separate processes. The theory is that this will help us to maintain more peer connections as it frees the networking code from many CPU intensive tasks that happen during sync. 

### How was it fixed?

Still lots of WIP stuff.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] Clean up commit history
- [ ] cleanup code
- [ ] ensure this works with light peers
- [x] ensure this works with beam sync
- [ ] fix "gave 0 headers when seeking common meat ancestors from {start_num}"

[//]: # (For important changes, please add a new entry to the running release notes PR)
[//]: # (You can find the current one using: https://github.com/ethereum/trinity/pulls?q=is%3Aopen+is%3Apr+label%3A%22Release+Notes%22 )
[//]: # (See: https://trinity-client.readthedocs.io/en/latest/contributing.html#pull-requests)
- [ ] Add entry to the [release notes PR](https://github.com/ethereum/trinity/pulls?q=is%3Aopen+is%3Apr+label%3A%22Release+Notes%22)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses]()
