### PR TITLE
Expose PeerJoined/PeerLeft events on eventbus

### DIFF
--- a/trinity/protocol/common/events.py
+++ b/trinity/protocol/common/events.py
@@ -66,6 +66,22 @@ class DisconnectPeerEvent(HasRemoteEvent):
 
 
 @dataclass
+class PeerJoinedEvent(HasRemoteEvent):
+    """
+    Event broadcasted when a new peer joined the pool.
+    """
+    pass
+
+
+@dataclass
+class PeerLeftEvent(HasRemoteEvent):
+    """
+    Event broadcasted when a peer left the pool.
+    """
+    pass
+
+
+@dataclass
 class PeerPoolMessageEvent(HasRemoteEvent):
     """
     Base event for all peer messages that are relayed on the event bus. The events are mapped

--- a/trinity/protocol/common/peer_pool_event_bus.py
+++ b/trinity/protocol/common/peer_pool_event_bus.py
@@ -44,6 +44,8 @@ from .events import (
     HasRemoteEvent,
     PeerCountRequest,
     PeerCountResponse,
+    PeerJoinedEvent,
+    PeerLeftEvent,
 )
 
 
@@ -154,6 +156,14 @@ class PeerPoolEventServer(BaseService, PeerSubscriber, Generic[TPeer]):
             while self.is_operational:
                 peer, cmd, msg = await self.wait(self.msg_queue.get())
                 await self.handle_native_peer_message(peer.remote, cmd, msg)
+
+    def register_peer(self, peer: BasePeer) -> None:
+        self.logger.debug2("Broadcasting PeerJoinedEvent for %s", peer)
+        self.event_bus.broadcast_nowait(PeerJoinedEvent(peer.remote))
+
+    def deregister_peer(self, peer: BasePeer) -> None:
+        self.logger.debug2("Broadcasting PeerLeftEvent for %s", peer)
+        self.event_bus.broadcast_nowait(PeerLeftEvent(peer.remote))
 
 
 class DefaultPeerPoolEventServer(PeerPoolEventServer[BasePeer]):


### PR DESCRIPTION
### What was wrong?

In order to be able to build plugins with complex peer pool interactions we need to expose events for when a peer joined or left.

This is a small spin out from my ongoing work on making all peer pool interactions accessible through the event bus. 

### How was it fixed?

Broadcast `PeerJoinedEvent` and `PeerLeftEvent` from within the `PeerPoolEventServer`.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] Clean up commit history

[//]: # (For important changes, please add a new entry to the running release notes PR)
[//]: # (You can find the current one using: https://github.com/ethereum/trinity/pulls?q=is%3Aopen+is%3Apr+label%3A%22Release+Notes%22 )
[//]: # (See: https://trinity-client.readthedocs.io/en/latest/contributing.html#pull-requests)
- [ ] Add entry to the [release notes PR](https://github.com/ethereum/trinity/pulls?q=is%3Aopen+is%3Apr+label%3A%22Release+Notes%22)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://static.boredpanda.com/blog/wp-content/uploads/2017/04/cute-baby-elephants-44-5901f54331c30__700.jpg)
