### PR TITLE
Use dataclass to reduce event boiler plate

### DIFF
--- a/p2p/events.py
+++ b/p2p/events.py
@@ -1,3 +1,6 @@
+from dataclasses import (
+    dataclass,
+)
 from typing import (
     Tuple,
     Type,
@@ -15,16 +18,16 @@ class BaseDiscoveryServiceResponse(BaseEvent):
     pass
 
 
+@dataclass
 class PeerCandidatesResponse(BaseDiscoveryServiceResponse):
 
-    def __init__(self, candidates: Tuple[Node, ...]) -> None:
-        self.candidates = candidates
+    candidates: Tuple[Node, ...]
 
 
+@dataclass
 class PeerCandidatesRequest(BaseRequestResponseEvent[PeerCandidatesResponse]):
 
-    def __init__(self, max_candidates: int) -> None:
-        self.max_candidates = max_candidates
+    max_candidates: int
 
     @staticmethod
     def expected_response_type() -> Type[PeerCandidatesResponse]:

--- a/setup.py
+++ b/setup.py
@@ -25,6 +25,7 @@ deps = {
         "bloom-filter==1.3",
         "cachetools>=3.1.0,<4.0.0",
         "coincurve>=10.0.0,<11.0.0",
+        "dataclasses>=0.6, <1;python_version<'3.7'",
         "eth-utils>=1.5.1,<2",
         "ipython>=6.2.1,<7.0.0",
         "plyvel==1.0.5",

--- a/trinity/events.py
+++ b/trinity/events.py
@@ -1,3 +1,4 @@
+from dataclasses import dataclass
 from typing import (
     Tuple,
 )
@@ -8,12 +9,13 @@ from lahja import (
 )
 
 
+@dataclass
 class ShutdownRequest(BaseEvent):
 
-    def __init__(self, reason: str="") -> None:
-        self.reason = reason
+    reason: str = ""
 
 
+@dataclass
 class EventBusConnected(BaseEvent):
     """
     Broadcasted when a new :class:`~lahja.endpoint.Endpoint` connects to the ``main``
@@ -24,10 +26,10 @@ class EventBusConnected(BaseEvent):
     :class:`~lahja.endpoint.Endpoint`, making them aware of other endpoints they can connect to.
     """
 
-    def __init__(self, connection_config: ConnectionConfig) -> None:
-        self.connection_config = connection_config
+    connection_config: ConnectionConfig
 
 
+@dataclass
 class AvailableEndpointsUpdated(BaseEvent):
     """
     Broadcasted by the ``main`` :class:`~lahja.endpoint.Endpoint` after it has received a
@@ -35,5 +37,4 @@ class AvailableEndpointsUpdated(BaseEvent):
     lists all available endpoints that are known at the time when the event is raised.
     """
 
-    def __init__(self, available_endpoints: Tuple[ConnectionConfig, ...]) -> None:
-        self.available_endpoints = available_endpoints
+    available_endpoints: Tuple[ConnectionConfig, ...]

--- a/trinity/extensibility/events.py
+++ b/trinity/extensibility/events.py
@@ -1,3 +1,6 @@
+from dataclasses import (
+    dataclass,
+)
 from typing import (
     Any,
     Type,
@@ -15,18 +18,20 @@ if TYPE_CHECKING:
     )
 
 
+@dataclass
 class PluginStartedEvent(BaseEvent):
     """
     Broadcasted when a plugin was started
     """
-    def __init__(self, plugin_type: Type['BasePlugin']) -> None:
-        self.plugin_type = plugin_type
+
+    plugin_type: Type['BasePlugin']
 
 
+@dataclass
 class ResourceAvailableEvent(BaseEvent):
     """
     Broadcasted when a resource becomes available
     """
-    def __init__(self, resource: Any, resource_type: Type[Any]) -> None:
-        self.resource = resource
-        self.resource_type = resource_type
+
+    resource: Any
+    resource_type: Type[Any]

--- a/trinity/nodes/events.py
+++ b/trinity/nodes/events.py
@@ -1,3 +1,6 @@
+from dataclasses import (
+    dataclass,
+)
 from typing import (
     Type,
 )
@@ -8,10 +11,10 @@ from lahja import (
 )
 
 
+@dataclass
 class NetworkIdResponse(BaseEvent):
 
-    def __init__(self, network_id: int) -> None:
-        self.network_id = network_id
+    network_id: int
 
 
 class NetworkIdRequest(BaseRequestResponseEvent[NetworkIdResponse]):

--- a/trinity/plugins/builtin/light_peer_chain_bridge/light_peer_chain_bridge.py
+++ b/trinity/plugins/builtin/light_peer_chain_bridge/light_peer_chain_bridge.py
@@ -1,3 +1,6 @@
+from dataclasses import (
+    dataclass,
+)
 from typing import (
     List,
     Type,
@@ -45,91 +48,90 @@ from trinity.sync.light.service import (
 
 class BaseLightPeerChainResponse(BaseEvent):
 
-    def __init__(self, error: Exception) -> None:
-        self.error = error
+    error: Exception
 
 
+@dataclass
 class BlockHeaderResponse(BaseLightPeerChainResponse):
 
-    def __init__(self, block_header: BlockHeader, error: Exception=None) -> None:
-        super().__init__(error)
-        self.block_header = block_header
+    block_header: BlockHeader
+    error: Exception = None
 
 
+@dataclass
 class BlockBodyResponse(BaseLightPeerChainResponse):
 
-    def __init__(self, block_body: BlockBody, error: Exception=None) -> None:
-        super().__init__(error)
-        self.block_body = block_body
+    block_body: BlockBody
+    error: Exception = None
 
 
+@dataclass
 class ReceiptsResponse(BaseLightPeerChainResponse):
 
-    def __init__(self, receipts: List[Receipt], error: Exception=None) -> None:
-        super().__init__(error)
-        self.receipts = receipts
+    receipts: List[Receipt]
+    error: Exception = None
 
 
+@dataclass
 class AccountResponse(BaseLightPeerChainResponse):
 
-    def __init__(self, account: Account, error: Exception=None) -> None:
-        super().__init__(error)
-        self.account = account
+    account: Account
+    error: Exception = None
 
 
+@dataclass
 class BytesResponse(BaseLightPeerChainResponse):
 
-    def __init__(self, bytez: bytes, error: Exception=None) -> None:
-        super().__init__(error)
-        self.bytez = bytez
+    bytez: bytes
+    error: Exception = None
 
 
+@dataclass
 class GetBlockHeaderByHashRequest(BaseRequestResponseEvent[BlockHeaderResponse]):
 
-    def __init__(self, block_hash: Hash32) -> None:
-        self.block_hash = block_hash
+    block_hash: Hash32
 
     @staticmethod
     def expected_response_type() -> Type[BlockHeaderResponse]:
         return BlockHeaderResponse
 
 
+@dataclass
 class GetBlockBodyByHashRequest(BaseRequestResponseEvent[BlockBodyResponse]):
 
-    def __init__(self, block_hash: Hash32) -> None:
-        self.block_hash = block_hash
+    block_hash: Hash32
 
     @staticmethod
     def expected_response_type() -> Type[BlockBodyResponse]:
         return BlockBodyResponse
 
 
+@dataclass
 class GetReceiptsRequest(BaseRequestResponseEvent[ReceiptsResponse]):
 
-    def __init__(self, block_hash: Hash32) -> None:
-        self.block_hash = block_hash
+    block_hash: Hash32
 
     @staticmethod
     def expected_response_type() -> Type[ReceiptsResponse]:
         return ReceiptsResponse
 
 
+@dataclass
 class GetAccountRequest(BaseRequestResponseEvent[AccountResponse]):
 
-    def __init__(self, block_hash: Hash32, address: Address) -> None:
-        self.block_hash = block_hash
-        self.address = address
+    block_hash: Hash32
+    address: Address
 
     @staticmethod
     def expected_response_type() -> Type[AccountResponse]:
         return AccountResponse
 
 
+@dataclass
 class GetContractCodeRequest(BaseRequestResponseEvent[BytesResponse]):
 
-    def __init__(self, block_hash: Hash32, address: Address) -> None:
-        self.block_hash = block_hash
-        self.address = address
+    block_hash: Hash32
+    address: Address
 
     @staticmethod
     def expected_response_type() -> Type[BytesResponse]:

--- a/trinity/plugins/builtin/network_db/connection/events.py
+++ b/trinity/plugins/builtin/network_db/connection/events.py
@@ -1,3 +1,6 @@
+from dataclasses import (
+    dataclass,
+)
 from typing import Type
 
 from lahja import (
@@ -12,21 +15,24 @@ class BaseConnectionTrackerEvent(BaseEvent):
     pass
 
 
+@dataclass
 class BlacklistEvent(BaseConnectionTrackerEvent):
-    def __init__(self, remote: Node, timeout_seconds: int, reason: str) -> None:
-        self.remote = remote
-        self.timeout_seconds = timeout_seconds
-        self.reason = reason
+
+    remote: Node
+    timeout_seconds: int
+    reason: str
 
 
+@dataclass
 class ShouldConnectToPeerResponse(BaseConnectionTrackerEvent):
-    def __init__(self, should_connect: bool) -> None:
-        self.should_connect = should_connect
+
+    should_connect: bool
 
 
+@dataclass
 class ShouldConnectToPeerRequest(BaseRequestResponseEvent[ShouldConnectToPeerResponse]):
-    def __init__(self, remote: Node) -> None:
-        self.remote = remote
+
+    remote: Node
 
     @staticmethod
     def expected_response_type() -> Type[ShouldConnectToPeerResponse]:

--- a/trinity/plugins/builtin/network_db/eth1_peer_db/events.py
+++ b/trinity/plugins/builtin/network_db/eth1_peer_db/events.py
@@ -1,3 +1,6 @@
+from dataclasses import (
+    dataclass,
+)
 import datetime
 from typing import Optional, Set, Type, Tuple
 
@@ -15,33 +18,29 @@ class BasePeerDBEvent(BaseEvent):
     pass
 
 
+@dataclass
 class TrackPeerEvent(BasePeerDBEvent):
-    def __init__(self,
-                 remote: Node,
-                 is_outbound: bool,
-                 last_connected_at: Optional[datetime.datetime],
-                 genesis_hash: Hash32,
-                 protocol: str,
-                 protocol_version: int,
-                 network_id: int) -> None:
-        self.remote = remote
-        self.is_outbound = is_outbound
-        self.last_connected_at = last_connected_at
-        self.genesis_hash = genesis_hash
-        self.protocol = protocol
-        self.protocol_version = protocol_version
-        self.network_id = network_id
+
+    remote: Node
+    is_outbound: bool
+    last_connected_at: Optional[datetime.datetime]
+    genesis_hash: Hash32
+    protocol: str
+    protocol_version: int
+    network_id: int
 
 
+@dataclass
 class GetPeerCandidatesResponse(BasePeerDBEvent):
-    def __init__(self, candidates: Tuple[Node, ...]) -> None:
-        self.candidates = candidates
+
+    candidates: Tuple[Node, ...]
 
 
+@dataclass
 class GetPeerCandidatesRequest(BaseRequestResponseEvent[GetPeerCandidatesResponse]):
-    def __init__(self, num_requested: int, connected_remotes: Set[Node]) -> None:
-        self.num_requested = num_requested
-        self.connected_remotes = connected_remotes
+
+    num_requested: int
+    connected_remotes: Set[Node]
 
     @staticmethod
     def expected_response_type() -> Type[GetPeerCandidatesResponse]:

--- a/trinity/plugins/eth2/beacon/slot_ticker.py
+++ b/trinity/plugins/eth2/beacon/slot_ticker.py
@@ -4,6 +4,9 @@ import time
 from cancel_token import (
     CancelToken,
 )
+from dataclasses import (
+    dataclass,
+)
 from lahja import (
     BaseEvent,
     BroadcastConfig,
@@ -26,11 +29,12 @@ from trinity.endpoint import (
 DEFAULT_CHECK_FREQUENCY = 6
 
 
+@dataclass
 class SlotTickEvent(BaseEvent):
-    def __init__(self, slot: Slot, elapsed_time: Second, is_second_tick: bool):
-        self.slot = slot
-        self.elapsed_time = elapsed_time
-        self.is_second_tick = is_second_tick
+
+    slot: Slot
+    elapsed_time: Second
+    is_second_tick: bool
 
 
 class SlotTicker(BaseService):

--- a/trinity/protocol/bcc/events.py
+++ b/trinity/protocol/bcc/events.py
@@ -1,3 +1,6 @@
+from dataclasses import (
+    dataclass,
+)
 from typing import (
     Tuple,
 )
@@ -24,19 +27,12 @@ class GetBeaconBlocksEvent(PeerPoolMessageEvent):
     pass
 
 
+@dataclass
 class SendBeaconBlocksEvent(HasRemoteEvent):
     """
     Event to proxy a ``BccPeer.sub_proto.send_blocks`` call from a proxy peer to the actual peer
     that sits in the peer pool.
     """
-    def __init__(self,
-                 remote: Node,
-                 blocks: Tuple[BaseBeaconBlock, ...],
-                 request_id: int) -> None:
-        self._remote = remote
-        self.blocks = blocks
-        self.request_id = request_id
-
-    @property
-    def remote(self) -> Node:
-        return self._remote
+    remote: Node
+    blocks: Tuple[BaseBeaconBlock, ...]
+    request_id: int

--- a/trinity/protocol/common/events.py
+++ b/trinity/protocol/common/events.py
@@ -1,6 +1,5 @@
-from abc import (
-    ABC,
-    abstractmethod,
+from dataclasses import (
+    dataclass,
 )
 from typing import (
     Type,
@@ -21,37 +20,30 @@ from p2p.protocol import (
 )
 
 
-class HasRemoteEvent(BaseEvent, ABC):
+@dataclass
+class HasRemoteEvent(BaseEvent):
     """
     Abstract base event for event types that carry a ``Node`` on the ``remote`` property.
     """
 
-    @property
-    @abstractmethod
-    def remote(self) -> Node:
-        pass
+    remote: Node
 
 
+@dataclass
 class ConnectToNodeCommand(HasRemoteEvent):
     """
     Event that wraps a node URI that the pool should connect to.
     """
-
-    def __init__(self, remote: Node) -> None:
-        self._remote = remote
-
-    @property
-    def remote(self) -> Node:
-        return self._remote
+    pass
 
 
+@dataclass
 class PeerCountResponse(BaseEvent):
     """
     Response event that wraps the count of peers connected to the pool.
     """
 
-    def __init__(self, peer_count: int) -> None:
-        self.peer_count = peer_count
+    peer_count: int
 
 
 class PeerCountRequest(BaseRequestResponseEvent[PeerCountResponse]):
@@ -64,20 +56,16 @@ class PeerCountRequest(BaseRequestResponseEvent[PeerCountResponse]):
         return PeerCountResponse
 
 
+@dataclass
 class DisconnectPeerEvent(HasRemoteEvent):
     """
     Event broadcasted when we want to disconnect from a peer
     """
 
-    def __init__(self, remote: Node, reason: DisconnectReason) -> None:
-        self._remote = remote
-        self.reason = reason
-
-    @property
-    def remote(self) -> Node:
-        return self._remote
+    reason: DisconnectReason
 
 
+@dataclass
 class PeerPoolMessageEvent(HasRemoteEvent):
     """
     Base event for all peer messages that are relayed on the event bus. The events are mapped
@@ -85,11 +73,5 @@ class PeerPoolMessageEvent(HasRemoteEvent):
     the event bus.
     """
 
-    def __init__(self, remote: Node, cmd: Command, msg: PayloadType) -> None:
-        self._remote = remote
-        self.cmd = cmd
-        self.msg = msg
-
-    @property
-    def remote(self) -> Node:
-        return self._remote
+    cmd: Command
+    msg: PayloadType

--- a/trinity/protocol/eth/events.py
+++ b/trinity/protocol/eth/events.py
@@ -1,3 +1,6 @@
+from dataclasses import (
+    dataclass,
+)
 from typing import (
     List,
     Tuple,
@@ -6,9 +9,6 @@ from typing import (
 from eth.rlp.blocks import BaseBlock
 from eth.rlp.headers import BlockHeader
 from eth.rlp.receipts import Receipt
-from p2p.kademlia import (
-    Node,
-)
 
 from trinity.protocol.common.events import (
     HasRemoteEvent,
@@ -68,57 +68,38 @@ class NewBlockHashesEvent(PeerPoolMessageEvent):
 # Events flowing from Proxy to PeerPool
 
 
+@dataclass
 class SendBlockHeadersEvent(HasRemoteEvent):
     """
     Event to proxy a ``ETHPeer.sub_proto.send_block_headers`` call from a proxy peer to the actual
     peer that sits in the peer pool.
     """
-    def __init__(self, remote: Node, headers: Tuple[BlockHeader, ...]) -> None:
-        self._remote = remote
-        self.headers = headers
 
-    @property
-    def remote(self) -> Node:
-        return self._remote
+    headers: Tuple[BlockHeader, ...]
 
 
+@dataclass
 class SendBlockBodiesEvent(HasRemoteEvent):
     """
     Event to proxy a ``ETHPeer.sub_proto.send_block_bodies`` call from a proxy peer to the actual
     peer that sits in the peer pool.
     """
-    def __init__(self, remote: Node, blocks: List[BaseBlock]) -> None:
-        self._remote = remote
-        self.blocks = blocks
-
-    @property
-    def remote(self) -> Node:
-        return self._remote
+    blocks: List[BaseBlock]
 
 
+@dataclass
 class SendNodeDataEvent(HasRemoteEvent):
     """
     Event to proxy a ``ETHPeer.sub_proto.send_node_data`` call from a proxy peer to the actual
     peer that sits in the peer pool.
     """
-    def __init__(self, remote: Node, nodes: Tuple[bytes, ...]) -> None:
-        self._remote = remote
-        self.nodes = nodes
-
-    @property
-    def remote(self) -> Node:
-        return self._remote
+    nodes: Tuple[bytes, ...]
 
 
+@dataclass
 class SendReceiptsEvent(HasRemoteEvent):
     """
     Event to proxy a ``ETHPeer.sub_proto.send_receipts`` call from a proxy peer to the actual
     peer that sits in the peer pool.
     """
-    def __init__(self, remote: Node, receipts: List[List[Receipt]]) -> None:
-        self._remote = remote
-        self.receipts = receipts
-
-    @property
-    def remote(self) -> Node:
-        return self._remote
+    receipts: List[List[Receipt]]

--- a/trinity/protocol/les/events.py
+++ b/trinity/protocol/les/events.py
@@ -1,11 +1,11 @@
+from dataclasses import (
+    dataclass,
+)
 from typing import (
     Tuple,
 )
 
 from eth.rlp.headers import BlockHeader
-from p2p.kademlia import (
-    Node,
-)
 
 from trinity.protocol.common.events import (
     HasRemoteEvent,
@@ -21,21 +21,12 @@ class GetBlockHeadersEvent(PeerPoolMessageEvent):
     pass
 
 
+@dataclass
 class SendBlockHeadersEvent(HasRemoteEvent):
     """
     Event to proxy a ``LESPeer.sub_proto.send_block_heades`` call from a proxy peer to the actual
     peer that sits in the peer pool.
     """
-    def __init__(self,
-                 remote: Node,
-                 headers: Tuple[BlockHeader, ...],
-                 buffer_value: int,
-                 request_id: int=None) -> None:
-        self._remote = remote
-        self.headers = headers
-        self.buffer_value = buffer_value
-        self.request_id = request_id
-
-    @property
-    def remote(self) -> Node:
-        return self._remote
+    headers: Tuple[BlockHeader, ...]
+    buffer_value: int
+    request_id: int

--- a/trinity/sync/common/events.py
+++ b/trinity/sync/common/events.py
@@ -1,3 +1,6 @@
+from dataclasses import (
+    dataclass,
+)
 from typing import (
     Optional,
     Tuple,
@@ -19,11 +22,10 @@ from trinity.sync.common.types import (
 )
 
 
+@dataclass
 class SyncingResponse(BaseEvent):
-    def __init__(self, is_syncing: bool, progress: Optional[SyncProgress]) -> None:
-        super().__init__()
-        self.is_syncing: bool = is_syncing
-        self.progress: Optional[SyncProgress] = progress
+    is_syncing: bool
+    progress: Optional[SyncProgress]
 
 
 class SyncingRequest(BaseRequestResponseEvent[SyncingResponse]):
@@ -40,20 +42,15 @@ class MissingAccountCollected(BaseEvent):
     pass
 
 
+@dataclass
 class CollectMissingAccount(BaseRequestResponseEvent[MissingAccountCollected]):
     """
     Beam Sync has been paused because the given address and/or missing_node_hash
     is missing from the state DB, at the given state root hash.
     """
-    def __init__(
-            self,
-            missing_node_hash: Hash32,
-            address_hash: Hash32,
-            state_root_hash: Hash32) -> None:
-        super().__init__()
-        self.missing_node_hash = missing_node_hash
-        self.address_hash = address_hash
-        self.state_root_hash = state_root_hash
+    missing_node_hash: Hash32
+    address_hash: Hash32
+    state_root_hash: Hash32
 
     @staticmethod
     def expected_response_type() -> Type[MissingAccountCollected]:
@@ -68,14 +65,13 @@ class MissingBytecodeCollected(BaseEvent):
     pass
 
 
+@dataclass
 class CollectMissingBytecode(BaseRequestResponseEvent[MissingBytecodeCollected]):
     """
     Beam Sync has been paused because the given bytecode
     is missing from the state DB, at the given state root hash.
     """
-    def __init__(self, bytecode_hash: Hash32) -> None:
-        super().__init__()
-        self.bytecode_hash = bytecode_hash
+    bytecode_hash: Hash32
 
     @staticmethod
     def expected_response_type() -> Type[MissingBytecodeCollected]:
@@ -90,56 +86,45 @@ class MissingStorageCollected(BaseEvent):
     pass
 
 
+@dataclass
 class CollectMissingStorage(BaseRequestResponseEvent[MissingStorageCollected]):
     """
     Beam Sync has been paused because the given storage key and/or missing_node_hash
     is missing from the state DB, at the given state root hash.
     """
-    def __init__(
-            self,
-            missing_node_hash: Hash32,
-            storage_key: Hash32,
-            storage_root_hash: Hash32,
-            account_address: Address) -> None:
 
-        super().__init__()
-        self.missing_node_hash = missing_node_hash
-        self.storage_key = storage_key
-        self.storage_root_hash = storage_root_hash
-        self.account_address = account_address
+    missing_node_hash: Hash32
+    storage_key: Hash32
+    storage_root_hash: Hash32
+    account_address: Address
 
     @staticmethod
     def expected_response_type() -> Type[MissingStorageCollected]:
         return MissingStorageCollected
 
 
+@dataclass
 class StatelessBlockImportDone(BaseEvent):
     """
     Response to :cls:`DoStatelessBlockImport`, emitted only after the block has
     been fully imported. This event is emitted whether the import was successful
     or a failure.
     """
-    def __init__(
-            self,
-            block: BaseBlock,
-            completed: bool,
-            result: Tuple[BaseBlock, Tuple[BaseBlock, ...], Tuple[BaseBlock, ...]],
-            exception: BaseException) -> None:
-        super().__init__()
-        self.block = block
-        self.completed = completed
-        self.result = result
-        self.exception = exception
+
+    block: BaseBlock
+    completed: bool
+    result: Tuple[BaseBlock, Tuple[BaseBlock, ...], Tuple[BaseBlock, ...]]
+    # flake8 gets confused by the Tuple syntax above
+    exception: BaseException  # noqa: E701
 
 
+@dataclass
 class DoStatelessBlockImport(BaseRequestResponseEvent[StatelessBlockImportDone]):
     """
     The syncer emits this event when it would like the Beam Sync process to
     start attempting a block import.
     """
-    def __init__(self, block: BaseBlock) -> None:
-        super().__init__()
-        self.block = block
+    block: BaseBlock
 
     @staticmethod
     def expected_response_type() -> Type[StatelessBlockImportDone]:


### PR DESCRIPTION
### What was wrong?

A lot of the boiler plate that comes with creating lahja events can be reduces using [dataclasses](https://docs.python.org/3/library/dataclasses.html). Unfortunately, dataclasses do not exist in Python 3.6 but there is a drop-in backport that we can conditionally install only for Python 3.6 environments.

### How was it fixed?

1. Conditionally add dataclasses backport for Python 3.6
2. Migrate places that can be converted to use dataclass (ongoing)

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] Clean up commit history

[//]: # (For important changes, please add a new entry to the running release notes PR)
[//]: # (You can find the current one using: https://github.com/ethereum/trinity/pulls?q=is%3Aopen+is%3Apr+label%3A%22Release+Notes%22 )
[//]: # (See: https://trinity-client.readthedocs.io/en/latest/contributing.html#pull-requests)
- [ ] Add entry to the [release notes PR](https://github.com/ethereum/trinity/pulls?q=is%3Aopen+is%3Apr+label%3A%22Release+Notes%22)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcRncN4HuTEnFgKvJ8w4bsepO3SfVrHQEi54O5KPVXEYAY-TR1uk)
