### PR TITLE
Use db-shell to connect to a running Trinity

### DIFF
--- a/trinity/db/eth1/manager.py
+++ b/trinity/db/eth1/manager.py
@@ -1,3 +1,4 @@
+import multiprocessing
 from multiprocessing.managers import (
     BaseManager,
 )
@@ -19,6 +20,8 @@ from trinity.initialization import (
 )
 from trinity._utils.mp import TracebackRecorder
 
+AUTH_KEY = b"not secure, but only connect over IPC"
+
 
 def create_db_server_manager(trinity_config: TrinityConfig,
                              base_db: BaseAtomicDB) -> BaseManager:
@@ -30,6 +33,9 @@ def create_db_server_manager(trinity_config: TrinityConfig,
         initialize_database(chain_config, chaindb, base_db)
 
     headerdb = HeaderDB(base_db)
+
+    # This enables connection when clients launch from another process on the shell
+    multiprocessing.current_process().authkey = AUTH_KEY
 
     class DBManager(BaseManager):
         pass
@@ -58,6 +64,9 @@ def create_db_consumer_manager(ipc_path: pathlib.Path, connect: bool=True) -> Ba
     We're still using 'str' here on param ipc_path because an issue with
     multi-processing not being able to interpret 'Path' objects correctly
     """
+    # This enables connection when launched from another process on the shell
+    multiprocessing.current_process().authkey = AUTH_KEY
+
     class DBManager(BaseManager):
         pass
 


### PR DESCRIPTION
### What was wrong?

Want to open the db shell on a running trinity client.

### How was it fixed?

Check if trinity is already running by looking for the database IPC file. If it is already created, connect to it using a `DBManager`. Otherwise, just open the database directly (the original case).

### To-Do

- [ ] Add entry to the [release notes PR](https://github.com/ethereum/trinity/pulls?q=is%3Aopen+is%3Apr+label%3A%22Release+Notes%22)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://www.pinclipart.com/picdir/middle/165-1655608_cute-reptiles-cute-snake-snake-art-fantasy-creatures.png)