### PR TITLE
Make requests work on proxy peers

### DIFF
--- a/tests/core/p2p-proto/conftest.py
+++ b/tests/core/p2p-proto/conftest.py
@@ -1,0 +1,39 @@
+import pytest
+
+from tests.core.integration_test_helpers import (
+    FakeAsyncAtomicDB,
+    load_fixture_db,
+    load_mining_chain,
+    DBFixture,
+)
+
+
+@pytest.fixture
+def leveldb_20():
+    yield from load_fixture_db(DBFixture.twenty_pow_headers)
+
+
+@pytest.fixture
+def leveldb_1000():
+    yield from load_fixture_db(DBFixture.thousand_pow_headers)
+
+
+@pytest.fixture
+def chaindb_1000(leveldb_1000):
+    chain = load_mining_chain(FakeAsyncAtomicDB(leveldb_1000))
+    assert chain.chaindb.get_canonical_head().block_number == 1000
+    return chain.chaindb
+
+
+@pytest.fixture
+def chaindb_20(leveldb_20):
+    chain = load_mining_chain(FakeAsyncAtomicDB(leveldb_20))
+    assert chain.chaindb.get_canonical_head().block_number == 20
+    return chain.chaindb
+
+
+@pytest.fixture
+def chaindb_fresh():
+    chain = load_mining_chain(FakeAsyncAtomicDB())
+    assert chain.chaindb.get_canonical_head().block_number == 0
+    return chain.chaindb

--- a/tests/core/p2p-proto/test_requests.py
+++ b/tests/core/p2p-proto/test_requests.py
@@ -1,0 +1,167 @@
+import pytest
+
+from p2p.exceptions import PeerConnectionLost
+
+from trinity.protocol.eth.peer import (
+    ETHPeerPoolEventServer,
+)
+from tests.core.integration_test_helpers import (
+    FakeAsyncChainDB,
+    run_peer_pool_event_server,
+    run_proxy_peer_pool,
+    run_request_server,
+)
+from tests.core.peer_helpers import (
+    get_directly_linked_peers,
+    MockPeerPoolWithConnectedPeers,
+)
+
+
+@pytest.mark.asyncio
+async def test_proxy_peer_requests(request,
+                                   event_bus,
+                                   other_event_bus,
+                                   event_loop,
+                                   chaindb_fresh,
+                                   chaindb_20):
+    server_event_bus = event_bus
+    client_event_bus = other_event_bus
+    client_peer, server_peer = await get_directly_linked_peers(
+        request,
+        event_loop,
+        alice_headerdb=FakeAsyncChainDB(chaindb_fresh.db),
+        bob_headerdb=FakeAsyncChainDB(chaindb_20.db),
+    )
+
+    client_peer_pool = MockPeerPoolWithConnectedPeers([client_peer], event_bus=client_event_bus)
+    server_peer_pool = MockPeerPoolWithConnectedPeers([server_peer], event_bus=server_event_bus)
+
+    async with run_peer_pool_event_server(
+        client_event_bus, client_peer_pool, handler_type=ETHPeerPoolEventServer
+    ), run_peer_pool_event_server(
+        server_event_bus, server_peer_pool, handler_type=ETHPeerPoolEventServer
+    ), run_request_server(
+        server_event_bus,
+        FakeAsyncChainDB(chaindb_20.db)
+    ), run_proxy_peer_pool(
+        client_event_bus
+    ) as client_proxy_peer_pool, run_proxy_peer_pool(
+        server_event_bus
+    ):
+
+        proxy_peer = await client_proxy_peer_pool.ensure_proxy_peer(client_peer.remote)
+
+        headers = await proxy_peer.requests.get_block_headers(0, 1, 0, False)
+
+        assert len(headers) == 1
+        block_header = headers[0]
+        assert block_header.block_number == 0
+
+        receipts = await proxy_peer.requests.get_receipts(headers)
+        assert len(receipts) == 1
+        receipt = receipts[0]
+        assert receipt[1][0] == block_header.receipt_root
+
+        block_bundles = await proxy_peer.requests.get_block_bodies(headers)
+        assert len(block_bundles) == 1
+        first_bundle = block_bundles[0]
+        assert first_bundle[1][0] == block_header.transaction_root
+
+        node_data = await proxy_peer.requests.get_node_data((block_header.state_root,))
+        assert node_data[0][0] == block_header.state_root
+
+
+@pytest.mark.asyncio
+async def test_proxy_peer_requests_with_timeouts(request,
+                                                 event_bus,
+                                                 other_event_bus,
+                                                 event_loop,
+                                                 chaindb_fresh,
+                                                 chaindb_20):
+
+    server_event_bus = event_bus
+    client_event_bus = other_event_bus
+    client_peer, server_peer = await get_directly_linked_peers(
+        request,
+        event_loop,
+        alice_headerdb=FakeAsyncChainDB(chaindb_fresh.db),
+        bob_headerdb=FakeAsyncChainDB(chaindb_20.db),
+    )
+
+    client_peer_pool = MockPeerPoolWithConnectedPeers([client_peer], event_bus=client_event_bus)
+    server_peer_pool = MockPeerPoolWithConnectedPeers([server_peer], event_bus=server_event_bus)
+
+    async with run_peer_pool_event_server(
+        client_event_bus, client_peer_pool, handler_type=ETHPeerPoolEventServer
+    ), run_peer_pool_event_server(
+        server_event_bus, server_peer_pool, handler_type=ETHPeerPoolEventServer
+    ), run_proxy_peer_pool(
+        client_event_bus
+    ) as client_proxy_peer_pool, run_proxy_peer_pool(
+        server_event_bus
+    ):
+
+        proxy_peer = await client_proxy_peer_pool.ensure_proxy_peer(client_peer.remote)
+
+        with pytest.raises(TimeoutError):
+            await proxy_peer.requests.get_block_headers(0, 1, 0, False, timeout=0.01)
+
+        with pytest.raises(TimeoutError):
+            await proxy_peer.requests.get_receipts((), timeout=0.01)
+
+        with pytest.raises(TimeoutError):
+            await proxy_peer.requests.get_block_bodies((), timeout=0.01)
+
+        with pytest.raises(TimeoutError):
+            await proxy_peer.requests.get_node_data((), timeout=0.01)
+
+
+@pytest.mark.asyncio
+async def test_requests_when_peer_in_client_vanishs(request,
+                                                    event_bus,
+                                                    other_event_bus,
+                                                    event_loop,
+                                                    chaindb_fresh,
+                                                    chaindb_20):
+
+    server_event_bus = event_bus
+    client_event_bus = other_event_bus
+    client_peer, server_peer = await get_directly_linked_peers(
+        request,
+        event_loop,
+        alice_headerdb=FakeAsyncChainDB(chaindb_fresh.db),
+        bob_headerdb=FakeAsyncChainDB(chaindb_20.db),
+    )
+
+    client_peer_pool = MockPeerPoolWithConnectedPeers([client_peer], event_bus=client_event_bus)
+    server_peer_pool = MockPeerPoolWithConnectedPeers([server_peer], event_bus=server_event_bus)
+
+    async with run_peer_pool_event_server(
+        client_event_bus, client_peer_pool, handler_type=ETHPeerPoolEventServer
+    ), run_peer_pool_event_server(
+        server_event_bus, server_peer_pool, handler_type=ETHPeerPoolEventServer
+    ), run_request_server(
+        server_event_bus,
+        FakeAsyncChainDB(chaindb_20.db)
+    ), run_proxy_peer_pool(
+        client_event_bus
+    ) as client_proxy_peer_pool, run_proxy_peer_pool(
+        server_event_bus
+    ):
+
+        proxy_peer = await client_proxy_peer_pool.ensure_proxy_peer(client_peer.remote)
+
+        # We remove the peer from the client and assume to see PeerConnectionLost exceptions raised
+        client_peer_pool.connected_nodes.pop(client_peer.remote)
+
+        with pytest.raises(PeerConnectionLost):
+            await proxy_peer.requests.get_block_headers(0, 1, 0, False)
+
+        with pytest.raises(PeerConnectionLost):
+            await proxy_peer.requests.get_receipts(())
+
+        with pytest.raises(PeerConnectionLost):
+            await proxy_peer.requests.get_block_bodies(())
+
+        with pytest.raises(PeerConnectionLost):
+            await proxy_peer.requests.get_node_data(())

--- a/tests/core/p2p-proto/test_sync.py
+++ b/tests/core/p2p-proto/test_sync.py
@@ -395,39 +395,8 @@ async def test_light_syncer(request,
 
 
 @pytest.fixture
-def leveldb_20():
-    yield from load_fixture_db(DBFixture.twenty_pow_headers)
-
-
-@pytest.fixture
-def leveldb_1000():
-    yield from load_fixture_db(DBFixture.thousand_pow_headers)
-
-
-@pytest.fixture
 def leveldb_churner():
     yield from load_fixture_db(DBFixture.state_churner)
-
-
-@pytest.fixture
-def chaindb_1000(leveldb_1000):
-    chain = load_mining_chain(FakeAsyncAtomicDB(leveldb_1000))
-    assert chain.chaindb.get_canonical_head().block_number == 1000
-    return chain.chaindb
-
-
-@pytest.fixture
-def chaindb_20(leveldb_20):
-    chain = load_mining_chain(FakeAsyncAtomicDB(leveldb_20))
-    assert chain.chaindb.get_canonical_head().block_number == 20
-    return chain.chaindb
-
-
-@pytest.fixture
-def chaindb_fresh():
-    chain = load_mining_chain(FakeAsyncAtomicDB())
-    assert chain.chaindb.get_canonical_head().block_number == 0
-    return chain.chaindb
 
 
 @pytest.fixture

--- a/trinity/protocol/bcc/peer.py
+++ b/trinity/protocol/bcc/peer.py
@@ -49,6 +49,9 @@ from trinity.protocol.bcc.commands import (
 from trinity.protocol.bcc.context import (
     BeaconContext,
 )
+from trinity.protocol.common.peer import (
+    BaseProxyPeer,
+)
 from trinity.protocol.common.peer_pool_event_bus import (
     PeerPoolEventServer,
 )
@@ -58,14 +61,20 @@ from .events import (
 )
 
 
-class BCCProxyPeer:
+class BCCProxyPeer(BaseProxyPeer):
     """
     A ``BCCPeer`` that can be used from any process instead of the actual peer pool peer.
     Any action performed on the ``BCCProxyPeer`` is delegated to the actual peer in the pool.
     This does not yet mimic all APIs of the real peer.
     """
 
-    def __init__(self, sub_proto: ProxyBCCProtocol):
+    def __init__(self,
+                 remote: Node,
+                 event_bus: TrinityEventBusEndpoint,
+                 sub_proto: ProxyBCCProtocol):
+
+        super().__init__(remote, event_bus)
+
         self.sub_proto = sub_proto
 
     @classmethod
@@ -73,7 +82,7 @@ class BCCProxyPeer:
                   remote: Node,
                   event_bus: TrinityEventBusEndpoint,
                   broadcast_config: BroadcastConfig) -> 'BCCProxyPeer':
-        return cls(ProxyBCCProtocol(remote, event_bus, broadcast_config))
+        return cls(remote, event_bus, ProxyBCCProtocol(remote, event_bus, broadcast_config))
 
 
 class BCCPeer(BasePeer):

--- a/trinity/protocol/common/events.py
+++ b/trinity/protocol/common/events.py
@@ -66,6 +66,22 @@ class DisconnectPeerEvent(HasRemoteEvent):
 
 
 @dataclass
+class PeerJoinedEvent(HasRemoteEvent):
+    """
+    Event broadcasted when a new peer joined the pool.
+    """
+    pass
+
+
+@dataclass
+class PeerLeftEvent(HasRemoteEvent):
+    """
+    Event broadcasted when a peer left the pool.
+    """
+    pass
+
+
+@dataclass
 class PeerPoolMessageEvent(HasRemoteEvent):
     """
     Base event for all peer messages that are relayed on the event bus. The events are mapped

--- a/trinity/protocol/common/events.py
+++ b/trinity/protocol/common/events.py
@@ -3,6 +3,7 @@ from dataclasses import (
 )
 from typing import (
     Type,
+    TypeVar
 )
 
 from lahja import (
@@ -29,7 +30,19 @@ class HasRemoteEvent(BaseEvent):
     remote: Node
 
 
-@dataclass
+TResponse = TypeVar('TResponse', bound=BaseEvent)
+
+
+class HasRemoteAndTimeoutRequest(BaseRequestResponseEvent[TResponse]):
+    """
+    Abstract base class for request types that carry a ``remote`` and ``timeout`` property.
+    """
+
+    def __init__(self, remote: Node, timeout: float) -> None:
+        self.remote = remote
+        self.timeout = timeout
+
+
 class ConnectToNodeCommand(HasRemoteEvent):
     """
     Event that wraps a node URI that the pool should connect to.

--- a/trinity/protocol/common/handlers.py
+++ b/trinity/protocol/common/handlers.py
@@ -63,7 +63,8 @@ if TYPE_CHECKING:
             BlockIdentifier,
             int,
             DefaultArg(int, 'skip'),
-            DefaultArg(int, 'reverse')
+            DefaultArg(int, 'reverse'),
+            DefaultArg(float, 'timeout')
         ],
         Awaitable[Tuple[BlockHeader, ...]]
     ]

--- a/trinity/protocol/common/peer_pool_event_bus.py
+++ b/trinity/protocol/common/peer_pool_event_bus.py
@@ -3,8 +3,10 @@ from abc import (
 )
 from typing import (
     Any,
+    Awaitable,
     Callable,
     cast,
+    Dict,
     FrozenSet,
     Generic,
     Type,
@@ -12,6 +14,10 @@ from typing import (
 )
 from cancel_token import (
     CancelToken,
+)
+
+from lahja import (
+    BroadcastConfig,
 )
 
 from p2p.exceptions import (
@@ -42,15 +48,20 @@ from .events import (
     ConnectToNodeCommand,
     DisconnectPeerEvent,
     HasRemoteEvent,
+    HasRemoteAndTimeoutRequest,
     PeerCountRequest,
     PeerCountResponse,
     PeerJoinedEvent,
     PeerLeftEvent,
 )
+from .peer import (
+    BaseProxyPeer,
+)
 
 
 TPeer = TypeVar('TPeer', bound=BasePeer)
 TStreamEvent = TypeVar('TStreamEvent', bound=HasRemoteEvent)
+TStreamRequest = TypeVar('TStreamRequest', bound=HasRemoteAndTimeoutRequest[Any])
 
 
 class PeerPoolEventServer(BaseService, PeerSubscriber, Generic[TPeer]):
@@ -97,6 +108,15 @@ class PeerPoolEventServer(BaseService, PeerSubscriber, Generic[TPeer]):
         Register a handler to be run every time that an event of type ``event_type`` appears.
         """
         self.run_daemon_task(self.handle_stream(event_type, event_handler_fn))
+
+    def run_daemon_request(
+            self,
+            event_type: Type[TStreamRequest],
+            event_handler_fn: Callable[[TPeer, TStreamRequest], Awaitable[Any]]) -> None:
+        """
+        Register a handler to be run every time that an request of type ``event_type`` appears.
+        """
+        self.run_daemon_task(self.handle_request_stream(event_type, event_handler_fn))
 
     @abstractmethod
     async def handle_native_peer_message(self,
@@ -151,6 +171,43 @@ class PeerPoolEventServer(BaseService, PeerSubscriber, Generic[TPeer]):
             else:
                 event_handler_fn(peer, event)
 
+    async def handle_request_stream(
+            self,
+            event_type: Type[TStreamRequest],
+            event_handler_fn: Callable[[TPeer, TStreamRequest], Any]) -> None:
+
+        async for event in self.wait_iter(self.event_bus.stream(event_type)):
+            try:
+                peer = self.get_peer(event.remote)
+            except PeerConnectionLost as e:
+                await self.event_bus.broadcast(
+                    event.expected_response_type()(None, e),
+                    event.broadcast_config()
+                )
+                continue
+            else:
+                try:
+                    self.logger.debug2("Replaying %s request on actual peer %r", event_type, peer)
+                    # This is on the server side, we need to track the timeout here. If we don't
+                    # have a request server running, the client (who does not track timeouts) will
+                    # hang forever.
+                    val = await self.wait(event_handler_fn(peer, event), timeout=event.timeout)
+                except Exception as e:
+                    await self.event_bus.broadcast(
+                        event.expected_response_type()(None, e),
+                        event.broadcast_config()
+                    )
+                else:
+                    self.logger.debug2(
+                        "Forwarding response to %s from %r to its proxy peer",
+                        event_type,
+                        peer
+                    )
+                    await self.event_bus.broadcast(
+                        event.expected_response_type()(val, None),
+                        event.broadcast_config()
+                    )
+
     async def handle_native_peer_messages(self) -> None:
         with self.subscribe(self.peer_pool):
             while self.is_operational:
@@ -173,3 +230,47 @@ class DefaultPeerPoolEventServer(PeerPoolEventServer[BasePeer]):
                                          cmd: Command,
                                          msg: PayloadType) -> None:
         pass
+
+
+TProxyPeer = TypeVar('TProxyPeer', bound=BaseProxyPeer)
+
+
+class BaseProxyPeerPool(BaseService, Generic[TProxyPeer]):
+    """
+    Base class for peer pools that can be used from any process instead of the actual peer pool
+    that runs in another process. Eventually, every process that needs to interact with the peer
+    pool should be able to use a proxy peer pool for all peer pool interactions.
+    """
+
+    def __init__(self,
+                 event_bus: TrinityEventBusEndpoint,
+                 broadcast_config: BroadcastConfig,
+                 token: CancelToken=None):
+        super().__init__(token)
+        self.event_bus = event_bus
+        self.broadcast_config = broadcast_config
+        self.connected_peers: Dict[Node, TProxyPeer] = dict()
+
+    @abstractmethod
+    def convert_node_to_proxy_peer(self,
+                                   remote: Node,
+                                   event_bus: TrinityEventBusEndpoint,
+                                   broadcast_config: BroadcastConfig) -> TProxyPeer:
+        pass
+
+    async def ensure_proxy_peer(self, remote: Node) -> TProxyPeer:
+
+        if remote not in self.connected_peers:
+            proxy_peer = self.convert_node_to_proxy_peer(
+                remote,
+                self.event_bus,
+                self.broadcast_config
+            )
+            self.connected_peers[remote] = proxy_peer
+            self.run_child_service(proxy_peer)
+            await proxy_peer.events.started.wait()
+
+        return self.connected_peers[remote]
+
+    async def _run(self) -> None:
+        await self.cancellation()

--- a/trinity/protocol/common/peer_pool_event_bus.py
+++ b/trinity/protocol/common/peer_pool_event_bus.py
@@ -44,6 +44,8 @@ from .events import (
     HasRemoteEvent,
     PeerCountRequest,
     PeerCountResponse,
+    PeerJoinedEvent,
+    PeerLeftEvent,
 )
 
 
@@ -154,6 +156,14 @@ class PeerPoolEventServer(BaseService, PeerSubscriber, Generic[TPeer]):
             while self.is_operational:
                 peer, cmd, msg = await self.wait(self.msg_queue.get())
                 await self.handle_native_peer_message(peer.remote, cmd, msg)
+
+    def register_peer(self, peer: BasePeer) -> None:
+        self.logger.debug2("Broadcasting PeerJoinedEvent for %s", peer)
+        self.event_bus.broadcast_nowait(PeerJoinedEvent(peer.remote))
+
+    def deregister_peer(self, peer: BasePeer) -> None:
+        self.logger.debug2("Broadcasting PeerLeftEvent for %s", peer)
+        self.event_bus.broadcast_nowait(PeerLeftEvent(peer.remote))
 
 
 class DefaultPeerPoolEventServer(PeerPoolEventServer[BasePeer]):

--- a/trinity/protocol/eth/events.py
+++ b/trinity/protocol/eth/events.py
@@ -4,15 +4,33 @@ from dataclasses import (
 from typing import (
     List,
     Tuple,
+    Type,
 )
 
 from eth.rlp.blocks import BaseBlock
 from eth.rlp.headers import BlockHeader
 from eth.rlp.receipts import Receipt
+from lahja import (
+    BaseEvent,
+)
+from p2p.kademlia import (
+    Node,
+)
+
+from eth_typing import (
+    BlockIdentifier,
+    Hash32,
+)
 
 from trinity.protocol.common.events import (
     HasRemoteEvent,
+    HasRemoteAndTimeoutRequest,
     PeerPoolMessageEvent,
+)
+from trinity.protocol.common.types import (
+    BlockBodyBundles,
+    NodeDataBundles,
+    ReceiptsBundles,
 )
 
 
@@ -103,3 +121,84 @@ class SendReceiptsEvent(HasRemoteEvent):
     peer that sits in the peer pool.
     """
     receipts: List[List[Receipt]]
+
+
+# EXCHANGE HANDLER REQUEST / RESPONSE PAIRS
+
+@dataclass
+class GetBlockHeadersResponse(BaseEvent):
+
+    headers: Tuple[BlockHeader, ...]
+    exception: Exception = None  # noqa: E701
+
+
+@dataclass
+class GetBlockHeadersRequest(HasRemoteAndTimeoutRequest[GetBlockHeadersResponse]):
+
+    remote: Node
+    block_number_or_hash: BlockIdentifier
+    max_headers: int
+    skip: int
+    reverse: bool
+    timeout: float
+
+    @staticmethod
+    def expected_response_type() -> Type[GetBlockHeadersResponse]:
+        return GetBlockHeadersResponse
+
+
+@dataclass
+class GetBlockBodiesResponse(BaseEvent):
+
+    bundles: BlockBodyBundles
+    exception: Exception = None  # noqa: E701
+
+
+@dataclass
+class GetBlockBodiesRequest(HasRemoteAndTimeoutRequest[GetBlockBodiesResponse]):
+
+    remote: Node
+    headers: Tuple[BlockHeader, ...]
+    timeout: float
+
+    @staticmethod
+    def expected_response_type() -> Type[GetBlockBodiesResponse]:
+        return GetBlockBodiesResponse
+
+
+@dataclass
+class GetNodeDataResponse(BaseEvent):
+
+    bundles: NodeDataBundles
+    exception: Exception = None  # noqa: E701
+
+
+@dataclass
+class GetNodeDataRequest(HasRemoteAndTimeoutRequest[GetNodeDataResponse]):
+
+    remote: Node
+    node_hashes: Tuple[Hash32, ...]
+    timeout: float
+
+    @staticmethod
+    def expected_response_type() -> Type[GetNodeDataResponse]:
+        return GetNodeDataResponse
+
+
+@dataclass
+class GetReceiptsResponse(BaseEvent):
+
+    bundles: ReceiptsBundles
+    exception: Exception = None  # noqa: E701
+
+
+@dataclass
+class GetReceiptsRequest(HasRemoteAndTimeoutRequest[GetReceiptsResponse]):
+
+    remote: Node
+    headers: Tuple[BlockHeader, ...]
+    timeout: float
+
+    @staticmethod
+    def expected_response_type() -> Type[GetReceiptsResponse]:
+        return GetReceiptsResponse

--- a/trinity/protocol/eth/handlers.py
+++ b/trinity/protocol/eth/handlers.py
@@ -1,7 +1,42 @@
+import logging
+from typing import (
+    cast,
+    Tuple,
+)
+
+from eth.rlp.headers import (
+    BlockHeader,
+)
+from eth.tools.logging import (
+    ExtendedDebugLogger,
+)
+from eth_typing import (
+    BlockIdentifier,
+    Hash32,
+)
+from lahja import (
+    AsyncioEndpoint,
+    BroadcastConfig,
+)
+from p2p.kademlia import (
+    Node,
+)
+
 from trinity.protocol.common.handlers import (
     BaseChainExchangeHandler,
 )
+from trinity.protocol.common.types import (
+    BlockBodyBundles,
+    NodeDataBundles,
+    ReceiptsBundles,
+)
 
+from .events import (
+    GetBlockBodiesRequest,
+    GetBlockHeadersRequest,
+    GetNodeDataRequest,
+    GetReceiptsRequest,
+)
 from .exchanges import (
     GetBlockBodiesExchange,
     GetBlockHeadersExchange,
@@ -22,3 +57,127 @@ class ETHExchangeHandler(BaseChainExchangeHandler):
     get_block_bodies: GetBlockBodiesExchange
     get_node_data: GetNodeDataExchange
     get_receipts: GetReceiptsExchange
+
+
+class ProxyETHExchangeHandler:
+    """
+    An ``ETHExchangeHandler`` that can be used outside of the process that runs the peer pool. Any
+    action performed on this class is delegated to the process that runs the peer pool.
+    """
+
+    def __init__(self,
+                 remote: Node,
+                 event_bus: AsyncioEndpoint,
+                 broadcast_config: BroadcastConfig):
+        self.remote = remote
+        self._event_bus = event_bus
+        self._broadcast_config = broadcast_config
+        self.logger = cast(
+            ExtendedDebugLogger,
+            logging.getLogger('trinity.protocol.eth.handlers.ProxyETHExchangeHandler')
+        )
+
+    def raise_if_needed(self, exception: Exception) -> None:
+        if exception is not None:
+            self.logger.warning(
+                "Raised %s while fetching from peer %s", exception, self.remote.uri
+            )
+            raise exception
+
+    async def get_block_headers(self,
+                                block_number_or_hash: BlockIdentifier,
+                                max_headers: int = None,
+                                skip: int = 0,
+                                reverse: bool = True,
+                                timeout: float = None) -> Tuple[BlockHeader, ...]:
+
+        response = await self._event_bus.request(
+            GetBlockHeadersRequest(
+                self.remote,
+                block_number_or_hash,
+                max_headers,
+                skip,
+                reverse,
+                timeout,
+            ),
+            self._broadcast_config
+        )
+
+        self.raise_if_needed(response.exception)
+
+        self.logger.debug2(
+            "ProxyETHExchangeHandler returning %s block headers from %s",
+            len(response.headers),
+            self.remote
+        )
+
+        return response.headers
+
+    async def get_block_bodies(self,
+                               headers: Tuple[BlockHeader, ...],
+                               timeout: float = None) -> BlockBodyBundles:
+
+        response = await self._event_bus.request(
+            GetBlockBodiesRequest(
+                self.remote,
+                headers,
+                timeout,
+            ),
+            self._broadcast_config
+        )
+
+        self.raise_if_needed(response.exception)
+
+        self.logger.debug2(
+            "ProxyETHExchangeHandler returning %s block bodies from %s",
+            len(response.bundles),
+            self.remote
+        )
+
+        return response.bundles
+
+    async def get_node_data(self,
+                            node_hashes: Tuple[Hash32, ...],
+                            timeout: float = None) -> NodeDataBundles:
+
+        response = await self._event_bus.request(
+            GetNodeDataRequest(
+                self.remote,
+                node_hashes,
+                timeout,
+            ),
+            self._broadcast_config
+        )
+
+        self.raise_if_needed(response.exception)
+
+        self.logger.debug2(
+            "ProxyETHExchangeHandler returning %s node bundles from %s",
+            len(response.bundles),
+            self.remote
+        )
+
+        return response.bundles
+
+    async def get_receipts(self,
+                           headers: Tuple[BlockHeader, ...],
+                           timeout: float = None) -> ReceiptsBundles:
+
+        response = await self._event_bus.request(
+            GetReceiptsRequest(
+                self.remote,
+                headers,
+                timeout,
+            ),
+            self._broadcast_config
+        )
+
+        self.raise_if_needed(response.exception)
+
+        self.logger.debug2(
+            "ProxyETHExchangeHandler returning %s receipt bundles from %s",
+            len(response.bundles),
+            self.remote
+        )
+
+        return response.bundles


### PR DESCRIPTION
### What was wrong?

This includes #725 but doesn't use these events yet (coming in a follow up PR).
This PR is a spin out from #721 which moves the syncing into isolated processes. I tried to find a clean subset of changes that are ready for review which I think this is. 

### How was it fixed?

1. Introduces a `BaseProxyPeerPool` which can be used from any process that wants to interact with the actual peer pool. In its current version, this doesn't do much apart from registering proxy peers. In a follow up PR it will start monitoring incoming/leaving peers automatically based on the `PeerJoinedEvent` / `PeerLeftEvent`.

2. It proxies all peer requests so that `proxy_peer.get_block_headers(...)` becomes possible. These are core APIs that the syncing code will use when it runs in its own process.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] Clean up commit history

[//]: # (For important changes, please add a new entry to the running release notes PR)
[//]: # (You can find the current one using: https://github.com/ethereum/trinity/pulls?q=is%3Aopen+is%3Apr+label%3A%22Release+Notes%22 )
[//]: # (See: https://trinity-client.readthedocs.io/en/latest/contributing.html#pull-requests)
- [ ] Add entry to the [release notes PR](https://github.com/ethereum/trinity/pulls?q=is%3Aopen+is%3Apr+label%3A%22Release+Notes%22)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcSmm37fIfym0AeUTuwSV11VRfIL9UZ_jrMXpF_uZ_kE2rx6cX5V)
