### PR TITLE
Final fix of OrderedTaskPrep del _dependencies bug

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,7 @@ deps = {
         # pinned to <3.7 until async fixtures work again
         # https://github.com/pytest-dev/pytest-asyncio/issues/89
         "pytest>=3.6,<3.7",
-        "pytest-asyncio==0.9.0",
+        "pytest-asyncio>=0.10.0,<0.11",
         "pytest-cov==2.5.1",
         "pytest-watch>=4.1.0,<5",
         "pytest-xdist==1.18.1",

--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ deps = {
         "ruamel.yaml>=0.15.87",
     ],
     'test': [
-        "hypothesis==3.69.5",
+        "hypothesis>=4.24.3,<5",
         "pexpect>=4.6, <5",
         "factory-boy==2.11.1",
         # pinned to <3.7 until async fixtures work again

--- a/tests/eth2/core/beacon/state_machines/forks/test_serenity_block_attestation_validation.py
+++ b/tests/eth2/core/beacon/state_machines/forks/test_serenity_block_attestation_validation.py
@@ -265,7 +265,11 @@ def test_validate_attestation_crosslink_data_root(sample_attestation_data_params
             )
 
 
-@settings(max_examples=1)
+@settings(
+    max_examples=1,
+    # Last CI run took >4.4 seconds. Allow up to 5.5s.
+    deadline=5500,
+)
 @given(random=st.randoms())
 @pytest.mark.parametrize(
     (

--- a/tests/eth2/core/beacon/state_machines/forks/test_serenity_epoch_processing.py
+++ b/tests/eth2/core/beacon/state_machines/forks/test_serenity_epoch_processing.py
@@ -411,7 +411,11 @@ def test_process_justification(monkeypatch,
 #
 # Crosslink
 #
-@settings(max_examples=1)
+@settings(
+    max_examples=1,
+    # Last CI run took >200ms. Allow up to 0.5s.
+    deadline=500,
+)
 @given(random=st.randoms())
 @pytest.mark.parametrize(
     (

--- a/tests/eth2/core/beacon/tools/builder/test_builder_validator.py
+++ b/tests/eth2/core/beacon/tools/builder/test_builder_validator.py
@@ -25,7 +25,11 @@ from eth2.beacon.tools.builder.validator import (
 
 
 @pytest.mark.slow
-@settings(max_examples=1)
+@settings(
+    max_examples=1,
+    # Last CI run took >10 seconds. Allow up to 15s.
+    deadline=15000,
+)
 @given(random=st.randoms())
 @pytest.mark.parametrize(
     (

--- a/trinity/_utils/tree_root.py
+++ b/trinity/_utils/tree_root.py
@@ -251,6 +251,9 @@ class RootTracker(Generic[TNodeID]):
         children = self._tree.children_of(node_id)
         self._link_children(node_root, original_depth, children)
 
+    def get_children(self, node_id: TNodeID) -> Tuple[TNodeID, ...]:
+        return self._tree.children_of(node_id)
+
     def get_root(self, node_id: TNodeID) -> Tuple[TNodeID, int]:
         """
         Look up the root of the tree that node_id is in, and the depth to that root.


### PR DESCRIPTION
### What was wrong?

Occasionally we would get an exception at this line:

```py
File "trinity/_utils/datastructures.py", line 703, in _prune
  del self._dependencies[prune_task_id]
```

### How was it fixed?

Rather than hunt down the corner case, removing that dependency tracker altogether was simpler.

The dependencies were tracked in `RootTracker` anyway, which is probably more robustly tested, and simpler.

### To-Do

- [ ] Add entry to the [release notes PR](https://github.com/ethereum/trinity/pulls?q=is%3Aopen+is%3Apr+label%3A%22Release+Notes%22)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcRgmegJjmtmQtEFw_LY8S0tPf38fRMe16-CfoVReQYs6B0_8BCb9A)
