### PR TITLE
Make Proxy peer pool track the peers in the actual peer pool + move tx pool into isolated process

### DIFF
--- a/tests/core/integration_test_helpers.py
+++ b/tests/core/integration_test_helpers.py
@@ -10,6 +10,9 @@ from async_generator import (
 from cancel_token import OperationCancelled
 from eth_keys import keys
 from eth_utils import decode_hex
+from eth_utils.toolz import (
+    curry,
+)
 
 from eth import MainnetChain, RopstenChain, constants
 from eth.chains.base import (
@@ -45,6 +48,18 @@ from trinity.protocol.eth.servers import (
 )
 
 ZIPPED_FIXTURES_PATH = Path(__file__).parent.parent / 'integration' / 'fixtures'
+
+
+@curry
+async def mock_request_response(request_type, response, bus):
+    async for req in bus.stream(request_type):
+        await bus.broadcast(response, req.broadcast_config())
+        break
+
+
+@curry
+def run_mock_request_response(request_type, response, bus):
+    asyncio.ensure_future(mock_request_response(request_type, response, bus))
 
 
 async def connect_to_peers_loop(peer_pool, nodes):

--- a/tests/core/json-rpc/test_ipc.py
+++ b/tests/core/json-rpc/test_ipc.py
@@ -6,7 +6,6 @@ import time
 
 from eth_utils.toolz import (
     assoc,
-    curry,
 )
 from eth_utils import (
     decode_hex,
@@ -34,12 +33,9 @@ from trinity.sync.common.types import (
 
 from trinity._utils.version import construct_trinity_client_identifier
 
-
-@curry
-async def mock_request_response(request_type, response, bus):
-    async for req in bus.stream(request_type):
-        await bus.broadcast(response, req.broadcast_config())
-        break
+from tests.core.integration_test_helpers import (
+    mock_request_response,
+)
 
 
 def wait_for(path):

--- a/tests/core/p2p-proto/test_base_proxy_peer_pool.py
+++ b/tests/core/p2p-proto/test_base_proxy_peer_pool.py
@@ -1,0 +1,92 @@
+import asyncio
+import pytest
+
+from p2p.tools.factories import NodeFactory
+
+from trinity.protocol.common.events import (
+    GetConnectedPeersRequest,
+    GetConnectedPeersResponse,
+    PeerJoinedEvent,
+    PeerLeftEvent,
+)
+
+from tests.core.integration_test_helpers import (
+    run_proxy_peer_pool,
+    run_mock_request_response,
+)
+
+TEST_NODES = tuple(NodeFactory() for i in range(4))
+
+
+@pytest.mark.asyncio
+async def test_can_instantiate_proxy_pool(event_bus):
+    async with run_proxy_peer_pool(event_bus) as proxy_peer_pool:
+        assert proxy_peer_pool is not None
+
+
+@pytest.mark.parametrize(
+    "response, expected_count",
+    (
+        (GetConnectedPeersResponse(tuple()), 0),
+        (GetConnectedPeersResponse(TEST_NODES), 4),
+    ),
+)
+@pytest.mark.asyncio
+async def test_fetch_initial_peers(event_bus, response, expected_count):
+
+    run_mock_request_response(GetConnectedPeersRequest, response, event_bus)
+
+    async with run_proxy_peer_pool(event_bus) as proxy_peer_pool:
+        peers = await proxy_peer_pool.fetch_initial_peers()
+        assert len(peers) == expected_count
+
+
+@pytest.mark.parametrize(
+    "response, expected_count",
+    (
+        (GetConnectedPeersResponse(tuple()), 0),
+        (GetConnectedPeersResponse(TEST_NODES), 4),
+    ),
+)
+@pytest.mark.asyncio
+async def test_get_peers(event_bus, response, expected_count):
+
+    run_mock_request_response(GetConnectedPeersRequest, response, event_bus)
+
+    async with run_proxy_peer_pool(event_bus) as proxy_peer_pool:
+        peers = await proxy_peer_pool.get_peers()
+        assert len(peers) == expected_count
+
+
+@pytest.mark.asyncio
+async def test_adds_new_peers(event_bus):
+
+    async with run_proxy_peer_pool(event_bus) as proxy_peer_pool:
+        run_mock_request_response(
+            GetConnectedPeersRequest, GetConnectedPeersResponse((TEST_NODES[0],)), event_bus)
+
+        assert len(await proxy_peer_pool.get_peers()) == 1
+
+        await event_bus.broadcast(PeerJoinedEvent(TEST_NODES[1]))
+        # Give the peer a moment to pickup the peer
+        await asyncio.sleep(0.01)
+
+        assert len(await proxy_peer_pool.get_peers()) == 2
+
+
+@pytest.mark.asyncio
+async def test_removes_peers(event_bus):
+
+    async with run_proxy_peer_pool(event_bus) as proxy_peer_pool:
+        run_mock_request_response(
+            GetConnectedPeersRequest, GetConnectedPeersResponse(TEST_NODES[:2]), event_bus)
+
+        assert len(await proxy_peer_pool.get_peers()) == 2
+
+        await event_bus.broadcast(PeerLeftEvent(TEST_NODES[0]))
+        # Give the peer a moment to remove the peer
+        await asyncio.sleep(0.01)
+
+        peers = await proxy_peer_pool.get_peers()
+        assert len(peers) == 1
+        assert peers[0].remote is TEST_NODES[1]

--- a/tests/core/tx-pool/test_tx_pool.py
+++ b/tests/core/tx-pool/test_tx_pool.py
@@ -2,13 +2,11 @@ import asyncio
 import pytest
 import uuid
 
-from eth.tools.logging import ExtendedDebugLogger
 from eth._utils.address import (
     force_bytes_to_address
 )
 
-from p2p.peer import PeerSubscriber
-from p2p.protocol import Command
+from p2p.tools.factories import NodeFactory
 
 from trinity.plugins.builtin.tx_pool.pool import (
     TxPool,
@@ -16,62 +14,28 @@ from trinity.plugins.builtin.tx_pool.pool import (
 from trinity.plugins.builtin.tx_pool.validators import (
     DefaultTransactionValidator
 )
+from trinity.protocol.common.events import (
+    GetConnectedPeersRequest,
+    GetConnectedPeersResponse,
+)
 from trinity.protocol.eth.commands import (
     Transactions
+)
+from trinity.protocol.eth.events import (
+    TransactionsEvent,
+    SendTransactionsEvent,
 )
 
 from tests.conftest import (
     funded_address_private_key
 )
-from tests.core.peer_helpers import (
-    get_directly_linked_peers,
-    MockPeerPoolWithConnectedPeers,
+from tests.core.integration_test_helpers import (
+    run_proxy_peer_pool,
+    run_mock_request_response,
 )
 
 
-class SamplePeerSubscriber(PeerSubscriber):
-    logger = ExtendedDebugLogger("")
-
-    subscription_msg_types = {Command}
-
-    @property
-    def msg_queue_maxsize(self) -> int:
-        return 100
-
-
-class TxsRecorder():
-    def __init__(self):
-        self.recorded_tx = []
-        self.send_count = 0
-
-    def send_txs(self, txs):
-        self.recorded_tx.extend(txs)
-        self.send_count = self.send_count + 1
-
-
-async def bootstrap_test_setup(monkeypatch, request, event_loop, chain, tx_validator):
-    peer1, peer2 = await get_directly_linked_peers(
-        request,
-        event_loop,
-    )
-
-    # We intercept sub_proto.send_transactions to record detailed information
-    # about which peer received what and was invoked how often.
-    peer1_txs_recorder = create_tx_recorder(monkeypatch, peer1)
-    peer2_txs_recorder = create_tx_recorder(monkeypatch, peer2)
-
-    pool = TxPool(
-        MockPeerPoolWithConnectedPeers([peer1, peer2]),
-        tx_validator
-    )
-
-    asyncio.ensure_future(pool.run())
-
-    def finalizer():
-        event_loop.run_until_complete(pool.cancel())
-    request.addfinalizer(finalizer)
-
-    return peer1, peer1_txs_recorder, peer2, peer2_txs_recorder, pool
+TEST_NODES = (NodeFactory(), NodeFactory())
 
 
 @pytest.fixture
@@ -79,131 +43,118 @@ def tx_validator(chain_with_block_validation):
     return DefaultTransactionValidator(chain_with_block_validation, 0)
 
 
+def observe_outgoing_transactions(event_bus):
+    outgoing_tx = []
+
+    event_bus.subscribe(
+        SendTransactionsEvent,
+        lambda event: outgoing_tx.append((event.remote, event.transactions))
+    )
+
+    return outgoing_tx
+
+
 @pytest.mark.asyncio
-async def test_tx_propagation(monkeypatch,
-                              request,
-                              event_loop,
+async def test_tx_propagation(event_bus,
                               chain_with_block_validation,
                               tx_validator):
 
-    peer1, peer1_txs_recorder, peer2, peer2_txs_recorder, pool = await bootstrap_test_setup(
-        monkeypatch,
-        request,
-        event_loop,
-        chain_with_block_validation,
-        tx_validator
-    )
+    initial_two_peers = TEST_NODES[:2]
+    node_one = initial_two_peers[0]
+    node_two = initial_two_peers[1]
 
-    txs_broadcasted_by_peer1 = [create_random_tx(chain_with_block_validation)]
+    async with run_proxy_peer_pool(event_bus) as peer_pool:
+        outgoing_tx = observe_outgoing_transactions(event_bus)
+        tx_pool = TxPool(event_bus, peer_pool, tx_validator)
+        asyncio.ensure_future(tx_pool.run())
 
-    # Peer1 sends some txs
-    await pool._handle_tx(peer1, txs_broadcasted_by_peer1)
+        run_mock_request_response(
+            GetConnectedPeersRequest, GetConnectedPeersResponse(initial_two_peers), event_bus)
 
-    # Check that we don't send the txs back to peer1 where they came from
-    assert peer1_txs_recorder.send_count == 0
+        await asyncio.sleep(0.01)
 
-    # Check that Peer2 receives them
-    assert len(peer2_txs_recorder.recorded_tx) == 1
-    assert peer2_txs_recorder.recorded_tx[0].hash == txs_broadcasted_by_peer1[0].hash
+        txs_broadcasted_by_peer1 = [create_random_tx(chain_with_block_validation)]
 
-    # Peer1 sends same txs again
-    await pool._handle_tx(peer1, txs_broadcasted_by_peer1)
+        # Peer1 sends some txs
+        await event_bus.broadcast(
+            TransactionsEvent(remote=node_one, msg=txs_broadcasted_by_peer1, cmd=Transactions)
+        )
 
-    # Check that Peer2 doesn't receive them again
-    assert peer2_txs_recorder.send_count == 1
+        await asyncio.sleep(0.01)
+        assert outgoing_tx == [
+            (node_two, txs_broadcasted_by_peer1),
+        ]
+        # Clear the recording, we asserted all we want and would like to have a fresh start
+        outgoing_tx.clear()
 
-    # Peer2 sends exact same txs back
-    await pool._handle_tx(peer2, txs_broadcasted_by_peer1)
+        # Peer1 sends same txs again
+        await event_bus.broadcast(
+            TransactionsEvent(remote=node_one, msg=txs_broadcasted_by_peer1, cmd=Transactions)
+        )
+        await asyncio.sleep(0.01)
+        # Check that Peer2 doesn't receive them again
+        assert len(outgoing_tx) == 0
 
-    # Check that Peer1 won't get them as that is where they originally came from
-    assert len(peer1_txs_recorder.recorded_tx) == 0
-    # Also ensure, we don't even call send_transactions with an empty tx list
-    assert peer1_txs_recorder.send_count == 0
+        # Peer2 sends exact same txs back
+        await event_bus.broadcast(
+            TransactionsEvent(remote=node_two, msg=txs_broadcasted_by_peer1, cmd=Transactions)
+        )
+        await asyncio.sleep(0.01)
 
-    # Peer2 sends old + new tx
-    txs_broadcasted_by_peer2 = [
-        create_random_tx(chain_with_block_validation),
-        txs_broadcasted_by_peer1[0]
-    ]
-    await pool._handle_tx(peer2, txs_broadcasted_by_peer2)
+        # Check that Peer1 won't get them as that is where they originally came from
+        assert len(outgoing_tx) == 0
 
-    # Check that Peer1 receives only the one tx that it didn't know about
-    assert len(peer1_txs_recorder.recorded_tx) == 1
-    assert peer1_txs_recorder.recorded_tx[0].hash == txs_broadcasted_by_peer2[0].hash
-    assert peer1_txs_recorder.send_count == 1
+        txs_broadcasted_by_peer2 = [
+            create_random_tx(chain_with_block_validation),
+            txs_broadcasted_by_peer1[0]
+        ]
+
+        # Peer2 sends old + new tx
+        await event_bus.broadcast(
+            TransactionsEvent(remote=node_two, msg=txs_broadcasted_by_peer2, cmd=Transactions)
+        )
+        await asyncio.sleep(0.01)
+
+        # Check that Peer1 receives only the one tx that it didn't know about
+        assert outgoing_tx == [
+            (node_one, [txs_broadcasted_by_peer2[0]]),
+        ]
 
 
 @pytest.mark.asyncio
-async def test_does_not_propagate_invalid_tx(monkeypatch,
-                                             request,
-                                             event_loop,
+async def test_does_not_propagate_invalid_tx(event_bus,
                                              chain_with_block_validation,
                                              tx_validator):
 
-    peer1, peer1_txs_recorder, peer2, peer2_txs_recorder, pool = await bootstrap_test_setup(
-        monkeypatch,
-        request,
-        event_loop,
-        chain_with_block_validation,
-        tx_validator
-    )
+    initial_two_peers = TEST_NODES[:2]
+    node_one = initial_two_peers[0]
+    node_two = initial_two_peers[1]
 
-    txs_broadcasted_by_peer1 = [
-        create_random_tx(chain_with_block_validation, is_valid=False),
-        create_random_tx(chain_with_block_validation)
-    ]
+    async with run_proxy_peer_pool(event_bus) as peer_pool:
+        outgoing_tx = observe_outgoing_transactions(event_bus)
+        tx_pool = TxPool(event_bus, peer_pool, tx_validator)
+        asyncio.ensure_future(tx_pool.run())
 
-    # Peer1 sends some txs
-    await pool._handle_tx(peer1, txs_broadcasted_by_peer1)
+        run_mock_request_response(
+            GetConnectedPeersRequest, GetConnectedPeersResponse(initial_two_peers), event_bus)
 
-    # Check that Peer2 received only the second tx which is valid
-    assert len(peer2_txs_recorder.recorded_tx) == 1
-    assert peer2_txs_recorder.recorded_tx[0].hash == txs_broadcasted_by_peer1[1].hash
+        await asyncio.sleep(0.01)
 
+        txs_broadcasted_by_peer1 = [
+            create_random_tx(chain_with_block_validation, is_valid=False),
+            create_random_tx(chain_with_block_validation)
+        ]
 
-@pytest.mark.asyncio
-async def test_tx_sending(request, event_loop, chain_with_block_validation, tx_validator):
-    # This test covers the communication end to end whereas the previous
-    # focusses on the rules of the transaction pool on when to send tx to whom
-    peer1, peer2 = await get_directly_linked_peers(
-        request,
-        event_loop,
-    )
+        # Peer1 sends some txs
+        await event_bus.broadcast(
+            TransactionsEvent(remote=node_one, msg=txs_broadcasted_by_peer1, cmd=Transactions)
+        )
+        await asyncio.sleep(0.01)
 
-    peer2_subscriber = SamplePeerSubscriber()
-    peer2.add_subscriber(peer2_subscriber)
-
-    pool = TxPool(MockPeerPoolWithConnectedPeers([peer1, peer2]), tx_validator)
-
-    asyncio.ensure_future(pool.run())
-
-    def finalizer():
-        event_loop.run_until_complete(pool.cancel())
-    request.addfinalizer(finalizer)
-
-    txs = [create_random_tx(chain_with_block_validation)]
-
-    peer1.sub_proto.send_transactions(txs)
-
-    # Ensure that peer2 gets the transactions
-    peer, cmd, msg = await asyncio.wait_for(
-        peer2_subscriber.msg_queue.get(),
-        timeout=0.1,
-    )
-
-    assert peer == peer2
-    assert isinstance(cmd, Transactions)
-    assert msg[0].hash == txs[0].hash
-
-
-def create_tx_recorder(monkeypatch, peer):
-    recorder = TxsRecorder()
-    monkeypatch.setattr(
-        peer.sub_proto,
-        'send_transactions',
-        lambda txs: recorder.send_txs(txs)
-    )
-    return recorder
+        # Check that Peer2 received only the second tx which is valid
+        assert outgoing_tx == [
+            (node_two, [txs_broadcasted_by_peer1[1]]),
+        ]
 
 
 def create_random_tx(chain, is_valid=True):

--- a/trinity/protocol/common/events.py
+++ b/trinity/protocol/common/events.py
@@ -2,6 +2,7 @@ from dataclasses import (
     dataclass,
 )
 from typing import (
+    Tuple,
     Type,
     TypeVar
 )
@@ -92,6 +93,19 @@ class PeerLeftEvent(HasRemoteEvent):
     Event broadcasted when a peer left the pool.
     """
     pass
+
+
+@dataclass
+class GetConnectedPeersResponse(BaseEvent):
+
+    remotes: Tuple[Node, ...]
+
+
+class GetConnectedPeersRequest(BaseRequestResponseEvent[GetConnectedPeersResponse]):
+
+    @staticmethod
+    def expected_response_type() -> Type[GetConnectedPeersResponse]:
+        return GetConnectedPeersResponse
 
 
 @dataclass

--- a/trinity/protocol/common/peer_pool_event_bus.py
+++ b/trinity/protocol/common/peer_pool_event_bus.py
@@ -3,12 +3,13 @@ from abc import (
 )
 from typing import (
     Any,
-    Awaitable,
+    AsyncIterator,
     Callable,
     cast,
     Dict,
     FrozenSet,
     Generic,
+    Tuple,
     Type,
     TypeVar,
 )
@@ -23,8 +24,9 @@ from lahja import (
 from p2p.exceptions import (
     PeerConnectionLost,
 )
-from p2p.kademlia import Node
-
+from p2p.kademlia import (
+    Node,
+)
 from p2p.peer import (
     BasePeer,
     PeerSubscriber,
@@ -47,6 +49,8 @@ from trinity.endpoint import (
 from .events import (
     ConnectToNodeCommand,
     DisconnectPeerEvent,
+    GetConnectedPeersRequest,
+    GetConnectedPeersResponse,
     HasRemoteEvent,
     HasRemoteAndTimeoutRequest,
     PeerCountRequest,
@@ -98,6 +102,7 @@ class PeerPoolEventServer(BaseService, PeerSubscriber, Generic[TPeer]):
         self.run_daemon_task(self.handle_peer_count_requests())
         self.run_daemon_task(self.handle_connect_to_node_requests())
         self.run_daemon_task(self.handle_native_peer_messages())
+        self.run_daemon_task(self.handle_get_connected_peers_requests())
 
         await self.cancellation()
 
@@ -112,7 +117,7 @@ class PeerPoolEventServer(BaseService, PeerSubscriber, Generic[TPeer]):
     def run_daemon_request(
             self,
             event_type: Type[TStreamRequest],
-            event_handler_fn: Callable[[TPeer, TStreamRequest], Awaitable[Any]]) -> None:
+            event_handler_fn: Callable[[TPeer, TStreamRequest], Any]) -> None:
         """
         Register a handler to be run every time that an request of type ``event_type`` appears.
         """
@@ -156,6 +161,13 @@ class PeerPoolEventServer(BaseService, PeerSubscriber, Generic[TPeer]):
         async for req in self.wait_iter(self.event_bus.stream(PeerCountRequest)):
             await self.event_bus.broadcast(
                 PeerCountResponse(len(self.peer_pool)),
+                req.broadcast_config()
+            )
+
+    async def handle_get_connected_peers_requests(self) -> None:
+        async for req in self.wait_iter(self.event_bus.stream(GetConnectedPeersRequest)):
+            await self.event_bus.broadcast(
+                GetConnectedPeersResponse(tuple(self.peer_pool.connected_nodes.keys())),
                 req.broadcast_config()
             )
 
@@ -251,6 +263,54 @@ class BaseProxyPeerPool(BaseService, Generic[TProxyPeer]):
         self.broadcast_config = broadcast_config
         self.connected_peers: Dict[Node, TProxyPeer] = dict()
 
+    async def stream_existing_and_joining_peers(self) -> AsyncIterator[TProxyPeer]:
+        for proxy_peer in await self.get_peers():
+            yield proxy_peer
+
+        async for new_proxy_peer in self.wait_iter(self.stream_peers_joining()):
+            yield new_proxy_peer
+
+    # TODO: PeerJoinedEvent/PeerLeftEvent should probably include a session id
+    async def stream_peers_joining(self) -> AsyncIterator[TProxyPeer]:
+        async for ev in self.wait_iter(self.event_bus.stream(PeerJoinedEvent)):
+            yield await self.ensure_proxy_peer(ev.remote)
+
+    async def handle_joining_peers(self) -> None:
+        async for peer in self.wait_iter(self.stream_peers_joining()):
+            # We just want to consume the AsyncIterator
+            self.logger.info("New Proxy Peer joined %s", peer)
+
+    async def handle_leaving_peers(self) -> None:
+        async for ev in self.wait_iter(self.event_bus.stream(PeerLeftEvent)):
+            if ev.remote not in self.connected_peers:
+                self.logger.warning("Wanted to remove peer but it is missing %s", ev.remote)
+            else:
+                proxy_peer = self.connected_peers.pop(ev.remote)
+                # TODO: Double check based on some session id if we are indeed
+                # removing the right peer
+                await proxy_peer.cancel()
+                self.logger.warning("Removed proxy peer from proxy pool %s", ev.remote)
+
+    async def fetch_initial_peers(self) -> Tuple[TProxyPeer, ...]:
+        response = await self.wait(
+            self.event_bus.request(GetConnectedPeersRequest(), self.broadcast_config)
+        )
+
+        return tuple([await self.ensure_proxy_peer(remote) for remote in response.remotes])
+
+    async def get_peers(self) -> Tuple[TProxyPeer, ...]:
+        """
+        Return proxy peer objects for all connected peers in the actual pool.
+        """
+
+        # The ProxyPeerPool could be started at any point in time after the actual peer pool.
+        # Based on this assumption, if we don't have any proxy peers yet, sync with the actual pool
+        # first. From that point on, the proxy peer pool will maintain the set of proxies based on
+        # the events of incoming / leaving peers.
+        if not any(self.connected_peers):
+            await self.fetch_initial_peers()
+        return tuple(self.connected_peers.values())
+
     @abstractmethod
     def convert_node_to_proxy_peer(self,
                                    remote: Node,
@@ -273,4 +333,6 @@ class BaseProxyPeerPool(BaseService, Generic[TProxyPeer]):
         return self.connected_peers[remote]
 
     async def _run(self) -> None:
+        self.run_daemon_task(self.handle_joining_peers())
+        self.run_daemon_task(self.handle_leaving_peers())
         await self.cancellation()

--- a/trinity/protocol/eth/events.py
+++ b/trinity/protocol/eth/events.py
@@ -10,6 +10,8 @@ from typing import (
 from eth.rlp.blocks import BaseBlock
 from eth.rlp.headers import BlockHeader
 from eth.rlp.receipts import Receipt
+from eth.rlp.transactions import BaseTransactionFields
+
 from lahja import (
     BaseEvent,
 )
@@ -123,7 +125,16 @@ class SendReceiptsEvent(HasRemoteEvent):
     receipts: List[List[Receipt]]
 
 
+@dataclass
+class SendTransactionsEvent(HasRemoteEvent):
+    """
+    Event to proxy a ``ETHPeer.sub_proto.send_transactions`` call from a proxy peer to the actual
+    peer that sits in the peer pool.
+    """
+    transactions: List[BaseTransactionFields]
+
 # EXCHANGE HANDLER REQUEST / RESPONSE PAIRS
+
 
 @dataclass
 class GetBlockHeadersResponse(BaseEvent):

--- a/trinity/protocol/eth/proto.py
+++ b/trinity/protocol/eth/proto.py
@@ -46,6 +46,7 @@ from .events import (
     SendBlockHeadersEvent,
     SendNodeDataEvent,
     SendReceiptsEvent,
+    SendTransactionsEvent,
 )
 
 from trinity._utils.logging import HasExtendedDebugLogger
@@ -233,4 +234,7 @@ class ProxyETHProtocol:
     # Transactions
     #
     def send_transactions(self, transactions: List[BaseTransactionFields]) -> None:
-        raise NotImplementedError("Not yet implemented")
+        self._event_bus.broadcast_nowait(
+            SendTransactionsEvent(self.remote, transactions),
+            self._broadcast_config,
+        )


### PR DESCRIPTION
### What was wrong?

This builds on #729. The proxy peer pool needs to track joining / leaving peers to have an accurate picture of what is happening in the real pool. This change should potentially be the last bit to e.g. allow moving the TxPool into an isolated process.

### How was it fixed?

- wrote code to initially sync with actual pool and then track based on `PeerJoinedEvent` / `PeerLeftEvent` from here

- wrote tests

- moved Tx pool into isolated process

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] Clean up commit history

[//]: # (For important changes, please add a new entry to the running release notes PR)
[//]: # (You can find the current one using: https://github.com/ethereum/trinity/pulls?q=is%3Aopen+is%3Apr+label%3A%22Release+Notes%22 )
[//]: # (See: https://trinity-client.readthedocs.io/en/latest/contributing.html#pull-requests)
- [ ] Add entry to the [release notes PR](https://github.com/ethereum/trinity/pulls?q=is%3Aopen+is%3Apr+label%3A%22Release+Notes%22)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://milkmaidmarian.com/wp-content/uploads/2011/05/newborn1pm.jpg?w=300)
