### PR TITLE
Discv5 whoareyou preparation

### DIFF
--- a/p2p/discv5/constants.py
+++ b/p2p/discv5/constants.py
@@ -20,3 +20,5 @@ IP_V6_SIZE = 16  # size of an IPv6 address
 
 ENR_REPR_PREFIX = "enr:"  # prefix used when printing an ENR
 MAX_ENR_SIZE = 300  # maximum allowed size of an ENR
+
+WHO_ARE_YOU_MAGIC_SUFFIX = b"WHOAREYOU"

--- a/p2p/discv5/packets.py
+++ b/p2p/discv5/packets.py
@@ -1,3 +1,5 @@
+import hashlib
+
 from typing import (
     cast,
     NamedTuple,
@@ -45,6 +47,7 @@ from p2p.discv5.constants import (
     TAG_SIZE,
     MAGIC_SIZE,
     ZERO_NONCE,
+    WHO_ARE_YOU_MAGIC_SUFFIX,
 )
 from p2p.discv5.typing import (
     AES128Key,
@@ -310,6 +313,23 @@ def prepare_auth_header_packet(*,
     )
 
 
+def prepare_who_are_you_packet(*,
+                               tag: Hash32,
+                               destination_node_id: Hash32,
+                               token: Nonce,
+                               id_nonce: bytes,
+                               enr_sequence_number: int,
+                               ) -> WhoAreYouPacket:
+    magic = compute_who_are_you_magic(destination_node_id)
+    return WhoAreYouPacket(
+        tag=tag,
+        magic=magic,
+        token=token,
+        id_nonce=id_nonce,
+        enr_sequence_number=enr_sequence_number,
+    )
+
+
 #
 # Packet data computation
 #
@@ -344,3 +364,8 @@ def compute_encrypted_message(initiator_key: AES128Key,
         authenticated_data=authenticated_data,
     )
     return encrypted_message
+
+
+def compute_who_are_you_magic(destination_node_id: Hash32) -> Hash32:
+    preimage = destination_node_id + WHO_ARE_YOU_MAGIC_SUFFIX
+    return Hash32(hashlib.sha256(preimage).digest())

--- a/tests/p2p/discv5/strategies.py
+++ b/tests/p2p/discv5/strategies.py
@@ -5,6 +5,7 @@ from hypothesis import (
 from p2p.discv5.constants import (
     AES128_KEY_SIZE,
     NONCE_SIZE,
+    MAGIC_SIZE,
     TAG_SIZE,
 )
 
@@ -15,3 +16,7 @@ key_st = st.binary(min_size=AES128_KEY_SIZE, max_size=AES128_KEY_SIZE)
 random_data_st = st.binary(min_size=3, max_size=8)
 # arbitrary size as we're not specifying an identity scheme
 pubkey_st = st.binary(min_size=32, max_size=32)
+node_id_st = st.binary(min_size=32, max_size=32)
+magic_st = st.binary(min_size=MAGIC_SIZE, max_size=MAGIC_SIZE)
+id_nonce_st = st.binary(min_size=16, max_size=32)  # arbitrary as there are no spec restrictions
+enr_seq_st = st.integers(min_value=0)

--- a/tests/p2p/discv5/test_packet_encoding.py
+++ b/tests/p2p/discv5/test_packet_encoding.py
@@ -27,18 +27,16 @@ from p2p.discv5.constants import (
     MAGIC_SIZE,
 )
 
+from tests.p2p.discv5.strategies import (
+    enr_seq_st,
+    id_nonce_st,
+    magic_st,
+    nonce_st,
+    tag_st,
+)
 
-nonce_st = st.binary(min_size=NONCE_SIZE, max_size=NONCE_SIZE)
-tag_st = st.binary(min_size=TAG_SIZE, max_size=TAG_SIZE)
 # arbitrary as we're not working with a particular identity scheme
 pubkey_st = st.binary(min_size=33, max_size=33)
-
-
-magic_st = st.binary(min_size=MAGIC_SIZE, max_size=MAGIC_SIZE)
-nonce_st = st.binary(min_size=NONCE_SIZE, max_size=NONCE_SIZE)
-tag_st = st.binary(min_size=TAG_SIZE, max_size=TAG_SIZE)
-id_nonce_st = st.binary(min_size=16, max_size=32)  # arbitrary as there are no spec restrictions
-enr_seq_st = st.integers(min_value=0)
 
 
 @given(

--- a/tests/p2p/discv5/test_packet_preparation.py
+++ b/tests/p2p/discv5/test_packet_preparation.py
@@ -9,8 +9,8 @@ from eth_utils import (
 )
 
 from p2p.discv5.packets import (
-    prepare_auth_header_packet,
-    prepare_who_are_you_packet,
+    AuthHeaderPacket,
+    WhoAreYouPacket,
 )
 from p2p.discv5.enr import (
     ENR,
@@ -63,7 +63,7 @@ def test_auth_header_preparation(tag,
     )
     id_nonce_signature = b"\x00" * 32
 
-    packet = prepare_auth_header_packet(
+    packet = AuthHeaderPacket.prepare(
         tag=tag,
         auth_tag=auth_tag,
         message=message,
@@ -121,7 +121,7 @@ def test_auth_header_preparation_without_enr(tag,
     )
     id_nonce_signature = b"\x00" * 32
 
-    packet = prepare_auth_header_packet(
+    packet = AuthHeaderPacket.prepare(
         tag=tag,
         auth_tag=auth_tag,
         message=message,
@@ -152,7 +152,7 @@ def test_auth_header_preparation_without_enr(tag,
     enr_seq=enr_seq_st,
 )
 def test_who_are_you_preparation(tag, node_id, token, id_nonce, enr_seq):
-    packet = prepare_who_are_you_packet(
+    packet = WhoAreYouPacket.prepare(
         tag=tag,
         destination_node_id=node_id,
         token=token,

--- a/tests/p2p/discv5/test_packet_preparation.py
+++ b/tests/p2p/discv5/test_packet_preparation.py
@@ -10,6 +10,7 @@ from eth_utils import (
 
 from p2p.discv5.packets import (
     prepare_auth_header_packet,
+    prepare_who_are_you_packet,
 )
 from p2p.discv5.enr import (
     ENR,
@@ -22,6 +23,7 @@ from p2p.discv5.encryption import (
 )
 from p2p.discv5.constants import (
     AUTH_SCHEME_NAME,
+    MAGIC_SIZE,
     ZERO_NONCE,
 )
 
@@ -30,6 +32,9 @@ from tests.p2p.discv5.strategies import (
     nonce_st,
     pubkey_st,
     tag_st,
+    node_id_st,
+    id_nonce_st,
+    enr_seq_st,
 )
 
 
@@ -137,3 +142,25 @@ def test_auth_header_preparation_without_enr(tag,
     assert is_list_like(decoded_auth_response) and len(decoded_auth_response) == 2
     assert decoded_auth_response[0] == id_nonce_signature
     assert decoded_auth_response[1] == []
+
+
+@given(
+    tag=tag_st,
+    node_id=node_id_st,
+    token=nonce_st,
+    id_nonce=id_nonce_st,
+    enr_seq=enr_seq_st,
+)
+def test_who_are_you_preparation(tag, node_id, token, id_nonce, enr_seq):
+    packet = prepare_who_are_you_packet(
+        tag=tag,
+        destination_node_id=node_id,
+        token=token,
+        id_nonce=id_nonce,
+        enr_sequence_number=enr_seq,
+    )
+    assert packet.tag == tag
+    assert packet.token == token
+    assert packet.id_nonce == id_nonce
+    assert packet.enr_sequence_number == enr_seq
+    assert len(packet.magic) == MAGIC_SIZE


### PR DESCRIPTION
A helper function to prepare WHOAREYOU packets. This may seem somewhat unnecessary given that most parameters are just passed to the packet constructor. Preparing message packets however is more involved (mostly because encryption), so for consistency an equivalent function for WHOAREYOU packets are implemented as well.

Builds on top of #736

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] Clean up commit history

[//]: # (For important changes, please add a new entry to the running release notes PR)
[//]: # (You can find the current one using: https://github.com/ethereum/trinity/pulls?q=is%3Aopen+is%3Apr+label%3A%22Release+Notes%22 )
[//]: # (See: https://trinity-client.readthedocs.io/en/latest/contributing.html#pull-requests)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://user-images.githubusercontent.com/29854669/59945111-dbfee180-9466-11e9-9e93-e54cfe5a0428.jpg)