### PR TITLE
Discv5 Auth Tag Packet Preparation

### DIFF
--- a/p2p/discv5/packets.py
+++ b/p2p/discv5/packets.py
@@ -127,6 +127,39 @@ class AuthTagPacket(NamedTuple):
     auth_tag: Nonce
     encrypted_message: bytes
 
+    @classmethod
+    def prepare(cls,
+                *,
+                tag: Hash32,
+                auth_tag: Nonce,
+                message: BaseMessage,
+                initiator_key: AES128Key,
+                ) -> "AuthTagPacket":
+        encrypted_message = compute_encrypted_message(
+            initiator_key=initiator_key,
+            auth_tag=auth_tag,
+            message=message,
+            authenticated_data=tag,
+        )
+        return cls(
+            tag=tag,
+            auth_tag=auth_tag,
+            encrypted_message=encrypted_message,
+        )
+
+    @classmethod
+    def prepare_random(cls,
+                       *,
+                       tag: Hash32,
+                       auth_tag: Nonce,
+                       random_data: bytes,
+                       ) -> "AuthTagPacket":
+        return cls(
+            tag=tag,
+            auth_tag=auth_tag,
+            encrypted_message=random_data,
+        )
+
     def to_wire_bytes(self) -> bytes:
         encoded_packet = b"".join((
             self.tag,


### PR DESCRIPTION
Helper function to create auth tag packets (mostly to automatically encrypt the message).

Builds on top of #737 

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] Clean up commit history

[//]: # (For important changes, please add a new entry to the running release notes PR)
[//]: # (You can find the current one using: https://github.com/ethereum/trinity/pulls?q=is%3Aopen+is%3Apr+label%3A%22Release+Notes%22 )
[//]: # (See: https://trinity-client.readthedocs.io/en/latest/contributing.html#pull-requests)
- [ ] Add entry to the [release notes PR](https://github.com/ethereum/trinity/pulls?q=is%3Aopen+is%3Apr+label%3A%22Release+Notes%22)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://user-images.githubusercontent.com/29854669/59947805-7ca4cf80-946e-11e9-9425-e1558a301999.jpg)
