### PR TITLE
Use trio for outermost layer of async execution via `trio-asyncio` library

### DIFF
--- a/p2p/_utils.py
+++ b/p2p/_utils.py
@@ -1,8 +1,3 @@
-from concurrent.futures import Executor, ProcessPoolExecutor
-import logging
-import os
-import signal
-
 import rlp
 
 
@@ -36,67 +31,6 @@ def get_devp2p_cmd_id(msg: bytes) -> int:
     as an integer.
     """
     return rlp.decode(msg[:1], sedes=rlp.sedes.big_endian_int)
-
-
-CPU_EMPTY_VALUES = {None, 0}
-
-
-_executor: Executor = None
-
-
-def ensure_global_asyncio_executor(cpu_count: int=None) -> Executor:
-    """
-    Returns a global `ProcessPoolExecutor` instance.
-
-    NOTE: We use the ProcessPoolExecutor to offload CPU intensive tasks to
-    separate processes to ensure we don't block the main networking process.
-    This pattern will only work correctly if used within a single process.  If
-    multiple processes use this executor API we'll end up with more workers
-    than there are CPU cores at which point the networking process will be
-    competing with all the worker processes for CPU resources.  At the point
-    where we need this in more than one process we will need to come up with a
-    different solution
-    """
-    global _executor
-
-    if _executor is None:
-        # Use CPU_COUNT - 1 processes to make sure we always leave one CPU idle
-        # so that it can run asyncio's event loop.
-        if cpu_count is None:
-            os_cpu_count = os.cpu_count()
-            if os_cpu_count in CPU_EMPTY_VALUES:
-                # Need this because os.cpu_count() returns None when the # of
-                # CPUs is indeterminable.
-                logger = logging.getLogger('p2p')
-                logger.warning(
-                    "Could not determine number of CPUs, defaulting to 1 instead of %s",
-                    os_cpu_count,
-                )
-                cpu_count = 1
-            else:
-                cpu_count = max(1, os_cpu_count - 1)
-        # The following block of code allows us to gracefully handle
-        # `KeyboardInterrupt` in the worker processes.  This is accomplished
-        # via two "hacks".
-        #
-        # First: We set the signal handler for SIGINT to the special case
-        # `SIG_IGN` which instructs the process to ignore SIGINT, while
-        # preserving the original signal handler.  We do this because child
-        # processes inherit the signal handlers of their parent processes.
-        #
-        # Second, we have to force the executor to initialize the worker
-        # processes, as they are not initialized on instantiation, but rather
-        # lazily when the first work is submitted.  We do this by calling the
-        # private method `_start_queue_management_thread`.
-        #
-        # Finally, we restore the original signal handler now that we know the
-        # child processes have been initialized to ensure that
-        # `KeyboardInterrupt` in the main process is still handled normally.
-        original_handler = signal.signal(signal.SIGINT, signal.SIG_IGN)
-        _executor = ProcessPoolExecutor(cpu_count)
-        _executor._start_queue_management_thread()  # type: ignore
-        signal.signal(signal.SIGINT, original_handler)
-    return _executor
 
 
 def trim_middle(arbitrary_string: str, max_length: int) -> str:

--- a/p2p/service.py
+++ b/p2p/service.py
@@ -240,8 +240,10 @@ class BaseService(ABC, CancellableMixin):
         self.run_task(_call_later_wrapped())
 
     async def _run_in_executor(self,
-                               executor: concurrent.futures.Executor,
-                               callback: Callable[..., Any], *args: Any) -> Any:
+                               callback: Callable[..., Any],
+                               *args: Any,
+                               executor: concurrent.futures.Executor = None,
+                               ) -> Any:
 
         loop = self.get_event_loop()
         try:

--- a/p2p/service.py
+++ b/p2p/service.py
@@ -123,7 +123,8 @@ class BaseService(ABC, CancellableMixin):
             # Trigger our cancel token to ensure all pending asyncio tasks and background
             # coroutines started by this service exit cleanly.
             self.events.cancelled.set()
-            self.cancel_token.trigger()
+            if not self.get_event_loop().is_closed():
+                self.cancel_token.trigger()
 
             await self.cleanup()
 

--- a/setup.py
+++ b/setup.py
@@ -35,10 +35,12 @@ deps = {
         "web3==4.4.1",
         "lahja>=0.14.0,<0.15.0",
         "termcolor>=1.1.0,<2.0.0",
-        "uvloop==0.11.2;platform_system=='Linux' or platform_system=='Darwin' or platform_system=='FreeBSD'",  # noqa: E501
         "websockets==5.0.1",
         "jsonschema==3.0.1",
         "mypy_extensions>=0.4.1,<1.0.0",
+        "trio>=0.11.0,<0.12",
+        "trio-asyncio>=0.10.0,<0.11",
+        "trio-typing>=0.2.0,<0.3",
         "typing_extensions>=3.7.2,<4.0.0",
         "ruamel.yaml==0.15.98",
         "argcomplete>=1.10.0,<2",

--- a/trinity/__init__.py
+++ b/trinity/__init__.py
@@ -1,5 +1,4 @@
 import pkg_resources
-import sys
 
 # TODO: update this to use the `trinity` version once extracted from py-evm
 __version__: str
@@ -11,20 +10,6 @@ except pkg_resources.DistributionNotFound:
 # This is to ensure we call setup_extended_logging() before anything else.
 import eth as _eth_module  # noqa: F401
 
-
-def is_uvloop_supported() -> bool:
-    return sys.platform in {'darwin', 'linux'} or sys.platform.startswith('freebsd')
-
-
-if is_uvloop_supported():
-    # Set `uvloop` as the default event loop
-    import asyncio  # noqa: E402
-
-    from eth._warnings import catch_and_ignore_import_warning
-    with catch_and_ignore_import_warning():
-        import uvloop  # noqa: E402
-
-    asyncio.set_event_loop_policy(uvloop.EventLoopPolicy())
 
 from .main import (  # noqa: F401
     main,

--- a/trinity/extensibility/asyncio.py
+++ b/trinity/extensibility/asyncio.py
@@ -28,7 +28,8 @@ class AsyncioIsolatedPlugin(BaseIsolatedPlugin):
             trio.run(self._spawn_start_coro)
 
     async def _spawn_start_coro(self) -> None:
-        async with trio_asyncio.open_loop():
+        async with trio_asyncio.open_loop() as loop:
+            self._loop = loop
             await self._prepare_start()
 
     @trio_asyncio.aio_as_trio
@@ -47,9 +48,5 @@ class AsyncioIsolatedPlugin(BaseIsolatedPlugin):
         await self.event_bus.broadcast(
             PluginStartedEvent(type(self))
         )
-
-        # Whenever new EventBus Endpoints come up the `main` process broadcasts this event
-        # and we connect to every Endpoint directly
-        asyncio.ensure_future(self.event_bus.auto_connect_new_announced_endpoints())
 
         await self.do_start()

--- a/trinity/extensibility/plugin.py
+++ b/trinity/extensibility/plugin.py
@@ -156,7 +156,7 @@ class BasePlugin(ABC):
         )
         self.logger.info("Plugin started: %s", self.name)
 
-    def do_start(self) -> None:
+    def do_start(self) -> Any:
         """
         Perform the actual plugin start routine. In the case of a `BaseIsolatedPlugin` this method
         will be called in a separate process.

--- a/trinity/extensibility/plugin.py
+++ b/trinity/extensibility/plugin.py
@@ -17,8 +17,10 @@ from multiprocessing import (
 )
 from typing import (
     Any,
+    Awaitable,
     Dict,
     NamedTuple,
+    Union,
 )
 
 from lahja.base import EndpointAPI
@@ -156,7 +158,7 @@ class BasePlugin(ABC):
         )
         self.logger.info("Plugin started: %s", self.name)
 
-    def do_start(self) -> Any:
+    def do_start(self) -> Union[None, Awaitable[None]]:
         """
         Perform the actual plugin start routine. In the case of a `BaseIsolatedPlugin` this method
         will be called in a separate process.

--- a/trinity/nodes/base.py
+++ b/trinity/nodes/base.py
@@ -16,8 +16,6 @@ from p2p.peer_pool import BasePeerPool
 from p2p.service import (
     BaseService,
 )
-from p2p._utils import ensure_global_asyncio_executor
-
 from trinity.chains.full import FullChain
 from trinity.db.eth1.header import (
     BaseAsyncHeaderDB,
@@ -130,7 +128,6 @@ class Node(BaseService, Generic[TPeer]):
     async def _run(self) -> None:
         # The `networking` process creates a process pool executor to offload cpu intensive
         # tasks. We should revisit that when we move the sync in its own process
-        ensure_global_asyncio_executor()
         self.run_daemon_task(self.handle_network_id_requests())
         self.run_daemon(self.get_p2p_server())
         self.run_daemon(self.get_event_server())

--- a/trinity/plugins/builtin/beam_exec/plugin.py
+++ b/trinity/plugins/builtin/beam_exec/plugin.py
@@ -36,7 +36,7 @@ class BeamChainExecutionPlugin(AsyncioIsolatedPlugin):
         if self.boot_info.args.sync_mode.upper() == SYNC_BEAM.upper():
             self.start()
 
-    def do_start(self) -> None:
+    async def do_start(self) -> None:
         trinity_config = self.boot_info.trinity_config
         app_config = trinity_config.get_app_config(Eth1AppConfig)
         chain_config = app_config.get_chain_config()
@@ -53,4 +53,4 @@ class BeamChainExecutionPlugin(AsyncioIsolatedPlugin):
 
         import_server = BlockImportServer(self.event_bus, self._beam_chain)
         asyncio.ensure_future(exit_with_services(import_server, self._event_bus_service))
-        asyncio.ensure_future(import_server.run())
+        await import_server.run()

--- a/trinity/plugins/builtin/ethstats/plugin.py
+++ b/trinity/plugins/builtin/ethstats/plugin.py
@@ -114,7 +114,7 @@ class EthstatsPlugin(AsyncioIsolatedPlugin):
 
         self.start()
 
-    def do_start(self) -> None:
+    async def do_start(self) -> None:
         service = EthstatsService(
             self.boot_info,
             self.event_bus,
@@ -129,4 +129,4 @@ class EthstatsPlugin(AsyncioIsolatedPlugin):
             service,
             self._event_bus_service,
         ))
-        asyncio.ensure_future(service.run())
+        await service.run()

--- a/trinity/plugins/builtin/json_rpc/plugin.py
+++ b/trinity/plugins/builtin/json_rpc/plugin.py
@@ -88,7 +88,7 @@ class JsonRpcServerPlugin(AsyncioIsolatedPlugin):
 
         return initialize_beacon_modules(None, self.event_bus)
 
-    def do_start(self) -> None:
+    async def do_start(self) -> None:
 
         trinity_config = self.boot_info.trinity_config
 
@@ -106,4 +106,4 @@ class JsonRpcServerPlugin(AsyncioIsolatedPlugin):
             ipc_server,
             self._event_bus_service,
         ))
-        asyncio.ensure_future(ipc_server.run())
+        await ipc_server.run()

--- a/trinity/plugins/builtin/network_db/plugin.py
+++ b/trinity/plugins/builtin/network_db/plugin.py
@@ -234,7 +234,7 @@ class NetworkDBPlugin(AsyncioIsolatedPlugin):
         else:
             yield self._get_eth1_peer_server()
 
-    def do_start(self) -> None:
+    async def do_start(self) -> None:
         try:
             tracker_services = self._get_services()
         except BadDatabaseError as err:
@@ -244,5 +244,4 @@ class NetworkDBPlugin(AsyncioIsolatedPlugin):
                 self._event_bus_service,
                 *tracker_services,
             ))
-            for service in tracker_services:
-                asyncio.ensure_future(service.run())
+            await asyncio.gather(*(service.run() for service in tracker_services))

--- a/trinity/plugins/builtin/peer_discovery/plugin.py
+++ b/trinity/plugins/builtin/peer_discovery/plugin.py
@@ -172,7 +172,7 @@ class PeerDiscoveryPlugin(AsyncioIsolatedPlugin):
             help="Disable peer discovery",
         )
 
-    def do_start(self) -> None:
+    async def do_start(self) -> None:
         discovery_bootstrap = DiscoveryBootstrapService(
             self.boot_info.args.disable_discovery,
             self.event_bus,
@@ -182,4 +182,4 @@ class PeerDiscoveryPlugin(AsyncioIsolatedPlugin):
             discovery_bootstrap,
             self._event_bus_service,
         ))
-        asyncio.ensure_future(discovery_bootstrap.run())
+        await discovery_bootstrap.run()

--- a/trinity/plugins/builtin/request_server/plugin.py
+++ b/trinity/plugins/builtin/request_server/plugin.py
@@ -63,7 +63,7 @@ class RequestServerPlugin(AsyncioIsolatedPlugin):
             help="Disables the Request Server",
         )
 
-    def do_start(self) -> None:
+    async def do_start(self) -> None:
 
         trinity_config = self.boot_info.trinity_config
 
@@ -83,7 +83,7 @@ class RequestServerPlugin(AsyncioIsolatedPlugin):
             raise Exception("Trinity config must have either eth1 or beacon chain config")
 
         asyncio.ensure_future(exit_with_services(server, self._event_bus_service))
-        asyncio.ensure_future(server.run())
+        await server.run()
 
     def make_eth1_request_server(self,
                                  app_config: Eth1AppConfig,

--- a/trinity/plugins/builtin/syncer/plugin.py
+++ b/trinity/plugins/builtin/syncer/plugin.py
@@ -289,7 +289,7 @@ class SyncerPlugin(AsyncioIsolatedPlugin):
 
         self.start()
 
-    def do_start(self) -> None:
+    async def do_start(self) -> None:
 
         trinity_config = self.boot_info.trinity_config
         NodeClass = trinity_config.get_app_config(Eth1AppConfig).node_class
@@ -301,7 +301,7 @@ class SyncerPlugin(AsyncioIsolatedPlugin):
             node,
             self._event_bus_service,
         ))
-        asyncio.ensure_future(node.run())
+        await node.run()
 
     async def launch_sync(self, node: Node[BasePeer]) -> None:
         await node.events.started.wait()

--- a/trinity/plugins/builtin/tx_pool/plugin.py
+++ b/trinity/plugins/builtin/tx_pool/plugin.py
@@ -70,7 +70,7 @@ class TxPlugin(AsyncioIsolatedPlugin):
                 unsupported_msg,
             ))
 
-    def do_start(self) -> None:
+    async def do_start(self) -> None:
 
         trinity_config = self.boot_info.trinity_config
         db_manager = create_db_consumer_manager(trinity_config.database_ipc_path)

--- a/trinity/plugins/builtin/upnp/nat.py
+++ b/trinity/plugins/builtin/upnp/nat.py
@@ -1,7 +1,4 @@
 import asyncio
-from concurrent.futures import (
-    ThreadPoolExecutor,
-)
 import ipaddress
 from typing import (
     AsyncGenerator,
@@ -153,11 +150,10 @@ class UPnPService(BaseService):
     async def _discover_upnp_devices(self) -> AsyncGenerator[upnpclient.upnp.Device, None]:
         loop = asyncio.get_event_loop()
         # Use loop.run_in_executor() because upnpclient.discover() is blocking and may take a
-        # while to complete. We must use a ThreadPoolExecutor() because the
-        # response from upnpclient.discover() can't be pickled.
+        # while to complete.
         try:
             devices = await self.wait(
-                loop.run_in_executor(ThreadPoolExecutor(max_workers=1), upnpclient.discover),
+                loop.run_in_executor(None, upnpclient.discover),
                 timeout=UPNP_DISCOVER_TIMEOUT_SECONDS,
             )
         except TimeoutError:

--- a/trinity/plugins/builtin/upnp/plugin.py
+++ b/trinity/plugins/builtin/upnp/plugin.py
@@ -43,11 +43,11 @@ class UpnpPlugin(AsyncioIsolatedPlugin):
             help="Disable upnp mapping",
         )
 
-    def do_start(self) -> None:
+    async def do_start(self) -> None:
         port = self.boot_info.trinity_config.port
         self.upnp_service = UPnPService(port)
         asyncio.ensure_future(exit_with_services(
             self.upnp_service,
             self._event_bus_service,
         ))
-        asyncio.ensure_future(self.upnp_service.run())
+        await self.upnp_service.run()

--- a/trinity/protocol/common/managers.py
+++ b/trinity/protocol/common/managers.py
@@ -17,7 +17,6 @@ from eth_utils import (
     ValidationError,
 )
 
-from p2p._utils import ensure_global_asyncio_executor
 from p2p.abc import CommandAPI, RequestAPI, TRequestPayload
 from p2p.constants import BLACKLIST_SECONDS_TOO_MANY_TIMEOUTS
 from p2p.exceptions import PeerConnectionLost
@@ -306,9 +305,6 @@ class ExchangeManager(Generic[TRequestPayload, TResponsePayload, TResult]):
 
                 if normalizer.is_normalization_slow:
                     result = await stream._run_in_executor(
-                        # We just retrieve the global executor that was created when the
-                        # Node launches. The node manages the lifecycle of the executor.
-                        ensure_global_asyncio_executor(),
                         normalizer.normalize_result,
                         payload
                     )


### PR DESCRIPTION
### What was wrong?

We want to migrate to trio but it's hard.....

### How was it fixed?

Use `trio-asyncio` to run things.  This changes the outermost layer while running trinity to use `trio`, leveraging the `trio-asyncio` implementation of the event loop to run the asyncio code.

With this we can incrementally swap out sections to use native asyncio in small pieces.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history

[//]: # (For important changes, please add a new entry to the running release notes PR)
[//]: # (You can find the current one using: https://github.com/ethereum/trinity/pulls?q=is%3Aopen+is%3Apr+label%3A%22Release+Notes%22 )
[//]: # (See: https://trinity-client.readthedocs.io/en/latest/contributing.html#pull-requests)
- [ ] Add entry to the [release notes PR](https://github.com/ethereum/trinity/pulls?q=is%3Aopen+is%3Apr+label%3A%22Release+Notes%22)

#### Cute Animal Picture

![pet-rat-photography-diane-ozdamar-10](https://user-images.githubusercontent.com/824194/60122434-6d5da480-9742-11e9-9841-bd4ccc4f866e.jpg)

