### PR TITLE
Move BeamSync plugin off the base plugins to eth1

### DIFF
--- a/trinity/plugins/registry.py
+++ b/trinity/plugins/registry.py
@@ -56,7 +56,6 @@ BASE_PLUGINS: Tuple[Type[BasePlugin], ...] = (
     PeerDiscoveryPlugin,
     RequestServerPlugin,
     UpnpPlugin,
-    BeamChainExecutionPlugin,
 )
 
 BEACON_NODE_PLUGINS: Tuple[Type[BasePlugin], ...] = (
@@ -66,6 +65,7 @@ BEACON_NODE_PLUGINS: Tuple[Type[BasePlugin], ...] = (
 
 
 ETH1_NODE_PLUGINS: Tuple[Type[BasePlugin], ...] = (
+    BeamChainExecutionPlugin,
     DbShellPlugin,
     EthstatsPlugin,
     LightPeerChainBridgePlugin,


### PR DESCRIPTION
### What was wrong?

Currently, the block executor plugin is configured as a base plugin, meaning it is shared across both `trinity` and `trinity-beacon`. It was getting in the way for the `trinity-beacon` command.

### How was it fixed?

Moved it to the eth1 plugins.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] Clean up commit history

[//]: # (For important changes, please add a new entry to the running release notes PR)
[//]: # (You can find the current one using: https://github.com/ethereum/trinity/pulls?q=is%3Aopen+is%3Apr+label%3A%22Release+Notes%22 )
[//]: # (See: https://trinity-client.readthedocs.io/en/latest/contributing.html#pull-requests)
- [ ] Add entry to the [release notes PR](https://github.com/ethereum/trinity/pulls?q=is%3Aopen+is%3Apr+label%3A%22Release+Notes%22)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcT0GhA5bLStqvOXu7BhFLNviAldEtbrMtw7b6ZlTVmL72_VeB_Itw)
