### PR TITLE
Use preferred node

### DIFF
--- a/eth2/beacon/scripts/run_beacon_nodes.py
+++ b/eth2/beacon/scripts/run_beacon_nodes.py
@@ -57,7 +57,7 @@ class Node:
     name: str
     node_privkey: str
     port: int
-    bootstrap_nodes: Tuple["Node", ...]
+    preferred_nodes: Tuple["Node", ...]
 
     start_time: float
     proc: asyncio.subprocess.Process
@@ -77,13 +77,13 @@ class Node:
             name: str,
             node_privkey: str,
             port: int,
-            bootstrap_nodes: Optional[Tuple["Node", ...]] = None) -> None:
+            preferred_nodes: Optional[Tuple["Node", ...]] = None) -> None:
         self.name = name
         self.node_privkey = PrivateKey(bytes.fromhex(node_privkey))
         self.port = port
-        if bootstrap_nodes is None:
-            bootstrap_nodes = []
-        self.bootstrap_nodes = bootstrap_nodes
+        if preferred_nodes is None:
+            preferred_nodes = []
+        self.preferred_nodes = preferred_nodes
 
         self.tasks = []
         self.start_time = time.monotonic()
@@ -119,11 +119,12 @@ class Node:
             f"--port={self.port}",
             f"--trinity-root-dir={self.root_dir}",
             f"--beacon-nodekey={remove_0x_prefix(self.node_privkey.to_hex())}",
+            "--disable-discovery",
             "-l debug",
         ]
-        if len(self.bootstrap_nodes) != 0:
-            bootstrap_nodes_str = ",".join([node.enode_id for node in self.bootstrap_nodes])
-            _cmds.append(f"--bootstrap_nodes={bootstrap_nodes_str}")
+        if len(self.preferred_nodes) != 0:
+            preferred_nodes_str = ",".join([node.enode_id for node in self.preferred_nodes])
+            _cmds.append(f"--preferred_nodes={preferred_nodes_str}")
         _cmd = " ".join(_cmds)
         return _cmd
 
@@ -186,8 +187,7 @@ class Node:
 
 async def main():
     num_validators = 5
-    time_bob_wait_for_alice = 15
-    genesis_delay = time_bob_wait_for_alice * 3
+    genesis_delay = 20
 
     proc = await run(
         f"rm -rf {Node.dir_root}"
@@ -198,6 +198,7 @@ async def main():
     )
     await proc.wait()
 
+    print("Generating genesis file")
     proc = await run(
         " ".join((
             "trinity-beacon",
@@ -219,19 +220,17 @@ async def main():
         name="alice",
         node_privkey="6b94ffa2d9b8ee85afb9d7153c463ea22789d3bbc5d961cc4f63a41676883c19",
         port=30304,
-        bootstrap_nodes=[],
+        preferred_nodes=[],
     )
-    asyncio.ensure_future(node_alice.run())
-
-    print(f"Sleeping {time_bob_wait_for_alice} seconds to wait until Alice is initialized")
-    await asyncio.sleep(time_bob_wait_for_alice)
-
     node_bob = Node(
         name="bob",
         node_privkey="f5ad1c57b5a489fc8f21ad0e5a19c1f1a60b8ab357a2100ff7e75f3fa8a4fd2e",
         port=30305,
-        bootstrap_nodes=[node_alice],
+        preferred_nodes=[node_alice],
     )
+    node_alice.preferred_nodes = [node_bob]
+
+    asyncio.ensure_future(node_alice.run())
     asyncio.ensure_future(node_bob.run())
 
     await asyncio.sleep(1000000)

--- a/trinity/plugins/eth2/beacon/plugin.py
+++ b/trinity/plugins/eth2/beacon/plugin.py
@@ -56,6 +56,10 @@ class BeaconNodePlugin(AsyncioIsolatedPlugin):
             help="enode://node1@0.0.0.0:1234,enode://node2@0.0.0.0:5678",
         )
         arg_parser.add_argument(
+            "--preferred_nodes",
+            help="enode://node1@0.0.0.0:1234,enode://node2@0.0.0.0:5678",
+        )
+        arg_parser.add_argument(
             "--beacon-nodekey",
             help="0xabcd",
         )


### PR DESCRIPTION
### What was wrong?

In the run_beacon_nodes.py script, disable discovery and use preferred node to minimize distraction to log messages.


#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://preview.redd.it/jqgvuix91u531.jpg?width=640&crop=smart&auto=webp&s=110dafffab825e4f0d1aa0f48a3ff64737e824ef)
