### PR TITLE
Log attestations and fix broadcasting msg to peers

### DIFF
--- a/eth2/beacon/types/blocks.py
+++ b/eth2/beacon/types/blocks.py
@@ -166,7 +166,9 @@ class BaseBeaconBlock(ssz.SignedSerializable, Configurable, ABC):
         return (
             f'<Block #{self.slot} '
             f'signing_root={encode_hex(self.signing_root)[2:10]} '
-            f'root={encode_hex(self.root)[2:10]}>'
+            f'root={encode_hex(self.root)[2:10]} '
+            f'attestations={self.num_attestations} '
+            '>'
         )
 
     @property

--- a/eth2/beacon/types/pending_attestations.py
+++ b/eth2/beacon/types/pending_attestations.py
@@ -38,3 +38,6 @@ class PendingAttestation(ssz.Serializable):
             custody_bitfield=custody_bitfield,
             inclusion_slot=inclusion_slot,
         )
+
+    def __repr__(self) -> str:
+        return f"<PA inclusion_slot={self.inclusion_slot}>"

--- a/eth2/beacon/types/pending_attestations.py
+++ b/eth2/beacon/types/pending_attestations.py
@@ -40,4 +40,4 @@ class PendingAttestation(ssz.Serializable):
         )
 
     def __repr__(self) -> str:
-        return f"<PA inclusion_slot={self.inclusion_slot}>"
+        return f"<PendingAttestation inclusion_slot={self.inclusion_slot}>"

--- a/trinity/plugins/eth2/beacon/validator.py
+++ b/trinity/plugins/eth2/beacon/validator.py
@@ -188,6 +188,14 @@ class Validator(BaseService):
             state.finalized_epoch,
             encode_hex(state.finalized_root),
         )
+        self.logger.debug(
+            bold_green("current_epoch_attestations  %s"),
+            state.current_epoch_attestations,
+        )
+        self.logger.debug(
+            bold_green("previous_epoch_attestations %s"),
+            state.previous_epoch_attestations,
+        )
         proposer_index = _get_proposer_index(
             state,
             slot,

--- a/trinity/protocol/bcc/servers.py
+++ b/trinity/protocol/bcc/servers.py
@@ -458,7 +458,7 @@ class BCCReceiveServer(BaseReceiveServer):
         for peer in self._peer_pool.connected_nodes.values():
             peer = cast(BCCPeer, peer)
             # skip the peer who send the attestations to us
-            if from_peer is not None and peer == from_peer:
+            if from_peer is not None and peer.remote == from_peer.remote:
                 continue
             self.logger.debug(bold_red("Send attestations=%s to peer=%s"), attestations, peer)
             peer.sub_proto.send_attestation_records(attestations)
@@ -551,7 +551,7 @@ class BCCReceiveServer(BaseReceiveServer):
         for peer in self._peer_pool.connected_nodes.values():
             peer = cast(BCCPeer, peer)
             # skip the peer who send the block to us
-            if from_peer is not None and peer == from_peer:
+            if from_peer is not None and peer.remote == from_peer.remote:
                 continue
             self.logger.debug(bold_red("Send block=%s to peer=%s"), block, peer)
             peer.sub_proto.send_new_block(block=block)


### PR DESCRIPTION
### What was wrong?

- Attestation included in the state is not logged.
- Trinity broadcasts message back to it's origin.

### How was it fixed?

- Add `__repr__`s and logs current / previous _epoch_attestations from state
- Explicitly compare peer with peer.remote

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://preview.redd.it/0a52yp7jzt531.png?width=640&crop=smart&auto=webp&s=4514bd72eeb0a8838b3750d30af0e9f5e28d0689)
