### PR TITLE
Discv5 AuthHeader decryption

### DIFF
--- a/p2p/discv5/packets.py
+++ b/p2p/discv5/packets.py
@@ -14,11 +14,12 @@ from rlp.sedes import (
 )
 from rlp.exceptions import (
     DecodingError,
+    DeserializationError,
 )
 
 from eth_utils import (
-    is_bytes,
     encode_hex,
+    is_bytes,
     is_list_like,
     ValidationError,
 )
@@ -32,6 +33,7 @@ from eth.validation import (
 )
 
 from p2p.discv5.encryption import (
+    aesgcm_decrypt,
     aesgcm_encrypt,
     validate_nonce,
 )
@@ -111,6 +113,51 @@ class AuthHeaderPacket(NamedTuple):
             auth_header=auth_header,
             encrypted_message=encrypted_message,
         )
+
+    def decrypt_auth_response(self, auth_response_key: AES128Key) -> Tuple[bytes, Optional[ENR]]:
+        """Extract id nonce signature and optional ENR from auth header packet."""
+        plain_text = aesgcm_decrypt(
+            key=auth_response_key,
+            nonce=ZERO_NONCE,
+            cipher_text=self.auth_header.encrypted_auth_response,
+            authenticated_data=self.tag,
+        )
+
+        try:
+            decoded_rlp = rlp.decode(plain_text)
+        except DecodingError as error:
+            raise ValidationError(
+                f"Auth response does not contain valid RLP: {encode_hex(plain_text)}"
+            )
+
+        if not is_list_like(decoded_rlp):
+            raise ValidationError(
+                f"Auth response contains bytes instead of list: {encode_hex(decoded_rlp)}"
+            )
+
+        if len(decoded_rlp) != 2:
+            raise ValidationError(
+                f"Auth response is a list of {len(decoded_rlp)} instead of two elements"
+            )
+        id_nonce_signature, serialized_enr = decoded_rlp
+
+        if not is_bytes(id_nonce_signature):
+            raise ValidationError(
+                f"Id nonce signature is a list instead of bytes: {id_nonce_signature}"
+            )
+
+        if not is_list_like(serialized_enr):
+            raise ValidationError(f"ENR is bytes instead of list: {encode_hex(serialized_enr)}")
+
+        if len(serialized_enr) == 0:
+            enr = None
+        else:
+            try:
+                enr = ENR.deserialize(serialized_enr)
+            except DeserializationError as error:
+                raise ValidationError("ENR in auth response is not properly encoded") from error
+
+        return id_nonce_signature, enr
 
     def to_wire_bytes(self) -> bytes:
         encoded_packet = b"".join((
@@ -401,3 +448,8 @@ def compute_encrypted_message(initiator_key: AES128Key,
 def compute_who_are_you_magic(destination_node_id: Hash32) -> Hash32:
     preimage = destination_node_id + WHO_ARE_YOU_MAGIC_SUFFIX
     return Hash32(hashlib.sha256(preimage).digest())
+
+
+#
+# Packet decryption
+#

--- a/tests/p2p/discv5/test_packet_decryption.py
+++ b/tests/p2p/discv5/test_packet_decryption.py
@@ -1,0 +1,137 @@
+import pytest
+
+from hypothesis import (
+    given,
+)
+
+from p2p.exceptions import (
+    DecryptionError,
+)
+
+from p2p.discv5.packets import (
+    AuthHeaderPacket,
+)
+from p2p.discv5.enr import (
+    ENR,
+)
+from p2p.discv5.messages import (
+    PingMessage,
+)
+from p2p.discv5.constants import (
+    AES128_KEY_SIZE,
+)
+
+from tests.p2p.discv5.strategies import (
+    tag_st,
+    nonce_st,
+    key_st,
+    pubkey_st,
+)
+
+
+@pytest.fixture
+def enr():
+    return ENR(
+        sequence_number=1,
+        signature=b"",
+        kv_pairs={
+            b"id": b"v4",
+        }
+    )
+
+
+@pytest.fixture
+def message(enr):
+    return PingMessage(
+        request_id=5,
+        enr_seq=enr.sequence_number,
+    )
+
+
+@given(
+    tag=tag_st,
+    auth_tag=nonce_st,
+    initiator_key=key_st,
+    auth_response_key=key_st,
+    ephemeral_pubkey=pubkey_st,
+)
+def test_auth_header_decryption_with_enr(tag,
+                                         auth_tag,
+                                         initiator_key,
+                                         auth_response_key,
+                                         ephemeral_pubkey,
+                                         enr,
+                                         message):
+    id_nonce_signature = b"\x00" * 32
+    packet = AuthHeaderPacket.prepare(
+        tag=tag,
+        auth_tag=auth_tag,
+        message=message,
+        initiator_key=initiator_key,
+        id_nonce_signature=id_nonce_signature,
+        auth_response_key=auth_response_key,
+        enr=enr,
+        ephemeral_pubkey=ephemeral_pubkey
+    )
+
+    recovered_id_nonce_signature, recovered_enr = packet.decrypt_auth_response(auth_response_key)
+    assert recovered_id_nonce_signature == id_nonce_signature
+    assert recovered_enr == enr
+
+
+@given(
+    tag=tag_st,
+    auth_tag=nonce_st,
+    initiator_key=key_st,
+    auth_response_key=key_st,
+    ephemeral_pubkey=pubkey_st,
+)
+def test_auth_header_decryption_without_enr(tag,
+                                            auth_tag,
+                                            initiator_key,
+                                            auth_response_key,
+                                            ephemeral_pubkey,
+                                            message):
+    id_nonce_signature = b"\x00" * 32
+    packet = AuthHeaderPacket.prepare(
+        tag=tag,
+        auth_tag=auth_tag,
+        message=message,
+        initiator_key=initiator_key,
+        id_nonce_signature=id_nonce_signature,
+        auth_response_key=auth_response_key,
+        enr=None,
+        ephemeral_pubkey=ephemeral_pubkey
+    )
+
+    recovered_id_nonce_signature, recovered_enr = packet.decrypt_auth_response(auth_response_key)
+    assert recovered_id_nonce_signature == id_nonce_signature
+    assert recovered_enr is None
+
+
+@given(
+    tag=tag_st,
+    auth_tag=nonce_st,
+    initiator_key=key_st,
+    ephemeral_pubkey=pubkey_st,
+)
+def test_invalid_auth_header_decryption_with_wrong_key(tag,
+                                                       auth_tag,
+                                                       initiator_key,
+                                                       ephemeral_pubkey,
+                                                       message):
+    id_nonce_signature = b"\x00" * 32
+    encryption_key = b"\x00" * AES128_KEY_SIZE
+    decryption_key = b"\x11" * AES128_KEY_SIZE
+    packet = AuthHeaderPacket.prepare(
+        tag=tag,
+        auth_tag=auth_tag,
+        message=message,
+        initiator_key=initiator_key,
+        id_nonce_signature=id_nonce_signature,
+        auth_response_key=encryption_key,
+        enr=None,
+        ephemeral_pubkey=ephemeral_pubkey
+    )
+    with pytest.raises(DecryptionError):
+        packet.decrypt_auth_response(decryption_key)


### PR DESCRIPTION
Function to decrypt the auth header packet during handshake, containing the signed id nonce and, optionally, an updated ENR.

Builds on top of #741 


### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] Clean up commit history

[//]: # (For important changes, please add a new entry to the running release notes PR)
[//]: # (You can find the current one using: https://github.com/ethereum/trinity/pulls?q=is%3Aopen+is%3Apr+label%3A%22Release+Notes%22 )
[//]: # (See: https://trinity-client.readthedocs.io/en/latest/contributing.html#pull-requests)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://user-images.githubusercontent.com/29854669/59965960-7ae21700-9515-11e9-806c-aa8f2a4dab7b.jpg)
