### PR TITLE
Fix broken JSON-RPC calls in light mode

### DIFF
--- a/trinity/plugins/builtin/json_rpc/plugin.py
+++ b/trinity/plugins/builtin/json_rpc/plugin.py
@@ -7,6 +7,10 @@ from typing import (
     Tuple
 )
 
+from eth.db.header import (
+    HeaderDB,
+)
+
 from trinity.config import (
     Eth1AppConfig,
     Eth1DbMode,
@@ -69,7 +73,8 @@ class JsonRpcServerPlugin(AsyncioIsolatedPlugin):
         chain: BaseAsyncChain
 
         if eth1_app_config.database_mode is Eth1DbMode.LIGHT:
-            header_db = db_manager.get_headerdb()  # type: ignore
+            db = db_manager.get_db()  # type: ignore
+            header_db = HeaderDB(db)
             event_bus_light_peer_chain = EventBusLightPeerChain(self.event_bus)
             chain = chain_config.light_chain_class(header_db, peer_chain=event_bus_light_peer_chain)
         elif eth1_app_config.database_mode is Eth1DbMode.FULL:

--- a/trinity/protocol/common/peer.py
+++ b/trinity/protocol/common/peer.py
@@ -177,7 +177,7 @@ class BaseChainPeerPool(BasePeerPool):
     def highest_td_peer(self) -> BaseChainPeer:
         peers = tuple(self.connected_nodes.values())
         if not peers:
-            raise NoConnectedPeers()
+            raise NoConnectedPeers("No connected peers")
         peers_by_td = groupby(operator.attrgetter('head_td'), peers)
         max_td = max(peers_by_td.keys())
         return random.choice(peers_by_td[max_td])


### PR DESCRIPTION
### What was wrong?

This PR addresses two different things:

1. Making JSON-RPC calls to a light client was broken
2. The `NoConnectedPeers` error had no message which is kinda unfortunate as the text is picked up by `web3` and so it is the only thing that could guide a user towards the problem

### How was it fixed?

1. The `LightPeerChain` needs a `HeaderDB` not a `AsyncHeaderDB`
2. Added a bit of test to the `NoConnectedPeers` error

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] Clean up commit history

[//]: # (For important changes, please add a new entry to the running release notes PR)
[//]: # (You can find the current one using: https://github.com/ethereum/trinity/pulls?q=is%3Aopen+is%3Apr+label%3A%22Release+Notes%22 )
[//]: # (See: https://trinity-client.readthedocs.io/en/latest/contributing.html#pull-requests)
- [ ] Add entry to the [release notes PR](https://github.com/ethereum/trinity/pulls?q=is%3Aopen+is%3Apr+label%3A%22Release+Notes%22)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcRCChsXi16aR7emaP3a-P-sCuBSW0ivq5lsTO_8UANWnlXFWz90Qg)
