### PR TITLE
Update the serialization so that the state is interpreted correctly

### DIFF
--- a/tests/eth2/integration/test_demo.py
+++ b/tests/eth2/integration/test_demo.py
@@ -23,6 +23,9 @@ from eth2.beacon.tools.builder.proposer import (
 from eth2.beacon.tools.builder.validator import (
     create_mock_signed_attestations_at_slot,
 )
+from eth2.beacon.tools.misc.ssz_vector import (
+    override_vector_lengths,
+)
 
 
 #
@@ -61,6 +64,7 @@ def test_demo(base_db,
         SHARD_COUNT=2,
         MIN_ATTESTATION_INCLUSION_DELAY=2,
     )
+    override_vector_lengths(config)
     fixture_sm_class = SerenityStateMachine.configure(
         __name__='SerenityStateMachineForTesting',
         config=config,


### PR DESCRIPTION
### What was wrong?

Part of our current SSZ typing includes `Vector` lengths that are configured at runtime.

The current strategy to handle this dynamism is to override the `py-ssz` metaclass data once we know the configuration values.

There was an integration test that was not doing this runtime configuration and somehow made its way into master, breaking the build.

### How was it fixed?

Setting the ssz config before the state in the failing test was instantiated.

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://proxy.duckduckgo.com/iu/?u=https%3A%2F%2Fi.ytimg.com%2Fvi%2FG7RdB0qM3qk%2Fmaxresdefault.jpg&f=1)
