### PR TITLE
Ensure we can only have a single concurrent handshake per remote

### DIFF
--- a/p2p/peer_pool.py
+++ b/p2p/peer_pool.py
@@ -10,6 +10,7 @@ from typing import (
     Dict,
     Iterator,
     List,
+    Set,
     Tuple,
     Type,
 )
@@ -122,11 +123,16 @@ class BasePeerPool(BaseService, AsyncIterable[BasePeer]):
         self.context = context
 
         self.connected_nodes: Dict[Node, BasePeer] = {}
+
         self._subscribers: List[PeerSubscriber] = []
         self._event_bus = event_bus
 
         # Restricts the number of concurrent connection attempts can be made
         self._connection_attempt_lock = asyncio.BoundedSemaphore(MAX_CONCURRENT_CONNECTION_ATTEMPTS)
+
+        # Ensure we can only have a single concurrent handshake in flight per remote
+        self._handshake_lock = asyncio.Lock()
+        self._inflight_handshakes: Set[Node] = set()
 
         self.peer_backends = self.setup_peer_backends()
         self.connection_tracker = self.setup_connection_tracker()
@@ -313,6 +319,13 @@ class BasePeerPool(BaseService, AsyncIterable[BasePeer]):
             self.logger.debug2("Skipping %s; already connected to it", remote)
             raise IneligiblePeer(f"Already connected to {remote}")
 
+        async with self._handshake_lock:
+            if remote in self._inflight_handshakes:
+                self.logger.debug2("Skipping %s; already shaking hands", remote)
+                raise IneligiblePeer(f"Already shaking hands with {remote}")
+            else:
+                self._inflight_handshakes.add(remote)
+
         try:
             should_connect = await self.wait(
                 self.connection_tracker.should_connect_to(remote),
@@ -330,7 +343,6 @@ class BasePeerPool(BaseService, AsyncIterable[BasePeer]):
             # We use self.wait() as well as passing our CancelToken to handshake() as a workaround
             # for https://github.com/ethereum/py-evm/issues/670.
             peer = await self.wait(handshake(remote, self.get_peer_factory()))
-
             return peer
         except OperationCancelled:
             # Pass it on to instruct our main loop to stop.
@@ -361,6 +373,10 @@ class BasePeerPool(BaseService, AsyncIterable[BasePeer]):
         except Exception:
             self.logger.exception("Unexpected error during auth/p2p handshake with %r", remote)
             raise
+        finally:
+            async with self._handshake_lock:
+                self.logger.debug("Removing %s from connect_lock", remote)
+                self._inflight_handshakes.remove(remote)
 
     async def connect_to_nodes(self, nodes: Iterator[Node]) -> None:
         # create an generator for the nodes


### PR DESCRIPTION
### What was wrong?

This bug was reported by @NIC619 via discord. Here is what happens:

When you run trinity with `--preferred_nodes` and `--no-discovery` it appears that the `DiscoveryPeerBackend` and the `BootnodesPeerBackend` will both return the same set of peers. This doesn't seem to be the actual problem though because I believe that we could have other circumstances leading to the same scenario.

The actual problem is that **if** (for whatever reason) we make multiple connection attempts to the same peer, we don't recognize and prevent it.

E.g the only check that we do is this one.

https://github.com/ethereum/trinity/blob/891a4254b262542120bef0bd9319ce50c38b2f94/p2p/peer_pool.py#L312-L314

But that does only check if we are already **connected**, not if we are already **trying to connect**.

### How was it fixed?

Added a check if we are already trying to connect to a peer to prevent multiple connections from happening. Notice that while this does incur a *lock*, this *lock* should be extremely swift and does not prevent us from connecting concurrently in general.

I guess that in the future, multiple connections to a single peer should become allowed but for **different protocols** (@pipermerriam this is what you are working on, right). For the current state of affairs, this strikes me as a simple fix.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] Clean up commit history

[//]: # (For important changes, please add a new entry to the running release notes PR)
[//]: # (You can find the current one using: https://github.com/ethereum/trinity/pulls?q=is%3Aopen+is%3Apr+label%3A%22Release+Notes%22 )
[//]: # (See: https://trinity-client.readthedocs.io/en/latest/contributing.html#pull-requests)
- [ ] Add entry to the [release notes PR](https://github.com/ethereum/trinity/pulls?q=is%3Aopen+is%3Apr+label%3A%22Release+Notes%22)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://ae01.alicdn.com/kf/HTB1eAbzXc_vK1Rjy0Foq6xIxVXaW/Animal-Canvas-Prints-Wall-Art-Funny-Cow-on-Green-Meadow-with-Alps-Background-Picture-Painting-On.jpg_640x640.jpg)
