### PR TITLE
Improve quality of logs for run_beacon_nodes script

### DIFF
--- a/eth2/beacon/scripts/run_beacon_nodes.py
+++ b/eth2/beacon/scripts/run_beacon_nodes.py
@@ -120,7 +120,9 @@ class Node:
             f"--trinity-root-dir={self.root_dir}",
             f"--beacon-nodekey={remove_0x_prefix(self.node_privkey.to_hex())}",
             "--disable-discovery",
-            "-l debug",
+            "--network-tracking-backend=do-not-track",
+            "--disable-upnp",
+            "-l debug2",
         ]
         if len(self.preferred_nodes) != 0:
             preferred_nodes_str = ",".join([node.enode_id for node in self.preferred_nodes])


### PR DESCRIPTION
### What was wrong?

While working on #761 I found these changes useful to reduce the scope of things and make the logs more focused.

### How was it fixed?

- The upnp service isn't that useful yet so I disabled it.
- The networking db *is* useful in general but I think it isn't really useful for this test setup.
- I also enabled DEBUG2 logs to increase output in general.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] Clean up commit history

[//]: # (For important changes, please add a new entry to the running release notes PR)
[//]: # (You can find the current one using: https://github.com/ethereum/trinity/pulls?q=is%3Aopen+is%3Apr+label%3A%22Release+Notes%22 )
[//]: # (See: https://trinity-client.readthedocs.io/en/latest/contributing.html#pull-requests)
- [ ] Add entry to the [release notes PR](https://github.com/ethereum/trinity/pulls?q=is%3Aopen+is%3Apr+label%3A%22Release+Notes%22)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](http://www.steerplanet.com/wp-content/uploads/2012/08/JerseyCalf.jpg)
