### PR TITLE
Add more API docs

### DIFF
--- a/docs/api/extensibility/index.rst
+++ b/docs/api/extensibility/index.rst
@@ -1,9 +1,7 @@
 Extensibility
 =============
 
-.. warning::
-
-  The extensibility API isn't stable yet. Expect breaking changes.
+.. include:: /fragments/unstable_api.rst
 
 .. toctree::
    :maxdepth: 4

--- a/docs/api/index.rst
+++ b/docs/api/index.rst
@@ -13,5 +13,6 @@ This section aims to provide a detailed description of all APIs. If you are look
 
    api.cli
    extensibility/index
+   protocol/index
 
 

--- a/docs/api/protocol/common/api.events.rst
+++ b/docs/api/protocol/common/api.events.rst
@@ -1,0 +1,35 @@
+Events
+======
+
+Common Protocol Events
+----------------------
+
+Common events used for all peer protocols. These events derive from :class:`~lahja.BaseEvent` and
+can thus be consumed through the event bus.
+
+.. autoclass:: trinity.protocol.common.events.ConnectToNodeCommand
+  :members:
+
+.. autoclass:: trinity.protocol.common.events.PeerCountRequest
+  :members:
+
+.. autoclass:: trinity.protocol.common.events.PeerCountResponse
+  :members:
+
+.. autoclass:: trinity.protocol.common.events.DisconnectPeerEvent
+  :members:
+
+.. autoclass:: trinity.protocol.common.events.PeerJoinedEvent
+  :members:
+
+.. autoclass:: trinity.protocol.common.events.PeerLeftEvent
+  :members:
+
+.. autoclass:: trinity.protocol.common.events.GetConnectedPeersRequest
+  :members:
+
+.. autoclass:: trinity.protocol.common.events.GetConnectedPeersResponse
+  :members:
+
+.. autoclass:: trinity.protocol.common.events.PeerPoolMessageEvent
+  :members:

--- a/docs/api/protocol/common/index.rst
+++ b/docs/api/protocol/common/index.rst
@@ -1,0 +1,11 @@
+Common
+======
+
+.. include:: /fragments/unstable_api.rst
+
+.. toctree::
+   :maxdepth: 4
+   :name: toc-trinity-api-protocol-common
+   :caption: Common Protocol Events
+
+   api.events.rst

--- a/docs/api/protocol/eth/api.events.rst
+++ b/docs/api/protocol/eth/api.events.rst
@@ -1,0 +1,65 @@
+Events
+======
+
+ETH Protocol Events
+-------------------
+
+Events used for the ETH peer protocols. These events derive from :class:`~lahja.BaseEvent` and
+can thus be consumed through the event bus.
+
+.. autoclass:: trinity.protocol.eth.events.GetBlockHeadersEvent
+  :members:
+
+.. autoclass:: trinity.protocol.eth.events.GetBlockBodiesEvent
+  :members:
+
+.. autoclass:: trinity.protocol.eth.events.GetReceiptsEvent
+  :members:
+
+.. autoclass:: trinity.protocol.eth.events.GetNodeDataEvent
+  :members:
+
+.. autoclass:: trinity.protocol.eth.events.TransactionsEvent
+  :members:
+
+.. autoclass:: trinity.protocol.eth.events.NewBlockHashesEvent
+  :members:
+
+.. autoclass:: trinity.protocol.eth.events.SendBlockHeadersEvent
+  :members:
+
+.. autoclass:: trinity.protocol.eth.events.SendBlockBodiesEvent
+  :members:
+
+.. autoclass:: trinity.protocol.eth.events.SendNodeDataEvent
+  :members:
+
+.. autoclass:: trinity.protocol.eth.events.SendReceiptsEvent
+  :members:
+
+.. autoclass:: trinity.protocol.eth.events.SendTransactionsEvent
+  :members:
+
+.. autoclass:: trinity.protocol.eth.events.GetBlockHeadersRequest
+  :members:
+
+.. autoclass:: trinity.protocol.eth.events.GetBlockHeadersResponse
+  :members:
+
+.. autoclass:: trinity.protocol.eth.events.GetBlockBodiesRequest
+  :members:
+
+.. autoclass:: trinity.protocol.eth.events.GetBlockBodiesResponse
+  :members:
+
+.. autoclass:: trinity.protocol.eth.events.GetNodeDataRequest
+  :members:
+
+.. autoclass:: trinity.protocol.eth.events.GetNodeDataResponse
+  :members:
+
+.. autoclass:: trinity.protocol.eth.events.GetReceiptsRequest
+  :members:
+
+.. autoclass:: trinity.protocol.eth.events.GetReceiptsResponse
+  :members:

--- a/docs/api/protocol/eth/index.rst
+++ b/docs/api/protocol/eth/index.rst
@@ -1,0 +1,11 @@
+ETH
+===
+
+.. include:: /fragments/unstable_api.rst
+
+.. toctree::
+   :maxdepth: 4
+   :name: toc-trinity-api-protocol-eth
+   :caption: ETH Protocol Events
+
+   api.events.rst

--- a/docs/api/protocol/index.rst
+++ b/docs/api/protocol/index.rst
@@ -1,0 +1,16 @@
+Protocol
+========
+
+The protocol APIs form the basis for all communication with peers. They provide building blocks,
+e.g. to create chain synchronizations, but do not implement them themselves.
+
+.. include:: /fragments/unstable_api.rst
+
+.. toctree::
+   :maxdepth: 4
+   :name: toc-trinity-api-protocol
+
+   common/index
+   eth/index
+   les/index
+

--- a/docs/api/protocol/les/api.events.rst
+++ b/docs/api/protocol/les/api.events.rst
@@ -1,0 +1,14 @@
+Events
+======
+
+LES Protocol Events
+-------------------
+
+Events used for the LES peer protocols. These events derive from :class:`~lahja.BaseEvent` and
+can thus be consumed through the event bus.
+
+.. autoclass:: trinity.protocol.les.events.GetBlockHeadersEvent
+  :members:
+
+.. autoclass:: trinity.protocol.les.events.SendBlockHeadersEvent
+  :members:

--- a/docs/api/protocol/les/index.rst
+++ b/docs/api/protocol/les/index.rst
@@ -1,0 +1,11 @@
+LES
+===
+
+.. include:: /fragments/unstable_api.rst
+
+.. toctree::
+   :maxdepth: 4
+   :name: toc-trinity-api-protocol-les
+   :caption: LES Protocol Events
+
+   api.events.rst

--- a/docs/fragments/unstable_api.rst
+++ b/docs/fragments/unstable_api.rst
@@ -1,0 +1,3 @@
+.. warning::
+
+  This API isn't stable yet. Expect breaking changes.


### PR DESCRIPTION
### What was wrong?

I wanted to have some docs on the `trinity.protocol` APIs

### How was it fixed?

I ended up just documenting the events because those are consumable by plugins. I'm hesitant to add docs on other `trinity.protocol` stuff because there's still a lot in flux (proxy peer pool, multi protocol support, reduce exposure of peer etc)

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] Clean up commit history

[//]: # (For important changes, please add a new entry to the running release notes PR)
[//]: # (You can find the current one using: https://github.com/ethereum/trinity/pulls?q=is%3Aopen+is%3Apr+label%3A%22Release+Notes%22 )
[//]: # (See: https://trinity-client.readthedocs.io/en/latest/contributing.html#pull-requests)
- [ ] Add entry to the [release notes PR](https://github.com/ethereum/trinity/pulls?q=is%3Aopen+is%3Apr+label%3A%22Release+Notes%22)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://upload.wikimedia.org/wikipedia/commons/thumb/5/57/Saiga_antelope_at_the_Stepnoi_Sanctuary.jpg/1280px-Saiga_antelope_at_the_Stepnoi_Sanctuary.jpg)
