### PR TITLE
Tab complete CLI options

### DIFF
--- a/docs/api/api.cli.rst
+++ b/docs/api/api.cli.rst
@@ -106,7 +106,7 @@ The following table shows various combinations of how to use logging in Trinity 
 Enabling tab completion
 ~~~~~~~~~~~~~~~~~~~~~~~
 
-It is possible to configure tab-complete for trinity greater then v0.1.0a25.
+Trinity can be configured to auto complete commands when the <tab> key is pressed.
 
 For permanent, not global tab complete activation, use:
 

--- a/docs/api/api.cli.rst
+++ b/docs/api/api.cli.rst
@@ -108,7 +108,7 @@ Enabling tab completion
 
 Trinity can be configured to auto complete commands when the <tab> key is pressed.
 
-For permanent, not global tab complete activation, use:
+After installing trinity, to activate tab-completion in future bash prompts, use:
 
 .. code:: sh
 

--- a/docs/api/api.cli.rst
+++ b/docs/api/api.cli.rst
@@ -101,3 +101,22 @@ The following table shows various combinations of how to use logging in Trinity 
 
 .. [5] **Increasing** the per-module log level above the general ``--file-log-level`` is not yet supported
        (See `issue 689 <https://github.com/ethereum/trinity/issues/689>`_ )
+
+
+Enabling tab completion
+~~~~~~~~~~~~~~~~~~~~~~~
+
+It is possible to configure tab-complete for trinity greater then v0.1.0a25.
+
+For permanent, not global tab complete activation, use:
+
+.. code:: sh
+
+    register-python-argcomplete trinity >> ~/.bashrc
+
+
+For one-time activation of argcomplete for trinity, use:
+
+.. code:: sh
+
+    eval "$(register-python-argcomplete trinity)"

--- a/newsfragments/768.feature.rst
+++ b/newsfragments/768.feature.rst
@@ -1,0 +1,2 @@
+Trinity can now autocomplete CLI parameters on ``<tab>``.
+Learn how to activate autocomplete in the :doc:`docs</api/api.cli>`.

--- a/setup.py
+++ b/setup.py
@@ -1,20 +1,9 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 import os
-import subprocess
 from setuptools import setup, find_packages
-from setuptools.command.install import install
 
 PYEVM_DEPENDENCY = "py-evm==0.3.0a1"
-
-
-class PostInstallCommand(install):
-    def run(self):
-        """Post-install script which activate argcomplete library."""
-        subprocess.call('register-python-argcomplete trinity >> ~/.bashrc', shell=True)
-        # To start using CLI with autocomplete immediately:
-        subprocess.call('eval "$(register-python-argcomplete trinity)"', shell=True)
-        install.run(self)
 
 
 deps = {
@@ -50,7 +39,7 @@ deps = {
         "mypy_extensions>=0.4.1,<1.0.0",
         "typing_extensions>=3.7.2,<4.0.0",
         "ruamel.yaml>=0.15.87",
-        "argcomplete==1.10.0",
+        "argcomplete>=1.10.0,<2",
     ],
     'test': [
         "hypothesis>=4.24.3,<5",
@@ -176,8 +165,5 @@ setup(
             'trinity=trinity:main',
             'trinity-beacon=trinity:main_beacon'
         ],
-    },
-    cmdclass={
-        'install': PostInstallCommand,
     },
 )

--- a/setup.py
+++ b/setup.py
@@ -1,9 +1,20 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 import os
+import subprocess
 from setuptools import setup, find_packages
+from setuptools.command.install import install
 
 PYEVM_DEPENDENCY = "py-evm==0.3.0a1"
+
+
+class PostInstallCommand(install):
+    def run(self):
+        """Post-install script which activate argcomplete library."""
+        subprocess.call('register-python-argcomplete trinity >> ~/.bashrc', shell=True)
+        # To start using CLI with autocomplete immediately: 
+        subprocess.call('eval "$(register-python-argcomplete trinity)"', shell=True)
+        install.run(self)
 
 
 deps = {
@@ -165,5 +176,8 @@ setup(
             'trinity=trinity:main',
             'trinity-beacon=trinity:main_beacon'
         ],
+    },
+    cmdclass={
+        'install': PostInstallCommand,
     },
 )

--- a/setup.py
+++ b/setup.py
@@ -39,6 +39,7 @@ deps = {
         "mypy_extensions>=0.4.1,<1.0.0",
         "typing_extensions>=3.7.2,<4.0.0",
         "ruamel.yaml>=0.15.87",
+        "argcomplete==1.10.0",
     ],
     'test': [
         "hypothesis>=4.24.3,<5",

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ class PostInstallCommand(install):
     def run(self):
         """Post-install script which activate argcomplete library."""
         subprocess.call('register-python-argcomplete trinity >> ~/.bashrc', shell=True)
-        # To start using CLI with autocomplete immediately: 
+        # To start using CLI with autocomplete immediately:
         subprocess.call('eval "$(register-python-argcomplete trinity)"', shell=True)
         install.run(self)
 

--- a/trinity/bootstrap.py
+++ b/trinity/bootstrap.py
@@ -1,5 +1,6 @@
 import asyncio
 from argparse import ArgumentParser, Namespace
+import argcomplete
 import logging
 import multiprocessing
 import os
@@ -115,6 +116,9 @@ def main_entry(trinity_boot: BootFn,
         plugins
     )
     plugin_manager.amend_argparser_config(parser, subparser)
+
+    argcomplete.autocomplete(parser)
+
     args = parser.parse_args()
 
     if not args.genesis and args.network_id not in PRECONFIGURED_NETWORKS:

--- a/trinity/plugins/builtin/fix_unclean_shutdown/plugin.py
+++ b/trinity/plugins/builtin/fix_unclean_shutdown/plugin.py
@@ -1,3 +1,4 @@
+import argcomplete
 from argparse import (
     ArgumentParser,
     Namespace,

--- a/trinity/plugins/builtin/fix_unclean_shutdown/plugin.py
+++ b/trinity/plugins/builtin/fix_unclean_shutdown/plugin.py
@@ -1,4 +1,3 @@
-import argcomplete
 from argparse import (
     ArgumentParser,
     Namespace,


### PR DESCRIPTION
### What was wrong?
Adding tab-complete CLI options (relates to https://github.com/ethereum/trinity/issues/370)


### How was it fixed?
Added new requirements: `argcomplete==1.10.0` and configure `argcomplete.autocomplete` module

Solution require to call `$ activate-global-python-argcomplete` - but it will install autocomplete globally.
We can just specify required module in ~/.bashrc (described in todo list below)

### To-Do
- [x] Update documentation with argcomplete activation steps

#### Cute Animal Picture

<img src="https://user-images.githubusercontent.com/2613381/60702726-883dcf00-9f21-11e9-89f6-59419854088e.png" height="200"> 