### PR TITLE
Move get_chain_config from TrinityConfig to Eth1AppConfig

### DIFF
--- a/tests/core/configuration/test_chain_config_object.py
+++ b/tests/core/configuration/test_chain_config_object.py
@@ -18,7 +18,7 @@ from eth.chains.ropsten import (
 )
 
 from trinity.config import (
-    ChainConfig,
+    Eth1ChainConfig,
 )
 from trinity.constants import (
     MAINNET_NETWORK_ID,
@@ -46,7 +46,7 @@ def assert_vm_configuration_equal(left, right):
     (MAINNET_NETWORK_ID, ROPSTEN_NETWORK_ID),
 )
 def test_chain_config_from_preconfigured_network(network_id):
-    chain_config = ChainConfig.from_preconfigured_network(network_id)
+    chain_config = Eth1ChainConfig.from_preconfigured_network(network_id)
     chain = chain_config.initialize_chain(AtomicDB(MemoryDB()))
 
     if network_id == MAINNET_NETWORK_ID:
@@ -90,7 +90,7 @@ def test_chain_config_eip1085_fixture_is_valid():
 
 
 def test_chain_config_from_eip1085_genesis_config():
-    chain_config = ChainConfig.from_eip1085_genesis_config(EIP1085_GENESIS_CONFIG)
+    chain_config = Eth1ChainConfig.from_eip1085_genesis_config(EIP1085_GENESIS_CONFIG)
 
     assert chain_config.chain_id == 1234
     assert chain_config.vm_configuration == ((0, ConstantinopleVM),)

--- a/tests/core/database/test_database_over_ipc_manager.py
+++ b/tests/core/database/test_database_over_ipc_manager.py
@@ -17,6 +17,7 @@ from trinity.db.eth1.manager import (
     create_db_server_manager,
 )
 from trinity.config import (
+    Eth1AppConfig,
     TrinityConfig,
 )
 from trinity.initialization import (
@@ -48,6 +49,7 @@ def database_server_ipc_path():
             network_id=ROPSTEN_NETWORK_ID,
             trinity_root_dir=temp_dir,
         )
+        trinity_config.add_app_config(Eth1AppConfig(trinity_config, None))
         initialize_data_dir(trinity_config)
 
         manager = create_db_server_manager(trinity_config, core_db)

--- a/tests/core/initialization/test_initialize_database.py
+++ b/tests/core/initialization/test_initialize_database.py
@@ -19,7 +19,7 @@ def chaindb(base_db):
     return ChainDB(base_db)
 
 
-def test_initialize_database(trinity_config, chaindb, base_db):
+def test_initialize_database(eth1_app_config, chaindb, base_db):
     assert not is_database_initialized(chaindb)
-    initialize_database(trinity_config.get_chain_config(), chaindb, base_db)
+    initialize_database(eth1_app_config.get_chain_config(), chaindb, base_db)
     assert is_database_initialized(chaindb)

--- a/trinity/config.py
+++ b/trinity/config.py
@@ -320,14 +320,6 @@ class TrinityConfig:
         elif nodekey is not None:
             self.nodekey = nodekey
 
-    def get_chain_config(self) -> ChainConfig:
-        # the `ChainConfig` object cannot be pickled so we can't cache this
-        # value since the TrinityConfig is sent across process boundaries.
-        if self.network_id in PRECONFIGURED_NETWORKS:
-            return ChainConfig.from_preconfigured_network(self.network_id)
-        else:
-            return ChainConfig.from_eip1085_genesis_config(self.genesis_config)
-
     @property
     def app_suffix(self) -> str:
         return "" if len(self.app_identifier) == 0 else f"-{self.app_identifier}"
@@ -584,6 +576,14 @@ class Eth1AppConfig(BaseAppConfig):
             return Eth1DbMode.LIGHT
         else:
             return Eth1DbMode.FULL
+
+    def get_chain_config(self) -> ChainConfig:
+        # the `ChainConfig` object cannot be pickled so we can't cache this
+        # value since the TrinityConfig is sent across process boundaries.
+        if self.trinity_config.network_id in PRECONFIGURED_NETWORKS:
+            return ChainConfig.from_preconfigured_network(self.trinity_config.network_id)
+        else:
+            return ChainConfig.from_eip1085_genesis_config(self.trinity_config.genesis_config)
 
     @property
     def node_class(self) -> Type['Node']:

--- a/trinity/config.py
+++ b/trinity/config.py
@@ -144,7 +144,7 @@ def _get_preconfigured_chain_name(network_id: int) -> str:
         raise TypeError(f"Unknown or unsupported `network_id`: {network_id}")
 
 
-class ChainConfig:
+class Eth1ChainConfig:
     def __init__(self,
                  genesis_data: GenesisData,
                  chain_name: str=None) -> None:
@@ -183,7 +183,7 @@ class ChainConfig:
     def from_eip1085_genesis_config(cls,
                                     genesis_config: Dict[str, Any],
                                     chain_name: str=None,
-                                    ) -> 'ChainConfig':
+                                    ) -> 'Eth1ChainConfig':
         genesis_data = extract_genesis_data(genesis_config)
         return cls(
             genesis_data=genesis_data,
@@ -192,7 +192,7 @@ class ChainConfig:
 
     @classmethod
     def from_preconfigured_network(cls,
-                                   network_id: int) -> 'ChainConfig':
+                                   network_id: int) -> 'Eth1ChainConfig':
         genesis_config = _load_preconfigured_genesis_config(network_id)
         chain_name = _get_preconfigured_chain_name(network_id)
         return cls.from_eip1085_genesis_config(genesis_config, chain_name)
@@ -240,7 +240,7 @@ TAppConfig = TypeVar('TAppConfig', bound='BaseAppConfig')
 class TrinityConfig:
     _trinity_root_dir: Path = None
 
-    _chain_config: ChainConfig = None
+    _chain_config: Eth1ChainConfig = None
 
     _data_dir: Path = None
     _nodekey_path: Path = None
@@ -577,13 +577,13 @@ class Eth1AppConfig(BaseAppConfig):
         else:
             return Eth1DbMode.FULL
 
-    def get_chain_config(self) -> ChainConfig:
+    def get_chain_config(self) -> Eth1ChainConfig:
         # the `ChainConfig` object cannot be pickled so we can't cache this
         # value since the TrinityConfig is sent across process boundaries.
         if self.trinity_config.network_id in PRECONFIGURED_NETWORKS:
-            return ChainConfig.from_preconfigured_network(self.trinity_config.network_id)
+            return Eth1ChainConfig.from_preconfigured_network(self.trinity_config.network_id)
         else:
-            return ChainConfig.from_eip1085_genesis_config(self.trinity_config.genesis_config)
+            return Eth1ChainConfig.from_eip1085_genesis_config(self.trinity_config.genesis_config)
 
     @property
     def node_class(self) -> Type['Node']:

--- a/trinity/db/eth1/manager.py
+++ b/trinity/db/eth1/manager.py
@@ -7,7 +7,10 @@ from eth.db.chain import ChainDB
 from eth.db.backends.base import BaseAtomicDB
 from eth.db.header import HeaderDB
 
-from trinity.config import TrinityConfig
+from trinity.config import (
+    Eth1AppConfig,
+    TrinityConfig,
+)
 from trinity.db.base import AsyncDBProxy
 from trinity.db.eth1.chain import AsyncChainDBProxy
 from trinity.db.eth1.header import (
@@ -23,7 +26,8 @@ from trinity._utils.mp import TracebackRecorder
 def create_db_server_manager(trinity_config: TrinityConfig,
                              base_db: BaseAtomicDB) -> BaseManager:
 
-    chain_config = trinity_config.get_chain_config()
+    eth1_app_config = trinity_config.get_app_config(Eth1AppConfig)
+    chain_config = eth1_app_config.get_chain_config()
     chaindb = ChainDB(base_db)
 
     if not is_database_initialized(chaindb):

--- a/trinity/initialization.py
+++ b/trinity/initialization.py
@@ -11,7 +11,7 @@ from trinity.config import (
     BeaconAppConfig,
     BeaconChainConfig,
     Eth1AppConfig,
-    ChainConfig,
+    Eth1ChainConfig,
     TrinityConfig,
 )
 
@@ -130,7 +130,7 @@ def initialize_data_dir(trinity_config: TrinityConfig) -> None:
             nodekey_file.write(nodekey.to_bytes())
 
 
-def initialize_database(chain_config: ChainConfig,
+def initialize_database(chain_config: Eth1ChainConfig,
                         chaindb: BaseChainDB,
                         base_db: BaseAtomicDB) -> None:
     try:

--- a/trinity/nodes/base.py
+++ b/trinity/nodes/base.py
@@ -23,7 +23,7 @@ from trinity.db.eth1.manager import (
     create_db_consumer_manager,
 )
 from trinity.config import (
-    ChainConfig,
+    Eth1ChainConfig,
     Eth1AppConfig,
     TrinityConfig,
 )
@@ -69,10 +69,10 @@ class Node(BaseService):
                 req.broadcast_config()
             )
 
-    _chain_config: ChainConfig = None
+    _chain_config: Eth1ChainConfig = None
 
     @property
-    def chain_config(self) -> ChainConfig:
+    def chain_config(self) -> Eth1ChainConfig:
         """
         Convenience and caching mechanism for the `ChainConfig`.
         """

--- a/trinity/nodes/base.py
+++ b/trinity/nodes/base.py
@@ -24,6 +24,7 @@ from trinity.db.eth1.manager import (
 )
 from trinity.config import (
     ChainConfig,
+    Eth1AppConfig,
     TrinityConfig,
 )
 from trinity.endpoint import (
@@ -76,7 +77,8 @@ class Node(BaseService):
         Convenience and caching mechanism for the `ChainConfig`.
         """
         if self._chain_config is None:
-            self._chain_config = self.trinity_config.get_chain_config()
+            app_config = self.trinity_config.get_app_config(Eth1AppConfig)
+            self._chain_config = app_config.get_chain_config()
         return self._chain_config
 
     @abstractmethod

--- a/trinity/plugins/builtin/attach/console.py
+++ b/trinity/plugins/builtin/attach/console.py
@@ -16,6 +16,7 @@ from trinity._utils.log_messages import (
     create_missing_ipc_error_message,
 )
 from trinity.config import (
+    Eth1AppConfig,
     TrinityConfig,
 )
 
@@ -99,7 +100,8 @@ def db_shell(use_ipython: bool, database_dir: Path, trinity_config: TrinityConfi
     db = LevelDB(database_dir)
     chaindb = ChainDB(db)
     head = chaindb.get_canonical_head()
-    chain_config = trinity_config.get_chain_config()
+    app_config = trinity_config.get_app_config(Eth1AppConfig)
+    chain_config = app_config.get_chain_config()
     chain = chain_config.full_chain_class(db)
 
     greeter = f"""

--- a/trinity/plugins/builtin/beam_exec/plugin.py
+++ b/trinity/plugins/builtin/beam_exec/plugin.py
@@ -1,5 +1,8 @@
 import asyncio
 
+from trinity.config import (
+    Eth1AppConfig,
+)
 from trinity.constants import (
     SYNC_BEAM,
 )
@@ -42,7 +45,8 @@ class BeamChainExecutionPlugin(AsyncioIsolatedPlugin):
 
     def do_start(self) -> None:
         trinity_config = self.boot_info.trinity_config
-        chain_config = trinity_config.get_chain_config()
+        app_config = trinity_config.get_app_config(Eth1AppConfig)
+        chain_config = app_config.get_chain_config()
 
         db_manager = create_db_consumer_manager(trinity_config.database_ipc_path)
 

--- a/trinity/plugins/builtin/ethstats/ethstats_service.py
+++ b/trinity/plugins/builtin/ethstats/ethstats_service.py
@@ -11,6 +11,9 @@ from p2p.service import (
 from trinity import (
     __version__,
 )
+from trinity.config import (
+    Eth1AppConfig,
+)
 from trinity.constants import (
     SYNC_LIGHT,
     TO_NETWORKING_BROADCAST_CONFIG,
@@ -162,8 +165,8 @@ class EthstatsService(BaseService):
 
     def get_chain(self) -> BaseChain:
         db_manager = create_db_consumer_manager(self.boot_info.trinity_config.database_ipc_path)
-
-        chain_config = self.boot_info.trinity_config.get_chain_config()
+        app_config = self.boot_info.trinity_config.get_app_config(Eth1AppConfig)
+        chain_config = app_config.get_chain_config()
 
         chain: BaseChain
 

--- a/trinity/plugins/builtin/json_rpc/plugin.py
+++ b/trinity/plugins/builtin/json_rpc/plugin.py
@@ -68,7 +68,7 @@ class JsonRpcServerPlugin(AsyncioIsolatedPlugin):
         db_manager = create_db_consumer_manager(trinity_config.database_ipc_path)
 
         eth1_app_config = trinity_config.get_app_config(Eth1AppConfig)
-        chain_config = trinity_config.get_chain_config()
+        chain_config = eth1_app_config.get_chain_config()
 
         chain: BaseAsyncChain
 

--- a/trinity/plugins/builtin/tx_pool/plugin.py
+++ b/trinity/plugins/builtin/tx_pool/plugin.py
@@ -11,6 +11,9 @@ from eth.chains.ropsten import (
     BYZANTIUM_ROPSTEN_BLOCK,
 )
 
+from trinity.config import (
+    Eth1AppConfig,
+)
 from trinity.constants import (
     SYNC_LIGHT,
     TO_NETWORKING_BROADCAST_CONFIG,
@@ -70,7 +73,8 @@ class TxPlugin(AsyncioIsolatedPlugin):
         db_manager = create_db_consumer_manager(trinity_config.database_ipc_path)
         db = db_manager.get_db()  # type: ignore
 
-        chain_config = trinity_config.get_chain_config()
+        app_config = trinity_config.get_app_config(Eth1AppConfig)
+        chain_config = app_config.get_chain_config()
 
         chain = chain_config.full_chain_class(db)
 


### PR DESCRIPTION
### What was wrong?

1. The `TrinityConfig` contains a `get_chain_config` API that is only meant to be used with the eth1 client. (Notice that the `BeaconAppConfig` does already contain a similar API for the specifically for the beacon chain)

2. The name `ChainConfig` should be changed to `Eth1ChainConfig` to be aligned with the `BeaconChainConfig` type and doesn't spark wrong assumptions.

### How was it fixed?

1. Moved the `get_chain_config` API from the `TrinityConfig` to the `Eth1AppConfig`

2. Renamed the `ChainConfig` type to `Eth1ChainConfig`

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] Clean up commit history

[//]: # (For important changes, please add a new entry to the running release notes PR)
[//]: # (You can find the current one using: https://github.com/ethereum/trinity/pulls?q=is%3Aopen+is%3Apr+label%3A%22Release+Notes%22 )
[//]: # (See: https://trinity-client.readthedocs.io/en/latest/contributing.html#pull-requests)
- [ ] Add entry to the [release notes PR](https://github.com/ethereum/trinity/pulls?q=is%3Aopen+is%3Apr+label%3A%22Release+Notes%22)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://www.sunnyskyz.com/uploads/2017/11/02umx-The-Saiga-antelope-looks-like-an-animal-out-of-a-science-fiction-movie.jpg)
