### PR TITLE
OrderedTaskPreparation robustness (to support syncing)

### DIFF
--- a/tests/core/task-queue-utils/test_ordered_task_preparation.py
+++ b/tests/core/task-queue-utils/test_ordered_task_preparation.py
@@ -696,7 +696,7 @@ async def test_wait_to_prune_until_yielded():
 @example(task_series=[0, 4, 2, 1, 5], prune_depth=1)
 @pytest.mark.parametrize('ignore_duplicates', (False,))
 @pytest.mark.parametrize('recomplete_idx', (None, 1))
-@pytest.mark.parametrize('batch_size', (1,))
+@pytest.mark.parametrize('batch_size', (1, 3))
 @pytest.mark.asyncio
 async def test_random_pruning(
         ignore_duplicates,

--- a/tests/core/task-queue-utils/test_ordered_task_preparation.py
+++ b/tests/core/task-queue-utils/test_ordered_task_preparation.py
@@ -694,7 +694,7 @@ async def test_wait_to_prune_until_yielded():
 @example(task_series=[1, 2, 0, 3], prune_depth=1)
 @example(task_series=[0, 1, 2, 3, 0, 4], prune_depth=1)
 @example(task_series=[0, 4, 2, 1, 5], prune_depth=1)
-@pytest.mark.parametrize('ignore_duplicates', (False,))
+@pytest.mark.parametrize('ignore_duplicates', (False, True))
 @pytest.mark.parametrize('recomplete_idx', (None, 1))
 @pytest.mark.parametrize('batch_size', (1, 3))
 @pytest.mark.asyncio

--- a/tests/core/task-queue-utils/test_ordered_task_preparation.py
+++ b/tests/core/task-queue-utils/test_ordered_task_preparation.py
@@ -6,7 +6,10 @@ from typing import NamedTuple
 from eth_utils import (
     ValidationError,
 )
-from eth_utils.toolz import identity
+from eth_utils.toolz import (
+    identity,
+    partition_all,
+)
 from hypothesis import (
     example,
     given,
@@ -690,8 +693,17 @@ async def test_wait_to_prune_until_yielded():
 @settings(max_examples=1000)
 @example(task_series=[1, 2, 0, 3], prune_depth=1)
 @example(task_series=[0, 1, 2, 3, 0, 4], prune_depth=1)
+@pytest.mark.parametrize('ignore_duplicates', (False,))
+@pytest.mark.parametrize('recomplete_idx', (None,))
+@pytest.mark.parametrize('batch_size', (1,))
 @pytest.mark.asyncio
-async def test_random_pruning(task_series, prune_depth):
+async def test_random_pruning(
+        ignore_duplicates,
+        recomplete_idx,
+        batch_size,
+        task_series,
+        prune_depth):
+
     ti = OrderedTaskPreparation(
         NoPrerequisites,
         identity,
@@ -701,11 +713,24 @@ async def test_random_pruning(task_series, prune_depth):
     )
     ti.set_finished_dependency(task_series[0])
 
-    for task in task_series:
+    for idx, task_batch in enumerate(partition_all(batch_size, task_series)):
+        if ignore_duplicates:
+            registerable_tasks = task_batch
+        else:
+            registerable_tasks = set(task_batch)
+
+        if idx == recomplete_idx:
+            task_to_mark_finished = task_batch[0] - 1
+            if task_to_mark_finished not in ti._tasks:
+                ti.set_finished_dependency(task_to_mark_finished)
+
         try:
-            ti.register_tasks((task, ))
+            ti.register_tasks(registerable_tasks, ignore_duplicates=ignore_duplicates)
         except DuplicateTasks:
-            continue
+            if ignore_duplicates:
+                raise
+            else:
+                continue
         if ti.has_ready_tasks():
             await wait(ti.ready_tasks())
 

--- a/tests/core/task-queue-utils/test_ordered_task_preparation.py
+++ b/tests/core/task-queue-utils/test_ordered_task_preparation.py
@@ -694,7 +694,7 @@ async def test_wait_to_prune_until_yielded():
 @example(task_series=[1, 2, 0, 3], prune_depth=1)
 @example(task_series=[0, 1, 2, 3, 0, 4], prune_depth=1)
 @pytest.mark.parametrize('ignore_duplicates', (False,))
-@pytest.mark.parametrize('recomplete_idx', (None,))
+@pytest.mark.parametrize('recomplete_idx', (None, 1))
 @pytest.mark.parametrize('batch_size', (1,))
 @pytest.mark.asyncio
 async def test_random_pruning(

--- a/tests/core/task-queue-utils/test_ordered_task_preparation.py
+++ b/tests/core/task-queue-utils/test_ordered_task_preparation.py
@@ -693,6 +693,7 @@ async def test_wait_to_prune_until_yielded():
 @settings(max_examples=1000)
 @example(task_series=[1, 2, 0, 3], prune_depth=1)
 @example(task_series=[0, 1, 2, 3, 0, 4], prune_depth=1)
+@example(task_series=[0, 4, 2, 1, 5], prune_depth=1)
 @pytest.mark.parametrize('ignore_duplicates', (False,))
 @pytest.mark.parametrize('recomplete_idx', (None, 1))
 @pytest.mark.parametrize('batch_size', (1,))

--- a/tests/core/task-queue-utils/test_ordered_task_preparation.py
+++ b/tests/core/task-queue-utils/test_ordered_task_preparation.py
@@ -250,11 +250,17 @@ async def test_no_prereq_tasks():
 async def test_ignore_duplicates():
     ti = OrderedTaskPreparation(NoPrerequisites, identity, lambda x: x - 1)
     ti.set_finished_dependency(1)
-    ti.register_tasks((2, ))
+
+    new_tasks = ti.register_tasks((2, ))
+    assert new_tasks == (2, )
+
     # this will ignore the 2 task:
-    ti.register_tasks((2, 3), ignore_duplicates=True)
+    new_tasks = ti.register_tasks((2, 3), ignore_duplicates=True)
+    assert new_tasks == (3, )
+
     # this will be completely ignored:
-    ti.register_tasks((2, 3), ignore_duplicates=True)
+    new_tasks = ti.register_tasks((2, 3), ignore_duplicates=True)
+    assert new_tasks == ()
 
     # with no prerequisites, tasks are *immediately* finished, as long as they are in order
     finished = await wait(ti.ready_tasks())

--- a/trinity/_utils/datastructures.py
+++ b/trinity/_utils/datastructures.py
@@ -692,6 +692,10 @@ class OrderedTaskPreparation(
             # ^ when this is called, pruning is triggered from
             # the tip of task 1 (whether or not task 2 is ready)
         """
+        # It is possible for this finished task to already be pruned, in which case, skip it
+        if task_id not in self._tasks:
+            return
+
         root_task_id, depth = self._roots.get_root(task_id)
         num_to_prune = depth - self._max_depth
         if num_to_prune <= 0:

--- a/trinity/_utils/datastructures.py
+++ b/trinity/_utils/datastructures.py
@@ -664,8 +664,10 @@ class OrderedTaskPreparation(
 
         # resolve tasks that depend on this task
         for depending_task_id in self._roots.get_children(task_id):
-            # we already know that this task is ready, so we only need to check completion
-            if self._tasks[depending_task_id].is_complete:
+            # We already know that the depending task is ready, so we only need to check:
+            # 1. Are all the prerequesites of the depending task complete?
+            # 2. Was the depending task previously incomplete?
+            if self._tasks[depending_task_id].is_complete and depending_task_id in self._unready:
                 yield depending_task_id
 
     def _prune_finished(self, task_id: TTaskID) -> None:


### PR DESCRIPTION
### What was wrong?

When debugging an OTP issue during sync, I wrote a new test, and it kept paying dividends as I kept adding variations. The variation/parameter that caught each issue is combined with the fix in a commit, so it is probably easiest to read this PR's diff commit by commit.

Additionally, I added a feature that will help sync avoid duplicate work: `register_tasks()` now returns the tasks that you registered. If `ignore_duplicates=True`, this is equal to the supplied argument (or an exception would be raised). If `ignore_duplicates=False`, then only the non-duplicates are returned.

The following issues were identified and fixed:
- completing a dependency of a task that's already complete (can happen with tight pruning)
- pruning bug when linking two segments of tasks (like completing C, after A, B, D, & E are registered)
- bug when you try to register duplicates in the same batch, like: `register_tasks((A, A), ignore_duplicates=True)`

### How was it fixed?

In corresponding order:
- Don't mark a dependent task as complete if it was already completed, even if you just completed it's dependency
- Don't try to look up a pruned root if the task is already complete
- If ignoring duplicates, ignore duplicates in the supplied batch, also

### To-Do

[//]: # (For important changes, please add a new entry to the running release notes PR)
[//]: # (You can find the current one using: https://github.com/ethereum/trinity/pulls?q=is%3Aopen+is%3Apr+label%3A%22Release+Notes%22 )
[//]: # (See: https://trinity-client.readthedocs.io/en/latest/contributing.html#pull-requests)
- [ ] Add entry to the [release notes PR](https://github.com/ethereum/trinity/pulls?q=is%3Aopen+is%3Apr+label%3A%22Release+Notes%22)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](http://setviral.com/wp-content/uploads/2015/09/17-cute-and-funny-photos-of-animals-celebrating-birthdays-13.jpg)
