### PR TITLE
Fix get state(machine) from non-canonical chain

### DIFF
--- a/eth2/beacon/chains/base.py
+++ b/eth2/beacon/chains/base.py
@@ -272,9 +272,7 @@ class BeaconChain(BaseBeaconChain):
             slot = at_slot
         sm_class = self.get_state_machine_class_for_block_slot(slot)
 
-        return sm_class(
-            chaindb=self.chaindb, attestation_pool=self.attestation_pool, slot=slot
-        )
+        return sm_class(chaindb=self.chaindb, attestation_pool=self.attestation_pool)
 
     @classmethod
     def get_genesis_state_machine_class(cls) -> Type["BaseBeaconStateMachine"]:

--- a/eth2/beacon/chains/base.py
+++ b/eth2/beacon/chains/base.py
@@ -388,16 +388,26 @@ class BeaconChain(BaseBeaconChain):
                 )
             )
 
-        head_state_slot = self.chaindb.get_head_state_slot()
-        if head_state_slot >= block.slot:
-            # Importing a block older than the head state. Hence head state can not be used to
-            # perform state transition.
-            prev_state_slot = parent_block.slot
+        # Default to use state machine and state at `parent_block.slot`.
+        # Change to the ones at head state slot if `block.slot` is on canonical chain
+        # and newer than head state slot.
+        state_machine = self.get_state_machine(at_slot=parent_block.slot)
+        state = self.get_state_by_slot(parent_block.slot)
+        try:
+            canonical_root_at_slot = self.get_canonical_block_root(parent_block.slot)
+        except BlockNotFound:
+            # No corresponding block at this slot which means parent block is not
+            # on canonical chain.
+            pass
         else:
-            prev_state_slot = head_state_slot
+            is_on_canonical_chain = parent_block.signing_root == canonical_root_at_slot
+            is_newer_than_head_state_slot = (
+                self.chaindb.get_head_state_slot() < block.slot
+            )
+            if is_on_canonical_chain and is_newer_than_head_state_slot:
+                state_machine = self.get_state_machine()
+                state = self.get_head_state()
 
-        state_machine = self.get_state_machine(prev_state_slot)
-        state = self.get_state_by_slot(prev_state_slot)
         state, imported_block = state_machine.import_block(
             block, state, check_proposer_signature=perform_validation
         )

--- a/eth2/beacon/state_machines/base.py
+++ b/eth2/beacon/state_machines/base.py
@@ -8,7 +8,7 @@ from eth2.beacon.fork_choice.scoring import ScoringFn as ForkChoiceScoringFn
 from eth2.beacon.operations.attestation_pool import AttestationPool
 from eth2.beacon.types.blocks import BaseBeaconBlock
 from eth2.beacon.types.states import BeaconState
-from eth2.beacon.typing import FromBlockParams, Slot
+from eth2.beacon.typing import FromBlockParams
 from eth2.configs import Eth2Config  # noqa: F401
 
 from .state_transitions import BaseStateTransition
@@ -19,20 +19,13 @@ class BaseBeaconStateMachine(Configurable, ABC):
     chaindb = None  # type: BaseBeaconChainDB
     config = None  # type: Eth2Config
 
-    slot = None  # type: Slot
-    _state = None  # type: BeaconState
-
     block_class = None  # type: Type[BaseBeaconBlock]
     state_class = None  # type: Type[BeaconState]
     state_transition_class = None  # type: Type[BaseStateTransition]
 
     @abstractmethod
     def __init__(
-        self,
-        chaindb: BaseBeaconChainDB,
-        attestation_pool: AttestationPool,
-        slot: Slot,
-        state: BeaconState = None,
+        self, chaindb: BaseBeaconChainDB, attestation_pool: AttestationPool
     ) -> None:
         ...
 
@@ -82,18 +75,10 @@ class BaseBeaconStateMachine(Configurable, ABC):
 
 class BeaconStateMachine(BaseBeaconStateMachine):
     def __init__(
-        self,
-        chaindb: BaseBeaconChainDB,
-        attestation_pool: AttestationPool,
-        slot: Slot,
-        state: BeaconState = None,
+        self, chaindb: BaseBeaconChainDB, attestation_pool: AttestationPool
     ) -> None:
         self.chaindb = chaindb
         self.attestation_pool = attestation_pool
-        if state is not None:
-            self._state = state
-        else:
-            self.slot = slot
 
     @classmethod
     def get_block_class(cls) -> Type[BaseBeaconBlock]:

--- a/tests/eth2/core/beacon/state_machines/forks/test_serenity_operation_processing.py
+++ b/tests/eth2/core/beacon/state_machines/forks/test_serenity_operation_processing.py
@@ -41,7 +41,7 @@ def test_process_max_attestations(
     attestations = create_mock_signed_attestations_at_slot(
         state=state,
         config=config,
-        state_machine=fixture_sm_class(chaindb, empty_attestation_pool, current_slot),
+        state_machine=fixture_sm_class(chaindb, empty_attestation_pool),
         attestation_slot=attestation_slot,
         beacon_block_root=genesis_block.signing_root,
         keymap=keymap,
@@ -215,9 +215,7 @@ def test_process_attestations(
     attestations = create_mock_signed_attestations_at_slot(
         state=state,
         config=config,
-        state_machine=fixture_sm_class(
-            chaindb, empty_attestation_pool, genesis_block.slot
-        ),
+        state_machine=fixture_sm_class(chaindb, empty_attestation_pool),
         attestation_slot=attestation_slot,
         beacon_block_root=genesis_block.signing_root,
         keymap=keymap,

--- a/tests/eth2/core/beacon/state_machines/forks/test_state_machine.py
+++ b/tests/eth2/core/beacon/state_machines/forks/test_state_machine.py
@@ -6,5 +6,5 @@ from eth2.beacon.state_machines.forks.xiao_long_bao import XiaoLongBaoStateMachi
 
 @pytest.mark.parametrize("sm_klass", (SerenityStateMachine, XiaoLongBaoStateMachine))
 def test_sm_class_well_defined(sm_klass):
-    state_machine = sm_klass(chaindb=None, attestation_pool=None, slot=None)
+    state_machine = sm_klass(chaindb=None, attestation_pool=None)
     assert state_machine.get_block_class()

--- a/tests/eth2/core/beacon/state_machines/test_state_transition.py
+++ b/tests/eth2/core/beacon/state_machines/test_state_transition.py
@@ -53,9 +53,7 @@ def test_per_slot_transition(
     block = create_mock_block(
         state=state,
         config=config,
-        state_machine=fixture_sm_class(
-            chaindb, empty_attestation_pool, genesis_block.slot
-        ),
+        state_machine=fixture_sm_class(chaindb, empty_attestation_pool),
         block_class=SerenityBeaconBlock,
         parent_block=genesis_block,
         keymap=keymap,
@@ -66,7 +64,7 @@ def test_per_slot_transition(
     chaindb.persist_block(block, SerenityBeaconBlock, fork_choice_scoring)
 
     # Get state machine instance
-    sm = fixture_sm_class(chaindb, empty_attestation_pool, block.slot)
+    sm = fixture_sm_class(chaindb, empty_attestation_pool)
 
     # Get state transition instance
     st = sm.state_transition_class(sm.config)

--- a/tests/eth2/integration/test_demo.py
+++ b/tests/eth2/integration/test_demo.py
@@ -73,7 +73,7 @@ def test_demo(base_db, validator_count, keymap, pubkeys, fork_choice_scoring):
         block = create_mock_block(
             state=state,
             config=config,
-            state_machine=fixture_sm_class(chaindb, attestation_pool, blocks[-1].slot),
+            state_machine=fixture_sm_class(chaindb, attestation_pool),
             block_class=SerenityBeaconBlock,
             parent_block=block,
             keymap=keymap,
@@ -82,7 +82,7 @@ def test_demo(base_db, validator_count, keymap, pubkeys, fork_choice_scoring):
         )
 
         # Get state machine instance
-        sm = fixture_sm_class(chaindb, attestation_pool, blocks[-1].slot)
+        sm = fixture_sm_class(chaindb, attestation_pool)
         state, _ = sm.import_block(block, state)
 
         chaindb.persist_state(state)
@@ -95,7 +95,7 @@ def test_demo(base_db, validator_count, keymap, pubkeys, fork_choice_scoring):
         attestations = create_mock_signed_attestations_at_slot(
             state=state,
             config=config,
-            state_machine=fixture_sm_class(chaindb, attestation_pool, block.slot),
+            state_machine=fixture_sm_class(chaindb, attestation_pool),
             attestation_slot=attestation_slot,
             beacon_block_root=block.signing_root,
             keymap=keymap,


### PR DESCRIPTION
### What was wrong?

When importing a block, we use head state instead of the state of it's parent block to apply state transition.
- Rationale: Because there could be empty slots between the block and it's parent block, this could save us some work by not having to apply those `per_slot_transition`s again.

However one slot can only map to one state - state of canonical chain. If we are going to process a block from a non-canonical chain, we shouldn't use the head state to apply state transition because the head state is the state of canonical chain.

### How was it fixed?
When importing a block, first check if the block is part of canonical chain.
- If it is, use the head state.
- If not, use the state of it's parent block and apply the `per_slot_transition`s to get the "head state" of the non-canonical chain.

#### Cute Animal Picture


![](https://cdn.pixabay.com/photo/2019/04/29/16/01/cat-4166453_1280.jpg)
