### PR TITLE
Add coverage on config APIs

### DIFF
--- a/docs/api/api.cli.rst
+++ b/docs/api/api.cli.rst
@@ -1,48 +1,135 @@
 Command Line Interface (CLI)
 ============================
 
+The following is a brief description of all the configurations available on the command line.
+We can also generate an always up-to-date version of them by running ``trinity --help``.
+
 .. code-block:: shell
 
     usage: trinity [-h] [--version] [--trinity-root-dir TRINITY_ROOT_DIR]
-                [-l {debug,info}] [--network-id NETWORK_ID | --ropsten]
-                [--sync-mode {full,light} | --light] [--data-dir DATA_DIR]
-                [--nodekey NODEKEY] [--nodekey-path NODEKEY_PATH]
-                {console,attach} ...
+                [--port PORT] [-l LEVEL] [--stderr-log-level STDERR_LOG_LEVEL]
+                [--file-log-level FILE_LOG_LEVEL]
+                [--network-id NETWORK_ID | --ropsten]
+                [--preferred-node PREFERRED_NODES] [--discv5]
+                [--max-peers MAX_PEERS] [--genesis GENESIS]
+                [--data-dir DATA_DIR] [--nodekey NODEKEY] [--profile]
+                [--disable-rpc]
+                [--network-tracking-backend {sqlite3,memory,do-not-track}]
+                [--disable-networkdb-plugin] [--disable-blacklistdb]
+                [--disable-eth1-peer-db]
+                [--enable-experimental-eth1-peer-tracking]
+                [--disable-discovery] [--disable-request-server]
+                [--disable-upnp] [--ethstats]
+                [--ethstats-server-url ETHSTATS_SERVER_URL]
+                [--ethstats-server-secret ETHSTATS_SERVER_SECRET]
+                [--ethstats-node-id ETHSTATS_NODE_ID]
+                [--ethstats-node-contact ETHSTATS_NODE_CONTACT]
+                [--ethstats-interval ETHSTATS_INTERVAL]
+                [--sync-mode {fast,full,beam,light,none}] [--tx-pool]
+                {attach,fix-unclean-shutdown,remove-network-db,db-shell} ...
 
     positional arguments:
-    {console,attach}
-        console             run the chain and start the trinity REPL
+    {attach,fix-unclean-shutdown,remove-network-db,db-shell}
         attach              open an REPL attached to a currently running chain
+        fix-unclean-shutdown
+                            close any dangling processes from a previous unclean
+                            shutdown
+        remove-network-db   Remove the on-disk sqlite database that tracks data
+                            about the p2p network
+        db-shell            open a REPL to inspect the db
 
     optional arguments:
     -h, --help            show this help message and exit
+    --disable-rpc         Disables the JSON-RPC Server
+    --disable-discovery   Disable peer discovery
+    --disable-request-server
+                            Disables the Request Server
+    --disable-upnp        Disable upnp mapping
+    --tx-pool             Enables the Transaction Pool (experimental)
 
-    sync mode:
+    core:
     --version             show program's version number and exit
     --trinity-root-dir TRINITY_ROOT_DIR
                             The filesystem path to the base directory that trinity
                             will store it's information. Default:
                             $XDG_DATA_HOME/.local/share/trinity
+    --port PORT           Port on which trinity should listen for incoming
+                            p2p/discovery connections. Default: 30303
 
     logging:
-    -l {debug,info}, --log-level {debug,info}
-                            Sets the logging level
+    -l LEVEL, --log-level LEVEL
+                            Configure the logging level. LEVEL must be one of:
+                            8/10/20/30/40/50 (numeric);
+                            debug2/debug/info/warn/warning/error/critical
+                            (lowercase);
+                            DEBUG2/DEBUG/INFO/WARN/WARNING/ERROR/CRITICAL
+                            (uppercase).
+    --stderr-log-level STDERR_LOG_LEVEL
+                            Configure the logging level for the stderr logging.
+    --file-log-level FILE_LOG_LEVEL
+                            Configure the logging level for file-based logging.
 
     network:
     --network-id NETWORK_ID
                             Network identifier (1=Mainnet, 3=Ropsten)
     --ropsten             Ropsten network: pre configured proof-of-work test
                             network. Shortcut for `--networkid=3`
-
-    sync mode:
-    --sync-mode {full,light}
+    --preferred-node PREFERRED_NODES
+                            An enode address which will be 'preferred' above nodes
+                            found using the discovery protocol
+    --discv5              Enable experimental v5 (topic) discovery mechanism
+    --max-peers MAX_PEERS
+                            Maximum number of network peers
 
     chain:
+    --genesis GENESIS     File containing a custom genesis block header
     --data-dir DATA_DIR   The directory where chain data is stored
     --nodekey NODEKEY     Hexadecimal encoded private key to use for the nodekey
-    --nodekey-path NODEKEY_PATH
-                            The filesystem path to the file which contains the
+                            or the filesystem path to the file which contains the
                             nodekey
+
+    debug:
+    --profile             Enables profiling via cProfile.
+
+    network db:
+    --network-tracking-backend {sqlite3,memory,do-not-track}
+                            Configure whether nodes are tracked and how. (sqlite3:
+                            persistent tracking across runs from an on-disk
+                            sqlite3 database, memory: tracking only in memory, do-
+                            not-track: no tracking)
+    --disable-networkdb-plugin
+                            Disables the builtin 'Networkt Database' plugin.
+                            **WARNING**: disabling this API without a proper
+                            replacement will cause your trinity node to crash.
+    --disable-blacklistdb
+                            Disables the blacklist database server component of
+                            the Network Database plugin.**WARNING**: disabling
+                            this API without a proper replacement will cause your
+                            trinity node to crash.
+    --disable-eth1-peer-db
+                            Disables the ETH1.0 peer database server component of
+                            the Network Database plugin.**WARNING**: disabling
+                            this API without a proper replacement will cause your
+                            trinity node to crash.
+    --enable-experimental-eth1-peer-tracking
+                            Enables the experimental tracking of metadata about
+                            successful connections to Eth1 peers.
+
+    ethstats (experimental):
+    --ethstats            Enable node stats reporting service
+    --ethstats-server-url ETHSTATS_SERVER_URL
+                            Node stats server URL (e. g. wss://example.com/api)
+    --ethstats-server-secret ETHSTATS_SERVER_SECRET
+                            Node stats server secret
+    --ethstats-node-id ETHSTATS_NODE_ID
+                            Node ID for stats server
+    --ethstats-node-contact ETHSTATS_NODE_CONTACT
+                            Node contact information for stats server
+    --ethstats-interval ETHSTATS_INTERVAL
+                            The interval at which data is reported back
+
+    sync mode:
+    --sync-mode {fast,full,beam,light,none}
 
 
 

--- a/docs/api/api.config.rst
+++ b/docs/api/api.config.rst
@@ -1,0 +1,33 @@
+Config
+======
+
+This section covers Trinity's configuration APIs that are being used within many internal
+components and are also exposed to the :doc:`extensibility API </api/extensibility/index>`.
+
+This is **not** about Trinity's command line configuration, which is covered in the
+:doc:`CLI section </api/api.cli>`.
+
+
+Trinity Config
+--------------
+
+.. autoclass:: trinity.config.TrinityConfig
+  :members:
+
+Base App Config
+---------------
+
+.. autoclass:: trinity.config.BaseAppConfig
+  :members:
+
+Eth1 App Config
+---------------
+
+.. autoclass:: trinity.config.Eth1AppConfig
+  :members:
+
+Beacon App Config
+-----------------
+
+.. autoclass:: trinity.config.BeaconAppConfig
+  :members:

--- a/docs/api/index.rst
+++ b/docs/api/index.rst
@@ -12,6 +12,7 @@ This section aims to provide a detailed description of all APIs. If you are look
    :name: toc-api-trinity
 
    api.cli
+   api.config
    extensibility/index
    protocol/index
 

--- a/newsfragments/775.doc.rst
+++ b/newsfragments/775.doc.rst
@@ -1,0 +1,2 @@
+Cover :class:`~trinity.config.TrinityConfig`, :class:`~trinity.config.Eth1AppConfig` and
+:class:`~trinity.config.BeaconAppConfig` in API docs.

--- a/newsfragments/778.doc.rst
+++ b/newsfragments/778.doc.rst
@@ -1,0 +1,1 @@
+Improve layout of API docs by grouping classmethods, methods and attributes.


### PR DESCRIPTION
### What was wrong?

We should cover the ``TrinityConfig``, ``Eth1AppConfig`` and ``BeaconAppConfig`` in the docs as these are important pieces that are also exposed to plugins / components.

### How was it fixed?

1. Added / fine tuned API docs directly in source
2. Linked them in our API docs

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] Clean up commit history

[//]: # (For important changes, please add a new entry to the running release notes PR)
[//]: # (You can find the current one using: https://github.com/ethereum/trinity/pulls?q=is%3Aopen+is%3Apr+label%3A%22Release+Notes%22 )
[//]: # (See: https://trinity-client.readthedocs.io/en/latest/contributing.html#pull-requests)
- [ ] Add entry to the [release notes PR](https://github.com/ethereum/trinity/pulls?q=is%3Aopen+is%3Apr+label%3A%22Release+Notes%22)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://www.thelocal.dk/userdata/images/article/64c9d551c2f480dda308eb1f9d812e8e35a7b2115874e17c88d0ed4c58505134.jpg)
