### PR TITLE
extend deadline for test

### DIFF
--- a/tests/eth2/core/beacon/state_machines/forks/test_serenity_epoch_processing.py
+++ b/tests/eth2/core/beacon/state_machines/forks/test_serenity_epoch_processing.py
@@ -822,7 +822,10 @@ def test_process_rewards_and_penalties_for_finality(
         )
 
 
-@settings(max_examples=1)
+@settings(
+    max_examples=1,
+    deadline=300,
+)
 @given(random=st.randoms())
 @pytest.mark.parametrize(
     (


### PR DESCRIPTION
### What was wrong?

Fix the flaky test here https://circleci.com/gh/ethereum/trinity/57773

### How was it fixed?

extend the hypothesis deadline to 300 milliseconds

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://preview.redd.it/2oyclvx6ia931.jpg?width=640&crop=smart&auto=webp&s=acb475599901d7a7aa8e05d72ff8cc53546b96e0)
