### PR TITLE
Remove visual distraction from docs

### DIFF
--- a/docs/_static/css/custom.css
+++ b/docs/_static/css/custom.css
@@ -1,0 +1,20 @@
+tt, code, pre {
+    font-family: monospace, sans-serif;
+    font-size: 96.5%;
+}
+
+.rst-content dl:not(.docutils) tt.descname,
+.rst-content dl:not(.docutils) tt.descclassname,
+.rst-content dl:not(.docutils) tt.descname,
+.rst-content dl:not(.docutils) code.descname,
+.rst-content dl:not(.docutils) tt.descclassname,
+.rst-content dl:not(.docutils) code.descclassname {
+  font-size: 130% !important;
+}
+
+.rst-content dl:not(.docutils) dl dt {
+  background: #fff;
+  border: none;
+  margin: 0;
+  padding: 0;
+}

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -115,7 +115,10 @@ html_theme = 'sphinx_rtd_theme'
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-# html_static_path = ['_static']
+html_static_path = ['_static']
+
+def setup(app):
+    app.add_stylesheet("css/custom.css")
 
 # Allows the mod index to function more helpfully (not everything under 'e')
 modindex_common_prefix = ['eth.']


### PR DESCRIPTION
### What was wrong?

I personally find the theme of the API docs a bit visual distracting (and I say that as someone who usually doesn't give a :hankey: about visuals). Imho, the default Python docs look much cleaner and so I went on to steal some bits.

(I tried stealing the whole theme but it's too heavily customized for a quick win).

Here's how API docs **currently** look.

![image](https://user-images.githubusercontent.com/521109/60901380-21484f00-a26e-11e9-8844-59aafa54d73d.png)

### How was it fixed?

This PR adds a tiny bit of custom css to

- get rid of these gray boxes for methods
- get rid of some margin/padding around method names
- increase size of method/class names
- use mono space font for method parameters

Here is what it would look like if this PR lands

![image](https://user-images.githubusercontent.com/521109/60902613-2f976a80-a270-11e9-92f3-4c86a603e7e0.png)

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] Clean up commit history

[//]: # (For important changes, please add a new entry to the running release notes PR)
[//]: # (You can find the current one using: https://github.com/ethereum/trinity/pulls?q=is%3Aopen+is%3Apr+label%3A%22Release+Notes%22 )
[//]: # (See: https://trinity-client.readthedocs.io/en/latest/contributing.html#pull-requests)
- [ ] Add entry to the [release notes PR](https://github.com/ethereum/trinity/pulls?q=is%3Aopen+is%3Apr+label%3A%22Release+Notes%22)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://miro.medium.com/max/1400/0*JWocE8Ntnk0hKQHT.jpg)
