### PR TITLE
Group members in docs by classmethods, methods, attributes

### DIFF
--- a/docs/_static/css/custom.css
+++ b/docs/_static/css/custom.css
@@ -18,3 +18,35 @@ tt, code, pre {
   margin: 0;
   padding: 0;
 }
+
+/* We instruct sphinx to order members groupwise and use the following css to add headlines */
+
+dl.attribute:before {
+  content: "Attributes";
+}
+
+dl.method:before {
+  content: "Methods";
+}
+
+dl.classmethod:before {
+  content: "Classmethods";
+}
+
+dl.method:before,
+dl.attribute:before,
+dl.classmethod:before {
+  background: #e7f2fa;
+  border-top: solid 3px #6ab0de;
+  color: #000;
+  display: inline-block;
+  font-weight: bold;
+  margin: 5px 0 10px 0;
+  padding: 5px;
+}
+
+dl.method ~ dl.method:before,
+dl.attribute ~ dl.attribute:before,
+dl.classmethod ~ dl.classmethod:before {
+  display: none;
+}

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -50,6 +50,7 @@ autodoc_default_options = {
     'undoc-members': None,
 }
 
+autodoc_member_order = 'groupwise'
 autodoc_mock_imports = ["snappy"]
 
 # Add any paths that contain templates here, relative to this directory.


### PR DESCRIPTION
### What was wrong?

One of the things that annoys me when looking at the API docs is that methods, classmethods and attributes do visually not stand much apart. 

![image](https://user-images.githubusercontent.com/521109/60918729-4e0f5d00-a294-11e9-839b-3dc3296b3369.png)

By default sphinx orders all members alphabetically and so methods, classmethods and attributes end up mixed and it's really hard to tell them apart.

### How was it fixed?

We can combine two things to improve the situation:

1. We can tell sphinx to order members `groupwise`

2. We can add css pseudo elements to inject headlines for each group

![image](https://user-images.githubusercontent.com/521109/60919405-e823d500-a295-11e9-959e-e44e3b963bc9.png)


### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] Clean up commit history

[//]: # (For important changes, please add a new entry to the running release notes PR)
[//]: # (You can find the current one using: https://github.com/ethereum/trinity/pulls?q=is%3Aopen+is%3Apr+label%3A%22Release+Notes%22 )
[//]: # (See: https://trinity-client.readthedocs.io/en/latest/contributing.html#pull-requests)
- [ ] Add entry to the [release notes PR](https://github.com/ethereum/trinity/pulls?q=is%3Aopen+is%3Apr+label%3A%22Release+Notes%22)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](http://eskipaper.com/images/beautiful-animal-pictures-5.jpg)
