### PR TITLE
Skip duplicate body downloads

### DIFF
--- a/newsfragments/780.bugfix.rst
+++ b/newsfragments/780.bugfix.rst
@@ -1,0 +1,2 @@
+Squashed bug that redownloads block bodies and logs this warning:
+``ValidationError: Cannot finish prereq BlockImportPrereqs.StoreBlockBodies of task``

--- a/trinity/_utils/datastructures.py
+++ b/trinity/_utils/datastructures.py
@@ -362,7 +362,7 @@ class BaseOrderedTaskPreparation(ABC, Generic[TTask, TTaskID]):
     def register_tasks(
             self,
             tasks: Tuple[TTask, ...],
-            ignore_duplicates: bool = False) -> Iterable[TTask]:
+            ignore_duplicates: bool = False) -> Tuple[TTask, ...]:
         pass
 
     @abstractmethod

--- a/trinity/_utils/datastructures.py
+++ b/trinity/_utils/datastructures.py
@@ -561,7 +561,7 @@ class OrderedTaskPreparation(
         # check if there are duplicate tasks within `tasks`
         if len(identified_tasks) < len(tasks) and not ignore_duplicates:
             raise ValidationError(
-                f"Not allowed to register same task twice. Tried to register: {tasks}"
+                f"May not register same task twice in the same call. Tried to register: {tasks}"
             )
 
         duplicates = tuple(

--- a/trinity/sync/beam/chain.py
+++ b/trinity/sync/beam/chain.py
@@ -301,7 +301,7 @@ class BeamBlockImporter(BaseBlockImporter, HasExtendedDebugLogger):
     async def import_block(
             self,
             block: BaseBlock) -> Tuple[BaseBlock, Tuple[BaseBlock, ...], Tuple[BaseBlock, ...]]:
-        self.logger.info("Fade importing %s with %d txns ...", block, len(block.transactions))
+        self.logger.info("Beam importing %s (%d txns) ...", block.header, len(block.transactions))
 
         new_account_nodes = await self._pre_check_addresses(block)
         self._preloaded_account_state += new_account_nodes

--- a/trinity/sync/beam/state.py
+++ b/trinity/sync/beam/state.py
@@ -598,7 +598,7 @@ class BeamDownloader(BaseService, PeerSubscriber):
         Request all nodes in the queue, running indefinitely
         """
         self._timer.start()
-        self.logger.info("Starting incremental state sync")
+        self.logger.info("Starting beam state sync")
         self.run_task(self._periodically_report_progress())
         with self.subscribe(self._peer_pool):
             await self.wait(self._match_node_requests_to_peers())

--- a/trinity/sync/common/headers.py
+++ b/trinity/sync/common/headers.py
@@ -108,9 +108,9 @@ class SkeletonSyncer(BaseService, Generic[TChainPeer]):
     async def _run(self) -> None:
         self.run_daemon_task(self._display_stats())
         await self.wait(self._quietly_fetch_full_skeleton())
-        self.logger.info("Skeleton %s stopped responding, waiting for sync to complete", self.peer)
+        self.logger.debug("Skeleton %s stopped responding, waiting for sync to complete", self.peer)
         await self.wait(self._fetched_headers.join())
-        self.logger.info("Skeleton %s emitted all headers", self.peer)
+        self.logger.debug("Skeleton %s emitted all headers", self.peer)
 
     async def _display_stats(self) -> None:
         queue = self._fetched_headers
@@ -458,7 +458,7 @@ class SkeletonSyncer(BaseService, Generic[TChainPeer]):
             return tuple()
 
         if not headers:
-            self.logger.info("Got no new headers from %s, exiting skeleton sync", peer)
+            self.logger.debug("Got no new headers from %s, exiting skeleton sync", peer)
             return tuple()
         else:
             return headers
@@ -849,7 +849,7 @@ class BaseHeaderChainSyncer(BaseService, HeaderSyncerAPI, Generic[TChainPeer]):
             if self._skeleton.is_operational:
                 self._skeleton.cancel_nowait()
         finally:
-            self.logger.info("Skeleton sync with %s ended", peer)
+            self.logger.debug("Skeleton sync with %s ended", peer)
             self._last_target_header_hash = peer.head_hash
             self._skeleton = None
 


### PR DESCRIPTION
### What was wrong?

Especially during Beam Sync, syncer tries to redownload the same block bodies repeatedly. It fails, and logs print this:
```
ValidationError: Cannot finish prereq BlockImportPrereqs.StoreBlockBodies of task 
```

### How was it fixed?

When the body syncer detects a repeated header, skip downloading its body.

Plus some bonus improvements in type annotation and logging.

### To-Do

[//]: # (For important changes, please add a new entry to the running release notes PR)
[//]: # (You can find the current one using: https://github.com/ethereum/trinity/pulls?q=is%3Aopen+is%3Apr+label%3A%22Release+Notes%22 )
[//]: # (See: https://trinity-client.readthedocs.io/en/latest/contributing.html#pull-requests)
- [x] Add entry to the [release notes PR](https://github.com/ethereum/trinity/pulls?q=is%3Aopen+is%3Apr+label%3A%22Release+Notes%22)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcQzyCrSbk4q8TkaSqBTOEiKfr1DdUqMqH-Y7ls6sz_Wr0f-NzHAvg)