### PR TITLE
Add trio based service implementation

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -269,6 +269,12 @@ jobs:
       - image: circleci/python:3.6
         environment:
           TOXENV: py36-p2p
+  py36-p2p-trio:
+    <<: *common
+    docker:
+      - image: circleci/python:3.6
+        environment:
+          TOXENV: py36-p2p-trio
   py36-eth2-core:
     <<: *common
     docker:
@@ -361,6 +367,12 @@ jobs:
       - image: circleci/python:3.7
         environment:
           TOXENV: py37-p2p
+  py37-p2p-trio:
+    <<: *common
+    docker:
+      - image: circleci/python:3.7
+        environment:
+          TOXENV: py37-p2p-trio
   py37-eth2-core:
     <<: *common
     docker:

--- a/newsfragments/790.feature.rst
+++ b/newsfragments/790.feature.rst
@@ -1,0 +1,2 @@
+Implement ``p2p.trio_service.Service`` abstraction using ``trio`` as a loose
+replacement for the existing ``asyncio`` based ``p2p.service.BaseService``.

--- a/p2p/trio_service.py
+++ b/p2p/trio_service.py
@@ -40,15 +40,19 @@ class ServiceAPI(ABC):
 
         .. code-block: python
 
-            # run the service and blocks until service finishes
-            await ManagerAPI.run_service(service)
-
-            # run the service in the background using a context manager
+            # 1. run the service in the background using a context manager
             async with run_service(service) as manager:
                 # service runs inside context block
                 ...
                 # service cancels and stops when context exits
             # service will have fully stopped
+
+            # 2. run the service blocking until completion
+            await Manager.run_service(service)
+
+            # 3. create manager and then run service blocking until completion
+            manager = Manager(service)
+            await manager.run()
         """
         ...
 
@@ -282,7 +286,6 @@ class Manager(ManagerAPI):
     @classmethod
     async def run_service(cls, service: ServiceAPI) -> None:
         manager = cls(service)
-        service.manager = manager
         await manager.run()
 
     async def run(self) -> None:

--- a/p2p/trio_service.py
+++ b/p2p/trio_service.py
@@ -1,0 +1,256 @@
+from abc import ABC, abstractmethod
+import logging
+import sys
+from types import TracebackType
+from typing import Any, Callable, Awaitable, Optional, Tuple, Type, AsyncIterator
+
+from async_generator import asynccontextmanager
+
+import trio
+
+import trio_typing
+
+
+class ManagerAPI(ABC):
+    @property
+    @abstractmethod
+    def has_started(self) -> bool:
+        ...
+
+    @property
+    @abstractmethod
+    def is_running(self) -> bool:
+        ...
+
+    @property
+    @abstractmethod
+    def is_cancelled(self) -> bool:
+        ...
+
+    @property
+    @abstractmethod
+    def is_stopped(self) -> bool:
+        ...
+
+    @property
+    @abstractmethod
+    def did_error(self) -> bool:
+        ...
+
+    @abstractmethod
+    def cancel(self) -> None:
+        ...
+
+    @abstractmethod
+    async def wait_started(self) -> None:
+        ...
+
+    @abstractmethod
+    async def wait_cancelled(self) -> None:
+        ...
+
+    @abstractmethod
+    async def wait_stopped(self) -> None:
+        ...
+
+    @abstractmethod
+    async def _run_daemon_task(self,
+                               coro: Callable[..., Awaitable[Any]],
+                               *args: Any,
+                               name: str = None) -> None:
+        ...
+
+
+LogicFnType = Callable[[ManagerAPI], Awaitable[Any]]
+
+
+class Service(ABC):
+    async def start(self, nursery: trio_typing.Nursery) -> 'ServiceManager':
+        manager = ServiceManager(self)
+        nursery.start_soon(manager.run)
+        return manager
+
+    @abstractmethod
+    async def run(self, manager: ManagerAPI) -> None:
+        ...
+
+
+def as_service(logic_fn: LogicFnType) -> Type[Service]:
+    """
+    Create a service out of a simple function
+    """
+    class _Service(Service):
+        def __init__(self, *args: Any, **kwargs: Any):
+            self._args = args
+            self._kwargs = kwargs
+
+        async def run(self, manager: ManagerAPI) -> None:
+            await logic_fn(manager, *self._args, **self._kwargs)  # type: ignore
+
+    _Service.__name__ = logic_fn.__name__
+    _Service.__doc__ = logic_fn.__doc__
+    return _Service
+
+
+class ServiceManager(ManagerAPI):
+    logger = logging.getLogger('p2p.trio_service.ServiceManager')
+
+    _run_error: Optional[Tuple[
+        Optional[Type[BaseException]],
+        Optional[BaseException],
+        Optional[TracebackType],
+    ]] = None
+
+    def __init__(self, logic: Service) -> None:
+        self.logic = logic
+
+        # events
+        self._started = trio.Event()
+        self._cancelled = trio.Event()
+        self._stopped = trio.Event()
+
+        # locks
+        self._run_lock = trio.Lock()
+
+    async def _handle_cancelled(self, nursery: trio_typing.Nursery) -> None:
+        """
+        Handles the case where cancellation occurs because the
+        `event.set_cancelled()` has been called, this propagates that to force
+        the nursery to be cancelled.
+        """
+        self.logger.debug('%s: _handle_cancelled waiting for cancellation', self)
+        await self._cancelled.wait()
+        self.logger.debug('%s: _handle_cancelled triggering nursery cancellation', self)
+        nursery.cancel_scope.cancel()
+
+    async def _handle_run(self) -> None:
+        """
+        Triggers cancellation in the case where the service exits normally or
+        throws an exception.
+        """
+        self._started.set()
+        try:
+            await self.logic.run(self)
+        except Exception as err:
+            self.logger.debug(
+                '%s: _handle_run got error, storing exception and setting cancelled',
+                self
+            )
+            self.logger.exception('GOT THIS')
+            self._run_error = sys.exc_info()
+        finally:
+            self.logger.debug('%s: _handle_run triggering service cancellation', self)
+            self.cancel()
+
+    async def run(self) -> None:
+        if self._run_lock.locked():
+            raise Exception("TODO: run lock already engaged")
+        elif self.has_started:
+            raise Exception("TODO: already started. No reentrance")
+
+        async with self._run_lock:
+
+            # Open a nursery
+            async with trio.open_nursery() as nursery:
+                self._nursery = nursery
+
+                nursery.start_soon(self._handle_cancelled, nursery)
+                nursery.start_soon(self._handle_run)
+
+                # This wait is not strictly necessary as this context block
+                # will not exit until the background tasks have completed.
+                await self.wait_cancelled()
+
+        # Mark as having stopped
+        self._stopped.set()
+        self.logger.debug('%s stopped', self)
+
+        # If an error occured, re-raise it here
+        if self.did_error:
+            _, exc_value, exc_tb = self._run_error
+            raise exc_value.with_traceback(exc_tb)
+
+    #
+    # Event API mirror
+    #
+    @property
+    def has_started(self) -> bool:
+        return self._started.is_set()
+
+    @property
+    def is_running(self) -> bool:
+        return self._started.is_set() and not self._stopped.is_set()
+
+    @property
+    def is_cancelled(self) -> bool:
+        return self._cancelled.is_set()
+
+    @property
+    def is_stopped(self) -> bool:
+        return self._stopped.is_set()
+
+    @property
+    def did_error(self) -> bool:
+        return self._run_error is not None
+
+    #
+    # Control API
+    #
+    def cancel(self) -> None:
+        if not self.has_started:
+            raise Exception("TODO: never started")
+        self._cancelled.set()
+
+    #
+    # Wait API
+    #
+    async def wait_started(self) -> None:
+        await self._started.wait()
+
+    async def wait_cancelled(self) -> None:
+        await self._cancelled.wait()
+
+    async def wait_stopped(self) -> None:
+        await self._stopped.wait()
+
+    async def _run_daemon_task(self,
+                               coro: Callable[..., Awaitable[Any]],
+                               *args: Any,
+                               name: str = None) -> None:
+        try:
+            await coro(*args)
+        except Exception as err:
+            self.logger.debug(
+                "Daemon task '%s' exited with error: %s",
+                name or coro,
+                err,
+                exc_info=True,
+            )
+        else:
+            self.logger.debug(
+                "Daemon task '%s' exited.",
+                name or coro,
+            )
+        finally:
+            self.cancel()
+
+    def run_daemon_task(self,
+                        coro: Callable[[Any], Awaitable[Any]],
+                        *args: Any,
+                        name: str = None) -> None:
+        self._nursery.start_soon(
+            self._run_daemon_task,
+            coro,
+            *args,
+        )
+
+
+@asynccontextmanager
+async def run_service(service: Service) -> AsyncIterator[ManagerAPI]:
+    async with trio.open_nursery() as nursery:
+        manager = await service.start(nursery)
+        try:
+            yield manager
+        finally:
+            manager.cancel()
+            await manager.wait_stopped()

--- a/setup.py
+++ b/setup.py
@@ -8,6 +8,7 @@ PYEVM_DEPENDENCY = "py-evm==0.3.0a1"
 
 deps = {
     'p2p': [
+        "async-generator==1.10",
         "asyncio-cancel-token==0.1.0a2",
         "async_lru>=0.1.0,<1.0.0",
         "cached-property>=1.5.1,<2",
@@ -18,10 +19,11 @@ deps = {
         "netifaces>=0.10.7<1",
         "pysha3>=1.0.0,<2.0.0",
         "SQLAlchemy>=1.3.3,<2",
+        'trio==0.11.0,<0.12',
+        'trio-typing>=0.2.0,<0.3',
         "upnpclient>=0.0.8,<1",
     ],
     'trinity': [
-        "async-generator==1.10",
         "bloom-filter==1.3",
         "cachetools>=3.1.0,<4.0.0",
         "coincurve>=10.0.0,<11.0.0",
@@ -48,15 +50,20 @@ deps = {
         # pinned to <3.7 until async fixtures work again
         # https://github.com/pytest-dev/pytest-asyncio/issues/89
         "pytest>=3.6,<3.7",
-        "pytest-asyncio>=0.10.0,<0.11",
+        # only needed for p2p
+        "pytest-asyncio-network-simulator==0.1.0a2;python_version>='3.6'",
         "pytest-cov==2.5.1",
         "pytest-watch>=4.1.0,<5",
         "pytest-xdist==1.18.1",
         "pytest-mock==1.10.4",
-        # only needed for p2p
-        "pytest-asyncio-network-simulator==0.1.0a2;python_version>='3.6'",
         # only for eth2
         "ruamel.yaml==0.15.98",
+    ],
+    'test-asyncio': [
+        "pytest-asyncio>=0.10.0,<0.11",
+    ],
+    'test-trio': [
+        'pytest-trio==0.5.2',
     ],
     'lint': [
         "flake8==3.5.0",

--- a/setup.py
+++ b/setup.py
@@ -59,6 +59,9 @@ deps = {
         # only for eth2
         "ruamel.yaml==0.15.98",
     ],
+    # We have to keep some separation between trio and asyncio based tests
+    # because `pytest-asyncio` is greedy and tries to run all asyncio fixtures.
+    # See: https://github.com/ethereum/trinity/pull/790
     'test-asyncio': [
         "pytest-asyncio>=0.10.0,<0.11",
     ],

--- a/tests/p2p-trio/test_service.py
+++ b/tests/p2p-trio/test_service.py
@@ -1,0 +1,109 @@
+import pytest
+
+import trio
+
+from p2p.trio_service import (
+    ServiceManager,
+    as_service,
+)
+
+
+async def do_service_lifecycle_check(manager,
+                                     manager_run_fn,
+                                     trigger_exit_condition_fn):
+    async with trio.open_nursery() as nursery:
+        assert manager.has_started is False
+        assert manager.is_running is False
+        assert manager.is_cancelled is False
+        assert manager.is_stopped is False
+
+        nursery.start_soon(manager_run_fn)
+
+        with trio.fail_after(0.1):
+            await manager.wait_started()
+
+        assert manager.has_started is True
+        assert manager.is_running is True
+        assert manager.is_cancelled is False
+        assert manager.is_stopped is False
+
+        # trigger the service to exit
+        trigger_exit_condition_fn()
+
+        with trio.fail_after(10):
+            await manager.wait_cancelled()
+
+        assert manager.has_started is True
+        assert manager.is_running is True
+        assert manager.is_cancelled is True
+        assert manager.is_stopped is False
+
+        with trio.fail_after(0.1):
+            await manager.wait_stopped()
+
+        assert manager.has_started is True
+        assert manager.is_running is False
+        assert manager.is_cancelled is True
+        assert manager.is_stopped is True
+
+
+@pytest.mark.trio
+async def test_trio_service_lifecycle_run_and_clean_exit():
+    trigger_exit = trio.Event()
+
+    @as_service
+    async def ServiceTest(manager):
+        await trigger_exit.wait()
+
+    service = ServiceTest()
+    manager = ServiceManager(service)
+
+    await do_service_lifecycle_check(manager, manager.run, trigger_exit.set)
+
+
+@pytest.mark.trio
+async def test_trio_service_lifecycle_run_and_internal_cancellation():
+    trigger_cancel = trio.Event()
+
+    @as_service
+    async def ServiceTest(manager):
+        await trigger_cancel.wait()
+        manager.cancel()
+
+    service = ServiceTest()
+    manager = ServiceManager(service)
+
+    await do_service_lifecycle_check(manager, manager.run, trigger_cancel.set)
+
+
+@pytest.mark.trio
+async def test_trio_service_lifecycle_run_and_external_cancellation():
+
+    @as_service
+    async def ServiceTest(manager):
+        while True:
+            await trio.sleep(1)
+
+    service = ServiceTest()
+    manager = ServiceManager(service)
+
+    await do_service_lifecycle_check(manager, manager.run, manager.cancel)
+
+
+@pytest.mark.trio
+async def test_trio_service_lifecycle_run_and_exception():
+    trigger_error = trio.Event()
+
+    @as_service
+    async def ServiceTest(manager):
+        await trigger_error.wait()
+        raise RuntimeError("Service throwing error")
+
+    service = ServiceTest()
+    manager = ServiceManager(service)
+
+    async def do_service_run():
+        with pytest.raises(RuntimeError, match="Service throwing error"):
+            await manager.run()
+
+    await do_service_lifecycle_check(manager, do_service_run, trigger_error.set)

--- a/tests/p2p-trio/test_service.py
+++ b/tests/p2p-trio/test_service.py
@@ -3,16 +3,24 @@ import pytest
 import trio
 
 from p2p.trio_service import (
-    ServiceManager,
+    Service,
+    Manager,
     as_service,
+    background_service,
 )
+
+
+class WaitCancelledService(Service):
+    async def run(self) -> None:
+        await self.manager.wait_cancelled()
 
 
 async def do_service_lifecycle_check(manager,
                                      manager_run_fn,
-                                     trigger_exit_condition_fn):
+                                     trigger_exit_condition_fn,
+                                     should_be_cancelled):
     async with trio.open_nursery() as nursery:
-        assert manager.has_started is False
+        assert manager.is_started is False
         assert manager.is_running is False
         assert manager.is_cancelled is False
         assert manager.is_stopped is False
@@ -22,7 +30,7 @@ async def do_service_lifecycle_check(manager,
         with trio.fail_after(0.1):
             await manager.wait_started()
 
-        assert manager.has_started is True
+        assert manager.is_started is True
         assert manager.is_running is True
         assert manager.is_cancelled is False
         assert manager.is_stopped is False
@@ -30,21 +38,33 @@ async def do_service_lifecycle_check(manager,
         # trigger the service to exit
         trigger_exit_condition_fn()
 
-        with trio.fail_after(10):
-            await manager.wait_cancelled()
+        if should_be_cancelled:
+            with trio.fail_after(0.01):
+                await manager.wait_cancelled()
 
-        assert manager.has_started is True
-        assert manager.is_running is True
-        assert manager.is_cancelled is True
-        assert manager.is_stopped is False
+            assert manager.is_started is True
+            # non-deterministic for whether the service would register as
+            # *running* or *stopped* at this stage because it may have stopped
+            # or it may be stopping.
+            assert manager.is_cancelled is True
 
         with trio.fail_after(0.1):
             await manager.wait_stopped()
 
-        assert manager.has_started is True
+        assert manager.is_started is True
         assert manager.is_running is False
-        assert manager.is_cancelled is True
+        assert manager.is_cancelled is should_be_cancelled
         assert manager.is_stopped is True
+
+
+def test_service_manager_initial_state():
+    service = WaitCancelledService()
+    manager = Manager(service)
+
+    assert manager.is_started is False
+    assert manager.is_running is False
+    assert manager.is_cancelled is False
+    assert manager.is_stopped is False
 
 
 @pytest.mark.trio
@@ -56,24 +76,14 @@ async def test_trio_service_lifecycle_run_and_clean_exit():
         await trigger_exit.wait()
 
     service = ServiceTest()
-    manager = ServiceManager(service)
+    manager = Manager(service)
 
-    await do_service_lifecycle_check(manager, manager.run, trigger_exit.set)
-
-
-@pytest.mark.trio
-async def test_trio_service_lifecycle_run_and_internal_cancellation():
-    trigger_cancel = trio.Event()
-
-    @as_service
-    async def ServiceTest(manager):
-        await trigger_cancel.wait()
-        manager.cancel()
-
-    service = ServiceTest()
-    manager = ServiceManager(service)
-
-    await do_service_lifecycle_check(manager, manager.run, trigger_cancel.set)
+    await do_service_lifecycle_check(
+        manager=manager,
+        manager_run_fn=manager.run,
+        trigger_exit_condition_fn=trigger_exit.set,
+        should_be_cancelled=False,
+    )
 
 
 @pytest.mark.trio
@@ -82,12 +92,17 @@ async def test_trio_service_lifecycle_run_and_external_cancellation():
     @as_service
     async def ServiceTest(manager):
         while True:
-            await trio.sleep(1)
+            await trio.sleep(0.1)
 
     service = ServiceTest()
-    manager = ServiceManager(service)
+    manager = Manager(service)
 
-    await do_service_lifecycle_check(manager, manager.run, manager.cancel)
+    await do_service_lifecycle_check(
+        manager=manager,
+        manager_run_fn=manager.run,
+        trigger_exit_condition_fn=manager.cancel,
+        should_be_cancelled=True,
+    )
 
 
 @pytest.mark.trio
@@ -100,10 +115,137 @@ async def test_trio_service_lifecycle_run_and_exception():
         raise RuntimeError("Service throwing error")
 
     service = ServiceTest()
-    manager = ServiceManager(service)
+    manager = Manager(service)
 
     async def do_service_run():
         with pytest.raises(RuntimeError, match="Service throwing error"):
             await manager.run()
 
-    await do_service_lifecycle_check(manager, do_service_run, trigger_error.set)
+    await do_service_lifecycle_check(
+        manager=manager,
+        manager_run_fn=do_service_run,
+        trigger_exit_condition_fn=trigger_error.set,
+        should_be_cancelled=True,
+    )
+
+
+@pytest.mark.trio
+async def test_trio_service_background_service_context_manager():
+    service = WaitCancelledService()
+
+    async with background_service(service) as manager:
+        # ensure the manager property is set.
+        assert hasattr(service, 'manager')
+        assert service.manager is manager
+
+        assert manager.is_started is True
+        assert manager.is_running is True
+        assert manager.is_cancelled is False
+        assert manager.is_stopped is False
+
+    assert manager.is_started is True
+    assert manager.is_running is False
+    assert manager.is_cancelled is True
+    assert manager.is_stopped is True
+
+
+@pytest.mark.trio
+async def test_trio_service_manager_stop():
+    service = WaitCancelledService()
+
+    async with background_service(service) as manager:
+        assert manager.is_started is True
+        assert manager.is_running is True
+        assert manager.is_cancelled is False
+        assert manager.is_stopped is False
+
+        await manager.stop()
+
+        assert manager.is_started is True
+        assert manager.is_running is False
+        assert manager.is_cancelled is True
+        assert manager.is_stopped is True
+
+
+@pytest.mark.trio
+async def test_trio_service_manager_run_task():
+    task_event = trio.Event()
+
+    @as_service
+    async def RunTaskService(manager):
+        async def task_fn():
+            task_event.set()
+        manager.run_task(task_fn)
+        await manager.wait_cancelled()
+
+    async with background_service(RunTaskService()):
+        with trio.fail_after(0.1):
+            await task_event.wait()
+
+
+@pytest.mark.trio
+async def test_trio_service_manager_run_task_waits_for_task_completion():
+    task_event = trio.Event()
+
+    @as_service
+    async def RunTaskService(manager):
+        async def task_fn():
+            await trio.sleep(0.01)
+            task_event.set()
+        manager.run_task(task_fn)
+        # the task is set to run in the background but then  the service exits.
+        # We want to be sure that the task is allowed to continue till
+        # completion unless explicitely cancelled.
+
+    async with background_service(RunTaskService()):
+        with trio.fail_after(0.1):
+            await task_event.wait()
+
+
+@pytest.mark.trio
+async def test_trio_service_manager_run_task_can_still_cancel_after_run_finishes():
+    task_event = trio.Event()
+    service_finished = trio.Event()
+
+    @as_service
+    async def RunTaskService(manager):
+        async def task_fn():
+            # this will never complete
+            await task_event.wait()
+
+        manager.run_task(task_fn)
+        # the task is set to run in the background but then  the service exits.
+        # We want to be sure that the task is allowed to continue till
+        # completion unless explicitely cancelled.
+        service_finished.set()
+
+    async with background_service(RunTaskService()) as manager:
+        with trio.fail_after(0.01):
+            await service_finished.wait()
+
+        # show that the service hangs waiting for the task to complete.
+        with trio.move_on_after(0.01) as cancel_scope:
+            await manager.wait_stopped()
+        assert cancel_scope.cancelled_caught is True
+
+        # trigger cancellation and see that the service actually stops
+        manager.cancel()
+        with trio.fail_after(0.01):
+            await manager.wait_stopped()
+
+
+@pytest.mark.trio
+async def test_trio_service_manager_propogates_and_records_exceptions():
+    @as_service
+    async def ThrowErrorService(manager):
+        raise RuntimeError('this is the error')
+
+    service = ThrowErrorService()
+    manager = Manager(service)
+
+    assert manager.did_error is False
+
+    with pytest.raises(RuntimeError, match='this is the error'):
+        await manager.run()
+
+    assert manager.did_error is True

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist=
-    py{36,37}-{eth1-core,p2p,integration,lightchain_integration,eth2-core,eth2-fixtures,eth2-integration,eth1-plugins,eth2-plugins,eth2-utils}
+    py{36,37}-{eth1-core,p2p,p2p-trio,integration,lightchain_integration,eth2-core,eth2-fixtures,eth2-integration,eth1-plugins,eth2-plugins,eth2-utils}
     py36-long_run_integration
     py36-rpc-blockchain
     py36-rpc-state-{frontier,homestead,tangerine_whistle,spurious_dragon,byzantium,constantinople,petersburg}
@@ -27,6 +27,7 @@ commands=
     eth2-fixtures: pytest -n 4 {posargs:tests/eth2/fixtures-tests/}
     eth2-integration: pytest -n 4 {posargs:tests/eth2/integration/}
     p2p: pytest -n 4 {posargs:tests/p2p}
+    p2p-trio: pytest -n 4 {posargs:tests/p2p-trio}
     eth1-plugins: pytest -n 4 {posargs:tests/plugins/tx_pool/}
     eth2-plugins: pytest -n 4 {posargs:tests/plugins/eth2/}
     rpc-blockchain: pytest -n 4 {posargs:tests/json-fixtures-over-rpc/test_rpc_fixtures.py -k 'not GeneralStateTests'}
@@ -45,12 +46,19 @@ commands=
     rpc-state-zero_knowledge: pytest -n 4 {posargs:tests/json-fixtures-over-rpc/test_rpc_fixtures.py -k 'GeneralStateTests and stZeroKnowledge'}
     lightchain_integration: pytest --integration {posargs:tests/integration/test_lightchain_integration.py}
 
-deps = .[p2p,trinity,eth2,test]
+deps = .[p2p,trinity,eth2,test,test-asyncio]
 
 basepython =
     py36: python3.6
     py37: python3.7
 
+[testenv:py36-p2p-trio]
+deps = .[p2p,test,test-trio]
+commands = pytest -n 4 {posargs:tests/p2p-trio}
+
+[testenv:py37-p2p-trio]
+deps = .[p2p,test,test-trio]
+commands = pytest -n 4 {posargs:tests/p2p-trio}
 
 [testenv:py36-docs]
 whitelist_externals=


### PR DESCRIPTION
### What was wrong?

We use the "Service" abstraction heavily in our existing code.  We need something loosely equivalent that can be used with `trio`

### How was it fixed?

Added a re-imagined implementation of the *Service* concept written in `trio`.


### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history

[//]: # (For important changes, please add a new entry to the running release notes PR)
[//]: # (You can find the current one using: https://github.com/ethereum/trinity/pulls?q=is%3Aopen+is%3Apr+label%3A%22Release+Notes%22 )
[//]: # (See: https://trinity-client.readthedocs.io/en/latest/contributing.html#pull-requests)
- [x] Add entry to the [release notes PR](https://github.com/ethereum/trinity/pulls?q=is%3Aopen+is%3Apr+label%3A%22Release+Notes%22)

#### Cute Animal Picture

![pet-rat-photography-diane-ozdamar-7](https://user-images.githubusercontent.com/824194/60993124-17c0f480-a30b-11e9-8e40-f548d16ccd5a.jpg)

