### PR TITLE
Fix bug in API docs layout

### DIFF
--- a/docs/_static/css/custom.css
+++ b/docs/_static/css/custom.css
@@ -19,23 +19,25 @@ tt, code, pre {
   padding: 0;
 }
 
-/* We instruct sphinx to order members groupwise and use the following css to add headlines */
+/* We instruct sphinx to order members groupwise and use the following css to add headlines.
+Notice that while the css differentiates between methods, classmethods and staticmethods,
+unfortunately, sphinx groups these all alphabetically as methods which means we only
+display them as one "methods" group. */
 
 dl.attribute:before {
   content: "Attributes";
 }
 
-dl.method:before {
+dl.method:before,
+dl.classmethod:before,
+dl.staticmethod:before {
   content: "Methods";
-}
-
-dl.classmethod:before {
-  content: "Classmethods";
 }
 
 dl.method:before,
 dl.attribute:before,
-dl.classmethod:before {
+dl.classmethod:before,
+dl.staticmethod:before {
   background: #e7f2fa;
   border-top: solid 3px #6ab0de;
   color: #000;
@@ -45,8 +47,17 @@ dl.classmethod:before {
   padding: 5px;
 }
 
-dl.method ~ dl.method:before,
-dl.attribute ~ dl.attribute:before,
-dl.classmethod ~ dl.classmethod:before {
+/* Remove method header if a previous element already introduced it */
+dl.attribute + dl.attribute:before,
+/* We have to treat all these as just "methods" (see comment further above) */
+dl.method + dl.method:before,
+dl.classmethod + dl.method:before,
+dl.staticmethod + dl.method:before,
+dl.method + dl.classmethod:before,
+dl.classmethod + dl.classmethod:before,
+dl.staticmethod + dl.classmethod:before,
+dl.method + dl.staticmethod:before,
+dl.staticmethod + dl.staticmethod:before,
+dl.classmethod + dl.staticmethod:before {
   display: none;
 }

--- a/newsfragments/794.doc.rst
+++ b/newsfragments/794.doc.rst
@@ -1,0 +1,3 @@
+In the API docs display class methods, static methods and methods as one group "methods".
+While we ideally wish to separate these, Sphinx keeps them all as one group which we'll
+be following until we find a better option.


### PR DESCRIPTION
### What was wrong?

First off, apologies, I spend way too much time going down this rabbit whole. Been knee deep debugging sphinx for a while :sweat_smile: 

So yesterday #778 introduced a feature for our API docs where members are nicely grouped. Unfortunately after merging #775 I've found out that sphinx groups class methods, static methods and methods all together alphabetically. 

This then leads to this clearly wrong and misleading layout.

![image](https://user-images.githubusercontent.com/521109/61056551-d5271700-a3f3-11e9-8d14-5fbccc725ed1.png)

It looks like a bug on Sphinx side and I've spend a while trying to come up with a monkey patch solution (+ intention to contribute upstream) but eventually I gave up and went for something simpler (for now)

### How was it fixed?

As Sphinx keeps class methods, static methods and methods all alphabetically sorted within one group, we follow the same and only separate methods and attributes.

![image](https://user-images.githubusercontent.com/521109/61056702-1e776680-a3f4-11e9-87e9-1c324af7912a.png)

This is a pure CSS fix that simply ensures the different classes for staticmethods, classmethods and methods are all treated equally when it comes to ordering and headlines.

It upsets me to the bone but I had to limit the losses.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

[//]: # (See: https://trinity-client.readthedocs.io/en/latest/contributing.html#pull-requests)
- [x] Add entry to the [release notes](https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://miro.medium.com/max/934/0*sE03cGCczllr0KOw.jpg)
