### PR TITLE
Specify IPC path for attach command

### DIFF
--- a/docs/api/api.cli.rst
+++ b/docs/api/api.cli.rst
@@ -138,11 +138,12 @@ Attach a REPL to a running Trinity instance
 We can attach a REPL to a running Trinity instance to perform RPC request or
 interact with a web3 instance.
 
- .. code-block:: shell
-     usage: trinity attach [-h] [ipc_path]
-     positional arguments:
+.. code-block:: shell
+
+    usage: trinity attach [-h] [ipc_path]
+    positional arguments:
         ipc_path    Specify an IPC path
-     optional arguments:
+    optional arguments:
         -h, --help  show this help message and exit
 
 Check out the :doc:`Quickstart </guides/quickstart>` for a full example.

--- a/docs/api/api.cli.rst
+++ b/docs/api/api.cli.rst
@@ -132,6 +132,23 @@ We can also generate an always up-to-date version of them by running ``trinity -
     --sync-mode {fast,full,beam,light,none}
 
 
+Builtin plugins CLI
+~~~~~~~~~~~~~~~~~~~
+
+**Attach plugin**
+
+Open an REPL attached to a currently running chain.
+
+.. code-block:: shell
+
+    usage: trinity attach [-h] [ipc_path]
+
+    positional arguments:
+        ipc_path    Specify an IPC path
+
+    optional arguments:
+        -h, --help  show this help message and exit
+
 
 Per-module logging
 ~~~~~~~~~~~~~~~~~~

--- a/docs/api/api.cli.rst
+++ b/docs/api/api.cli.rst
@@ -132,22 +132,20 @@ We can also generate an always up-to-date version of them by running ``trinity -
     --sync-mode {fast,full,beam,light,none}
 
 
-Builtin plugins CLI
-~~~~~~~~~~~~~~~~~~~
+Attach a REPL to a running Trinity instance
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-**Attach plugin**
+We can attach a REPL to a running Trinity instance to perform RPC request or
+interact with a web3 instance.
 
-Open an REPL attached to a currently running chain.
-
-.. code-block:: shell
-
-    usage: trinity attach [-h] [ipc_path]
-
-    positional arguments:
+ .. code-block:: shell
+     usage: trinity attach [-h] [ipc_path]
+     positional arguments:
         ipc_path    Specify an IPC path
-
-    optional arguments:
+     optional arguments:
         -h, --help  show this help message and exit
+
+Check out the :doc:`Quickstart </guides/quickstart>` for a full example.
 
 
 Per-module logging

--- a/newsfragments/796.feature.rst
+++ b/newsfragments/796.feature.rst
@@ -1,0 +1,2 @@
+trinity attach can now accept path to ipc as parameter
+Learn more :doc:`docs</api/api.cli>`.

--- a/trinity/_utils/log_messages.py
+++ b/trinity/_utils/log_messages.py
@@ -6,6 +6,7 @@ def create_missing_ipc_error_message(ipc_path: Path) -> str:
         f"The IPC path at {str(ipc_path)} is not found. \n"
         "Please run "
         "'trinity --data-dir <path-to-running-nodes-data-dir> attach' "
+        "or 'trinity attach <path-to-jsonrpc.ipc>'"
         "to specify the IPC path."
     )
     return log_message

--- a/trinity/plugins/builtin/attach/plugin.py
+++ b/trinity/plugins/builtin/attach/plugin.py
@@ -5,6 +5,7 @@ from argparse import (
 )
 import pkg_resources
 import sys
+import pathlib
 
 from trinity.config import (
     Eth1AppConfig,
@@ -43,13 +44,20 @@ class AttachPlugin(BaseMainProcessPlugin):
             'attach',
             help='open an REPL attached to a currently running chain',
         )
+        attach_parser.add_argument(
+            'ipc_path',
+            nargs='?',
+            type=pathlib.Path,
+            help='Specify an IPC path'
+        )
 
         attach_parser.set_defaults(func=cls.run_console)
 
     @classmethod
     def run_console(cls, args: Namespace, trinity_config: TrinityConfig) -> None:
         try:
-            console(trinity_config.jsonrpc_ipc_path, use_ipython=is_ipython_available())
+            ipc_path = args.ipc_path or trinity_config.jsonrpc_ipc_path
+            console(ipc_path, use_ipython=is_ipython_available())
         except FileNotFoundError as err:
             cls.get_logger().error(str(err))
             sys.exit(1)


### PR DESCRIPTION
### What was wrong?
Add CLI positional argument for attach console plugin to specifying the IPC path.

Related to #23

### How was it fixed?
Added new CLI positional parameter to attach the console plugin.

### To-Do
- [x] Update documentation
- [x] add a newsfragment **(not sure it is required?)**

#### Cute Animal Picture
![image](https://user-images.githubusercontent.com/2613381/61076417-00365880-a43e-11e9-927f-83af2c405c1d.png)

