### PR TITLE
[hotfix] pin `ruamel.yaml==0.15.98`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ deps = {
         "jsonschema==3.0.1",
         "mypy_extensions>=0.4.1,<1.0.0",
         "typing_extensions>=3.7.2,<4.0.0",
-        "ruamel.yaml>=0.15.87",
+        "ruamel.yaml==0.15.98",
         "argcomplete>=1.10.0,<2",
     ],
     'test': [
@@ -56,7 +56,7 @@ deps = {
         # only needed for p2p
         "pytest-asyncio-network-simulator==0.1.0a2;python_version>='3.6'",
         # only for eth2
-        "ruamel.yaml>=0.15.87,<0.16",
+        "ruamel.yaml==0.15.98,<0.16",
     ],
     'lint': [
         "flake8==3.5.0",

--- a/setup.py
+++ b/setup.py
@@ -56,7 +56,7 @@ deps = {
         # only needed for p2p
         "pytest-asyncio-network-simulator==0.1.0a2;python_version>='3.6'",
         # only for eth2
-        "ruamel.yaml==0.15.98,<0.16",
+        "ruamel.yaml==0.15.98",
     ],
     'lint': [
         "flake8==3.5.0",


### PR DESCRIPTION
### What was wrong?

Somehow `ruamel.yaml` `0.15.99` is incompatible in type hinting.

### How was it fixed?

Pin `ruamel.yaml==0.15.98` for now.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

[//]: # (See: https://trinity-client.readthedocs.io/en/latest/contributing.html#pull-requests)
- [ ] Add entry to the [release notes](https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

#### Cute Animal Picture

🐴 