### PR TITLE
Refactor how we get state from `BeaconChain`

### DIFF
--- a/eth2/beacon/db/exceptions.py
+++ b/eth2/beacon/db/exceptions.py
@@ -14,9 +14,9 @@ class HeadStateSlotNotFound(BeaconDBException):
     pass
 
 
-class StateSlotNotFound(BeaconDBException):
+class StateNotFound(BeaconDBException):
     """
-    Exception raised if state root with the given slot number does not exist.
+    Exception raised if state with the given state does not exist.
     """
 
     pass

--- a/eth2/beacon/state_machines/base.py
+++ b/eth2/beacon/state_machines/base.py
@@ -65,9 +65,12 @@ class BaseBeaconStateMachine(Configurable, ABC):
     #
     @abstractmethod
     def import_block(
-        self, block: BaseBeaconBlock, check_proposer_signature: bool = True
+        self,
+        block: BaseBeaconBlock,
+        state: BeaconState,
+        check_proposer_signature: bool = True,
     ) -> Tuple[BeaconState, BaseBeaconBlock]:
-        ...
+        pass
 
     @staticmethod
     @abstractmethod
@@ -91,14 +94,6 @@ class BeaconStateMachine(BaseBeaconStateMachine):
             self._state = state
         else:
             self.slot = slot
-
-    @property
-    def state(self) -> BeaconState:
-        if self._state is None:
-            self._state = self.chaindb.get_state_by_slot(
-                self.slot, self.get_state_class()
-            )
-        return self._state
 
     @classmethod
     def get_block_class(cls) -> Type[BaseBeaconBlock]:
@@ -143,10 +138,13 @@ class BeaconStateMachine(BaseBeaconStateMachine):
     # Import block API
     #
     def import_block(
-        self, block: BaseBeaconBlock, check_proposer_signature: bool = True
+        self,
+        block: BaseBeaconBlock,
+        state: BeaconState,
+        check_proposer_signature: bool = True,
     ) -> Tuple[BeaconState, BaseBeaconBlock]:
         state = self.state_transition.apply_state_transition(
-            self.state, block=block, check_proposer_signature=check_proposer_signature
+            state, block=block, check_proposer_signature=check_proposer_signature
         )
 
         block = block.copy(state_root=state.hash_tree_root)

--- a/eth2/beacon/state_machines/base.py
+++ b/eth2/beacon/state_machines/base.py
@@ -70,7 +70,7 @@ class BaseBeaconStateMachine(Configurable, ABC):
         state: BeaconState,
         check_proposer_signature: bool = True,
     ) -> Tuple[BeaconState, BaseBeaconBlock]:
-        pass
+        ...
 
     @staticmethod
     @abstractmethod

--- a/eth2/beacon/tools/builder/proposer.py
+++ b/eth2/beacon/tools/builder/proposer.py
@@ -83,7 +83,9 @@ def create_block_on_state(
     block = block.copy(body=body)
 
     # Apply state transition to get state root
-    state, block = state_machine.import_block(block, check_proposer_signature=False)
+    state, block = state_machine.import_block(
+        block, state, check_proposer_signature=False
+    )
 
     # Sign
     signature = sign_transaction(

--- a/eth2/beacon/tools/fixtures/helpers.py
+++ b/eth2/beacon/tools/fixtures/helpers.py
@@ -53,7 +53,7 @@ def apply_blocks(
     post_state = state.copy()
     for block in test_case.blocks:
         sm = sm_class(chaindb, attestation_pool, None, post_state)
-        post_state, imported_block = sm.import_block(block)
+        post_state, imported_block = sm.import_block(block, post_state)
         chaindb.persist_state(post_state)
         if imported_block.state_root != block.state_root:
             raise ValidationError(

--- a/tests/eth2/core/beacon/chains/test_beacon_chain.py
+++ b/tests/eth2/core/beacon/chains/test_beacon_chain.py
@@ -2,14 +2,13 @@ import copy
 
 import pytest
 
-
-from eth2.beacon.exceptions import BlockClassError
 from eth2.beacon.chains.base import BeaconChain
 from eth2.beacon.db.exceptions import AttestationRootNotFound, StateNotFound
-from eth2.beacon.types.blocks import BeaconBlock
+from eth2.beacon.exceptions import BlockClassError
+from eth2.beacon.state_machines.forks.serenity.blocks import SerenityBeaconBlock
 from eth2.beacon.tools.builder.proposer import create_mock_block
 from eth2.beacon.tools.builder.validator import create_mock_signed_attestations_at_slot
-from eth2.beacon.state_machines.forks.serenity.blocks import SerenityBeaconBlock
+from eth2.beacon.types.blocks import BeaconBlock
 
 
 @pytest.fixture

--- a/tests/eth2/core/beacon/chains/test_beacon_chain.py
+++ b/tests/eth2/core/beacon/chains/test_beacon_chain.py
@@ -2,13 +2,14 @@ import copy
 
 import pytest
 
-from eth2.beacon.chains.base import BeaconChain
-from eth2.beacon.db.exceptions import AttestationRootNotFound, StateSlotNotFound
+
 from eth2.beacon.exceptions import BlockClassError
-from eth2.beacon.state_machines.forks.serenity.blocks import SerenityBeaconBlock
+from eth2.beacon.chains.base import BeaconChain
+from eth2.beacon.db.exceptions import AttestationRootNotFound, StateNotFound
+from eth2.beacon.types.blocks import BeaconBlock
 from eth2.beacon.tools.builder.proposer import create_mock_block
 from eth2.beacon.tools.builder.validator import create_mock_signed_attestations_at_slot
-from eth2.beacon.types.blocks import BeaconBlock
+from eth2.beacon.state_machines.forks.serenity.blocks import SerenityBeaconBlock
 
 
 @pytest.fixture
@@ -60,12 +61,12 @@ def test_canonical_chain(valid_chain, genesis_slot, fork_choice_scoring):
 def test_get_state_by_slot(valid_chain, genesis_block, genesis_state, config, keymap):
     # Fisrt, skip block and check if `get_state_by_slot` returns the expected state
     state_machine = valid_chain.get_state_machine(genesis_block.slot)
-    state = state_machine.state
+    state = valid_chain.get_head_state()
     block_skipped_slot = genesis_block.slot + 1
     block_skipped_state = state_machine.state_transition.apply_state_transition(
         state, future_slot=block_skipped_slot
     )
-    with pytest.raises(StateSlotNotFound):
+    with pytest.raises(StateNotFound):
         valid_chain.get_state_by_slot(block_skipped_slot)
     valid_chain.chaindb.persist_state(block_skipped_state)
     assert (
@@ -86,7 +87,7 @@ def test_get_state_by_slot(valid_chain, genesis_block, genesis_state, config, ke
         attestations=(),
     )
     valid_chain.import_block(block)
-    state = valid_chain.get_state_machine().state
+    state = valid_chain.get_head_state()
     assert (
         valid_chain.get_state_by_slot(proposed_slot).hash_tree_root
         == state.hash_tree_root

--- a/tests/eth2/core/beacon/db/test_beacon_chaindb.py
+++ b/tests/eth2/core/beacon/db/test_beacon_chaindb.py
@@ -159,9 +159,9 @@ def test_chaindb_get_head_state_slot(chaindb, state):
 def test_chaindb_state(chaindb, state):
     chaindb.persist_state(state)
     state_class = BeaconState
+    result_state_root = chaindb.get_state_root_by_slot(state.slot)
+    assert result_state_root == state.hash_tree_root
     result_state = chaindb.get_state_by_root(state.hash_tree_root, state_class)
-    assert result_state.hash_tree_root == state.hash_tree_root
-    result_state = chaindb.get_state_by_slot(state.slot, state_class)
     assert result_state.hash_tree_root == state.hash_tree_root
 
 

--- a/tests/eth2/integration/test_demo.py
+++ b/tests/eth2/integration/test_demo.py
@@ -83,7 +83,7 @@ def test_demo(base_db, validator_count, keymap, pubkeys, fork_choice_scoring):
 
         # Get state machine instance
         sm = fixture_sm_class(chaindb, attestation_pool, blocks[-1].slot)
-        state, _ = sm.import_block(block)
+        state, _ = sm.import_block(block, state)
 
         chaindb.persist_state(state)
         chaindb.persist_block(block, SerenityBeaconBlock, fork_choice_scoring)

--- a/tests/plugins/eth2/beacon/test_receive_server.py
+++ b/tests/plugins/eth2/beacon/test_receive_server.py
@@ -637,9 +637,12 @@ async def test_bcc_receive_server_get_ready_attestations(
             slot = XIAO_LONG_BAO_CONFIG.GENESIS_SLOT
         state = MockState()
 
+        def mock_get_head_state(self):
+            return state
+
         def mock_get_attestation_data_slot(state, data, config):
             return data.slot
-        mocker.patch("eth2.beacon.state_machines.base.BeaconStateMachine.state", state)
+        mocker.patch("eth2.beacon.chains.base.BeaconChain.get_head_state", mock_get_head_state)
         mocker.patch(
             "trinity.protocol.bcc.servers.get_attestation_data_slot",
             mock_get_attestation_data_slot,

--- a/tests/plugins/eth2/beacon/test_validator.py
+++ b/tests/plugins/eth2/beacon/test_validator.py
@@ -127,7 +127,7 @@ def _get_slot_with_validator_selected(candidate_indices, state, config):
 async def test_validator_propose_block_succeeds(event_loop, event_bus):
     alice, bob = await get_linked_validators(event_loop=event_loop, event_bus=event_bus)
     state_machine = alice.chain.get_state_machine()
-    state = state_machine.state
+    state = alice.chain.get_head_state()
 
     slot, proposer_index = _get_slot_with_validator_selected(
         alice.validator_privkeys,
@@ -159,7 +159,7 @@ async def test_validator_propose_block_succeeds(event_loop, event_bus):
 async def test_validator_propose_block_fails(event_loop, event_bus):
     alice, bob = await get_linked_validators(event_loop=event_loop, event_bus=event_bus)
     state_machine = alice.chain.get_state_machine()
-    state = state_machine.state
+    state = alice.chain.get_head_state()
 
     assert set(alice.validator_privkeys).intersection(set(bob.validator_privkeys)) == set()
     slot, proposer_index = _get_slot_with_validator_selected(
@@ -183,7 +183,7 @@ async def test_validator_propose_block_fails(event_loop, event_bus):
 async def test_validator_skip_block(event_loop, event_bus):
     alice = await get_validator(event_loop=event_loop, event_bus=event_bus, indices=[0])
     state_machine = alice.chain.get_state_machine()
-    state = state_machine.state
+    state = alice.chain.get_head_state()
     slot = state.slot + 1
     post_state = alice.skip_block(
         slot=slot,
@@ -255,7 +255,7 @@ async def test_validator_handle_slot_tick(event_loop, event_bus, monkeypatch):
 async def test_validator_handle_first_tick(event_loop, event_bus, monkeypatch):
     alice, bob = await get_linked_validators(event_loop=event_loop, event_bus=event_bus)
     state_machine = alice.chain.get_state_machine()
-    state = state_machine.state
+    state = alice.chain.get_head_state()
 
     # test: `handle_first_tick` should call `propose_block` if the validator get selected
     slot_to_propose, index = _get_slot_with_validator_selected(
@@ -279,8 +279,7 @@ async def test_validator_handle_first_tick(event_loop, event_bus, monkeypatch):
 @pytest.mark.asyncio
 async def test_validator_handle_second_tick(event_loop, event_bus, monkeypatch):
     alice, bob = await get_linked_validators(event_loop=event_loop, event_bus=event_bus)
-    state_machine = alice.chain.get_state_machine()
-    state = state_machine.state
+    state = alice.chain.get_head_state()
 
     # test: `handle_second_tick` should call `attest`
     # and skip_block` if `state.slot` is behind latest slot
@@ -308,7 +307,7 @@ async def test_validator_get_committee_assigment(event_loop, event_bus):
     alice_indices = [7]
     alice = await get_validator(event_loop=event_loop, event_bus=event_bus, indices=alice_indices)
     state_machine = alice.chain.get_state_machine()
-    state = state_machine.state
+    state = alice.chain.get_head_state()
     epoch = compute_epoch_of_slot(state.slot, state_machine.config.SLOTS_PER_EPOCH)
 
     assert alice.this_epoch_assignment[alice_indices[0]][0] == -1
@@ -322,7 +321,7 @@ async def test_validator_attest(event_loop, event_bus, monkeypatch):
     alice = await get_validator(event_loop=event_loop, event_bus=event_bus, indices=alice_indices)
     head = alice.chain.get_canonical_head()
     state_machine = alice.chain.get_state_machine()
-    state = state_machine.state
+    state = alice.chain.get_head_state()
 
     epoch = compute_epoch_of_slot(state.slot, state_machine.config.SLOTS_PER_EPOCH)
     assignment = alice._get_this_epoch_assignment(alice_indices[0], epoch)
@@ -357,7 +356,7 @@ async def test_validator_include_ready_attestations(event_loop, event_bus, monke
     alice_indices = list(range(8))
     alice = await get_validator(event_loop=event_loop, event_bus=event_bus, indices=alice_indices)
     state_machine = alice.chain.get_state_machine()
-    state = state_machine.state
+    state = alice.chain.get_head_state()
 
     attesting_slot = state.slot + 1
     attestations = await alice.attest(attesting_slot)

--- a/trinity/plugins/eth2/beacon/validator.py
+++ b/trinity/plugins/eth2/beacon/validator.py
@@ -143,7 +143,7 @@ class Validator(BaseService):
         # update `this_epoch_assignment` if it's outdated
         if this_epoch > self.this_epoch_assignment[validator_index][0]:
             state_machine = self.chain.get_state_machine()
-            state = state_machine.state
+            state = self.chain.get_head_state()
             self.this_epoch_assignment[validator_index] = (
                 this_epoch,
                 get_committee_assignment(
@@ -158,7 +158,7 @@ class Validator(BaseService):
     async def handle_first_tick(self, slot: Slot) -> None:
         head = self.chain.get_canonical_head()
         state_machine = self.chain.get_state_machine()
-        state = state_machine.state
+        state = self.chain.get_head_state()
         self.logger.debug(
             # Align with debug log below
             bold_green("Head       epoch=%s slot=%s state_root=%s"),
@@ -212,7 +212,7 @@ class Validator(BaseService):
 
     async def handle_second_tick(self, slot: Slot) -> None:
         state_machine = self.chain.get_state_machine()
-        state = state_machine.state
+        state = self.chain.get_head_state()
         if state.slot < slot:
             self.skip_block(
                 slot=slot,
@@ -307,7 +307,7 @@ class Validator(BaseService):
         attestations: Tuple[Attestation, ...] = ()
         head = self.chain.get_canonical_head()
         state_machine = self.chain.get_state_machine()
-        state = state_machine.state
+        state = self.chain.get_head_state()
         epoch = compute_epoch_of_slot(slot, self.slots_per_epoch)
 
         validator_assignments = {

--- a/trinity/protocol/bcc/servers.py
+++ b/trinity/protocol/bcc/servers.py
@@ -420,7 +420,7 @@ class BCCReceiveServer(BaseReceiveServer):
                                attestations: Iterable[Attestation]) -> Iterable[Attestation]:
         state_machine = self.chain.get_state_machine()
         config = state_machine.config
-        state = state_machine.state
+        state = self.chain.get_head_state()
         for attestation in attestations:
             # Fast forward to state in future slot in order to pass
             # attestation.data.slot validity check
@@ -567,7 +567,7 @@ class BCCReceiveServer(BaseReceiveServer):
     def get_ready_attestations(self) -> Iterable[Attestation]:
         state_machine = self.chain.get_state_machine()
         config = state_machine.config
-        state = state_machine.state
+        state = self.chain.get_head_state()
         for attestation in self.attestation_pool.get_all():
             data = attestation.data
             attestation_slot = get_attestation_data_slot(state, data, config)


### PR DESCRIPTION
### What was wrong?
Part of the state cache design (#732) and the precondition of #774.

### How was it fixed?

To prepare for having state cache in `BeaconChain`, we don't query `state` in `StateMachine.state`; instead, we get the state from `BeaconChain`.


### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

[//]: # (See: https://trinity-client.readthedocs.io/en/latest/contributing.html#pull-requests)
- [ ] Add entry to the [release notes](https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

#### Cute Animal Picture
![480px-Golden_Retriever_Buddy_0311](https://upload.wikimedia.org/wikipedia/commons/b/b0/Golden_Retriever_Buddy_0311.jpg)
(Wimting CC BY-SA 4.0)