### PR TITLE
Beam Sync: support uncle validation in the first six blocks

### DIFF
--- a/newsfragments/803.bugfix.rst
+++ b/newsfragments/803.bugfix.rst
@@ -1,0 +1,2 @@
+When starting beam sync, download previous six block bodies, so that uncle validation can succeed.
+It needs to verify that new block imports don't add any uncles that were already added recently.

--- a/tests/core/integration_test_helpers.py
+++ b/tests/core/integration_test_helpers.py
@@ -143,8 +143,10 @@ class FakeAsyncMainnetChain(MainnetChain):
 
 class FakeAsyncChain(MiningChain):
     coro_import_block = coro_import_block
+    coro_get_block_by_header = async_passthrough('get_block_by_header')
     coro_get_block_header_by_hash = async_passthrough('get_block_header_by_hash')
     coro_get_canonical_head = async_passthrough('get_canonical_head')
+    coro_get_canonical_block_by_number = async_passthrough('get_canonical_block_by_number')
     coro_validate_chain = async_passthrough('validate_chain')
     coro_validate_receipt = async_passthrough('validate_receipt')
     chaindb_class = FakeAsyncChainDB

--- a/trinity/chains/coro.py
+++ b/trinity/chains/coro.py
@@ -6,6 +6,8 @@ from .base import BaseAsyncChain
 
 
 class AsyncChainMixin(BaseAsyncChain):
+    coro_get_ancestors = async_method('get_ancestors')
+    coro_get_ancestor_headers = async_method('get_ancestor_headers')
     coro_get_block_by_hash = async_method('get_block_by_hash')
     coro_get_block_by_header = async_method('get_block_by_header')
     coro_get_block_header_by_hash = async_method('get_block_header_by_hash')

--- a/trinity/sync/beam/state.py
+++ b/trinity/sync/beam/state.py
@@ -66,6 +66,7 @@ class BeamDownloader(BaseService, PeerSubscriber):
     Coordinate the request of needed state data: accounts, storage, bytecodes, and
     other arbitrary intermediate nodes in the trie.
     """
+    do_predictive_downloads = False
     _total_processed_nodes = 0
     _urgent_processed_nodes = 0
     _predictive_processed_nodes = 0
@@ -467,6 +468,9 @@ class BeamDownloader(BaseService, PeerSubscriber):
         Identify node hashes for nodes we might need in the future, and insert them to the
         predictive node queue.
         """
+        if not self.do_predictive_downloads:
+            return
+
         # priority is the depth of the node away from an urgent node, plus one.
         # For example, the child of an urgent node has priority 2
         if priority > 3:

--- a/trinity/sync/full/chain.py
+++ b/trinity/sync/full/chain.py
@@ -580,8 +580,15 @@ class FastChainBodySyncer(BaseBodyChainSyncer):
         # Track whether the fast chain syncer completed its goal
         self.is_complete = False
 
+    async def _sync_from(self) -> BlockHeader:
+        """
+        Select which header should be the last known header.
+        Start by importing headers that are children of this tip.
+        """
+        return await self.db.coro_get_canonical_head()
+
     async def _run(self) -> None:
-        head = await self.wait(self.db.coro_get_canonical_head())
+        head = await self.wait(self._sync_from())
         self.tracker = ChainSyncPerformanceTracker(head)
 
         self._block_persist_tracker.set_finished_dependency(head)


### PR DESCRIPTION
### What was wrong?

Beam sync did header-only sync until it switched over to beam sync imports. Those imports need to validate uncles, which expects the block bodies from the previous six blocks (to make sure the uncle isn't a duplicate). The validation would crash because the block bodies for the previous six blocks were unavailable.

Also, some missing docs, and node prediction had a net-negative performance impact (in my tests)

### How was it fixed?

- Download just the previous six block bodies (by doing fast sync)
- Add some more docs
- Turn off trie node predictive downloads, for now

### To-Do

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

[//]: # (See: https://trinity-client.readthedocs.io/en/latest/contributing.html#pull-requests)
- [x] Add entry to the [release notes](https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://i.chzbgr.com/full/4771919360/hF93827BC/)
