### PR TITLE
Remove blspy from eth2 extras

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -106,7 +106,6 @@ deps = {
         "rlp>=1.1.0,<2.0.0",
         PYEVM_DEPENDENCY,
         "ssz==0.1.0a10",
-        "blspy>=0.1.8,<1",  # for `bls_chia`
     ],
     'libp2p': [
         "base58>=1.0.3",


### PR DESCRIPTION
### What was wrong?

We recently implicitly added a system dependency against `cmake` that effects anyone trying to install trinity.

### How was it fixed?

Just trying to figure out the things that would break and if we can opt-in to install `bls-bindings` for these plalces.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

[//]: # (See: https://trinity-client.readthedocs.io/en/latest/contributing.html#pull-requests)
- [ ] Add entry to the [release notes](https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses]()
