### PR TITLE
Properly cancel all of the BaseService tasks by awaiting them after cancellation

### DIFF
--- a/newsfragments/809.bugfix.rst
+++ b/newsfragments/809.bugfix.rst
@@ -1,0 +1,1 @@
+Proper cancellation of subtasks upon cancellation of ``p2p.service.BaseService``


### PR DESCRIPTION
### What was wrong?

It looks like we've been failing to properly cancel sub-tasks in `BaseService`.  A look at the [documentation for `Task.cancel()`](https://docs.python.org/3/library/asyncio-task.html#asyncio.Task.cancel) shows that after calling `cancel()` we also need to await the task (and then catch the cancellation that arises)

### How was it fixed?

Added an additional `await task` inside of a `try/except` which silently discards the `asyncio.CancellationError`


### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

[//]: # (See: https://trinity-client.readthedocs.io/en/latest/contributing.html#pull-requests)
- [x] Add entry to the [release notes](https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses]()
