### PR TITLE
Fix memory leak in handshake lock routine

### DIFF
--- a/newsfragments/811.bugfix.rst
+++ b/newsfragments/811.bugfix.rst
@@ -1,0 +1,4 @@
+The recently introduced fix that ensures we do not run multiple concurrent
+handshakes to the same peer accidentially introduced a (rarely exposed) memory
+leak. This fix introduces a ``ResourceLock`` and refactores the code to use it
+to also fix the previously introduced memory leak.

--- a/p2p/resource_lock.py
+++ b/p2p/resource_lock.py
@@ -1,0 +1,30 @@
+import asyncio
+from collections.abc import Hashable
+from typing import AsyncIterator
+import weakref
+
+from async_generator import asynccontextmanager
+
+
+class ResourceLock:
+    """
+    Manage a set of locks for some set of hashable resources.
+    """
+    _locks: 'weakref.WeakKeyDictionary[Hashable, asyncio.Lock]'
+
+    def __init__(self) -> None:
+        self._locks = weakref.WeakKeyDictionary()
+
+    @asynccontextmanager
+    async def lock(self, resource: Hashable) -> AsyncIterator[None]:
+        if resource not in self._locks:
+            self._locks[resource] = asyncio.Lock()
+        lock = self._locks[resource]
+        async with lock:
+            yield
+
+    def is_locked(self, resource: Hashable) -> bool:
+        if resource not in self._locks:
+            return False
+        else:
+            return self._locks[resource].locked()


### PR DESCRIPTION
### What was wrong?

The recently introduced fix that ensures we do not run multiple concurrent
handshakes to the same peer accidentially introduced a (rarely exposed) memory
leak. 

### How was it fixed?

This fix introduces a ``ResourceLock`` and refactores the code to use it
to also fix the previously introduced memory leak.


### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

[//]: # (See: https://trinity-client.readthedocs.io/en/latest/contributing.html#pull-requests)
- [x] Add entry to the [release notes](https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://2.bp.blogspot.com/-NOQNASHP0d4/WVdhD-sAHPI/AAAAAAABfWE/VmpH5oQ8wjYmwFhx6ensxrWPeUw8tcyswCLcBGAs/s1600/IMG_7087.JPG)
