### PR TITLE
Use Node in trinity-beacon

### DIFF
--- a/eth2/beacon/scripts/run_beacon_nodes.py
+++ b/eth2/beacon/scripts/run_beacon_nodes.py
@@ -20,6 +20,10 @@ from typing import (
 
 from pathlib import Path
 
+from libp2p.peer.id import (
+    ID,
+)
+
 from eth_keys.datatypes import (
     PrivateKey,
 )
@@ -113,12 +117,12 @@ class Node:
         return self.dir_root / self.name
 
     @property
-    def peer_id(self) -> Multiaddr:
+    def peer_id(self) -> ID:
         return peer_id_from_pubkey(self.node_privkey.public_key)
 
     @property
-    def maddr(self) -> str:
-        return f"/ip4/127.0.0.1/tcp/{self.port}/p2p/{self.peer_id}"
+    def maddr(self) -> Multiaddr:
+        return Multiaddr(f"/ip4/127.0.0.1/tcp/{self.port}/p2p/{self.peer_id}")
 
     @property
     def cmd(self) -> str:
@@ -133,7 +137,7 @@ class Node:
             "-l debug2",
         ]
         if len(self.preferred_nodes) != 0:
-            preferred_nodes_str = ",".join([node.maddr for node in self.preferred_nodes])
+            preferred_nodes_str = ",".join([str(node.maddr) for node in self.preferred_nodes])
             _cmds.append(f"--preferred_nodes={preferred_nodes_str}")
         _cmd = " ".join(_cmds)
         return _cmd

--- a/setup.py
+++ b/setup.py
@@ -42,6 +42,10 @@ deps = {
         "typing_extensions>=3.7.2,<4.0.0",
         "ruamel.yaml==0.15.98",
         "argcomplete>=1.10.0,<2",
+        "multiaddr>=0.0.8,<0.1.0",
+        "pymultihash>=0.8.2",
+        # FIXME: Change to libp2p/py-libp2p after the branch is merged.
+        "libp2p @ git+https://git@github.com/libp2p/py-libp2p@69a3553"
     ],
     'test': [
         "hypothesis>=4.24.3,<5",
@@ -107,12 +111,6 @@ deps = {
         "ssz==0.1.0a12",
         "blspy>=0.1.8,<1",  # for `bls_chia`
     ],
-    'libp2p': [
-        "multiaddr>=0.0.8,<0.1.0",
-        "pymultihash>=0.8.2",
-        # FIXME: Change to PyPI after latest changes are released
-        "libp2p @ git+https://git@github.com/libp2p/py-libp2p@69a3553"
-    ],
 }
 
 # NOTE: Snappy breaks RTD builds. Until we have a more mature solution
@@ -128,8 +126,7 @@ deps['dev'] = (
     deps['test'] +
     deps['doc'] +
     deps['lint'] +
-    deps['eth2'] +
-    deps['libp2p']
+    deps['eth2']
 )
 
 

--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,7 @@ deps = {
         "argcomplete>=1.10.0,<2",
         "multiaddr>=0.0.8,<0.1.0",
         "pymultihash>=0.8.2",
-        # FIXME: Change to libp2p/py-libp2p after the branch is merged.
+        # FIXME: Change to PyPI when the commit is released.
         "libp2p @ git+https://git@github.com/libp2p/py-libp2p@69a3553"
     ],
     'test': [

--- a/tests/libp2p/bcc/test_node.py
+++ b/tests/libp2p/bcc/test_node.py
@@ -1,7 +1,11 @@
+import asyncio
+
 import pytest
 
-from multiaddr import (
-    Multiaddr,
+from libp2p.peer.id import ID
+
+from trinity.protocol.bcc_libp2p.factories import (
+    NodeFactory,
 )
 
 
@@ -14,7 +18,7 @@ from multiaddr import (
 @pytest.mark.asyncio
 async def test_node(nodes):
     node = nodes[0]
-    expected_addrs = [node.listen_maddr.encapsulate(Multiaddr(f"/p2p/{node.peer_id}"))]
+    expected_addrs = [node.listen_maddr_with_peer_id]
     assert node.host.get_addrs() == expected_addrs
 
 
@@ -25,7 +29,14 @@ async def test_node(nodes):
     )
 )
 @pytest.mark.asyncio
-async def test_node_dial_peer(nodes):
+async def test_node_dial_peer(nodes, unused_tcp_port_factory):
+    # Test: Exception raised when dialing a wrong addr
+    with pytest.raises(ConnectionRefusedError):
+        await nodes[0].dial_peer(
+            nodes[1].listen_ip,
+            unused_tcp_port_factory(),
+            ID("123"),
+        )
     # Test: 0 <-> 1
     await nodes[0].dial_peer(
         nodes[1].listen_ip,
@@ -51,3 +62,38 @@ async def test_node_dial_peer(nodes):
     assert nodes[1].peer_id in nodes[2].host.get_network().connections
     assert nodes[2].peer_id in nodes[1].host.get_network().connections
     assert len(nodes[1].host.get_network().connections) == 2
+
+
+@pytest.mark.parametrize(
+    "num_nodes",
+    (
+        3,
+    )
+)
+@pytest.mark.asyncio
+async def test_node_dial_peer_maddr(nodes):
+    # Test: 0 <-> 1 <-> 2
+    await nodes[1].dial_peer_maddr(nodes[2].listen_maddr_with_peer_id)
+    await nodes[1].dial_peer_maddr(nodes[0].listen_maddr_with_peer_id)
+    assert nodes[1].peer_id in nodes[2].host.get_network().connections
+    assert nodes[2].peer_id in nodes[1].host.get_network().connections
+    assert nodes[1].peer_id in nodes[0].host.get_network().connections
+    assert nodes[0].peer_id in nodes[1].host.get_network().connections
+
+
+@pytest.mark.parametrize(
+    "num_nodes",
+    (
+        2,
+    )
+)
+@pytest.mark.asyncio
+async def test_node_connect_preferred_nodes(nodes):
+    new_node = NodeFactory.with_args(
+        preferred_nodes=[node.listen_maddr_with_peer_id for node in nodes]
+    )
+    asyncio.ensure_future(new_node.run())
+    await new_node.events.started.wait()
+    assert len(new_node.host.get_network().connections) == 0
+    await new_node.connect_preferred_nodes()
+    assert len(new_node.host.get_network().connections) == len(nodes)

--- a/tests/libp2p/bcc/test_node.py
+++ b/tests/libp2p/bcc/test_node.py
@@ -4,6 +4,8 @@ import pytest
 
 from libp2p.peer.id import ID
 
+from p2p.tools.factories import get_open_port
+
 from trinity.protocol.bcc_libp2p.factories import (
     NodeFactory,
 )
@@ -29,12 +31,12 @@ async def test_node(nodes):
     )
 )
 @pytest.mark.asyncio
-async def test_node_dial_peer(nodes, unused_tcp_port):
+async def test_node_dial_peer(nodes):
     # Test: Exception raised when dialing a wrong addr
     with pytest.raises(ConnectionRefusedError):
         await nodes[0].dial_peer(
             nodes[1].listen_ip,
-            unused_tcp_port,
+            get_open_port(),
             ID("123"),
         )
     # Test: 0 <-> 1

--- a/tests/libp2p/bcc/test_node.py
+++ b/tests/libp2p/bcc/test_node.py
@@ -29,12 +29,12 @@ async def test_node(nodes):
     )
 )
 @pytest.mark.asyncio
-async def test_node_dial_peer(nodes, unused_tcp_port_factory):
+async def test_node_dial_peer(nodes, unused_tcp_port):
     # Test: Exception raised when dialing a wrong addr
     with pytest.raises(ConnectionRefusedError):
         await nodes[0].dial_peer(
             nodes[1].listen_ip,
-            unused_tcp_port_factory(),
+            unused_tcp_port,
             ID("123"),
         )
     # Test: 0 <-> 1

--- a/tests/plugins/eth2/beacon/test_validator.py
+++ b/tests/plugins/eth2/beacon/test_validator.py
@@ -189,7 +189,7 @@ async def test_validator_propose_block_succeeds(event_loop, event_bus):
     assert new_head != head
 
     # test: ensure the block is broadcast to its peer
-    assert block in alice.node.list_beacon_block
+    assert block in alice.p2p_node.list_beacon_block
 
 
 @pytest.mark.asyncio

--- a/tests/plugins/eth2/beacon/test_validator.py
+++ b/tests/plugins/eth2/beacon/test_validator.py
@@ -59,24 +59,15 @@ from .helpers import (
 override_lengths(XIAO_LONG_BAO_CONFIG)
 
 
-class FakeProtocol:
-    def __init__(self):
-        self.inbox = []
-
-    def send_new_block(self, block):
-        self.inbox.append(block)
-
-
 class FakeNode:
     def __init__(self):
         self.list_beacon_block = []
-        self.list_attestations = []
 
     async def broadcast_beacon_block(self, block):
         self.list_beacon_block.append(block)
 
     async def broadcast_attestations(self, attestations):
-        self.list_attestations.append(attestations)
+        pass
 
 
 def get_chain_from_genesis(db, indices):

--- a/tox.ini
+++ b/tox.ini
@@ -125,14 +125,14 @@ commands =
     pytest -n 1 {posargs:tests/trinity_long_run/}
 
 [testenv:py37-libp2p]
-deps = .[p2p,trinity,eth2,test,libp2p]
+deps = .[p2p,trinity,eth2,test]
 passenv =
     TRAVIS_EVENT_TYPE
 commands =
     pytest -n 1 {posargs:tests/libp2p}
 
 [common-lint]
-deps = .[p2p,trinity,lint,eth2,libp2p]
+deps = .[p2p,trinity,lint,eth2]
 commands=
     flake8 {toxinidir}/p2p
     flake8 {toxinidir}/tests

--- a/trinity/config.py
+++ b/trinity/config.py
@@ -44,6 +44,10 @@ from eth_typing import (
     BLSPubkey,
 )
 
+from multiaddr import (
+    Multiaddr,
+)
+
 from eth2.beacon.chains.testnet import (
     TestnetChain,
 )
@@ -738,10 +742,10 @@ class BeaconAppConfig(BaseAppConfig):
         if args is not None:
             # This is quick and dirty way to get bootstrap_nodes
             trinity_config.bootstrap_nodes = tuple(
-                KademliaNode.from_uri(enode) for enode in args.bootstrap_nodes.split(',')
+                Multiaddr(maddr) for maddr in args.bootstrap_nodes.split(',')
             ) if args.bootstrap_nodes is not None else tuple()
             trinity_config.preferred_nodes = tuple(
-                KademliaNode.from_uri(enode) for enode in args.preferred_nodes.split(',')
+                Multiaddr(maddr) for maddr in args.preferred_nodes.split(',')
             ) if args.preferred_nodes is not None else tuple()
         return cls(trinity_config)
 

--- a/trinity/plugins/eth2/beacon/plugin.py
+++ b/trinity/plugins/eth2/beacon/plugin.py
@@ -60,11 +60,11 @@ class BeaconNodePlugin(AsyncioIsolatedPlugin):
     def configure_parser(cls, arg_parser: ArgumentParser, subparser: _SubParsersAction) -> None:
         arg_parser.add_argument(
             "--bootstrap_nodes",
-            help="enode://node1@0.0.0.0:1234,enode://node2@0.0.0.0:5678",
+            help="/ip4/127.0.0.1/tcp/1234/p2p/node1_peer_id,/ip4/127.0.0.1/tcp/5678/p2p/node1_peer_id",  # noqa: E501
         )
         arg_parser.add_argument(
             "--preferred_nodes",
-            help="enode://node1@0.0.0.0:1234,enode://node2@0.0.0.0:5678",
+            help="/ip4/127.0.0.1/tcp/1234/p2p/node1_peer_id,/ip4/127.0.0.1/tcp/5678/p2p/node1_peer_id",  # noqa: E501
         )
         arg_parser.add_argument(
             "--beacon-nodekey",

--- a/trinity/plugins/eth2/beacon/plugin.py
+++ b/trinity/plugins/eth2/beacon/plugin.py
@@ -60,11 +60,11 @@ class BeaconNodePlugin(AsyncioIsolatedPlugin):
     def configure_parser(cls, arg_parser: ArgumentParser, subparser: _SubParsersAction) -> None:
         arg_parser.add_argument(
             "--bootstrap_nodes",
-            help="/ip4/127.0.0.1/tcp/1234/p2p/node1_peer_id,/ip4/127.0.0.1/tcp/5678/p2p/node1_peer_id",  # noqa: E501
+            help="/ip4/127.0.0.1/tcp/1234/p2p/node1_peer_id,/ip4/127.0.0.1/tcp/5678/p2p/node2_peer_id",  # noqa: E501
         )
         arg_parser.add_argument(
             "--preferred_nodes",
-            help="/ip4/127.0.0.1/tcp/1234/p2p/node1_peer_id,/ip4/127.0.0.1/tcp/5678/p2p/node1_peer_id",  # noqa: E501
+            help="/ip4/127.0.0.1/tcp/1234/p2p/node1_peer_id,/ip4/127.0.0.1/tcp/5678/p2p/node2_peer_id",  # noqa: E501
         )
         arg_parser.add_argument(
             "--beacon-nodekey",

--- a/trinity/plugins/eth2/beacon/plugin.py
+++ b/trinity/plugins/eth2/beacon/plugin.py
@@ -14,16 +14,16 @@ from eth_keys.datatypes import (
     PrivateKey,
 )
 
+from libp2p.security.insecure_security import (
+    InsecureTransport,
+)
+
 from eth2.beacon.operations.attestation_pool import AttestationPool
 from eth2.beacon.types.attestations import (
     Attestation,
 )
 from eth2.beacon.typing import (
     ValidatorIndex,
-)
-
-from libp2p.security.insecure_security import (
-    InsecureTransport,
 )
 
 from p2p import ecies

--- a/trinity/plugins/eth2/beacon/plugin.py
+++ b/trinity/plugins/eth2/beacon/plugin.py
@@ -93,12 +93,14 @@ class BeaconNodePlugin(AsyncioIsolatedPlugin):
         else:
             privkey = ecies.generate_privkey()
 
+        # TODO: Handle `bootstrap_nodes`.
         libp2p_node = Node(
             privkey=privkey,
             listen_ip="127.0.0.1",  # FIXME: Should be configurable
             listen_port=self.boot_info.args.port,
             security_protocol_ops={SECURITY_PROTOCOL_ID: InsecureTransport("plaintext")},
-            muxer_protocol_ids=[MULTIPLEXING_PROTOCOL_ID],
+            muxer_protocol_ids=(MULTIPLEXING_PROTOCOL_ID,),
+            preferred_nodes=self.boot_info.args.preferred_nodes,
         )
 
         state = chain.get_state_by_slot(chain_config.genesis_config.GENESIS_SLOT)

--- a/trinity/plugins/eth2/beacon/plugin.py
+++ b/trinity/plugins/eth2/beacon/plugin.py
@@ -100,7 +100,7 @@ class BeaconNodePlugin(AsyncioIsolatedPlugin):
             listen_port=self.boot_info.args.port,
             security_protocol_ops={SECURITY_PROTOCOL_ID: InsecureTransport("plaintext")},
             muxer_protocol_ids=(MULTIPLEXING_PROTOCOL_ID,),
-            preferred_nodes=self.boot_info.args.preferred_nodes,
+            preferred_nodes=trinity_config.preferred_nodes,
         )
 
         state = chain.get_state_by_slot(chain_config.genesis_config.GENESIS_SLOT)

--- a/trinity/plugins/eth2/beacon/plugin.py
+++ b/trinity/plugins/eth2/beacon/plugin.py
@@ -4,6 +4,7 @@ from argparse import (
 )
 import asyncio
 from typing import (
+    Tuple,
     cast,
 )
 
@@ -14,6 +15,9 @@ from eth_keys.datatypes import (
 )
 
 from eth2.beacon.operations.attestation_pool import AttestationPool
+from eth2.beacon.types.attestations import (
+    Attestation,
+)
 from eth2.beacon.typing import (
     ValidatorIndex,
 )
@@ -106,13 +110,16 @@ class BeaconNodePlugin(AsyncioIsolatedPlugin):
             validator_index = cast(ValidatorIndex, registry_pubkeys.index(pubkey))
             validator_privkeys[validator_index] = validator_keymap[pubkey]
 
+        def fake_get_ready_attestations_fn() -> Tuple[Attestation, ...]:
+            return tuple()
+
         validator = Validator(
             chain=chain,
             p2p_node=libp2p_node,
             validator_privkeys=validator_privkeys,
             event_bus=self.event_bus,
             token=libp2p_node.cancel_token,
-            get_ready_attestations_fn=lambda _: tuple(),  # FIXME: BCCReceiveServer.get_ready_attestations  # noqa: E501
+            get_ready_attestations_fn=fake_get_ready_attestations_fn,  # FIXME: BCCReceiveServer.get_ready_attestations  # noqa: E501
         )
 
         slot_ticker = SlotTicker(

--- a/trinity/plugins/eth2/beacon/validator.py
+++ b/trinity/plugins/eth2/beacon/validator.py
@@ -244,6 +244,7 @@ class Validator(BaseService):
             block.body.attestations,
         )
         self.chain.import_block(block)
+        self.logger.debug2("Brodcasting block %s", block)
         await self.p2p_node.broadcast_beacon_block(block)
         return block
 
@@ -366,5 +367,6 @@ class Validator(BaseService):
                 self.latest_attested_epoch[validator_index] = epoch
             attestations = attestations + (attestation,)
 
+        self.logger.debug2("Brodcasting attestations %s", attestations)
         await self.p2p_node.broadcast_attestations(attestations)
         return attestations

--- a/trinity/plugins/eth2/beacon/validator.py
+++ b/trinity/plugins/eth2/beacon/validator.py
@@ -237,14 +237,14 @@ class Validator(BaseService):
             parent_block=head_block,
             attestations=ready_attestations,
         )
-        self.logger.info(
+        self.logger.debug(
             bold_green("Validator=%s proposing block=%s with attestations=%s"),
             proposer_index,
             block,
             block.body.attestations,
         )
         self.chain.import_block(block)
-        self.logger.debug2("Brodcasting block %s", block)
+        self.logger.debug("Brodcasting block %s", block)
         await self.p2p_node.broadcast_beacon_block(block)
         return block
 
@@ -367,6 +367,6 @@ class Validator(BaseService):
                 self.latest_attested_epoch[validator_index] = epoch
             attestations = attestations + (attestation,)
 
-        self.logger.debug2("Brodcasting attestations %s", attestations)
+        self.logger.debug("Brodcasting attestations %s", attestations)
         await self.p2p_node.broadcast_attestations(attestations)
         return attestations

--- a/trinity/protocol/bcc_libp2p/factories.py
+++ b/trinity/protocol/bcc_libp2p/factories.py
@@ -1,4 +1,5 @@
 from typing import (
+    Any,
     Tuple,
 )
 
@@ -33,10 +34,18 @@ class NodeFactory(factory.Factory):
     listen_ip = "127.0.0.1"
     listen_port = factory.LazyFunction(get_open_port)
     security_protocol_ops = {SECURITY_PROTOCOL_ID: InsecureTransport("plaintext")}
-    muxer_protocol_ids = [MULTIPLEXING_PROTOCOL_ID]
+    muxer_protocol_ids = (MULTIPLEXING_PROTOCOL_ID,)
+    gossipsub_params = None
+    cancel_token = None
+    bootstrap_nodes = None
+    preferred_nodes = None
 
     @classmethod
     def create_batch(cls, number: int) -> Tuple[Node, ...]:
         return tuple(
             cls() for _ in range(number)
         )
+
+    @classmethod
+    def with_args(cls, *args: Any, **kwargs: Any) -> Node:
+        return cls(*args, **kwargs)

--- a/trinity/protocol/bcc_libp2p/node.py
+++ b/trinity/protocol/bcc_libp2p/node.py
@@ -165,7 +165,7 @@ class Node(BaseService):
 
     async def dial_peer_maddr(self, maddr: Multiaddr) -> None:
         """
-        Dial the peer ``peer_id`` through the IPv4 protocol
+        Parse `maddr`, get the ip:port and PeerID, and call `dial_peer` with the parameters.
         """
         ip = maddr.value_for_protocol(protocols.P_IP4)
         port = maddr.value_for_protocol(protocols.P_TCP)

--- a/trinity/protocol/bcc_libp2p/node.py
+++ b/trinity/protocol/bcc_libp2p/node.py
@@ -159,7 +159,9 @@ class Node(BaseService):
         await self._broadcast_data(PUBSUB_TOPIC_BEACON_ATTESTATION, ssz.encode(attestations))
 
     async def _broadcast_data(self, topic: str, data: bytes) -> None:
-        await self.pubsub.publish(topic, data)
+        # TODO: Use `pubsub.publish` when it is finished in the upstream
+        # await self.pubsub.publish(topic, data)
+        pass
 
     @property
     def peer_id(self) -> ID:


### PR DESCRIPTION
### What was wrong?
Step 2 in https://github.com/ethereum/trinity/issues/798. This PR depends on https://github.com/ethereum/trinity/pull/795.

### How was it fixed?
- Remove all existing p2p stuff in trinity-beacon
- Add pubsub operations in Node
- Call `node.broadcast_xxx` in `Validator`

### To-Do
- [x] Make sure whether we just remove `--preferred-node`, or just implement it through initially connecting those peers when the node is up.

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://scontent.ftpe11-2.fna.fbcdn.net/v/t1.0-9/65227712_1282268818634183_391500639990972416_o.jpg?_nc_cat=108&_nc_oc=AQnAya0cGxH-xDV8zK45AAzI3fokekMHzhsuICmzEZhSCJJKan2-qAWCupp9T-cxy4XfysUEpETisDxcoyyvIQD4&_nc_ht=scontent.ftpe11-2.fna&oh=52352c6a113a0a3bc15d70dbb0e4ec15&oe=5DAB9A71)
