### PR TITLE
fix committee indices

### DIFF
--- a/eth2/beacon/tools/builder/validator.py
+++ b/eth2/beacon/tools/builder/validator.py
@@ -68,6 +68,7 @@ from eth2.beacon.types.states import BeaconState
 from eth2.beacon.types.voluntary_exits import VoluntaryExit
 from eth2.beacon.typing import (
     Bitfield,
+    CommitteeIndex,
     Epoch,
     Gwei,
     Shard,
@@ -241,7 +242,7 @@ def aggregate_votes(
         bitfield: Bitfield,
         sigs: Sequence[BLSSignature],
         voting_sigs: Sequence[BLSSignature],
-        attesting_indices: Sequence[ValidatorIndex]
+        attesting_indices: Sequence[CommitteeIndex]
 ) -> Tuple[Bitfield, BLSSignature]:
     """
     Aggregate the votes.
@@ -530,7 +531,7 @@ def _get_target_root(state: BeaconState,
 def _get_mock_message_and_attesting_indices(
         attestation_data: AttestationData,
         committee: Sequence[ValidatorIndex],
-        num_voted_attesters: int) -> Tuple[Hash32, Tuple[ValidatorIndex, ...]]:
+        num_voted_attesters: int) -> Tuple[Hash32, Tuple[CommitteeIndex, ...]]:
     """
     Get ``message_hash`` and voting indices of the given ``committee``.
     """
@@ -542,9 +543,8 @@ def _get_mock_message_and_attesting_indices(
     committee_size = len(committee)
     assert num_voted_attesters <= committee_size
 
-    # Index in committee
     attesting_indices = tuple(
-        ValidatorIndex(i) for i in random.sample(range(committee_size), num_voted_attesters)
+        CommitteeIndex(i) for i in random.sample(range(committee_size), num_voted_attesters)
     )
 
     return message_hash, tuple(sorted(attesting_indices))

--- a/eth2/beacon/typing.py
+++ b/eth2/beacon/typing.py
@@ -13,6 +13,7 @@ Bitfield = NewType('Bitfield', Tuple[bool, ...])
 
 
 ValidatorIndex = NewType('ValidatorIndex', int)  # uint64
+CommitteeIndex = NewType('CommitteeIndex', int)  # uint64 The i-th position in a committee tuple
 
 Gwei = NewType('Gwei', int)  # uint64
 


### PR DESCRIPTION
### What was wrong?

The validator index and the index in a committee confuse devs.

This is a committee with validator indices: `committee = (1, 3, 5, 7)`
Sometimes we refer the second validator in the committee `committee[1]`, which is 3

### How was it fixed?

Add a type CommitteeIndex

So in the above example, we have CommitteeIndex 1 and ValidatorIndex 3.


#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://preview.redd.it/lrf10hqax7b31.jpg?width=640&crop=smart&auto=webp&s=171a32909dff0e78570a9ac908385f77245feb7b)
