### PR TITLE
Implement UDP communication services for discv5

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -353,6 +353,7 @@ workflows:
       - py37-eth1-core
       - py37-wheel-cli
       - py37-p2p
+      - py36-p2p-trio
       - py37-eth2-core
       - py37-eth2-utils
       # temporarily disable fixtures tests while we update
@@ -378,6 +379,7 @@ workflows:
       - py36-eth1-core
       - py36-wheel-cli
       - py36-p2p
+      - py36-p2p-trio
       - py36-eth2-core
       - py36-eth2-utils
       # temporarily disable fixtures tests while we update

--- a/p2p/discv5/channel_services.py
+++ b/p2p/discv5/channel_services.py
@@ -1,0 +1,66 @@
+import logging
+from typing import (
+    NamedTuple,
+)
+
+from trio.socket import (
+    SocketType,
+)
+from trio.abc import (
+    ReceiveChannel,
+    SendChannel,
+)
+
+from p2p.trio_service import (
+    as_service,
+    Manager,
+)
+
+from p2p.discv5.constants import (
+    DATAGRAM_BUFFER_SIZE,
+)
+
+
+class Endpoint(NamedTuple):
+    ip_address: bytes
+    port: int
+
+
+class IncomingDatagram(NamedTuple):
+    datagram: bytes
+    sender: Endpoint
+
+
+class OutgoingDatagram(NamedTuple):
+    datagram: bytes
+    receiver: Endpoint
+
+
+@as_service
+async def DatagramReceiver(manager: Manager,
+                           socket: SocketType,
+                           incoming_datagram_send_channel: SendChannel[IncomingDatagram],
+                           ) -> None:
+    """Read datagrams from a socket and send them to a channel."""
+    logger = logging.getLogger('p2p.discv5.channel_services.DatagramReceiver')
+
+    async with incoming_datagram_send_channel:
+        while manager.is_running:
+            datagram, (ip_address, port) = await socket.recvfrom(DATAGRAM_BUFFER_SIZE)
+            logger.debug(f"Received {len(datagram)} bytes from {(ip_address, port)}")
+            incoming_datagram = IncomingDatagram(datagram, Endpoint(ip_address, port))
+            await incoming_datagram_send_channel.send(incoming_datagram)
+
+
+@as_service
+async def DatagramSender(manager: Manager,
+                         outgoing_datagram_receive_channel: ReceiveChannel[OutgoingDatagram],
+                         socket: SocketType,
+                         ) -> None:
+    """Take datagrams from a channel and send them via a socket to their designated receivers."""
+    logger = logging.getLogger('p2p.discv5.channel_services.DatagramSender')
+
+    async with outgoing_datagram_receive_channel:
+        async for datagram, (ip_address, port) in outgoing_datagram_receive_channel:
+            logger.debug(f"Sending {len(datagram)} bytes to {(ip_address, port)}")
+            await socket.sendto(datagram, (ip_address, port))

--- a/p2p/discv5/channel_services.py
+++ b/p2p/discv5/channel_services.py
@@ -13,7 +13,7 @@ from trio.abc import (
 
 from p2p.trio_service import (
     as_service,
-    Manager,
+    ManagerAPI,
 )
 
 from p2p.discv5.constants import (
@@ -37,7 +37,7 @@ class OutgoingDatagram(NamedTuple):
 
 
 @as_service
-async def DatagramReceiver(manager: Manager,
+async def DatagramReceiver(manager: ManagerAPI,
                            socket: SocketType,
                            incoming_datagram_send_channel: SendChannel[IncomingDatagram],
                            ) -> None:
@@ -53,7 +53,7 @@ async def DatagramReceiver(manager: Manager,
 
 
 @as_service
-async def DatagramSender(manager: Manager,
+async def DatagramSender(manager: ManagerAPI,
                          outgoing_datagram_receive_channel: ReceiveChannel[OutgoingDatagram],
                          socket: SocketType,
                          ) -> None:

--- a/p2p/discv5/constants.py
+++ b/p2p/discv5/constants.py
@@ -22,3 +22,6 @@ ENR_REPR_PREFIX = "enr:"  # prefix used when printing an ENR
 MAX_ENR_SIZE = 300  # maximum allowed size of an ENR
 
 WHO_ARE_YOU_MAGIC_SUFFIX = b"WHOAREYOU"
+
+# buffer size used for incoming UDP datagrams (should be larger than MAX_PACKET_SIZE)
+DATAGRAM_BUFFER_SIZE = 2048

--- a/p2p/trio_service.py
+++ b/p2p/trio_service.py
@@ -5,7 +5,7 @@ import sys
 from types import TracebackType
 from typing import Any, Callable, Awaitable, Optional, Tuple, Type, AsyncIterator
 
-from mypy_extensions import VarArg, KwArg
+from mypy_extensions import VarArg
 
 from async_generator import asynccontextmanager
 
@@ -170,7 +170,7 @@ class ManagerAPI(ABC):
         ...
 
 
-LogicFnType = Callable[[ManagerAPI, VarArg(), KwArg()], Awaitable[Any]]
+LogicFnType = Callable[..., Awaitable[Any]]
 
 
 class Service(ServiceAPI):

--- a/setup.py
+++ b/setup.py
@@ -50,8 +50,6 @@ deps = {
         # pinned to <3.7 until async fixtures work again
         # https://github.com/pytest-dev/pytest-asyncio/issues/89
         "pytest>=3.6,<3.7",
-        # only needed for p2p
-        "pytest-asyncio-network-simulator==0.1.0a2;python_version>='3.6'",
         "pytest-cov==2.5.1",
         "pytest-watch>=4.1.0,<5",
         "pytest-xdist==1.18.1",
@@ -64,6 +62,7 @@ deps = {
     # See: https://github.com/ethereum/trinity/pull/790
     'test-asyncio': [
         "pytest-asyncio>=0.10.0,<0.11",
+        "pytest-asyncio-network-simulator==0.1.0a2;python_version>='3.6'",
     ],
     'test-trio': [
         'pytest-trio==0.5.2',

--- a/tests/p2p-trio/test_channel_services.py
+++ b/tests/p2p-trio/test_channel_services.py
@@ -1,0 +1,63 @@
+import trio
+
+import pytest
+
+from p2p.trio_service import (
+    background_service,
+)
+
+from p2p.discv5.channel_services import (
+    DatagramReceiver,
+    DatagramSender,
+    OutgoingDatagram,
+)
+
+
+@pytest.fixture
+async def socket_pair():
+    sending_socket = trio.socket.socket(
+        family=trio.socket.AF_INET,
+        type=trio.socket.SOCK_DGRAM,
+    )
+    receiving_socket = trio.socket.socket(
+        family=trio.socket.AF_INET,
+        type=trio.socket.SOCK_DGRAM,
+    )
+    # specifying 0 as port number results in using random available port
+    await sending_socket.bind(("127.0.0.1", 0))
+    await receiving_socket.bind(("127.0.0.1", 0))
+    return sending_socket, receiving_socket
+
+
+async def test_datagram_receiver(socket_pair):
+    sending_socket, receiving_socket = socket_pair
+    receiver_address = receiving_socket.getsockname()
+    sender_address = sending_socket.getsockname()
+
+    send_channel, receive_channel = trio.open_memory_channel(1)
+    async with background_service(DatagramReceiver(receiving_socket, send_channel)):
+        data = b"some packet"
+
+        await sending_socket.sendto(data, receiver_address)
+        with trio.fail_after(0.5):
+            received_datagram = await receive_channel.receive()
+
+        assert received_datagram.datagram == data
+        assert received_datagram.sender.ip_address == sender_address[0]
+        assert received_datagram.sender.port == sender_address[1]
+
+
+async def test_datagram_sender(socket_pair):
+    sending_socket, receiving_socket = socket_pair
+    receiver_address = receiving_socket.getsockname()
+    sender_address = sending_socket.getsockname()
+
+    send_channel, receive_channel = trio.open_memory_channel(1)
+    async with background_service(DatagramSender(receive_channel, sending_socket)):
+        outgoing_datagram = OutgoingDatagram(b"some packet", receiver_address)
+        await send_channel.send(outgoing_datagram)
+
+        with trio.fail_after(0.5):
+            data, sender = await receiving_socket.recvfrom(1024)
+        assert data == outgoing_datagram.datagram
+        assert sender == sender_address

--- a/tox.ini
+++ b/tox.ini
@@ -99,7 +99,7 @@ skip_install=true
 use_develop=false
 
 [common-integration]
-deps = .[p2p,trinity,eth2,test]
+deps = .[p2p,trinity,eth2,test,test-asyncio]
 passenv =
     TRAVIS_EVENT_TYPE
 commands=


### PR DESCRIPTION
Add two simple services that read and write data to and from a UDP socket.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] Fix async fixtures: For some reason they don't work even though they should ("RuntimeError: Cannot be used outside of a run context")
- [ ] Tell CI to run tests with `trio_mode` enabled
- [ ] Fix type hints if possible
- [ ] Clean up commit history

#### Cute Animal Picture

![animal-animal-photography-avian-2629372](https://user-images.githubusercontent.com/29854669/61589805-a8bb8980-abaf-11e9-93a0-53f24e8fd237.jpg)
