### PR TITLE
Add abstract base classes for many of the main p2p APIs

### DIFF
--- a/newsfragments/818.misc.rst
+++ b/newsfragments/818.misc.rst
@@ -1,0 +1,1 @@
+Add ``p2p.abc`` which houses abstract base classes for ``p2p.kademlia.Node``, ``p2p.kademlia.Address``, ``p2p.protocol.Command``, ``p2p.protocol.Protocol`` and ``p2p.protocol.Transport``

--- a/p2p/abc.py
+++ b/p2p/abc.py
@@ -1,0 +1,245 @@
+from abc import ABC, abstractmethod
+from typing import (
+    Any,
+    ClassVar,
+    Dict,
+    Generic,
+    List,
+    Tuple,
+    Type,
+    Union,
+    TypeVar,
+)
+
+from rlp import sedes
+
+from cancel_token import CancelToken
+
+from eth_keys import datatypes
+
+from p2p.typing import CapabilityType, PayloadType, StructureType
+
+
+TAddress = TypeVar('TAddress', bound='AddressAPI')
+
+
+class AddressAPI(ABC):
+    udp_port: int
+    tcp_port: int
+
+    @abstractmethod
+    def __init__(self, ip: str, udp_port: int, tcp_port: int = 0) -> None:
+        ...
+
+    @property
+    @abstractmethod
+    def is_loopback(self) -> bool:
+        ...
+
+    @property
+    @abstractmethod
+    def is_unspecified(self) -> bool:
+        ...
+
+    @property
+    @abstractmethod
+    def is_reserved(self) -> bool:
+        ...
+
+    @property
+    @abstractmethod
+    def is_private(self) -> bool:
+        ...
+
+    @property
+    @abstractmethod
+    def ip(self) -> str:
+        ...
+
+    @abstractmethod
+    def __eq__(self, other: Any) -> bool:
+        ...
+
+    def __repr__(self) -> str:
+        return 'Address(%s:udp:%s|tcp:%s)' % (self.ip, self.udp_port, self.tcp_port)
+
+    @abstractmethod
+    def to_endpoint(self) -> List[bytes]:
+        ...
+
+    @classmethod
+    @abstractmethod
+    def from_endpoint(cls: Type[TAddress],
+                      ip: str,
+                      udp_port: bytes,
+                      tcp_port: bytes = b'\x00\x00') -> TAddress:
+        ...
+
+
+TNode = TypeVar('TNode', bound='NodeAPI')
+
+
+class NodeAPI(ABC):
+    pubkey: datatypes.PublicKey
+    address: AddressAPI
+    id: int
+
+    @abstractmethod
+    def __init__(self, pubkey: datatypes.PublicKey, address: AddressAPI) -> None:
+        ...
+
+    @classmethod
+    @abstractmethod
+    def from_uri(cls: Type[TNode], uri: str) -> TNode:
+        ...
+
+    @abstractmethod
+    def uri(self) -> str:
+        ...
+
+    @abstractmethod
+    def distance_to(self, id: int) -> int:
+        ...
+
+    # mypy doesn't have support for @total_ordering
+    # https://github.com/python/mypy/issues/4610
+    @abstractmethod
+    def __lt__(self, other: Any) -> bool:
+        ...
+
+    @abstractmethod
+    def __eq__(self, other: Any) -> bool:
+        ...
+
+    @abstractmethod
+    def __ne__(self, other: Any) -> bool:
+        ...
+
+    @abstractmethod
+    def __hash__(self) -> int:
+        ...
+
+
+class CommandAPI(ABC):
+    structure: StructureType
+
+    cmd_id: int
+    cmd_id_offset: int
+    snappy_support: bool
+
+    @abstractmethod
+    def __init__(self, cmd_id_offset: int, snappy_support: bool) -> None:
+        ...
+
+    @property
+    @abstractmethod
+    def is_base_protocol(self) -> bool:
+        ...
+
+    @abstractmethod
+    def encode_payload(self, data: Union[PayloadType, sedes.CountableList]) -> bytes:
+        ...
+
+    @abstractmethod
+    def decode_payload(self, rlp_data: bytes) -> PayloadType:
+        ...
+
+    @abstractmethod
+    def encode(self, data: PayloadType) -> Tuple[bytes, bytes]:
+        ...
+
+    @abstractmethod
+    def decode(self, data: bytes) -> PayloadType:
+        ...
+
+    @abstractmethod
+    def decompress_payload(self, raw_payload: bytes) -> bytes:
+        ...
+
+    @abstractmethod
+    def compress_payload(self, raw_payload: bytes) -> bytes:
+        ...
+
+
+# A payload to be delivered with a request
+TRequestPayload = TypeVar('TRequestPayload', bound=PayloadType, covariant=True)
+
+
+class RequestAPI(ABC, Generic[TRequestPayload]):
+    """
+    Must define command_payload during init. This is the data that will
+    be sent to the peer with the request command.
+    """
+    # Defined at init time, with specific parameters:
+    command_payload: TRequestPayload
+
+    # Defined as class attributes in subclasses
+    # outbound command type
+    cmd_type: Type[CommandAPI]
+    # response command type
+    response_type: Type[CommandAPI]
+
+
+class ProtocolAPI(ABC):
+    transport: 'TransportAPI'
+    name: ClassVar[str]
+    version: ClassVar[int]
+
+    cmd_length: int
+
+    cmd_id_offset: int
+
+    commands: Tuple[CommandAPI, ...]
+    cmd_by_type: Dict[Type[CommandAPI], CommandAPI]
+    cmd_by_id: Dict[int, CommandAPI]
+
+    @abstractmethod
+    def __init__(self, transport: 'TransportAPI', cmd_id_offset: int, snappy_support: bool) -> None:
+        ...
+
+    @abstractmethod
+    def send_request(self, request: RequestAPI[PayloadType]) -> None:
+        ...
+
+    @abstractmethod
+    def supports_command(self, cmd_type: Type[CommandAPI]) -> bool:
+        ...
+
+    @classmethod
+    @abstractmethod
+    def as_capability(cls) -> CapabilityType:
+        ...
+
+
+class TransportAPI(ABC):
+    remote: NodeAPI
+
+    @property
+    @abstractmethod
+    def is_closing(self) -> bool:
+        ...
+
+    @property
+    @abstractmethod
+    def public_key(self) -> datatypes.PublicKey:
+        ...
+
+    @abstractmethod
+    async def read(self, n: int, token: CancelToken) -> bytes:
+        ...
+
+    @abstractmethod
+    def write(self, data: bytes) -> None:
+        ...
+
+    @abstractmethod
+    async def recv(self, token: CancelToken) -> bytes:
+        ...
+
+    @abstractmethod
+    def send(self, header: bytes, body: bytes) -> None:
+        ...
+
+    @abstractmethod
+    def close(self) -> None:
+        ...

--- a/p2p/auth.py
+++ b/p2p/auth.py
@@ -20,7 +20,7 @@ from eth_hash.auto import keccak
 from cancel_token import CancelToken
 
 from p2p import ecies
-from p2p import kademlia
+from p2p.abc import NodeAPI
 from p2p.constants import REPLY_TIMEOUT
 from p2p.exceptions import (
     BadAckMessage,
@@ -45,7 +45,7 @@ from .constants import (
 
 
 async def handshake(
-        remote: kademlia.Node,
+        remote: NodeAPI,
         privkey: datatypes.PrivateKey,
         token: CancelToken) -> Tuple[bytes, bytes, sha3.keccak_256, sha3.keccak_256, asyncio.StreamReader, asyncio.StreamWriter]:  # noqa: E501
     """
@@ -117,7 +117,7 @@ class HandshakeBase:
     _is_initiator = False
 
     def __init__(
-            self, remote: kademlia.Node, privkey: datatypes.PrivateKey,
+            self, remote: NodeAPI, privkey: datatypes.PrivateKey,
             use_eip8: bool, token: CancelToken) -> None:
         self.remote = remote
         self.privkey = privkey

--- a/p2p/constants.py
+++ b/p2p/constants.py
@@ -138,3 +138,31 @@ BLACKLIST_SECONDS_TOO_MANY_TIMEOUTS = 60 * 5  # 5 minutes
 # too quickly as well as the amount of time they will be blacklisted for doing
 # so.
 BLACKLIST_SECONDS_QUICK_DISCONNECT = 60
+
+#
+# Kademlia Constants
+#
+
+# number of bits per hop
+KADEMLIA_BITS_PER_HOP = 8
+
+# bucket size for kademlia routing table
+KADEMLIA_BUCKET_SIZE = 16
+
+# round trip message timout
+KADEMLIA_REQUEST_TIMEOUT = 7.2
+
+# Amount of time to consider a bucket idle
+KADEMLIA_IDLE_BUCKET_REFRESH_INTERVAL = 3600
+
+# Number of parallele `find_node` lookups that can be in progress
+KADEMLIA_FIND_CONCURRENCY = 3
+
+# Size of public keys in bits
+KADEMLIA_PUBLIC_KEY_SIZE = 512
+
+# Size of a node id in bits
+KADEMLIA_ID_SIZE = 256
+
+# Maximum node `id` for a kademlia node
+KADEMLIA_MAX_NODE_ID = (2 ** KADEMLIA_ID_SIZE) - 1

--- a/p2p/disconnect.py
+++ b/p2p/disconnect.py
@@ -1,0 +1,19 @@
+import enum
+
+
+@enum.unique
+class DisconnectReason(enum.Enum):
+    """More details at https://github.com/ethereum/wiki/wiki/%C3%90%CE%9EVp2p-Wire-Protocol#p2p"""
+    disconnect_requested = 0
+    tcp_sub_system_error = 1
+    bad_protocol = 2
+    useless_peer = 3
+    too_many_peers = 4
+    already_connected = 5
+    incompatible_p2p_version = 6
+    null_node_identity_received = 7
+    client_quitting = 8
+    unexpected_identity = 9
+    connected_to_self = 10
+    timeout = 11
+    subprotocol_error = 16

--- a/p2p/discovery.py
+++ b/p2p/discovery.py
@@ -16,6 +16,7 @@ from typing import (
     Any,
     Callable,
     cast,
+    DefaultDict,
     Dict,
     Hashable,
     Iterable,
@@ -67,10 +68,11 @@ from p2p.events import (
     BaseRequestResponseEvent,
     PeerCandidatesResponse,
 )
-from p2p.exceptions import AlreadyWaitingDiscoveryResponse, NoEligibleNodes, UnableToGetDiscV5Ticket
-from p2p.kademlia import Node as KademliaNode
-from p2p import kademlia
 from p2p import protocol
+from p2p import constants
+from p2p.abc import AddressAPI, NodeAPI
+from p2p.exceptions import AlreadyWaitingDiscoveryResponse, NoEligibleNodes, UnableToGetDiscV5Ticket
+from p2p.kademlia import Address, Node, RoutingTable, check_relayed_addr, sort_by_distance
 from p2p.service import BaseService
 
 if TYPE_CHECKING:
@@ -81,9 +83,9 @@ else:
     UserDict = collections.UserDict
 
 # V4 handler methods take a Node, payload and msg_hash as arguments.
-V4_HANDLER_TYPE = Callable[[kademlia.Node, Tuple[Any, ...], Hash32], None]
+V4_HANDLER_TYPE = Callable[[NodeAPI, Tuple[Any, ...], Hash32], None]
 # V5 handler methods take a Node, payload, msg_hash and msg as arguments.
-V5_HANDLER_TYPE = Callable[[kademlia.Node, Tuple[Any, ...], Hash32, bytes], None]
+V5_HANDLER_TYPE = Callable[[NodeAPI, Tuple[Any, ...], Hash32, bytes], None]
 
 MAX_ENTRIES_PER_TOPIC = 50
 # UDP packet constants.
@@ -152,14 +154,14 @@ class DiscoveryProtocol(asyncio.DatagramProtocol):
 
     def __init__(self,
                  privkey: datatypes.PrivateKey,
-                 address: kademlia.Address,
-                 bootstrap_nodes: Tuple[kademlia.Node, ...],
+                 address: AddressAPI,
+                 bootstrap_nodes: Sequence[NodeAPI],
                  cancel_token: CancelToken) -> None:
         self.privkey = privkey
         self.address = address
         self.bootstrap_nodes = bootstrap_nodes
-        self.this_node = kademlia.Node(self.pubkey, address)
-        self.routing = kademlia.RoutingTable(self.this_node)
+        self.this_node = Node(self.pubkey, address)
+        self.routing = RoutingTable(self.this_node)
         self.topic_table = TopicTable(self.logger)
         self.pong_callbacks = CallbackManager()
         self.ping_callbacks = CallbackManager()
@@ -168,7 +170,7 @@ class DiscoveryProtocol(asyncio.DatagramProtocol):
         self.parity_pong_tokens: Dict[Hash32, Hash32] = {}
         self.cancel_token = CancelToken('DiscoveryProtocol').chain(cancel_token)
 
-    def update_routing_table(self, node: kademlia.Node) -> None:
+    def update_routing_table(self, node: NodeAPI) -> None:
         """Update the routing table entry for the given node."""
         eviction_candidate = self.routing.add_node(node)
         if eviction_candidate:
@@ -178,7 +180,7 @@ class DiscoveryProtocol(asyncio.DatagramProtocol):
             # replacement cache.
             asyncio.ensure_future(self.bond(eviction_candidate))
 
-    async def bond(self, node: kademlia.Node) -> bool:
+    async def bond(self, node: NodeAPI) -> bool:
         """Bond with the given node.
 
         Bonding consists of pinging the node, waiting for a pong and maybe a ping as well.
@@ -224,7 +226,7 @@ class DiscoveryProtocol(asyncio.DatagramProtocol):
         self.update_routing_table(node)
         return True
 
-    async def wait_ping(self, remote: kademlia.Node) -> bool:
+    async def wait_ping(self, remote: NodeAPI) -> bool:
         """Wait for a ping from the given remote.
 
         This coroutine adds a callback to ping_callbacks and yields control until that callback is
@@ -237,20 +239,20 @@ class DiscoveryProtocol(asyncio.DatagramProtocol):
             got_ping = False
             try:
                 got_ping = await self.cancel_token.cancellable_wait(
-                    event.wait(), timeout=kademlia.k_request_timeout)
+                    event.wait(), timeout=constants.KADEMLIA_REQUEST_TIMEOUT)
                 self.logger.debug2('got expected ping from %s', remote)
             except TimeoutError:
                 self.logger.debug2('timed out waiting for ping from %s', remote)
 
         return got_ping
 
-    async def wait_pong_v4(self, remote: kademlia.Node, token: Hash32) -> bool:
+    async def wait_pong_v4(self, remote: NodeAPI, token: Hash32) -> bool:
         event = asyncio.Event()
         callback = event.set
         return await self._wait_pong(remote, token, event, callback)
 
     async def _wait_pong(
-            self, remote: kademlia.Node, token: Hash32, event: asyncio.Event,
+            self, remote: NodeAPI, token: Hash32, event: asyncio.Event,
             callback: Callable[..., Any]) -> bool:
         """Wait for a pong from the given remote containing the given token.
 
@@ -264,7 +266,7 @@ class DiscoveryProtocol(asyncio.DatagramProtocol):
             got_pong = False
             try:
                 got_pong = await self.cancel_token.cancellable_wait(
-                    event.wait(), timeout=kademlia.k_request_timeout)
+                    event.wait(), timeout=constants.KADEMLIA_REQUEST_TIMEOUT)
                 self.logger.debug2('got expected pong with token %s', encode_hex(token))
             except TimeoutError:
                 self.logger.debug2(
@@ -275,52 +277,55 @@ class DiscoveryProtocol(asyncio.DatagramProtocol):
 
         return got_pong
 
-    async def wait_neighbours(self, remote: kademlia.Node) -> Tuple[kademlia.Node, ...]:
+    async def wait_neighbours(self, remote: NodeAPI) -> Tuple[NodeAPI, ...]:
         """Wait for a neihgbours packet from the given node.
 
         Returns the list of neighbours received.
         """
         event = asyncio.Event()
-        neighbours: List[kademlia.Node] = []
+        neighbours: List[NodeAPI] = []
 
-        def process(response: List[kademlia.Node]) -> None:
+        def process(response: List[NodeAPI]) -> None:
             neighbours.extend(response)
             # This callback is expected to be called multiple times because nodes usually
             # split the neighbours replies into multiple packets, so we only call event.set() once
             # we've received enough neighbours.
-            if len(neighbours) >= kademlia.k_bucket_size:
+            if len(neighbours) >= constants.KADEMLIA_BUCKET_SIZE:
                 event.set()
 
         with self.neighbours_callbacks.acquire(remote, process):
             try:
                 await self.cancel_token.cancellable_wait(
-                    event.wait(), timeout=kademlia.k_request_timeout)
+                    event.wait(), timeout=constants.KADEMLIA_REQUEST_TIMEOUT)
                 self.logger.debug2('got expected neighbours response from %s', remote)
             except TimeoutError:
                 self.logger.debug2(
-                    'timed out waiting for %d neighbours from %s', kademlia.k_bucket_size, remote)
+                    'timed out waiting for %d neighbours from %s',
+                    constants.KADEMLIA_BUCKET_SIZE,
+                    remote,
+                )
 
         return tuple(n for n in neighbours if n != self.this_node)
 
-    def _mkpingid(self, token: Hash32, node: kademlia.Node) -> Hash32:
+    def _mkpingid(self, token: Hash32, node: NodeAPI) -> Hash32:
         return Hash32(token + node.pubkey.to_bytes())
 
-    def _send_find_node(self, node: kademlia.Node, target_node_id: int) -> None:
+    def _send_find_node(self, node: NodeAPI, target_node_id: int) -> None:
         if self.use_v5:
             self.send_find_node_v5(node, target_node_id)
         else:
             self.send_find_node_v4(node, target_node_id)
 
-    async def lookup(self, node_id: int) -> Tuple[kademlia.Node, ...]:
+    async def lookup(self, node_id: int) -> Tuple[NodeAPI, ...]:
         """Lookup performs a network search for nodes close to the given target.
 
         It approaches the target by querying nodes that are closer to it on each iteration.  The
         given target does not need to be an actual node identifier.
         """
-        nodes_asked: Set[kademlia.Node] = set()
-        nodes_seen: Set[kademlia.Node] = set()
+        nodes_asked: Set[NodeAPI] = set()
+        nodes_seen: Set[NodeAPI] = set()
 
-        async def _find_node(node_id: int, remote: kademlia.Node) -> Tuple[kademlia.Node, ...]:
+        async def _find_node(node_id: int, remote: NodeAPI) -> Tuple[NodeAPI, ...]:
             # Short-circuit in case our token has been triggered to avoid trying to send requests
             # over a transport that is probably closed already.
             self.cancel_token.raise_if_triggered()
@@ -342,9 +347,9 @@ class DiscoveryProtocol(asyncio.DatagramProtocol):
             self.logger.debug2("bonded with %s candidates", bonded.count(True))
             return tuple(c for c in candidates if bonded[candidates.index(c)])
 
-        def _exclude_if_asked(nodes: Iterable[kademlia.Node]) -> List[kademlia.Node]:
+        def _exclude_if_asked(nodes: Iterable[NodeAPI]) -> List[NodeAPI]:
             nodes_to_ask = list(set(nodes).difference(nodes_asked))
-            return kademlia.sort_by_distance(nodes_to_ask, node_id)[:kademlia.k_find_concurrency]
+            return sort_by_distance(nodes_to_ask, node_id)[:constants.KADEMLIA_FIND_CONCURRENCY]
 
         closest = self.routing.neighbours(node_id)
         self.logger.debug("starting lookup; initial neighbours: %s", closest)
@@ -361,7 +366,7 @@ class DiscoveryProtocol(asyncio.DatagramProtocol):
             results = await asyncio.gather(*next_find_node_queries)
             for candidates in results:
                 closest.extend(candidates)
-            closest = kademlia.sort_by_distance(closest, node_id)[:kademlia.k_bucket_size]
+            closest = sort_by_distance(closest, node_id)[:constants.KADEMLIA_BUCKET_SIZE]
             nodes_to_ask = _exclude_if_asked(closest)
 
         self.logger.debug(
@@ -369,16 +374,16 @@ class DiscoveryProtocol(asyncio.DatagramProtocol):
         )
         return tuple(closest)
 
-    async def lookup_random(self) -> Tuple[kademlia.Node, ...]:
-        return await self.lookup(random.randint(0, kademlia.k_max_node_id))
+    async def lookup_random(self) -> Tuple[NodeAPI, ...]:
+        return await self.lookup(random.randint(0, constants.KADEMLIA_MAX_NODE_ID))
 
-    def get_random_bootnode(self) -> Iterator[kademlia.Node]:
+    def get_random_bootnode(self) -> Iterator[NodeAPI]:
         if self.bootstrap_nodes:
             yield random.choice(self.bootstrap_nodes)
         else:
             self.logger.warning('No bootnodes available')
 
-    def get_nodes_to_connect(self, count: int) -> Iterator[kademlia.Node]:
+    def get_nodes_to_connect(self, count: int) -> Iterator[NodeAPI]:
         return self.routing.get_random_nodes(count)
 
     @property
@@ -434,7 +439,7 @@ class DiscoveryProtocol(asyncio.DatagramProtocol):
 
     def datagram_received(self, data: Union[bytes, Text], addr: Tuple[str, int]) -> None:
         ip_address, udp_port = addr
-        address = kademlia.Address(ip_address, udp_port)
+        address = Address(ip_address, udp_port)
         # The prefix below is what geth uses to identify discv5 msgs.
         # https://github.com/ethereum/go-ethereum/blob/c4712bf96bc1bae4a5ad4600e9719e4a74bde7d5/p2p/discv5/udp.go#L149  # noqa: E501
         if text_if_str(to_bytes, data).startswith(V5_ID_STRING):
@@ -442,7 +447,7 @@ class DiscoveryProtocol(asyncio.DatagramProtocol):
         else:
             self.receive(address, cast(bytes, data))
 
-    def send(self, node: kademlia.Node, message: bytes) -> None:
+    def send(self, node: NodeAPI, message: bytes) -> None:
         self.transport.sendto(message, (node.address.ip, node.address.udp_port))
 
     async def stop(self) -> None:
@@ -453,7 +458,7 @@ class DiscoveryProtocol(asyncio.DatagramProtocol):
         # and exit cleanly when they notice the cancel token has been triggered.
         await asyncio.sleep(0.1)
 
-    def receive(self, address: kademlia.Address, message: bytes) -> None:
+    def receive(self, address: AddressAPI, message: bytes) -> None:
         try:
             remote_pubkey, cmd_id, payload, message_hash = _unpack_v4(message)
         except DefectiveMessage as e:
@@ -472,29 +477,29 @@ class DiscoveryProtocol(asyncio.DatagramProtocol):
         if len(payload) != cmd.elem_count:
             self.logger.error('invalid %s payload: %s', cmd.name, payload)
             return
-        node = kademlia.Node(remote_pubkey, address)
+        node = Node(remote_pubkey, address)
         handler = self._get_handler(cmd)
         handler(node, payload, message_hash)
 
-    def recv_pong_v4(self, node: kademlia.Node, payload: Tuple[Any, ...], _: Hash32) -> None:
+    def recv_pong_v4(self, node: NodeAPI, payload: Sequence[Any], _: Hash32) -> None:
         # The pong payload should have 3 elements: to, token, expiration
         _, token, _ = payload
         self.logger.debug2('<<< pong (v4) from %s (token == %s)', node, encode_hex(token))
         self.process_pong_v4(node, token)
 
-    def recv_neighbours_v4(self, node: kademlia.Node, payload: Tuple[Any, ...], _: Hash32) -> None:
+    def recv_neighbours_v4(self, node: NodeAPI, payload: Sequence[Any], _: Hash32) -> None:
         # The neighbours payload should have 2 elements: nodes, expiration
         nodes, _ = payload
         neighbours = _extract_nodes_from_payload(node.address, nodes, self.logger)
         self.logger.debug2('<<< neighbours from %s: %s', node, neighbours)
         self.process_neighbours(node, neighbours)
 
-    def recv_ping_v4(self, node: kademlia.Node, _: Any, message_hash: Hash32) -> None:
+    def recv_ping_v4(self, node: NodeAPI, _: Any, message_hash: Hash32) -> None:
         self.logger.debug2('<<< ping(v4) from %s', node)
         self.process_ping(node, message_hash)
         self.send_pong_v4(node, message_hash)
 
-    def recv_find_node_v4(self, node: kademlia.Node, payload: Tuple[Any, ...], _: Hash32) -> None:
+    def recv_find_node_v4(self, node: NodeAPI, payload: Sequence[Any], _: Hash32) -> None:
         # The find_node payload should have 2 elements: node_id, expiration
         self.logger.debug2('<<< find_node from %s', node)
         node_id, _ = payload
@@ -508,7 +513,7 @@ class DiscoveryProtocol(asyncio.DatagramProtocol):
         found = self.routing.neighbours(big_endian_to_int(node_id))
         self.send_neighbours_v4(node, found)
 
-    def send_ping_v4(self, node: kademlia.Node) -> Hash32:
+    def send_ping_v4(self, node: NodeAPI) -> Hash32:
         version = rlp.sedes.big_endian_int.serialize(PROTO_VERSION)
         payload = (version, self.address.to_endpoint(), node.address.to_endpoint())
         message = _pack_v4(CMD_PING.id, payload, self.privkey)
@@ -523,20 +528,20 @@ class DiscoveryProtocol(asyncio.DatagramProtocol):
         self.parity_pong_tokens[parity_token] = token
         return token
 
-    def send_find_node_v4(self, node: kademlia.Node, target_node_id: int) -> None:
+    def send_find_node_v4(self, node: NodeAPI, target_node_id: int) -> None:
         node_id = int_to_big_endian(
-            target_node_id).rjust(kademlia.k_pubkey_size // 8, b'\0')
+            target_node_id).rjust(constants.KADEMLIA_PUBLIC_KEY_SIZE // 8, b'\0')
         self.logger.debug2('>>> find_node to %s', node)
         message = _pack_v4(CMD_FIND_NODE.id, tuple([node_id]), self.privkey)
         self.send(node, message)
 
-    def send_pong_v4(self, node: kademlia.Node, token: Hash32) -> None:
+    def send_pong_v4(self, node: NodeAPI, token: Hash32) -> None:
         self.logger.debug2('>>> pong %s', node)
         payload = (node.address.to_endpoint(), token)
         message = _pack_v4(CMD_PONG.id, payload, self.privkey)
         self.send(node, message)
 
-    def send_neighbours_v4(self, node: kademlia.Node, neighbours: List[kademlia.Node]) -> None:
+    def send_neighbours_v4(self, node: NodeAPI, neighbours: List[NodeAPI]) -> None:
         nodes = []
         neighbours = sorted(neighbours)
         for n in neighbours:
@@ -550,7 +555,7 @@ class DiscoveryProtocol(asyncio.DatagramProtocol):
                                node, neighbours[i:i + max_neighbours])
             self.send(node, message)
 
-    def process_neighbours(self, remote: kademlia.Node, neighbours: List[kademlia.Node]) -> None:
+    def process_neighbours(self, remote: NodeAPI, neighbours: List[NodeAPI]) -> None:
         """Process a neighbours response.
 
         Neighbours responses should only be received as a reply to a find_node, and that is only
@@ -566,7 +571,7 @@ class DiscoveryProtocol(asyncio.DatagramProtocol):
         else:
             callback(neighbours)
 
-    def process_pong_v4(self, remote: kademlia.Node, token: Hash32) -> None:
+    def process_pong_v4(self, remote: NodeAPI, token: Hash32) -> None:
         """Process a pong packet.
 
         Pong packets should only be received as a response to a ping, so the actual processing is
@@ -594,7 +599,7 @@ class DiscoveryProtocol(asyncio.DatagramProtocol):
         else:
             callback()
 
-    def process_ping(self, remote: kademlia.Node, hash_: Hash32) -> None:
+    def process_ping(self, remote: NodeAPI, hash_: Hash32) -> None:
         """Process a received ping packet.
 
         A ping packet may come any time, unrequested, or may be prompted by us bond()ing with a
@@ -620,7 +625,7 @@ class DiscoveryProtocol(asyncio.DatagramProtocol):
     # Discovery v5 specific methods
     #
 
-    def send_v5(self, node: kademlia.Node, message: bytes) -> Hash32:
+    def send_v5(self, node: NodeAPI, message: bytes) -> Hash32:
         msg_hash = keccak(message)
         self.send(node, V5_ID_STRING + message)
         return msg_hash
@@ -645,7 +650,7 @@ class DiscoveryProtocol(asyncio.DatagramProtocol):
         else:
             raise ValueError(f"Unknown command: {cmd}")
 
-    def receive_v5(self, address: kademlia.Address, message: bytes) -> None:
+    def receive_v5(self, address: AddressAPI, message: bytes) -> None:
         try:
             remote_pubkey, cmd_id, payload, message_hash = _unpack_v5(message)
         except DefectiveMessage as e:
@@ -656,11 +661,11 @@ class DiscoveryProtocol(asyncio.DatagramProtocol):
         if len(payload) != cmd.elem_count:
             self.logger.error('invalid %s payload: %s', cmd.name, payload)
             return
-        node = kademlia.Node(remote_pubkey, address)
+        node = Node(remote_pubkey, address)
         handler = self._get_handler_v5(cmd)
         handler(node, payload, message_hash, message)
 
-    def recv_ping_v5(self, node: kademlia.Node, payload: Tuple[Any, ...],
+    def recv_ping_v5(self, node: NodeAPI, payload: Sequence[Any],
                      message_hash: Hash32, _: bytes) -> None:
         # version, from, to, expiration, topics
         _, _, _, _, topics = payload
@@ -673,30 +678,30 @@ class DiscoveryProtocol(asyncio.DatagramProtocol):
         self.send_pong_v5(node, message_hash, topic_hash, ticket_serial, wait_periods)
 
     def recv_pong_v5(
-            self, node: kademlia.Node, payload: Tuple[Any, ...], _: Hash32, raw_msg: bytes) -> None:
+            self, node: NodeAPI, payload: Sequence[Any], _: Hash32, raw_msg: bytes) -> None:
         # to, token, expiration, topic_hash, ticket_serial, wait_periods
         _, token, _, _, _, wait_periods = payload
         wait_periods = [big_endian_to_int(wait_period) for wait_period in wait_periods]
         self.logger.debug2('<<< pong (v5) from %s (token == %s)', node, encode_hex(token))
         self.process_pong_v5(node, token, raw_msg, wait_periods)
 
-    def recv_find_node_v5(self, node: kademlia.Node, payload: Tuple[Any, ...],
+    def recv_find_node_v5(self, node: NodeAPI, payload: Sequence[Any],
                           msg_hash: Hash32, _: bytes) -> None:
         # FIND_NODE in v5 is identical to v4, so just call the v4 handler.
         self.recv_find_node_v4(node, payload, msg_hash)
 
-    def recv_neighbours_v5(self, node: kademlia.Node, payload: Tuple[Any, ...],
+    def recv_neighbours_v5(self, node: NodeAPI, payload: Sequence[Any],
                            msg_hash: Hash32, _: bytes) -> None:
         # NEIGHBOURS in v5 is identical to v4, so just call the v4 handler.
         self.recv_neighbours_v4(node, payload, msg_hash)
 
-    def recv_find_nodehash(self, node: kademlia.Node, payload: Tuple[Any, ...],
+    def recv_find_nodehash(self, node: NodeAPI, payload: Sequence[Any],
                            _: Hash32, _b: bytes) -> None:
         target_hash, _ = payload
         self.logger.debug2('<<< find_nodehash from %s, target: %s', node, target_hash)
         # TODO: Reply with a neighbours msg.
 
-    def recv_topic_register(self, node: kademlia.Node, payload: Tuple[Any, ...],
+    def recv_topic_register(self, node: NodeAPI, payload: Sequence[Any],
                             _: Hash32, _m: bytes) -> None:
         topics, idx, raw_pong = payload
         topic_idx = big_endian_to_int(idx)
@@ -706,14 +711,14 @@ class DiscoveryProtocol(asyncio.DatagramProtocol):
         _, _, _, _, ticket_serial, _ = pong_payload
         self.topic_table.use_ticket(node, big_endian_to_int(ticket_serial), topics[topic_idx])
 
-    def recv_topic_query(self, node: kademlia.Node, payload: Tuple[Any, ...],
+    def recv_topic_query(self, node: NodeAPI, payload: Sequence[Any],
                          message_hash: Hash32, _: bytes) -> None:
         topic, _ = payload
         self.logger.debug2('<<< topic_query (%s) from %s', topic, node)
         nodes = self.topic_table.get_nodes(topic)
         self.send_topic_nodes(node, message_hash, nodes)
 
-    def recv_topic_nodes(self, node: kademlia.Node, payload: Tuple[Any, ...],
+    def recv_topic_nodes(self, node: NodeAPI, payload: Sequence[Any],
                          _: Hash32, _m: bytes) -> None:
         echo, raw_nodes = payload
         nodes = _extract_nodes_from_payload(node.address, raw_nodes, self.logger)
@@ -726,7 +731,7 @@ class DiscoveryProtocol(asyncio.DatagramProtocol):
         else:
             callback(echo, nodes)
 
-    def send_ping_v5(self, node: kademlia.Node, topics: List[bytes]) -> Hash32:
+    def send_ping_v5(self, node: NodeAPI, topics: List[bytes]) -> Hash32:
         version = rlp.sedes.big_endian_int.serialize(PROTO_VERSION_V5)
         payload = (
             version, self.address.to_endpoint(), node.address.to_endpoint(),
@@ -738,7 +743,7 @@ class DiscoveryProtocol(asyncio.DatagramProtocol):
         return token
 
     def send_pong_v5(
-            self, node: kademlia.Node, token: Hash32, topic_hash: Hash32,
+            self, node: NodeAPI, token: Hash32, topic_hash: Hash32,
             ticket_serial: int, wait_periods: List[int]) -> None:
         self.logger.debug2('>>> pong (v5) %s', node)
         payload = (
@@ -747,21 +752,21 @@ class DiscoveryProtocol(asyncio.DatagramProtocol):
         message = _pack_v5(CMD_PONG_V5.id, payload, self.privkey)
         self.send_v5(node, message)
 
-    def send_find_node_v5(self, node: kademlia.Node, target_node_id: int) -> None:
+    def send_find_node_v5(self, node: NodeAPI, target_node_id: int) -> None:
         node_id = int_to_big_endian(
-            target_node_id).rjust(kademlia.k_pubkey_size // 8, b'\0')
+            target_node_id).rjust(constants.KADEMLIA_PUBLIC_KEY_SIZE // 8, b'\0')
         self.logger.debug2('>>> find_node to %s', node)
         message = _pack_v5(CMD_FIND_NODE.id, (node_id, _get_msg_expiration()), self.privkey)
         self.send_v5(node, message)
 
-    def send_topic_query(self, node: kademlia.Node, topic: bytes) -> Hash32:
+    def send_topic_query(self, node: NodeAPI, topic: bytes) -> Hash32:
         self.logger.debug2('>>> topic_query (%s) to %s', topic, node)
         payload = (topic, _get_msg_expiration())
         message = _pack_v5(CMD_TOPIC_QUERY.id, payload, self.privkey)
         return self.send_v5(node, message)
 
     def send_topic_register(
-            self, node: kademlia.Node, topics: List[bytes], idx: int, pong: bytes) -> None:
+            self, node: NodeAPI, topics: List[bytes], idx: int, pong: bytes) -> None:
         if idx >= len(topics):
             raise ValueError(f"Invalid topic idx: {idx}")
         message = _pack_v5(CMD_TOPIC_REGISTER.id, (topics, idx, pong), self.privkey)
@@ -769,7 +774,7 @@ class DiscoveryProtocol(asyncio.DatagramProtocol):
         self.send_v5(node, message)
 
     def send_topic_nodes(
-            self, node: kademlia.Node, echo: Hash32, nodes: Tuple[kademlia.Node, ...]) -> None:
+            self, node: NodeAPI, echo: Hash32, nodes: Sequence[NodeAPI]) -> None:
         encoded_nodes = tuple(
             n.address.to_endpoint() + [n.pubkey.to_bytes()]
             for n in nodes)
@@ -780,15 +785,15 @@ class DiscoveryProtocol(asyncio.DatagramProtocol):
             self.send_v5(node, message)
 
     async def wait_topic_nodes(
-            self, remote: kademlia.Node, echo: Hash32) -> Tuple[kademlia.Node, ...]:
+            self, remote: NodeAPI, echo: Hash32) -> Tuple[NodeAPI, ...]:
         """Wait for a topic_nodes msg from the given node.
 
         Returns the list of nodes received.
         """
         event = asyncio.Event()
-        nodes: List[kademlia.Node] = []
+        nodes: List[NodeAPI] = []
 
-        def process(received_echo: Hash32, response: List[kademlia.Node]) -> None:
+        def process(received_echo: Hash32, response: List[NodeAPI]) -> None:
             if received_echo != echo:
                 self.logger.warning(
                     "Unexpected topic_nodes from %s, expected echo %s, got %s",
@@ -805,7 +810,7 @@ class DiscoveryProtocol(asyncio.DatagramProtocol):
         with self.topic_nodes_callbacks.acquire(remote, process):
             try:
                 await self.cancel_token.cancellable_wait(
-                    event.wait(), timeout=kademlia.k_request_timeout)
+                    event.wait(), timeout=constants.KADEMLIA_REQUEST_TIMEOUT)
             except TimeoutError:
                 # A timeout here just means we didn't get at least MAX_ENTRIES_PER_TOPIC nodes,
                 # but we'll still process the ones we get.
@@ -816,7 +821,7 @@ class DiscoveryProtocol(asyncio.DatagramProtocol):
 
         return tuple(n for n in nodes if n != self.this_node)
 
-    async def get_ticket(self, node: kademlia.Node, topics: List[bytes]) -> 'Ticket':
+    async def get_ticket(self, node: NodeAPI, topics: List[bytes]) -> 'Ticket':
         token = self.send_ping_v5(node, topics)
         try:
             got_pong, raw_pong, wait_periods = await self.wait_pong_v5(node, token)
@@ -830,7 +835,7 @@ class DiscoveryProtocol(asyncio.DatagramProtocol):
         return Ticket(node, raw_pong, topics, wait_periods)
 
     async def wait_pong_v5(
-            self, remote: kademlia.Node, token: Hash32) -> Tuple[bool, bytes, List[float]]:
+            self, remote: NodeAPI, token: Hash32) -> Tuple[bool, bytes, List[float]]:
         event = asyncio.Event()
         wait_periods: List[float] = []
         pong: bytes = None
@@ -844,7 +849,7 @@ class DiscoveryProtocol(asyncio.DatagramProtocol):
         got_pong = await self._wait_pong(remote, token, event, callback)
         return got_pong, pong, wait_periods
 
-    def process_pong_v5(self, remote: kademlia.Node, token: Hash32, raw_msg: bytes,
+    def process_pong_v5(self, remote: NodeAPI, token: Hash32, raw_msg: bytes,
                         wait_periods: List[float]) -> None:
         pingid = self._mkpingid(token, remote)
         try:
@@ -861,15 +866,15 @@ class PreferredNodeDiscoveryProtocol(DiscoveryProtocol):
     trying to find nodes.  Each preferred node can only be used once every
     preferred_node_recycle_time seconds.
     """
-    preferred_nodes: Sequence[kademlia.Node] = None
+    preferred_nodes: Sequence[NodeAPI] = None
     preferred_node_recycle_time: int = 300
-    _preferred_node_tracker: Dict[kademlia.Node, float] = None
+    _preferred_node_tracker: Dict[NodeAPI, float] = None
 
     def __init__(self,
                  privkey: datatypes.PrivateKey,
-                 address: kademlia.Address,
-                 bootstrap_nodes: Tuple[kademlia.Node, ...],
-                 preferred_nodes: Sequence[kademlia.Node],
+                 address: AddressAPI,
+                 bootstrap_nodes: Sequence[NodeAPI],
+                 preferred_nodes: Sequence[NodeAPI],
                  cancel_token: CancelToken) -> None:
         super().__init__(privkey, address, bootstrap_nodes, cancel_token)
 
@@ -878,7 +883,7 @@ class PreferredNodeDiscoveryProtocol(DiscoveryProtocol):
         self._preferred_node_tracker = collections.defaultdict(lambda: 0)
 
     @to_tuple
-    def _get_eligible_preferred_nodes(self) -> Iterator[kademlia.Node]:
+    def _get_eligible_preferred_nodes(self) -> Iterator[NodeAPI]:
         """
         Return nodes from the preferred_nodes which have not been used within
         the last preferred_node_recycle_time
@@ -888,7 +893,7 @@ class PreferredNodeDiscoveryProtocol(DiscoveryProtocol):
             if time.time() - last_used > self.preferred_node_recycle_time:
                 yield node
 
-    def _get_random_preferred_node(self) -> kademlia.Node:
+    def _get_random_preferred_node(self) -> NodeAPI:
         """
         Return a random node from the preferred list.
         """
@@ -898,7 +903,7 @@ class PreferredNodeDiscoveryProtocol(DiscoveryProtocol):
         node = random.choice(eligible_nodes)
         return node
 
-    def get_random_bootnode(self) -> Iterator[kademlia.Node]:
+    def get_random_bootnode(self) -> Iterator[NodeAPI]:
         """
         Return a single node to bootstrap, preferring nodes from the preferred list.
         """
@@ -909,7 +914,7 @@ class PreferredNodeDiscoveryProtocol(DiscoveryProtocol):
         except NoEligibleNodes:
             yield from super().get_random_bootnode()
 
-    def get_nodes_to_connect(self, count: int) -> Iterator[kademlia.Node]:
+    def get_nodes_to_connect(self, count: int) -> Iterator[NodeAPI]:
         """
         Return up to `count` nodes, preferring nodes from the preferred list.
         """
@@ -930,13 +935,13 @@ class DiscoveryByTopicProtocol(DiscoveryProtocol):
     def __init__(self,
                  topic: bytes,
                  privkey: datatypes.PrivateKey,
-                 address: kademlia.Address,
-                 bootstrap_nodes: Tuple[kademlia.Node, ...],
+                 address: AddressAPI,
+                 bootstrap_nodes: Sequence[NodeAPI],
                  cancel_token: CancelToken) -> None:
         super().__init__(privkey, address, bootstrap_nodes, cancel_token)
         self.topic = topic
 
-    def get_nodes_to_connect(self, count: int) -> Iterator[kademlia.Node]:
+    def get_nodes_to_connect(self, count: int) -> Iterator[NodeAPI]:
         topic_nodes = self.topic_table.get_nodes(self.topic)
         for node in topic_nodes:
             yield node
@@ -944,7 +949,7 @@ class DiscoveryByTopicProtocol(DiscoveryProtocol):
         num_nodes_needed = max(0, count - len(topic_nodes))
         yield from super().get_nodes_to_connect(num_nodes_needed)
 
-    async def lookup_random(self) -> Tuple[kademlia.Node, ...]:
+    async def lookup_random(self) -> Tuple[NodeAPI, ...]:
         query_nodes = list(self.routing.get_random_nodes(self._concurrent_topic_nodes_requests))
         expected_echoes = tuple(
             (n, self.send_topic_query(n, self.topic))
@@ -957,7 +962,7 @@ class DiscoveryByTopicProtocol(DiscoveryProtocol):
         for node in seen_nodes:
             self.topic_table.add_node(node, self.topic)
 
-        if len(seen_nodes) < kademlia.k_bucket_size:
+        if len(seen_nodes) < constants.KADEMLIA_BUCKET_SIZE:
             # Not enough nodes were found for our topic, so perform a regular kademlia lookup for
             # a random node ID.
             extra_nodes = await super().lookup_random()
@@ -968,15 +973,17 @@ class DiscoveryByTopicProtocol(DiscoveryProtocol):
 
 class StaticDiscoveryService(BaseService):
     """A 'discovery' service that only connects to the given nodes"""
+    _static_peers: Tuple[NodeAPI, ...]
+    _event_bus: EndpointAPI
 
     def __init__(
             self,
             event_bus: EndpointAPI,
-            static_peers: Tuple[KademliaNode, ...],
+            static_peers: Sequence[NodeAPI],
             token: CancelToken = None) -> None:
         super().__init__(token)
         self._event_bus = event_bus
-        self._static_peers = static_peers
+        self._static_peers = tuple(static_peers)
 
     async def handle_get_peer_candidates_requests(self) -> None:
         async for event in self._event_bus.stream(PeerCandidatesRequest):
@@ -988,7 +995,7 @@ class StaticDiscoveryService(BaseService):
             candidates = self._select_nodes(1)
             await self._broadcast_nodes(event, candidates)
 
-    def _select_nodes(self, max_nodes: int) -> Tuple[KademliaNode, ...]:
+    def _select_nodes(self, max_nodes: int) -> Tuple[NodeAPI, ...]:
         if max_nodes >= len(self._static_peers):
             candidates = self._static_peers
             self.logger.debug2("Replying with all static nodes: %r", candidates)
@@ -1000,9 +1007,9 @@ class StaticDiscoveryService(BaseService):
     async def _broadcast_nodes(
             self,
             event: BaseRequestResponseEvent[PeerCandidatesResponse],
-            nodes: Tuple[KademliaNode, ...]) -> None:
+            nodes: Sequence[NodeAPI]) -> None:
         await self._event_bus.broadcast(
-            event.expected_response_type()(nodes),
+            event.expected_response_type()(tuple(nodes)),
             event.broadcast_config()
         )
 
@@ -1131,16 +1138,16 @@ class NodeTicketInfo:
 
 class TopicTable:
     registration_lifetime = 60 * 60
+    topics: DefaultDict[bytes, 'collections.OrderedDict[NodeAPI, float]']
 
     def __init__(self, logger: ExtendedDebugLogger) -> None:
         self.logger = logger
         # A per-topic FIFO set of nodes.
-        self.topics: Dict[bytes, 'collections.OrderedDict[kademlia.Node, float]'] = (
-            collections.defaultdict(collections.OrderedDict))
+        self.topics = collections.defaultdict(collections.OrderedDict)
         # The IDs of the last issued/used tickets for any given node.
-        self.node_tickets: Dict[kademlia.Node, NodeTicketInfo] = {}
+        self.node_tickets: Dict[NodeAPI, NodeTicketInfo] = {}
 
-    def add_node(self, node: kademlia.Node, topic: bytes) -> None:
+    def add_node(self, node: NodeAPI, topic: bytes) -> None:
         entries = self.topics[topic]
         if node in entries:
             entries.pop(node)
@@ -1148,7 +1155,7 @@ class TopicTable:
             entries.popitem(last=False)
         entries[node] = time.time() + self.registration_lifetime
 
-    def get_nodes(self, topic: bytes) -> Tuple[kademlia.Node, ...]:
+    def get_nodes(self, topic: bytes) -> Tuple[NodeAPI, ...]:
         if topic not in self.topics:
             return tuple()
         else:
@@ -1158,7 +1165,7 @@ class TopicTable:
             self.topics[topic] = collections.OrderedDict(entries)
             return tuple(node for node, _ in entries)
 
-    def use_ticket(self, node: kademlia.Node, ticket_serial: int, topic: bytes) -> None:
+    def use_ticket(self, node: NodeAPI, ticket_serial: int, topic: bytes) -> None:
         ticket_info = self.node_tickets.get(node)
         if ticket_info is None:
             self.logger.debug("No ticket found for %s", node)
@@ -1172,7 +1179,7 @@ class TopicTable:
         ticket_info.last_used = ticket_serial
         self.add_node(node, topic)
 
-    def issue_ticket(self, node: kademlia.Node) -> int:
+    def issue_ticket(self, node: NodeAPI) -> int:
         node_info = self.node_tickets.setdefault(node, NodeTicketInfo())
         node_info.last_issued += 1
         return node_info.last_issued
@@ -1180,7 +1187,7 @@ class TopicTable:
 
 class Ticket:
 
-    def __init__(self, node: kademlia.Node, pong: bytes, topics: List[bytes],
+    def __init__(self, node: NodeAPI, pong: bytes, topics: List[bytes],
                  wait_periods: List[float]) -> None:
         now = time.time()
         self.issue_time = now
@@ -1195,14 +1202,14 @@ class Ticket:
 
 @to_list
 def _extract_nodes_from_payload(
-        sender: kademlia.Address,
+        sender: AddressAPI,
         payload: List[Tuple[str, bytes, bytes, bytes]],
-        logger: ExtendedDebugLogger) -> Iterator[kademlia.Node]:
+        logger: ExtendedDebugLogger) -> Iterator[NodeAPI]:
     for item in payload:
         ip, udp_port, tcp_port, node_id = item
-        address = kademlia.Address.from_endpoint(ip, udp_port, tcp_port)
-        if kademlia.check_relayed_addr(sender, address):
-            yield kademlia.Node(keys.PublicKey(node_id), address)
+        address = Address.from_endpoint(ip, udp_port, tcp_port)
+        if check_relayed_addr(sender, address):
+            yield Node(keys.PublicKey(node_id), address)
         else:
             logger.debug("Skipping invalid address %s relayed by %s", address, sender)
 
@@ -1214,8 +1221,8 @@ def _get_max_neighbours_per_packet() -> int:
     # packets.
     # Use an IPv6 address here as we're interested in the size of the biggest possible node
     # representation.
-    addr = kademlia.Address('::1', 30303, 30303)
-    node_data = addr.to_endpoint() + [b'\x00' * (kademlia.k_pubkey_size // 8)]
+    addr = Address('::1', 30303, 30303)
+    node_data = addr.to_endpoint() + [b'\x00' * (constants.KADEMLIA_PUBLIC_KEY_SIZE // 8)]
     neighbours = [node_data]
     expiration = rlp.sedes.big_endian_int.serialize(_get_msg_expiration())
     payload = rlp.encode([neighbours] + [expiration])
@@ -1225,7 +1232,7 @@ def _get_max_neighbours_per_packet() -> int:
     return len(neighbours) - 1
 
 
-def _pack_v4(cmd_id: int, payload: Tuple[Any, ...], privkey: datatypes.PrivateKey) -> bytes:
+def _pack_v4(cmd_id: int, payload: Sequence[Any], privkey: datatypes.PrivateKey) -> bytes:
     """Create and sign a UDP message to be sent to a remote node.
 
     See https://github.com/ethereum/devp2p/blob/master/rlpx.md#node-discovery for information on
@@ -1233,7 +1240,7 @@ def _pack_v4(cmd_id: int, payload: Tuple[Any, ...], privkey: datatypes.PrivateKe
     """
     cmd_id = to_bytes(cmd_id)
     expiration = rlp.sedes.big_endian_int.serialize(_get_msg_expiration())
-    encoded_data = cmd_id + rlp.encode(payload + tuple([expiration]))
+    encoded_data = cmd_id + rlp.encode(tuple(payload) + (expiration,))
     signature = privkey.sign_msg(encoded_data)
     message_hash = keccak(signature.to_bytes() + encoded_data)
     return message_hash + signature.to_bytes() + encoded_data
@@ -1262,7 +1269,7 @@ def _get_msg_expiration() -> int:
     return int(time.time() + EXPIRATION)
 
 
-def _pack_v5(cmd_id: int, payload: Tuple[Any, ...], privkey: datatypes.PrivateKey) -> bytes:
+def _pack_v5(cmd_id: int, payload: Sequence[Any], privkey: datatypes.PrivateKey) -> bytes:
     """Create and sign a discovery v5 UDP message to be sent to a remote node."""
     cmd_id = to_bytes(cmd_id)
     encoded_data = cmd_id + rlp.encode(payload)
@@ -1292,7 +1299,7 @@ def _unpack_v5(message: bytes) -> Tuple[datatypes.PublicKey, int, Tuple[Any, ...
 class CallbackLock:
     def __init__(self,
                  callback: Callable[..., Any],
-                 timeout: float=2 * kademlia.k_request_timeout) -> None:
+                 timeout: float=2 * constants.KADEMLIA_REQUEST_TIMEOUT) -> None:
         self.callback = callback
         self.timeout = timeout
         self.created_at = time.time()
@@ -1369,15 +1376,15 @@ def _test() -> None:
     # running on that port.
     listen_port = 30304
     privkey = ecies.generate_privkey()
-    addr = kademlia.Address(listen_host, listen_port, listen_port)
+    addr = Address(listen_host, listen_port, listen_port)
     if args.bootnode:
-        bootstrap_nodes = tuple([kademlia.Node.from_uri(args.bootnode)])
+        bootstrap_nodes = tuple([Node.from_uri(args.bootnode)])
     elif args.v5:
         bootstrap_nodes = tuple(
-            kademlia.Node.from_uri(enode) for enode in constants.DISCOVERY_V5_BOOTNODES)
+            Node.from_uri(enode) for enode in constants.DISCOVERY_V5_BOOTNODES)
     else:
         bootstrap_nodes = tuple(
-            kademlia.Node.from_uri(enode) for enode in constants.ROPSTEN_BOOTNODES)
+            Node.from_uri(enode) for enode in constants.ROPSTEN_BOOTNODES)
 
     cancel_token = CancelToken("discovery")
     if args.v5:

--- a/p2p/events.py
+++ b/p2p/events.py
@@ -11,7 +11,7 @@ from lahja import (
     BaseRequestResponseEvent,
 )
 
-from .kademlia import Node
+from p2p.abc import NodeAPI
 
 
 class BaseDiscoveryServiceResponse(BaseEvent):
@@ -21,7 +21,7 @@ class BaseDiscoveryServiceResponse(BaseEvent):
 @dataclass
 class PeerCandidatesResponse(BaseDiscoveryServiceResponse):
 
-    candidates: Tuple[Node, ...]
+    candidates: Tuple[NodeAPI, ...]
 
 
 @dataclass

--- a/p2p/peer_backend.py
+++ b/p2p/peer_backend.py
@@ -9,12 +9,8 @@ from lahja import (
     EndpointAPI,
 )
 
-from p2p.constants import (
-    DISCOVERY_EVENTBUS_ENDPOINT,
-)
-from p2p.kademlia import (
-    Node,
-)
+from p2p.abc import NodeAPI
+from p2p.constants import DISCOVERY_EVENTBUS_ENDPOINT
 from p2p.events import (
     PeerCandidatesRequest,
     RandomBootnodeRequest,
@@ -25,7 +21,7 @@ class BasePeerBackend(ABC):
     @abstractmethod
     async def get_peer_candidates(self,
                                   num_requested: int,
-                                  connected_remotes: Set[Node]) -> Tuple[Node, ...]:
+                                  connected_remotes: Set[NodeAPI]) -> Tuple[NodeAPI, ...]:
         pass
 
 
@@ -38,7 +34,7 @@ class DiscoveryPeerBackend(BasePeerBackend):
 
     async def get_peer_candidates(self,
                                   num_requested: int,
-                                  connected_remotes: Set[Node]) -> Tuple[Node, ...]:
+                                  connected_remotes: Set[NodeAPI]) -> Tuple[NodeAPI, ...]:
         await self.event_bus.wait_until_any_endpoint_subscribed_to(PeerCandidatesRequest)
         response = await self.event_bus.request(
             PeerCandidatesRequest(num_requested),
@@ -57,7 +53,7 @@ class BootnodesPeerBackend(BasePeerBackend):
 
     async def get_peer_candidates(self,
                                   num_requested: int,
-                                  connected_remotes: Set[Node]) -> Tuple[Node, ...]:
+                                  connected_remotes: Set[NodeAPI]) -> Tuple[NodeAPI, ...]:
         if len(connected_remotes) == 0:
             await self.event_bus.wait_until_any_endpoint_subscribed_to(RandomBootnodeRequest)
             response = await self.event_bus.request(

--- a/p2p/tools/paragon/peer.py
+++ b/p2p/tools/paragon/peer.py
@@ -1,22 +1,17 @@
 from typing import (
     Iterable,
 )
+
+from p2p.abc import CommandAPI
 from p2p.peer import (
     BasePeer,
     BasePeerContext,
     BasePeerFactory,
 )
-from p2p.peer_pool import (
-    BasePeerPool,
-)
-from p2p.protocol import (
-    Command,
-    _DecodedMsgType,
-)
+from p2p.peer_pool import BasePeerPool
+from p2p.typing import PayloadType
 
-from .proto import (
-    ParagonProtocol,
-)
+from .proto import ParagonProtocol
 
 
 class ParagonPeer(BasePeer):
@@ -27,7 +22,7 @@ class ParagonPeer(BasePeer):
         pass
 
     async def process_sub_proto_handshake(
-            self, cmd: Command, msg: _DecodedMsgType) -> None:
+            self, cmd: CommandAPI, msg: PayloadType) -> None:
         pass
 
     async def do_sub_proto_handshake(self) -> None:

--- a/p2p/tracking/connection.py
+++ b/p2p/tracking/connection.py
@@ -5,7 +5,7 @@ from typing import (
     Type,
 )
 
-from p2p.kademlia import Node
+from p2p.abc import NodeAPI
 from p2p.exceptions import (
     BaseP2PError,
     HandshakeFailure,
@@ -41,24 +41,24 @@ class BaseConnectionTracker(ABC):
     """
     logger = logging.getLogger('p2p.tracking.connection.ConnectionTracker')
 
-    def record_failure(self, remote: Node, failure: BaseP2PError) -> None:
+    def record_failure(self, remote: NodeAPI, failure: BaseP2PError) -> None:
         timeout_seconds = get_timeout_for_failure(failure)
         failure_name = type(failure).__name__
 
         return self.record_blacklist(remote, timeout_seconds, failure_name)
 
     @abstractmethod
-    def record_blacklist(self, remote: Node, timeout_seconds: int, reason: str) -> None:
+    def record_blacklist(self, remote: NodeAPI, timeout_seconds: int, reason: str) -> None:
         pass
 
     @abstractmethod
-    async def should_connect_to(self, remote: Node) -> bool:
+    async def should_connect_to(self, remote: NodeAPI) -> bool:
         pass
 
 
 class NoopConnectionTracker(BaseConnectionTracker):
-    def record_blacklist(self, remote: Node, timeout_seconds: int, reason: str) -> None:
+    def record_blacklist(self, remote: NodeAPI, timeout_seconds: int, reason: str) -> None:
         pass
 
-    async def should_connect_to(self, remote: Node) -> bool:
+    async def should_connect_to(self, remote: NodeAPI) -> bool:
         return True

--- a/p2p/transport.py
+++ b/p2p/transport.py
@@ -26,6 +26,7 @@ from p2p._utils import (
     roundup_16,
     sxor,
 )
+from p2p.abc import NodeAPI, TransportAPI
 from p2p.auth import (
     decode_authentication,
     HandshakeResponder,
@@ -48,11 +49,11 @@ from p2p.exceptions import (
 from p2p.kademlia import Address, Node
 
 
-class Transport:
+class Transport(TransportAPI):
     logger = cast(ExtendedDebugLogger, logging.getLogger('p2p.connection.Transport'))
 
     def __init__(self,
-                 remote: Node,
+                 remote: NodeAPI,
                  private_key: datatypes.PrivateKey,
                  reader: asyncio.StreamReader,
                  writer: asyncio.StreamWriter,
@@ -85,9 +86,9 @@ class Transport:
 
     @classmethod
     async def connect(cls,
-                      remote: Node,
+                      remote: NodeAPI,
                       private_key: datatypes.PrivateKey,
-                      token: CancelToken) -> 'Transport':
+                      token: CancelToken) -> TransportAPI:
         """Perform the auth and P2P handshakes with the given remote.
 
         Return an instance of the given peer_class (must be a subclass of
@@ -127,7 +128,7 @@ class Transport:
                                  reader: asyncio.StreamReader,
                                  writer: asyncio.StreamWriter,
                                  private_key: datatypes.PrivateKey,
-                                 token: CancelToken) -> 'Transport':
+                                 token: CancelToken) -> TransportAPI:
         try:
             msg = await token.cancellable_wait(
                 reader.readexactly(ENCRYPTED_AUTH_MSG_LEN),

--- a/p2p/typing.py
+++ b/p2p/typing.py
@@ -1,0 +1,26 @@
+from typing import Any, Dict, List, Tuple, Union
+
+from mypy_extensions import TypedDict
+
+import rlp
+
+
+class TypedDictPayload(TypedDict):
+    pass
+
+
+PayloadType = Union[
+    Dict[str, Any],
+    List[rlp.Serializable],
+    Tuple[rlp.Serializable, ...],
+    TypedDictPayload,
+]
+
+
+StructureType = Union[
+    Tuple[Tuple[str, Any], ...],
+]
+
+
+CapabilityType = Tuple[str, int]
+CapabilitiesType = Tuple[CapabilityType, ...]

--- a/tests/core/p2p-proto/test_peer.py
+++ b/tests/core/p2p-proto/test_peer.py
@@ -2,7 +2,7 @@ import asyncio
 
 import pytest
 
-from p2p.p2p_proto import DisconnectReason
+from p2p.disconnect import DisconnectReason
 
 from trinity.protocol.eth.peer import ETHPeer
 from trinity.protocol.eth.proto import ETHProtocol

--- a/tests/p2p/test_discovery.py
+++ b/tests/p2p/test_discovery.py
@@ -15,8 +15,8 @@ from eth_keys import keys
 
 from cancel_token import CancelToken
 
+from p2p import constants
 from p2p import discovery
-from p2p import kademlia
 from p2p.tools.factories import (
     AddressFactory,
     DiscoveryProtocolFactory,
@@ -28,7 +28,7 @@ from p2p.tools.factories import (
 # Force our tests to fail quickly if they accidentally make network requests.
 @pytest.fixture(autouse=True)
 def short_timeout(monkeypatch):
-    monkeypatch.setattr(kademlia, 'k_request_timeout', 0.05)
+    monkeypatch.setattr(constants, 'KADEMLIA_REQUEST_TIMEOUT', 0.05)
 
 
 @pytest.fixture
@@ -60,7 +60,7 @@ def test_ping_pong(alice, bob):
 def _test_find_node_neighbours(use_v5, alice, bob):
     # Add some nodes to bob's routing table so that it has something to use when replying to
     # alice's find_node.
-    for _ in range(kademlia.k_bucket_size * 2):
+    for _ in range(constants.KADEMLIA_BUCKET_SIZE * 2):
         bob.update_routing_table(NodeFactory())
 
     # Connect alice's and bob's transports directly so we don't need to deal with the complexities
@@ -87,7 +87,7 @@ def _test_find_node_neighbours(use_v5, alice, bob):
         assert node == bob.this_node
         neighbours.extend(discovery._extract_nodes_from_payload(
             node.address, payload[0], bob.logger))
-    assert len(neighbours) == kademlia.k_bucket_size
+    assert len(neighbours) == constants.KADEMLIA_BUCKET_SIZE
 
 
 def test_find_node_neighbours_v4(alice, bob):

--- a/trinity/plugins/builtin/network_db/connection/events.py
+++ b/trinity/plugins/builtin/network_db/connection/events.py
@@ -8,7 +8,7 @@ from lahja import (
     BaseRequestResponseEvent,
 )
 
-from p2p.kademlia import Node
+from p2p.abc import NodeAPI
 
 
 class BaseConnectionTrackerEvent(BaseEvent):
@@ -18,7 +18,7 @@ class BaseConnectionTrackerEvent(BaseEvent):
 @dataclass
 class BlacklistEvent(BaseConnectionTrackerEvent):
 
-    remote: Node
+    remote: NodeAPI
     timeout_seconds: int
     reason: str
 
@@ -32,7 +32,7 @@ class ShouldConnectToPeerResponse(BaseConnectionTrackerEvent):
 @dataclass
 class ShouldConnectToPeerRequest(BaseRequestResponseEvent[ShouldConnectToPeerResponse]):
 
-    remote: Node
+    remote: NodeAPI
 
     @staticmethod
     def expected_response_type() -> Type[ShouldConnectToPeerResponse]:

--- a/trinity/plugins/builtin/network_db/eth1_peer_db/events.py
+++ b/trinity/plugins/builtin/network_db/eth1_peer_db/events.py
@@ -11,7 +11,7 @@ from lahja import (
 
 from eth_typing import Hash32
 
-from p2p.kademlia import Node
+from p2p.abc import NodeAPI
 
 
 class BasePeerDBEvent(BaseEvent):
@@ -21,7 +21,7 @@ class BasePeerDBEvent(BaseEvent):
 @dataclass
 class TrackPeerEvent(BasePeerDBEvent):
 
-    remote: Node
+    remote: NodeAPI
     is_outbound: bool
     last_connected_at: Optional[datetime.datetime]
     genesis_hash: Hash32
@@ -33,14 +33,14 @@ class TrackPeerEvent(BasePeerDBEvent):
 @dataclass
 class GetPeerCandidatesResponse(BasePeerDBEvent):
 
-    candidates: Tuple[Node, ...]
+    candidates: Tuple[NodeAPI, ...]
 
 
 @dataclass
 class GetPeerCandidatesRequest(BaseRequestResponseEvent[GetPeerCandidatesResponse]):
 
     num_requested: int
-    connected_remotes: Set[Node]
+    connected_remotes: Set[NodeAPI]
 
     @staticmethod
     def expected_response_type() -> Type[GetPeerCandidatesResponse]:

--- a/trinity/plugins/builtin/tx_pool/pool.py
+++ b/trinity/plugins/builtin/tx_pool/pool.py
@@ -18,12 +18,8 @@ from eth.rlp.transactions import (
     BaseTransactionFields
 )
 
-from p2p.kademlia import (
-    Node,
-)
-from p2p.service import (
-    BaseService
-)
+from p2p.abc import NodeAPI
+from p2p.service import BaseService
 
 from trinity.protocol.eth.peer import (
     ETHProxyPeer,
@@ -76,7 +72,7 @@ class TxPool(BaseService):
             txs = cast(List[BaseTransactionFields], event.msg)
             await self._handle_tx(event.remote, txs)
 
-    async def _handle_tx(self, sender: Node, txs: List[BaseTransactionFields]) -> None:
+    async def _handle_tx(self, sender: NodeAPI, txs: List[BaseTransactionFields]) -> None:
 
         self.logger.debug('Received %d transactions from %s', len(txs), sender)
 
@@ -111,10 +107,10 @@ class TxPool(BaseService):
             if self.tx_validation_fn(val)
         ]
 
-    def _construct_bloom_entry(self, remote: Node, tx: BaseTransactionFields) -> bytes:
+    def _construct_bloom_entry(self, remote: NodeAPI, tx: BaseTransactionFields) -> bytes:
         return f"{repr(remote)}-{tx.hash}-{self._bloom_salt}".encode()
 
-    def _add_txs_to_bloom(self, remote: Node, txs: Iterable[BaseTransactionFields]) -> None:
+    def _add_txs_to_bloom(self, remote: NodeAPI, txs: Iterable[BaseTransactionFields]) -> None:
         for val in txs:
             self._bloom.add(self._construct_bloom_entry(remote, val))
 

--- a/trinity/protocol/bcc/events.py
+++ b/trinity/protocol/bcc/events.py
@@ -1,24 +1,12 @@
-from dataclasses import (
-    dataclass,
-)
-from typing import (
-    Tuple,
-)
+from dataclasses import dataclass
+from typing import Tuple
 
-from eth2.beacon.types.blocks import (
-    BaseBeaconBlock,
-)
-from lahja import (
-    BaseEvent,
-)
+from eth2.beacon.types.blocks import BaseBeaconBlock
+from lahja import BaseEvent
 
-from p2p.kademlia import (
-    Node,
-)
+from p2p.abc import NodeAPI
 
-from trinity.protocol.common.events import (
-    PeerPoolMessageEvent,
-)
+from trinity.protocol.common.events import PeerPoolMessageEvent
 
 
 class GetBeaconBlocksEvent(PeerPoolMessageEvent):
@@ -35,6 +23,6 @@ class SendBeaconBlocksEvent(BaseEvent):
     Event to proxy a ``BccPeer.sub_proto.send_blocks`` call from a proxy peer to the actual peer
     that sits in the peer pool.
     """
-    remote: Node
+    remote: NodeAPI
     blocks: Tuple[BaseBeaconBlock, ...]
     request_id: int

--- a/trinity/protocol/bcc/proto.py
+++ b/trinity/protocol/bcc/proto.py
@@ -13,7 +13,7 @@ from lahja import (
 )
 import ssz
 
-from p2p.kademlia import Node
+from p2p.abc import NodeAPI
 from p2p.protocol import Protocol
 
 from eth2.beacon.types.blocks import BaseBeaconBlock
@@ -114,7 +114,7 @@ class ProxyBCCProtocol:
     """
 
     def __init__(self,
-                 remote: Node,
+                 remote: NodeAPI,
                  event_bus: EndpointAPI,
                  broadcast_config: BroadcastConfig):
         self.remote = remote

--- a/trinity/protocol/bcc/requests.py
+++ b/trinity/protocol/bcc/requests.py
@@ -10,9 +10,7 @@ from eth2.beacon.typing import (
     Slot,
 )
 
-from p2p.protocol import (
-    BaseRequest,
-)
+from p2p.abc import RequestAPI
 
 from trinity.protocol.bcc.commands import (
     GetBeaconBlocks,
@@ -21,7 +19,7 @@ from trinity.protocol.bcc.commands import (
 )
 
 
-class GetBeaconBlocksRequest(BaseRequest[GetBeaconBlocksMessage]):
+class GetBeaconBlocksRequest(RequestAPI[GetBeaconBlocksMessage]):
     cmd_type = GetBeaconBlocks
     response_type = BeaconBlocks
 

--- a/trinity/protocol/common/boot.py
+++ b/trinity/protocol/common/boot.py
@@ -5,8 +5,8 @@ from eth_utils import ValidationError
 from eth.rlp.headers import BlockHeader
 from eth.vm.forks import HomesteadVM
 
+from p2p.disconnect import DisconnectReason
 from p2p.exceptions import PeerConnectionLost
-from p2p.p2p_proto import DisconnectReason
 from p2p.peer import BasePeerBootManager
 
 from trinity.exceptions import DAOForkCheckFailure

--- a/trinity/protocol/common/commands.py
+++ b/trinity/protocol/common/commands.py
@@ -1,16 +1,14 @@
-from abc import ABC, abstractmethod
+from abc import abstractmethod
 from typing import Tuple
 
 from eth.rlp.headers import BlockHeader
 
-from p2p.protocol import (
-    Command,
-    _DecodedMsgType,
-)
+from p2p.protocol import Command
+from p2p.typing import PayloadType
 
 
-class BaseBlockHeaders(ABC, Command):
+class BaseBlockHeaders(Command):
 
     @abstractmethod
-    def extract_headers(self, msg: _DecodedMsgType) -> Tuple[BlockHeader, ...]:
+    def extract_headers(self, msg: PayloadType) -> Tuple[BlockHeader, ...]:
         raise NotImplementedError("Must be implemented by subclasses")

--- a/trinity/protocol/common/events.py
+++ b/trinity/protocol/common/events.py
@@ -11,14 +11,9 @@ from lahja import (
     BaseRequestResponseEvent,
 )
 
-from p2p.kademlia import Node
-from p2p.p2p_proto import (
-    DisconnectReason,
-)
-from p2p.protocol import (
-    Command,
-    PayloadType,
-)
+from p2p.abc import CommandAPI, NodeAPI
+from p2p.disconnect import DisconnectReason
+from p2p.typing import PayloadType
 
 
 @dataclass
@@ -26,7 +21,7 @@ class ConnectToNodeCommand(BaseEvent):
     """
     Event that wraps a node URI that the pool should connect to.
     """
-    remote: Node
+    remote: NodeAPI
 
 
 @dataclass
@@ -53,7 +48,7 @@ class DisconnectPeerEvent(BaseEvent):
     """
     Event broadcasted when we want to disconnect from a peer
     """
-    remote: Node
+    remote: NodeAPI
     reason: DisconnectReason
 
 
@@ -62,7 +57,7 @@ class PeerJoinedEvent(BaseEvent):
     """
     Event broadcasted when a new peer joined the pool.
     """
-    remote: Node
+    remote: NodeAPI
 
 
 @dataclass
@@ -70,13 +65,13 @@ class PeerLeftEvent(BaseEvent):
     """
     Event broadcasted when a peer left the pool.
     """
-    remote: Node
+    remote: NodeAPI
 
 
 @dataclass
 class GetConnectedPeersResponse(BaseEvent):
 
-    remotes: Tuple[Node, ...]
+    remotes: Tuple[NodeAPI, ...]
 
 
 class GetConnectedPeersRequest(BaseRequestResponseEvent[GetConnectedPeersResponse]):
@@ -93,6 +88,6 @@ class PeerPoolMessageEvent(BaseEvent):
     to individual subclasses for every different ``cmd`` to allow efficient consumption through
     the event bus.
     """
-    remote: Node
-    cmd: Command
+    remote: NodeAPI
+    cmd: CommandAPI
     msg: PayloadType

--- a/trinity/protocol/common/exchanges.py
+++ b/trinity/protocol/common/exchanges.py
@@ -7,11 +7,7 @@ from typing import (
     Type,
 )
 
-from p2p.protocol import (
-    BaseRequest,
-    Command,
-    TRequestPayload,
-)
+from p2p.abc import CommandAPI, RequestAPI, TRequestPayload
 
 from trinity._utils.decorators import classproperty
 from .trackers import (
@@ -46,9 +42,9 @@ class BaseExchange(ABC, Generic[TRequestPayload, TResponsePayload, TResult]):
     TResult is the response data after normalization
     """
 
-    request_class: Type[BaseRequest[TRequestPayload]]
+    request_class: Type[RequestAPI[TRequestPayload]]
     tracker_class: Type[BasePerformanceTracker[Any, TResult]]
-    tracker: BasePerformanceTracker[BaseRequest[TRequestPayload], TResult]
+    tracker: BasePerformanceTracker[RequestAPI[TRequestPayload], TResult]
 
     def __init__(self, mgr: ExchangeManager[TRequestPayload, TResponsePayload, TResult]) -> None:
         self._manager = mgr
@@ -56,7 +52,7 @@ class BaseExchange(ABC, Generic[TRequestPayload, TResponsePayload, TResult]):
 
     async def get_result(
             self,
-            request: BaseRequest[TRequestPayload],
+            request: RequestAPI[TRequestPayload],
             normalizer: BaseNormalizer[TResponsePayload, TResult],
             result_validator: BaseValidator[TResult],
             payload_validator: Callable[[TRequestPayload, TResponsePayload], None],
@@ -84,7 +80,7 @@ class BaseExchange(ABC, Generic[TRequestPayload, TResponsePayload, TResult]):
         )
 
     @classproperty
-    def response_cmd_type(cls) -> Type[Command]:
+    def response_cmd_type(cls) -> Type[CommandAPI]:
         return cls.request_class.response_type
 
     @abstractmethod

--- a/trinity/protocol/common/peer.py
+++ b/trinity/protocol/common/peer.py
@@ -23,9 +23,9 @@ from eth_utils.toolz import groupby
 from eth.constants import GENESIS_BLOCK_NUMBER
 from eth.vm.base import BaseVM
 
-from p2p.p2p_proto import DisconnectReason
+from p2p.abc import NodeAPI
+from p2p.disconnect import DisconnectReason
 from p2p.exceptions import NoConnectedPeers
-from p2p.kademlia import Node
 from p2p.peer import (
     BasePeer,
     BasePeerFactory,
@@ -140,7 +140,7 @@ class BaseProxyPeer(BaseService):
     """
 
     def __init__(self,
-                 remote: Node,
+                 remote: NodeAPI,
                  event_bus: EndpointAPI,
                  token: CancelToken = None):
 
@@ -170,7 +170,7 @@ class BaseChainPeerFactory(BasePeerFactory):
 
 
 class BaseChainPeerPool(BasePeerPool):
-    connected_nodes: Dict[Node, BaseChainPeer]  # type: ignore
+    connected_nodes: Dict[NodeAPI, BaseChainPeer]  # type: ignore
     peer_factory_class: Type[BaseChainPeerFactory]
     peer_tracker: BaseEth1PeerTracker
 

--- a/trinity/protocol/common/servers.py
+++ b/trinity/protocol/common/servers.py
@@ -20,17 +20,14 @@ from eth.rlp.headers import BlockHeader
 from lahja import (
     BroadcastConfig,
 )
-from p2p import protocol
+
+from p2p.abc import CommandAPI, NodeAPI
 from p2p.cancellable import CancellableMixin
-from p2p.kademlia import Node
 from p2p.peer import (
     BasePeer,
     PeerSubscriber,
 )
-from p2p.protocol import (
-    Command,
-    _DecodedMsgType,
-)
+from p2p.typing import PayloadType
 from p2p.service import BaseService
 
 from trinity.db.eth1.header import BaseAsyncHeaderDB
@@ -70,8 +67,8 @@ class BaseRequestServer(BaseService, PeerSubscriber):
     async def _quiet_handle_msg(
             self,
             peer: BasePeer,
-            cmd: protocol.Command,
-            msg: protocol._DecodedMsgType) -> None:
+            cmd: CommandAPI,
+            msg: PayloadType) -> None:
         try:
             await self._handle_msg(peer, cmd, msg)
         except OperationCancelled:
@@ -82,7 +79,7 @@ class BaseRequestServer(BaseService, PeerSubscriber):
             self.logger.exception("Unexpected error when processing msg from %s", peer)
 
     @abstractmethod
-    async def _handle_msg(self, peer: BasePeer, cmd: Command, msg: _DecodedMsgType) -> None:
+    async def _handle_msg(self, peer: BasePeer, cmd: CommandAPI, msg: PayloadType) -> None:
         """
         Identify the command, and react appropriately.
         """
@@ -120,9 +117,9 @@ class BaseIsolatedRequestServer(BaseService):
 
     async def _quiet_handle_msg(
             self,
-            remote: Node,
-            cmd: protocol.Command,
-            msg: protocol._DecodedMsgType) -> None:
+            remote: NodeAPI,
+            cmd: CommandAPI,
+            msg: PayloadType) -> None:
         try:
             await self._handle_msg(remote, cmd, msg)
         except OperationCancelled:
@@ -134,9 +131,9 @@ class BaseIsolatedRequestServer(BaseService):
 
     @abstractmethod
     async def _handle_msg(self,
-                          remote: Node,
-                          cmd: Command,
-                          msg: protocol._DecodedMsgType) -> None:
+                          remote: NodeAPI,
+                          cmd: CommandAPI,
+                          msg: PayloadType) -> None:
         pass
 
 

--- a/trinity/protocol/common/trackers.py
+++ b/trinity/protocol/common/trackers.py
@@ -7,9 +7,7 @@ from typing import (
 )
 
 
-from p2p.protocol import (
-    BaseRequest,
-)
+from p2p.abc import RequestAPI
 
 from trinity._utils.ema import EMA
 from trinity._utils.logging import HasExtendedDebugLogger
@@ -21,7 +19,7 @@ from .types import (
 )
 
 
-TRequest = TypeVar('TRequest', bound=BaseRequest[Any])
+TRequest = TypeVar('TRequest', bound=RequestAPI[Any])
 
 
 class BasePerformanceTracker(ABC, HasExtendedDebugLogger, Generic[TRequest, TResult]):

--- a/trinity/protocol/eth/commands.py
+++ b/trinity/protocol/eth/commands.py
@@ -8,10 +8,8 @@ from eth.rlp.headers import BlockHeader
 from eth.rlp.receipts import Receipt
 from eth.rlp.transactions import BaseTransactionFields
 
-from p2p.protocol import (
-    Command,
-    _DecodedMsgType,
-)
+from p2p.protocol import Command
+from p2p.typing import PayloadType
 
 from trinity.protocol.common.commands import BaseBlockHeaders
 from trinity.rlp.block_body import BlockBody
@@ -56,7 +54,7 @@ class BlockHeaders(BaseBlockHeaders):
     _cmd_id = 4
     structure = sedes.CountableList(BlockHeader)
 
-    def extract_headers(self, msg: _DecodedMsgType) -> Tuple[BlockHeader, ...]:
+    def extract_headers(self, msg: PayloadType) -> Tuple[BlockHeader, ...]:
         return tuple(msg)
 
 

--- a/trinity/protocol/eth/events.py
+++ b/trinity/protocol/eth/events.py
@@ -16,9 +16,8 @@ from lahja import (
     BaseEvent,
     BaseRequestResponseEvent,
 )
-from p2p.kademlia import (
-    Node,
-)
+
+from p2p.abc import NodeAPI
 
 from eth_typing import (
     BlockIdentifier,
@@ -93,7 +92,7 @@ class SendBlockHeadersEvent(BaseEvent):
     Event to proxy a ``ETHPeer.sub_proto.send_block_headers`` call from a proxy peer to the actual
     peer that sits in the peer pool.
     """
-    remote: Node
+    remote: NodeAPI
     headers: Tuple[BlockHeader, ...]
 
 
@@ -103,7 +102,7 @@ class SendBlockBodiesEvent(BaseEvent):
     Event to proxy a ``ETHPeer.sub_proto.send_block_bodies`` call from a proxy peer to the actual
     peer that sits in the peer pool.
     """
-    remote: Node
+    remote: NodeAPI
     blocks: List[BaseBlock]
 
 
@@ -113,7 +112,7 @@ class SendNodeDataEvent(BaseEvent):
     Event to proxy a ``ETHPeer.sub_proto.send_node_data`` call from a proxy peer to the actual
     peer that sits in the peer pool.
     """
-    remote: Node
+    remote: NodeAPI
     nodes: Tuple[bytes, ...]
 
 
@@ -123,7 +122,7 @@ class SendReceiptsEvent(BaseEvent):
     Event to proxy a ``ETHPeer.sub_proto.send_receipts`` call from a proxy peer to the actual
     peer that sits in the peer pool.
     """
-    remote: Node
+    remote: NodeAPI
     receipts: List[List[Receipt]]
 
 
@@ -133,7 +132,7 @@ class SendTransactionsEvent(BaseEvent):
     Event to proxy a ``ETHPeer.sub_proto.send_transactions`` call from a proxy peer to the actual
     peer that sits in the peer pool.
     """
-    remote: Node
+    remote: NodeAPI
     transactions: List[BaseTransactionFields]
 
 # EXCHANGE HANDLER REQUEST / RESPONSE PAIRS
@@ -149,7 +148,7 @@ class GetBlockHeadersResponse(BaseEvent):
 @dataclass
 class GetBlockHeadersRequest(BaseRequestResponseEvent[GetBlockHeadersResponse]):
 
-    remote: Node
+    remote: NodeAPI
     block_number_or_hash: BlockIdentifier
     max_headers: int
     skip: int
@@ -171,7 +170,7 @@ class GetBlockBodiesResponse(BaseEvent):
 @dataclass
 class GetBlockBodiesRequest(BaseRequestResponseEvent[GetBlockBodiesResponse]):
 
-    remote: Node
+    remote: NodeAPI
     headers: Tuple[BlockHeader, ...]
     timeout: float
 
@@ -190,7 +189,7 @@ class GetNodeDataResponse(BaseEvent):
 @dataclass
 class GetNodeDataRequest(BaseRequestResponseEvent[GetNodeDataResponse]):
 
-    remote: Node
+    remote: NodeAPI
     node_hashes: Tuple[Hash32, ...]
     timeout: float
 
@@ -209,7 +208,7 @@ class GetReceiptsResponse(BaseEvent):
 @dataclass
 class GetReceiptsRequest(BaseRequestResponseEvent[GetReceiptsResponse]):
 
-    remote: Node
+    remote: NodeAPI
     headers: Tuple[BlockHeader, ...]
     timeout: float
 

--- a/trinity/protocol/eth/handlers.py
+++ b/trinity/protocol/eth/handlers.py
@@ -18,9 +18,7 @@ from lahja import (
     BroadcastConfig,
     EndpointAPI,
 )
-from p2p.kademlia import (
-    Node,
-)
+from p2p.abc import NodeAPI
 
 from trinity.protocol.common.handlers import (
     BaseChainExchangeHandler,
@@ -66,7 +64,7 @@ class ProxyETHExchangeHandler:
     """
 
     def __init__(self,
-                 remote: Node,
+                 remote: NodeAPI,
                  event_bus: EndpointAPI,
                  broadcast_config: BroadcastConfig):
         self.remote = remote

--- a/trinity/protocol/eth/proto.py
+++ b/trinity/protocol/eth/proto.py
@@ -15,15 +15,13 @@ from lahja import EndpointAPI
 from eth.rlp.headers import BlockHeader
 from eth.rlp.receipts import Receipt
 from eth.rlp.transactions import BaseTransactionFields
+
 from lahja import (
     BroadcastConfig,
 )
-from p2p.kademlia import (
-    Node,
-)
-from p2p.protocol import (
-    Protocol,
-)
+
+from p2p.abc import NodeAPI
+from p2p.protocol import Protocol
 
 from trinity.protocol.common.peer import ChainInfo
 from trinity.rlp.block_body import BlockBody
@@ -171,7 +169,7 @@ class ProxyETHProtocol:
     """
 
     def __init__(self,
-                 remote: Node,
+                 remote: NodeAPI,
                  event_bus: EndpointAPI,
                  broadcast_config: BroadcastConfig):
         self.remote = remote

--- a/trinity/protocol/eth/requests.py
+++ b/trinity/protocol/eth/requests.py
@@ -8,7 +8,7 @@ from eth_typing import (
     BlockIdentifier,
     Hash32,
 )
-from p2p.protocol import BaseRequest
+from p2p.abc import RequestAPI
 
 from trinity.protocol.eth.constants import MAX_HEADERS_FETCH
 from trinity.protocol.common.requests import (
@@ -46,7 +46,7 @@ class HeaderRequest(BaseHeaderRequest):
         self.reverse = reverse
 
 
-class GetBlockHeadersRequest(BaseRequest[Dict[str, Any]]):
+class GetBlockHeadersRequest(RequestAPI[Dict[str, Any]]):
     cmd_type = GetBlockHeaders
     response_type = BlockHeaders
 
@@ -63,7 +63,7 @@ class GetBlockHeadersRequest(BaseRequest[Dict[str, Any]]):
         }
 
 
-class GetReceiptsRequest(BaseRequest[Tuple[Hash32, ...]]):
+class GetReceiptsRequest(RequestAPI[Tuple[Hash32, ...]]):
     cmd_type = GetReceipts
     response_type = Receipts
 
@@ -71,7 +71,7 @@ class GetReceiptsRequest(BaseRequest[Tuple[Hash32, ...]]):
         self.command_payload = block_hashes
 
 
-class GetNodeDataRequest(BaseRequest[Tuple[Hash32, ...]]):
+class GetNodeDataRequest(RequestAPI[Tuple[Hash32, ...]]):
     cmd_type = GetNodeData
     response_type = NodeData
 
@@ -79,7 +79,7 @@ class GetNodeDataRequest(BaseRequest[Tuple[Hash32, ...]]):
         self.command_payload = node_hashes
 
 
-class GetBlockBodiesRequest(BaseRequest[Tuple[Hash32, ...]]):
+class GetBlockBodiesRequest(RequestAPI[Tuple[Hash32, ...]]):
     cmd_type = GetBlockBodies
     response_type = BlockBodies
 

--- a/trinity/protocol/eth/servers.py
+++ b/trinity/protocol/eth/servers.py
@@ -26,13 +26,9 @@ from lahja import (
 from trie.exceptions import (
     MissingTrieNode,
 )
-from p2p import protocol
-from p2p.kademlia import (
-    Node,
-)
-from p2p.protocol import (
-    Command,
-)
+
+from p2p.abc import CommandAPI, NodeAPI
+from p2p.typing import PayloadType
 
 from trinity.db.eth1.chain import BaseAsyncChainDB
 from trinity.protocol.common.servers import (
@@ -190,9 +186,9 @@ class ETHRequestServer(BaseIsolatedRequestServer):
         self._handler = ETHPeerRequestHandler(db, self.cancel_token)
 
     async def _handle_msg(self,
-                          remote: Node,
-                          cmd: Command,
-                          msg: protocol._DecodedMsgType) -> None:
+                          remote: NodeAPI,
+                          cmd: CommandAPI,
+                          msg: PayloadType) -> None:
 
         self.logger.debug2("Peer %s requested %s", remote, cmd)
         peer = ETHProxyPeer.from_node(remote, self.event_bus, self.broadcast_config)

--- a/trinity/protocol/les/commands.py
+++ b/trinity/protocol/les/commands.py
@@ -18,10 +18,8 @@ from rlp import sedes
 from eth.rlp.headers import BlockHeader
 from eth.rlp.receipts import Receipt
 
-from p2p.protocol import (
-    Command,
-    _DecodedMsgType,
-)
+from p2p.protocol import Command
+from p2p.typing import PayloadType
 
 from trinity.protocol.common.commands import BaseBlockHeaders
 from trinity.rlp.block_body import BlockBody
@@ -66,7 +64,7 @@ class Status(Command):
                 continue
             yield key, self._deserialize_item(key, value)
 
-    def encode_payload(self, data: Union[_DecodedMsgType, sedes.CountableList]) -> bytes:
+    def encode_payload(self, data: Union[PayloadType, sedes.CountableList]) -> bytes:
         response = [
             (key, self._serialize_item(key, value))
             for key, value
@@ -129,7 +127,7 @@ class BlockHeaders(BaseBlockHeaders):
         ('headers', sedes.CountableList(BlockHeader)),
     )
 
-    def extract_headers(self, msg: _DecodedMsgType) -> Tuple[BlockHeader, ...]:
+    def extract_headers(self, msg: PayloadType) -> Tuple[BlockHeader, ...]:
         msg = cast(Dict[str, Any], msg)
         return tuple(msg['headers'])
 
@@ -193,7 +191,7 @@ class Proofs(Command):
         ('proofs', sedes.CountableList(sedes.CountableList(sedes.raw))),
     )
 
-    def decode_payload(self, rlp_data: bytes) -> _DecodedMsgType:
+    def decode_payload(self, rlp_data: bytes) -> PayloadType:
         decoded = super().decode_payload(rlp_data)
         decoded = cast(Dict[str, Any], decoded)
         # This is just to make Proofs messages compatible with ProofsV2, so that LightPeerChain

--- a/trinity/protocol/les/events.py
+++ b/trinity/protocol/les/events.py
@@ -19,7 +19,7 @@ from lahja import (
     BaseEvent,
     BaseRequestResponseEvent,
 )
-from p2p.kademlia import Node
+from p2p.abc import NodeAPI
 
 from trinity.protocol.common.events import (
     PeerPoolMessageEvent,
@@ -128,7 +128,7 @@ class SendBlockHeadersEvent(BaseEvent):
     Event to proxy a ``LESPeer.sub_proto.send_block_heades`` call from a proxy peer to the actual
     peer that sits in the peer pool.
     """
-    remote: Node
+    remote: NodeAPI
     headers: Tuple[BlockHeader, ...]
     buffer_value: int
     request_id: int

--- a/trinity/protocol/les/proto.py
+++ b/trinity/protocol/les/proto.py
@@ -5,6 +5,11 @@ from typing import (
     Union,
 )
 
+from lahja import (
+    BroadcastConfig,
+    EndpointAPI,
+)
+
 from eth_typing import (
     BlockNumber,
     Hash32,
@@ -12,16 +17,8 @@ from eth_typing import (
 
 from eth.rlp.headers import BlockHeader
 
-from lahja import (
-    BroadcastConfig,
-    EndpointAPI,
-)
-from p2p.kademlia import (
-    Node,
-)
-from p2p.protocol import (
-    Protocol,
-)
+from p2p.abc import NodeAPI
+from p2p.protocol import Protocol
 
 from trinity.protocol.common.peer import ChainInfo
 from trinity._utils.les import gen_request_id
@@ -46,9 +43,7 @@ from .commands import (
     ContractCodeRequest,
     ContractCodes,
 )
-from .events import (
-    SendBlockHeadersEvent,
-)
+from .events import SendBlockHeadersEvent
 from . import constants
 
 if TYPE_CHECKING:
@@ -239,7 +234,7 @@ class ProxyLESProtocol:
     action performed on this class is delegated to the process that runs the peer pool.
     """
     def __init__(self,
-                 remote: Node,
+                 remote: NodeAPI,
                  event_bus: EndpointAPI,
                  broadcast_config: BroadcastConfig):
         self.remote = remote

--- a/trinity/protocol/les/requests.py
+++ b/trinity/protocol/les/requests.py
@@ -5,7 +5,7 @@ from typing import (
 
 from eth_typing import BlockIdentifier
 
-from p2p.protocol import BaseRequest
+from p2p.abc import RequestAPI
 
 from trinity.protocol.common.requests import (
     BaseHeaderRequest,
@@ -40,7 +40,7 @@ class HeaderRequest(BaseHeaderRequest):
         self.request_id = request_id
 
 
-class GetBlockHeadersRequest(BaseRequest[Dict[str, Any]]):
+class GetBlockHeadersRequest(RequestAPI[Dict[str, Any]]):
     cmd_type = GetBlockHeaders
     response_type = BlockHeaders
 

--- a/trinity/protocol/les/servers.py
+++ b/trinity/protocol/les/servers.py
@@ -10,13 +10,8 @@ from lahja import (
     EndpointAPI,
 )
 
-from p2p.kademlia import (
-    Node,
-)
-from p2p.protocol import (
-    Command,
-    _DecodedMsgType,
-)
+from p2p.abc import CommandAPI, NodeAPI
+from p2p.typing import PayloadType
 
 from trinity.db.eth1.header import BaseAsyncHeaderDB
 from trinity.protocol.common.servers import (
@@ -71,9 +66,9 @@ class LightRequestServer(BaseIsolatedRequestServer):
         self._handler = LESPeerRequestHandler(db, self.cancel_token)
 
     async def _handle_msg(self,
-                          remote: Node,
-                          cmd: Command,
-                          msg: _DecodedMsgType) -> None:
+                          remote: NodeAPI,
+                          cmd: CommandAPI,
+                          msg: PayloadType) -> None:
 
         self.logger.debug2("Peer %s requested %s", remote, cmd)
         peer = LESProxyPeer.from_node(remote, self.event_bus, self.broadcast_config)

--- a/trinity/server.py
+++ b/trinity/server.py
@@ -16,19 +16,14 @@ from cancel_token import CancelToken, OperationCancelled
 from eth_typing import BlockNumber
 from eth.vm.base import BaseVM
 
-from p2p.constants import (
-    DEFAULT_MAX_PEERS,
-)
+from p2p.abc import NodeAPI
+from p2p.constants import DEFAULT_MAX_PEERS
+from p2p.disconnect import DisconnectReason
 from p2p.exceptions import (
     HandshakeFailure,
     PeerConnectionLost,
 )
-from p2p.kademlia import (
-    Node,
-)
-from p2p.p2p_proto import (
-    DisconnectReason,
-)
+from p2p.kademlia import Node
 from p2p.service import BaseService
 from p2p.transport import Transport
 
@@ -71,8 +66,8 @@ class BaseServer(BaseService, Generic[TPeerPool]):
                  base_db: BaseAsyncDB,
                  network_id: int,
                  max_peers: int = DEFAULT_MAX_PEERS,
-                 bootstrap_nodes: Tuple[Node, ...] = None,
-                 preferred_nodes: Sequence[Node] = None,
+                 bootstrap_nodes: Sequence[NodeAPI] = None,
+                 preferred_nodes: Sequence[NodeAPI] = None,
                  event_bus: EndpointAPI = None,
                  token: CancelToken = None,
                  ) -> None:
@@ -245,8 +240,8 @@ class BCCServer(BaseServer[BCCPeerPool]):
                  base_db: BaseAsyncDB,
                  network_id: int,
                  max_peers: int = DEFAULT_MAX_PEERS,
-                 bootstrap_nodes: Tuple[Node, ...] = None,
-                 preferred_nodes: Sequence[Node] = None,
+                 bootstrap_nodes: Sequence[NodeAPI] = None,
+                 preferred_nodes: Sequence[NodeAPI] = None,
                  event_bus: EndpointAPI = None,
                  token: CancelToken = None,
                  ) -> None:

--- a/trinity/sync/beam/state.py
+++ b/trinity/sync/beam/state.py
@@ -12,6 +12,7 @@ from typing import (
 
 from lahja import EndpointAPI
 
+import rlp
 
 from eth_hash.auto import keccak
 from eth_utils import (
@@ -26,13 +27,11 @@ from eth_typing import (
 
 from cancel_token import CancelToken, OperationCancelled
 
-
+from p2p.abc import CommandAPI
 from p2p.exceptions import BaseP2PError, PeerConnectionLost
 from p2p.peer import BasePeer, PeerSubscriber
-from p2p.protocol import Command
 from p2p.service import BaseService
 
-import rlp
 from trie import HexaryTrie
 from trie.exceptions import MissingTrieNode
 
@@ -77,7 +76,7 @@ class BeamDownloader(BaseService, PeerSubscriber):
     _reply_timeout = 20  # seconds
 
     # We are only interested in peers entering or leaving the pool
-    subscription_msg_types: FrozenSet[Type[Command]] = frozenset()
+    subscription_msg_types: FrozenSet[Type[CommandAPI]] = frozenset()
 
     # This is a rather arbitrary value, but when the sync is operating normally we never see
     # the msg queue grow past a few hundred items, so this should be a reasonable limit for

--- a/trinity/sync/common/chain.py
+++ b/trinity/sync/common/chain.py
@@ -34,12 +34,8 @@ from p2p.constants import (
     MAX_REORG_DEPTH,
     SEAL_CHECK_RANDOM_SAMPLE_RATE,
 )
-from p2p.p2p_proto import (
-    DisconnectReason,
-)
-from p2p.service import (
-    BaseService,
-)
+from p2p.disconnect import DisconnectReason
+from p2p.service import BaseService
 
 from trinity._utils.headers import (
     skip_complete_headers,

--- a/trinity/sync/common/headers.py
+++ b/trinity/sync/common/headers.py
@@ -39,11 +39,12 @@ from eth.exceptions import (
     HeaderNotFound,
 )
 from eth.rlp.headers import BlockHeader
+
+from p2p.abc import CommandAPI
 from p2p.constants import SEAL_CHECK_RANDOM_SAMPLE_RATE
+from p2p.disconnect import DisconnectReason
 from p2p.exceptions import BaseP2PError, PeerConnectionLost
-from p2p.p2p_proto import DisconnectReason
 from p2p.peer import BasePeer, PeerSubscriber
-from p2p.protocol import Command
 from p2p.service import BaseService
 
 from trinity.chains.base import BaseAsyncChain
@@ -539,7 +540,7 @@ HeaderStitcher = OrderedTaskPreparation[BlockHeader, Hash32, OrderedTaskPreparat
 
 class HeaderMeatSyncer(BaseService, PeerSubscriber, Generic[TChainPeer]):
     # We are only interested in peers entering or leaving the pool
-    subscription_msg_types: FrozenSet[Type[Command]] = frozenset()
+    subscription_msg_types: FrozenSet[Type[CommandAPI]] = frozenset()
     msg_queue_maxsize = 2000
 
     _filler_header_tasks: TaskQueue[Tuple[BlockHeader, int, TChainPeer]]

--- a/trinity/sync/full/chain.py
+++ b/trinity/sync/full/chain.py
@@ -47,10 +47,10 @@ from eth.rlp.headers import BlockHeader
 from eth.rlp.receipts import Receipt
 from eth.rlp.transactions import BaseTransaction
 
-from p2p.p2p_proto import DisconnectReason
+from p2p.abc import CommandAPI
+from p2p.disconnect import DisconnectReason
 from p2p.exceptions import BaseP2PError, PeerConnectionLost
 from p2p.peer import BasePeer, PeerSubscriber
-from p2p.protocol import Command
 from p2p.service import BaseService
 from p2p.token_bucket import TokenBucket
 
@@ -113,7 +113,7 @@ class BaseBodyChainSyncer(BaseService, PeerSubscriber):
     "If no peers are available for downloading the chain data, retry after this many seconds"
 
     # We are only interested in peers entering or leaving the pool
-    subscription_msg_types: FrozenSet[Type[Command]] = frozenset()
+    subscription_msg_types: FrozenSet[Type[CommandAPI]] = frozenset()
 
     # This is a rather arbitrary value, but when the sync is operating normally we never see
     # the msg queue grow past a few hundred items, so this should be a reasonable limit for

--- a/trinity/sync/full/state.py
+++ b/trinity/sync/full/state.py
@@ -38,10 +38,8 @@ from eth.db.backends.level import LevelDB
 from eth.rlp.accounts import Account
 from eth.tools.logging import ExtendedDebugLogger
 
+from p2p.abc import CommandAPI
 from p2p.service import BaseService
-from p2p.protocol import (
-    Command,
-)
 
 from p2p.exceptions import (
     NoEligiblePeers,
@@ -102,7 +100,7 @@ class StateDownloader(BaseService, PeerSubscriber):
         self._peer_missing_nodes: Dict[ETHPeer, Set[Hash32]] = collections.defaultdict(set)
 
     # We are only interested in peers entering or leaving the pool
-    subscription_msg_types: FrozenSet[Type[Command]] = frozenset()
+    subscription_msg_types: FrozenSet[Type[CommandAPI]] = frozenset()
 
     # This is a rather arbitrary value, but when the sync is operating normally we never see
     # the msg queue grow past a few hundred items, so this should be a reasonable limit for


### PR DESCRIPTION
### What was wrong?

The `p2p` had some warts leftover from original  implementation and organization and it has been proving useful to have true abstract base class API definitions for the main APIs that are exposed in the `p2p` module.

### How was it fixed?

- Added the `p2p.abc` module which contains pure abstract definitions of the APIs for `Command`, `Protocol`, `Transport`, `Node` and `Address`
- Added `p2p.disconnect` to house the `DisconnectReason` enum (this fixes a circular import issue)
- Added `p2p.typing` to house some values that are used for type hints.
- Moved some constants from `p2p.kademlia` to `p2p.constants`
- Removed most places where a module from `p2p` was imported in favor of directly importing the things it uses from that module.
- Condensed many multi-line imports that only import one thing to be a single line.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

[//]: # (See: https://trinity-client.readthedocs.io/en/latest/contributing.html#pull-requests)
- [x] Add entry to the [release notes](https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses]()
