### PR TITLE
Fix issue w/ spec implementation when running final updates

### DIFF
--- a/eth2/beacon/state_machines/forks/serenity/epoch_processing.py
+++ b/eth2/beacon/state_machines/forks/serenity/epoch_processing.py
@@ -834,7 +834,13 @@ def process_final_updates(state: BeaconState, config: Eth2Config) -> BeaconState
     new_validators = _update_effective_balances(state, config)
     new_start_shard = _compute_next_start_shard(state, config)
     new_active_index_roots = _compute_next_active_index_roots(state, config)
-    new_compact_committees_roots = _compute_next_compact_committees_roots(state, config)
+    new_compact_committees_roots = _compute_next_compact_committees_roots(
+        state.copy(
+            validators=new_validators,
+            start_shard=new_start_shard,
+        ),
+        config
+    )
     new_slashings = _compute_next_slashings(state, config)
     new_randao_mixes = _compute_next_randao_mixes(state, config)
     new_historical_roots = _compute_next_historical_roots(state, config)


### PR DESCRIPTION
### What was wrong?

We were using the wrong set of validators and start shard when computing the epoch's compact committees root.

### How was it fixed?

Use the correct values. Note this implementation will almost certainly need to be improved but "get it right, then get it fast" etc.

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://s.hdnux.com/photos/01/02/64/04/17514756/3/920x920.jpg)
