### PR TITLE
Only update the justified checkpoint if there has been some change

### DIFF
--- a/eth2/beacon/state_machines/forks/serenity/epoch_processing.py
+++ b/eth2/beacon/state_machines/forks/serenity/epoch_processing.py
@@ -213,12 +213,15 @@ def _determine_new_justified_checkpoint_and_bitfield(
         config,
     )
 
-    new_current_justified_root = get_block_root(
-        state,
-        new_current_justified_epoch,
-        config.SLOTS_PER_EPOCH,
-        config.SLOTS_PER_HISTORICAL_ROOT,
-    )
+    if new_current_justified_epoch != state.current_justified_checkpoint.epoch:
+        new_current_justified_root = get_block_root(
+            state,
+            new_current_justified_epoch,
+            config.SLOTS_PER_EPOCH,
+            config.SLOTS_PER_HISTORICAL_ROOT,
+        )
+    else:
+        new_current_justified_root = state.current_justified_checkpoint.root
 
     return (
         Checkpoint(


### PR DESCRIPTION
### What was wrong?

We were optimistically updating the current justified checkpoint regardless of any change, assuming that the checkpoint's root would correspond to the epoch.

This condition fails to hold at genesis and a conformance tests surfaced the bug.

### How was it fixed?

Only update the checkpoint if there has actually been a change.

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://proxy.duckduckgo.com/iu/?u=https%3A%2F%2Fi.pinimg.com%2Foriginals%2Fb7%2F59%2F12%2Fb7591215b8c3804b5d532107d8f80b05.jpg&f=1)
