### PR TITLE
Expose NewBlockEvent on the event bus

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ develop-eggs
 .installed.cfg
 lib
 lib64
+pip-wheel-metadata
 
 # Installer logs
 pip-log.txt

--- a/newsfragments/822.feature.rst
+++ b/newsfragments/822.feature.rst
@@ -1,0 +1,1 @@
+Expose ``NewBlockEvent`` on the event bus.

--- a/trinity/protocol/eth/events.py
+++ b/trinity/protocol/eth/events.py
@@ -77,6 +77,14 @@ class TransactionsEvent(PeerPoolMessageEvent):
     pass
 
 
+class NewBlockEvent(PeerPoolMessageEvent):
+    """
+    Event to carry a ``NewBlock`` command from the peer pool to any process that
+    subscribes the event through the event bus.
+    """
+    pass
+
+
 class NewBlockHashesEvent(PeerPoolMessageEvent):
     """
     Event to carry a ``Transactions`` command from the peer pool to any process that

--- a/trinity/protocol/eth/peer.py
+++ b/trinity/protocol/eth/peer.py
@@ -65,6 +65,7 @@ from .events import (
     GetNodeDataEvent,
     GetNodeDataRequest,
     GetReceiptsRequest,
+    NewBlockEvent,
     NewBlockHashesEvent,
     SendBlockBodiesEvent,
     SendBlockHeadersEvent,
@@ -187,6 +188,7 @@ class ETHPeerPoolEventServer(PeerPoolEventServer[ETHPeer]):
         GetNodeData,
         Transactions,
         NewBlockHashes,
+        NewBlock,
     })
 
     async def _run(self) -> None:
@@ -277,6 +279,8 @@ class ETHPeerPoolEventServer(PeerPoolEventServer[ETHPeer]):
             await self.event_bus.broadcast(GetReceiptsEvent(remote, cmd, msg))
         elif isinstance(cmd, GetNodeData):
             await self.event_bus.broadcast(GetNodeDataEvent(remote, cmd, msg))
+        elif isinstance(cmd, NewBlock):
+            await self.event_bus.broadcast(NewBlockEvent(remote, cmd, msg))
         elif isinstance(cmd, NewBlockHashes):
             await self.event_bus.broadcast(NewBlockHashesEvent(remote, cmd, msg))
         elif isinstance(cmd, Transactions):


### PR DESCRIPTION
### What was wrong?

This is a little spin off from #721 that splits peer pool and sync into two separate processes. This exposes a `NewBlockEvent` on the event bus which is an important event for components to utilize (e.g. to build sync strategies on)

### How was it fixed?

- Created `NewBlockEvent`
- Dispatch the `NewBlockEvent` whenever the native `NewBlock` command pops up

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

[//]: # (See: https://trinity-client.readthedocs.io/en/latest/contributing.html#pull-requests)
- [ ] Add entry to the [release notes](https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses]()
