### PR TITLE
Rework the proposer candidate selection test to terminate more quickly

### DIFF
--- a/tests/eth2/core/beacon/db/test_beacon_chaindb.py
+++ b/tests/eth2/core/beacon/db/test_beacon_chaindb.py
@@ -130,7 +130,7 @@ def test_chaindb_get_score(chaindb, sample_beacon_block_params, fork_choice_scor
 
 
 def test_chaindb_set_score(chaindb, block, maximum_score_value):
-    score = random.randint(0, maximum_score_value)
+    score = random.randrange(0, maximum_score_value)
     chaindb.set_score(block, score)
 
     block_score = chaindb.get_score(block.signing_root)

--- a/tests/eth2/core/beacon/test_committee_helpers.py
+++ b/tests/eth2/core/beacon/test_committee_helpers.py
@@ -155,14 +155,18 @@ def test_find_proposer_in_committee(genesis_validators,
     epoch = random.randint(config.GENESIS_EPOCH, 2**64)
     proposer_index = random.randint(0, len(genesis_validators))
 
-    # NOTE: not realistic to have negative balance, but should test the spirit of the function
     validators = tuple()
+    # NOTE: validators supplied to ``_find_proposer_in_committee``
+    # should at a minimum have 17 ETH as ``effective_balance``.
+    # Using 1 ETH should maintain the same spirit of the test and
+    # ensure we can know the likely candidate ahead of time.
+    one_eth_in_gwei = 1 * 10**9
     for index, validator in enumerate(genesis_validators):
         if index == proposer_index:
             validators += (validator,)
         else:
             validators += (validator.copy(
-                effective_balance=-1,
+                effective_balance=one_eth_in_gwei,
             ),)
 
     assert _find_proposer_in_committee(

--- a/tests/eth2/core/beacon/test_committee_helpers.py
+++ b/tests/eth2/core/beacon/test_committee_helpers.py
@@ -152,8 +152,8 @@ SOME_SEED = b'\x33' * 32
 
 def test_find_proposer_in_committee(genesis_validators,
                                     config):
-    epoch = random.randint(config.GENESIS_EPOCH, 2**64)
-    proposer_index = random.randint(0, len(genesis_validators))
+    epoch = random.randrange(config.GENESIS_EPOCH, 2**64)
+    proposer_index = random.randrange(0, len(genesis_validators))
 
     validators = tuple()
     # NOTE: validators supplied to ``_find_proposer_in_committee``

--- a/tests/eth2/core/beacon/test_epoch_processing_helpers.py
+++ b/tests/eth2/core/beacon/test_epoch_processing_helpers.py
@@ -124,7 +124,7 @@ def test_get_attesting_indices(genesis_state,
             shard=target_shard,
         ),
     )
-    some_subset_count = random.randint(1, len(some_committee) // 2)
+    some_subset_count = random.randrange(1, len(some_committee) // 2)
     some_subset = random.sample(some_committee, some_subset_count)
 
     bitfield = get_empty_bitfield(len(some_committee))
@@ -144,7 +144,7 @@ def test_get_attesting_indices(genesis_state,
 
 
 def test_compute_activation_exit_epoch(activation_exit_delay):
-    epoch = random.randint(0, FAR_FUTURE_EPOCH)
+    epoch = random.randrange(0, FAR_FUTURE_EPOCH)
     entry_exit_effect_epoch = compute_activation_exit_epoch(
         epoch,
         activation_exit_delay,
@@ -357,7 +357,7 @@ def test_get_unslashed_attesting_indices(genesis_state,
             shard=target_shard,
         ),
     )
-    some_subset_count = random.randint(1, len(some_committee) // 2)
+    some_subset_count = random.randrange(1, len(some_committee) // 2)
     some_subset = random.sample(some_committee, some_subset_count)
 
     bitfield = get_empty_bitfield(len(some_committee))

--- a/tests/eth2/core/beacon/test_validator_status_helpers.py
+++ b/tests/eth2/core/beacon/test_validator_status_helpers.py
@@ -50,7 +50,7 @@ def test_activate_validator(genesis_state,
                             validator_count,
                             pubkeys,
                             config):
-    some_future_epoch = config.GENESIS_EPOCH + random.randint(1, 2**32)
+    some_future_epoch = config.GENESIS_EPOCH + random.randrange(1, 2**32)
 
     if is_already_activated:
         assert validator_count > 0
@@ -97,7 +97,7 @@ def test_compute_exit_queue_epoch(genesis_state,
                                   config):
     state = genesis_state
     for index in random.sample(range(len(state.validators)), len(state.validators) // 4):
-        some_future_epoch = config.GENESIS_EPOCH + random.randint(1, 2**32)
+        some_future_epoch = config.GENESIS_EPOCH + random.randrange(1, 2**32)
         state = state.update_validator_with_fn(
             index,
             lambda validator, *_: validator.copy(
@@ -113,7 +113,7 @@ def test_compute_exit_queue_epoch(genesis_state,
         for index, validator in enumerate(state.validators):
             if validator.exit_epoch == FAR_FUTURE_EPOCH:
                 continue
-            some_prior_epoch = random.randint(
+            some_prior_epoch = random.randrange(
                 config.GENESIS_EPOCH,
                 expected_candidate_exit_queue_epoch,
             )
@@ -145,7 +145,7 @@ def test_compute_exit_queue_epoch(genesis_state,
             for index, validator in state.validators
             if validator.exit_epoch == expected_candidate_exit_queue_epoch
         }
-        additional_queued_validator_count = random.randint(
+        additional_queued_validator_count = random.randrange(
             len(queued_validators),
             len(state.validators),
         )
@@ -233,7 +233,7 @@ def test_set_validator_slashed(genesis_state,
                                validator_count,
                                pubkeys,
                                config):
-    some_future_epoch = config.GENESIS_EPOCH + random.randint(1, 2**32)
+    some_future_epoch = config.GENESIS_EPOCH + random.randrange(1, 2**32)
 
     assert len(genesis_state.validators) > 0
     some_validator = genesis_state.validators[0]
@@ -271,7 +271,7 @@ def test_set_validator_slashed(genesis_state,
 def test_slash_validator(genesis_state,
                          config):
     some_epoch = (
-        config.GENESIS_EPOCH + random.randint(1, 2**32) + config.EPOCHS_PER_SLASHINGS_VECTOR
+        config.GENESIS_EPOCH + random.randrange(1, 2**32) + config.EPOCHS_PER_SLASHINGS_VECTOR
     )
     earliest_slashable_epoch = some_epoch - config.EPOCHS_PER_SLASHINGS_VECTOR
     slashable_range = range(earliest_slashable_epoch, some_epoch)


### PR DESCRIPTION
### What was wrong?

Thanks to @ChihChengLiang for help in diagnosing the issue on CI,

we found that this test was timing out... sometime.

This was happening because the underlying proposer selection algorithm is not
guaranteed to terminate (only to do so w/ high probability quickly under
normal circumstances). We were supplying a test case that was triggering the
pathological behavior.


### How was it fixed?

Better test case that should have better runtime characteristics.

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://i.imgur.com/xyPtn4m.jpg)
