### PR TITLE
Handshake interface

### DIFF
--- a/p2p/discv5/enr.py
+++ b/p2p/discv5/enr.py
@@ -228,11 +228,23 @@ class BaseENR(Mapping[bytes, Any], ABC):
 
     @property
     def public_key(self) -> bytes:
-        return self.identity_scheme.extract_public_key(self)
+        try:
+            return self.identity_scheme.extract_public_key(self)
+        except KeyError:
+            raise Exception(
+                "Invariant: presence of public key in ENR has been checked in identity scheme "
+                "structure check during initialization"
+            )
 
     @property
     def node_id(self) -> bytes:
-        return self.identity_scheme.extract_node_id(self)
+        try:
+            return self.identity_scheme.extract_node_id(self)
+        except KeyError:
+            raise Exception(
+                "Invariant: presence of public key in ENR has been checked in identity scheme "
+                "structure check during initialization"
+            )
 
     def get_signing_message(self) -> bytes:
         return rlp.encode(self, ENRContentSedes)

--- a/p2p/discv5/identity_schemes.py
+++ b/p2p/discv5/identity_schemes.py
@@ -5,8 +5,9 @@ from abc import (
 from collections import (
     UserDict,
 )
-
+import os
 from typing import (
+    Tuple,
     Type,
     TYPE_CHECKING,
 )
@@ -25,6 +26,14 @@ from eth_utils import (
     encode_hex,
     keccak,
     ValidationError,
+)
+
+from p2p.discv5.typing import (
+    AES128Key,
+    SessionKeys,
+)
+from p2p.discv5.constants import (
+    AES128_KEY_SIZE,
 )
 
 
@@ -67,35 +76,83 @@ class IdentityScheme(ABC):
 
     id: bytes = None
 
+    #
+    # ENR
+    #
     @classmethod
     @abstractmethod
     def create_enr_signature(cls, enr: "BaseENR", private_key: bytes) -> bytes:
         """Create and return the signature for an ENR."""
-        pass
+        ...
 
     @classmethod
     @abstractmethod
     def validate_enr_structure(cls, enr: "BaseENR") -> None:
         """Validate that the data required by the identity scheme is present and valid in an ENR."""
-        pass
+        ...
 
     @classmethod
     @abstractmethod
     def validate_enr_signature(cls, enr: "ENR") -> None:
         """Validate the signature of an ENR."""
-        pass
+        ...
 
     @classmethod
     @abstractmethod
     def extract_public_key(cls, enr: "BaseENR") -> bytes:
         """Retrieve the public key from an ENR."""
-        pass
+        ...
 
     @classmethod
     @abstractmethod
     def extract_node_id(cls, enr: "BaseENR") -> bytes:
         """Retrieve the node id from an ENR."""
-        pass
+        ...
+
+    #
+    # Handshake
+    #
+    @classmethod
+    @abstractmethod
+    def create_handshake_key_pair(cls) -> Tuple[bytes, bytes]:
+        """Create a random private/public key pair used for performing a handshake."""
+        ...
+
+    @classmethod
+    @abstractmethod
+    def validate_handshake_public_key(cls, public_key: bytes) -> None:
+        """Validate that a public key received during handshake is valid."""
+        ...
+
+    @classmethod
+    @abstractmethod
+    def compute_session_keys(cls,
+                             *,
+                             local_private_key: bytes,
+                             peer_public_key: bytes,
+                             initiator_node_id: bytes,
+                             recipient_node_id: bytes,
+                             id_nonce: bytes,
+                             ) -> SessionKeys:
+        """Compute the symmetric session keys."""
+        ...
+
+    def create_id_nonce_signature(cls,
+                                  *,
+                                  id_nonce: bytes,
+                                  private_key: bytes,
+                                  ) -> bytes:
+        """Sign an id nonce received during handshake."""
+        ...
+
+    def validate_id_nonce_signature(cls,
+                                    *,
+                                    id_nonce: bytes,
+                                    signature: bytes,
+                                    public_key: bytes,
+                                    ) -> None:
+        """Validate the id nonce signature received from a peer."""
+        ...
 
 
 @default_identity_scheme_registry.register
@@ -104,6 +161,11 @@ class V4IdentityScheme(IdentityScheme):
     id = b"v4"
     public_key_enr_key = b"secp256k1"
 
+    private_key_size = 32
+
+    #
+    # ENR
+    #
     @classmethod
     def create_enr_signature(cls, enr: "BaseENR", private_key: bytes) -> bytes:
         message = enr.get_signing_message()
@@ -117,34 +179,106 @@ class V4IdentityScheme(IdentityScheme):
             raise ValidationError(f"ENR is missing required key {cls.public_key_enr_key}")
 
         public_key = cls.extract_public_key(enr)
-        try:
-            PublicKey.from_compressed_bytes(public_key)
-        except EthKeysValidationError as error:
-            raise ValidationError(
-                f"ENR public key {encode_hex(public_key)} is invalid: {error}"
-            ) from error
+        cls.validate_public_key(public_key)
 
     @classmethod
     def validate_enr_signature(cls, enr: "ENR") -> None:
-        public_key_object = PublicKey.from_compressed_bytes(enr.public_key)
-        message = enr.get_signing_message()
-
-        try:
-            signature = NonRecoverableSignature(enr.signature)
-        except BadSignature:
-            is_valid = False
-        else:
-            is_valid = signature.verify_msg(message, public_key_object)
-
-        if not is_valid:
-            raise ValidationError("Invalid signature")
+        cls.validate_signature(
+            message=enr.get_signing_message(),
+            signature=enr.signature,
+            public_key=enr.public_key,
+        )
 
     @classmethod
     def extract_public_key(cls, enr: "BaseENR") -> bytes:
-        return enr[cls.public_key_enr_key]
+        try:
+            return enr[cls.public_key_enr_key]
+        except KeyError as error:
+            raise KeyError("ENR does not contain public key") from error
 
     @classmethod
     def extract_node_id(cls, enr: "BaseENR") -> bytes:
         public_key_object = PublicKey.from_compressed_bytes(enr.public_key)
         uncompressed_bytes = public_key_object.to_bytes()
         return keccak(uncompressed_bytes)
+
+    #
+    # Handshake
+    #
+    @classmethod
+    def create_handshake_key_pair(cls) -> Tuple[bytes, bytes]:
+        private_key = os.urandom(cls.private_key_size)
+        public_key = PrivateKey(private_key).public_key.to_compressed_bytes()
+        return private_key, public_key
+
+    @classmethod
+    def validate_handshake_public_key(cls, public_key: bytes) -> None:
+        cls.validate_public_key(public_key)
+
+    @classmethod
+    def compute_session_keys(cls,
+                             *,
+                             local_private_key: bytes,
+                             peer_public_key: bytes,
+                             initiator_node_id: bytes,
+                             recipient_node_id: bytes,
+                             id_nonce: bytes,
+                             ) -> SessionKeys:
+        # TODO: do it properly
+        return SessionKeys(
+            initiator_key=AES128Key(b"\x00" * AES128_KEY_SIZE),
+            recipient_key=AES128Key(b"\x11" * AES128_KEY_SIZE),
+            auth_response_key=AES128Key(b"\x22" * AES128_KEY_SIZE),
+        )
+
+    @classmethod
+    def create_id_nonce_signature(cls,
+                                  *,
+                                  id_nonce: bytes,
+                                  private_key: bytes,
+                                  ) -> bytes:
+        private_key_object = PrivateKey(private_key)
+        signature = private_key_object.sign_msg_non_recoverable(id_nonce)
+        return bytes(signature)
+
+    @classmethod
+    def validate_id_nonce_signature(cls,
+                                    *,
+                                    id_nonce: bytes,
+                                    signature: bytes,
+                                    public_key: bytes,
+                                    ) -> None:
+        cls.validate_signature(
+            message=id_nonce,
+            signature=signature,
+            public_key=public_key,
+        )
+
+    #
+    # Helpers
+    #
+    @classmethod
+    def validate_public_key(cls, public_key: bytes) -> None:
+        try:
+            PublicKey.from_compressed_bytes(public_key)
+        except (EthKeysValidationError, ValueError) as error:
+            raise ValidationError(
+                f"Public key {encode_hex(public_key)} is invalid: {error}"
+            ) from error
+
+    @classmethod
+    def validate_signature(cls, *, message: bytes, signature: bytes, public_key: bytes) -> None:
+        public_key_object = PublicKey.from_compressed_bytes(public_key)
+
+        try:
+            signature_object = NonRecoverableSignature(signature)
+        except BadSignature:
+            is_valid = False
+        else:
+            is_valid = signature_object.verify_msg(message, public_key_object)
+
+        if not is_valid:
+            raise ValidationError(
+                f"Signature {encode_hex(signature)} is not valid for message {encode_hex(message)} "
+                f"and public key {encode_hex(public_key)}"
+            )

--- a/p2p/discv5/typing.py
+++ b/p2p/discv5/typing.py
@@ -1,7 +1,17 @@
 from typing import (
+    Callable,
+    NamedTuple,
     NewType,
 )
 
 
 AES128Key = NewType("AES128Key", bytes)
 Nonce = NewType("Nonce", bytes)
+
+RandomBytesFn = Callable[[int], bytes]  # function that returns a number of random bytes
+
+
+class SessionKeys(NamedTuple):
+    initiator_key: AES128Key
+    recipient_key: AES128Key
+    auth_response_key: AES128Key

--- a/tests/p2p/discv5/strategies.py
+++ b/tests/p2p/discv5/strategies.py
@@ -2,6 +2,14 @@ from hypothesis import (
     strategies as st,
 )
 
+from eth_utils import (
+    int_to_big_endian,
+)
+
+from eth_keys.constants import (
+    SECPK1_N,
+)
+
 from p2p.discv5.constants import (
     AES128_KEY_SIZE,
     NONCE_SIZE,
@@ -21,3 +29,7 @@ node_id_st = st.binary(min_size=32, max_size=32)
 magic_st = st.binary(min_size=MAGIC_SIZE, max_size=MAGIC_SIZE)
 id_nonce_st = st.binary(min_size=ID_NONCE_SIZE, max_size=ID_NONCE_SIZE)
 enr_seq_st = st.integers(min_value=0)
+
+private_key_st = st.integers(min_value=1, max_value=SECPK1_N).map(
+    int_to_big_endian,
+).map(lambda key: key.rjust(32, b"\x00"))

--- a/tests/p2p/discv5/test_enr.py
+++ b/tests/p2p/discv5/test_enr.py
@@ -33,6 +33,7 @@ OFFICIAL_TEST_DATA = {
         "pMa2_oxVtw0RW_QAdpzBQA8yWM0xOIN1ZHCCdl8"
     ),
     "private_key": decode_hex("b71c71a67e1177ad4e901695e1b4b9ee17ae16c6668d313eac2f96dbcda3f291"),
+    "public_key": decode_hex("03ca634cae0d49acb401d8a4c6b6fe8c55b70d115bf400769cc1400f3258cd3138"),
     "node_id": decode_hex("a448f24c6d18e575453db13171562b71999873db5b286df957af199ec94617f7"),
     "identity_scheme": V4IdentityScheme,
     "sequence_number": 1,
@@ -53,18 +54,26 @@ class MockIdentityScheme(IdentityScheme):
     private_key_size = 32
 
     @classmethod
-    def create_signature(cls, enr, private_key: bytes) -> bytes:
+    def create_enr_signature(cls, enr, private_key: bytes) -> bytes:
         if len(private_key) != cls.private_key_size:
             raise ValidationError("Invalid private key")
         return private_key + enr.get_signing_message()
 
     @classmethod
-    def validate_signature(cls, enr) -> None:
-        if not enr.signature == cls.extract_node_address(enr) + enr.get_signing_message():
+    def validate_enr_structure(cls, enr) -> None:
+        pass
+
+    @classmethod
+    def validate_enr_signature(cls, enr) -> None:
+        if not enr.signature == enr.node_id + enr.get_signing_message():
             raise ValidationError("Invalid signature")
 
     @classmethod
-    def extract_node_address(cls, enr) -> bytes:
+    def extract_public_key(cls, enr) -> bytes:
+        return b""
+
+    @classmethod
+    def extract_node_id(cls, enr) -> bytes:
         return enr.signature[:cls.private_key_size]
 
 
@@ -168,7 +177,7 @@ def test_signing(mock_identity_scheme, identity_scheme_registry):
     )
     private_key = b"\x00" * 32
     enr = unsigned_enr.to_signed_enr(private_key)
-    assert enr.signature == mock_identity_scheme.create_signature(enr, private_key)
+    assert enr.signature == mock_identity_scheme.create_enr_signature(enr, private_key)
 
 
 def test_signature_validation(mock_identity_scheme, identity_scheme_registry):
@@ -196,18 +205,25 @@ def test_signature_validation(mock_identity_scheme, identity_scheme_registry):
         )
 
 
-def test_extract_node_address(mock_identity_scheme, identity_scheme_registry):
+def test_public_key(mock_identity_scheme, identity_scheme_registry):
     unsigned_enr = UnsignedENR(0, {b"id": b"mock"}, identity_scheme_registry)
     private_key = b"\x00" * 32
     enr = unsigned_enr.to_signed_enr(private_key)
-    assert enr.extract_node_address() == private_key
+    assert enr.public_key == mock_identity_scheme.extract_public_key(enr)
+
+
+def test_node_id(mock_identity_scheme, identity_scheme_registry):
+    unsigned_enr = UnsignedENR(0, {b"id": b"mock"}, identity_scheme_registry)
+    private_key = b"\x00" * 32
+    enr = unsigned_enr.to_signed_enr(private_key)
+    assert enr.node_id == private_key
 
 
 def test_signature_scheme_selection(mock_identity_scheme, identity_scheme_registry):
     mock_enr = ENR(0, {b"id": b"mock"}, b"", identity_scheme_registry)
     assert mock_enr.identity_scheme is mock_identity_scheme
 
-    v4_enr = ENR(0, {b"id": b"v4"}, b"", identity_scheme_registry)
+    v4_enr = ENR(0, {b"id": b"v4", b"secp256k1": b"\x02" * 33}, b"", identity_scheme_registry)
     assert v4_enr.identity_scheme is V4IdentityScheme
 
     with pytest.raises(ValidationError):
@@ -331,12 +347,27 @@ def test_serialization_roundtrip(identity_scheme_registry):
     assert recovered_enr == original_enr
 
 
+
+@pytest.mark.parametrize("invalid_kv_pairs", (
+    {b"id": b"v4"},  # missing public key
+    {b"id": b"v4", b"secp256k1": b"\x00"},  # invalid public key
+))
+def test_v4_structure_validation(invalid_kv_pairs, identity_scheme_registry):
+    with pytest.raises(ValidationError):
+        UnsignedENR(
+            sequence_number=0,
+            kv_pairs=invalid_kv_pairs,
+            identity_scheme_registry=identity_scheme_registry,
+        )
+
+
 def test_official_test_vector():
     enr = ENR.from_repr(OFFICIAL_TEST_DATA["repr"])  # use default identity scheme registry
 
     assert enr.sequence_number == OFFICIAL_TEST_DATA["sequence_number"]
     assert dict(enr) == OFFICIAL_TEST_DATA["kv_pairs"]
-    assert enr.extract_node_address() == OFFICIAL_TEST_DATA["node_id"]
+    assert enr.public_key == OFFICIAL_TEST_DATA["public_key"]
+    assert enr.node_id == OFFICIAL_TEST_DATA["node_id"]
     assert enr.identity_scheme is OFFICIAL_TEST_DATA["identity_scheme"]
     assert repr(enr) == OFFICIAL_TEST_DATA["repr"]
 

--- a/tests/p2p/discv5/test_enr.py
+++ b/tests/p2p/discv5/test_enr.py
@@ -347,7 +347,6 @@ def test_serialization_roundtrip(identity_scheme_registry):
     assert recovered_enr == original_enr
 
 
-
 @pytest.mark.parametrize("invalid_kv_pairs", (
     {b"id": b"v4"},  # missing public key
     {b"id": b"v4", b"secp256k1": b"\x00"},  # invalid public key

--- a/tests/p2p/discv5/test_identity_schemes.py
+++ b/tests/p2p/discv5/test_identity_schemes.py
@@ -50,7 +50,7 @@ def test_enr_signing():
         b"secp256k1": private_key.public_key.to_compressed_bytes(),
         b"key1": b"value1",
     })
-    signature = V4IdentityScheme.create_signature(unsigned_enr, private_key.to_bytes())
+    signature = V4IdentityScheme.create_enr_signature(unsigned_enr, private_key.to_bytes())
 
     message_hash = keccak(unsigned_enr.get_signing_message())
     assert private_key.public_key.verify_msg_hash(message_hash, NonRecoverableSignature(signature))
@@ -65,14 +65,28 @@ def test_enr_signature_validation():
     })
     enr = unsigned_enr.to_signed_enr(private_key.to_bytes())
 
-    V4IdentityScheme.validate_signature(enr)
+    V4IdentityScheme.validate_enr_signature(enr)
 
     forged_enr = ENR(enr.sequence_number, dict(enr), b"\x00" * 64)
     with pytest.raises(ValidationError):
-        V4IdentityScheme.validate_signature(forged_enr)
+        V4IdentityScheme.validate_enr_signature(forged_enr)
 
 
-def test_enr_node_address():
+def test_enr_public_key():
+    private_key = PrivateKey(b"\x11" * 32)
+    public_key = private_key.public_key.to_compressed_bytes()
+    unsigned_enr = UnsignedENR(0, {
+        b"id": b"v4",
+        b"secp256k1": public_key,
+        b"key1": b"value1",
+    })
+    enr = unsigned_enr.to_signed_enr(private_key.to_bytes())
+
+    assert V4IdentityScheme.extract_public_key(unsigned_enr) == public_key
+    assert V4IdentityScheme.extract_public_key(enr) == public_key
+
+
+def test_enr_node_id():
     private_key = PrivateKey(b"\x11" * 32)
     unsigned_enr = UnsignedENR(0, {
         b"id": b"v4",
@@ -81,5 +95,5 @@ def test_enr_node_address():
     })
     enr = unsigned_enr.to_signed_enr(private_key.to_bytes())
 
-    node_address = V4IdentityScheme.extract_node_address(enr)
-    assert node_address == keccak(private_key.public_key.to_bytes())
+    node_id = V4IdentityScheme.extract_node_id(enr)
+    assert node_id == keccak(private_key.public_key.to_compressed_bytes())

--- a/tests/p2p/discv5/test_packet_decryption.py
+++ b/tests/p2p/discv5/test_packet_decryption.py
@@ -4,6 +4,10 @@ from hypothesis import (
     given,
 )
 
+from eth_keys.datatypes import (
+    PrivateKey,
+)
+
 from p2p.exceptions import (
     DecryptionError,
 )
@@ -38,6 +42,7 @@ def enr():
         signature=b"",
         kv_pairs={
             b"id": b"v4",
+            b"secp256k1": PrivateKey(b"\x01" * 32).public_key.to_compressed_bytes(),
         }
     )
 

--- a/tests/p2p/discv5/test_packet_preparation.py
+++ b/tests/p2p/discv5/test_packet_preparation.py
@@ -61,6 +61,7 @@ def test_auth_header_preparation(tag,
         signature=b"",
         kv_pairs={
             b"id": b"v4",
+            b"secp256k1": b"\x02" * 33,
         }
     )
     message = PingMessage(


### PR DESCRIPTION
### What was wrong?

Identity scheme class only worked with ENR, but it's also responsible for the handshake.

### How was it fixed?

Implement the basic interface and add a placeholder so that we don't have to implement the cryptography as long as it isn't properly specified.

Also some minor stuff:
- rename node address to node id (both are used interchangeably in the spec, but address may collide with endpoint address)
- add method to access public key (we'll need that for the handshake)
- make node id and public key accessible on the ENR via properties

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://user-images.githubusercontent.com/29854669/61731364-9726dd00-ad7b-11e9-94ca-47d4e0a08610.jpg)