### PR TITLE
Add P2PProtocol.send_ping

### DIFF
--- a/newsfragments/826.feature.rst
+++ b/newsfragments/826.feature.rst
@@ -1,0 +1,1 @@
+Add ``p2p.p2p_proto.P2PProtocol.send_ping`` and ``p2p.p2p_proto.P2PProtocol.send_hello`` methods.

--- a/newsfragments/828.feature.rst
+++ b/newsfragments/828.feature.rst
@@ -1,0 +1,1 @@
+Add ``p2p.peer.receive_handshake`` to encapsulate the logic for handling incoming connections.

--- a/p2p/p2p_proto.py
+++ b/p2p/p2p_proto.py
@@ -2,7 +2,6 @@ from typing import (
     cast,
     Any,
     Dict,
-    Tuple,
 )
 
 from eth_utils.toolz import assoc
@@ -13,7 +12,7 @@ from rlp import sedes
 from p2p.abc import TransportAPI
 from p2p.disconnect import DisconnectReason as _DisconnectReason
 from p2p.exceptions import MalformedMessage
-from p2p.typing import PayloadType
+from p2p.typing import PayloadType, CapabilitiesType
 
 from p2p.protocol import (
     Command,
@@ -79,7 +78,7 @@ class P2PProtocol(Protocol):
     def __init__(self,
                  transport: TransportAPI,
                  snappy_support: bool,
-                 capabilities: Tuple[Tuple[str, int], ...],
+                 capabilities: CapabilitiesType,
                  listen_port: int) -> None:
         # For the base protocol the cmd_id_offset is always 0.
         # For the base protocol snappy compression should be disabled
@@ -90,11 +89,25 @@ class P2PProtocol(Protocol):
     def send_handshake(self) -> None:
         # TODO: move import out once this is in the trinity codebase
         from trinity._utils.version import construct_trinity_client_identifier
-        data = dict(version=self.version,
-                    client_version_string=construct_trinity_client_identifier(),
-                    capabilities=self.capabilities,
-                    listen_port=self.listen_port,
-                    remote_pubkey=self.transport.public_key.to_bytes())
+        self.send_hello(
+            version=self.version,
+            client_version_string=construct_trinity_client_identifier(),
+            capabilities=self.capabilities,
+            listen_port=self.listen_port,
+            remote_pubkey=self.transport.public_key.to_bytes(),
+        )
+
+    def send_hello(self,
+                   version: int,
+                   client_version_string: str,
+                   capabilities: CapabilitiesType,
+                   listen_port: int,
+                   remote_pubkey: bytes) -> None:
+        data = dict(version=version,
+                    client_version_string=client_version_string,
+                    capabilities=capabilities,
+                    listen_port=listen_port,
+                    remote_pubkey=remote_pubkey)
         header, body = Hello(self.cmd_id_offset, self.snappy_support).encode(data)
         self.transport.send(header, body)
 
@@ -104,6 +117,10 @@ class P2PProtocol(Protocol):
             self.cmd_id_offset,
             self.snappy_support
         ).encode(msg)
+        self.transport.send(header, body)
+
+    def send_ping(self) -> None:
+        header, body = Ping(self.cmd_id_offset, self.snappy_support).encode({})
         self.transport.send(header, body)
 
     def send_pong(self) -> None:


### PR DESCRIPTION
extracted from #684 

### What was wrong?

We had no mechanism for sending the `Ping` message and the code for sending the `Hello` message was burried in the handshake code.

### How was it fixed?

Extracted these to be their own methods on the `P2PProtocol` class.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

[//]: # (See: https://trinity-client.readthedocs.io/en/latest/contributing.html#pull-requests)
- [x] Add entry to the [release notes](https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![13-10-12 Summer (1)C650](https://user-images.githubusercontent.com/824194/61733562-4d1f0680-ad3d-11e9-8eab-baecd5a5fa5c.JPG)

