### PR TITLE
Remove handshake parameters from p2p protocol class

### DIFF
--- a/newsfragments/829.feature.rst
+++ b/newsfragments/829.feature.rst
@@ -1,0 +1,1 @@
+The ``p2p.p2p_proto.P2PProtocol`` class now requires that handshake parameters be passed into the ``send_handshake`` method.  These parameters are now part of the ``p2p.peer.BasePeerContext`` class.

--- a/p2p/p2p_proto.py
+++ b/p2p/p2p_proto.py
@@ -12,7 +12,7 @@ from rlp import sedes
 from p2p.abc import TransportAPI
 from p2p.disconnect import DisconnectReason as _DisconnectReason
 from p2p.exceptions import MalformedMessage
-from p2p.typing import PayloadType, CapabilitiesType
+from p2p.typing import CapabilitiesType, PayloadType
 
 from p2p.protocol import (
     Command,
@@ -77,23 +77,20 @@ class P2PProtocol(Protocol):
 
     def __init__(self,
                  transport: TransportAPI,
-                 snappy_support: bool,
-                 capabilities: CapabilitiesType,
-                 listen_port: int) -> None:
+                 snappy_support: bool) -> None:
         # For the base protocol the cmd_id_offset is always 0.
         # For the base protocol snappy compression should be disabled
         super().__init__(transport, cmd_id_offset=0, snappy_support=snappy_support)
-        self.capabilities = capabilities
-        self.listen_port = listen_port
 
-    def send_handshake(self) -> None:
-        # TODO: move import out once this is in the trinity codebase
-        from trinity._utils.version import construct_trinity_client_identifier
+    def send_handshake(self,
+                       client_version_string: str,
+                       capabilities: CapabilitiesType,
+                       listen_port: int) -> None:
         self.send_hello(
             version=self.version,
-            client_version_string=construct_trinity_client_identifier(),
-            capabilities=self.capabilities,
-            listen_port=self.listen_port,
+            client_version_string=client_version_string,
+            capabilities=capabilities,
+            listen_port=listen_port,
             remote_pubkey=self.transport.public_key.to_bytes(),
         )
 

--- a/p2p/peer.py
+++ b/p2p/peer.py
@@ -149,7 +149,12 @@ class BasePeerBootManager(BaseService):
 
 
 class BasePeerContext:
-    pass
+    client_version_string: str
+    listen_port: int
+
+    def __init__(self, client_version_string: str, listen_port: int) -> None:
+        self.client_version_string = client_version_string
+        self.listen_port = listen_port
 
 
 class BasePeer(BaseService):
@@ -187,8 +192,6 @@ class BasePeer(BaseService):
         self.base_protocol = P2PProtocol(
             transport=self.transport,
             snappy_support=False,
-            capabilities=self.capabilities,
-            listen_port=self.listen_port,
         )
 
         # Optional event bus handle
@@ -318,7 +321,11 @@ class BasePeer(BaseService):
 
         Raises HandshakeFailure if the handshake is not successful.
         """
-        self.base_protocol.send_handshake()
+        self.base_protocol.send_handshake(
+            client_version_string=self.context.client_version_string,
+            capabilities=self.capabilities,
+            listen_port=self.context.listen_port,
+        )
 
         cmd, msg = await self.read_msg()
 
@@ -480,8 +487,6 @@ class BasePeer(BaseService):
                 self.base_protocol = P2PProtocol(
                     self.transport,
                     snappy_support=snappy_support,
-                    capabilities=self.capabilities,
-                    listen_port=self.listen_port,
                 )
 
         remote_capabilities = msg['capabilities']

--- a/p2p/tools/paragon/peer.py
+++ b/p2p/tools/paragon/peer.py
@@ -34,6 +34,11 @@ class ParagonContext(BasePeerContext):
     # used to store data specific to a certain peer class.
     paragon: str = "paragon"
 
+    def __init__(self,
+                 client_version_string: str = 'paragon-test',
+                 listen_port: int = 30303) -> None:
+        super().__init__(client_version_string, listen_port)
+
 
 class ParagonPeerFactory(BasePeerFactory):
     peer_class = ParagonPeer

--- a/tests/core/p2p-proto/bcc/helpers.py
+++ b/tests/core/p2p-proto/bcc/helpers.py
@@ -129,6 +129,8 @@ async def _setup_alice_and_bob_factories(alice_chain_db, bob_chain_db):
     alice_context = BeaconContext(
         chain_db=alice_chain_db,
         network_id=1,
+        client_version_string='alice',
+        listen_port=30303,
     )
 
     alice_factory = BCCPeerFactory(
@@ -143,6 +145,8 @@ async def _setup_alice_and_bob_factories(alice_chain_db, bob_chain_db):
     bob_context = BeaconContext(
         chain_db=bob_chain_db,
         network_id=1,
+        client_version_string='bob',
+        listen_port=30304,
     )
 
     bob_factory = BCCPeerFactory(

--- a/tests/core/peer_helpers.py
+++ b/tests/core/peer_helpers.py
@@ -52,6 +52,8 @@ async def _setup_alice_and_bob_factories(
         headerdb=alice_headerdb,
         network_id=1,
         vm_configuration=tuple(),
+        client_version_string='alice',
+        listen_port=30303,
     )
 
     if alice_peer_class is ETHPeer:
@@ -77,6 +79,8 @@ async def _setup_alice_and_bob_factories(
         headerdb=bob_headerdb,
         network_id=1,
         vm_configuration=tuple(),
+        client_version_string='bob',
+        listen_port=30304,
     )
 
     if bob_peer_class is ETHPeer:

--- a/tests/integration/test_lightchain_integration.py
+++ b/tests/integration/test_lightchain_integration.py
@@ -167,6 +167,8 @@ async def test_lightchain_integration(
         headerdb=headerdb,
         network_id=ROPSTEN_NETWORK_ID,
         vm_configuration=ROPSTEN_VM_CONFIGURATION,
+        client_version_string='trinity-test',
+        listen_port=30303,
     )
     peer_pool = LESPeerPool(
         privkey=ecies.generate_privkey(),

--- a/tests/p2p/test_auth.py
+++ b/tests/p2p/test_auth.py
@@ -126,7 +126,11 @@ async def test_handshake():
         transport=initiator_transport,
         context=ParagonContext(),
     )
-    initiator_peer.base_protocol.send_handshake()
+    initiator_peer.base_protocol.send_handshake(
+        client_version_string=initiator_peer.context.client_version_string,
+        capabilities=initiator_peer.capabilities,
+        listen_port=initiator_peer.context.listen_port,
+    )
     responder_transport = Transport(
         remote=responder_remote,
         private_key=responder.privkey,
@@ -141,7 +145,11 @@ async def test_handshake():
         transport=responder_transport,
         context=ParagonContext(),
     )
-    responder_peer.base_protocol.send_handshake()
+    responder_peer.base_protocol.send_handshake(
+        client_version_string=responder_peer.context.client_version_string,
+        capabilities=responder_peer.capabilities,
+        listen_port=responder_peer.context.listen_port,
+    )
 
     # The handshake msgs sent by each peer (above) are going to be fed directly into their remote's
     # reader, and thus the read_msg() calls will return immediately.
@@ -236,7 +244,11 @@ async def test_handshake_eip8():
         transport=initiator_transport,
         context=ParagonContext(),
     )
-    initiator_peer.base_protocol.send_handshake()
+    initiator_peer.base_protocol.send_handshake(
+        client_version_string=initiator_peer.context.client_version_string,
+        capabilities=initiator_peer.capabilities,
+        listen_port=initiator_peer.context.listen_port,
+    )
     responder_transport = Transport(
         remote=responder_remote,
         private_key=responder.privkey,
@@ -251,7 +263,11 @@ async def test_handshake_eip8():
         transport=responder_transport,
         context=ParagonContext(),
     )
-    responder_peer.base_protocol.send_handshake()
+    responder_peer.base_protocol.send_handshake(
+        client_version_string=responder_peer.context.client_version_string,
+        capabilities=responder_peer.capabilities,
+        listen_port=responder_peer.context.listen_port,
+    )
 
     # The handshake msgs sent by each peer (above) are going to be fed directly into their remote's
     # reader, and thus the read_msg() calls will return immediately.

--- a/trinity/protocol/bcc/context.py
+++ b/trinity/protocol/bcc/context.py
@@ -6,6 +6,9 @@ class BeaconContext(BasePeerContext):
 
     def __init__(self,
                  chain_db: BaseAsyncBeaconChainDB,
-                 network_id: int) -> None:
+                 network_id: int,
+                 client_version_string: str,
+                 listen_port: int) -> None:
+        super().__init__(client_version_string, listen_port)
         self.chain_db = chain_db
         self.network_id = network_id

--- a/trinity/protocol/common/context.py
+++ b/trinity/protocol/common/context.py
@@ -14,7 +14,11 @@ class ChainContext(BasePeerContext):
     def __init__(self,
                  headerdb: BaseAsyncHeaderDB,
                  network_id: int,
-                 vm_configuration: Tuple[Tuple[int, Type[BaseVM]], ...]) -> None:
+                 vm_configuration: Tuple[Tuple[int, Type[BaseVM]], ...],
+                 client_version_string: str,
+                 listen_port: int,
+                 ) -> None:
+        super().__init__(client_version_string, listen_port)
         self.headerdb = headerdb
         self.network_id = network_id
         self.vm_configuration = vm_configuration

--- a/trinity/server.py
+++ b/trinity/server.py
@@ -29,6 +29,7 @@ from p2p.service import BaseService
 
 from eth2.beacon.chains.base import BeaconChain
 
+from trinity._utils.version import construct_trinity_client_identifier
 from trinity.chains.base import BaseAsyncChain
 from trinity.constants import DEFAULT_PREFERRED_NODES
 from trinity.db.base import BaseAsyncDB
@@ -193,6 +194,8 @@ class FullServer(BaseServer[ETHPeerPool]):
             headerdb=self.headerdb,
             network_id=self.network_id,
             vm_configuration=self.chain.vm_configuration,
+            client_version_string=construct_trinity_client_identifier(),
+            listen_port=self.port,
         )
         return ETHPeerPool(
             privkey=self.privkey,
@@ -210,6 +213,8 @@ class LightServer(BaseServer[LESPeerPool]):
             headerdb=self.headerdb,
             network_id=self.network_id,
             vm_configuration=self.chain.vm_configuration,
+            client_version_string=construct_trinity_client_identifier(),
+            listen_port=self.port,
         )
         return LESPeerPool(
             privkey=self.privkey,
@@ -273,6 +278,8 @@ class BCCServer(BaseServer[BCCPeerPool]):
         context = BeaconContext(
             chain_db=cast(BaseAsyncBeaconChainDB, self.chaindb),
             network_id=self.network_id,
+            client_version_string=construct_trinity_client_identifier(),
+            listen_port=self.port,
         )
         return BCCPeerPool(
             privkey=self.privkey,

--- a/trinity/sync/full/service.py
+++ b/trinity/sync/full/service.py
@@ -160,7 +160,9 @@ def _test() -> None:
     context = ChainContext(
         headerdb=chaindb,
         network_id=network_id,
-        vm_configuration=ROPSTEN_VM_CONFIGURATION
+        vm_configuration=ROPSTEN_VM_CONFIGURATION,
+        client_version_string='test',
+        listen_port=30303,
     )
     peer_pool = ETHPeerPool(privkey=privkey, context=context)
     if args.enode:

--- a/trinity/sync/full/state.py
+++ b/trinity/sync/full/state.py
@@ -365,6 +365,8 @@ def _test() -> None:
         headerdb=chaindb,
         network_id=network_id,
         vm_configuration=ROPSTEN_VM_CONFIGURATION,
+        client_version_string='test',
+        listen_port=30303,
     )
     peer_pool = ETHPeerPool(
         privkey=ecies.generate_privkey(),


### PR DESCRIPTION
extracted from #684 

### What was wrong?

The `p2p.p2p_proto.P2PProtocol` class diverges from the standard implementation by having some of the handshake parameters get passed in during class instantiation.

### How was it fixed?

Changed these parameters to be provided at the time of sending the handshake.


### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

[//]: # (See: https://trinity-client.readthedocs.io/en/latest/contributing.html#pull-requests)
- [x] Add entry to the [release notes](https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![13-10-12 Summer (22)C750](https://user-images.githubusercontent.com/824194/61736575-a2f6ad00-ad43-11e9-98ce-20f584936d5a.JPG)

