### PR TITLE
Add factory for transports that are directly connected

### DIFF
--- a/newsfragments/830.feature.rst
+++ b/newsfragments/830.feature.rst
@@ -1,0 +1,1 @@
+Add a new ``p2p.tools.factories.TransportPairFactory`` for generating directly connected ``p2p.transport.Transport`` objects.

--- a/p2p/tools/asyncio_streams.py
+++ b/p2p/tools/asyncio_streams.py
@@ -1,38 +1,67 @@
 import asyncio
-from typing import cast, Any, Callable, Dict, Tuple
+from typing import Any, Dict, Tuple
 
 
-class MockTransport:
+class MemoryProtocol(asyncio.Protocol):
     def __init__(self) -> None:
-        self._is_closing = False
+        self._closed_event = asyncio.Event()
 
+    async def _drain_helper(self) -> None:
+        pass
+
+    @property
+    async def _closed(self) -> None:
+        await self._closed_event.wait()
+
+
+class MemoryTransport(asyncio.WriteTransport):
+    """
+    A fake version of the ``asyncio.BaseTransport``:
+
+    https://docs.python.org/3/library/asyncio-protocol.html#asyncio.BaseTransport
+    """
+    def __init__(self,
+                 reader: asyncio.StreamReader,
+                 extra: Dict[str, Any] = None) -> None:
+        self._is_closing = False
+        self._reader = reader
+        super().__init__(extra)
+
+    #
+    # BaseTransport methods
+    #
+    # methods we don't overwrite because they already raise NotImplementedError
+    # and we don't need them
+    # - set_protocol
+    # - get_protocol
     def close(self) -> None:
         self._is_closing = True
 
     def is_closing(self) -> bool:
         return self._is_closing
 
+    #
+    # WriteTransport methods
+    #
+    # methods we don't overwrite because they already raise NotImplementedError
+    # and we don't need them
+    # - set_write_buffer_limits
+    # - get_write_buffer_size
+    def write(self, data):
+        self._reader.feed_data(data)
 
-class MockStreamWriter:
-    def __init__(self, write_target: Callable[..., None]) -> None:
-        self._target = write_target
-        self.transport = MockTransport()
-        self._extra_info: Dict[str, Any] = {}
+    def writelines(self, list_of_data):
+        data = b''.join(list_of_data)
+        self.write(data)
 
-    def write(self, *args: Any, **kwargs: Any) -> None:
-        self._target(*args, **kwargs)
+    def write_eof(self):
+        self._is_closing = True
 
-    def close(self) -> None:
-        self.transport.close()
+    def can_write_eof(self):
+        True
 
-    async def drain(self) -> None:
-        pass
-
-    def set_extra_info(self, name: str, value: Any) -> None:
-        self._extra_info[name] = value
-
-    def get_extra_info(self, name: str) -> Any:
-        return self._extra_info.get(name)
+    def abort(self):
+        self._is_closing = True
 
 
 TConnectedStreams = Tuple[
@@ -41,14 +70,23 @@ TConnectedStreams = Tuple[
 ]
 
 
-def get_directly_connected_streams() -> TConnectedStreams:
-    bob_reader = asyncio.StreamReader()
+def get_directly_connected_streams(alice_extra_info: Dict[str, Any] = None,
+                                   bob_extra_info: Dict[str, Any] = None,
+                                   loop: asyncio.AbstractEventLoop = None) -> TConnectedStreams:
     alice_reader = asyncio.StreamReader()
+    bob_reader = asyncio.StreamReader()
+
+    alice_transport = MemoryTransport(bob_reader, extra=alice_extra_info)
+    bob_transport = MemoryTransport(alice_reader, extra=bob_extra_info)
+
+    alice_protocol = MemoryProtocol()
+    bob_protocol = MemoryProtocol()
+
     # Link the alice's writer to the bob's reader, and the bob's writer to the
     # alice's reader.
-    bob_writer = MockStreamWriter(alice_reader.feed_data)
-    alice_writer = MockStreamWriter(bob_reader.feed_data)
+    bob_writer = asyncio.StreamWriter(bob_transport, bob_protocol, alice_reader, loop=None)
+    alice_writer = asyncio.StreamWriter(alice_transport, alice_protocol, bob_reader, loop=None)
     return (
-        (alice_reader, cast(asyncio.StreamWriter, alice_writer)),
-        (bob_reader, cast(asyncio.StreamWriter, bob_writer)),
+        (alice_reader, alice_writer),
+        (bob_reader, bob_writer),
     )

--- a/p2p/tools/asyncio_streams.py
+++ b/p2p/tools/asyncio_streams.py
@@ -1,5 +1,5 @@
 import asyncio
-from typing import cast, Any, Callable, Tuple
+from typing import cast, Any, Callable, Dict, Tuple
 
 
 class MockTransport:
@@ -17,12 +17,22 @@ class MockStreamWriter:
     def __init__(self, write_target: Callable[..., None]) -> None:
         self._target = write_target
         self.transport = MockTransport()
+        self._extra_info: Dict[str, Any] = {}
 
     def write(self, *args: Any, **kwargs: Any) -> None:
         self._target(*args, **kwargs)
 
     def close(self) -> None:
         self.transport.close()
+
+    async def drain(self) -> None:
+        pass
+
+    def set_extra_info(self, name: str, value: Any) -> None:
+        self._extra_info[name] = value
+
+    def get_extra_info(self, name: str) -> Any:
+        return self._extra_info.get(name)
 
 
 TConnectedStreams = Tuple[

--- a/p2p/tools/asyncio_streams.py
+++ b/p2p/tools/asyncio_streams.py
@@ -1,5 +1,5 @@
 import asyncio
-from typing import Any, Dict, Tuple
+from typing import Any, Dict, Sequence, Tuple
 
 
 class MemoryProtocol(asyncio.Protocol):
@@ -47,20 +47,20 @@ class MemoryTransport(asyncio.WriteTransport):
     # and we don't need them
     # - set_write_buffer_limits
     # - get_write_buffer_size
-    def write(self, data):
+    def write(self, data: bytes) -> None:
         self._reader.feed_data(data)
 
-    def writelines(self, list_of_data):
+    def writelines(self, list_of_data: Sequence[bytes]) -> None:
         data = b''.join(list_of_data)
         self.write(data)
 
-    def write_eof(self):
+    def write_eof(self) -> None:
         self._is_closing = True
 
-    def can_write_eof(self):
-        True
+    def can_write_eof(self) -> bool:
+        return True
 
-    def abort(self):
+    def abort(self) -> None:
         self._is_closing = True
 
 

--- a/p2p/tools/factories.py
+++ b/p2p/tools/factories.py
@@ -133,13 +133,15 @@ async def TransportPairFactory(*,
     f_alice: 'asyncio.Future[TransportAPI]' = asyncio.Future()
     handshake_finished = asyncio.Event()
 
+    bob_peername = (bob_remote.address.ip, bob_remote.address.udp_port, bob_remote.address.tcp_port)
+    alice_peername = (alice_remote.address.ip, alice_remote.address.udp_port, alice_remote.address.tcp_port)  # noqa: E501
+
     (
         (alice_reader, alice_writer),
         (bob_reader, bob_writer),
-    ) = get_directly_connected_streams()
-    bob_writer.set_extra_info(  # type: ignore  # this is actually a MockStreamWriter
-        'peername',
-        (bob_remote.address.ip, bob_remote.address.udp_port, bob_remote.address.tcp_port),
+    ) = get_directly_connected_streams(
+        bob_extra_info={'peername': bob_peername},
+        alice_extra_info={'peername': alice_peername},
     )
 
     async def establish_transport() -> None:

--- a/p2p/tools/factories.py
+++ b/p2p/tools/factories.py
@@ -1,3 +1,4 @@
+import asyncio
 import random
 import socket
 from typing import Any, Tuple
@@ -12,10 +13,15 @@ from eth_utils import (
 from eth_keys import datatypes
 from eth_keys import keys
 
+from p2p import auth
 from p2p import discovery
-from p2p import kademlia
+from p2p.abc import AddressAPI, NodeAPI, TransportAPI
 from p2p.ecies import generate_privkey
+from p2p.kademlia import Node, Address
+from p2p.transport import Transport
+
 from p2p.tools.memory_transport import MemoryTransport
+from p2p.tools.asyncio_streams import get_directly_connected_streams
 
 
 try:
@@ -47,26 +53,26 @@ def PublicKeyFactory() -> keys.PublicKey:
 
 class AddressFactory(factory.Factory):
     class Meta:
-        model = kademlia.Address
+        model = Address
 
     ip = factory.Sequence(lambda n: f'10.{(n // 65536) % 256}.{(n // 256) % 256}.{n % 256}')
     udp_port = factory.LazyFunction(get_open_port)
     tcp_port = 0
 
     @classmethod
-    def localhost(cls, *args: Any, **kwargs: Any) -> kademlia.Address:
+    def localhost(cls, *args: Any, **kwargs: Any) -> AddressAPI:
         return cls(*args, ip='127.0.0.1', **kwargs)
 
 
 class NodeFactory(factory.Factory):
     class Meta:
-        model = kademlia.Node
+        model = Node
 
     pubkey = factory.LazyFunction(PublicKeyFactory)
     address = factory.SubFactory(AddressFactory)
 
     @classmethod
-    def with_nodeid(cls, nodeid: int, *args: Any, **kwargs: Any) -> kademlia.Node:
+    def with_nodeid(cls, nodeid: int, *args: Any, **kwargs: Any) -> NodeAPI:
         node = cls(*args, **kwargs)
         node.id = nodeid
         return node
@@ -95,13 +101,86 @@ class DiscoveryProtocolFactory(factory.Factory):
         return cls(*args, privkey=privkey, **kwargs)
 
 
-def MemoryTransportPairFactory(alice_remote: kademlia.Node = None,
+async def TransportPairFactory(*,
+                               alice_remote: NodeAPI = None,
+                               alice_private_key: keys.PrivateKey = None,
+                               alice_token: CancelToken = None,
+                               bob_remote: NodeAPI = None,
+                               bob_private_key: keys.PrivateKey = None,
+                               bob_token: CancelToken = None,
+                               use_eip8: bool = False,
+                               ) -> Tuple[TransportAPI, TransportAPI]:
+    if alice_private_key is None:
+        alice_private_key = PrivateKeyFactory()
+    if alice_remote is None:
+        alice_remote = NodeFactory(pubkey=alice_private_key.public_key)
+    if alice_token is None:
+        alice_token = CancelTokenFactory(name='alice')
+
+    if bob_private_key is None:
+        bob_private_key = PrivateKeyFactory()
+    if bob_remote is None:
+        bob_remote = NodeFactory(pubkey=bob_private_key.public_key)
+    if bob_token is None:
+        bob_token = CancelTokenFactory(name='bob')
+
+    assert alice_private_key.public_key == alice_remote.pubkey
+    assert bob_private_key.public_key == bob_remote.pubkey
+    assert alice_private_key != bob_private_key
+
+    initiator = auth.HandshakeInitiator(bob_remote, alice_private_key, use_eip8, alice_token)
+
+    f_alice: 'asyncio.Future[TransportAPI]' = asyncio.Future()
+    handshake_finished = asyncio.Event()
+
+    (
+        (alice_reader, alice_writer),
+        (bob_reader, bob_writer),
+    ) = get_directly_connected_streams()
+    bob_writer.set_extra_info(  # type: ignore  # this is actually a MockStreamWriter
+        'peername',
+        (bob_remote.address.ip, bob_remote.address.udp_port, bob_remote.address.tcp_port),
+    )
+
+    async def establish_transport() -> None:
+        aes_secret, mac_secret, egress_mac, ingress_mac = await auth._handshake(
+            initiator, alice_reader, alice_writer, alice_token)
+
+        transport = Transport(
+            remote=alice_remote,
+            private_key=alice_private_key,
+            reader=alice_reader,
+            writer=alice_writer,
+            aes_secret=aes_secret,
+            mac_secret=mac_secret,
+            egress_mac=egress_mac,
+            ingress_mac=ingress_mac,
+        )
+
+        f_alice.set_result(transport)
+        handshake_finished.set()
+
+    asyncio.ensure_future(establish_transport())
+
+    bob_transport = await asyncio.wait_for(Transport.receive_connection(
+        reader=bob_reader,
+        writer=bob_writer,
+        private_key=bob_private_key,
+        token=bob_token,
+    ), timeout=1)
+
+    await asyncio.wait_for(handshake_finished.wait(), timeout=0.1)
+    alice_transport = await asyncio.wait_for(f_alice, timeout=0.1)
+    return alice_transport, bob_transport
+
+
+def MemoryTransportPairFactory(alice_remote: NodeAPI = None,
                                alice_private_key: datatypes.PrivateKey = None,
                                alice_token: CancelToken = None,
-                               bob_remote: kademlia.Node = None,
+                               bob_remote: NodeAPI = None,
                                bob_private_key: datatypes.PrivateKey = None,
                                bob_token: CancelToken = None,
-                               ) -> Tuple[MemoryTransport, MemoryTransport]:
+                               ) -> Tuple[TransportAPI, TransportAPI]:
     if alice_remote is None:
         alice_remote = NodeFactory()
     if alice_private_key is None:

--- a/p2p/tools/memory_transport.py
+++ b/p2p/tools/memory_transport.py
@@ -8,14 +8,14 @@ from eth_keys import datatypes
 
 from cancel_token import CancelToken
 
-from p2p.kademlia import Node
+from p2p.abc import NodeAPI, TransportAPI
 from p2p.tools.asyncio_streams import get_directly_connected_streams
 from p2p.exceptions import PeerConnectionLost
 
 
-class MemoryTransport:
+class MemoryTransport(TransportAPI):
     def __init__(self,
-                 remote: Node,
+                 remote: NodeAPI,
                  private_key: datatypes.PrivateKey,
                  reader: asyncio.StreamReader,
                  writer: asyncio.StreamWriter,
@@ -31,9 +31,9 @@ class MemoryTransport:
 
     @classmethod
     def connected_pair(cls,
-                       alice: Tuple[Node, datatypes.PrivateKey, CancelToken],
-                       bob: Tuple[Node, datatypes.PrivateKey, CancelToken],
-                       ) -> Tuple['MemoryTransport', 'MemoryTransport']:
+                       alice: Tuple[NodeAPI, datatypes.PrivateKey, CancelToken],
+                       bob: Tuple[NodeAPI, datatypes.PrivateKey, CancelToken],
+                       ) -> Tuple[TransportAPI, TransportAPI]:
         (
             (alice_reader, alice_writer),
             (bob_reader, bob_writer),

--- a/p2p/tools/paragon/__init__.py
+++ b/p2p/tools/paragon/__init__.py
@@ -14,7 +14,6 @@ from .peer import (  # noqa: F401
     ParagonPeerPool,
 )
 from .helpers import (  # noqa: F401
-    get_directly_connected_streams,
     get_directly_linked_peers,
     get_directly_linked_peers_without_handshake,
 )

--- a/tests/p2p/test_auth.py
+++ b/tests/p2p/test_auth.py
@@ -19,6 +19,8 @@ from p2p.p2p_proto import Hello
 from p2p.tools.paragon import (
     ParagonPeer,
     ParagonContext,
+)
+from p2p.tools.asyncio_streams import (
     get_directly_connected_streams,
 )
 from p2p.transport import Transport

--- a/tests/p2p/test_transport_factories.py
+++ b/tests/p2p/test_transport_factories.py
@@ -1,0 +1,62 @@
+import asyncio
+import pytest
+
+import rlp
+from rlp import sedes
+
+from p2p.tools.factories import (
+    TransportPairFactory,
+    MemoryTransportPairFactory,
+    CancelTokenFactory,
+)
+from p2p.protocol import Command
+
+
+class CommandForTest(Command):
+    _cmd_id = 0
+    structure = (
+        ('data', sedes.binary),
+    )
+
+
+@pytest.fixture(params=('memory', 'real'))
+async def transport_pair(request):
+    if request.param == 'memory':
+        return MemoryTransportPairFactory()
+    elif request.param == 'real':
+        return await TransportPairFactory()
+    else:
+        raise Exception(f"Unknown: {request.param}")
+
+
+@pytest.mark.asyncio
+async def test_transport_pair_factories(transport_pair):
+    token = CancelTokenFactory()
+    alice_transport, bob_transport = transport_pair
+
+    done = asyncio.Event()
+
+    async def manage_bob(expected):
+        for msg in expected:
+            data = await bob_transport.recv(token)
+            assert msg == data
+        done.set()
+
+    messages = (
+        b'unicorns',
+        b'rainbows',
+        b'',
+        b'\x00' * 256,
+        b'\x00' * 65536,
+    )
+    cmd = CommandForTest(5, False)
+    rlp_messages = tuple(
+        rlp.encode(cmd.cmd_id, sedes.big_endian_int) + rlp.encode((msg,))
+        for msg in messages
+    )
+    asyncio.ensure_future(manage_bob(rlp_messages))
+    for message in messages:
+        header, body = cmd.encode({'data': message})
+        alice_transport.send(header, body)
+
+    await asyncio.wait_for(done.wait(), timeout=0.1)


### PR DESCRIPTION
extracted from #684 

### What was wrong?

We have factory for doing direct in-memory communication using the `TransportAPI` that bypasses all of the encryption components but did not have one for creating real linked transport objects.

### How was it fixed?

Added a new `p2p.tools.factories.TransportPairFactory` which connects two `p2p.transport.Transport` objects together over an in-memory set of `asyncio` streams.  The utilities under `p2p.tools.paragon.helpers` have also been updated to make use of these factories.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

[//]: # (See: https://trinity-client.readthedocs.io/en/latest/contributing.html#pull-requests)
- [x] Add entry to the [release notes](https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![12-05-26 wlh Psych (1)C750](https://user-images.githubusercontent.com/824194/61738623-ef43ec00-ad47-11e9-9383-e51ee4ba2248.JPG)

