### PR TITLE
Remove dead code for logging to terminal during testS

### DIFF
--- a/tests/p2p/conftest.py
+++ b/tests/p2p/conftest.py
@@ -1,33 +1,5 @@
 import pytest
 
-"""
-# Uncomment the following lines to globally change the logging level for all
-# `p2p` namespaced loggers.  Useful for debugging failing tests in async code
-# when the only output you get is a timeout or something else which doens't
-# indicate where things failed.
-import pytest
-
-@pytest.fixture(autouse=True, scope="session")
-def p2p_logger():
-    import logging
-    import sys
-
-    logger = logging.getLogger('p2p')
-
-    handler = logging.StreamHandler(sys.stdout)
-
-    # level = DEBUG2_LEVEL_NUM
-    level = logging.DEBUG
-    level = logging.INFO
-
-    logger.setLevel(level)
-    handler.setLevel(level)
-
-    logger.addHandler(handler)
-
-    return logger
-"""
-
 
 @pytest.fixture(autouse=True)
 def _network_sim(router):


### PR DESCRIPTION
### What was wrong?

Dead code in `tests/p2p/conftest.py`

### How was it fixed?

Removed it.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

[//]: # (See: https://trinity-client.readthedocs.io/en/latest/contributing.html#pull-requests)
- [x] Add entry to the [release notes](https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![16-02-01 MacTravish (15)C1000](https://user-images.githubusercontent.com/824194/61738810-55c90a00-ad48-11e9-82c3-777f2cd9ba1d.JPG)

