### PR TITLE
Fix ordering of p2p.abc module

### DIFF
--- a/p2p/abc.py
+++ b/p2p/abc.py
@@ -60,9 +60,6 @@ class AddressAPI(ABC):
     def __eq__(self, other: Any) -> bool:
         ...
 
-    def __repr__(self) -> str:
-        return 'Address(%s:udp:%s|tcp:%s)' % (self.ip, self.udp_port, self.tcp_port)
-
     @abstractmethod
     def to_endpoint(self) -> List[bytes]:
         ...
@@ -180,37 +177,6 @@ class RequestAPI(ABC, Generic[TRequestPayload]):
     response_type: Type[CommandAPI]
 
 
-class ProtocolAPI(ABC):
-    transport: 'TransportAPI'
-    name: ClassVar[str]
-    version: ClassVar[int]
-
-    cmd_length: int
-
-    cmd_id_offset: int
-
-    commands: Tuple[CommandAPI, ...]
-    cmd_by_type: Dict[Type[CommandAPI], CommandAPI]
-    cmd_by_id: Dict[int, CommandAPI]
-
-    @abstractmethod
-    def __init__(self, transport: 'TransportAPI', cmd_id_offset: int, snappy_support: bool) -> None:
-        ...
-
-    @abstractmethod
-    def send_request(self, request: RequestAPI[PayloadType]) -> None:
-        ...
-
-    @abstractmethod
-    def supports_command(self, cmd_type: Type[CommandAPI]) -> bool:
-        ...
-
-    @classmethod
-    @abstractmethod
-    def as_capability(cls) -> CapabilityType:
-        ...
-
-
 class TransportAPI(ABC):
     remote: NodeAPI
 
@@ -242,4 +208,35 @@ class TransportAPI(ABC):
 
     @abstractmethod
     def close(self) -> None:
+        ...
+
+
+class ProtocolAPI(ABC):
+    transport: TransportAPI
+    name: ClassVar[str]
+    version: ClassVar[int]
+
+    cmd_length: int
+
+    cmd_id_offset: int
+
+    commands: Tuple[CommandAPI, ...]
+    cmd_by_type: Dict[Type[CommandAPI], CommandAPI]
+    cmd_by_id: Dict[int, CommandAPI]
+
+    @abstractmethod
+    def __init__(self, transport: TransportAPI, cmd_id_offset: int, snappy_support: bool) -> None:
+        ...
+
+    @abstractmethod
+    def send_request(self, request: RequestAPI[PayloadType]) -> None:
+        ...
+
+    @abstractmethod
+    def supports_command(self, cmd_type: Type[CommandAPI]) -> bool:
+        ...
+
+    @classmethod
+    @abstractmethod
+    def as_capability(cls) -> CapabilityType:
         ...


### PR DESCRIPTION
### What was wrong?

The `p2p.abc` module had the `ProtocolAPI` before the `TransportAPI` which was opposite.

### How was it fixed?

Swapped the order of these being defined.

Also removed the `__repr__` implementation on `AddressAPI` which should not have been present.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

[//]: # (See: https://trinity-client.readthedocs.io/en/latest/contributing.html#pull-requests)
- [x] Add entry to the [release notes](https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![16-10-14 Honeysuckle (7)C1000](https://user-images.githubusercontent.com/824194/61813233-79508b00-ae02-11e9-9cb5-c163b230b909.JPG)
