### PR TITLE
Implement multiplexer

### DIFF
--- a/newsfragments/835.feature.rst
+++ b/newsfragments/835.feature.rst
@@ -1,1 +1,1 @@
-Add ``p2p.multiplexer.Multiplexer`` for multiplexing the individual protocol messages for a devp2p connection.
+Add ``p2p.multiplexer.Multiplexer`` for combining the commands from different devp2p sub-protocols into a single network write stream, and split the incoming network stream into individually retrievable sub-protocol commands.

--- a/newsfragments/835.feature.rst
+++ b/newsfragments/835.feature.rst
@@ -1,0 +1,1 @@
+Add ``p2p.multiplexer.Multiplexer`` for multiplexing the individual protocol messages for a devp2p connection.

--- a/p2p/abc.py
+++ b/p2p/abc.py
@@ -290,11 +290,7 @@ class MultiplexerAPI(ABC):
     # Protocol API
     #
     @abstractmethod
-    def has_protocol(self, protocol_identifier: Union[str, ProtocolAPI, Type[ProtocolAPI]]) -> bool:
-        ...
-
-    @abstractmethod
-    def get_protocol_by_name(self, name: str) -> ProtocolAPI:
+    def has_protocol(self, protocol_identifier: Union[ProtocolAPI, Type[ProtocolAPI]]) -> bool:
         ...
 
     @abstractmethod

--- a/p2p/abc.py
+++ b/p2p/abc.py
@@ -315,7 +315,7 @@ class MultiplexerAPI(ABC):
     @abstractmethod
     def stream_protocol_messages(self,
                                  protocol_identifier: Union[ProtocolAPI, Type[ProtocolAPI]],
-                                 ) -> AsyncIterable[Tuple[CommandAPI, PayloadType]]:
+                                 ) -> AsyncIterable[Tuple[CommandAPI, Payload]]:
         ...
 
     #

--- a/p2p/exceptions.py
+++ b/p2p/exceptions.py
@@ -52,6 +52,14 @@ class MalformedMessage(BaseP2PError):
     pass
 
 
+class UnknownProtocol(BaseP2PError):
+    """
+    Raised in cases where a given protocol is not present such as not part of a
+    Multiplexer connection.
+    """
+    pass
+
+
 class UnknownProtocolCommand(BaseP2PError):
     """
     Raised when the received protocal command isn't known.

--- a/p2p/multiplexer.py
+++ b/p2p/multiplexer.py
@@ -1,0 +1,315 @@
+import asyncio
+import collections
+import logging
+from typing import (
+    AsyncIterable,
+    AsyncIterator,
+    cast,
+    Dict,
+    DefaultDict,
+    Sequence,
+    Tuple,
+    Type,
+    Union,
+)
+
+from async_generator import asynccontextmanager
+
+from cancel_token import CancelToken, OperationCancelled
+
+from eth_utils.toolz import cons
+
+from eth.tools.logging import ExtendedDebugLogger
+
+from p2p._utils import (
+    get_devp2p_cmd_id,
+)
+from p2p.abc import (
+    CommandAPI,
+    MultiplexerAPI,
+    NodeAPI,
+    ProtocolAPI,
+    TransportAPI,
+    TProtocol,
+)
+from p2p.cancellable import CancellableMixin
+from p2p.exceptions import (
+    UnknownProtocol,
+    UnknownProtocolCommand,
+)
+from p2p.p2p_proto import P2PProtocol
+from p2p.protocol import (
+    PayloadType,
+    Protocol,
+)
+from p2p.resource_lock import ResourceLock
+
+
+async def stream_transport_messages(transport: TransportAPI,
+                                    base_protocol: P2PProtocol,
+                                    *protocols: ProtocolAPI,
+                                    token: CancelToken = None,
+                                    ) -> AsyncIterator[Tuple[ProtocolAPI, CommandAPI, PayloadType]]:
+    """
+    Streams 3-tuples of (Protocol, Command, Payload) over the provided `Transport`
+    """
+    # A cache for looking up the proper protocol instance for a given command
+    # id.
+    cmd_id_cache: Dict[int, ProtocolAPI] = {}
+
+    while not transport.is_closing:
+        raw_msg = await transport.recv(token)
+
+        cmd_id = get_devp2p_cmd_id(raw_msg)
+
+        if cmd_id not in cmd_id_cache:
+            if cmd_id < base_protocol.cmd_length:
+                cmd_id_cache[cmd_id] = base_protocol
+            else:
+                for protocol in protocols:
+                    if cmd_id < protocol.cmd_id_offset + protocol.cmd_length:
+                        cmd_id_cache[cmd_id] = protocol
+                        break
+                else:
+                    protocol_infos = '  '.join(tuple(
+                        f"{proto.name}@{proto.version}[offset={proto.cmd_id_offset},cmd_length={proto.cmd_length}]"  # noqa: E501
+                        for proto in cons(base_protocol, protocols)
+                    ))
+                    raise UnknownProtocolCommand(
+                        f"No protocol found for cmd_id {cmd_id}: Available "
+                        f"protocol/offsets are: {protocol_infos}"
+                    )
+
+        msg_proto = cmd_id_cache[cmd_id]
+        cmd = msg_proto.cmd_by_id[cmd_id]
+        msg = cmd.decode(raw_msg)
+
+        yield msg_proto, cmd, msg
+
+        # yield to the event loop for a moment to allow `transport.is_closing`
+        # a chance to update.
+        await asyncio.sleep(0)
+
+
+class Multiplexer(CancellableMixin, MultiplexerAPI):
+    logger = cast(ExtendedDebugLogger, logging.getLogger('p2p.multiplexer.Multiplexer'))
+
+    _multiplex_token: CancelToken
+
+    _transport: TransportAPI
+    _msg_counts: DefaultDict[Type[CommandAPI], int]
+
+    _protocol_locks: ResourceLock
+    _protocol_queues: Dict[Type[ProtocolAPI], 'asyncio.Queue[Tuple[CommandAPI, PayloadType]]']
+
+    def __init__(self,
+                 transport: TransportAPI,
+                 base_protocol: P2PProtocol,
+                 protocols: Sequence[ProtocolAPI],
+                 token: CancelToken = None,
+                 max_queue_size: int = 4096) -> None:
+        if token is None:
+            loop = None
+        else:
+            loop = token.loop
+        base_token = CancelToken(f'multiplexer[{transport.remote}]', loop=loop)
+
+        if token is None:
+            self.cancel_token = base_token
+        else:
+            self.cancel_token = base_token.chain(token)
+
+        self._transport = transport
+        # the base `p2p` protocol instance.
+        self._base_protocol = base_protocol
+
+        # the sub-protocol instances
+        self._protocols = protocols
+
+        # Lock to ensure that multiple call sites cannot concurrently stream
+        # messages.
+        self._multiplex_lock = asyncio.Lock()
+
+        # Lock management on a per-protocol basis to ensure we only have one
+        # stream consumer for each protocol.
+        self._protocol_locks = ResourceLock()
+
+        # Each protocol gets a queue where messages for the individual protocol
+        # are placed when streamed from the transport
+        self._protocol_queues = {
+            type(protocol): asyncio.Queue(max_queue_size)
+            for protocol
+            in self.get_protocols()
+        }
+
+        self._msg_counts = collections.defaultdict(int)
+
+    def __str__(self) -> str:
+        protocol_infos = ','.join(tuple(
+            f"{proto.name}:{proto.version}"
+            for proto
+            in self.get_protocols()
+        ))
+        return f"Multiplexer[{protocol_infos}]"
+
+    def __repr__(self) -> str:
+        return f"<{self}>"
+
+    #
+    # Transport API
+    #
+    def get_transport(self) -> TransportAPI:
+        return self._transport
+
+    #
+    # Message Counts
+    #
+    def get_total_msg_count(self) -> int:
+        return sum(self._msg_counts.values())
+
+    #
+    # Proxy Transport methods
+    #
+    @property
+    def remote(self) -> NodeAPI:
+        return self._transport.remote
+
+    @property
+    def is_closing(self) -> bool:
+        return self._transport.is_closing
+
+    def close(self) -> None:
+        # TODO: maybe graceflly close streams?
+        self._transport.close()
+        self.cancel_token.trigger()
+
+    #
+    # Protocol API
+    #
+    def has_protocol(self, protocol_identifier: Union[str, ProtocolAPI, Type[ProtocolAPI]]) -> bool:
+        try:
+            if isinstance(protocol_identifier, str):
+                self.get_protocol_by_name(protocol_identifier)
+                return True
+            elif isinstance(protocol_identifier, Protocol):
+                self.get_protocol_by_type(type(protocol_identifier))
+                return True
+            elif isinstance(protocol_identifier, type):
+                self.get_protocol_by_type(protocol_identifier)
+                return True
+            else:
+                raise TypeError(
+                    f"Unsupported protocol value: {protocol_identifier} of type "
+                    f"{type(protocol_identifier)}"
+                )
+        except UnknownProtocol:
+            return False
+
+    def get_protocol_by_name(self, name: str) -> ProtocolAPI:
+        if name == self._base_protocol.name:
+            return self._base_protocol
+
+        for protocol in self._protocols:
+            if protocol.name == name:
+                return protocol
+        raise UnknownProtocol(f"Protocol with name '{name}' not found")
+
+    def get_protocol_by_type(self, protocol_class: Type[TProtocol]) -> TProtocol:
+        if protocol_class is P2PProtocol:
+            return cast(TProtocol, self._base_protocol)
+
+        for protocol in self._protocols:
+            if type(protocol) is protocol_class:
+                return cast(TProtocol, protocol)
+        raise UnknownProtocol(f"No protocol found with type {protocol_class}")
+
+    def get_base_protocol(self) -> P2PProtocol:
+        return self._base_protocol
+
+    def get_protocols(self) -> Tuple[ProtocolAPI, ...]:
+        return tuple(cons(self._base_protocol, self._protocols))
+
+    #
+    # Streaming API
+    #
+    async def stream_protocol_messages(self,
+                                       protocol_identifier: Union[ProtocolAPI, Type[ProtocolAPI]],
+                                       ) -> AsyncIterable[Tuple[CommandAPI, PayloadType]]:
+        """
+        Stream the messages for the specified protocol.
+        """
+        if isinstance(protocol_identifier, Protocol):
+            protocol_class = type(protocol_identifier)
+        elif isinstance(protocol_identifier, type) and issubclass(protocol_identifier, Protocol):
+            protocol_class = protocol_identifier
+        else:
+            raise TypeError("Unknown protocol identifier: {protocol}")
+
+        if not self.has_protocol(protocol_class):
+            raise Exception(f"TODO: Unknown protocol '{protocol_class}'")
+
+        if self._protocol_locks.is_locked(protocol_class):
+            raise Exception(f"Streaming lock for {protocol_class} is not free.")
+
+        async with self._protocol_locks.lock(protocol_class):
+            msg_queue = self._protocol_queues[protocol_class]
+
+            while not self.is_closing:
+                yield await self.wait(msg_queue.get(), token=self._multiplex_token)
+
+    #
+    # Message reading and streaming API
+    #
+    @asynccontextmanager
+    async def multiplex(self) -> AsyncIterator[None]:
+        """
+        API for running the background task that feeds individual protocol
+        queues that allows each individual protocol to stream only its own
+        messages.
+        """
+        # We generate a new token for each time the multiplexer is used to
+        # multiplex so that we can reliably cancel it without requiring the
+        # master token for the multiplexer to be cancelled.
+        async with self._multiplex_lock:
+            multiplex_token = CancelToken(
+                'multiplex',
+                loop=self.cancel_token.loop,
+            ).chain(self.cancel_token)
+            self._multiplex_token = multiplex_token
+            asyncio.ensure_future(self._do_multiplexing(multiplex_token))
+            try:
+                yield
+            finally:
+                multiplex_token.trigger()
+                del self._multiplex_token
+
+    async def _do_multiplexing(self, token: CancelToken) -> None:
+        """
+        Background task that reads messages from the transport and feeds them
+        into individual queues for each of the protocols.
+        """
+        msg_stream = self.wait_iter(stream_transport_messages(
+            self._transport,
+            self._base_protocol,
+            *self._protocols,
+            token=token,
+        ), token=token)
+        try:
+            async for protocol, cmd, msg in msg_stream:
+                # track total number of messages received for each command type.
+                self._msg_counts[type(cmd)] += 1
+
+                queue = self._protocol_queues[type(protocol)]
+                try:
+                    await self.wait(queue.put((cmd, msg)), token=token)
+                except asyncio.QueueFull:
+                    self.logger.error(
+                        (
+                            "Multiplexing queue for protocol '%s' full. "
+                            "discarding message: %s"
+                        ),
+                        protocol,
+                        cmd,
+                    )
+        except OperationCancelled:
+            pass

--- a/tests/p2p/test_multiplexer.py
+++ b/tests/p2p/test_multiplexer.py
@@ -68,9 +68,9 @@ async def test_multiplexer_properties():
     )
     transport = multiplexer.get_transport()
 
-    base_protocol = multiplexer.get_protocol_by_name('p2p')
-    second_protocol = multiplexer.get_protocol_by_name('second')
-    third_protocol = multiplexer.get_protocol_by_name('third')
+    base_protocol = multiplexer.get_protocol_by_type(P2PProtocol)
+    second_protocol = multiplexer.get_protocol_by_type(SecondProtocol)
+    third_protocol = multiplexer.get_protocol_by_type(ThirdProtocol)
 
     assert multiplexer.get_base_protocol() is base_protocol
     assert multiplexer.get_protocols() == (base_protocol, second_protocol, third_protocol)
@@ -79,24 +79,15 @@ async def test_multiplexer_properties():
     assert multiplexer.get_protocol_by_type(SecondProtocol) is second_protocol
     assert multiplexer.get_protocol_by_type(ThirdProtocol) is third_protocol
 
-    assert multiplexer.get_protocol_by_name('p2p') is base_protocol
-    assert multiplexer.get_protocol_by_name('second') is second_protocol
-    assert multiplexer.get_protocol_by_name('third') is third_protocol
-
-    assert multiplexer.has_protocol('p2p') is True
-    assert multiplexer.has_protocol('second') is True
-    assert multiplexer.has_protocol('third') is True
-    assert multiplexer.has_protocol('unknown') is False
+    assert multiplexer.has_protocol(P2PProtocol) is True
+    assert multiplexer.has_protocol(SecondProtocol) is True
+    assert multiplexer.has_protocol(ThirdProtocol) is True
+    assert multiplexer.has_protocol(UnknownProtocol) is False
 
     assert multiplexer.has_protocol(base_protocol) is True
     assert multiplexer.has_protocol(second_protocol) is True
     assert multiplexer.has_protocol(third_protocol) is True
     assert multiplexer.has_protocol(UnknownProtocol(transport, 16, False)) is False
-
-    assert multiplexer.has_protocol(P2PProtocol) is True
-    assert multiplexer.has_protocol(SecondProtocol) is True
-    assert multiplexer.has_protocol(ThirdProtocol) is True
-    assert multiplexer.has_protocol(UnknownProtocol) is False
 
     assert multiplexer.remote is transport.remote
 
@@ -109,8 +100,8 @@ async def test_multiplexer_only_p2p_protocol():
             alice_stream = alice_multiplexer.stream_protocol_messages(P2PProtocol)
             bob_stream = bob_multiplexer.stream_protocol_messages(P2PProtocol)
 
-            alice_p2p_protocol = alice_multiplexer.get_protocol_by_name('p2p')
-            bob_p2p_protocol = bob_multiplexer.get_protocol_by_name('p2p')
+            alice_p2p_protocol = alice_multiplexer.get_protocol_by_type(P2PProtocol)
+            bob_p2p_protocol = bob_multiplexer.get_protocol_by_type(P2PProtocol)
 
             alice_p2p_protocol.send_ping()
             cmd, _ = await asyncio.wait_for(bob_stream.asend(None), timeout=0.1)
@@ -133,11 +124,11 @@ async def test_multiplexer_p2p_and_paragon_protocol():
             alice_second_stream = alice_multiplexer.stream_protocol_messages(SecondProtocol)
             bob_second_stream = bob_multiplexer.stream_protocol_messages(SecondProtocol)
 
-            alice_p2p_protocol = alice_multiplexer.get_protocol_by_name('p2p')
-            alice_second_protocol = alice_multiplexer.get_protocol_by_name('second')
+            alice_p2p_protocol = alice_multiplexer.get_protocol_by_type(P2PProtocol)
+            alice_second_protocol = alice_multiplexer.get_protocol_by_type(SecondProtocol)
 
-            bob_p2p_protocol = bob_multiplexer.get_protocol_by_name('p2p')
-            bob_second_protocol = bob_multiplexer.get_protocol_by_name('second')
+            bob_p2p_protocol = bob_multiplexer.get_protocol_by_type(P2PProtocol)
+            bob_second_protocol = bob_multiplexer.get_protocol_by_type(SecondProtocol)
 
             alice_second_protocol.send_cmd(CommandA)
             alice_p2p_protocol.send_ping()
@@ -177,13 +168,13 @@ async def test_multiplexer_p2p_and_two_more_protocols():
             alice_third_stream = alice_multiplexer.stream_protocol_messages(ThirdProtocol)
             bob_third_stream = bob_multiplexer.stream_protocol_messages(ThirdProtocol)
 
-            alice_p2p_protocol = alice_multiplexer.get_protocol_by_name('p2p')
-            alice_second_protocol = alice_multiplexer.get_protocol_by_name('second')
-            alice_third_protocol = alice_multiplexer.get_protocol_by_name('third')
+            alice_p2p_protocol = alice_multiplexer.get_protocol_by_type(P2PProtocol)
+            alice_second_protocol = alice_multiplexer.get_protocol_by_type(SecondProtocol)
+            alice_third_protocol = alice_multiplexer.get_protocol_by_type(ThirdProtocol)
 
-            bob_p2p_protocol = bob_multiplexer.get_protocol_by_name('p2p')
-            bob_second_protocol = bob_multiplexer.get_protocol_by_name('second')
-            bob_third_protocol = bob_multiplexer.get_protocol_by_name('third')
+            bob_p2p_protocol = bob_multiplexer.get_protocol_by_type(P2PProtocol)
+            bob_second_protocol = bob_multiplexer.get_protocol_by_type(SecondProtocol)
+            bob_third_protocol = bob_multiplexer.get_protocol_by_type(ThirdProtocol)
 
             alice_second_protocol.send_cmd(CommandA)
             alice_third_protocol.send_cmd(CommandC)

--- a/tests/p2p/test_multiplexer.py
+++ b/tests/p2p/test_multiplexer.py
@@ -1,0 +1,220 @@
+import asyncio
+
+import pytest
+
+from p2p.protocol import Command, Protocol
+from p2p.p2p_proto import Ping, Pong, P2PProtocol
+
+from p2p.tools.factories import MultiplexerPairFactory
+
+
+class CommandA(Command):
+    _cmd_id = 0
+    structure = ()
+
+
+class CommandB(Command):
+    _cmd_id = 1
+    structure = ()
+
+
+class SecondProtocol(Protocol):
+    name = 'second'
+    version = 1
+    _commands = (CommandA, CommandB)
+    cmd_length = 2
+
+    def send_cmd(self, cmd_type) -> None:
+        header, body = self.cmd_by_type[cmd_type].encode({})
+        self.transport.send(header, body)
+
+
+class CommandC(Command):
+    _cmd_id = 0
+    structure = ()
+
+
+class CommandD(Command):
+    _cmd_id = 1
+    structure = ()
+
+
+class ThirdProtocol(Protocol):
+    name = 'third'
+    version = 1
+    _commands = (CommandC, CommandD)
+    cmd_length = 2
+
+    def send_cmd(self, cmd_type) -> None:
+        header, body = self.cmd_by_type[cmd_type].encode({})
+        self.transport.send(header, body)
+
+
+class UnknownProtocol(Protocol):
+    name = 'unknown'
+    version = 1
+    _commands = (CommandC, CommandD)
+    cmd_length = 2
+
+    def send_cmd(self, cmd_type) -> None:
+        header, body = self.cmd_by_type[cmd_type].encode({})
+        self.transport.send(header, body)
+
+
+@pytest.mark.asyncio
+async def test_multiplexer_properties():
+    multiplexer, _ = MultiplexerPairFactory(
+        protocol_types=(SecondProtocol, ThirdProtocol),
+    )
+    transport = multiplexer.get_transport()
+
+    base_protocol = multiplexer.get_protocol_by_name('p2p')
+    second_protocol = multiplexer.get_protocol_by_name('second')
+    third_protocol = multiplexer.get_protocol_by_name('third')
+
+    assert multiplexer.get_base_protocol() is base_protocol
+    assert multiplexer.get_protocols() == (base_protocol, second_protocol, third_protocol)
+
+    assert multiplexer.get_protocol_by_type(P2PProtocol) is base_protocol
+    assert multiplexer.get_protocol_by_type(SecondProtocol) is second_protocol
+    assert multiplexer.get_protocol_by_type(ThirdProtocol) is third_protocol
+
+    assert multiplexer.get_protocol_by_name('p2p') is base_protocol
+    assert multiplexer.get_protocol_by_name('second') is second_protocol
+    assert multiplexer.get_protocol_by_name('third') is third_protocol
+
+    assert multiplexer.has_protocol('p2p') is True
+    assert multiplexer.has_protocol('second') is True
+    assert multiplexer.has_protocol('third') is True
+    assert multiplexer.has_protocol('unknown') is False
+
+    assert multiplexer.has_protocol(base_protocol) is True
+    assert multiplexer.has_protocol(second_protocol) is True
+    assert multiplexer.has_protocol(third_protocol) is True
+    assert multiplexer.has_protocol(UnknownProtocol(transport, 16, False)) is False
+
+    assert multiplexer.has_protocol(P2PProtocol) is True
+    assert multiplexer.has_protocol(SecondProtocol) is True
+    assert multiplexer.has_protocol(ThirdProtocol) is True
+    assert multiplexer.has_protocol(UnknownProtocol) is False
+
+    assert multiplexer.remote is transport.remote
+
+
+@pytest.mark.asyncio
+async def test_multiplexer_only_p2p_protocol():
+    alice_multiplexer, bob_multiplexer = MultiplexerPairFactory()
+    async with alice_multiplexer.multiplex():
+        async with bob_multiplexer.multiplex():
+            alice_stream = alice_multiplexer.stream_protocol_messages(P2PProtocol)
+            bob_stream = bob_multiplexer.stream_protocol_messages(P2PProtocol)
+
+            alice_p2p_protocol = alice_multiplexer.get_protocol_by_name('p2p')
+            bob_p2p_protocol = bob_multiplexer.get_protocol_by_name('p2p')
+
+            alice_p2p_protocol.send_ping()
+            cmd, _ = await asyncio.wait_for(bob_stream.asend(None), timeout=0.1)
+            assert isinstance(cmd, Ping)
+
+            bob_p2p_protocol.send_pong()
+            cmd, _ = await asyncio.wait_for(alice_stream.asend(None), timeout=0.1)
+
+
+@pytest.mark.asyncio
+async def test_multiplexer_p2p_and_paragon_protocol():
+    alice_multiplexer, bob_multiplexer = MultiplexerPairFactory(
+        protocol_types=(SecondProtocol,),
+    )
+
+    async with alice_multiplexer.multiplex():
+        async with bob_multiplexer.multiplex():
+            alice_p2p_stream = alice_multiplexer.stream_protocol_messages(P2PProtocol)
+            bob_p2p_stream = bob_multiplexer.stream_protocol_messages(P2PProtocol)
+            alice_second_stream = alice_multiplexer.stream_protocol_messages(SecondProtocol)
+            bob_second_stream = bob_multiplexer.stream_protocol_messages(SecondProtocol)
+
+            alice_p2p_protocol = alice_multiplexer.get_protocol_by_name('p2p')
+            alice_second_protocol = alice_multiplexer.get_protocol_by_name('second')
+
+            bob_p2p_protocol = bob_multiplexer.get_protocol_by_name('p2p')
+            bob_second_protocol = bob_multiplexer.get_protocol_by_name('second')
+
+            alice_second_protocol.send_cmd(CommandA)
+            alice_p2p_protocol.send_ping()
+            alice_second_protocol.send_cmd(CommandB)
+            cmd, _ = await asyncio.wait_for(bob_p2p_stream.asend(None), timeout=0.1)
+            assert isinstance(cmd, Ping)
+
+            bob_second_protocol.send_cmd(CommandA)
+            bob_p2p_protocol.send_pong()
+            bob_second_protocol.send_cmd(CommandB)
+            cmd, _ = await asyncio.wait_for(alice_p2p_stream.asend(None), timeout=0.1)
+            assert isinstance(cmd, Pong)
+
+            cmd_1, _ = await asyncio.wait_for(bob_second_stream.asend(None), timeout=0.1)  # noqa: E501
+            cmd_2, _ = await asyncio.wait_for(bob_second_stream.asend(None), timeout=0.1)  # noqa: E501
+            cmd_3, _ = await asyncio.wait_for(alice_second_stream.asend(None), timeout=0.1)  # noqa: E501
+            cmd_4, _ = await asyncio.wait_for(alice_second_stream.asend(None), timeout=0.1)  # noqa: E501
+
+            assert isinstance(cmd_1, CommandA)
+            assert isinstance(cmd_2, CommandB)
+            assert isinstance(cmd_3, CommandA)
+            assert isinstance(cmd_4, CommandB)
+
+
+@pytest.mark.asyncio
+async def test_multiplexer_p2p_and_two_more_protocols():
+    alice_multiplexer, bob_multiplexer = MultiplexerPairFactory(
+        protocol_types=(SecondProtocol, ThirdProtocol),
+    )
+
+    async with alice_multiplexer.multiplex():
+        async with bob_multiplexer.multiplex():
+            alice_p2p_stream = alice_multiplexer.stream_protocol_messages(P2PProtocol)
+            bob_p2p_stream = bob_multiplexer.stream_protocol_messages(P2PProtocol)
+            alice_second_stream = alice_multiplexer.stream_protocol_messages(SecondProtocol)
+            bob_second_stream = bob_multiplexer.stream_protocol_messages(SecondProtocol)
+            alice_third_stream = alice_multiplexer.stream_protocol_messages(ThirdProtocol)
+            bob_third_stream = bob_multiplexer.stream_protocol_messages(ThirdProtocol)
+
+            alice_p2p_protocol = alice_multiplexer.get_protocol_by_name('p2p')
+            alice_second_protocol = alice_multiplexer.get_protocol_by_name('second')
+            alice_third_protocol = alice_multiplexer.get_protocol_by_name('third')
+
+            bob_p2p_protocol = bob_multiplexer.get_protocol_by_name('p2p')
+            bob_second_protocol = bob_multiplexer.get_protocol_by_name('second')
+            bob_third_protocol = bob_multiplexer.get_protocol_by_name('third')
+
+            alice_second_protocol.send_cmd(CommandA)
+            alice_third_protocol.send_cmd(CommandC)
+            alice_p2p_protocol.send_ping()
+            alice_second_protocol.send_cmd(CommandB)
+            alice_third_protocol.send_cmd(CommandD)
+            cmd, _ = await asyncio.wait_for(bob_p2p_stream.asend(None), timeout=0.1)
+            assert isinstance(cmd, Ping)
+
+            bob_second_protocol.send_cmd(CommandA)
+            bob_third_protocol.send_cmd(CommandC)
+            bob_p2p_protocol.send_pong()
+            bob_second_protocol.send_cmd(CommandB)
+            bob_third_protocol.send_cmd(CommandD)
+            cmd, _ = await asyncio.wait_for(alice_p2p_stream.asend(None), timeout=0.1)
+            assert isinstance(cmd, Pong)
+
+            cmd_1, _ = await asyncio.wait_for(bob_third_stream.asend(None), timeout=0.1)  # noqa: E501
+            cmd_2, _ = await asyncio.wait_for(bob_third_stream.asend(None), timeout=0.1)  # noqa: E501
+            cmd_3, _ = await asyncio.wait_for(bob_second_stream.asend(None), timeout=0.1)  # noqa: E501
+            cmd_4, _ = await asyncio.wait_for(bob_second_stream.asend(None), timeout=0.1)  # noqa: E501
+            cmd_5, _ = await asyncio.wait_for(alice_third_stream.asend(None), timeout=0.1)  # noqa: E501
+            cmd_6, _ = await asyncio.wait_for(alice_third_stream.asend(None), timeout=0.1)  # noqa: E501
+            cmd_7, _ = await asyncio.wait_for(alice_second_stream.asend(None), timeout=0.1)  # noqa: E501
+            cmd_8, _ = await asyncio.wait_for(alice_second_stream.asend(None), timeout=0.1)  # noqa: E501
+
+            assert isinstance(cmd_1, CommandC)
+            assert isinstance(cmd_2, CommandD)
+            assert isinstance(cmd_3, CommandA)
+            assert isinstance(cmd_4, CommandB)
+            assert isinstance(cmd_5, CommandC)
+            assert isinstance(cmd_6, CommandD)
+            assert isinstance(cmd_7, CommandA)
+            assert isinstance(cmd_8, CommandB)


### PR DESCRIPTION
Extracted from #684

depends on #836

depends on #838 

should be merged after #834 

### What was wrong?

In order to facilitate speaking multiple devp2p protocols, we need mechanisms for dividing the messages up by their individual protocol streams.  

### How was it fixed?

This is part of #684  It brings in a single component, the `p2p.multiplexer.Multiplexer`.  This class is intentionally **not** a service.  This is because it must be used outside of the service context during the handshake process to facilitate individual protocol handshakes streaming only the messages pertinent to that protocol.

This PR only introduces the class and the relevant tests for it in order to keep the PR adequately small.

You can see how this API is used in this commit: https://github.com/ethereum/trinity/pull/847/commits/c6fb7d85f4944b5c6a90362a7e23fa6d6e128281

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

[//]: # (See: https://trinity-client.readthedocs.io/en/latest/contributing.html#pull-requests)
- [x] Add entry to the [release notes](https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![17-05-17 Ramone Sheared (16)C1000](https://user-images.githubusercontent.com/824194/61816954-a5700a00-ae0a-11e9-845b-80cadc5589ac.JPG)

