### PR TITLE
Add get_cmd_id_offsets helper function

### DIFF
--- a/newsfragments/836.feature.rst
+++ b/newsfragments/836.feature.rst
@@ -1,0 +1,1 @@
+Adds ``p2p.protocol.get_cmd_offsets`` helper function for computing the command id offsets for devp2p protocols

--- a/p2p/constants.py
+++ b/p2p/constants.py
@@ -166,3 +166,7 @@ KADEMLIA_ID_SIZE = 256
 
 # Maximum node `id` for a kademlia node
 KADEMLIA_MAX_NODE_ID = (2 ** KADEMLIA_ID_SIZE) - 1
+
+
+# Reserved command length for the base `p2p` protocol
+P2P_PROTOCOL_COMMAND_LENGTH = 16

--- a/p2p/constants.py
+++ b/p2p/constants.py
@@ -169,4 +169,5 @@ KADEMLIA_MAX_NODE_ID = (2 ** KADEMLIA_ID_SIZE) - 1
 
 
 # Reserved command length for the base `p2p` protocol
+# - https://github.com/ethereum/devp2p/blob/master/rlpx.md#message-id-based-multiplexing
 P2P_PROTOCOL_COMMAND_LENGTH = 16

--- a/p2p/p2p_proto.py
+++ b/p2p/p2p_proto.py
@@ -10,6 +10,7 @@ import rlp
 from rlp import sedes
 
 from p2p.abc import TransportAPI
+from p2p.constants import P2P_PROTOCOL_COMMAND_LENGTH
 from p2p.disconnect import DisconnectReason as _DisconnectReason
 from p2p.exceptions import MalformedMessage
 from p2p.typing import CapabilitiesType, PayloadType
@@ -73,7 +74,7 @@ class P2PProtocol(Protocol):
     name = 'p2p'
     version = 5
     _commands = (Hello, Ping, Pong, Disconnect)
-    cmd_length = 16
+    cmd_length = P2P_PROTOCOL_COMMAND_LENGTH
 
     def __init__(self,
                  transport: TransportAPI,

--- a/p2p/protocol.py
+++ b/p2p/protocol.py
@@ -229,9 +229,15 @@ def _pad_to_16_byte_boundary(data: bytes) -> bytes:
     return data
 
 
-def get_cmd_offsets(protocol_types: Tuple[Type[ProtocolAPI], ...]) -> Tuple[int, ...]:
+def get_cmd_offsets(protocol_types: Sequence[Type[ProtocolAPI]]) -> Tuple[int, ...]:
+    """
+    Computes the `command_id_offsets` for each protocol.  The first offset is
+    always P2P_PROTOCOL_COMMAND_LENGTH since the first protocol always begins
+    after the base `p2p` protocol.  Each subsequent protocol is the accumulated
+    sum of all of the protocol offsets that came before it.
+    """
     return tuple(accumulate(
         lambda prev_offset, protocol_class: prev_offset + protocol_class.cmd_length,
         protocol_types,
         P2P_PROTOCOL_COMMAND_LENGTH,
-    ))[:-1]
+    ))[:-1]  # the `[:-1]` is to discard the last accumulated offset which is not needed

--- a/tests/p2p/test_get_cmd_id_offsets.py
+++ b/tests/p2p/test_get_cmd_id_offsets.py
@@ -1,0 +1,36 @@
+import pytest
+
+from p2p.constants import P2P_PROTOCOL_COMMAND_LENGTH
+from p2p.protocol import Protocol, get_cmd_offsets
+
+
+class With2(Protocol):
+    cmd_length = 2
+
+
+class With5(Protocol):
+    cmd_length = 5
+
+
+class With7(Protocol):
+    cmd_length = 7
+
+
+BASE_OFFSET = P2P_PROTOCOL_COMMAND_LENGTH
+
+
+@pytest.mark.parametrize(
+    'protocols,offsets',
+    (
+        ((), ()),
+        ((With2,), (BASE_OFFSET,)),
+        ((With5,), (BASE_OFFSET,)),
+        ((With7,), (BASE_OFFSET,)),
+        ((With2, With5), (BASE_OFFSET, BASE_OFFSET + 2)),
+        ((With5, With2), (BASE_OFFSET, BASE_OFFSET + 5)),
+        ((With7, With2, With5), (BASE_OFFSET, BASE_OFFSET + 7, BASE_OFFSET + 7 + 2)),
+    ),
+)
+def test_get_cmd_offsets(protocols, offsets):
+    actual = get_cmd_offsets(protocols)
+    assert actual == offsets


### PR DESCRIPTION
extracted from #684 

### What was wrong?

For a given set of protocols we need to compute the offsets for their command ids

### How was it fixed?

Added a helper function for computing these offset values.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

[//]: # (See: https://trinity-client.readthedocs.io/en/latest/contributing.html#pull-requests)
- [x] Add entry to the [release notes](https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![15-01-17 Sport - P1150162 C1000](https://user-images.githubusercontent.com/824194/61817189-30e99b00-ae0b-11e9-8c36-ca92d6140bca.JPG)

