### PR TITLE
Use YAML `unsafe` mode in eth2-fixtures loader for performance

### DIFF
--- a/eth2/beacon/tools/fixtures/loading.py
+++ b/eth2/beacon/tools/fixtures/loading.py
@@ -73,7 +73,7 @@ def get_config(root_project_dir: Path, config_name: ConfigName) -> Eth2Config:
 
     # TODO: change the path after the constants presets are copied to submodule
     path = root_project_dir / 'tests/eth2/fixtures'
-    yaml = YAML()
+    yaml = YAML(typ="unsafe")
     file_name = config_name + '.yaml'
     file_to_open = path / file_name
     with open(file_to_open, 'U') as f:
@@ -94,8 +94,8 @@ def get_test_file_from_dict(data: Dict[str, Any],
     config = get_config(root_project_dir, config_name)
 
     parsed_test_cases = tuple(
-        parse_test_case_fn(test_case, config)
-        for test_case in data['test_cases']
+        parse_test_case_fn(test_case, index, config)
+        for index, test_case in enumerate(data['test_cases'])
     )
     return TestFile(
         file_name=file_name,
@@ -116,7 +116,7 @@ def load_from_yaml_files(root_project_dir: Path,
                          dir_path: Path,
                          config_names: Sequence[ConfigName],
                          parse_test_case_fn: Callable[..., Any]) -> Iterable[TestFile]:
-    yaml = YAML()
+    yaml = YAML(typ="unsafe")
     entries = get_yaml_files_pathes(dir_path)
     for file_path in entries:
         file_name = os.path.basename(file_path)

--- a/eth2/beacon/tools/fixtures/test_case.py
+++ b/eth2/beacon/tools/fixtures/test_case.py
@@ -16,7 +16,7 @@ from eth2.beacon.typing import (
 
 @dataclass
 class BaseTestCase:
-    line_number: int
+    index: int
 
 
 @dataclass

--- a/tests/eth2/fixtures/helpers.py
+++ b/tests/eth2/fixtures/helpers.py
@@ -42,7 +42,7 @@ def get_test_cases(root_project_dir, fixture_pathes, config_names, parse_test_ca
 
 def get_test_id(test_file, test_case):
     description = test_case.description if hasattr(test_case, 'description') else ''
-    return f"{test_file.file_name}:{test_case.line_number}:{description}"
+    return f"{test_file.file_name}:{test_case.index}:{description}"
 
 
 def mark_test_case(test_file, test_case, bls_setting=False):

--- a/tests/eth2/fixtures/mainnet.yaml
+++ b/tests/eth2/fixtures/mainnet.yaml
@@ -1,0 +1,133 @@
+# Mainnet preset
+# Note: the intention of this file (for now) is to illustrate what a mainnet configuration could look like.
+# Some of these constants may still change before the launch of Phase 0.
+
+
+# Misc
+# ---------------------------------------------------------------
+# 2**10 (= 1,024)
+SHARD_COUNT: 1024
+# 2**7 (= 128)
+TARGET_COMMITTEE_SIZE: 128
+# 2**12 (= 4,096)
+MAX_VALIDATORS_PER_COMMITTEE: 4096
+# 2**2 (= 4)
+MIN_PER_EPOCH_CHURN_LIMIT: 4
+# 2**16 (= 65,536)
+CHURN_LIMIT_QUOTIENT: 65536
+# See issue 563
+SHUFFLE_ROUND_COUNT: 90
+# `2**16` (= 65,536)
+MIN_GENESIS_ACTIVE_VALIDATOR_COUNT: 65536
+# Jan 3, 2020
+MIN_GENESIS_TIME: 1578009600
+
+
+
+# Deposit contract
+# ---------------------------------------------------------------
+# **TBD**
+DEPOSIT_CONTRACT_ADDRESS: 0x1234567890123456789012345678901234567890
+
+
+# Gwei values
+# ---------------------------------------------------------------
+# 2**0 * 10**9 (= 1,000,000,000) Gwei
+MIN_DEPOSIT_AMOUNT: 1000000000
+# 2**5 * 10**9 (= 32,000,000,000) Gwei
+MAX_EFFECTIVE_BALANCE: 32000000000
+# 2**4 * 10**9 (= 16,000,000,000) Gwei
+EJECTION_BALANCE: 16000000000
+# 2**0 * 10**9 (= 1,000,000,000) Gwei
+EFFECTIVE_BALANCE_INCREMENT: 1000000000
+
+
+# Initial values
+# ---------------------------------------------------------------
+# 0, GENESIS_EPOCH is derived from this constant
+GENESIS_SLOT: 0
+BLS_WITHDRAWAL_PREFIX: 0x00
+
+
+# Time parameters
+# ---------------------------------------------------------------
+# 6 seconds 6 seconds
+SECONDS_PER_SLOT: 6
+# 2**0 (= 1) slots 6 seconds
+MIN_ATTESTATION_INCLUSION_DELAY: 1
+# 2**6 (= 64) slots 6.4 minutes
+SLOTS_PER_EPOCH: 64
+# 2**0 (= 1) epochs 6.4 minutes
+MIN_SEED_LOOKAHEAD: 1
+# 2**2 (= 4) epochs 25.6 minutes
+ACTIVATION_EXIT_DELAY: 4
+# 2**10 (= 1,024) slots ~1.7 hours
+SLOTS_PER_ETH1_VOTING_PERIOD: 1024
+# 2**13 (= 8,192) slots ~13 hours
+SLOTS_PER_HISTORICAL_ROOT: 8192
+# 2**8 (= 256) epochs ~27 hours
+MIN_VALIDATOR_WITHDRAWABILITY_DELAY: 256
+# 2**11 (= 2,048) epochs 9 days
+PERSISTENT_COMMITTEE_PERIOD: 2048
+# 2**6 (= 64) epochs ~7 hours
+MAX_EPOCHS_PER_CROSSLINK: 64
+# 2**2 (= 4) epochs 25.6 minutes
+MIN_EPOCHS_TO_INACTIVITY_PENALTY: 4
+# 2**14 (= 16,384) epochs ~73 days
+EARLY_DERIVED_SECRET_PENALTY_MAX_FUTURE_EPOCHS: 16384
+
+
+
+# State vector lengths
+# ---------------------------------------------------------------
+# 2**16 (= 65,536) epochs ~0.8 years
+EPOCHS_PER_HISTORICAL_VECTOR: 65536
+# 2**13 (= 8,192) epochs ~36 days
+EPOCHS_PER_SLASHINGS_VECTOR: 8192
+# 2**24 (= 16,777,216) historical roots, ~26,131 years
+HISTORICAL_ROOTS_LIMIT: 16777216
+# 2**40 (= 1,099,511,627,776) validator spots
+VALIDATOR_REGISTRY_LIMIT: 1099511627776
+
+
+# Reward and penalty quotients
+# ---------------------------------------------------------------
+# 2**6 (= 64)
+BASE_REWARD_FACTOR: 64
+# 2**9 (= 512)
+WHISTLEBLOWER_REWARD_QUOTIENT: 512
+# 2**3 (= 8)
+PROPOSER_REWARD_QUOTIENT: 8
+# 2**25 (= 33,554,432)
+INACTIVITY_PENALTY_QUOTIENT: 33554432
+# 2**5 (= 32)
+MIN_SLASHING_PENALTY_QUOTIENT: 32
+
+
+# Max operations per block
+# ---------------------------------------------------------------
+# 2**4 (= 16)
+MAX_PROPOSER_SLASHINGS: 16
+# 2**0 (= 1)
+MAX_ATTESTER_SLASHINGS: 1
+# 2**7 (= 128)
+MAX_ATTESTATIONS: 128
+# 2**4 (= 16)
+MAX_DEPOSITS: 16
+# 2**4 (= 16)
+MAX_VOLUNTARY_EXITS: 16
+# Originally 2**4 (= 16), disabled for now.
+MAX_TRANSFERS: 0
+
+
+# Signature domains
+# ---------------------------------------------------------------
+DOMAIN_BEACON_PROPOSER: 0x00000000
+DOMAIN_RANDAO: 0x01000000
+DOMAIN_ATTESTATION: 0x02000000
+DOMAIN_DEPOSIT: 0x03000000
+DOMAIN_VOLUNTARY_EXIT: 0x04000000
+DOMAIN_TRANSFER: 0x05000000
+DOMAIN_CUSTODY_BIT_CHALLENGE: 0x06000000
+DOMAIN_SHARD_PROPOSER: 0x80000000
+DOMAIN_SHARD_ATTESTER: 0x81000000

--- a/tests/eth2/fixtures/shuffling-fixtures/test_shuffling_core.py
+++ b/tests/eth2/fixtures/shuffling-fixtures/test_shuffling_core.py
@@ -51,11 +51,11 @@ class ShufflingTestCase(BaseTestCase):
 #
 # Helpers for generating test suite
 #
-def parse_shuffling_test_case(test_case, config):
+def parse_shuffling_test_case(test_case, index, config):
     override_lengths(config)
 
     return ShufflingTestCase(
-        line_number=test_case.lc.line,
+        index=index,
         seed=decode_hex(test_case['seed']),
         count=test_case['count'],
         shuffled=tuple(test_case['shuffled']),

--- a/tests/eth2/fixtures/state-fixtures/test_sanity.py
+++ b/tests/eth2/fixtures/state-fixtures/test_sanity.py
@@ -59,7 +59,7 @@ class SanityTestCase(StateTestCase):
 #
 # Helpers for generating test suite
 #
-def parse_sanity_test_case(test_case, config):
+def parse_sanity_test_case(test_case, index, config):
     override_lengths(config)
 
     bls_setting = get_bls_setting(test_case)
@@ -68,7 +68,7 @@ def parse_sanity_test_case(test_case, config):
     slots = get_slots(test_case)
 
     return SanityTestCase(
-        line_number=test_case.lc.line,
+        index=index,
         bls_setting=bls_setting,
         description=test_case['description'],
         pre=pre,


### PR DESCRIPTION
### What was wrong?
The normal YAML loader mode is too slow for loading `Mainnet` yaml test vectors.

### How was it fixed?

1. Change it to `YAML(typ="unsafe")`and sacrifice the `line_number` lookup.
2. Since we don't have `line_number` now, instead, we use the `index` of `test_cases` to identify the test case.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

[//]: # (See: https://trinity-client.readthedocs.io/en/latest/contributing.html#pull-requests)
- [ ] Add entry to the [release notes](https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![image](https://user-images.githubusercontent.com/9263930/61821105-0d653580-ae89-11e9-8e48-aaeb30f4d4c0.png)
