### PR TITLE
Remove unused CancelToken from MemoryTransport

### DIFF
--- a/newsfragments/838.removal.rst
+++ b/newsfragments/838.removal.rst
@@ -1,0 +1,1 @@
+Remove unused ``token`` argument from ``p2p.tools.memory_transport.MemoryTransport`` constructor

--- a/newsfragments/839.bugfix.rst
+++ b/newsfragments/839.bugfix.rst
@@ -1,0 +1,1 @@
+Fix issue where test state was leaking between tests in ``tests/p2p/test_discovery.py``

--- a/p2p/tools/memory_transport.py
+++ b/p2p/tools/memory_transport.py
@@ -18,36 +18,30 @@ class MemoryTransport(TransportAPI):
                  remote: NodeAPI,
                  private_key: datatypes.PrivateKey,
                  reader: asyncio.StreamReader,
-                 writer: asyncio.StreamWriter,
-                 token: CancelToken = None) -> None:
+                 writer: asyncio.StreamWriter) -> None:
         self.remote = remote
         self._private_key = private_key
         self._reader = reader
         self._writer = writer
 
-        if token is None:
-            token = CancelToken('MemoryTransport')
-        self._token = token
-
     @classmethod
     def connected_pair(cls,
-                       alice: Tuple[NodeAPI, datatypes.PrivateKey, CancelToken],
-                       bob: Tuple[NodeAPI, datatypes.PrivateKey, CancelToken],
+                       alice: Tuple[NodeAPI, datatypes.PrivateKey],
+                       bob: Tuple[NodeAPI, datatypes.PrivateKey],
                        ) -> Tuple[TransportAPI, TransportAPI]:
         (
             (alice_reader, alice_writer),
             (bob_reader, bob_writer),
         ) = get_directly_connected_streams()
-        alice_remote, alice_private_key, alice_token = alice
-        bob_remote, bob_private_key, bob_token = bob
+        alice_remote, alice_private_key = alice
+        bob_remote, bob_private_key = bob
         alice_transport = cls(
             alice_remote,
             alice_private_key,
             alice_reader,
             alice_writer,
-            alice_token,
         )
-        bob_transport = cls(bob_remote, bob_private_key, bob_reader, bob_writer, bob_token)
+        bob_transport = cls(bob_remote, bob_private_key, bob_reader, bob_writer)
         return alice_transport, bob_transport
 
     @cached_property

--- a/p2p/tools/paragon/helpers.py
+++ b/p2p/tools/paragon/helpers.py
@@ -64,10 +64,8 @@ async def get_directly_linked_peers_without_handshake(
     alice_transport, bob_transport = MemoryTransportPairFactory(
         alice_remote=alice_remote,
         alice_private_key=alice_factory.privkey,
-        alice_token=alice_factory.cancel_token,
         bob_remote=bob_remote,
         bob_private_key=bob_factory.privkey,
-        bob_token=bob_factory.cancel_token,
     )
 
     alice = alice_factory.create_peer(alice_transport)

--- a/tests/p2p/test_discovery.py
+++ b/tests/p2p/test_discovery.py
@@ -458,11 +458,9 @@ class MockHandler:
 
 
 class MockDiscoveryProtocol(discovery.DiscoveryProtocol):
-
-    messages = []
-
     def __init__(self, bootnodes):
         privkey = keys.PrivateKey(keccak(b"seed"))
+        self.messages = []
         super().__init__(privkey, AddressFactory(), bootnodes, CancelToken("discovery-test"))
 
     def send_ping_v4(self, node):


### PR DESCRIPTION
### What was wrong?

The `MemoryTransport` accepted a `CancelToken` as part of the constructor but it never actually uses it.

### How was it fixed?

Removed it.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

[//]: # (See: https://trinity-client.readthedocs.io/en/latest/contributing.html#pull-requests)
- [x] Add entry to the [release notes](https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses]()
