### PR TITLE
Fix state leak across discovery tests

### DIFF
--- a/newsfragments/839.bugfix.rst
+++ b/newsfragments/839.bugfix.rst
@@ -1,0 +1,1 @@
+Fix issue where test state was leaking between tests in ``tests/p2p/test_discovery.py``

--- a/tests/p2p/test_discovery.py
+++ b/tests/p2p/test_discovery.py
@@ -458,11 +458,9 @@ class MockHandler:
 
 
 class MockDiscoveryProtocol(discovery.DiscoveryProtocol):
-
-    messages = []
-
     def __init__(self, bootnodes):
         privkey = keys.PrivateKey(keccak(b"seed"))
+        self.messages = []
         super().__init__(privkey, AddressFactory(), bootnodes, CancelToken("discovery-test"))
 
     def send_ping_v4(self, node):


### PR DESCRIPTION
### What was wrong?

Tests were failing intermittently due to one of the classes being used in the tests defining a class level mutable value.

### How was it fixed?

Changed to have the `messages` property be reset upon instantiation.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

[//]: # (See: https://trinity-client.readthedocs.io/en/latest/contributing.html#pull-requests)
- [x] Add entry to the [release notes](https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses]()
