### PR TITLE
Relocate `bcc_libp2p/factories.py`

### DIFF
--- a/tests/libp2p/bcc/conftest.py
+++ b/tests/libp2p/bcc/conftest.py
@@ -2,7 +2,7 @@ import asyncio
 
 import pytest
 
-from trinity.protocol.bcc_libp2p.factories import (
+from trinity.tools.factories import (
     NodeFactory,
 )
 

--- a/tests/libp2p/bcc/test_node.py
+++ b/tests/libp2p/bcc/test_node.py
@@ -6,7 +6,7 @@ from libp2p.peer.id import ID
 
 from p2p.tools.factories import get_open_port
 
-from trinity.protocol.bcc_libp2p.factories import (
+from trinity.tools.factories import (
     NodeFactory,
 )
 

--- a/trinity/tools/factories.py
+++ b/trinity/tools/factories.py
@@ -3,8 +3,6 @@ from typing import (
     Tuple,
 )
 
-import factory
-
 from libp2p.security.insecure_security import (
     InsecureTransport,
 )
@@ -12,6 +10,9 @@ from libp2p.security.insecure_security import (
 from trinity.protocol.bcc_libp2p.configs import (
     SECURITY_PROTOCOL_ID,
     MULTIPLEXING_PROTOCOL_ID,
+)
+from trinity.protocol.bcc_libp2p.node import (
+    Node,
 )
 
 from p2p.ecies import (
@@ -21,9 +22,10 @@ from p2p.tools.factories import (
     get_open_port,
 )
 
-from .node import (
-    Node,
-)
+try:
+    import factory
+except ImportError:
+    raise ImportError("The trinity.tools.factories module requires the `factory_boy` library.")
 
 
 class NodeFactory(factory.Factory):


### PR DESCRIPTION
### What was wrong?
Fixes https://github.com/ethereum/trinity/issues/833.


### How was it fixed?
`trinity/protocol/bcc_libp2p/factories.py` is moved to `trinity/tools/factories.py`.


#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://scontent.ftpe12-2.fna.fbcdn.net/v/t1.0-9/67210092_1298078393719892_1495438381889355776_n.jpg?_nc_cat=109&_nc_oc=AQn2AVkd5gLaOp_y1OckcVJCecQDQvIO8aAq3S9DWUKkrKdhb3qRjmFvXSEO_pCBfADL7TrE60AcVqd8lI4xSUjD&_nc_ht=scontent.ftpe12-2.fna&oh=73ff973d38b719243e7159b2077ed313&oe=5DA50D8B)
