### PR TITLE
Refactor utility function

### DIFF
--- a/trinity/_utils/errors.py
+++ b/trinity/_utils/errors.py
@@ -1,0 +1,18 @@
+from typing import (
+    TypeVar
+)
+from typing_extensions import Protocol
+
+
+class SupportsError(Protocol):
+    error: Exception
+
+
+TSupportsError = TypeVar('TSupportsError', bound=SupportsError)
+
+
+def pass_or_raise(value: TSupportsError) -> TSupportsError:
+    if value.error is not None:
+        raise value.error
+
+    return value

--- a/trinity/chains/light_eventbus.py
+++ b/trinity/chains/light_eventbus.py
@@ -1,9 +1,5 @@
 from typing import (
     List,
-    TypeVar,
-)
-from typing_extensions import (
-    Protocol,
 )
 
 from lahja import EndpointAPI
@@ -37,13 +33,9 @@ from trinity.protocol.les.events import (
     GetContractCodeRequest,
     GetReceiptsRequest,
 )
-
-
-class SupportsError(Protocol):
-    error: Exception
-
-
-TResponse = TypeVar('TResponse', bound=SupportsError)
+from trinity._utils.errors import (
+    pass_or_raise,
+)
 
 
 class EventBusLightPeerChain(BaseLightPeerChain):
@@ -57,37 +49,30 @@ class EventBusLightPeerChain(BaseLightPeerChain):
 
     async def coro_get_block_header_by_hash(self, block_hash: Hash32) -> BlockHeader:
         event = GetBlockHeaderByHashRequest(block_hash)
-        return self._pass_or_raise(
+        return pass_or_raise(
             await self.event_bus.request(event, TO_NETWORKING_BROADCAST_CONFIG)
         ).block_header
 
     async def coro_get_block_body_by_hash(self, block_hash: Hash32) -> BlockBody:
         event = GetBlockBodyByHashRequest(block_hash)
-        return self._pass_or_raise(
+        return pass_or_raise(
             await self.event_bus.request(event, TO_NETWORKING_BROADCAST_CONFIG)
         ).block_body
 
     async def coro_get_receipts(self, block_hash: Hash32) -> List[Receipt]:
         event = GetReceiptsRequest(block_hash)
-        return self._pass_or_raise(
+        return pass_or_raise(
             await self.event_bus.request(event, TO_NETWORKING_BROADCAST_CONFIG)
         ).receipts
 
     async def coro_get_account(self, block_hash: Hash32, address: Address) -> Account:
         event = GetAccountRequest(block_hash, address)
-        return self._pass_or_raise(
+        return pass_or_raise(
             await self.event_bus.request(event, TO_NETWORKING_BROADCAST_CONFIG)
         ).account
 
     async def coro_get_contract_code(self, block_hash: Hash32, address: Address) -> bytes:
         event = GetContractCodeRequest(block_hash, address)
-        return self._pass_or_raise(
+        return pass_or_raise(
             await self.event_bus.request(event, TO_NETWORKING_BROADCAST_CONFIG)
         ).bytez
-
-    @staticmethod
-    def _pass_or_raise(response: TResponse) -> TResponse:
-        if response.error is not None:
-            raise response.error
-
-        return response

--- a/trinity/protocol/eth/events.py
+++ b/trinity/protocol/eth/events.py
@@ -150,7 +150,7 @@ class SendTransactionsEvent(BaseEvent):
 class GetBlockHeadersResponse(BaseEvent):
 
     headers: Tuple[BlockHeader, ...]
-    exception: Exception = None  # noqa: E701
+    error: Exception = None
 
 
 @dataclass
@@ -172,7 +172,7 @@ class GetBlockHeadersRequest(BaseRequestResponseEvent[GetBlockHeadersResponse]):
 class GetBlockBodiesResponse(BaseEvent):
 
     bundles: BlockBodyBundles
-    exception: Exception = None  # noqa: E701
+    error: Exception = None
 
 
 @dataclass
@@ -191,7 +191,7 @@ class GetBlockBodiesRequest(BaseRequestResponseEvent[GetBlockBodiesResponse]):
 class GetNodeDataResponse(BaseEvent):
 
     bundles: NodeDataBundles
-    exception: Exception = None  # noqa: E701
+    error: Exception = None
 
 
 @dataclass
@@ -210,7 +210,7 @@ class GetNodeDataRequest(BaseRequestResponseEvent[GetNodeDataResponse]):
 class GetReceiptsResponse(BaseEvent):
 
     bundles: ReceiptsBundles
-    exception: Exception = None  # noqa: E701
+    error: Exception = None
 
 
 @dataclass

--- a/trinity/protocol/eth/handlers.py
+++ b/trinity/protocol/eth/handlers.py
@@ -28,6 +28,9 @@ from trinity.protocol.common.types import (
     NodeDataBundles,
     ReceiptsBundles,
 )
+from trinity._utils.errors import (
+    SupportsError,
+)
 
 from .events import (
     GetBlockBodiesRequest,
@@ -75,12 +78,12 @@ class ProxyETHExchangeHandler:
             logging.getLogger('trinity.protocol.eth.handlers.ProxyETHExchangeHandler')
         )
 
-    def raise_if_needed(self, exception: Exception) -> None:
-        if exception is not None:
+    def raise_if_needed(self, value: SupportsError) -> None:
+        if value.error is not None:
             self.logger.warning(
-                "Raised %s while fetching from peer %s", exception, self.remote.uri
+                "Raised %s while fetching from peer %s", value.error, self.remote.uri
             )
-            raise exception
+            raise value.error
 
     async def get_block_headers(self,
                                 block_number_or_hash: BlockIdentifier,
@@ -101,7 +104,7 @@ class ProxyETHExchangeHandler:
             self._broadcast_config
         )
 
-        self.raise_if_needed(response.exception)
+        self.raise_if_needed(response)
 
         self.logger.debug2(
             "ProxyETHExchangeHandler returning %s block headers from %s",
@@ -124,7 +127,7 @@ class ProxyETHExchangeHandler:
             self._broadcast_config
         )
 
-        self.raise_if_needed(response.exception)
+        self.raise_if_needed(response)
 
         self.logger.debug2(
             "ProxyETHExchangeHandler returning %s block bodies from %s",
@@ -147,7 +150,7 @@ class ProxyETHExchangeHandler:
             self._broadcast_config
         )
 
-        self.raise_if_needed(response.exception)
+        self.raise_if_needed(response)
 
         self.logger.debug2(
             "ProxyETHExchangeHandler returning %s node bundles from %s",
@@ -170,7 +173,7 @@ class ProxyETHExchangeHandler:
             self._broadcast_config
         )
 
-        self.raise_if_needed(response.exception)
+        self.raise_if_needed(response)
 
         self.logger.debug2(
             "ProxyETHExchangeHandler returning %s receipt bundles from %s",


### PR DESCRIPTION
### What was wrong?

This is a little spin out from #721 

1. Properties on response events that carry errors were named inconsistently (`error` or `exception`)
2. Those that are named `exception` trigger an flake8 error that we suppressed so far
3. The utility method that re-raises these errors can be shared across different places but wasn't so far

### How was it fixed?

1. Consistently named them `error` as that also lets us get rid of these unrelated flake8 issues
2. Moved the `pass_or_raise` method into a utility module
3. Profit?

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

[//]: # (See: https://trinity-client.readthedocs.io/en/latest/contributing.html#pull-requests)
- [x] No release notes entry needed (refactoring)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](http://amolife.com/image/images/stories/Animals/Animal/sweetest_animal_kiss.jpg)
