### PR TITLE
Drop type suffix from various types

### DIFF
--- a/p2p/abc.py
+++ b/p2p/abc.py
@@ -17,7 +17,7 @@ from cancel_token import CancelToken
 
 from eth_keys import datatypes
 
-from p2p.typing import CapabilityType, PayloadType, StructureType
+from p2p.typing import Capability, Payload, Structure
 
 
 TAddress = TypeVar('TAddress', bound='AddressAPI')
@@ -118,7 +118,7 @@ class NodeAPI(ABC):
 
 
 class CommandAPI(ABC):
-    structure: StructureType
+    structure: Structure
 
     cmd_id: int
     cmd_id_offset: int
@@ -134,19 +134,19 @@ class CommandAPI(ABC):
         ...
 
     @abstractmethod
-    def encode_payload(self, data: Union[PayloadType, sedes.CountableList]) -> bytes:
+    def encode_payload(self, data: Union[Payload, sedes.CountableList]) -> bytes:
         ...
 
     @abstractmethod
-    def decode_payload(self, rlp_data: bytes) -> PayloadType:
+    def decode_payload(self, rlp_data: bytes) -> Payload:
         ...
 
     @abstractmethod
-    def encode(self, data: PayloadType) -> Tuple[bytes, bytes]:
+    def encode(self, data: Payload) -> Tuple[bytes, bytes]:
         ...
 
     @abstractmethod
-    def decode(self, data: bytes) -> PayloadType:
+    def decode(self, data: bytes) -> Payload:
         ...
 
     @abstractmethod
@@ -159,7 +159,7 @@ class CommandAPI(ABC):
 
 
 # A payload to be delivered with a request
-TRequestPayload = TypeVar('TRequestPayload', bound=PayloadType, covariant=True)
+TRequestPayload = TypeVar('TRequestPayload', bound=Payload, covariant=True)
 
 
 class RequestAPI(ABC, Generic[TRequestPayload]):
@@ -229,7 +229,7 @@ class ProtocolAPI(ABC):
         ...
 
     @abstractmethod
-    def send_request(self, request: RequestAPI[PayloadType]) -> None:
+    def send_request(self, request: RequestAPI[Payload]) -> None:
         ...
 
     @abstractmethod
@@ -238,5 +238,5 @@ class ProtocolAPI(ABC):
 
     @classmethod
     @abstractmethod
-    def as_capability(cls) -> CapabilityType:
+    def as_capability(cls) -> Capability:
         ...

--- a/p2p/p2p_proto.py
+++ b/p2p/p2p_proto.py
@@ -13,7 +13,7 @@ from p2p.abc import TransportAPI
 from p2p.constants import P2P_PROTOCOL_COMMAND_LENGTH
 from p2p.disconnect import DisconnectReason as _DisconnectReason
 from p2p.exceptions import MalformedMessage
-from p2p.typing import CapabilitiesType, PayloadType
+from p2p.typing import Capabilities, Payload
 
 from p2p.protocol import (
     Command,
@@ -51,7 +51,7 @@ class Disconnect(Command):
         except ValueError:
             return "unknown reason"
 
-    def decode(self, data: bytes) -> PayloadType:
+    def decode(self, data: bytes) -> Payload:
         try:
             raw_decoded = cast(Dict[str, int], super().decode(data))
         except rlp.exceptions.ListDeserializationError:
@@ -85,7 +85,7 @@ class P2PProtocol(Protocol):
 
     def send_handshake(self,
                        client_version_string: str,
-                       capabilities: CapabilitiesType,
+                       capabilities: Capabilities,
                        listen_port: int) -> None:
         self.send_hello(
             version=self.version,
@@ -98,7 +98,7 @@ class P2PProtocol(Protocol):
     def send_hello(self,
                    version: int,
                    client_version_string: str,
-                   capabilities: CapabilitiesType,
+                   capabilities: Capabilities,
                    listen_port: int,
                    remote_pubkey: bytes) -> None:
         data = dict(version=version,

--- a/p2p/tools/paragon/helpers.py
+++ b/p2p/tools/paragon/helpers.py
@@ -122,7 +122,7 @@ async def get_directly_linked_peers(
 async def process_v4_p2p_handshake(
         self: BasePeer,
         cmd: protocol.Command,
-        msg: protocol.PayloadType) -> None:
+        msg: protocol.Payload) -> None:
     """
     This function is the replacement to the existing process_p2p_handshake
     function.

--- a/p2p/tools/paragon/peer.py
+++ b/p2p/tools/paragon/peer.py
@@ -9,7 +9,7 @@ from p2p.peer import (
     BasePeerFactory,
 )
 from p2p.peer_pool import BasePeerPool
-from p2p.typing import PayloadType
+from p2p.typing import Payload
 
 from .proto import ParagonProtocol
 
@@ -22,7 +22,7 @@ class ParagonPeer(BasePeer):
         pass
 
     async def process_sub_proto_handshake(
-            self, cmd: CommandAPI, msg: PayloadType) -> None:
+            self, cmd: CommandAPI, msg: Payload) -> None:
         pass
 
     async def do_sub_proto_handshake(self) -> None:

--- a/p2p/typing.py
+++ b/p2p/typing.py
@@ -9,7 +9,7 @@ class TypedDictPayload(TypedDict):
     pass
 
 
-PayloadType = Union[
+Payload = Union[
     Dict[str, Any],
     List[rlp.Serializable],
     Tuple[rlp.Serializable, ...],
@@ -17,10 +17,10 @@ PayloadType = Union[
 ]
 
 
-StructureType = Union[
+Structure = Union[
     Tuple[Tuple[str, Any], ...],
 ]
 
 
-CapabilityType = Tuple[str, int]
-CapabilitiesType = Tuple[CapabilityType, ...]
+Capability = Tuple[str, int]
+Capabilities = Tuple[Capability, ...]

--- a/trinity/protocol/bcc/peer.py
+++ b/trinity/protocol/bcc/peer.py
@@ -30,7 +30,7 @@ from p2p.peer import (
     BasePeerFactory,
 )
 from p2p.peer_pool import BasePeerPool
-from p2p.protocol import PayloadType
+from p2p.protocol import Payload
 
 from trinity.db.beacon.chain import BaseAsyncBeaconChainDB
 from trinity.protocol.bcc.handlers import BCCExchangeHandler
@@ -98,7 +98,7 @@ class BCCPeer(BasePeer):
         head = await self.chain_db.coro_get_canonical_head(BeaconBlock)
         self.sub_proto.send_handshake(genesis_root, head.slot, self.network_id)
 
-    async def process_sub_proto_handshake(self, cmd: CommandAPI, msg: PayloadType) -> None:
+    async def process_sub_proto_handshake(self, cmd: CommandAPI, msg: Payload) -> None:
         if not isinstance(cmd, Status):
             await self.disconnect(DisconnectReason.subprotocol_error)
             raise HandshakeFailure(f"Expected a BCC Status msg, got {cmd}, disconnecting")
@@ -172,7 +172,7 @@ class BCCPeerPoolEventServer(PeerPoolEventServer[BCCPeer]):
     async def handle_native_peer_message(self,
                                          remote: NodeAPI,
                                          cmd: CommandAPI,
-                                         msg: PayloadType) -> None:
+                                         msg: Payload) -> None:
 
         if isinstance(cmd, GetBeaconBlocks):
             await self.event_bus.broadcast(GetBeaconBlocksEvent(remote, cmd, msg))

--- a/trinity/protocol/bcc/servers.py
+++ b/trinity/protocol/bcc/servers.py
@@ -35,7 +35,7 @@ import ssz
 
 from p2p.abc import CommandAPI, NodeAPI
 from p2p.peer import BasePeer
-from p2p.typing import PayloadType
+from p2p.typing import Payload
 
 from eth2.beacon.typing import (
     Slot,
@@ -115,7 +115,7 @@ class BCCRequestServer(BaseIsolatedRequestServer):
     async def _handle_msg(self,
                           remote: NodeAPI,
                           cmd: CommandAPI,
-                          msg: PayloadType) -> None:
+                          msg: Payload) -> None:
 
         self.logger.debug("cmd %s" % cmd)
         if isinstance(cmd, GetBeaconBlocks):
@@ -328,7 +328,7 @@ class BCCReceiveServer(BaseReceiveServer):
         self.orphan_block_pool = OrphanBlockPool()
 
     async def _handle_msg(self, base_peer: BasePeer, cmd: CommandAPI,
-                          msg: PayloadType) -> None:
+                          msg: Payload) -> None:
         peer = cast(BCCPeer, base_peer)
         self.logger.debug("cmd %s" % cmd)
         if isinstance(cmd, Attestations):

--- a/trinity/protocol/common/commands.py
+++ b/trinity/protocol/common/commands.py
@@ -4,11 +4,11 @@ from typing import Tuple
 from eth.rlp.headers import BlockHeader
 
 from p2p.protocol import Command
-from p2p.typing import PayloadType
+from p2p.typing import Payload
 
 
 class BaseBlockHeaders(Command):
 
     @abstractmethod
-    def extract_headers(self, msg: PayloadType) -> Tuple[BlockHeader, ...]:
+    def extract_headers(self, msg: Payload) -> Tuple[BlockHeader, ...]:
         raise NotImplementedError("Must be implemented by subclasses")

--- a/trinity/protocol/common/events.py
+++ b/trinity/protocol/common/events.py
@@ -13,7 +13,7 @@ from lahja import (
 
 from p2p.abc import CommandAPI, NodeAPI
 from p2p.disconnect import DisconnectReason
-from p2p.typing import PayloadType
+from p2p.typing import Payload
 
 
 @dataclass
@@ -90,4 +90,4 @@ class PeerPoolMessageEvent(BaseEvent):
     """
     remote: NodeAPI
     cmd: CommandAPI
-    msg: PayloadType
+    msg: Payload

--- a/trinity/protocol/common/normalizers.py
+++ b/trinity/protocol/common/normalizers.py
@@ -4,7 +4,7 @@ from typing import (
     TypeVar,
 )
 
-from p2p.protocol import PayloadType
+from p2p.protocol import Payload
 
 from .types import (
     TResponsePayload,
@@ -29,7 +29,7 @@ class BaseNormalizer(ABC, Generic[TResponsePayload, TResult]):
         raise NotImplementedError()
 
 
-TPassthrough = TypeVar('TPassthrough', bound=PayloadType)
+TPassthrough = TypeVar('TPassthrough', bound=Payload)
 
 
 class NoopNormalizer(BaseNormalizer[TPassthrough, TPassthrough]):

--- a/trinity/protocol/common/peer_pool_event_bus.py
+++ b/trinity/protocol/common/peer_pool_event_bus.py
@@ -30,7 +30,7 @@ from p2p.peer import (
 )
 from p2p.peer_pool import BasePeerPool
 from p2p.service import BaseService
-from p2p.typing import PayloadType
+from p2p.typing import Payload
 
 from .events import (
     ConnectToNodeCommand,
@@ -112,7 +112,7 @@ class PeerPoolEventServer(BaseService, PeerSubscriber, Generic[TPeer]):
     async def handle_native_peer_message(self,
                                          remote: NodeAPI,
                                          cmd: CommandAPI,
-                                         msg: PayloadType) -> None:
+                                         msg: Payload) -> None:
         """
         Process every native peer message. Subclasses should overwrite this to forward specific
         peer messages on the event bus. The handler is called for every message that is defined in
@@ -222,7 +222,7 @@ class DefaultPeerPoolEventServer(PeerPoolEventServer[BasePeer]):
     async def handle_native_peer_message(self,
                                          remote: NodeAPI,
                                          cmd: CommandAPI,
-                                         msg: PayloadType) -> None:
+                                         msg: Payload) -> None:
         pass
 
 

--- a/trinity/protocol/common/servers.py
+++ b/trinity/protocol/common/servers.py
@@ -27,7 +27,7 @@ from p2p.peer import (
     BasePeer,
     PeerSubscriber,
 )
-from p2p.typing import PayloadType
+from p2p.typing import Payload
 from p2p.service import BaseService
 
 from trinity.db.eth1.header import BaseAsyncHeaderDB
@@ -68,7 +68,7 @@ class BaseRequestServer(BaseService, PeerSubscriber):
             self,
             peer: BasePeer,
             cmd: CommandAPI,
-            msg: PayloadType) -> None:
+            msg: Payload) -> None:
         try:
             await self._handle_msg(peer, cmd, msg)
         except OperationCancelled:
@@ -79,7 +79,7 @@ class BaseRequestServer(BaseService, PeerSubscriber):
             self.logger.exception("Unexpected error when processing msg from %s", peer)
 
     @abstractmethod
-    async def _handle_msg(self, peer: BasePeer, cmd: CommandAPI, msg: PayloadType) -> None:
+    async def _handle_msg(self, peer: BasePeer, cmd: CommandAPI, msg: Payload) -> None:
         """
         Identify the command, and react appropriately.
         """
@@ -119,7 +119,7 @@ class BaseIsolatedRequestServer(BaseService):
             self,
             remote: NodeAPI,
             cmd: CommandAPI,
-            msg: PayloadType) -> None:
+            msg: Payload) -> None:
         try:
             await self._handle_msg(remote, cmd, msg)
         except OperationCancelled:
@@ -133,7 +133,7 @@ class BaseIsolatedRequestServer(BaseService):
     async def _handle_msg(self,
                           remote: NodeAPI,
                           cmd: CommandAPI,
-                          msg: PayloadType) -> None:
+                          msg: Payload) -> None:
         pass
 
 

--- a/trinity/protocol/common/types.py
+++ b/trinity/protocol/common/types.py
@@ -9,14 +9,14 @@ from eth_typing import (
     Hash32,
 )
 from p2p.peer import BasePeer
-from p2p.protocol import PayloadType
+from p2p.protocol import Payload
 
 from trinity.rlp.block_body import BlockBody
 
 TPeer = TypeVar('TPeer', bound=BasePeer)
 
 # A payload delivered by a responding command
-TResponsePayload = TypeVar('TResponsePayload', bound=PayloadType)
+TResponsePayload = TypeVar('TResponsePayload', bound=Payload)
 
 # The returned value at the end of an exchange
 TResult = TypeVar('TResult')

--- a/trinity/protocol/eth/commands.py
+++ b/trinity/protocol/eth/commands.py
@@ -9,7 +9,7 @@ from eth.rlp.receipts import Receipt
 from eth.rlp.transactions import BaseTransactionFields
 
 from p2p.protocol import Command
-from p2p.typing import PayloadType
+from p2p.typing import Payload
 
 from trinity.protocol.common.commands import BaseBlockHeaders
 from trinity.rlp.block_body import BlockBody
@@ -54,7 +54,7 @@ class BlockHeaders(BaseBlockHeaders):
     _cmd_id = 4
     structure = sedes.CountableList(BlockHeader)
 
-    def extract_headers(self, msg: PayloadType) -> Tuple[BlockHeader, ...]:
+    def extract_headers(self, msg: Payload) -> Tuple[BlockHeader, ...]:
         return tuple(msg)
 
 

--- a/trinity/protocol/eth/peer.py
+++ b/trinity/protocol/eth/peer.py
@@ -19,7 +19,7 @@ from p2p.exceptions import (
 )
 from p2p.disconnect import DisconnectReason
 from p2p.protocol import (
-    PayloadType,
+    Payload,
 )
 
 from trinity.exceptions import (
@@ -94,7 +94,7 @@ class ETHPeer(BaseChainPeer):
             self._requests = ETHExchangeHandler(self)
         return self._requests
 
-    def handle_sub_proto_msg(self, cmd: CommandAPI, msg: PayloadType) -> None:
+    def handle_sub_proto_msg(self, cmd: CommandAPI, msg: Payload) -> None:
         if isinstance(cmd, NewBlock):
             msg = cast(Dict[str, Any], msg)
             header, _, _ = msg['block']
@@ -110,7 +110,7 @@ class ETHPeer(BaseChainPeer):
         self.sub_proto.send_handshake(await self._local_chain_info)
 
     async def process_sub_proto_handshake(
-            self, cmd: CommandAPI, msg: PayloadType) -> None:
+            self, cmd: CommandAPI, msg: Payload) -> None:
         if not isinstance(cmd, Status):
             await self.disconnect(DisconnectReason.subprotocol_error)
             raise HandshakeFailure(f"Expected a ETH Status msg, got {cmd}, disconnecting")
@@ -266,7 +266,7 @@ class ETHPeerPoolEventServer(PeerPoolEventServer[ETHPeer]):
     async def handle_native_peer_message(self,
                                          remote: NodeAPI,
                                          cmd: CommandAPI,
-                                         msg: PayloadType) -> None:
+                                         msg: Payload) -> None:
 
         if isinstance(cmd, GetBlockHeaders):
             await self.event_bus.broadcast(GetBlockHeadersEvent(remote, cmd, msg))

--- a/trinity/protocol/eth/servers.py
+++ b/trinity/protocol/eth/servers.py
@@ -28,7 +28,7 @@ from trie.exceptions import (
 )
 
 from p2p.abc import CommandAPI, NodeAPI
-from p2p.typing import PayloadType
+from p2p.typing import Payload
 
 from trinity.db.eth1.chain import BaseAsyncChainDB
 from trinity.protocol.common.servers import (
@@ -188,7 +188,7 @@ class ETHRequestServer(BaseIsolatedRequestServer):
     async def _handle_msg(self,
                           remote: NodeAPI,
                           cmd: CommandAPI,
-                          msg: PayloadType) -> None:
+                          msg: Payload) -> None:
 
         self.logger.debug2("Peer %s requested %s", remote, cmd)
         peer = ETHProxyPeer.from_node(remote, self.event_bus, self.broadcast_config)

--- a/trinity/protocol/les/commands.py
+++ b/trinity/protocol/les/commands.py
@@ -19,7 +19,7 @@ from eth.rlp.headers import BlockHeader
 from eth.rlp.receipts import Receipt
 
 from p2p.protocol import Command
-from p2p.typing import PayloadType
+from p2p.typing import Payload
 
 from trinity.protocol.common.commands import BaseBlockHeaders
 from trinity.rlp.block_body import BlockBody
@@ -64,7 +64,7 @@ class Status(Command):
                 continue
             yield key, self._deserialize_item(key, value)
 
-    def encode_payload(self, data: Union[PayloadType, sedes.CountableList]) -> bytes:
+    def encode_payload(self, data: Union[Payload, sedes.CountableList]) -> bytes:
         response = [
             (key, self._serialize_item(key, value))
             for key, value
@@ -127,7 +127,7 @@ class BlockHeaders(BaseBlockHeaders):
         ('headers', sedes.CountableList(BlockHeader)),
     )
 
-    def extract_headers(self, msg: PayloadType) -> Tuple[BlockHeader, ...]:
+    def extract_headers(self, msg: Payload) -> Tuple[BlockHeader, ...]:
         msg = cast(Dict[str, Any], msg)
         return tuple(msg['headers'])
 
@@ -191,7 +191,7 @@ class Proofs(Command):
         ('proofs', sedes.CountableList(sedes.CountableList(sedes.raw))),
     )
 
-    def decode_payload(self, rlp_data: bytes) -> PayloadType:
+    def decode_payload(self, rlp_data: bytes) -> Payload:
         decoded = super().decode_payload(rlp_data)
         decoded = cast(Dict[str, Any], decoded)
         # This is just to make Proofs messages compatible with ProofsV2, so that LightPeerChain

--- a/trinity/protocol/les/peer.py
+++ b/trinity/protocol/les/peer.py
@@ -28,7 +28,7 @@ from p2p.abc import CommandAPI, NodeAPI
 from p2p.disconnect import DisconnectReason
 from p2p.exceptions import HandshakeFailure
 from p2p.peer_pool import BasePeerPool
-from p2p.typing import PayloadType
+from p2p.typing import Payload
 
 from trinity.rlp.block_body import BlockBody
 from trinity.exceptions import (
@@ -97,7 +97,7 @@ class LESPeer(BaseChainPeer):
             self._requests = LESExchangeHandler(self)
         return self._requests
 
-    def handle_sub_proto_msg(self, cmd: CommandAPI, msg: PayloadType) -> None:
+    def handle_sub_proto_msg(self, cmd: CommandAPI, msg: Payload) -> None:
         head_info = cast(Dict[str, Union[int, Hash32, BlockNumber]], msg)
         if isinstance(cmd, Announce):
             self.head_td = cast(int, head_info['head_td'])
@@ -110,7 +110,7 @@ class LESPeer(BaseChainPeer):
         self.sub_proto.send_handshake(await self._local_chain_info)
 
     async def process_sub_proto_handshake(
-            self, cmd: CommandAPI, msg: PayloadType) -> None:
+            self, cmd: CommandAPI, msg: Payload) -> None:
         if not isinstance(cmd, (Status, StatusV2)):
             await self.disconnect(DisconnectReason.subprotocol_error)
             raise HandshakeFailure(f"Expected a LES Status msg, got {cmd}, disconnecting")
@@ -246,7 +246,7 @@ class LESPeerPoolEventServer(PeerPoolEventServer[LESPeer]):
     async def handle_native_peer_message(self,
                                          remote: NodeAPI,
                                          cmd: CommandAPI,
-                                         msg: PayloadType) -> None:
+                                         msg: Payload) -> None:
         if isinstance(cmd, GetBlockHeaders):
             await self.event_bus.broadcast(GetBlockHeadersEvent(remote, cmd, msg))
         else:

--- a/trinity/protocol/les/servers.py
+++ b/trinity/protocol/les/servers.py
@@ -11,7 +11,7 @@ from lahja import (
 )
 
 from p2p.abc import CommandAPI, NodeAPI
-from p2p.typing import PayloadType
+from p2p.typing import Payload
 
 from trinity.db.eth1.header import BaseAsyncHeaderDB
 from trinity.protocol.common.servers import (
@@ -68,7 +68,7 @@ class LightRequestServer(BaseIsolatedRequestServer):
     async def _handle_msg(self,
                           remote: NodeAPI,
                           cmd: CommandAPI,
-                          msg: PayloadType) -> None:
+                          msg: Payload) -> None:
 
         self.logger.debug2("Peer %s requested %s", remote, cmd)
         peer = LESProxyPeer.from_node(remote, self.event_bus, self.broadcast_config)

--- a/trinity/sync/light/service.py
+++ b/trinity/sync/light/service.py
@@ -63,7 +63,7 @@ from p2p.service import (
     BaseService,
     service_timeout,
 )
-from p2p.typing import PayloadType
+from p2p.typing import Payload
 
 from trinity.db.eth1.header import BaseAsyncHeaderDB
 from trinity.protocol.les.peer import LESPeer, LESPeerPool
@@ -106,7 +106,7 @@ class LightPeerChain(PeerSubscriber, BaseService, BaseLightPeerChain):
         BaseService.__init__(self, token)
         self.headerdb = headerdb
         self.peer_pool = peer_pool
-        self._pending_replies: Dict[int, Callable[[PayloadType], None]] = {}
+        self._pending_replies: Dict[int, Callable[[Payload], None]] = {}
 
     # TODO: be more specific about what messages we want.
     subscription_msg_types: FrozenSet[Type[CommandAPI]] = frozenset({Command})
@@ -133,7 +133,7 @@ class LightPeerChain(PeerSubscriber, BaseService, BaseLightPeerChain):
         reply = None
         got_reply = asyncio.Event()
 
-        def callback(value: PayloadType) -> None:
+        def callback(value: Payload) -> None:
             nonlocal reply
             reply = value
             got_reply.set()


### PR DESCRIPTION
### What was wrong?

We have various types (aliases to other types to be precise) that were named with a `Type` suffix. It doesn't appeal to me and here is why:

1. It feels redundant to have a type end with `Type`
2. It's not common in the code base (e.g. we use `Transport` not `TransportType`)
3. It's confusing with things that represent different *kinds*  of something e.g.

```python
class BloodType(enum.Enum):
    AB_NEGATIVE
    B_NEGATIVE
    AB_POSITIVE
   ...
```
:point_up: This is an example where I **do** think the `Type` suffix is appropriate

4. It is wasting some extra chars.

### How was it fixed?

Removed the `Type` suffix

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

[//]: # (See: https://trinity-client.readthedocs.io/en/latest/contributing.html#pull-requests)
- [ ] Add entry to the [release notes](https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](http://animalslook.com/wp-content/uploads/2011/01/20.jpg)
