### PR TITLE
Use multiplexer in peer class

### DIFF
--- a/newsfragments/847.feature.rst
+++ b/newsfragments/847.feature.rst
@@ -1,0 +1,1 @@
+Use the ``p2p.multiplexer.Multiplexer`` within the ``BasePeer`` to handle the incoming message stream.

--- a/p2p/abc.py
+++ b/p2p/abc.py
@@ -2,7 +2,7 @@ from abc import ABC, abstractmethod
 from typing import (
     Any,
     AsyncContextManager,
-    AsyncIterable,
+    AsyncIterator,
     ClassVar,
     Dict,
     Generic,
@@ -311,7 +311,7 @@ class MultiplexerAPI(ABC):
     @abstractmethod
     def stream_protocol_messages(self,
                                  protocol_identifier: Union[ProtocolAPI, Type[ProtocolAPI]],
-                                 ) -> AsyncIterable[Tuple[CommandAPI, Payload]]:
+                                 ) -> AsyncIterator[Tuple[CommandAPI, Payload]]:
         ...
 
     #

--- a/p2p/exceptions.py
+++ b/p2p/exceptions.py
@@ -102,13 +102,6 @@ class TooManyTimeouts(BaseP2PError):
     pass
 
 
-class RemoteDisconnected(BaseP2PError):
-    """
-    Raised when a remote disconnected.
-    """
-    pass
-
-
 class NoConnectedPeers(BaseP2PError):
     """
     Raised when we are not connected to any peers.

--- a/p2p/service.py
+++ b/p2p/service.py
@@ -151,7 +151,7 @@ class BaseService(ABC, CancellableMixin):
             except OperationCancelled:
                 pass
             except Exception as e:
-                self.logger.warning("Task %s finished unexpectedly: %s", awaitable, e)
+                self.logger.warning("Task %s finished unexpectedly: %r", awaitable, e)
                 self.logger.debug("Task failure traceback", exc_info=True)
             else:
                 self.logger.debug2("Task %s finished with no errors", awaitable)

--- a/p2p/tools/memory_transport.py
+++ b/p2p/tools/memory_transport.py
@@ -13,6 +13,13 @@ from p2p.tools.asyncio_streams import get_directly_connected_streams
 from p2p.exceptions import PeerConnectionLost
 
 
+CONNECTION_LOST_ERRORS = (
+    asyncio.IncompleteReadError,
+    ConnectionResetError,
+    BrokenPipeError,
+)
+
+
 class MemoryTransport(TransportAPI):
     def __init__(self,
                  remote: NodeAPI,
@@ -54,7 +61,7 @@ class MemoryTransport(TransportAPI):
                 self._reader.readexactly(n),
                 timeout=2,
             )
-        except (asyncio.IncompleteReadError, ConnectionResetError, BrokenPipeError) as err:
+        except CONNECTION_LOST_ERRORS as err:
             raise PeerConnectionLost from err
 
     def write(self, data: bytes) -> None:

--- a/tests/p2p/test_peer_collect_sub_proto_msgs.py
+++ b/tests/p2p/test_peer_collect_sub_proto_msgs.py
@@ -22,12 +22,10 @@ async def test_peer_subscriber_filters_messages(request, event_loop):
         remote.sub_proto.send_broadcast_data(b'broadcast-b')
         remote.sub_proto.send_get_sum(7, 8)
         remote.sub_proto.send_broadcast_data(b'broadcast-c')
-        await asyncio.sleep(0.01)
+        # yield to let remote and peer transmit.
+        await asyncio.sleep(0.05)
 
     assert collector not in peer._subscribers
-
-    # yield to let remote and peer transmit.
-    await asyncio.sleep(0.01)
 
     all_messages = collector.get_messages()
     assert len(all_messages) == 4

--- a/trinity/protocol/les/peer.py
+++ b/trinity/protocol/les/peer.py
@@ -98,8 +98,8 @@ class LESPeer(BaseChainPeer):
         return self._requests
 
     def handle_sub_proto_msg(self, cmd: CommandAPI, msg: Payload) -> None:
-        head_info = cast(Dict[str, Union[int, Hash32, BlockNumber]], msg)
         if isinstance(cmd, Announce):
+            head_info = cast(Dict[str, Union[int, Hash32, BlockNumber]], msg)
             self.head_td = cast(int, head_info['head_td'])
             self.head_hash = cast(Hash32, head_info['head_hash'])
             self.head_number = cast(BlockNumber, head_info['head_number'])


### PR DESCRIPTION
Builds from #835 

### What was wrong?

The `p2p.multiplexer.Multiplexer` is not actively being used.

### How was it fixed?

Integrated it into the `BasePeer` class to handling the message stream.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

[//]: # (See: https://trinity-client.readthedocs.io/en/latest/contributing.html#pull-requests)
- [x] Add entry to the [release notes](https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses]()
