### PR TITLE
Simplify the ResourceLock

### DIFF
--- a/p2p/resource_lock.py
+++ b/p2p/resource_lock.py
@@ -1,9 +1,6 @@
 import asyncio
 from collections.abc import Hashable
-from typing import AsyncIterator
 import weakref
-
-from async_generator import asynccontextmanager
 
 
 class ResourceLock:
@@ -15,13 +12,11 @@ class ResourceLock:
     def __init__(self) -> None:
         self._locks = weakref.WeakKeyDictionary()
 
-    @asynccontextmanager
-    async def lock(self, resource: Hashable) -> AsyncIterator[None]:
+    def lock(self, resource: Hashable) -> asyncio.Lock:
         if resource not in self._locks:
             self._locks[resource] = asyncio.Lock()
         lock = self._locks[resource]
-        async with lock:
-            yield
+        return lock
 
     def is_locked(self, resource: Hashable) -> bool:
         if resource not in self._locks:


### PR DESCRIPTION
### What was wrong?

The `ResourceLock` introduced in #811 doesn't need to use an `asynccontextmanager`.  This is due to being able to simply return the lock value, resulting in the method being usable as-if it was written as an `asynccontextmanager`

### How was it fixed?

Just removed the async components.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

[//]: # (See: https://trinity-client.readthedocs.io/en/latest/contributing.html#pull-requests)
- [x] Add entry to the [release notes](https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![Spanish_Lace-home](https://user-images.githubusercontent.com/824194/61906518-bf801a00-aee8-11e9-938d-166c52288b19.jpg)

