### PR TITLE
Implement factories for generating devp2p protocols

### DIFF
--- a/newsfragments/850.feature.rst
+++ b/newsfragments/850.feature.rst
@@ -1,0 +1,1 @@
+Add factories for creating devp2p protocols and commands for testing.

--- a/p2p/tools/factories.py
+++ b/p2p/tools/factories.py
@@ -209,15 +209,13 @@ STRUCTURE_SEDES = (
 
 
 @to_tuple
-def StructureFactory(*sedes: Tuple[str, Any],
-                     high_water_mark: int = 4,
+def StructureFactory(high_water_mark: int = 4,
                      ) -> Iterable[Tuple[str, Any]]:
-    yield from sedes
     for idx in range(high_water_mark):
         name = f"field_{idx}"
         sedes = random.choice(STRUCTURE_SEDES)
         yield (name, sedes)
-        if random.randint(idx, high_water_mark + 2) >= high_water_mark:
+        if random.randrange(idx, high_water_mark + 2) >= high_water_mark:
             break
 
 
@@ -324,7 +322,7 @@ def ProtocolFactory(name: str = None,
     if version is None:
         version = 1
     if commands is None:
-        num_commands = random.randint(1, 6)
+        num_commands = random.randrange(1, 6)
         commands = tuple(
             CommandFactory(cmd_id=cmd_id)
             for cmd_id in range(num_commands)


### PR DESCRIPTION
pulled from #835 

### What was wrong?

In working on testing the `Multiplexer` and `Connection` objects that are coming in #684 I found I needed protocols for testing purposes.

### How was it fixed?

Created factories for generating random Devp2p protocols and commands in `p2p.tools.factories`

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

[//]: # (See: https://trinity-client.readthedocs.io/en/latest/contributing.html#pull-requests)
- [x] Add entry to the [release notes](https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses]()
