### PR TITLE
Update slashing penalty calculation

### DIFF
--- a/eth2/beacon/state_machines/forks/serenity/epoch_processing.py
+++ b/eth2/beacon/state_machines/forks/serenity/epoch_processing.py
@@ -701,13 +701,11 @@ def process_registry_updates(state: BeaconState, config: Eth2Config) -> BeaconSt
 
 def _determine_slashing_penalty(total_penalties: Gwei,
                                 total_balance: Gwei,
-                                balance: Gwei) -> Gwei:
-    return Gwei(
-        balance * min(
-            total_penalties * 3,
-            total_balance,
-        ) // total_balance
-    )
+                                balance: Gwei,
+                                increment: int) -> Gwei:
+    penalty_numerator = balance // increment * min(total_penalties * 3, total_balance)
+    penalty = penalty_numerator // total_balance * increment
+    return Gwei(penalty)
 
 
 def process_slashings(state: BeaconState, config: Eth2Config) -> BeaconState:
@@ -722,6 +720,7 @@ def process_slashings(state: BeaconState, config: Eth2Config) -> BeaconState:
                 Gwei(sum(state.slashings)),
                 total_balance,
                 validator.effective_balance,
+                config.EFFECTIVE_BALANCE_INCREMENT
             )
             state = decrease_balance(state, index, penalty)
     return state

--- a/eth2/beacon/state_machines/forks/serenity/epoch_processing.py
+++ b/eth2/beacon/state_machines/forks/serenity/epoch_processing.py
@@ -720,7 +720,7 @@ def process_slashings(state: BeaconState, config: Eth2Config) -> BeaconState:
                 Gwei(sum(state.slashings)),
                 total_balance,
                 validator.effective_balance,
-                config.EFFECTIVE_BALANCE_INCREMENT
+                config.EFFECTIVE_BALANCE_INCREMENT,
             )
             state = decrease_balance(state, index, penalty)
     return state

--- a/eth2/beacon/state_machines/forks/serenity/epoch_processing.py
+++ b/eth2/beacon/state_machines/forks/serenity/epoch_processing.py
@@ -702,7 +702,7 @@ def process_registry_updates(state: BeaconState, config: Eth2Config) -> BeaconSt
 def _determine_slashing_penalty(total_penalties: Gwei,
                                 total_balance: Gwei,
                                 balance: Gwei,
-                                increment: int) -> Gwei:
+                                increment: Gwei) -> Gwei:
     penalty_numerator = balance // increment * min(total_penalties * 3, total_balance)
     penalty = penalty_numerator // total_balance * increment
     return Gwei(penalty)

--- a/tests/eth2/core/beacon/state_machines/forks/test_serenity_epoch_processing.py
+++ b/tests/eth2/core/beacon/state_machines/forks/test_serenity_epoch_processing.py
@@ -720,17 +720,17 @@ def test_process_registry_updates(validator_count,
     [
         # total_penalties * 3 is less than total_balance
         (
-            10**9,  # 1 ETH
+            32 * 10**9,  # 1 ETH
             (32 * 10**9 * 10),
             # effective_balance * total_penalties * 3 // total_balance
-            (32 * 10**9) * (3 * 10**9) // (32 * 10**9 * 10),
+            ((32 * 10**9) // 10**9) * (3 * 32 * 10**9) // (32 * 10**9 * 10) * 10**9,
         ),
         # total_balance is less than total_penalties * 3
         (
             32 * 4 * 10**9,
             (32 * 10**9 * 10),
             # effective_balance * total_balance // total_balance,
-            (32 * 10**9) * (32 * 10**9 * 10) // (32 * 10**9 * 10),
+            (32 * 10**9) // 10**9 * (32 * 10**9 * 10) // (32 * 10**9 * 10) * 10**9,
         ),
     ]
 )
@@ -752,6 +752,7 @@ def test_determine_slashing_penalty(genesis_state,
         total_penalties,
         total_balance,
         state.validators[validator_index].effective_balance,
+        config.EFFECTIVE_BALANCE_INCREMENT,
     )
     assert penalty == expected_penalty
 
@@ -771,8 +772,8 @@ def test_determine_slashing_penalty(genesis_state,
             4,
             8,
             8,
-            (2 * 10**9, 10**9) + (0,) * 6,
-            9 * 10**8,
+            (19 * 10**9, 10**9) + (0,) * 6,
+            (32 * 10**9 // 10**9 * 60 * 10**9) // (320 * 10**9) * 10**9,
         ),
     ]
 )


### PR DESCRIPTION
### What was wrong?

We factored out the `EFFECTIVE_BALANCE_INCREMENT` to avoid overflowing a `uint64`-sized type in the spec and I thought it would not introduce a change under Python but it was causing us to fail some epoch processing spec tests.

### How was it fixed?

Use the calculation the spec uses.

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://proxy.duckduckgo.com/iu/?u=http%3A%2F%2Fimages.fanpop.com%2Fimages%2Fimage_uploads%2FBunny-Wallpapers-bunny-rabbits-128639_1024_768.jpg&f=1)
