### PR TITLE
Parallel beam sync execution

### DIFF
--- a/newsfragments/855.feature.rst
+++ b/newsfragments/855.feature.rst
@@ -1,0 +1,2 @@
+Beam Sync: parallel execution of blocks. When connected to a peer on a local network, can now
+keep up with mainnet (assuming a beefy machine). Also added beam stats in the logs.

--- a/trinity/plugins/builtin/beam_preview/plugin.py
+++ b/trinity/plugins/builtin/beam_preview/plugin.py
@@ -1,0 +1,89 @@
+import asyncio
+from abc import abstractmethod
+
+from lahja import EndpointAPI
+
+from trinity._utils.shutdown import exit_with_services
+from trinity.config import (
+    Eth1AppConfig,
+)
+from trinity.constants import (
+    SYNC_BEAM,
+)
+from trinity.db.eth1.manager import (
+    create_db_consumer_manager
+)
+from trinity.extensibility import (
+    AsyncioIsolatedPlugin,
+)
+from trinity.sync.beam.importer import (
+    make_pausing_beam_chain,
+    BlockPreviewServer,
+)
+
+
+class BeamChainPreviewPlugin(AsyncioIsolatedPlugin):
+    """
+    Subscribe to events that request a block import: ``DoStatelessBlockPreview``.
+    On every preview, run through all the transactions, downloading the
+    necessary data to execute them with the EVM.
+
+    The beam sync previewer blocks when data is missing, so it's important to run
+    in an isolated process.
+    """
+    _beam_chain = None
+
+    @property
+    @abstractmethod
+    def shard_num(self) -> int:
+        """
+        Which shard this particular plugin belongs to. Currently,
+        there are always 4 shards, so this number must be one of:
+        {0, 1, 2, 3}.
+        """
+        ...
+
+    @property
+    def name(self) -> str:
+        return f"Beam Sync Chain Preview {self.shard_num}"
+
+    def on_ready(self, manager_eventbus: EndpointAPI) -> None:
+        if self.boot_info.args.sync_mode.upper() == SYNC_BEAM.upper():
+            self.start()
+
+    def do_start(self) -> None:
+        trinity_config = self.boot_info.trinity_config
+        app_config = trinity_config.get_app_config(Eth1AppConfig)
+        chain_config = app_config.get_chain_config()
+
+        db_manager = create_db_consumer_manager(trinity_config.database_ipc_path)
+
+        self._beam_chain = make_pausing_beam_chain(
+            chain_config.vm_configuration,
+            chain_config.chain_id,
+            db_manager.get_db(),  # type: ignore
+            self.event_bus,
+            self._loop,
+            # these preview executions are lower priority than the primary block import
+            urgent=False,
+        )
+
+        import_server = BlockPreviewServer(self.event_bus, self._beam_chain, self.shard_num)
+        asyncio.ensure_future(exit_with_services(import_server, self._event_bus_service))
+        asyncio.ensure_future(import_server.run())
+
+
+class BeamChainPreviewPlugin0(BeamChainPreviewPlugin):
+    shard_num = 0
+
+
+class BeamChainPreviewPlugin1(BeamChainPreviewPlugin):
+    shard_num = 1
+
+
+class BeamChainPreviewPlugin2(BeamChainPreviewPlugin):
+    shard_num = 2
+
+
+class BeamChainPreviewPlugin3(BeamChainPreviewPlugin):
+    shard_num = 3

--- a/trinity/plugins/registry.py
+++ b/trinity/plugins/registry.py
@@ -14,6 +14,12 @@ from trinity.plugins.builtin.attach.plugin import (
 from trinity.plugins.builtin.beam_exec.plugin import (
     BeamChainExecutionPlugin,
 )
+from trinity.plugins.builtin.beam_preview.plugin import (
+    BeamChainPreviewPlugin0,
+    BeamChainPreviewPlugin1,
+    BeamChainPreviewPlugin2,
+    BeamChainPreviewPlugin3,
+)
 from trinity.plugins.builtin.ethstats.plugin import (
     EthstatsPlugin,
 )
@@ -64,6 +70,10 @@ BEACON_NODE_PLUGINS: Tuple[Type[BasePlugin], ...] = (
 
 ETH1_NODE_PLUGINS: Tuple[Type[BasePlugin], ...] = (
     BeamChainExecutionPlugin,
+    BeamChainPreviewPlugin0,
+    BeamChainPreviewPlugin1,
+    BeamChainPreviewPlugin2,
+    BeamChainPreviewPlugin3,
     EthstatsPlugin,
     SyncerPlugin,
     TxPlugin,

--- a/trinity/sync/beam/chain.py
+++ b/trinity/sync/beam/chain.py
@@ -580,7 +580,7 @@ class BeamBlockImporter(BaseBlockImporter, BaseService):
         """
         senders = [transaction.sender for transaction in transactions]
         recipients = [transaction.to for transaction in transactions if transaction.to]
-        addresses = set(senders + recipients)
+        addresses = set(senders + recipients + [header.coinbase])
         collected_nodes = await self._state_downloader.download_accounts(
             addresses,
             parent_state_root,

--- a/trinity/sync/beam/constants.py
+++ b/trinity/sync/beam/constants.py
@@ -11,3 +11,9 @@ REQUEST_BUFFER_MULTIPLIER = 16
 # How long should we wait after a peer gives us an empty response for node data,
 # before we ask for some new data from them? Measured in seconds.
 EMPTY_PEER_RESPONSE_PENALTY = 1
+
+# How many different processes are running previews? They will split the
+# block imports equally. A higher number means a slower startup, but more
+# previews are possible at a time (given that you have enough CPU cores).
+# The sensitivity of this number is relatively unexplored.
+NUM_PREVIEW_SHARDS = 4

--- a/trinity/sync/beam/service.py
+++ b/trinity/sync/beam/service.py
@@ -38,7 +38,6 @@ class BeamSyncService(BaseService):
             self.chaindb,
             self.peer_pool,
             self.event_bus,
-            force_beam_block_number=None,
             token=self.cancel_token,
         )
         await beam_syncer.run()

--- a/trinity/sync/common/chain.py
+++ b/trinity/sync/common/chain.py
@@ -264,13 +264,14 @@ class BaseBlockImporter(ABC):
             self,
             header: BlockHeader,
             transactions: Tuple[BaseTransaction, ...],
+            parent_state_root: Hash32,
             lagging: bool = True) -> None:
         """
         Give the importer a chance to preview upcoming blocks. This can improve performance
 
         :param header: The header of the upcoming block
         :param transactions: The transactions in the upcoming block
-        :param old_state_root: The state root hash at the beginning of the upcoming block
+        :param parent_state_root: The state root hash at the beginning of the upcoming block
             (the end of the previous block)
         :param lagging: Is the upcoming block *very* far ahead of the current block?
 

--- a/trinity/sync/common/events.py
+++ b/trinity/sync/common/events.py
@@ -8,6 +8,8 @@ from typing import (
 )
 
 from eth.rlp.blocks import BaseBlock
+from eth.rlp.headers import BlockHeader
+from eth.rlp.transactions import BaseTransaction
 from eth_typing import (
     Address,
     Hash32,
@@ -52,6 +54,7 @@ class CollectMissingAccount(BaseRequestResponseEvent[MissingAccountCollected]):
     missing_node_hash: Hash32
     address_hash: Hash32
     state_root_hash: Hash32
+    urgent: bool
 
     @staticmethod
     def expected_response_type() -> Type[MissingAccountCollected]:
@@ -73,6 +76,7 @@ class CollectMissingBytecode(BaseRequestResponseEvent[MissingBytecodeCollected])
     is missing from the state DB, at the given state root hash.
     """
     bytecode_hash: Hash32
+    urgent: bool
 
     @staticmethod
     def expected_response_type() -> Type[MissingBytecodeCollected]:
@@ -99,6 +103,7 @@ class CollectMissingStorage(BaseRequestResponseEvent[MissingStorageCollected]):
     storage_key: Hash32
     storage_root_hash: Hash32
     account_address: Address
+    urgent: bool
 
     @staticmethod
     def expected_response_type() -> Type[MissingStorageCollected]:
@@ -131,3 +136,12 @@ class DoStatelessBlockImport(BaseRequestResponseEvent[StatelessBlockImportDone])
     @staticmethod
     def expected_response_type() -> Type[StatelessBlockImportDone]:
         return StatelessBlockImportDone
+
+
+@dataclass
+class DoStatelessBlockPreview(BaseEvent):
+    """
+    Event to identify and download the data needed to execute the given transactions
+    """
+    header: BlockHeader
+    transactions: Tuple[BaseTransaction, ...]

--- a/trinity/sync/full/constants.py
+++ b/trinity/sync/full/constants.py
@@ -22,4 +22,13 @@ BLOCK_QUEUE_SIZE_TARGET = 1000
 # This is specifically for blocks where execution happens locally.
 # So each block might have a pretty significant execution time, on
 #   the order of seconds.
-BLOCK_IMPORT_QUEUE_SIZE = 10
+# This is also used during Beam sync (maybe we should have a different constant?)
+# The number is derived by:
+#   - number of parallel processes running (currently 4)
+#   - how many block executions can run comfortably in a single process (~2)
+#       About half the time is spent executing, and the other half waiting on nodes
+#       This might change when we start benchmarking against remote nodes
+#   - how many blocks finish early/quickly, ~half, which doubles capacity (~2)
+#   So we multiply all these together to get 16 parallel executions to permit.
+#   The first block in the queue doesn't get previewed, which brings us to 17.
+BLOCK_IMPORT_QUEUE_SIZE = 17


### PR DESCRIPTION
### What was wrong?

Beam Sync couldn't keep up

### How was it fixed?

Look ahead to upcoming blocks. Download state required to run those blocks, so that almost all of the state required is available by the time the canonical chain catches up.

Using this strategy, I've been often able to keep up with mainnet when connected to a peer on a local network.

~~I'll peel out pieces of this into smaller chunks until this is a reasonable size to review. It's just a reference point for the other PRs I peel out.~~

In order for this to run locally, you ~~have to patch~~ *need the latest master from* py-evm. ~~I'll add the patch to a comment below.~~

The part I'm least happy with is how the ancestor headers are handled in the preview execution: they are preemptively inserted to the database. This means that other places that assume some meaning in the header being present in the database (like the header syncer) could be confused. The header syncer had to be updated to check if the header was *really* present by also checking for the score.

A close runner up for hackiness is how preview stats are collected. There's some fairly awkward subclass patching. I haven't come up with anything better, yet.

Open to ideas on both!

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

[//]: # (See: https://trinity-client.readthedocs.io/en/latest/contributing.html#pull-requests)
- [ ] Add entry to the [release notes](https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses]()
