### PR TITLE
Send preview of upcoming blocks to block importer

### DIFF
--- a/p2p/peer_pool.py
+++ b/p2p/peer_pool.py
@@ -471,7 +471,7 @@ class BasePeerPool(BaseService, AsyncIterable[BasePeer]):
             if subscribers:
                 longest_queue = max(
                     self._subscribers, key=operator.attrgetter('queue_size'))
-                self.logger.info(
+                self.logger.debug(
                     "Peer subscribers: %d, longest queue: %s(%d)",
                     subscribers, longest_queue.__class__.__name__, longest_queue.queue_size)
 

--- a/trinity/sync/common/chain.py
+++ b/trinity/sync/common/chain.py
@@ -27,6 +27,7 @@ from eth.rlp.blocks import (
 from eth.rlp.headers import (
     BlockHeader,
 )
+from eth.rlp.transactions import BaseTransaction
 
 from eth2.beacon.types.blocks import BaseBeaconBlock
 
@@ -257,6 +258,27 @@ class BaseBlockImporter(ABC):
     async def import_block(
             self,
             block: BaseBlock) -> Tuple[BaseBlock, Tuple[BaseBlock, ...], Tuple[BaseBlock, ...]]:
+        pass
+
+    async def preview_transactions(
+            self,
+            header: BlockHeader,
+            transactions: Tuple[BaseTransaction, ...],
+            lagging: bool = True) -> None:
+        """
+        Give the importer a chance to preview upcoming blocks. This can improve performance
+
+        :param header: The header of the upcoming block
+        :param transactions: The transactions in the upcoming block
+        :param old_state_root: The state root hash at the beginning of the upcoming block
+            (the end of the previous block)
+        :param lagging: Is the upcoming block *very* far ahead of the current block?
+
+        The lagging parameter is used to take actions that may be resource-intensive and slow,
+        but will accelerate the block once we catch up to it. A slow preparation is a waste of
+        resources unless the upcoming block is far enough in the future.
+        """
+        # default action: none
         pass
 
 

--- a/trinity/sync/full/chain.py
+++ b/trinity/sync/full/chain.py
@@ -1168,6 +1168,11 @@ class RegularChainBodySyncer(BaseBodyChainSyncer):
             raise Exception("Invariant: unreachable code path")
 
     def _header_to_block(self, header: BlockHeader) -> BaseBlock:
+        """
+        This method converts a header that was queued up for sync into its full block
+        representation. It may not be called until after the body is marked as fully
+        downloaded, as tracked by self._block_import_tracker.
+        """
         vm_class = self.chain.get_vm_class(header)
         block_class = vm_class.get_block_class()
 
@@ -1195,7 +1200,7 @@ class RegularChainBodySyncer(BaseBodyChainSyncer):
                 [(q.num_in_progress(), len(q), q._maxsize) for q in (
                     self._block_body_tasks,
                 )],
-                "yes" if self._db_buffer_capacity.is_set() else "no",
+                self._db_buffer_capacity.is_set(),
                 self._import_active.locked(),
             )
 

--- a/trinity/sync/full/chain.py
+++ b/trinity/sync/full/chain.py
@@ -12,7 +12,6 @@ from typing import (
     Awaitable,
     Callable,
     Dict,
-    Iterable,
     List,
     NamedTuple,
     FrozenSet,
@@ -26,7 +25,6 @@ from eth_typing import Hash32
 from eth_utils import (
     humanize_hash,
     humanize_seconds,
-    to_tuple,
     ValidationError,
 )
 from eth_utils.toolz import (
@@ -77,7 +75,7 @@ from trinity.sync.common.peers import WaitingPeers
 from trinity.sync.full.constants import (
     HEADER_QUEUE_SIZE_TARGET,
     BLOCK_QUEUE_SIZE_TARGET,
-    BLOCK_IMPORT_QUEUE_SIZE_TARGET,
+    BLOCK_IMPORT_QUEUE_SIZE,
 )
 from trinity._utils.datastructures import (
     BaseOrderedTaskPreparation,
@@ -965,6 +963,9 @@ class RegularChainBodySyncer(BaseBodyChainSyncer):
 
     Here, the run() method will execute the sync loop forever, until our CancelToken is triggered.
     """
+    # track whether there is currently a block being imported
+    _is_importing = False
+
     def __init__(self,
                  chain: BaseAsyncChain,
                  db: BaseAsyncChainDB,
@@ -980,6 +981,8 @@ class RegularChainBodySyncer(BaseBodyChainSyncer):
             id_extractor=attrgetter('hash'),
             # make sure that a block is not imported until the parent block is imported
             dependency_extractor=attrgetter('parent_hash'),
+            # Avoid problems by keeping twice as much data as the import queue size
+            max_depth=BLOCK_IMPORT_QUEUE_SIZE * 2,
         )
         self._block_importer = block_importer
 
@@ -992,12 +995,16 @@ class RegularChainBodySyncer(BaseBodyChainSyncer):
             5,  # burst up to 5 logs after a lag
         )
 
+        # the queue of blocks that are downloaded and ready to be imported
+        self._import_queue: 'asyncio.Queue[BaseBlock]' = asyncio.Queue(BLOCK_IMPORT_QUEUE_SIZE)
+
     async def _run(self) -> None:
         head = await self.wait(self.db.coro_get_canonical_head())
         self._block_import_tracker.set_finished_dependency(head)
         self.run_daemon_task(self._launch_prerequisite_tasks())
         self.run_daemon_task(self._assign_body_download_to_peers())
         self.run_daemon_task(self._import_ready_blocks())
+        self.run_daemon_task(self._preview_ready_blocks())
         self.run_daemon_task(self._display_stats())
         await super()._run()
 
@@ -1040,17 +1047,19 @@ class RegularChainBodySyncer(BaseBodyChainSyncer):
             completed_headers,
         )
 
-    async def _import_ready_blocks(self) -> None:
+    async def _preview_ready_blocks(self) -> None:
         """
-        Wait for block bodies to be downloaded, then import the blocks.
+        Wait for block bodies to be downloaded, then compile the blocks and
+        preview them to the importer.
+
+        It's important to do this in a separate step from importing so that
+        previewing can get ahead of import by a few blocks.
         """
         await self.wait(self._got_first_header.wait())
         while self.is_operational:
-            timer = Timer()
-
             # This tracker waits for all prerequisites to be complete, and returns headers in
             # order, so that each header's parent is already persisted.
-            get_ready_coro = self._block_import_tracker.ready_tasks(BLOCK_IMPORT_QUEUE_SIZE_TARGET)
+            get_ready_coro = self._block_import_tracker.ready_tasks(1)
             completed_headers = await self.wait(get_ready_coro)
 
             if self._block_import_tracker.has_ready_tasks():
@@ -1061,26 +1070,61 @@ class RegularChainBodySyncer(BaseBodyChainSyncer):
                 # There is available capacity, let any waiting coroutines continue
                 self._db_buffer_capacity.set()
 
-            await self._import_blocks(completed_headers)
+            header = completed_headers[0]
+            block = self._header_to_block(header)
 
-            head = await self.wait(self.db.coro_get_canonical_head())
-            self.logger.info(
-                "Synced chain segment with %d blocks in %.2f seconds, new head: %s",
-                len(completed_headers),
-                timer.elapsed,
-                head,
+            # put block in short queue for import, wait here if queue is full
+            await self.wait(self._import_queue.put(block))
+
+            # emit block for preview, potentially execute it
+
+            # We want to limit how many parallel preview blocks are importing, so
+            #   we wait for the above put() to complete before running the following...
+            num_queued_items = self._import_queue.qsize()
+            # We are targeting at least two blocks in front before running a preview execution.
+            #   Previewing a block can take a while, so it's a waste to run it
+            #   when the block is about to be actually imported.
+            # We can tell that `block` has two in front, if qsize() == 2 after
+            #   inserting it: one block is actively importing, and one is already
+            #   in the queue.
+            lagging = num_queued_items >= 2
+            if not lagging:
+                self.logger.debug(
+                    "Skipping parallel execution of %s, because import queue is ~empty",
+                    header,
+                )
+
+            # We *always* run the preview to:
+            #   - look up the addresses referenced by the transaction (sender and recipient)
+            #   - store the header (for future evm execution that might look up old block hashes)
+            # We only run the preview *execution* if we are lagging
+            # TODO should this be split into two calls then?
+            await self._block_importer.preview_transactions(
+                header,
+                block.transactions,
+                lagging,
             )
 
-    async def _import_blocks(self, headers: Tuple[BlockHeader, ...]) -> None:
+    async def _import_ready_blocks(self) -> None:
         """
-        Import the blocks for the corresponding headers
-
-        :param headers: headers that have the block bodies downloaded
+        Wait for block bodies to be downloaded, then compile the blocks and
+        preview them to the importer.
         """
-        unimported_blocks = self._headers_to_blocks(headers)
+        await self.wait(self._got_first_header.wait())
+        while self.is_operational:
+            if self._import_queue.empty():
+                self._is_importing = False
+                waiting_for_next_block = Timer()
 
-        for block in unimported_blocks:
-            timer = Timer()
+            block = await self.wait(self._import_queue.get())
+            if not self._is_importing:
+                self.logger.info(
+                    "Paused block import %.1fs, while collecting %s body",
+                    waiting_for_next_block.elapsed,
+                    block.header,
+                )
+                self._is_importing = True
+
             await self._import_block(block)
 
     async def _import_block(self, block: BaseBlock) -> None:
@@ -1122,23 +1166,21 @@ class RegularChainBodySyncer(BaseBodyChainSyncer):
         else:
             raise Exception("Invariant: unreachable code path")
 
-    @to_tuple
-    def _headers_to_blocks(self, headers: Iterable[BlockHeader]) -> Iterable[BaseBlock]:
-        for header in headers:
-            vm_class = self.chain.get_vm_class(header)
-            block_class = vm_class.get_block_class()
+    def _header_to_block(self, header: BlockHeader) -> BaseBlock:
+        vm_class = self.chain.get_vm_class(header)
+        block_class = vm_class.get_block_class()
 
-            if _is_body_empty(header):
-                transactions: List[BaseTransaction] = []
-                uncles: List[BlockHeader] = []
-            else:
-                body = self._pending_bodies.pop(header)
-                tx_class = block_class.get_transaction_class()
-                transactions = [tx_class.from_base_transaction(tx)
-                                for tx in body.transactions]
-                uncles = body.uncles
+        if _is_body_empty(header):
+            transactions: List[BaseTransaction] = []
+            uncles: List[BlockHeader] = []
+        else:
+            body = self._pending_bodies.pop(header)
+            tx_class = block_class.get_transaction_class()
+            transactions = [tx_class.from_base_transaction(tx)
+                            for tx in body.transactions]
+            uncles = body.uncles
 
-            yield block_class(header, transactions, uncles)
+        return block_class(header, transactions, uncles)
 
     async def _display_stats(self) -> None:
         self.logger.debug("Regular sync waiting for first header to arrive")
@@ -1148,11 +1190,12 @@ class RegularChainBodySyncer(BaseBodyChainSyncer):
         while self.is_operational:
             await self.sleep(5)
             self.logger.debug(
-                "(in progress, queued, max size) of bodies, receipts: %r. Write capacity? %s",
+                "(progress, queued, max) of bodies, receipts: %r. Write capacity? %s Importing? %s",
                 [(q.num_in_progress(), len(q), q._maxsize) for q in (
                     self._block_body_tasks,
                 )],
                 "yes" if self._db_buffer_capacity.is_set() else "no",
+                self._is_importing,
             )
 
 

--- a/trinity/sync/full/constants.py
+++ b/trinity/sync/full/constants.py
@@ -22,4 +22,4 @@ BLOCK_QUEUE_SIZE_TARGET = 1000
 # This is specifically for blocks where execution happens locally.
 # So each block might have a pretty significant execution time, on
 #   the order of seconds.
-BLOCK_IMPORT_QUEUE_SIZE_TARGET = 10
+BLOCK_IMPORT_QUEUE_SIZE = 10


### PR DESCRIPTION
### What was wrong?

Peeled from #855 

Send preview of upcoming blocks to block importer

### How was it fixed?

Note: the diff looks a little larger than it really is, because of a dedent that wasn't properly lined up in the diff. I pulled that into a different commit (89a2a9a859) for a smaller review of the remainder (3bdc6cd5).

- Added a mechanism to "preview" upcoming blocks to the BlockImporter class.
- Added a queue at the end of regular block sync import, to preview some number of blocks ahead of the import
- Added some more logs to help keep track of what's going on

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

[//]: # (See: https://trinity-client.readthedocs.io/en/latest/contributing.html#pull-requests)
- [x] ~~Add entry to the [release notes](https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)~~

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](http://www.hawaiiankingdom.info/C1324550973/E20060127142402/Media/Pueo-beam1.jpg)
