### PR TITLE
fix loggers not having a level set and always logging debug2

### DIFF
--- a/newsfragments/860.bugfix.rst
+++ b/newsfragments/860.bugfix.rst
@@ -1,0 +1,1 @@
+Fix for ``DEBUG2`` logs always being shown irrespective of log level.

--- a/trinity/_utils/logging.py
+++ b/trinity/_utils/logging.py
@@ -97,7 +97,7 @@ def setup_trinity_stderr_logging(level: int=None,
     if level is None:
         level = logging.INFO
     logger = logging.getLogger()
-    logger.setLevel(0)
+    logger.setLevel(level)
 
     handler_stream = logging.StreamHandler(sys.stderr)
     handler_stream.setLevel(level)
@@ -133,6 +133,7 @@ def setup_trinity_file_and_queue_logging(
     handler_file.setFormatter(LOG_FORMATTER)
 
     logger.addHandler(handler_file)
+    logger.setLevel(level)
 
     listener = QueueListener(
         log_queue,


### PR DESCRIPTION
### What was wrong?

Setting the root logger to level `0` causes all loggers without an explicit level to have their level be `NOTSET` which results in `debug2` logs always being shown.

### How was it fixed?

Trying just removing the line.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

[//]: # (See: https://trinity-client.readthedocs.io/en/latest/contributing.html#pull-requests)
- [x] Add entry to the [release notes](https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses]()
