### PR TITLE
Fix bug with test when calculating slashed validator withdrawable epoch

### DIFF
--- a/tests/eth2/core/beacon/test_validator_status_helpers.py
+++ b/tests/eth2/core/beacon/test_validator_status_helpers.py
@@ -364,8 +364,9 @@ def test_slash_validator(genesis_state,
             validator = state.validators[index]
             assert validator.exit_epoch != FAR_FUTURE_EPOCH
             assert validator.slashed
-            assert validator.withdrawable_epoch == (
-                epoch + config.EPOCHS_PER_SLASHINGS_VECTOR
+            assert validator.withdrawable_epoch == max(
+                validator.exit_epoch + config.MIN_VALIDATOR_WITHDRAWABILITY_DELAY,
+                epoch + config.EPOCHS_PER_SLASHINGS_VECTOR,
             )
 
             slashed_epoch_index = epoch % config.EPOCHS_PER_SLASHINGS_VECTOR


### PR DESCRIPTION
### What was wrong?

Fixes #858.

### How was it fixed?

There was a bug in the test when finding a slashed validator's withdrawable epoch. The test now uses the actual computation to account for the fact when there is a deep (enough) exit queue.

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://proxy.duckduckgo.com/iu/?u=https%3A%2F%2Ftailandfur.com%2Fwp-content%2Fuploads%2F2014%2F03%2FCute-Duck-4.jpg&f=1)
