### PR TITLE
Implement Tag Utils

### DIFF
--- a/p2p/discv5/tags.py
+++ b/p2p/discv5/tags.py
@@ -1,0 +1,23 @@
+import hashlib
+
+from eth_typing import (
+    Hash32,
+)
+
+from p2p._utils import (
+    sxor,
+)
+
+
+def compute_tag(source_node_id: bytes, destination_node_id: bytes) -> Hash32:
+    """Compute the tag used in message packets sent between two nodes."""
+    destination_node_id_hash = hashlib.sha256(destination_node_id).digest()
+    tag = sxor(destination_node_id_hash, source_node_id)
+    return Hash32(tag)
+
+
+def recover_source_id_from_tag(tag: Hash32, destination_node_id: bytes) -> bytes:
+    """Recover the node id of the source from the tag in a message packet."""
+    destination_node_id_hash = hashlib.sha256(destination_node_id).digest()
+    source_node_id = sxor(tag, destination_node_id_hash)
+    return source_node_id

--- a/tests/p2p/discv5/test_tags.py
+++ b/tests/p2p/discv5/test_tags.py
@@ -1,0 +1,47 @@
+import pytest
+
+from hypothesis import (
+    given,
+    strategies as st,
+)
+
+from eth_utils import (
+    decode_hex,
+)
+
+from p2p.discv5.tags import (
+    compute_tag,
+    recover_source_id_from_tag
+)
+
+
+@given(
+    st.binary(min_size=32, max_size=32),
+    st.binary(min_size=32, max_size=32),
+)
+def test_source_recovery(source, destination):
+    tag = compute_tag(source, destination)
+    recovered_src = recover_source_id_from_tag(tag, destination)
+    assert recovered_src == source
+
+
+@pytest.mark.parametrize(("source", "destination", "tag"), (
+    (
+        decode_hex("0x0000000000000000000000000000000000000000000000000000000000000000"),
+        decode_hex("0x0000000000000000000000000000000000000000000000000000000000000000"),
+        decode_hex("66687aadf862bd776c8fc18b8e9f8e20089714856ee233b3902a591d0d5f2925"),
+    ),
+    (
+        decode_hex("0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"),
+        decode_hex("0x0000000000000000000000000000000000000000000000000000000000000000"),
+        decode_hex("0x99978552079d428893703e74716071dff768eb7a911dcc4c6fd5a6e2f2a0d6da"),
+    ),
+    (
+        decode_hex("0xf72d359a057d2c4dbb4502edd4b9ca5f71fe7f93357e733c5f18cadd754e30de"),
+        decode_hex("0x4a0f699062a9871bd8ef06f94f51d338bba02aaaedefde860093ad5f1e64dc25"),
+        decode_hex("0xa979df942382a64ea3ace81dd5ceb9d95c05ef3ef8e2515b4ab5e45638029b0a"),
+    ),
+))
+def test_tags(source, destination, tag):
+    assert compute_tag(source, destination) == tag
+    assert recover_source_id_from_tag(tag, destination) == source


### PR DESCRIPTION
Each Discv5 packet has a tag that XORs the receiver and the sender node ids together and allows the receiver to recover the sender id. This PR implements the necessary functions to work with those tags.

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://user-images.githubusercontent.com/29854669/62228514-16409480-b3be-11e9-910a-5eeb26d341ed.jpg)
