### PR TITLE
Fix beam sync flaky test

### DIFF
--- a/tests/core/p2p-proto/test_sync.py
+++ b/tests/core/p2p-proto/test_sync.py
@@ -1,4 +1,5 @@
 import asyncio
+import uuid
 
 from eth.exceptions import HeaderNotFound
 from lahja import ConnectionConfig, AsyncioEndpoint
@@ -154,11 +155,15 @@ async def test_beam_syncer(
         alice_headerdb=FakeAsyncHeaderDB(chaindb_fresh.db),
         bob_headerdb=FakeAsyncHeaderDB(chaindb_churner.db))
 
+    # Need a name that will be unique per xdist-process, otherwise
+    #   lahja IPC endpoints in each process will clobber each other
+    unique_process_name = uuid.uuid4()
+
     # manually add endpoint for beam vm to make requests
-    pausing_config = ConnectionConfig.from_name("PausingEndpoint")
+    pausing_config = ConnectionConfig.from_name(f"PausingEndpoint-{unique_process_name}")
 
     # manually add endpoint for trie data gatherer to serve requests
-    gatherer_config = ConnectionConfig.from_name("GathererEndpoint")
+    gatherer_config = ConnectionConfig.from_name(f"GathererEndpoint-{unique_process_name}")
 
     client_peer_pool = MockPeerPoolWithConnectedPeers([client_peer])
     server_peer_pool = MockPeerPoolWithConnectedPeers([server_peer], event_bus=event_bus)


### PR DESCRIPTION
### What was wrong?

Fixes #865 

### How was it fixed?

Gave each IPC endpoint a unique name, so that running tests in parallel wouldn't clobber each other.

Reproduced locally: the tests fail fairly reliably without the patch, and succeed always with it.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

[//]: # (See: https://trinity-client.readthedocs.io/en/latest/contributing.html#pull-requests)
- [x] ~~Add entry to the [release notes](https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)~~

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://i.pinimg.com/originals/ea/ba/c5/eabac5e2fffa3a6a50688dd8ef9e64f0.jpg)
