### PR TITLE
Implement handshake initiator and recipient

### DIFF
--- a/p2p/discv5/constants.py
+++ b/p2p/discv5/constants.py
@@ -8,6 +8,9 @@ NONCE_SIZE = 12  # size of an AESGCM nonce
 TAG_SIZE = 32  # size of the tag packet prefix
 MAGIC_SIZE = 32  # size of the magic hash in the who are you packet
 
+RANDOM_ENCRYPTED_DATA_SIZE = 12  # size of the random data we put in packets before handshake
+ID_NONCE_SIZE = 12  # size of the id nonce we generate for the peer during handshake
+
 MAX_PACKET_SIZE = 1280  # maximum allowed size of a packet
 
 ZERO_NONCE = Nonce(b"\x00" * NONCE_SIZE)  # nonce used for the auth header packet

--- a/p2p/discv5/handshake.py
+++ b/p2p/discv5/handshake.py
@@ -1,0 +1,435 @@
+from abc import (
+    ABC,
+    abstractmethod,
+)
+from contextlib import asynccontextmanager
+import logging
+from typing import (
+    AsyncGenerator,
+    Optional,
+    Type,
+)
+
+import trio
+from trio.abc import (
+    ReceiveChannel,
+    SendChannel,
+)
+
+from eth_utils import (
+    encode_hex,
+    ValidationError,
+)
+
+from eth_typing import (
+    Hash32,
+)
+
+from p2p.trio_service import Service
+
+from p2p.exceptions import (
+    DecryptionError,
+    HandshakeFailure,
+)
+
+from p2p.discv5.enr import ENR
+from p2p.discv5.identity_schemes import IdentityScheme
+from p2p.discv5.packets import (
+    AuthHeaderPacket,
+    AuthTagPacket,
+    WhoAreYouPacket,
+    get_random_auth_tag,
+    get_random_encrypted_data,
+    get_random_id_nonce,
+)
+from p2p.discv5.tags import (
+    compute_tag,
+)
+from p2p.discv5.typing import (
+    AES128Key,
+    IncomingMessage,
+    IncomingPacket,
+    Nonce,
+    OutgoingMessage,
+    OutgoingPacket,
+    SessionKeys,
+)
+
+
+class BaseHandshakeService(Service, ABC):
+
+    def __init__(self,
+                 peer_node_id: bytes,
+                 local_enr: ENR,
+                 local_private_key: bytes,
+                 incoming_packet_receive_channel: ReceiveChannel[IncomingPacket],
+                 outgoing_packet_send_channel: SendChannel[OutgoingPacket],
+                 session_keys_send_channel: SendChannel[SessionKeys],
+                 ) -> None:
+        self.logger = logging.getLogger("p2p.discv5.handshake." + self.__class__.__name__)
+
+        self.peer_node_id = peer_node_id
+
+        self.local_enr = local_enr
+        self.local_private_key = local_private_key
+
+        self.incoming_packet_receive_channel = incoming_packet_receive_channel
+        self.outgoing_packet_send_channel = outgoing_packet_send_channel
+
+        self.session_keys_send_channel = session_keys_send_channel
+
+    async def drop_incoming_packets(self) -> None:
+        async for incoming_packet in self.incoming_packet_receive_channel:
+            self.logger.debug(
+                f"Dropping {incoming_packet.__class__.__name__} from "
+                f"{encode_hex(self.peer_node_id)} as handshake is currently in progress"
+            )
+            continue
+
+    @asynccontextmanager
+    async def while_dropping_incoming_packets(self) -> AsyncGenerator[None, None]:
+        """Context manager to ignore incoming packets while working on other tasks."""
+        async with trio.open_nursery() as nursery:
+            nursery.start_soon(self.drop_incoming_packets)
+            try:
+                yield
+            finally:
+                nursery.cancel_scope.cancel()
+
+    @abstractmethod
+    @property
+    def identity_scheme(self) -> Type[IdentityScheme]:
+        ...
+
+    @property
+    def tag(self) -> Hash32:
+        return compute_tag(
+            source_node_id=self.local_enr.node_id,
+            destination_node_id=self.peer_node_id,
+        )
+
+
+class HandshakeInitiator(BaseHandshakeService):
+
+    def __init__(self,
+                 *,
+                 peer_enr: ENR,
+                 local_enr: ENR,
+                 local_private_key: bytes,
+                 initial_message: OutgoingMessage,
+                 incoming_packet_receive_channel: ReceiveChannel[IncomingPacket],
+                 outgoing_packet_send_channel: SendChannel[OutgoingPacket],
+                 session_keys_send_channel: SendChannel[SessionKeys],
+                 ) -> None:
+        self.peer_enr = peer_enr
+        self.peer_node_id = self.peer_enr.node_id
+        self.local_enr = local_enr
+
+        self.initial_message = initial_message
+
+        self.incoming_packet_receive_channel = incoming_packet_receive_channel
+        self.outgoing_packet_send_channel = outgoing_packet_send_channel
+
+        self.session_keys_send_channel = session_keys_send_channel
+
+    @property
+    def identity_scheme(self) -> Type[IdentityScheme]:
+        return self.peer_enr.identity_scheme
+
+    async def run(self) -> None:
+        self.logger.info(f"Initiating handshake with {encode_hex(self.peer_node_id)}")
+
+        async with self.incoming_packet_receive_channel, self.outgoing_packet_send_channel:
+            async with self.while_dropping_incoming_packets():
+                token = await self.send_initiating_packet()
+
+            # wait for the who are you response
+            incoming_packet = await self.receive_who_are_you_response(token)
+            who_are_you_packet = incoming_packet.packet
+
+            # compute session keys
+            ephemeral_private_key, ephemeral_public_key = self.identity_scheme.get_random_key_pair()
+            session_keys = self.identity_scheme.compute_session_keys(
+                local_private_key=ephemeral_private_key,
+                peer_public_key=self.peer_enr.public_key,
+                initiator_node_id=self.local_enr.node_id,
+                recipient_node_id=self.peer_node_id,
+                id_nonce=who_are_you_packet.id_nonce,
+            )
+
+            # send auth header response and finalize handshake
+            async with self.while_dropping_incoming_packets():
+                await self.send_auth_header_packet(
+                    who_are_you_packet,
+                    session_keys,
+                    ephemeral_public_key,
+                )
+                await self.session_keys_send_channel.send(session_keys)
+
+        self.logger.info(f"Successfully completed handshake with {encode_hex(self.peer_node_id)}")
+
+    async def send_initiating_packet(self) -> None:
+        self.logger.debug(
+            f"Sending random data to {encode_hex(self.peer_node_id)} to trigger WhoAreYou response"
+        )
+
+        auth_tag_packet = AuthTagPacket.prepare_random(
+            tag=self.tag,
+            auth_tag=get_random_auth_tag(),
+            random_data=get_random_encrypted_data()
+        )
+        outgoing_packet = OutgoingPacket(
+            packet=auth_tag_packet,
+            receiver=self.initial_message.receiver,
+        )
+        await self.outgoing_packet_send_channel.send(outgoing_packet)
+
+    async def receive_who_are_you_response(self, token: Nonce) -> IncomingPacket:
+        self.logger.debug("Waiting for WhoAreYou packet from {encode_hex(self.peer_node_id)}")
+
+        async for incoming_packet in self.incoming_packet_receive_channel:
+            packet = incoming_packet.packet
+            if isinstance(packet, WhoAreYouPacket):
+                if packet.token == token:
+                    self.logger.debug(
+                        f"Received expected WhoAreYou response from {encode_hex(self.peer_node_id)}"
+                    )
+                    return incoming_packet
+                else:
+                    self.logger.warning(
+                        f"Received WhoAreYou packet from {encode_hex(self.peer_node_id)}, but the "
+                        f"token {encode_hex(packet.token)} does not match the auth tag of the "
+                        f"initating packet ({encode_hex(token)})."
+                    )
+                    continue
+            else:
+                self.logger.debug(
+                    f"Dropping {incoming_packet.__class__.__name__} from "
+                    f"{encode_hex(self.peer_node_id)} since we are awaiting a WhoAreYou packet"
+                )
+                continue
+
+    async def send_auth_header_packet(self,
+                                      who_are_you_packet: WhoAreYouPacket,
+                                      session_keys: SessionKeys,
+                                      ephemeral_public_key: bytes,
+                                      ) -> None:
+        id_nonce_signature = self.identity_scheme.create_id_nonce_signature(
+            id_nonce=who_are_you_packet.id_nonce,
+            private_key=self.local_private_key,
+        )
+
+        if who_are_you_packet.enr_sequence_number < self.local_enr.sequence_number:
+            enr = self.local_enr
+        else:
+            enr = None
+
+        auth_header_packet = AuthHeaderPacket.prepare(
+            tag=self.tag,
+            auth_tag=get_random_auth_tag(),
+            message=self.initial_message,
+            initiator_key=session_keys.initator_key,
+            id_nonce_signature=id_nonce_signature,
+            auth_response_key=session_keys.auth_response_key,
+            enr=enr,
+            ephemeral_pubkey=ephemeral_public_key,
+        )
+
+        self.logger.debug(f"Sending AuthHeaderPacket to {encode_hex(self.peer_node_id)}")
+        await self.outgoing_packet_send_channel.send(auth_header_packet)
+
+
+class HandshakeRecipient(BaseHandshakeService):
+
+    def __init__(self,
+                 *,
+                 peer_node_id: bytes,
+                 peer_enr: Optional[ENR],
+                 local_enr: ENR,
+                 local_private_key: bytes,
+                 initiating_packet: IncomingPacket,
+                 incoming_packet_receive_channel: ReceiveChannel[IncomingPacket],
+                 outgoing_packet_send_channel: SendChannel[OutgoingPacket],
+                 session_keys_send_channel: SendChannel[SessionKeys],
+                 enr_update_send_channel: SendChannel[ENR],
+                 incoming_message_send_channel: SendChannel[IncomingMessage],
+                 ) -> None:
+        super().__init__(
+            peer_node_id=peer_node_id,
+            local_enr=local_enr,
+            local_private_key=local_private_key,
+            incoming_packet_receive_channel=incoming_packet_receive_channel,
+            outgoing_packet_send_channel=outgoing_packet_send_channel,
+            session_keys_send_channel=session_keys_send_channel,
+        )
+
+        if peer_enr is not None:
+            if peer_enr.node_id != peer_node_id:
+                raise ValueError("Node id according to ENR does not match explicitly given one")
+
+        self.peer_enr = peer_enr
+        self.enr_update_send_channel = enr_update_send_channel
+        self.incoming_message_send_channel = incoming_message_send_channel
+
+        self.initiating_packet = initiating_packet
+        if not isinstance(self.initiating_packet.packet, AuthTagPacket):
+            raise TypeError("Handshake must be initiated by AuthTagPacket")
+
+    @property
+    def identity_scheme(self) -> Type[IdentityScheme]:
+        return self.local_enr.identity_scheme
+
+    async def run(self) -> None:
+        self.logger.info(f"Starting handshake as recipient with {encode_hex(self.peer_node_id)}")
+
+        async with (
+            self.incoming_packet_receive_channel,
+            self.outgoing_packet_send_channel,
+            self.enr_update_send_channel,
+            self.session_keys_send_channel,
+            self.incoming_message_send_channel,
+        ):
+            async with self.while_dropping_incoming_packets():
+                id_nonce = await self.send_who_are_you_response()
+
+            incoming_packet = await self.receive_auth_header_response()
+            auth_header_packet = incoming_packet.packet
+
+            ephemeral_public_key = auth_header_packet.auth_header.ephemeral_public_key
+            try:
+                self.identity_scheme.validate_public_key(ephemeral_public_key)
+            except ValidationError as error:
+                raise HandshakeFailure(
+                    f"AuthHeader packet from contains invalid ephemeral public key "
+                    f"{encode_hex(ephemeral_public_key)}"
+                ) from error
+
+            session_keys = self.identity_scheme.compute_session_keys(
+                local_private_key=self.local_private_key,
+                peer_public_key=ephemeral_public_key,
+                initiator_node_id=self.peer_node_id,
+                recipient_node_id=self.local_enr.node_id,
+                id_nonce=id_nonce,
+            )
+
+            enr = self.decrypt_and_validate_auth_response(
+                auth_header_packet,
+                session_keys.auth_response_key,
+                id_nonce,
+            )
+
+            try:
+                message = auth_header_packet.decrypt(session_keys.initiator_key)
+            except DecryptionError as error:
+                raise HandshakeFailure(
+                    "Failed to decrypt message with newly established session keys"
+                ) from error
+            except ValidationError as error:
+                raise HandshakeFailure("Received invalid message") from error
+            else:
+                incoming_message = IncomingMessage(
+                    message=message,
+                    sender=incoming_packet.sender,
+                    node_id=self.peer_node_id,
+                )
+
+            self.logger.info(
+                f"Successfully completed handshake with {encode_hex(self.peer_node_id)}"
+            )
+            async with self.while_dropping_incoming_packets():
+                if enr is not None:
+                    await self.enr_update_send_channel.send(enr)
+                await self.session_keys_send_channel.send(session_keys)
+                await self.incoming_message_send_channel.send(incoming_message)
+
+    def decrypt_and_validate_auth_response(self,
+                                           auth_header_packet: AuthHeaderPacket,
+                                           auth_response_key: AES128Key,
+                                           id_nonce: bytes,
+                                           ) -> Optional[ENR]:
+        # decrypt
+        try:
+            id_nonce_signature, enr = auth_header_packet.decrypt_auth_response(auth_response_key)
+        except DecryptionError as error:
+            raise HandshakeFailure("Unable to decrypt auth response") from error
+        except ValidationError as error:
+            raise HandshakeFailure("Invalid auth response content") from error
+
+        # validate ENR if present
+        if enr is None:
+            if self.peer_enr is None:
+                raise HandshakeFailure("Peer failed to send their ENR")
+            else:
+                current_peer_enr = self.peer_enr
+        else:
+            try:
+                enr.validate_signature()
+            except ValidationError as error:
+                raise HandshakeFailure("ENR in auth response contains invalid signature") from error
+
+            if enr.sequence_number <= self.peer_enr.sequence_number:
+                raise HandshakeFailure(
+                    "ENR in auth response is not newer than what we already have"
+                )
+
+            if enr.node_id != self.peer_node_id:
+                raise HandshakeFailure(
+                    f"ENR received from peer belongs to different node ({encode_hex(enr.node_id)} "
+                    f"instead of {encode_hex(self.peer_node_id)})"
+                )
+
+            current_peer_enr = enr
+
+        # validate id nonce signature
+        try:
+            self.identity_scheme.validate_id_nonce_signature(
+                signature=id_nonce_signature,
+                id_nonce=id_nonce,
+                public_key=current_peer_enr.public_key,
+            )
+        except ValidationError as error:
+            raise HandshakeFailure("Invalid id nonce signature in auth response") from error
+
+        return enr
+
+    async def send_who_are_you_response(self) -> bytes:
+        id_nonce = get_random_id_nonce()
+
+        if self.peer_enr is None:
+            enr_sequence_number = 0
+        else:
+            enr_sequence_number = self.peer_enr.sequence_number
+
+        who_are_you_packet = WhoAreYouPacket.prepare(
+            tag=self.tag,
+            destination_node_id=self.peer_node_id,
+            token=self.initiating_packet.packet.auth_tag,
+            id_nonce=id_nonce,
+            enr_sequence_number=enr_sequence_number,
+        )
+        outgoing_packet = OutgoingPacket(
+            packet=who_are_you_packet,
+            receiver=self.initiating_packet.sender,
+        )
+        self.logger.debug(f"Sending WhoAreYou response to {encode_hex(self.peer_node_id)}")
+        await self.outgoing_packet_send_channel.send(outgoing_packet)
+
+        return id_nonce
+
+    async def receive_auth_header_response(self) -> IncomingPacket:
+        self.logger.debug("Waiting for AuthHeaderPacket from {encode_hex(self.peer_node_id)}")
+
+        async for incoming_packet in self.incoming_packet_receive_channel:
+            packet = incoming_packet.packet
+            if isinstance(packet, AuthHeaderPacket):
+                self.logger.debug(
+                    f"Received expected AuthHeaderPacket response from "
+                    f"{encode_hex(self.peer_node_id)}"
+                )
+                return incoming_packet
+            else:
+                self.logger.debug(
+                    f"Dropping {packet.__class__.__name__} from {encode_hex(self.peer_node_id)} "
+                    f"since we are awaiting an AuthHeader packet"
+                )
+                continue

--- a/p2p/discv5/packets.py
+++ b/p2p/discv5/packets.py
@@ -1,5 +1,5 @@
 import hashlib
-
+import os
 from typing import (
     cast,
     NamedTuple,
@@ -47,9 +47,12 @@ from p2p.discv5.enr import (
 )
 from p2p.discv5.constants import (
     AUTH_SCHEME_NAME,
+    RANDOM_ENCRYPTED_DATA_SIZE,
+    ID_NONCE_SIZE,
     MAX_PACKET_SIZE,
     TAG_SIZE,
     MAGIC_SIZE,
+    NONCE_SIZE,
     ZERO_NONCE,
     WHO_ARE_YOU_MAGIC_SUFFIX,
 )
@@ -508,3 +511,18 @@ def _decrypt_message(initiator_key: AES128Key,
         raise ValidationError("Encrypted message does not contain valid RLP") from error
 
     return message
+
+
+#
+# Random content
+#
+def get_random_id_nonce() -> bytes:
+    return os.urandom(ID_NONCE_SIZE)
+
+
+def get_random_auth_tag() -> Nonce:
+    return Nonce(os.urandom(NONCE_SIZE))
+
+
+def get_random_encrypted_data() -> bytes:
+    return os.urandom(RANDOM_ENCRYPTED_DATA_SIZE)

--- a/tests/p2p-trio/test_full_handshake.py
+++ b/tests/p2p-trio/test_full_handshake.py
@@ -1,0 +1,289 @@
+import math
+
+import pytest
+
+import trio
+
+from p2p.trio_service import (
+    Manager,
+)
+
+from p2p.discv5.enr import (
+    UnsignedENR,
+)
+from p2p.discv5.identity_schemes import (
+    V4IdentityScheme,
+)
+from p2p.discv5.handshake import (
+    HandshakeInitiator,
+    HandshakeRecipient,
+)
+
+
+#
+# Fixtures
+#
+@pytest.fixture
+def initiator_key_pair():
+    return V4IdentityScheme.create_random_key_pair()
+
+
+@pytest.fixture
+def initiator_private_key(initiator_key_pair):
+    private_key, _ = initiator_key_pair
+    return private_key
+
+
+@pytest.fixture
+def initiator_public_key(initiator_key_pair):
+    _, public_key = initiator_key_pair
+    return public_key
+
+
+@pytest.fixture
+def recipient_key_pair():
+    return V4IdentityScheme.create_random_key_pair()
+
+
+@pytest.fixture
+def recipient_private_key(recipient_key_pair):
+    private_key, _ = recipient_key_pair
+    return private_key
+
+
+@pytest.fixture
+def recipient_public_key(recipient_key_pair):
+    _, public_key = recipient_key_pair
+    return public_key
+
+
+@pytest.fixture
+def initiator_enr(initiator_private_key, initiator_public_key):
+    return UnsignedENR(
+        sequence_number=3,
+        kv_pairs={
+            b"id": b"v4",
+            b"secp256k1": initiator_public_key,
+        }
+    ).to_signed_enr(initiator_private_key)
+
+
+@pytest.fixture
+def recipient_enr(recipient_private_key, recipient_public_key):
+    return UnsignedENR(
+        sequence_number=3,
+        kv_pairs={
+            b"id": b"v4",
+            b"secp256k1": recipient_public_key,
+        }
+    ).to_signed_enr(recipient_private_key)
+
+
+@pytest.fixture
+def initiator_endpoint():
+    return Endpoint(
+        ip_address=b"initiator",
+        port=123456,
+    )
+
+
+@pytest.fixture
+def recipient_endpoint():
+    return Endpoint(
+        ip_address=b"recipient",
+        port=123456,
+    )
+
+
+@pytest.fixture
+def run_handshake_test(initiator_private_key,
+                       recipient_private_key,
+                       initiator_enr,
+                       recipient_enr,
+                       initiator_endpoint,
+                       recipient_endpoint):
+
+    async def run_handshake_test(additional_initiator_kwargs=None,
+                                 additional_recipient_kwargs=None):
+        # packet channels
+        initiator_outgoing_send, initiator_outgoing_receive = trio.open_memory_channel(0)
+        recipient_incoming_send, recipient_incoming_receive = trio.open_memory_channel(0)
+        recipient_outgoing_send, recipient_outgoing_receive = trio.open_memory_channel(0)
+        initiator_incoming_send, initiator_incoming_receive = trio.open_memory_channel(0)
+
+        async def bridge_packet_channels(outgoing_receive, incoming_send):
+            async with outgoing_receive:
+                async for outgoing_packet in outgoing_receive:
+                    if outgoing_packet.receiver == recipient_endpoint:
+                        sender = initiator_endpoint
+                    elif outgoing_packet.receiver == initiator_endpoint:
+                        sender = recipient_endpoint
+                    else:
+                        assert False, "Unknown receiver endpoint"
+
+                    incoming_packet = IncomingPacket(
+                        packet=outgoing_packet.packet,
+                        sender=sender,
+                    )
+                    await incoming_send.send(incoming_packet)
+
+        # use unbounded channels so that we can process the results at the end without risking to
+        # block the handshake services
+        initiator_session_keys_channel_pair = trio.open_memory_channel(math.inf)
+        recipient_session_keys_channel_pair = trio.open_memory_channel(math.inf)
+        recipient_enr_update_channel_pair = trio.open_memory_channel(math.inf)
+        recipient_message_channel_pair = trio.open_memory_channel(math.inf)
+
+        initial_message = OutgoingMessage(
+            message=PingMessage(request_id=5, enr_seq=recipient_enr.sequence_number),
+            node_id=recipient_enr.node_id,
+            receiver=recipient_endpoint,
+        )
+        handshake_initiator = HandshakeInitiator(**{
+            **{
+                "peer_enr": recipient_enr,
+                "local_enr": initiator_enr,
+                "local_private_key": initiator_private_key,
+                "initial_message": initial_message,
+                "incoming_packet_receive_channel": initiator_incoming_receive,
+                "outgoing_packet_send_channel": initiator_outgoing_send,
+                "session_keys_send_channel": initiator_session_keys_channel_pair[0],
+            },
+            **(additional_initiator_kwargs or {}),
+        })
+
+        async def run_handshake_recipient():
+            initiating_packet = await recipient_incoming_receive.receive()
+            handshake_recipient = HandshakeRecipient(**{
+                **{
+                    "peer_node_id": initiator_enr.node_id,
+                    "peer_enr": initiator_enr,
+                    "local_enr": recipient_enr,
+                    "local_private_key": recipient_private_key,
+                    "initiating_packet": initiating_packet,
+                    "incoming_packet_receive_channel": recipient_incoming_receive,
+                    "outgoing_packet_send_channel": recipient_outgoing_send,
+                    "session_keys_send_channel": recipient_session_keys_channel_pair[0],
+                    "enr_update_send_channel": recipient_enr_update_channel_pair[0],
+                    "incoming_message_send_channel": recipient_message_channel_pair[0],
+                },
+                **(additional_recipient_kwargs or {}),
+            })
+            await Manager.run(handshake_recipient)
+
+        async with trio.open_nursery() as nursery:
+            nursery.start_soon(
+                bridge_packet_channels,
+                initiator_outgoing_receive,
+                recipient_incoming_send,
+            )
+            nursery.start_soon(
+                bridge_packet_channels,
+                recipient_outgoing_receive,
+                initiator_incoming_send,
+            )
+
+            async with trio.open_nursery() as handshake_nursery:
+                handshake_nursery.start_soon(Manager.run, handshake_initiator)
+                handshake_nursery.start_soon(run_handshake_recipient)
+
+            nursery.cancel_scope.cancel()
+
+
+def assert_empty(receive_channel):
+    with pytest.raises(trio.WouldBlock):
+        receive_channel.receive_nowait()
+
+
+#
+# Tests
+#
+async def test_session_keys_are_equal(run_handshake_test):
+    initiator_session_keys_channel_pair = trio.open_memory_channel(math.inf)
+    recipient_session_keys_channel_pair = trio.open_memory_channel(math.inf)
+
+    with trio.fail_after(0.5):
+        run_handshake_test(
+            additional_initiator_kwargs={
+                "session_keys_send_channel": initiator_session_keys_channel_pair[0],
+            },
+            additional_recipient_kwargs={
+                "session_keys_send_channel": recipient_session_keys_channel_pair[0],
+            },
+        )
+
+    initiator_session_keys = initiator_session_keys_channel_pair[1].receive_nowait()
+    recipient_session_keys = recipient_session_keys_channel_pair[1].receive_nowait()
+    assert initiator_session_keys == recipient_session_keys
+    assert_empty(initiator_session_keys_channel_pair[1])
+    assert_empty(recipient_session_keys_channel_pair[1])
+
+
+async def test_enr_update(run_handshake_test, initiator_enr, initiator_private_key):
+    enr_channel_pair = trio.open_memory_channel(math.inf)
+
+    # no ENR is sent if recipient knows the most up to date one
+    with trio.fail_after(0.5):
+        run_handshake_test(
+            additional_recipient_kwargs={
+                "peer_enr": initiator_enr,
+                "enr_update_send_channel": enr_channel_pair[0],
+            },
+        )
+    assert_empty(enr_channel_pair[1])
+
+    # ENR is sent if recipient knows no ENR at all
+    with trio.fail_after(0.5):
+        run_handshake_test(
+            additional_recipient_kwargs={
+                "peer_enr": None,
+                "enr_update_send_channel": enr_channel_pair[0],
+            },
+        )
+    enr = enr_channel_pair[1].receive_nowait()
+    assert enr == initiator_enr
+    assert_empty(enr_channel_pair[1])
+
+    # ENR is sent if recipient only knows outdated ENR
+    outdated_enr = UnsignedENR(
+        sequence_number=initiator_enr.sequence_number - 1,
+        kv_pairs=dict(initiator_enr),
+    ).to_signed_enr(initiator_private_key)
+    with trio.fail_after(0.5):
+        run_handshake_test(
+            additional_recipient_kwargs={
+                "peer_enr": outdated_enr,
+                "enr_update_send_channel": enr_channel_pair[0],
+            },
+        )
+    enr = enr_channel_pair[1].receive_nowait()
+    assert enr == initiator_enr
+    assert_empty(enr_channel_pair[1])
+
+
+async def test_message_is_transmitted(run_handshake_test,
+                                      initiator_endpoint,
+                                      recipient_endpoint,
+                                      recipient_enr):
+    message_channel_pair = trio.open_memory_channel(math.inf)
+
+    initial_message = OutgoingMessage(
+        message=PingMessage(request_id=0, enr_seq=recipient_enr.sequence_number),
+        node_id=recipient_enr.node_id,
+        receiver=recipient_endpoint,
+    )
+    with trio.fail_after(0.5):
+        run_handshake_test(
+            additional_initiator_kwargs={
+                "initial_message": initial_message,
+            },
+            additional_recipient_kwargs={
+                "incoming_message_send_channel": message_channel_pair[0],
+            },
+        )
+
+    received_message = message_channel_pair[1].receive_nowait()
+    assert received_message.sender == initiator_endpoint
+    assert received_message.node_id == initiator_enr.node_id
+    assert received_message.message == initial_message.message
+    assert_empty(message_channel_pair[1])


### PR DESCRIPTION
This adds two trio services that perform a handshake either as initiator or recipient. The idea is that there's some kind of peer class that launches one of them if necessary (i.e. if they receive a message they can't decrypt or they want to send a message to a new peer) and then hands over all responsibility to it. Once the handshake is complete the service exits and the peer class can take over again.

I've tried different architectures and this one seems the cleanest to me, mostly because initiator and recipient logic is separated into different classes, but at the same time fully contained in them. This makes it relatively easy to follow the protocol step by step without having to jump around to much. The disadvantage is that we also have to deal with packets that are not related to the handshake but are received at the same time. Fortunately, according to the spec we can just drop them as peers are expected to resend them once the handshake is complete, which makes the handling quite easy.

I've kept the tests relatively high-level: Just connect an initiator to a recipient and see that it works properly. This is obviously not enough because we're missing all the conditions under which a handshake is supposed to fail. But for now I'd rather not write more detailed tests as it's a pretty open ended task and we (hopefully) will get a standardized official test suite at some point anyway.

It's not ready to merge or for a detailed review yet: I've written it mostly blindly as it builds on top of #825, #864 and also some minor refactoring I'd like to do before (mostly adding some more detailed type hints for stuff like node ids, id nonces, etc.). So this doesn't actually work right now, but the general structure is pretty much finished I would say. But I'm also fine to wait for a review until all lower level work is done. Just wanted to open a PR to get it out.

Unfortunately, the PR is pretty big. The only way I can see to make it split it up into two (one for initiator and one for recipient). But I'm not sure if that actually makes reviewing easier?


### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

[//]: # (See: https://trinity-client.readthedocs.io/en/latest/contributing.html#pull-requests)
- [ ] Add entry to the [release notes](https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://user-images.githubusercontent.com/29854669/62385032-428e1980-b554-11e9-91d9-fbcbf54413fe.jpg)