### PR TITLE
Implement handshaker api for devp2p protocol

### DIFF
--- a/newsfragments/869.feature.rst
+++ b/newsfragments/869.feature.rst
@@ -1,0 +1,3 @@
+Implement ``p2p.handshake`` API.  This provides a generic interface for
+performing proper DevP2p handshakes using multiple sub-protocols without
+needing involvement of the ``BasePeer``.

--- a/p2p/_utils.py
+++ b/p2p/_utils.py
@@ -1,7 +1,9 @@
+import collections
 from concurrent.futures import Executor, ProcessPoolExecutor
 import logging
 import os
 import signal
+from typing import Hashable, Sequence, Tuple, TypeVar
 
 import rlp
 
@@ -113,3 +115,15 @@ def trim_middle(arbitrary_string: str, max_length: int) -> str:
         else:
             last_half = ''
         return f"{first_half}✂✂✂{last_half}"
+
+
+TValue = TypeVar('TValue', bound=Hashable)
+
+
+def duplicates(elements: Sequence[TValue]) -> Tuple[TValue, ...]:
+    return tuple(
+        value for
+        value, count in
+        collections.Counter(elements).items()
+        if count > 1
+    )

--- a/p2p/abc.py
+++ b/p2p/abc.py
@@ -25,7 +25,7 @@ from p2p.typing import Capability, Payload, Structure
 
 if TYPE_CHECKING:
     from p2p.p2p_proto import (  # noqa: F401
-        P2PProtocol,
+        BaseP2PProtocol,
     )
 
 
@@ -298,7 +298,7 @@ class MultiplexerAPI(ABC):
         ...
 
     @abstractmethod
-    def get_base_protocol(self) -> 'P2PProtocol':
+    def get_base_protocol(self) -> 'BaseP2PProtocol':
         ...
 
     @abstractmethod

--- a/p2p/exceptions.py
+++ b/p2p/exceptions.py
@@ -175,3 +175,9 @@ class UnableToGetDiscV5Ticket(BaseP2PError):
     Raised when we're unable to get a discv5 ticket from a remote peer.
     """
     pass
+
+
+class NoMatchingPeerCapabilities(BaseP2PError):
+    """
+    Raised during primary p2p handshake if there are no common capabilities with a peer.
+    """

--- a/p2p/handshake.py
+++ b/p2p/handshake.py
@@ -1,0 +1,317 @@
+from abc import ABC, abstractmethod
+import asyncio
+import functools
+import logging
+import operator
+from typing import (
+    cast,
+    Any,
+    Dict,
+    Iterable,
+    NamedTuple,
+    Type,
+    Tuple,
+)
+
+from cancel_token import CancelToken
+
+from eth_utils import to_tuple
+from eth_utils.toolz import groupby, valmap
+
+from eth.tools.logging import ExtendedDebugLogger
+
+from p2p.abc import TransportAPI, MultiplexerAPI
+from p2p.constants import (
+    SNAPPY_PROTOCOL_VERSION,
+)
+from p2p.exceptions import (
+    HandshakeFailure,
+    NoMatchingPeerCapabilities,
+)
+from p2p.multiplexer import (
+    stream_transport_messages,
+    Multiplexer,
+)
+from p2p.p2p_proto import (
+    Hello,
+    BaseP2PProtocol,
+    P2PProtocol,
+    P2PProtocolV4,
+)
+from p2p.protocol import (
+    get_cmd_offsets,
+    Protocol,
+)
+from p2p.typing import (
+    Capabilities,
+    Capability,
+)
+
+
+class HandshakeReceipt:
+    """
+    Data storage object for ephemeral data exchanged during protocol
+    handshakes.
+    """
+    protocol: Protocol
+
+    def __init__(self, protocol: Protocol) -> None:
+        self.protocol = protocol
+
+
+class Handshaker(ABC):
+    """
+    Base class that handles the handshake for a given protocol.  The primary
+    justification for this class's existence is to house parameters that are
+    needed for the protocol handshake.
+    """
+    logger = cast(ExtendedDebugLogger, logging.getLogger('p2p.connection.ProtocolHandler'))
+
+    protocol_class: Type[Protocol]
+
+    @abstractmethod
+    async def do_handshake(self,
+                           multiplexer: MultiplexerAPI,
+                           protocol: Protocol) -> HandshakeReceipt:
+        """
+        Perform the actual handshake for the protocol.
+        """
+        ...
+
+
+class DevP2PReceipt(HandshakeReceipt):
+    """
+    Record of the handshake data from the core `p2p` protocol handshake.
+    """
+    def __init__(self,
+                 protocol: BaseP2PProtocol,
+                 version: int,
+                 client_version_string: str,
+                 capabilities: Capabilities,
+                 listen_port: int,
+                 remote_public_key: bytes) -> None:
+        super().__init__(protocol)
+        self.version = version
+        self.client_version_string = client_version_string
+        self.capabilities = capabilities
+        self.listen_port = listen_port
+        self.remote_public_key = remote_public_key
+
+
+class DevP2PHandshakeParams(NamedTuple):
+    client_version_string: str
+    listen_port: int
+    version: int
+
+    def get_base_protocol_class(self) -> Type[BaseP2PProtocol]:
+        if self.version == 5:
+            return P2PProtocol
+        elif self.version == 4:
+            return P2PProtocolV4
+        else:
+            raise Exception(
+                f"Unknown protocol version: {self.version}.  Expected one of "
+                f"`4` or `5`"
+            )
+
+
+@to_tuple
+def _select_capabilities(remote_capabilities: Capabilities,
+                         local_capabilities: Capabilities) -> Iterable[Capability]:
+    """Select the sub-protocol to use when talking to the remote.
+
+    Find the highest version of our supported sub-protocols that is also supported by the
+    remote and stores an instance of it (with the appropriate cmd_id offset) in
+    self.protocol.
+
+    Raises NoMatchingPeerCapabilities if none of our supported protocols match one of the
+    remote's protocols.
+    """
+    # Determine the remote capabilites that intersect with our own.
+    matching_capabilities = tuple(sorted(
+        set(local_capabilities).intersection(remote_capabilities),
+        key=operator.itemgetter(0),
+    ))
+    # generate a dictionary of each capability grouped by name and sorted by
+    # version in descending order.
+    sort_by_version = functools.partial(sorted, key=operator.itemgetter(1), reverse=True)
+    capabilities_by_name = valmap(
+        tuple,
+        valmap(
+            sort_by_version,
+            groupby(operator.itemgetter(0), matching_capabilities),
+        ),
+    )
+
+    # now we loop over the names that have a matching capability and return the
+    # *highest* version one.
+    for name in sorted(capabilities_by_name.keys()):
+        yield capabilities_by_name[name][0]
+
+
+async def _do_p2p_handshake(transport: TransportAPI,
+                            capabilites: Capabilities,
+                            p2p_handshake_params: DevP2PHandshakeParams,
+                            base_protocol: BaseP2PProtocol,
+                            token: CancelToken) -> Tuple[DevP2PReceipt, BaseP2PProtocol]:
+    client_version_string, listen_port, version = p2p_handshake_params
+    if version != base_protocol.version:
+        raise Exception(
+            f"Protocol class has versin `{base_protocol.version}` but handshake "
+            f"params have version `{version}`"
+        )
+    base_protocol.send_handshake(client_version_string, capabilites, listen_port)
+
+    # The base `p2p` protocol handshake directly streams the messages as it has
+    # strict requirements about receiving the `Hello` message first.
+    async for _, cmd, msg in stream_transport_messages(transport, base_protocol, token=token):
+        if not isinstance(cmd, Hello):
+            raise HandshakeFailure(
+                f"First message across the DevP2P connection must be a Hello "
+                f"msg, got {cmd}, disconnecting"
+            )
+
+        msg = cast(Dict[str, Any], msg)
+
+        protocol: BaseP2PProtocol
+
+        if base_protocol.version >= SNAPPY_PROTOCOL_VERSION:
+            # Check whether to support Snappy Compression or not
+            # based on other peer's p2p protocol version
+            snappy_support = msg['version'] >= SNAPPY_PROTOCOL_VERSION
+
+            if snappy_support:
+                # Now update the base protocol to support snappy compression
+                # This is needed so that Trinity is compatible with parity since
+                # parity sends Ping immediately after handshake
+                protocol = P2PProtocol(
+                    transport,
+                    snappy_support=True,
+                )
+            else:
+                protocol = base_protocol
+        else:
+            protocol = base_protocol
+
+        devp2p_receipt = DevP2PReceipt(
+            protocol=protocol,
+            version=msg['version'],
+            client_version_string=msg['client_version_string'],
+            capabilities=msg['capabilities'],
+            remote_public_key=msg['remote_pubkey'],
+            listen_port=msg['listen_port'],
+        )
+        break
+    else:
+        raise HandshakeFailure("DevP2P message stream exited before finishing handshake")
+
+    return devp2p_receipt, protocol
+
+
+async def negotiate_protocol_handshakes(transport: TransportAPI,
+                                        p2p_handshake_params: DevP2PHandshakeParams,
+                                        protocol_handshakers: Tuple[Handshaker, ...],
+                                        token: CancelToken,
+                                        ) -> Tuple[MultiplexerAPI, DevP2PReceipt, Tuple[HandshakeReceipt, ...]]:  # noqa: E501
+    """
+    Negotiate the handshakes for both the base `p2p` protocol and the
+    appropriate sub protocols.  The basic logic follows the following steps.
+
+    * perform the base `p2p` handshake.
+    * using the capabilities exchanged during the `p2p` handshake, select the
+      appropriate sub protocols.
+    * allow each sub-protocol to perform its own handshake.
+    * return the established `Multiplexer` as well as the `HandshakeReceipt`
+      objects from each handshake.
+    """
+    # The `p2p` Protocol class that will be used.
+    p2p_protocol_class = p2p_handshake_params.get_base_protocol_class()
+
+    # Collect our local capabilities, the set of (name, version) pairs for all
+    # of the protocols that we support.
+    local_capabilities = tuple(
+        handshaker.protocol_class.as_capability()
+        for handshaker
+        in protocol_handshakers
+    )
+    # We create an *ephemeral* version of the base `p2p` protocol with snappy
+    # compression disabled for the handshake.  As part of the handshake, a new
+    # instance of this protocol will be created with snappy compression enabled
+    # if it is supported by the protocol version.
+    ephemeral_base_protocol: BaseP2PProtocol
+    if issubclass(p2p_protocol_class, P2PProtocolV4):
+        ephemeral_base_protocol = p2p_protocol_class(transport)
+    elif issubclass(p2p_protocol_class, P2PProtocol):
+        ephemeral_base_protocol = p2p_protocol_class(transport, False)
+    else:
+        raise Exception(f"Unknown p2p protocol class: {p2p_protocol_class}")
+    # Perform the actual `p2p` protocol handshake.  We need the remote
+    # capabilities data from the receipt to select the appropriate sub
+    # protocols.
+    devp2p_receipt, base_protocol = await _do_p2p_handshake(
+        transport,
+        local_capabilities,
+        p2p_handshake_params,
+        ephemeral_base_protocol,
+        token,
+    )
+
+    # This data structure is simply for easy retrieval of the proper
+    # `Handshaker` for each selectd protocol.
+    protocol_handshakers_by_capability = dict(zip(local_capabilities, protocol_handshakers))
+    # Using our local capabilities and the ones transmitted by the remote
+    # select the highest shared version of each shared protocol.
+    selected_capabilities = _select_capabilities(
+        devp2p_receipt.capabilities,
+        protocol_handshakers_by_capability.keys()
+    )
+    # If there are no capability matches throw an exception.
+    if len(selected_capabilities) < 1:
+        raise NoMatchingPeerCapabilities(
+            "Found no matching capabilities between self and peer:\n"
+            f" - local : {tuple(sorted(protocol_handshakers_by_capability.keys()))}\n"
+            f" - remote: {devp2p_receipt.capabilities}"
+        )
+
+    # Retrieve the handshakers which correspond to the selected protocols.
+    # These are needed to perform the actual handshake logic for each protocol.
+    selected_handshakers = tuple(
+        protocol_handshakers_by_capability[capability]
+        for capability in selected_capabilities
+    )
+    # Grab the `Protocol` class for each of the selected protocols.  We need
+    # this to compute the offsets for each protocol's command ids, as well as
+    # for instantiation of the protocol instances.
+    selected_protocol_types = tuple(
+        handshaker.protocol_class
+        for handshaker
+        in selected_handshakers
+    )
+    # Compute the offsets for each protocol's command ids
+    protocol_cmd_offsets = get_cmd_offsets(selected_protocol_types)
+    # Now instantiate instances of each of the protocol classes.
+    selected_protocols = tuple(
+        protocol_class(transport, cmd_id_offset, base_protocol.snappy_support)
+        for protocol_class, cmd_id_offset
+        in zip(selected_protocol_types, protocol_cmd_offsets)
+    )
+    # Create `Multiplexer` to abstract all of the protocols into a single
+    # interface to stream only messages relevant to the given protocol.
+    multiplexer = Multiplexer(transport, base_protocol, selected_protocols, token=token)
+
+    # This context manager runs a background task which reads messages off of
+    # the `Transport` and feeds them into protocol specific queues.  Each
+    # protocol is responsible for reading its own messages from that queue via
+    # the `Multiplexer.stream_protocol_messages` API.
+    async with multiplexer.multiplex():
+        # Concurrently perform the handshakes for each protocol, gathering up
+        # the returned receipts.
+        protocol_receipts = await asyncio.gather(*(
+            handshaker.do_handshake(multiplexer, protocol)
+            for handshaker, protocol
+            in zip(selected_handshakers, selected_protocols)
+        ))
+    # Return the `Multiplexer` object as well as the handshake receipts.  The
+    # `Multiplexer` object acts as a container for the individual protocol
+    # instances.
+    return multiplexer, devp2p_receipt, protocol_receipts

--- a/p2p/p2p_proto.py
+++ b/p2p/p2p_proto.py
@@ -75,6 +75,14 @@ class BaseP2PProtocol(Protocol):
     _commands = (Hello, Ping, Pong, Disconnect)
     cmd_length = P2P_PROTOCOL_COMMAND_LENGTH
 
+    def __init__(self, transport: TransportAPI, cmd_id_offset: int, snappy_support: bool) -> None:
+        if cmd_id_offset != 0:
+            raise TypeError(
+                f"The base `p2p` protocol **must** have a cmd_id_offset of 0. "
+                f"Got `{cmd_id_offset}`"
+            )
+        super().__init__(transport, cmd_id_offset, snappy_support)
+
     def send_handshake(
             self,
             client_version_string: str,
@@ -122,12 +130,14 @@ class BaseP2PProtocol(Protocol):
 class P2PProtocolV4(BaseP2PProtocol):
     version = 4
 
-    def __init__(self, transport: TransportAPI) -> None:
-        super().__init__(transport, cmd_id_offset=0, snappy_support=False)
+    def __init__(self, transport: TransportAPI, cmd_id_offset: int, snappy_support: bool) -> None:
+        if snappy_support is True:
+            raise TypeError(
+                f"Snappy support is not supported before version 5 of the p2p "
+                f"protocol.  Currently using version `{self.version}`"
+            )
+        super().__init__(transport, cmd_id_offset=cmd_id_offset, snappy_support=False)
 
 
 class P2PProtocol(BaseP2PProtocol):
     version = 5
-
-    def __init__(self, transport: TransportAPI, snappy_support: bool) -> None:
-        super().__init__(transport, cmd_id_offset=0, snappy_support=snappy_support)

--- a/p2p/peer.py
+++ b/p2p/peer.py
@@ -188,6 +188,7 @@ class BasePeer(BaseService):
         # snappy compression
         self.base_protocol = P2PProtocol(
             transport=self.transport,
+            cmd_id_offset=0,
             snappy_support=False,
         )
 
@@ -468,6 +469,7 @@ class BasePeer(BaseService):
             # parity sends Ping immediately after Handshake
                 self.base_protocol = P2PProtocol(
                     self.transport,
+                    cmd_id_offset=0,
                     snappy_support=snappy_support,
                 )
 

--- a/p2p/tools/factories.py
+++ b/p2p/tools/factories.py
@@ -374,7 +374,7 @@ def MultiplexerPairFactory(*,
         in zip(protocol_types, cmd_id_offsets)
     )
 
-    alice_p2p_protocol = P2PProtocol(alice_transport, snappy_support)
+    alice_p2p_protocol = P2PProtocol(alice_transport, 0, snappy_support)
     alice_multiplexer = Multiplexer(
         transport=alice_transport,
         base_protocol=alice_p2p_protocol,
@@ -382,7 +382,7 @@ def MultiplexerPairFactory(*,
         token=cancel_token,
     )
 
-    bob_p2p_protocol = P2PProtocol(bob_transport, False)
+    bob_p2p_protocol = P2PProtocol(bob_transport, 0, snappy_support)
     bob_multiplexer = Multiplexer(
         transport=bob_transport,
         base_protocol=bob_p2p_protocol,

--- a/p2p/tools/factories.py
+++ b/p2p/tools/factories.py
@@ -20,6 +20,7 @@ from p2p import auth
 from p2p import discovery
 from p2p.abc import AddressAPI, NodeAPI, ProtocolAPI, TransportAPI, MultiplexerAPI
 from p2p.ecies import generate_privkey
+from p2p.handshake import DevP2PHandshakeParams
 from p2p.kademlia import Node, Address
 from p2p.multiplexer import Multiplexer
 from p2p.p2p_proto import P2PProtocol
@@ -389,3 +390,12 @@ def MultiplexerPairFactory(*,
         token=cancel_token,
     )
     return alice_multiplexer, bob_multiplexer
+
+
+class DevP2PHandshakeParamsFactory(factory.Factory):
+    class Meta:
+        model = DevP2PHandshakeParams
+
+    listen_port = 30303
+    client_version_string = 'test'
+    version = 5

--- a/tests/p2p/test_duplicates_util.py
+++ b/tests/p2p/test_duplicates_util.py
@@ -1,0 +1,23 @@
+import pytest
+
+from p2p._utils import duplicates
+
+
+@pytest.mark.parametrize(
+    'elements,expected',
+    (
+        ((), ()),
+        ((1,), ()),
+        ((1, 2), ()),
+        ((2, 1, 2), (2,)),
+        ((2, 1, 2, 4, 3, 4), (2, 4)),
+        ([], ()),
+        ([1], ()),
+        ([1, 2], ()),
+        ([2, 1, 2], (2,)),
+        ([2, 1, 2, 3, 4, 3], (2, 3)),
+    ),
+)
+def test_duplicates_with_identity_fn(elements, expected):
+    dups = duplicates(elements)
+    assert dups == expected

--- a/tests/p2p/test_handshake.py
+++ b/tests/p2p/test_handshake.py
@@ -1,0 +1,200 @@
+import asyncio
+import pytest
+
+from p2p.tools.factories import (
+    CancelTokenFactory,
+    MemoryTransportPairFactory,
+    ProtocolFactory,
+    DevP2PHandshakeParamsFactory,
+)
+from p2p.p2p_proto import P2PProtocol, P2PProtocolV4
+from p2p.handshake import (
+    negotiate_protocol_handshakes,
+    DevP2PHandshakeParams,
+    Handshaker,
+    HandshakeReceipt,
+)
+
+
+class NoopHandshaker(Handshaker):
+    def __init__(self, protocol_class):
+        self.protocol_class = protocol_class
+
+    async def do_handshake(self, multiplexer, protocol):
+        return HandshakeReceipt(protocol)
+
+
+@pytest.mark.asyncio
+async def test_handshake_with_v4_and_v5_disables_snappy():
+    token = CancelTokenFactory()
+    alice_transport, bob_transport = MemoryTransportPairFactory()
+
+    alice_p2p_params = DevP2PHandshakeParamsFactory(
+        client_version_string='alice-client',
+        listen_port=alice_transport.remote.address.tcp_port,
+    )
+    bob_p2p_params = DevP2PHandshakeParams(
+        client_version_string='bob-client',
+        listen_port=bob_transport.remote.address.tcp_port,
+        version=4,
+    )
+
+    protocol_class = ProtocolFactory()
+
+    alice_coro = negotiate_protocol_handshakes(
+        alice_transport,
+        alice_p2p_params,
+        (NoopHandshaker(protocol_class),),
+        token=token,
+    )
+    bob_coro = negotiate_protocol_handshakes(
+        bob_transport,
+        bob_p2p_params,
+        (NoopHandshaker(protocol_class),),
+        token=token,
+    )
+
+    alice_result, bob_result = await asyncio.gather(alice_coro, bob_coro)
+
+    alice_multiplexer, alice_p2p_receipt, alice_receipts = alice_result
+    bob_multiplexer, bob_p2p_receipt, bob_receipts = bob_result
+
+    alice_p2p_protocol = alice_p2p_receipt.protocol
+    bob_p2p_protocol = bob_p2p_receipt.protocol
+
+    assert isinstance(alice_p2p_protocol, P2PProtocol)
+    assert alice_p2p_protocol.snappy_support is False
+
+    assert isinstance(bob_p2p_protocol, P2PProtocolV4)
+    assert bob_p2p_protocol.snappy_support is False
+
+
+@pytest.mark.asyncio
+async def test_handshake_with_single_protocol():
+    token = CancelTokenFactory()
+    alice_transport, bob_transport = MemoryTransportPairFactory()
+
+    alice_p2p_params = DevP2PHandshakeParamsFactory(
+        client_version_string='alice-client',
+        listen_port=alice_transport.remote.address.tcp_port,
+    )
+    bob_p2p_params = DevP2PHandshakeParamsFactory(
+        client_version_string='bob-client',
+        listen_port=bob_transport.remote.address.tcp_port,
+    )
+
+    protocol_class = ProtocolFactory()
+
+    alice_coro = negotiate_protocol_handshakes(
+        alice_transport,
+        alice_p2p_params,
+        (NoopHandshaker(protocol_class),),
+        token=token,
+    )
+    bob_coro = negotiate_protocol_handshakes(
+        bob_transport,
+        bob_p2p_params,
+        (NoopHandshaker(protocol_class),),
+        token=token,
+    )
+
+    alice_result, bob_result = await asyncio.gather(alice_coro, bob_coro)
+
+    alice_multiplexer, alice_p2p_receipt, alice_receipts = alice_result
+    bob_multiplexer, bob_p2p_receipt, bob_receipts = bob_result
+
+    assert len(alice_receipts) == 1
+    assert len(bob_receipts) == 1
+
+    alice_receipt = alice_receipts[0]
+    bob_receipt = bob_receipts[0]
+
+    assert alice_p2p_receipt.client_version_string == 'bob-client'
+    assert bob_p2p_receipt.client_version_string == 'alice-client'
+
+    assert isinstance(alice_receipt.protocol, protocol_class)
+    assert isinstance(bob_receipt.protocol, protocol_class)
+
+    assert isinstance(alice_multiplexer.get_base_protocol(), P2PProtocol)
+    assert isinstance(alice_multiplexer.get_protocols()[0], P2PProtocol)
+    assert isinstance(alice_multiplexer.get_protocols()[1], protocol_class)
+
+    assert isinstance(bob_multiplexer.get_base_protocol(), P2PProtocol)
+    assert isinstance(bob_multiplexer.get_protocols()[0], P2PProtocol)
+    assert isinstance(bob_multiplexer.get_protocols()[1], protocol_class)
+
+    alice_p2p_protocol = alice_p2p_receipt.protocol
+    assert alice_p2p_protocol.snappy_support is True
+
+    bob_p2p_protocol = bob_p2p_receipt.protocol
+    assert bob_p2p_protocol.snappy_support is True
+
+
+@pytest.mark.asyncio
+async def test_handshake_with_multiple_protocols():
+    A1 = ProtocolFactory(name='a', version=1)
+    A2 = ProtocolFactory(name='a', version=2)
+    A3 = ProtocolFactory(name='a', version=3)
+    B5 = ProtocolFactory(name='b', version=5)
+    B6 = ProtocolFactory(name='b', version=6)
+    B7 = ProtocolFactory(name='b', version=7)
+    C2 = ProtocolFactory(name='c', version=2)
+    C3 = ProtocolFactory(name='c', version=3)
+
+    alice_protos = (A1, A2, A3, B5, B7, C3)
+    bob_protos = (A2, B6, C3, C2)
+    # expected overlap A2, C3
+
+    alice_handshakers = tuple(map(NoopHandshaker, alice_protos))
+    bob_handshakers = tuple(map(NoopHandshaker, bob_protos))
+
+    token = CancelTokenFactory()
+    alice_transport, bob_transport = MemoryTransportPairFactory()
+
+    alice_p2p_params = DevP2PHandshakeParamsFactory(
+        client_version_string='alice-client',
+        listen_port=alice_transport.remote.address.tcp_port,
+    )
+    bob_p2p_params = DevP2PHandshakeParamsFactory(
+        client_version_string='bob-client',
+        listen_port=bob_transport.remote.address.tcp_port,
+    )
+
+    alice_coro = negotiate_protocol_handshakes(
+        alice_transport,
+        alice_p2p_params,
+        alice_handshakers,
+        token=token,
+    )
+    bob_coro = negotiate_protocol_handshakes(
+        bob_transport,
+        bob_p2p_params,
+        bob_handshakers,
+        token=token,
+    )
+
+    alice_result, bob_result = await asyncio.gather(alice_coro, bob_coro)
+
+    alice_multiplexer, alice_p2p_receipt, alice_receipts = alice_result
+    bob_multiplexer, bob_p2p_receipt, bob_receipts = bob_result
+
+    assert len(alice_receipts) == 2
+    assert len(bob_receipts) == 2
+
+    assert isinstance(alice_p2p_receipt.protocol, P2PProtocol)
+    assert isinstance(alice_receipts[0].protocol, A2)
+    assert isinstance(alice_receipts[1].protocol, C3)
+
+    assert isinstance(alice_p2p_receipt.protocol, P2PProtocol)
+    assert isinstance(bob_receipts[0].protocol, A2)
+    assert isinstance(bob_receipts[1].protocol, C3)
+
+    assert isinstance(alice_multiplexer.get_base_protocol(), P2PProtocol)
+    assert isinstance(alice_multiplexer.get_protocols()[0], P2PProtocol)
+    assert isinstance(alice_multiplexer.get_protocols()[1], A2)
+    assert isinstance(alice_multiplexer.get_protocols()[2], C3)
+
+    assert isinstance(bob_multiplexer.get_base_protocol(), P2PProtocol)
+    assert isinstance(bob_multiplexer.get_protocols()[0], P2PProtocol)
+    assert isinstance(bob_multiplexer.get_protocols()[1], A2)
+    assert isinstance(bob_multiplexer.get_protocols()[2], C3)

--- a/tests/p2p/test_peer_collect_sub_proto_msgs.py
+++ b/tests/p2p/test_peer_collect_sub_proto_msgs.py
@@ -22,8 +22,13 @@ async def test_peer_subscriber_filters_messages(request, event_loop):
         remote.sub_proto.send_broadcast_data(b'broadcast-b')
         remote.sub_proto.send_get_sum(7, 8)
         remote.sub_proto.send_broadcast_data(b'broadcast-c')
-        # yield to let remote and peer transmit.
-        await asyncio.sleep(0.05)
+        # yield to let remote and peer transmit messages.  This can take a
+        # small amount of time so we give it a few rounds of the event loop to
+        # finish transmitting.
+        for _ in range(10):
+            await asyncio.sleep(0.01)
+            if collector.msg_queue.qsize() >= 4:
+                break
 
     assert collector not in peer._subscribers
 

--- a/tests/p2p/test_select_capabilities.py
+++ b/tests/p2p/test_select_capabilities.py
@@ -1,0 +1,87 @@
+import pytest
+
+from hypothesis import (
+    given,
+    strategies as st,
+)
+
+from eth_utils.toolz import groupby
+
+from p2p.handshake import _select_capabilities
+
+
+A1 = ('A', 1)
+A2 = ('A', 2)
+B1 = ('B', 1)
+B2 = ('B', 2)
+
+
+@pytest.mark.parametrize(
+    'remote_caps,local_caps,expected',
+    (
+        # simple case of single cap
+        ((A1,), (A1,), (A1,)),
+        ((B1,), (B1,), (B1,)),
+        # simple case of multiple caps
+        ((A1, B1), (A1, B1), (A1, B1)),
+        # same simple cases but with ordering changed
+        ((A1, B1), (B1, A1), (A1, B1)),
+        ((B1, A1), (A1, B1), (A1, B1)),
+        ((B1, A1), (B1, A1), (A1, B1)),
+        # multiple of same proto full overlap
+        ((A1, A2), (A2,), (A2,)),
+        ((A1, A2), (A1,), (A1,)),
+        # multiple of same proto partial overlap
+        ((A1,), (A1, A2), (A1,)),
+        ((A2,), (A1, A2), (A2,)),
+        # multiple protocols, multiple versions
+        ((A1, B1, A2, B2), (A1, B1, A2, B2), (A2, B2)),
+        ((A1, B1, A2, B2), (A1, B1, A2), (A2, B1)),
+        ((A1, B1, B2), (A1, B1, A2, B2), (A1, B2)),
+        # multiple protocols, not all overlap
+        ((A1, B1, A2, B2), (A1, A2), (A2,)),
+        ((A1, B1, B2), (A1, A2), (A1,)),
+        # no matches
+        ((A1,), (A2,), ()),
+        ((A2,), (A1,), ()),
+        ((B1,), (A1,), ()),
+        ((B1, A1), (B2, A2), ()),
+        ((B1, B2), (A1, A2), ()),
+        ((A1, B1, B2), (A2,), ()),
+    )
+)
+def test_select_p2p_capabiltiies(remote_caps, local_caps, expected):
+    actual = _select_capabilities(remote_caps, local_caps)
+    assert actual == expected
+
+
+cap_st = st.tuples(
+    st.binary(min_size=1, max_size=5),
+    st.integers(min_value=0, max_value=10),
+)
+
+
+@given(
+    remote_caps=st.lists(cap_st),
+    local_caps=st.lists(cap_st),
+)
+def test_select_p2p_capabiltiies_fuzzy(remote_caps, local_caps):
+    common_caps = set(remote_caps).intersection(local_caps)
+    common_caps_by_name = groupby(lambda cap: cap[0], common_caps)
+
+    selected_caps = _select_capabilities(remote_caps, local_caps)
+
+    if not common_caps:
+        assert len(selected_caps) == 0
+    else:
+        # must be a subset of the common capabilities
+        assert set(selected_caps).issubset(common_caps)
+
+        # must be alphabetically sorted by capability name
+        sorted_caps = tuple(sorted(selected_caps, key=lambda cap: cap[0]))
+        assert sorted_caps == selected_caps
+
+        # for each name, should be the highest common version
+        for name, version in selected_caps:
+            greatest_common_version = max((version for name, version in common_caps_by_name[name]))
+            assert greatest_common_version == version

--- a/trinity/protocol/eth/handshaker.py
+++ b/trinity/protocol/eth/handshaker.py
@@ -1,0 +1,78 @@
+from typing import cast, Any, Dict
+
+from eth_utils import encode_hex
+
+from p2p.abc import MultiplexerAPI
+from p2p.exceptions import (
+    HandshakeFailure,
+)
+from p2p.handshake import (
+    HandshakeReceipt,
+    Handshaker,
+)
+from p2p.protocol import Protocol
+
+from trinity.exceptions import WrongGenesisFailure, WrongNetworkFailure
+
+from .proto import ETHProtocol, ETHHandshakeParams
+from .commands import Status
+
+
+class ETHHandshakeReceipt(HandshakeReceipt):
+    handshake_params: ETHHandshakeParams
+
+    def __init__(self, handshake_params: ETHHandshakeParams) -> None:
+        self.handshake_params = handshake_params
+
+
+class ETHHandshaker(Handshaker):
+    protocol_class = ETHProtocol
+    handshake_params: ETHHandshakeParams
+
+    def __init__(self, handshake_params: ETHHandshakeParams) -> None:
+        self.handshake_params = handshake_params
+
+    async def do_handshake(self,
+                           multiplexer: MultiplexerAPI,
+                           protocol: Protocol) -> ETHHandshakeReceipt:
+        """Perform the handshake for the sub-protocol agreed with the remote peer.
+
+        Raises HandshakeFailure if the handshake is not successful.
+        """
+        protocol = cast(ETHProtocol, protocol)
+        protocol.send_handshake(self.handshake_params)
+
+        async for cmd, msg in multiplexer.stream_protocol_messages(protocol):
+            if not isinstance(cmd, Status):
+                raise HandshakeFailure(f"Expected a ETH Status msg, got {cmd}, disconnecting")
+
+            msg = cast(Dict[str, Any], msg)
+
+            receipt = ETHHandshakeReceipt(ETHHandshakeParams(
+                version=msg['protocol_version'],
+                network_id=msg['network_id'],
+                total_difficulty=msg['td'],
+                head_hash=msg['best_hash'],
+                genesis_hash=msg['genesis_hash'],
+            ))
+
+            if receipt.handshake_params.network_id != self.handshake_params.network_id:
+                raise WrongNetworkFailure(
+                    f"{multiplexer.remote} network "
+                    f"({receipt.handshake_params.network_id}) does not match ours "
+                    f"({self.handshake_params.network_id}), disconnecting"
+                )
+
+            if receipt.handshake_params.genesis_hash != self.handshake_params.genesis_hash:
+                raise WrongGenesisFailure(
+                    f"{multiplexer.remote} genesis "
+                    f"({encode_hex(receipt.handshake_params.genesis_hash)}) does "
+                    f"not match ours ({self.handshake_params.genesis_hash}), "
+                    f"disconnecting"
+                )
+
+            break
+        else:
+            raise HandshakeFailure("Message stream exited before finishing handshake")
+
+        return receipt

--- a/trinity/protocol/eth/peer.py
+++ b/trinity/protocol/eth/peer.py
@@ -70,7 +70,7 @@ from .events import (
     SendReceiptsEvent,
     TransactionsEvent,
 )
-from .proto import ETHProtocol, ProxyETHProtocol
+from .proto import ETHProtocol, ProxyETHProtocol, ETHHandshakeParams
 from .handlers import ETHExchangeHandler, ProxyETHExchangeHandler
 
 
@@ -107,7 +107,15 @@ class ETHPeer(BaseChainPeer):
         super().handle_sub_proto_msg(cmd, msg)
 
     async def send_sub_proto_handshake(self) -> None:
-        self.sub_proto.send_handshake(await self._local_chain_info)
+        chain_info = await self._local_chain_info
+        handshake_params = ETHHandshakeParams(
+            version=self.sub_proto.version,
+            head_hash=chain_info.block_hash,
+            genesis_hash=chain_info.genesis_hash,
+            total_difficulty=chain_info.total_difficulty,
+            network_id=chain_info.network_id,
+        )
+        self.sub_proto.send_handshake(handshake_params)
 
     async def process_sub_proto_handshake(
             self, cmd: CommandAPI, msg: Payload) -> None:

--- a/trinity/protocol/eth/proto.py
+++ b/trinity/protocol/eth/proto.py
@@ -1,5 +1,6 @@
 from typing import (
     List,
+    NamedTuple,
     Tuple,
     TYPE_CHECKING,
     Union,
@@ -9,6 +10,8 @@ from eth_typing import (
     Hash32,
     BlockNumber,
 )
+
+from eth_utils import ValidationError
 
 from lahja import EndpointAPI
 
@@ -23,7 +26,6 @@ from lahja import (
 from p2p.abc import NodeAPI
 from p2p.protocol import Protocol
 
-from trinity.protocol.common.peer import ChainInfo
 from trinity.rlp.block_body import BlockBody
 
 from .commands import (
@@ -54,6 +56,14 @@ if TYPE_CHECKING:
     from .peer import ETHPeer  # noqa: F401
 
 
+class ETHHandshakeParams(NamedTuple):
+    head_hash: Hash32
+    genesis_hash: Hash32
+    network_id: int
+    total_difficulty: int
+    version: int
+
+
 # HasExtendedDebugLogger must come before Protocol so there's self.logger.debug2()
 class ETHProtocol(HasExtendedDebugLogger, Protocol):
     name = 'eth'
@@ -72,13 +82,18 @@ class ETHProtocol(HasExtendedDebugLogger, Protocol):
 
     peer: 'ETHPeer'
 
-    def send_handshake(self, chain_info: ChainInfo) -> None:
+    def send_handshake(self, handshake_params: ETHHandshakeParams) -> None:
+        if handshake_params.version != self.version:
+            raise ValidationError(
+                f"ETH protocol version mismatch: "
+                f"params:{handshake_params.version} != proto:{self.version}"
+            )
         resp = {
-            'protocol_version': self.version,
-            'network_id': chain_info.network_id,
-            'td': chain_info.total_difficulty,
-            'best_hash': chain_info.block_hash,
-            'genesis_hash': chain_info.genesis_hash,
+            'protocol_version': handshake_params.version,
+            'network_id': handshake_params.network_id,
+            'td': handshake_params.total_difficulty,
+            'best_hash': handshake_params.head_hash,
+            'genesis_hash': handshake_params.genesis_hash,
         }
         cmd = Status(self.cmd_id_offset, self.snappy_support)
         self.logger.debug2("Sending ETH/Status msg: %s", resp)
@@ -175,6 +190,9 @@ class ProxyETHProtocol:
         self.remote = remote
         self._event_bus = event_bus
         self._broadcast_config = broadcast_config
+
+    def send_handshake(self, handshake_params: ETHHandshakeParams) -> None:
+        raise NotImplementedError("`ProxyETHProtocol.send_handshake` Not yet implemented")
 
     #
     # Node Data

--- a/trinity/protocol/les/handshaker.py
+++ b/trinity/protocol/les/handshaker.py
@@ -1,0 +1,123 @@
+from typing import (
+    cast,
+    Any,
+    Dict,
+    Type,
+    Union,
+)
+
+from eth_utils import encode_hex
+
+from p2p.abc import MultiplexerAPI
+from p2p.exceptions import (
+    HandshakeFailure,
+)
+from p2p.handshake import (
+    HandshakeReceipt,
+    Handshaker,
+)
+from p2p.protocol import Protocol
+
+from trinity.exceptions import WrongGenesisFailure, WrongNetworkFailure
+
+from .commands import Status, StatusV2
+
+from .proto import LESHandshakeParams, LESProtocol, LESProtocolV2
+
+
+AnyLESProtocol = Union[LESProtocol, LESProtocolV2]
+AnyLESProtocolClass = Union[Type[LESProtocol], Type[LESProtocolV2]]
+
+
+class LESHandshakeReceipt(HandshakeReceipt):
+    handshake_params: LESHandshakeParams
+
+    def __init__(self,
+                 protocol: AnyLESProtocol,
+                 handshake_params: LESHandshakeParams,
+                 ) -> None:
+        super().__init__(protocol)
+        self.handshake_params = handshake_params
+
+
+class BaseLESHandshaker(Handshaker):
+    handshake_params: LESHandshakeParams
+
+    def __init__(self, handshake_params: LESHandshakeParams) -> None:
+        if handshake_params.version != self.protocol_class.version:
+            raise Exception("DID NOT MATCH")
+        self.handshake_params = handshake_params
+
+    async def do_handshake(self,
+                           multiplexer: MultiplexerAPI,
+                           protocol: Protocol) -> LESHandshakeReceipt:
+        """Perform the handshake for the sub-protocol agreed with the remote peer.
+
+        Raises HandshakeFailure if the handshake is not successful.
+        """
+        protocol = cast(AnyLESProtocol, protocol)
+        protocol.send_handshake(self.handshake_params)
+
+        async for cmd, msg in multiplexer.stream_protocol_messages(protocol):
+            if not isinstance(cmd, (Status, StatusV2)):
+                raise HandshakeFailure(f"Expected a LES Status msg, got {cmd}, disconnecting")
+
+            msg = cast(Dict[str, Any], msg)
+
+            params = LESHandshakeParams(
+                version=msg['protocolVersion'],
+                network_id=msg['networkId'],
+                head_td=msg['headTd'],
+                head_hash=msg['headHash'],
+                head_num=msg['headNum'],
+                genesis_hash=msg['genesisHash'],
+                serve_headers=('serveHeaders' in msg),
+                serve_chain_since=msg.get('serveChainSince'),
+                serve_state_since=msg.get('serveStateSince'),
+                serve_recent_chain=msg.get('serveRecentChain'),
+                serve_recent_state=msg.get('serveRecentState'),
+                tx_relay=('txRelay' in msg),
+                flow_control_bl=msg.get('flowControl/BL'),
+                flow_control_mcr=msg.get('flowControl/MRC'),
+                flow_control_mrr=msg.get('flowControl/MRR'),
+                announce_type=msg.get('announceType'),  # TODO: only in StatusV2
+            )
+
+            receipt = LESHandshakeReceipt(protocol, params)
+
+            if receipt.handshake_params.network_id != self.handshake_params.network_id:
+                raise WrongNetworkFailure(
+                    f"{multiplexer.remote} network "
+                    f"({receipt.handshake_params.network_id}) does not match ours "
+                    f"({self.handshake_params.network_id}), disconnecting"
+                )
+
+            if receipt.handshake_params.genesis_hash != self.handshake_params.genesis_hash:
+                raise WrongGenesisFailure(
+                    f"{multiplexer.remote} genesis "
+                    f"({encode_hex(receipt.handshake_params.genesis_hash)}) does "
+                    f"not match ours "
+                    f"({encode_hex(self.handshake_params.genesis_hash)}), "
+                    f"disconnecting"
+                )
+
+            # Eventually we might want to keep connections to peers where we
+            # are the only side serving data, but right now both our chain
+            # syncer and the Peer.boot() method expect the remote to reply to
+            # header requests, so if they don't we simply disconnect here.
+            if receipt.handshake_params.serve_headers is False:
+                raise HandshakeFailure(f"{multiplexer.remote} doesn't serve headers, disconnecting")
+
+            break
+        else:
+            raise HandshakeFailure("Message stream exited before finishing handshake")
+
+        return receipt
+
+
+class LESV1Handshaker(BaseLESHandshaker):
+    protocol_class = LESProtocol
+
+
+class LESV2Handshaker(BaseLESHandshaker):
+    protocol_class = LESProtocolV2


### PR DESCRIPTION
extracted from #684 

### What was wrong?

The logic for performing the sub-protocol devp2p handshake currently lives in the peer class.  In order for us to support multiple arbitrary sub-protocols, the peer class needs to be agnostic/unaware of the individual protocol handshake logic.

### How was it fixed?

This implements but does not put into use a new API for encapsulating the p2p handshake logic.  Each sub protocol implements a `Handshaker` which holds the logic for performing the handshake and typically a `HandshakeReceipt` that acts as a data storage object for recording data exchanged during the handshake.

A subsequent PR will modify the actual handshake code to make use of this API.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

[//]: # (See: https://trinity-client.readthedocs.io/en/latest/contributing.html#pull-requests)
- [x] Add entry to the [release notes](https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![15-03-15 Lana wlh (1)C1000face](https://user-images.githubusercontent.com/824194/62395248-ea8fec80-b52c-11e9-8275-1bd466c9a302.JPG)

