### PR TITLE
Beam state immediate predictive nodes

### DIFF
--- a/newsfragments/877.bugfix.rst
+++ b/newsfragments/877.bugfix.rst
@@ -1,0 +1,2 @@
+Beam Sync stats: Count the extra single node that is sometimes required when downloading the nodes
+needed to look up an account or storage. (Usually because of a trie reorg)

--- a/newsfragments/877.performance.rst
+++ b/newsfragments/877.performance.rst
@@ -1,0 +1,3 @@
+Immediately insert Beam Sync nodes that are "predicted" (soon to be used during parallel execution)
+This saves a round trip on live execution, when parallel execution already downloaded a node.
+Also, more aggressively make predictive requests if no urgent requests are waiting in the queue.

--- a/trinity/sync/beam/chain.py
+++ b/trinity/sync/beam/chain.py
@@ -512,28 +512,28 @@ class MissingDataEventHandler(BaseService):
             asyncio.ensure_future(self._serve_storage(event))
 
     async def _serve_account(self, event: CollectMissingAccount) -> None:
-        await self._state_downloader.ensure_node_present(event.missing_node_hash)
         _, num_nodes_collected = await self._state_downloader.download_account(
             event.address_hash,
             event.state_root_hash,
         )
+        bonus_node = await self._state_downloader.ensure_nodes_present({event.missing_node_hash})
         await self._event_bus.broadcast(
-            MissingAccountCollected(num_nodes_collected),
+            MissingAccountCollected(num_nodes_collected + bonus_node),
             event.broadcast_config(),
         )
 
     async def _serve_bytecode(self, event: CollectMissingBytecode) -> None:
-        await self._state_downloader.ensure_node_present(event.bytecode_hash)
+        await self._state_downloader.ensure_nodes_present({event.bytecode_hash})
         await self._event_bus.broadcast(MissingBytecodeCollected(), event.broadcast_config())
 
     async def _serve_storage(self, event: CollectMissingStorage) -> None:
-        await self._state_downloader.ensure_node_present(event.missing_node_hash)
         num_nodes_collected = await self._state_downloader.download_storage(
             event.storage_key,
             event.storage_root_hash,
             event.account_address,
         )
+        bonus_node = await self._state_downloader.ensure_nodes_present({event.missing_node_hash})
         await self._event_bus.broadcast(
-            MissingStorageCollected(num_nodes_collected),
+            MissingStorageCollected(num_nodes_collected + bonus_node),
             event.broadcast_config(),
         )

--- a/trinity/sync/beam/constants.py
+++ b/trinity/sync/beam/constants.py
@@ -1,0 +1,5 @@
+# Peers are typically expected to have predicted nodes available,
+#   so it's reasonable to ask for all-predictive nodes from a peer.
+# Urgent node requests usually come in pretty fast, so
+#   even at a small value (like 1ms), this timeout is rarely triggered.
+DELAY_BEFORE_NON_URGENT_REQUEST = 0.001

--- a/trinity/sync/beam/constants.py
+++ b/trinity/sync/beam/constants.py
@@ -3,3 +3,11 @@
 # Urgent node requests usually come in pretty fast, so
 #   even at a small value (like 1ms), this timeout is rarely triggered.
 DELAY_BEFORE_NON_URGENT_REQUEST = 0.001
+
+# How much large should our buffer be? This is a multiplier on how many
+# nodes we can request at once from a single peer.
+REQUEST_BUFFER_MULTIPLIER = 16
+
+# How long should we wait after a peer gives us an empty response for node data,
+# before we ask for some new data from them? Measured in seconds.
+EMPTY_PEER_RESPONSE_PENALTY = 1

--- a/trinity/sync/beam/state.py
+++ b/trinity/sync/beam/state.py
@@ -152,7 +152,7 @@ class BeamDownloader(BaseService, PeerSubscriber):
         Wait until the node that is the preimage of `node_hash` is available in the database.
         If it is not available in the first check, request it from peers.
 
-        Mark this node as preductive, which reduces request priority.
+        Mark this node as predictive, which reduces request priority.
 
         :return: whether node was missing from the database on the first check
         """
@@ -325,7 +325,7 @@ class BeamDownloader(BaseService, PeerSubscriber):
     async def _match_node_requests_to_peers(self) -> None:
         """
         Monitor TaskQueue for needed trie nodes, and request them from peers. Repeat as necessary.
-        Prefer urgent nodes over preductive ones.
+        Prefer urgent nodes over predictive ones.
         """
         while self.is_operational:
             urgent_batch_id, urgent_hashes = await self._get_waiting_urgent_hashes()

--- a/trinity/sync/beam/state.py
+++ b/trinity/sync/beam/state.py
@@ -12,8 +12,6 @@ from typing import (
 
 from lahja import EndpointAPI
 
-import rlp
-
 from eth_hash.auto import keccak
 from eth_utils import (
     encode_hex,
@@ -71,6 +69,8 @@ class BeamDownloader(BaseService, PeerSubscriber):
     _urgent_processed_nodes = 0
     _predictive_processed_nodes = 0
     _total_timeouts = 0
+    _predictive_only_requests = 0
+    _total_requests = 0
     _timer = Timer(auto_start=False)
     _report_interval = 10  # Number of seconds between progress reports.
     _reply_timeout = 20  # seconds
@@ -110,8 +110,6 @@ class BeamDownloader(BaseService, PeerSubscriber):
             buffer_size,
             lambda node_hash: self._hash_to_priority[node_hash],
         )
-        self._predicted_nodes: Dict[Hash32, bytes] = {}
-        self._prediction_successes = 0
 
         self._peers_without_full_trie: Set[ETHPeer] = set()
 
@@ -139,12 +137,15 @@ class BeamDownloader(BaseService, PeerSubscriber):
         if self._is_node_missing(node_hash):
             if node_hash not in self._node_tasks:
                 await self._node_tasks.add((node_hash, ))
-            await self._node_hashes_present((node_hash, ))
+            await self._node_hashes_present({node_hash})
             return 1
         else:
             return 0
 
-    async def predictive_node_present(self, node_hash: Hash32) -> int:
+    async def predictive_node_present(
+            self,
+            node_hash: Hash32,
+            priority: int = 1) -> int:
         """
         Wait until the node that is the preimage of `node_hash` is available in the database.
         If it is not available in the first check, request it from peers.
@@ -155,9 +156,9 @@ class BeamDownloader(BaseService, PeerSubscriber):
         """
         if self._is_node_missing(node_hash):
             if node_hash not in self._node_tasks and node_hash not in self._maybe_useful_nodes:
-                self._hash_to_priority[node_hash] = 1
+                self._hash_to_priority[node_hash] = priority
                 await self._maybe_useful_nodes.add((node_hash, ))
-            await self._node_hashes_present((node_hash, ))
+            await self._node_hashes_present({node_hash})
             return 1
         else:
             return 0
@@ -168,26 +169,35 @@ class BeamDownloader(BaseService, PeerSubscriber):
 
         :return: whether nodes had to be downloaded
         """
-        missing_nodes = tuple(set(
+        missing_nodes = set(
             node_hash for node_hash in node_hashes if self._is_node_missing(node_hash)
-        ))
-        await self._node_tasks.add(missing_nodes)
+        )
+        unrequested_nodes = tuple(
+            node_hash for node_hash in missing_nodes if node_hash not in self._node_tasks
+        )
+        await self._node_tasks.add(unrequested_nodes)
         await self._node_hashes_present(missing_nodes)
-        return len(missing_nodes)
+        return len(unrequested_nodes)
 
-    async def predictive_nodes_present(self, node_hashes: Iterable[Hash32]) -> int:
+    async def predictive_nodes_present(
+            self,
+            node_hashes: Iterable[Hash32],
+            priority: int = 1) -> int:
         """
         Like :meth:`predictive_node_present`, but waits for multiple nodes to be available.
 
         :return: whether nodes had to be downloaded
         """
-        missing_nodes = tuple(set(
+        missing_nodes = set(
             node_hash for node_hash in node_hashes if self._is_node_missing(node_hash)
-        ))
-        await self._maybe_useful_nodes.add(tuple(
-            node_hash for node_hash in missing_nodes
-            if node_hash not in self._maybe_useful_nodes
-        ))
+        )
+        unrequested_nodes = tuple(
+            node_hash for node_hash in missing_nodes if node_hash not in self._maybe_useful_nodes
+        )
+        for node_hash in unrequested_nodes:
+            self._hash_to_priority[node_hash] = priority
+
+        await self._maybe_useful_nodes.add(unrequested_nodes)
         await self._node_hashes_present(missing_nodes)
         return len(missing_nodes)
 
@@ -197,19 +207,7 @@ class BeamDownloader(BaseService, PeerSubscriber):
 
         self.logger.debug2("checking if node 0x%s is present", node_hash.hex())
 
-        if node_hash not in self._db:
-            # Instead of immediately storing predicted nodes, we keep them in memory
-            # So when we check if a node is available, we also check if prediction is in memory
-            if node_hash in self._predicted_nodes:
-                # Part of the benefit is that we can identify how effective our predictions are
-                self._prediction_successes += 1
-                # Now we store the predictive node in the database
-                self._db[node_hash] = self._predicted_nodes.pop(node_hash)
-                return False
-            else:
-                return True
-        else:
-            return False
+        return node_hash not in self._db
 
     async def download_accounts(
             self,
@@ -360,6 +358,10 @@ class BeamDownloader(BaseService, PeerSubscriber):
                     f"Some of the requested node hashes are too short! {short_node_urgent_hashes!r}"
                 )
 
+            if urgent_batch_id is None:
+                self._predictive_only_requests += 1
+            self._total_requests += 1
+
             # Request all the nodes from the given peer, and immediately move on to
             #   try to request other nodes from another peer.
             self.run_task(self._get_nodes_from_peer(
@@ -405,8 +407,7 @@ class BeamDownloader(BaseService, PeerSubscriber):
             urgent_hashes: Tuple[Hash32, ...],
             predictive_hashes: Tuple[Hash32, ...]) -> Tuple[Hash32, ...]:
         non_urgent_predictive_hashes = tuple(set(predictive_hashes).difference(urgent_hashes))
-        request_urgent_hashes = tuple(h for h in urgent_hashes if h not in self._predicted_nodes)
-        return request_urgent_hashes + non_urgent_predictive_hashes
+        return urgent_hashes + non_urgent_predictive_hashes
 
     async def _get_nodes_from_peer(
             self,
@@ -437,16 +438,16 @@ class BeamDownloader(BaseService, PeerSubscriber):
         if len(urgent_nodes) == 0 and urgent_batch_id is not None:
             self.logger.info("%s returned no urgent nodes from %r", peer, urgent_node_hashes)
 
-        for node_hash, node in urgent_nodes.items():
-            self._db[node_hash] = node
-            await self._spawn_predictive_nodes(node, priority=1)
+        # batch all DB writes into one, for performance
+        with self._db.atomic_batch() as batch:
+            for node_hash, node in nodes:
+                batch[node_hash] = node
+
         if urgent_batch_id is not None:
             self._node_tasks.complete(urgent_batch_id, tuple(urgent_nodes.keys()))
 
-        self._predicted_nodes.update(predictive_nodes)
-        for node_hash, node in predictive_nodes.items():
-            priority = self._hash_to_priority.pop(node_hash)
-            await self._spawn_predictive_nodes(node, priority=priority + 1)
+        for node_hash in predictive_nodes.keys():
+            del self._hash_to_priority[node_hash]
 
         if predictive_batch_id is not None:
             # retire all predictions, if the responding node doesn't have them, then we don't
@@ -463,55 +464,14 @@ class BeamDownloader(BaseService, PeerSubscriber):
             for new_data in self._new_data_events:
                 new_data.set()
 
-    async def _spawn_predictive_nodes(self, node: bytes, priority: int) -> None:
-        """
-        Identify node hashes for nodes we might need in the future, and insert them to the
-        predictive node queue.
-        """
-        if not self.do_predictive_downloads:
-            return
-
-        # priority is the depth of the node away from an urgent node, plus one.
-        # For example, the child of an urgent node has priority 2
-        if priority > 3:
-            # We would simply download all nodes if we kept adding predictions, so
-            # instead we cut it off at a certain depth
-            return
-
-        try:
-            decoded_node = rlp.decode(node)
-        except rlp.DecodingError:
-            # Could not decode rlp, it's probably a bytecode, carry on...
-            return
-
-        if len(decoded_node) == 17 and (priority <= 2 or all(decoded_node[:16])):
-            # if this is a fully filled branch node, then spawn predictive node tasks
-            predictive_room = min(
-                self._maybe_useful_nodes._maxsize - len(self._maybe_useful_nodes),
-                16,
-            )
-            request_nodes = tuple(
-                Hash32(h) for h in decoded_node[:16]
-                if _is_hash(h) and Hash32(h) not in self._maybe_useful_nodes
-            )
-            queue_hashes = set(request_nodes[:predictive_room])
-            for sub_hash in queue_hashes:
-                self._hash_to_priority[sub_hash] = priority
-
-            new_nodes = tuple(h for h in queue_hashes if h not in self._maybe_useful_nodes)
-            # this should always complete immediately because of the drop above
-            await self._maybe_useful_nodes.add(new_nodes)
-        else:
-            self.logger.debug2("Not predicting node: %r", decoded_node)
-
     def _is_node_present(self, node_hash: Hash32) -> bool:
         """
         Check if node_hash has data in the database or in the predicted node set.
         """
-        return node_hash in self._db or node_hash in self._predicted_nodes
+        return node_hash in self._db
 
-    async def _node_hashes_present(self, node_hashes: Tuple[Hash32, ...]) -> None:
-        remaining_hashes = set(node_hashes)
+    async def _node_hashes_present(self, node_hashes: Set[Hash32]) -> None:
+        remaining_hashes = node_hashes.copy()
 
         # save an event that gets triggered when new data comes in
         new_data = asyncio.Event()
@@ -609,11 +569,13 @@ class BeamDownloader(BaseService, PeerSubscriber):
 
     async def _periodically_report_progress(self) -> None:
         while self.is_operational:
-            msg = "processed=%d  " % self._total_processed_nodes
+            msg = "all=%d  " % self._total_processed_nodes
             msg += "urgent=%d  " % self._urgent_processed_nodes
-            msg += "predictive=%d  " % self._predictive_processed_nodes
-            msg += "pred_success=%d  " % self._prediction_successes
-            msg += "tnps=%d  " % (self._total_processed_nodes / self._timer.elapsed)
+            msg += "pred=%d  " % self._predictive_processed_nodes
+            msg += "all/sec=%d  " % (self._total_processed_nodes / self._timer.elapsed)
+            msg += "urgent/sec=%d  " % (self._urgent_processed_nodes / self._timer.elapsed)
+            msg += "reqs=%d  " % (self._total_requests)
+            msg += "pred_reqs=%d  " % (self._predictive_only_requests)
             msg += "timeouts=%d" % self._total_timeouts
             self.logger.info("Beam-Sync: %s", msg)
             await self.sleep(self._report_interval)

--- a/trinity/sync/beam/state.py
+++ b/trinity/sync/beam/state.py
@@ -48,12 +48,13 @@ from trinity.protocol.eth.peer import ETHPeer, ETHPeerPool
 from trinity.protocol.eth import (
     constants as eth_constants,
 )
-from trinity.sync.beam.constants import DELAY_BEFORE_NON_URGENT_REQUEST
+from trinity.sync.beam.constants import (
+    DELAY_BEFORE_NON_URGENT_REQUEST,
+    REQUEST_BUFFER_MULTIPLIER,
+    EMPTY_PEER_RESPONSE_PENALTY,
+)
 
 from trinity.sync.common.peers import WaitingPeers
-
-REQUEST_BUFFER_MULTIPLIER = 16
-EMPTY_PEER_RESPONSE_PENALTY = 1
 
 
 def _is_hash(maybe_hash: bytes) -> bool:

--- a/trinity/sync/beam/state.py
+++ b/trinity/sync/beam/state.py
@@ -49,6 +49,8 @@ from trinity.protocol.eth.peer import ETHPeer, ETHPeerPool
 from trinity.protocol.eth import (
     constants as eth_constants,
 )
+from trinity.sync.beam.constants import DELAY_BEFORE_NON_URGENT_REQUEST
+
 from trinity.sync.common.peers import WaitingPeers
 
 REQUEST_BUFFER_MULTIPLIER = 16
@@ -375,7 +377,7 @@ class BeamDownloader(BaseService, PeerSubscriber):
     async def _get_waiting_urgent_hashes(self) -> Tuple[int, Tuple[Hash32, ...]]:
         # if any predictive nodes are waiting, then time out after a short pause to grab them
         if self._allow_predictive_only and self._maybe_useful_nodes.num_pending():
-            timeout = 0.05
+            timeout = DELAY_BEFORE_NON_URGENT_REQUEST
         else:
             timeout = None
         try:

--- a/trinity/sync/beam/state.py
+++ b/trinity/sync/beam/state.py
@@ -332,8 +332,8 @@ class BeamDownloader(BaseService, PeerSubscriber):
 
             predictive_batch_id, predictive_hashes = self._maybe_add_predictive_nodes(urgent_hashes)
 
-            # combine to single tuple of hashes
-            node_hashes = self._combine_urgent_predictive(urgent_hashes, predictive_hashes)
+            # combine to single tuple of unique hashes
+            node_hashes = self._append_unique_hashes(urgent_hashes, predictive_hashes)
 
             if not node_hashes:
                 self.logger.warning("restarting because empty node hashes")
@@ -403,12 +403,12 @@ class BeamDownloader(BaseService, PeerSubscriber):
         else:
             return None, ()
 
-    def _combine_urgent_predictive(
-            self,
-            urgent_hashes: Tuple[Hash32, ...],
-            predictive_hashes: Tuple[Hash32, ...]) -> Tuple[Hash32, ...]:
-        non_urgent_predictive_hashes = tuple(set(predictive_hashes).difference(urgent_hashes))
-        return urgent_hashes + non_urgent_predictive_hashes
+    @staticmethod
+    def _append_unique_hashes(
+            first_hashes: Tuple[Hash32, ...],
+            non_unique_hashes: Tuple[Hash32, ...]) -> Tuple[Hash32, ...]:
+        unique_hashes_to_add = tuple(set(non_unique_hashes).difference(first_hashes))
+        return first_hashes + unique_hashes_to_add
 
     async def _get_nodes_from_peer(
             self,

--- a/trinity/sync/beam/state.py
+++ b/trinity/sync/beam/state.py
@@ -270,7 +270,6 @@ class BeamDownloader(BaseService, PeerSubscriber):
                 with self._trie_db.at_root(root_hash) as snapshot:
                     account_rlp = snapshot[account_hash]
             except MissingTrieNode as exc:
-                await self.ensure_node_present(exc.missing_node_hash)
                 if predictive:
                     await self.predictive_node_present(exc.missing_node_hash)
                 else:


### PR DESCRIPTION
### What was wrong?

Beam Sync predicted nodes were being collected, but still triggered a fault for the actual execution (and then pulled the node out of memory). These faults caused a meaningful slow-down.

Additionally, the "predection" mechanism changed significantly in practice, which left some cruft around that needed deletion. (It used to be looking down the trie for more nodes, but now it's executing blocks in the future, which we know will be needed)


### How was it fixed?

- Immediately insert predicted nodes
- Delete old "down-tree prediction" mechanism
- Bugfix an account node lookup that was always marked urgent, even if the caller said it was predicted
- More aggressively collect predicted nodes, by reducing a timeout of waiting for urgent nodes (peer nodes are now expected to have them available)

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

[//]: # (See: https://trinity-client.readthedocs.io/en/latest/contributing.html#pull-requests)
- [x] Add entry to the [release notes](https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://66.media.tumblr.com/bd60bf4a0e95e5331f895a0d29227768/tumblr_ngqkc7ITgw1qf6rvbo1_400.jpg)