### PR TITLE
Fix bug with trinity not shutting down cleanly

### DIFF
--- a/newsfragments/878.bugfix.rst
+++ b/newsfragments/878.bugfix.rst
@@ -1,0 +1,1 @@
+Fixes issue with Trinity not shutting down when issues a ``CTRL+C``.

--- a/p2p/peer_pool.py
+++ b/p2p/peer_pool.py
@@ -201,10 +201,13 @@ class BasePeerPool(BaseService, AsyncIterable[BasePeer]):
 
             await self.wait(rate_limiter.take())
 
-            await self.wait(asyncio.gather(*(
-                self._add_peers_from_backend(backend)
-                for backend in self.peer_backends
-            )))
+            try:
+                await self.wait(asyncio.gather(*(
+                    self._add_peers_from_backend(backend)
+                    for backend in self.peer_backends
+                )))
+            except OperationCancelled:
+                break
 
     def __len__(self) -> int:
         return len(self.connected_nodes)

--- a/trinity/_utils/mp.py
+++ b/trinity/_utils/mp.py
@@ -32,12 +32,14 @@ def async_method(method_name: str) -> Callable[..., Any]:
             method_name,
             args,
         )
+    method.__name__ = method_name
     return method
 
 
 def sync_method(method_name: str) -> Callable[..., Any]:
     def method(self: Any, *args: Any, **kwargs: Any) -> Any:
         return self._callmethod(method_name, args, kwargs)
+    method.__name__ = method_name
     return method
 
 

--- a/trinity/sync/common/headers.py
+++ b/trinity/sync/common/headers.py
@@ -165,10 +165,10 @@ class SkeletonSyncer(BaseService, Generic[TChainPeer]):
             # validate that parents and children match
             pairs = tuple(zip(parents, children))
             try:
-                validate_pair_coros = [
+                validate_pair_coros = (
                     self.wait(self._chain.coro_validate_chain(parent, (child, )))
                     for parent, child in pairs
-                ]
+                )
                 await self.wait(asyncio.gather(*validate_pair_coros, loop=self.get_event_loop()))
             except ValidationError as e:
                 self.logger.warning(


### PR DESCRIPTION
fixes #872 

### What was wrong?

When the `PluginManager` was moved into a service I failed to tie the shutdown process of the plugin manager to the shutdown process of the service and that caused Trinity to hang on shutdown since it didn't propagate the shutdown request to the various plugins.

### How was it fixed?

Made sure to call `PluginManager.shutdown_blocking` in the `BaseService._cleanup`.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

[//]: # (See: https://trinity-client.readthedocs.io/en/latest/contributing.html#pull-requests)
- [x] Add entry to the [release notes](https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses]()
