### PR TITLE
Convert all abstractmethods to use Elipsis as function body

### DIFF
--- a/eth2/_utils/bls/backends/base.py
+++ b/eth2/_utils/bls/backends/base.py
@@ -19,14 +19,14 @@ class BaseBLSBackend(ABC):
     @staticmethod
     @abstractmethod
     def privtopub(k: int) -> BLSPubkey:
-        pass
+        ...
 
     @staticmethod
     @abstractmethod
     def sign(message_hash: Hash32,
              privkey: int,
              domain: Domain) -> BLSSignature:
-        pass
+        ...
 
     @staticmethod
     @abstractmethod
@@ -34,17 +34,17 @@ class BaseBLSBackend(ABC):
                pubkey: BLSPubkey,
                signature: BLSSignature,
                domain: Domain) -> bool:
-        pass
+        ...
 
     @staticmethod
     @abstractmethod
     def aggregate_signatures(signatures: Sequence[BLSSignature]) -> BLSSignature:
-        pass
+        ...
 
     @staticmethod
     @abstractmethod
     def aggregate_pubkeys(pubkeys: Sequence[BLSPubkey]) -> BLSPubkey:
-        pass
+        ...
 
     @staticmethod
     @abstractmethod
@@ -52,4 +52,4 @@ class BaseBLSBackend(ABC):
                         message_hashes: Sequence[Hash32],
                         signature: BLSSignature,
                         domain: Domain) -> bool:
-        pass
+        ...

--- a/eth2/beacon/chains/base.py
+++ b/eth2/beacon/chains/base.py
@@ -80,7 +80,7 @@ class BaseBeaconChain(Configurable, ABC):
     @classmethod
     @abstractmethod
     def get_chaindb_class(cls) -> Type[BaseBeaconChainDB]:
-        pass
+        ...
 
     #
     # Chain API
@@ -92,7 +92,7 @@ class BaseBeaconChain(Configurable, ABC):
                      genesis_state: BeaconState,
                      genesis_block: BaseBeaconBlock,
                      genesis_config: Eth2GenesisConfig) -> 'BaseBeaconChain':
-        pass
+        ...
 
     #
     # State Machine API
@@ -102,63 +102,63 @@ class BaseBeaconChain(Configurable, ABC):
     def get_state_machine_class(
             cls,
             block: BaseBeaconBlock) -> Type['BaseBeaconStateMachine']:
-        pass
+        ...
 
     @abstractmethod
     def get_state_machine(self, at_slot: Slot=None) -> 'BaseBeaconStateMachine':
-        pass
+        ...
 
     @classmethod
     @abstractmethod
     def get_state_machine_class_for_block_slot(
             cls,
             slot: Slot) -> Type['BaseBeaconStateMachine']:
-        pass
+        ...
 
     @classmethod
     @abstractmethod
     def get_genesis_state_machine_class(self) -> Type['BaseBeaconStateMachine']:
-        pass
+        ...
 
     #
     # State API
     #
     @abstractmethod
     def get_state_by_slot(self, slot: Slot) -> Hash32:
-        pass
+        ...
 
     #
     # Block API
     #
     @abstractmethod
     def get_block_class(self, block_root: Hash32) -> Type[BaseBeaconBlock]:
-        pass
+        ...
 
     @abstractmethod
     def create_block_from_parent(self,
                                  parent_block: BaseBeaconBlock,
                                  block_params: FromBlockParams) -> BaseBeaconBlock:
-        pass
+        ...
 
     @abstractmethod
     def get_block_by_root(self, block_root: Hash32) -> BaseBeaconBlock:
-        pass
+        ...
 
     @abstractmethod
     def get_canonical_head(self) -> BaseBeaconBlock:
-        pass
+        ...
 
     @abstractmethod
     def get_score(self, block_root: Hash32) -> int:
-        pass
+        ...
 
     @abstractmethod
     def get_canonical_block_by_slot(self, slot: Slot) -> BaseBeaconBlock:
-        pass
+        ...
 
     @abstractmethod
     def get_canonical_block_root(self, slot: Slot) -> Hash32:
-        pass
+        ...
 
     @abstractmethod
     def import_block(
@@ -166,18 +166,18 @@ class BaseBeaconChain(Configurable, ABC):
             block: BaseBeaconBlock,
             perform_validation: bool=True
     ) -> Tuple[BaseBeaconBlock, Tuple[BaseBeaconBlock, ...], Tuple[BaseBeaconBlock, ...]]:
-        pass
+        ...
 
     #
     # Attestation API
     #
     @abstractmethod
     def get_attestation_by_root(self, attestation_root: Hash32)-> Attestation:
-        pass
+        ...
 
     @abstractmethod
     def attestation_exists(self, attestation_root: Hash32) -> bool:
-        pass
+        ...
 
 
 class BeaconChain(BaseBeaconChain):

--- a/eth2/beacon/db/schema.py
+++ b/eth2/beacon/db/schema.py
@@ -12,12 +12,12 @@ class BaseSchema(ABC):
     @staticmethod
     @abstractmethod
     def make_head_state_slot_lookup_key() -> bytes:
-        pass
+        ...
 
     @staticmethod
     @abstractmethod
     def make_slot_to_state_root_lookup_key(slot: int) -> bytes:
-        pass
+        ...
 
     #
     # Block
@@ -25,32 +25,32 @@ class BaseSchema(ABC):
     @staticmethod
     @abstractmethod
     def make_canonical_head_root_lookup_key() -> bytes:
-        pass
+        ...
 
     @staticmethod
     @abstractmethod
     def make_block_root_to_slot_lookup_key(block_root: Hash32) -> bytes:
-        pass
+        ...
 
     @staticmethod
     @abstractmethod
     def make_block_slot_to_root_lookup_key(slot: int) -> bytes:
-        pass
+        ...
 
     @staticmethod
     @abstractmethod
     def make_block_root_to_score_lookup_key(block_root: Hash32) -> bytes:
-        pass
+        ...
 
     @staticmethod
     @abstractmethod
     def make_finalized_head_root_lookup_key() -> bytes:
-        pass
+        ...
 
     @staticmethod
     @abstractmethod
     def make_justified_head_root_lookup_key() -> bytes:
-        pass
+        ...
 
     #
     # Attestaion
@@ -58,7 +58,7 @@ class BaseSchema(ABC):
     @staticmethod
     @abstractmethod
     def make_attestation_root_to_block_lookup_key(attestaton_root: Hash32) -> bytes:
-        pass
+        ...
 
 
 class SchemaV1(BaseSchema):

--- a/eth2/beacon/state_machines/base.py
+++ b/eth2/beacon/state_machines/base.py
@@ -47,31 +47,31 @@ class BaseBeaconStateMachine(Configurable, ABC):
                  attestation_pool: AttestationPool,
                  slot: Slot,
                  state: BeaconState=None) -> None:
-        pass
+        ...
 
     @classmethod
     @abstractmethod
     def get_block_class(cls) -> Type[BaseBeaconBlock]:
-        pass
+        ...
 
     @classmethod
     @abstractmethod
     def get_state_class(cls) -> Type[BeaconState]:
-        pass
+        ...
 
     @classmethod
     @abstractmethod
     def get_state_transiton_class(cls) -> Type[BaseStateTransition]:
-        pass
+        ...
 
     @property
     @abstractmethod
     def state_transition(self) -> BaseStateTransition:
-        pass
+        ...
 
     @abstractmethod
     def get_fork_choice_scoring(self) -> ForkChoiceScoringFn:
-        pass
+        ...
 
     #
     # Import block API
@@ -80,13 +80,13 @@ class BaseBeaconStateMachine(Configurable, ABC):
     def import_block(self,
                      block: BaseBeaconBlock,
                      check_proposer_signature: bool=True) -> Tuple[BeaconState, BaseBeaconBlock]:
-        pass
+        ...
 
     @staticmethod
     @abstractmethod
     def create_block_from_parent(parent_block: BaseBeaconBlock,
                                  block_params: FromBlockParams) -> BaseBeaconBlock:
-        pass
+        ...
 
 
 class BeaconStateMachine(BaseBeaconStateMachine):

--- a/eth2/beacon/state_machines/state_transitions.py
+++ b/eth2/beacon/state_machines/state_transitions.py
@@ -37,4 +37,4 @@ class BaseStateTransition(Configurable, ABC):
         ``block`` takes precedence over ``future_slot``. Perform a subsequent call to this
         method without the block if you need both functionalities.
         """
-        pass
+        ...

--- a/eth2/beacon/types/blocks.py
+++ b/eth2/beacon/types/blocks.py
@@ -162,7 +162,7 @@ class BaseBeaconBlock(ssz.SignedSerializable, Configurable, ABC):
         """
         Return the block denoted by the given block root.
         """
-        raise NotImplementedError("Must be implemented by subclasses")
+        ...
 
 
 class BeaconBlock(BaseBeaconBlock):

--- a/newsfragments/880.misc.rst
+++ b/newsfragments/880.misc.rst
@@ -1,0 +1,1 @@
+Cleanup all ``abc.abstractmethod`` function bodies to use an ``Elipsis`` object.

--- a/p2p/discv5/enr.py
+++ b/p2p/discv5/enr.py
@@ -257,11 +257,11 @@ class BaseENR(Mapping[bytes, Any], ABC):
 
     @abstractmethod
     def __eq__(self, other: Any) -> bool:
-        pass
+        ...
 
     @abstractmethod
     def __hash__(self) -> int:
-        pass
+        ...
 
 
 class UnsignedENR(BaseENR, ENRContentSedes):

--- a/p2p/discv5/identity_schemes.py
+++ b/p2p/discv5/identity_schemes.py
@@ -68,17 +68,17 @@ class IdentityScheme(ABC):
     @classmethod
     @abstractmethod
     def create_signature(cls, enr: "BaseENR", private_key: bytes) -> bytes:
-        pass
+        ...
 
     @classmethod
     @abstractmethod
     def validate_signature(cls, enr: "ENR") -> None:
-        pass
+        ...
 
     @classmethod
     @abstractmethod
     def extract_node_address(cls, enr: "ENR") -> bytes:
-        pass
+        ...
 
 
 @default_identity_scheme_registry.register

--- a/p2p/peer.py
+++ b/p2p/peer.py
@@ -254,12 +254,12 @@ class BasePeer(BaseService):
 
     @abstractmethod
     async def send_sub_proto_handshake(self) -> None:
-        pass
+        ...
 
     @abstractmethod
     async def process_sub_proto_handshake(
             self, cmd: CommandAPI, msg: Payload) -> None:
-        pass
+        ...
 
     @contextlib.contextmanager
     def collect_sub_proto_messages(self) -> Iterator['MsgBuffer']:
@@ -564,7 +564,7 @@ class PeerSubscriber(ABC):
         commands are handled exclusively at the peer level and cannot be
         consumed with this API.
         """
-        pass
+        ...
 
     @functools.lru_cache(maxsize=64)
     def is_subscription_command(self, cmd_type: Type[CommandAPI]) -> bool:
@@ -579,7 +579,7 @@ class PeerSubscriber(ABC):
         The max size of messages the underlying :meth:`msg_queue` can keep before it starts
         discarding new messages. Implementers need to overwrite this to specify the maximum size.
         """
-        pass
+        ...
 
     def register_peer(self, peer: BasePeer) -> None:
         """
@@ -699,7 +699,7 @@ class BasePeerFactory(ABC):
     @property
     @abstractmethod
     def peer_class(self) -> Type[BasePeer]:
-        pass
+        ...
 
     def __init__(self,
                  privkey: datatypes.PrivateKey,

--- a/p2p/peer_backend.py
+++ b/p2p/peer_backend.py
@@ -22,7 +22,7 @@ class BasePeerBackend(ABC):
     async def get_peer_candidates(self,
                                   num_requested: int,
                                   connected_remotes: Set[NodeAPI]) -> Tuple[NodeAPI, ...]:
-        pass
+        ...
 
 
 TO_DISCOVERY_BROADCAST_CONFIG = BroadcastConfig(filter_endpoint=DISCOVERY_EVENTBUS_ENDPOINT)

--- a/p2p/peer_pool.py
+++ b/p2p/peer_pool.py
@@ -212,7 +212,7 @@ class BasePeerPool(BaseService, AsyncIterable[BasePeer]):
     @property
     @abstractmethod
     def peer_factory_class(self) -> Type[BasePeerFactory]:
-        pass
+        ...
 
     def get_peer_factory(self) -> BasePeerFactory:
         return self.peer_factory_class(

--- a/p2p/tracking/connection.py
+++ b/p2p/tracking/connection.py
@@ -49,11 +49,11 @@ class BaseConnectionTracker(ABC):
 
     @abstractmethod
     def record_blacklist(self, remote: NodeAPI, timeout_seconds: int, reason: str) -> None:
-        pass
+        ...
 
     @abstractmethod
     async def should_connect_to(self, remote: NodeAPI) -> bool:
-        pass
+        ...
 
 
 class NoopConnectionTracker(BaseConnectionTracker):

--- a/trinity/_utils/datastructures.py
+++ b/trinity/_utils/datastructures.py
@@ -356,22 +356,22 @@ class NoPrerequisites(Enum):
 class BaseOrderedTaskPreparation(ABC, Generic[TTask, TTaskID]):
     @abstractmethod
     def set_finished_dependency(self, finished_task: TTask) -> None:
-        pass
+        ...
 
     @abstractmethod
     def register_tasks(
             self,
             tasks: Tuple[TTask, ...],
             ignore_duplicates: bool = False) -> Tuple[TTask, ...]:
-        pass
+        ...
 
     @abstractmethod
     async def ready_tasks(self, max_results: int = None) -> Tuple[TTask, ...]:
-        pass
+        ...
 
     @abstractmethod
     def has_ready_tasks(self) -> bool:
-        pass
+        ...
 
 
 class OrderedTaskPreparation(

--- a/trinity/chains/base.py
+++ b/trinity/chains/base.py
@@ -17,7 +17,7 @@ class BaseAsyncChainAPI(ABC):
                                 block: BlockHeader,
                                 perform_validation: bool=True,
                                 ) -> Tuple[BaseBlock, Tuple[BaseBlock, ...], Tuple[BaseBlock, ...]]:
-        pass
+        ...
 
     @abstractmethod
     async def coro_validate_chain(
@@ -25,28 +25,28 @@ class BaseAsyncChainAPI(ABC):
             parent: BlockHeader,
             chain: Tuple[BlockHeader, ...],
             seal_check_random_sample_rate: int = 1) -> None:
-        pass
+        ...
 
     @abstractmethod
     async def coro_validate_receipt(self,
                                     receipt: Receipt,
                                     at_header: BlockHeader) -> None:
-        pass
+        ...
 
     @abstractmethod
     async def coro_get_block_by_hash(self,
                                      block_hash: Hash32) -> BaseBlock:
-        pass
+        ...
 
     @abstractmethod
     async def coro_get_block_by_header(self,
                                        header: BlockHeader) -> BaseBlock:
-        pass
+        ...
 
     @abstractmethod
     async def coro_get_canonical_block_by_number(self,
                                                  block_number: BlockNumber) -> BaseBlock:
-        pass
+        ...
 
 
 class BaseAsyncChain(BaseAsyncChainAPI, BaseChain):

--- a/trinity/chains/header.py
+++ b/trinity/chains/header.py
@@ -11,11 +11,11 @@ from eth.rlp.headers import BlockHeader
 class BaseAsyncHeaderChain(BaseHeaderChain):
     @abstractmethod
     async def coro_get_canonical_head(self) -> BlockHeader:
-        raise NotImplementedError("Chain classes must implement this method")
+        ...
 
     @abstractmethod
     async def coro_import_header(self, header: BlockHeader) -> Tuple[BlockHeader, ...]:
-        raise NotImplementedError("Chain classes must implement this method")
+        ...
 
 
 class AsyncHeaderChain(HeaderChain, BaseAsyncHeaderChain):

--- a/trinity/db/beacon/chain.py
+++ b/trinity/db/beacon/chain.py
@@ -40,7 +40,7 @@ class BaseAsyncBeaconChainDB(ABC):
             block_class: Type[BaseBeaconBlock],
             fork_choice_scoring: ForkChoiceScoringFn,
     ) -> Tuple[Tuple[bytes, ...], Tuple[bytes, ...]]:
-        pass
+        ...
 
     #
     # Canonical Chain API
@@ -48,44 +48,44 @@ class BaseAsyncBeaconChainDB(ABC):
 
     @abstractmethod
     async def coro_get_canonical_block_root(self, slot: int) -> Hash32:
-        pass
+        ...
 
     @abstractmethod
     async def coro_get_genesis_block_root(self) -> Hash32:
-        pass
+        ...
 
     @abstractmethod
     async def coro_get_canonical_block_by_slot(
             self,
             slot: int,
             block_class: Type[BaseBeaconBlock]) -> BaseBeaconBlock:
-        pass
+        ...
 
     @abstractmethod
     async def coro_get_canonical_head(self, block_class: Type[BaseBeaconBlock]) -> BaseBeaconBlock:
-        pass
+        ...
 
     @abstractmethod
     async def coro_get_canonical_head_root(self)-> Hash32:
-        pass
+        ...
 
     @abstractmethod
     async def coro_get_finalized_head(self, block_class: Type[BaseBeaconBlock]) -> BaseBeaconBlock:
-        pass
+        ...
 
     @abstractmethod
     async def coro_get_block_by_root(self,
                                      block_root: Hash32,
                                      block_class: Type[BaseBeaconBlock]) -> BaseBeaconBlock:
-        pass
+        ...
 
     @abstractmethod
     async def coro_get_score(self, block_root: Hash32) -> int:
-        pass
+        ...
 
     @abstractmethod
     async def coro_block_exists(self, block_root: Hash32) -> bool:
-        pass
+        ...
 
     @abstractmethod
     async def coro_persist_block_chain(
@@ -94,41 +94,41 @@ class BaseAsyncBeaconChainDB(ABC):
             block_class: Type[BaseBeaconBlock],
             fork_choice_scorings: Iterable[ForkChoiceScoringFn],
     ) -> Tuple[Tuple[BaseBeaconBlock, ...], Tuple[BaseBeaconBlock, ...]]:
-        pass
+        ...
 
     #
     # Beacon State
     #
     @abstractmethod
     async def coro_get_state_by_root(self, state_root: Hash32) -> BeaconState:
-        pass
+        ...
 
     @abstractmethod
     async def coro_persist_state(self,
                                  state: BeaconState) -> None:
-        pass
+        ...
 
     #
     # Attestation API
     #
     @abstractmethod
     def coro_get_attestation_key_by_root(self, attestation_root: Hash32)-> Tuple[Hash32, int]:
-        pass
+        ...
 
     @abstractmethod
     def coro_attestation_exists(self, attestation_root: Hash32) -> bool:
-        pass
+        ...
 
     #
     # Raw Database API
     #
     @abstractmethod
     async def coro_exists(self, key: bytes) -> bool:
-        pass
+        ...
 
     @abstractmethod
     async def coro_get(self, key: bytes) -> bytes:
-        pass
+        ...
 
 
 class AsyncBeaconChainDBPreProxy(BaseAsyncBeaconChainDB):

--- a/trinity/db/eth1/chain.py
+++ b/trinity/db/eth1/chain.py
@@ -33,39 +33,39 @@ class BaseAsyncChainDB(BaseAsyncHeaderDB):
 
     @abstractmethod
     async def coro_exists(self, key: bytes) -> bool:
-        pass
+        ...
 
     @abstractmethod
     async def coro_get(self, key: bytes) -> bytes:
-        pass
+        ...
 
     @abstractmethod
     async def coro_persist_block(self, block: BaseBlock) -> None:
-        pass
+        ...
 
     @abstractmethod
     async def coro_persist_uncles(self, uncles: Tuple[BlockHeader]) -> Hash32:
-        pass
+        ...
 
     @abstractmethod
     async def coro_persist_trie_data_dict(self, trie_data_dict: Dict[Hash32, bytes]) -> None:
-        pass
+        ...
 
     @abstractmethod
     async def coro_get_block_transactions(
             self,
             header: BlockHeader,
             transaction_class: Type[BaseTransaction]) -> Iterable[BaseTransaction]:
-        pass
+        ...
 
     @abstractmethod
     async def coro_get_block_uncles(self, uncles_hash: Hash32) -> List[BlockHeader]:
-        pass
+        ...
 
     @abstractmethod
     async def coro_get_receipts(
             self, header: BlockHeader, receipt_class: Type[Receipt]) -> List[Receipt]:
-        pass
+        ...
 
 
 class AsyncChainDBPreProxy(BaseAsyncChainDB):

--- a/trinity/db/eth1/header.py
+++ b/trinity/db/eth1/header.py
@@ -33,39 +33,39 @@ class BaseAsyncHeaderDB(ABC):
     """
     @abstractmethod
     async def coro_get_canonical_block_hash(self, block_number: BlockNumber) -> Hash32:
-        raise NotImplementedError("ChainDB classes must implement this method")
+        ...
 
     @abstractmethod
     async def coro_get_canonical_block_header_by_number(self, block_number: BlockNumber) -> BlockHeader:  # noqa: E501
-        raise NotImplementedError("ChainDB classes must implement this method")
+        ...
 
     @abstractmethod
     async def coro_get_canonical_head(self) -> BlockHeader:
-        raise NotImplementedError("ChainDB classes must implement this method")
+        ...
 
     #
     # Header API
     #
     @abstractmethod
     async def coro_get_block_header_by_hash(self, block_hash: Hash32) -> BlockHeader:
-        raise NotImplementedError("ChainDB classes must implement this method")
+        ...
 
     @abstractmethod
     async def coro_get_score(self, block_hash: Hash32) -> int:
-        raise NotImplementedError("ChainDB classes must implement this method")
+        ...
 
     @abstractmethod
     async def coro_header_exists(self, block_hash: Hash32) -> bool:
-        raise NotImplementedError("ChainDB classes must implement this method")
+        ...
 
     @abstractmethod
     async def coro_persist_header(self, header: BlockHeader) -> Tuple[BlockHeader, ...]:
-        raise NotImplementedError("ChainDB classes must implement this method")
+        ...
 
     @abstractmethod
     async def coro_persist_header_chain(self,
                                         headers: Iterable[BlockHeader]) -> Tuple[BlockHeader, ...]:
-        raise NotImplementedError("ChainDB classes must implement this method")
+        ...
 
 
 class AsyncHeaderDBPreProxy(BaseAsyncHeaderDB):

--- a/trinity/extensibility/plugin.py
+++ b/trinity/extensibility/plugin.py
@@ -70,7 +70,7 @@ class BasePlugin(ABC):
     @property
     @abstractmethod
     def event_bus(self) -> EndpointAPI:
-        pass
+        ...
 
     @property
     @abstractmethod
@@ -78,7 +78,7 @@ class BasePlugin(ABC):
         """
         Describe the name of the plugin.
         """
-        pass
+        ...
 
     @property
     def normalized_name(self) -> str:
@@ -213,7 +213,7 @@ class BaseIsolatedPlugin(BasePlugin):
 
     @abstractmethod
     def _spawn_start(self) -> None:
-        pass
+        ...
 
     def stop(self) -> None:
         """

--- a/trinity/nodes/base.py
+++ b/trinity/nodes/base.py
@@ -88,7 +88,7 @@ class Node(BaseService, Generic[TPeer]):
 
     @abstractmethod
     def get_chain(self) -> BaseChain:
-        raise NotImplementedError("Node classes must implement this method")
+        ...
 
     def get_full_chain(self) -> FullChain:
         if self._full_chain is None:
@@ -102,14 +102,14 @@ class Node(BaseService, Generic[TPeer]):
         """
         Return the ``PeerPoolEventServer`` of the node
         """
-        raise NotImplementedError("Node classes must implement this method")
+        ...
 
     @abstractmethod
     def get_peer_pool(self) -> BasePeerPool:
         """
         Return the PeerPool instance of the node
         """
-        raise NotImplementedError("Node classes must implement this method")
+        ...
 
     @abstractmethod
     def get_p2p_server(self) -> BaseService:
@@ -117,7 +117,7 @@ class Node(BaseService, Generic[TPeer]):
         This is the main service that will be run, when calling :meth:`run`.
         It's typically responsible for syncing the chain, with peer connections.
         """
-        raise NotImplementedError("Node classes must implement this method")
+        ...
 
     @property
     def db_manager(self) -> BaseManager:

--- a/trinity/plugins/builtin/network_db/eth1_peer_db/tracker.py
+++ b/trinity/plugins/builtin/network_db/eth1_peer_db/tracker.py
@@ -171,13 +171,13 @@ class BaseEth1PeerTracker(BasePeerBackend, PeerSubscriber):
                               protocol: str,
                               protocol_version: int,
                               network_id: int) -> None:
-        pass
+        ...
 
     @abstractmethod
     async def get_peer_candidates(self,
                                   num_requested: int,
                                   connected_remotes: Set[NodeAPI]) -> Tuple[NodeAPI, ...]:
-        pass
+        ...
 
 
 class NoopEth1PeerTracker(BaseEth1PeerTracker):

--- a/trinity/plugins/builtin/syncer/plugin.py
+++ b/trinity/plugins/builtin/syncer/plugin.py
@@ -86,7 +86,7 @@ class BaseSyncStrategy(ABC):
     @classmethod
     @abstractmethod
     def get_sync_mode(cls) -> str:
-        pass
+        ...
 
     @abstractmethod
     async def sync(self,
@@ -96,7 +96,7 @@ class BaseSyncStrategy(ABC):
                    peer_pool: BasePeerPool,
                    event_bus: EndpointAPI,
                    cancel_token: CancelToken) -> None:
-        pass
+        ...
 
 
 class NoopSyncStrategy(BaseSyncStrategy):

--- a/trinity/protocol/common/commands.py
+++ b/trinity/protocol/common/commands.py
@@ -11,4 +11,4 @@ class BaseBlockHeaders(Command):
 
     @abstractmethod
     def extract_headers(self, msg: Payload) -> Tuple[BlockHeader, ...]:
-        raise NotImplementedError("Must be implemented by subclasses")
+        ...

--- a/trinity/protocol/common/exchanges.py
+++ b/trinity/protocol/common/exchanges.py
@@ -88,4 +88,4 @@ class BaseExchange(ABC, Generic[TRequestPayload, TResponsePayload, TResult]):
         """
         Issue the request to the peer for the desired data
         """
-        raise NotImplementedError('__call__ must be defined on every Exchange')
+        ...

--- a/trinity/protocol/common/handlers.py
+++ b/trinity/protocol/common/handlers.py
@@ -27,7 +27,7 @@ class BaseExchangeHandler(ABC):
     @property
     @abstractmethod
     def _exchange_config(self) -> Dict[str, Type[BaseExchange[Any, Any, Any]]]:
-        pass
+        ...
 
     def __init__(self, peer: BasePeer) -> None:
         self._peer = peer

--- a/trinity/protocol/common/normalizers.py
+++ b/trinity/protocol/common/normalizers.py
@@ -26,7 +26,7 @@ class BaseNormalizer(ABC, Generic[TResponsePayload, TResult]):
         """
         Convert underlying peer message to final result
         """
-        raise NotImplementedError()
+        ...
 
 
 TPassthrough = TypeVar('TPassthrough', bound=Payload)

--- a/trinity/protocol/common/peer.py
+++ b/trinity/protocol/common/peer.py
@@ -82,12 +82,12 @@ class BaseChainPeer(BasePeer):
     @property
     @abstractmethod
     def requests(self) -> BaseChainExchangeHandler:
-        pass
+        ...
 
     @property
     @abstractmethod
     def max_headers_fetch(self) -> int:
-        pass
+        ...
 
     @property
     def headerdb(self) -> BaseAsyncHeaderDB:

--- a/trinity/protocol/common/peer_pool_event_bus.py
+++ b/trinity/protocol/common/peer_pool_event_bus.py
@@ -118,7 +118,7 @@ class PeerPoolEventServer(BaseService, PeerSubscriber, Generic[TPeer]):
         peer messages on the event bus. The handler is called for every message that is defined in
         ``self.subscription_msg_types``.
         """
-        pass
+        ...
 
     def get_peer(self, remote: NodeAPI) -> TPeer:
         """
@@ -298,7 +298,7 @@ class BaseProxyPeerPool(BaseService, Generic[TProxyPeer]):
                                    remote: NodeAPI,
                                    event_bus: EndpointAPI,
                                    broadcast_config: BroadcastConfig) -> TProxyPeer:
-        pass
+        ...
 
     async def ensure_proxy_peer(self, remote: NodeAPI) -> TProxyPeer:
 

--- a/trinity/protocol/common/requests.py
+++ b/trinity/protocol/common/requests.py
@@ -18,7 +18,7 @@ class BaseHeaderRequest(ABC):
     @property
     @abstractmethod
     def max_size(self) -> int:
-        pass
+        ...
 
     def generate_block_numbers(self, block_number: BlockNumber=None) -> Tuple[BlockNumber, ...]:
         if block_number is None and not self.is_numbered:

--- a/trinity/protocol/common/servers.py
+++ b/trinity/protocol/common/servers.py
@@ -83,7 +83,7 @@ class BaseRequestServer(BaseService, PeerSubscriber):
         """
         Identify the command, and react appropriately.
         """
-        pass
+        ...
 
 
 class BaseIsolatedRequestServer(BaseService):
@@ -134,7 +134,7 @@ class BaseIsolatedRequestServer(BaseService):
                           remote: NodeAPI,
                           cmd: CommandAPI,
                           msg: Payload) -> None:
-        pass
+        ...
 
 
 class BasePeerRequestHandler(CancellableMixin, HasExtendedDebugLogger):

--- a/trinity/protocol/common/trackers.py
+++ b/trinity/protocol/common/trackers.py
@@ -53,7 +53,7 @@ class BasePerformanceTracker(ABC, HasExtendedDebugLogger, Generic[TRequest, TRes
         case `None` should be returned.  (Specifically the `GetBlockHeaders`
         anchored to a block hash.
         """
-        pass
+        ...
 
     @abstractmethod
     def _get_result_size(self, result: TResult) -> int:
@@ -61,7 +61,7 @@ class BasePerformanceTracker(ABC, HasExtendedDebugLogger, Generic[TRequest, TRes
         The result size represents the number of *things* that were returned,
         not taking into account the sizes of individual items.
         """
-        pass
+        ...
 
     @abstractmethod
     def _get_result_item_count(self, result: TResult) -> int:
@@ -70,7 +70,7 @@ class BasePerformanceTracker(ABC, HasExtendedDebugLogger, Generic[TRequest, TRes
         response, taking into account things like the size of individual
         response items such as the number of transactions in a block.
         """
-        pass
+        ...
 
     def get_stats(self) -> str:
         """

--- a/trinity/protocol/common/validators.py
+++ b/trinity/protocol/common/validators.py
@@ -36,7 +36,7 @@ class BaseValidator(ABC, Generic[TResponse]):
     """
     @abstractmethod
     def validate_result(self, result: TResponse) -> None:
-        pass
+        ...
 
 
 class BaseBlockHeadersValidator(BaseValidator[Tuple[BlockHeader, ...]]):

--- a/trinity/server.py
+++ b/trinity/server.py
@@ -100,7 +100,7 @@ class BaseServer(BaseService, Generic[TPeerPool]):
 
     @abstractmethod
     def _make_peer_pool(self) -> TPeerPool:
-        pass
+        ...
 
     async def _start_tcp_listener(self) -> None:
         # TODO: Support IPv6 addresses as well.

--- a/trinity/sync/common/chain.py
+++ b/trinity/sync/common/chain.py
@@ -258,7 +258,7 @@ class BaseBlockImporter(ABC):
     async def import_block(
             self,
             block: BaseBlock) -> Tuple[BaseBlock, Tuple[BaseBlock, ...], Tuple[BaseBlock, ...]]:
-        pass
+        ...
 
     async def preview_transactions(
             self,
@@ -297,7 +297,7 @@ class BaseSyncBlockImporter(ABC):
     def import_block(
             self,
             block: BaseBlock) -> Tuple[BaseBlock, Tuple[BaseBlock, ...], Tuple[BaseBlock, ...]]:
-        pass
+        ...
 
 
 class SyncBlockImporter(BaseSyncBlockImporter):

--- a/trinity/sync/common/headers.py
+++ b/trinity/sync/common/headers.py
@@ -498,7 +498,7 @@ class HeaderSyncerAPI(ABC):
 
     @abstractmethod
     def get_target_header_hash(self) -> Hash32:
-        pass
+        ...
 
 
 class ManualHeaderSyncer(HeaderSyncerAPI):
@@ -837,7 +837,7 @@ class BaseHeaderChainSyncer(BaseService, HeaderSyncerAPI, Generic[TChainPeer]):
     @property
     @abstractmethod
     def tip_monitor_class(self) -> Type[BaseChainTipMonitor]:
-        pass
+        ...
 
     async def _run(self) -> None:
         self.run_daemon(self._tip_monitor)

--- a/trinity/sync/light/service.py
+++ b/trinity/sync/light/service.py
@@ -74,23 +74,23 @@ class BaseLightPeerChain(ABC):
 
     @abstractmethod
     async def coro_get_block_header_by_hash(self, block_hash: Hash32) -> BlockHeader:
-        pass
+        ...
 
     @abstractmethod
     async def coro_get_block_body_by_hash(self, block_hash: Hash32) -> BlockBody:
-        pass
+        ...
 
     @abstractmethod
     async def coro_get_receipts(self, block_hash: Hash32) -> List[Receipt]:
-        pass
+        ...
 
     @abstractmethod
     async def coro_get_account(self, block_hash: Hash32, address: ETHAddress) -> Account:
-        pass
+        ...
 
     @abstractmethod
     async def coro_get_contract_code(self, block_hash: Hash32, address: ETHAddress) -> bytes:
-        pass
+        ...
 
 
 class LightPeerChain(PeerSubscriber, BaseService, BaseLightPeerChain):


### PR DESCRIPTION
### What was wrong?

Mixed conventions for how to denote the empty body of an `abc.abstractmethod`

### How was it fixed?

Converted all of them to use an `...` `Elipsis` for their body.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

[//]: # (See: https://trinity-client.readthedocs.io/en/latest/contributing.html#pull-requests)
- [x] Add entry to the [release notes](https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses]()
