### PR TITLE
fix logging message

### DIFF
--- a/newsfragments/881.bugfix.rst
+++ b/newsfragments/881.bugfix.rst
@@ -1,0 +1,1 @@
+Fix ``__str__`` implementation of ``BaseProxyPeer`` to properly represent the ``p2p.kademlia.Node`` URI.

--- a/trinity/protocol/common/peer.py
+++ b/trinity/protocol/common/peer.py
@@ -149,7 +149,7 @@ class BaseProxyPeer(BaseService):
         super().__init__(token)
 
     def __str__(self) -> str:
-        return f"{self.__class__.__name__} {self.remote.uri}"
+        return f"{self.__class__.__name__} {self.remote}"
 
     async def _run(self) -> None:
         self.logger.debug("Starting Proxy Peer %s", self)


### PR DESCRIPTION
### What was wrong?

The `uri` property @  `p2p.kademlia.Node.uri` is a function (not a `property`).  The `__str__` implementation of `BaseProxyPeer` was treating it like it was a property.

### How was it fixed?

Update the `__str__` implementation to properly call the function to get the uri.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

[//]: # (See: https://trinity-client.readthedocs.io/en/latest/contributing.html#pull-requests)
- [x] Add entry to the [release notes](https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses]()
