### PR TITLE
Beam Sync: annotate event with num nodes collected

### DIFF
--- a/trinity/sync/beam/chain.py
+++ b/trinity/sync/beam/chain.py
@@ -513,11 +513,14 @@ class MissingDataEventHandler(BaseService):
 
     async def _serve_account(self, event: CollectMissingAccount) -> None:
         await self._state_downloader.ensure_node_present(event.missing_node_hash)
-        await self._state_downloader.download_account(
+        _, num_nodes_collected = await self._state_downloader.download_account(
             event.address_hash,
             event.state_root_hash,
         )
-        await self._event_bus.broadcast(MissingAccountCollected(), event.broadcast_config())
+        await self._event_bus.broadcast(
+            MissingAccountCollected(num_nodes_collected),
+            event.broadcast_config(),
+        )
 
     async def _serve_bytecode(self, event: CollectMissingBytecode) -> None:
         await self._state_downloader.ensure_node_present(event.bytecode_hash)
@@ -525,9 +528,12 @@ class MissingDataEventHandler(BaseService):
 
     async def _serve_storage(self, event: CollectMissingStorage) -> None:
         await self._state_downloader.ensure_node_present(event.missing_node_hash)
-        await self._state_downloader.download_storage(
+        num_nodes_collected = await self._state_downloader.download_storage(
             event.storage_key,
             event.storage_root_hash,
             event.account_address,
         )
-        await self._event_bus.broadcast(MissingStorageCollected(), event.broadcast_config())
+        await self._event_bus.broadcast(
+            MissingStorageCollected(num_nodes_collected),
+            event.broadcast_config(),
+        )

--- a/trinity/sync/common/events.py
+++ b/trinity/sync/common/events.py
@@ -34,12 +34,13 @@ class SyncingRequest(BaseRequestResponseEvent[SyncingResponse]):
         return SyncingResponse
 
 
+@dataclass
 class MissingAccountCollected(BaseEvent):
     """
     Response to :cls:`CollectMissingAccount`, emitted only after the account has
     been downloaded from a peer, and can be retrieved in the database.
     """
-    pass
+    num_nodes_collected: int
 
 
 @dataclass
@@ -78,12 +79,13 @@ class CollectMissingBytecode(BaseRequestResponseEvent[MissingBytecodeCollected])
         return MissingBytecodeCollected
 
 
+@dataclass
 class MissingStorageCollected(BaseEvent):
     """
     Response to :cls:`CollectMissingStorage`, emitted only after the storage value has
     been downloaded from a peer, and can be retrieved in the database.
     """
-    pass
+    num_nodes_collected: int
 
 
 @dataclass


### PR DESCRIPTION
### What was wrong?

We are missing statistics on number of trie nodes collected by block during Beam Sync.

### How was it fixed?

Return the number of nodes requested during a `CollectMissingAccount` request, adding the result to the `MissingAccountCollected` response event. (and the same for storage requests)

Bytecode is always a single node request, so it's irrelevant.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

[//]: # (See: https://trinity-client.readthedocs.io/en/latest/contributing.html#pull-requests)
- [ ] ~~Add entry to the [release notes](https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)~~

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://render.fineartamerica.com/images/rendered/medium/canvas-print/mirror/break/images/artworkimages/medium/1/balancing-goat-danielle-yandell-canvas-print.jpg)

I'm starting to run out of animals on balance beams...