### PR TITLE
Add "Performance section" to generated release notes

### DIFF
--- a/newsfragments/884.doc.rst
+++ b/newsfragments/884.doc.rst
@@ -1,0 +1,1 @@
+Add a "Performance improvements" section to the release notes

--- a/newsfragments/README.md
+++ b/newsfragments/README.md
@@ -10,6 +10,7 @@ Each file should be named like `<ISSUE>.<TYPE>.rst`, where
 
 * `feature`
 * `bugfix`
+* `performance`
 * `doc`
 * `removal`
 * `misc`

--- a/newsfragments/validate_files.py
+++ b/newsfragments/validate_files.py
@@ -7,11 +7,12 @@ import os
 import pathlib
 
 ALLOWED_EXTENSIONS = {
-    '.feature.rst',
     '.bugfix.rst',
     '.doc.rst',
-    '.removal.rst',
+    '.feature.rst',
     '.misc.rst',
+    '.performance.rst',
+    '.removal.rst',
 }
 
 ALLOWED_FILES = {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,3 +5,33 @@ filename = "docs/release_notes.rst"
 directory = "newsfragments"
 underlines = ["-", "~", "^"]
 issue_format = "`#{issue} <https://github.com/ethereum/trinity/issues/{issue}>`__"
+
+[[tool.towncrier.type]]
+directory = "feature"
+name = "Features"
+showcontent = true
+
+[[tool.towncrier.type]]
+directory = "bugfix"
+name = "Bugfixes"
+showcontent = true
+
+[[tool.towncrier.type]]
+directory = "performance"
+name = "Performance improvements"
+showcontent = true
+
+[[tool.towncrier.type]]
+directory = "doc"
+name = "Improved Documentation"
+showcontent = true
+
+[[tool.towncrier.type]]
+directory = "removal"
+name = "Deprecations and Removals"
+showcontent = true
+
+[[tool.towncrier.type]]
+directory = "misc"
+name = "Miscellaneous internal changes"
+showcontent = false


### PR DESCRIPTION
### What was wrong?

The frequently used "Performance improvements" section of our release notes got lost when we migrated to `towncrier`. We want it back.

### How was it fixed?

Manually configure the sections `towncrier` uses and add a `Performance improvements` category.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

[//]: # (See: https://trinity-client.readthedocs.io/en/latest/contributing.html#pull-requests)
- [ ] Add entry to the [release notes](https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://allthatsinteresting.com/wordpress/wp-content/uploads/2013/06/colorful-critter.jpg)
