### PR TITLE
added from field to transactions requested through JSON-RPC

### DIFF
--- a/newsfragments/889.bugfix.rst
+++ b/newsfragments/889.bugfix.rst
@@ -1,0 +1,1 @@
+Add missing field `from` to the response of `RPC` calls `eth_getTransactionByBlockHashAndIndex` and `eth_getTransactionByBlockNumberAndIndex`.

--- a/tests/json-fixtures-over-rpc/test_rpc_fixtures.py
+++ b/tests/json-fixtures-over-rpc/test_rpc_fixtures.py
@@ -6,6 +6,7 @@ from pathlib import Path
 import pytest
 
 from eth_utils.toolz import (
+    compose,
     dissoc,
     identity,
     get_in,
@@ -13,10 +14,15 @@ from eth_utils.toolz import (
 
 from eth_utils import (
     add_0x_prefix,
+    is_address,
     is_hex,
     is_integer,
     is_string,
+    to_checksum_address,
     to_tuple,
+)
+from eth_utils.curried import (
+    apply_formatter_if,
 )
 
 from eth.chains.mainnet import (
@@ -164,7 +170,10 @@ RPC_TRANSACTION_NORMALIZERS = {
     'gasPrice': remove_leading_zeros,
     'value': remove_leading_zeros,
     'data': empty_to_0x,
-    'to': add_0x_prefix,
+    'to': compose(
+        apply_formatter_if(is_address, to_checksum_address),
+        add_0x_prefix
+    ),
     'r': remove_leading_zeros,
     's': remove_leading_zeros,
     'v': remove_leading_zeros,
@@ -335,6 +344,7 @@ def validate_rpc_transaction_vs_fixture(transaction, fixture):
     actual_transaction = dissoc(
         transaction,
         'hash',
+        'from',
     )
     assert actual_transaction == expected
 

--- a/trinity/rpc/format.py
+++ b/trinity/rpc/format.py
@@ -12,10 +12,13 @@ from eth_utils.toolz import (
 )
 
 from eth_utils import (
+    apply_formatter_if,
     apply_formatters_to_dict,
     decode_hex,
     encode_hex,
     int_to_big_endian,
+    is_address,
+    to_checksum_address,
 )
 
 import rlp
@@ -37,18 +40,23 @@ from trinity.chains.base import BaseAsyncChain
 
 
 def transaction_to_dict(transaction: BaseTransaction) -> Dict[str, str]:
-    return dict(
-        hash=encode_hex(transaction.hash),
-        nonce=hex(transaction.nonce),
-        gas=hex(transaction.gas),
-        gasPrice=hex(transaction.gas_price),
-        to=encode_hex(transaction.to),
-        value=hex(transaction.value),
-        input=encode_hex(transaction.data),
-        r=hex(transaction.r),
-        s=hex(transaction.s),
-        v=hex(transaction.v),
-    )
+    return {
+        'hash': encode_hex(transaction.hash),
+        'nonce': hex(transaction.nonce),
+        'gas': hex(transaction.gas),
+        'gasPrice': hex(transaction.gas_price),
+        'from': to_checksum_address(transaction.sender),
+        'to': apply_formatter_if(
+            is_address,
+            to_checksum_address,
+            encode_hex(transaction.to)
+        ),
+        'value': hex(transaction.value),
+        'input': encode_hex(transaction.data),
+        'r': hex(transaction.r),
+        's': hex(transaction.s),
+        'v': hex(transaction.v),
+    }
 
 
 hexstr_to_int = functools.partial(int, base=16)


### PR DESCRIPTION
### What was wrong?
`eth_getTransactionByBlockHashAndIndex` and `eth_getTransactionByBlockNumberAndIndex` did not include `from` address. The output looked like this:
```
In [9]: w3.eth.getTransactionByBlock('0x45bb3a355c28c2f4c966eaad1e54b59b1f663c09264c5ab5c12218aac4cb4c0d', 1)
Out[9]:
AttributeDict({'hash': HexBytes('0x251112243025884f168152933401d96f9579a0ebcb433e305ab56347a2731a23'),
 'nonce': 0,
 'gas': 2000000,
 'gasPrice': 4000000000,
 'to': '0xF6DB16a918C5486458d90025204Fd6fA46c5273C',
 'value': 12100000000000000,
 'input': '0x',
 'r': HexBytes('0x44fa73dadee897539109a12a38a67ad51a58f66f5db2544564fc9d71c4fab243'),
 's': HexBytes('0x138a8452f0b880ce2ae3cbd27b4072279a7a8877eda74971a13352f8f383d997'),
 'v': 41})
```


### How was it fixed?
`from` field was added for `eth_getTransactionByBlockHashAndIndex` and `eth_getTransactionByBlockNumberAndIndex`. The new response looks like this:
```
In [14]: w3.eth.getTransactionByBlock('0x45bb3a355c28c2f4c966eaad1e54b59b1f663c09264c5ab5c12218aac4cb4c0d', 1)
Out[14]:
AttributeDict({'hash': HexBytes('0x251112243025884f168152933401d96f9579a0ebcb433e305ab56347a2731a23'),
 'nonce': 0,
 'gas': 2000000,
 'gasPrice': 4000000000,
 'to': '0xF6DB16a918C5486458d90025204Fd6fA46c5273C',
 'value': 12100000000000000,
 'input': '0x',
 'r': HexBytes('0x44fa73dadee897539109a12a38a67ad51a58f66f5db2544564fc9d71c4fab243'),
 's': HexBytes('0x138a8452f0b880ce2ae3cbd27b4072279a7a8877eda74971a13352f8f383d997'),
 'v': 41,
 'from': '0x340AEdf6a7309456045740Bd014EE8bE30D568a6'})
```

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

[//]: # (See: https://trinity-client.readthedocs.io/en/latest/contributing.html#pull-requests)
- [x] Add entry to the [release notes](https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://i.redd.it/rx52lutkr1f31.jpg)
