### PR TITLE
Cleanup Quickstart and start cookbook

### DIFF
--- a/docs/cookbook.rst
+++ b/docs/cookbook.rst
@@ -1,0 +1,101 @@
+Cookbook
+========
+
+The Cookbook is a collection of simple recipes that demonstrate good practices to accomplish
+common tasks. The examples are usually short answers to simple "How do I..." questions that go
+beyond simple API descriptions but also don't need a full guide to become clear.
+
+
+.. _cookbook_recipe_running_as_a_light_client:
+
+Running as a light client
+-------------------------
+
+.. warning::
+
+    It may take a **very** long time for Trinity to find an LES node with open
+    slots.  This is not a bug with trinity, but rather a shortage of nodes
+    serving LES. Everyone should consider running their own LES server to improve
+    the health of the network.
+
+Use the ``--sync-mode=light`` flag to instruct Trinity to run as a light node.
+
+
+.. _cookbook_recipe_ropsten_vs_mainnet:
+
+Ropsten vs Mainnet
+------------------
+
+Trinity currently only supports running against either the Ethereum Mainnet or
+Ropsten testnet.  Use ``--ropsten`` to run against Ropsten.
+
+
+.. code:: sh
+
+  trinity --ropsten
+
+
+.. _cookbook_recipe_connecting_to_preferred_nodes:
+
+
+Connecting to preferred nodes
+-----------------------------
+
+We can use the ``--preferred-node`` command line flag to instruct Trinity to prioritize connecting
+to specific nodes. This flag takes an enode URI as a single argument but can be used multiple times
+to prioritize connecting to a set of specific nodes.
+
+.. code:: sh
+
+  trinity --preferred-node enode://a41defa74e8d9d4152699cb9a0d195377da95833769ad6b386092ac3b16c184eb4ef4b4f02889e0b5097ff50fb5847ba99694d40b61f911cdea07b444b00e676@127.0.0.1:30304
+
+
+Using ``--preferred-node`` is a good way to ensure Trinity running in
+``sync-mode=light`` mode connects to known peers who serve LES.
+
+
+.. _cookbook_recipe_retrieving_chain_information_via_web3:
+
+
+Retrieving Chain information via web3
+-------------------------------------
+
+While just running ``trinity`` already causes the node to start syncing, it doesn't let us interact
+with the chain directly (apart from the JSON-RPC API).
+
+However, we can attach an interactive shell to a running Trinity instance with the
+``attach`` subcommand. The interactive ``ipython`` shell binds a
+`web3 <http://web3py.readthedocs.io>`_ instance to the ``w3`` variable.
+
+.. code:: sh
+
+  trinity attach
+
+Now that Trinity runs in an interactive shell mode, let's try to get some information about the
+latest block by calling ``w3.eth.getBlock('latest')``.
+
+.. code:: sh
+
+  In [1]: w3.eth.getBlock(0)
+  Out[1]:
+  AttributeDict({'difficulty': 17179869184,
+    'extraData': HexBytes('0x11bbe8db4e347b4e8c937c1c8370e4b5ed33adb3db69cbdb7a38e1e50b1b82fa'),
+    'gasLimit': 5000,
+    'gasUsed': 0,
+    'hash': HexBytes('0xd4e56740f876aef8c010b86a40d5f56745a118d0906a34e69aec8c0db1cb8fa3'),
+    'logsBloom': HexBytes('0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000'),
+    'mixHash': HexBytes('0x0000000000000000000000000000000000000000000000000000000000000000'),
+    'nonce': HexBytes('0x0000000000000042'),
+    'number': 0,
+    'parentHash': HexBytes('0x0000000000000000000000000000000000000000000000000000000000000000'),
+    'receiptsRoot': HexBytes('0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421'),
+    'sha3Uncles': HexBytes('0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347'),
+    'stateRoot': HexBytes('0xd7f8974fb5ac78d9ac099b9ad5018bedc2ce0a72dad1827a1709da30580f0544'),
+    'timestamp': 0,
+    'transactionsRoot': HexBytes('0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421'),
+    'miner': '0x0000000000000000000000000000000000000000',
+    'totalDifficulty': 17179869184,
+    'uncles': [],
+    'size': 540,
+    'transactions': []})
+

--- a/docs/guides/quickstart.rst
+++ b/docs/guides/quickstart.rst
@@ -156,100 +156,18 @@ Once Trinity successfully connected to other peers we should see it starting to 
   INFO  05-29 02:23:17       chain  Imported chain segment in 0 seconds, new head: #767 (aeb6)
 
 
-Running as a light client
--------------------------
+What's next?
+~~~~~~~~~~~~
 
-.. warning::
+Now that we've got things running, there's a lot ahead to learn. Check out the existing guides on
+Trinity's general :doc:`Architecture </guides/architecture>`, :doc:`Writing Plugins </guides/writing_plugins>`
+or scan the :doc:`Cookbook </cookbook>` for short recipes to learn how to:
 
-    It may take a **very** long time for Trinity to find an LES node with open
-    slots.  This is not a bug with trinity, but rather a shortage of nodes
-    serving LES.  Please consider running your own LES server to help improve
-    the health of the network.
-
-Use the ``--sync-mode=light`` flag to instruct Trinity to run as a light node.
-
-
-Ropsten vs Mainnet
-------------------
-
-Trinity currently only supports running against either the Ethereum Mainnet or
-Ropsten testnet.  Use ``--ropsten`` to run against Ropsten.
-
-
-.. code:: sh
-
-  trinity --ropsten
-
-
-
-Connecting to preferred nodes
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-If you would like to have Trinity prioritize connecting to specific nodes, you
-can use the ``--preferred-node`` command line flag.  This flag takes an enode
-URI as a single argument and will instruct Trinity to prioritize connecting to
-this node.
-
-.. code:: sh
-
-  trinity --preferred-node enode://a41defa74e8d9d4152699cb9a0d195377da95833769ad6b386092ac3b16c184eb4ef4b4f02889e0b5097ff50fb5847ba99694d40b61f911cdea07b444b00e676@127.0.0.1:30304
-
-
-Using ``--preferred-node`` is a good way to ensure Trinity running in
-``sync-mode=light`` mode connects to known peers who serve LES.
-
-
-Retrieving Chain information via web3
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-While just running ``trinity`` already causes the node to start syncing, it doesn't let us interact
-with the chain directly (apart from the JSON-RPC API).
-
-However, we can attach an interactive shell to a running Trinity instance with the
-``attach`` subcommand. The interactive ``ipython`` shell binds a
-`web3 <http://web3py.readthedocs.io>`_ instance to the ``w3`` variable.
-
-.. code:: sh
-
-  trinity attach
-
-Now that Trinity runs in an interactive shell mode, let's try to get some information about the
-latest block by calling ``w3.eth.getBlock('latest')``.
-
-.. code:: sh
-
-  In [9]: w3.eth.getBlock('latest')
-  Out[9]:
-  AttributeDict({'difficulty': 743444339302,
-  'extraData': HexBytes('0x476574682f4c5649562f76312e302e302f6c696e75782f676f312e342e32'),
-  'gasLimit': 5000,
-  'gasUsed': 0,
-  'hash': HexBytes('0x1a8487dfb8de7ee27b9cca30b6f3f6c9676eae29c10eef39b86890ed15eeed01'),
-  'logsBloom': HexBytes('0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000'),
-  'mixHash': HexBytes('0xf693b8e4bc30728600da40a0578c14ddb7ad08a64e329a19d9355d5665588aef'),
-  'nonce': HexBytes('0x7382884a72533c59'),
-  'number': 12479,
-  'parentHash': HexBytes('0x889c36c51463f100cf50ec2e2a92886aa7ebb3f99fa8c817343214a92f967a29'),
-  'receiptsRoot': HexBytes('0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421'),
-  'sha3Uncles': HexBytes('0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347'),
-  'stateRoot': HexBytes('0x6ad1ecb7d516c679e7c476956159051fa32848f3ba631a47c3fb72937ed86987'),
-  'timestamp': 1438368997,
-  'transactionsRoot': HexBytes('0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421'),
-  'miner': '0xbb7B8287f3F0a933474a79eAe42CBCa977791171',
-  'totalDifficulty': 3961372514945562,
-  'uncles': [],
-  'size': 544,
-  'transactions': []})
-
-You can attach to an existing Trinity process using the ``attach`` comand.
-
-.. code:: sh
-
-  trinity attach
-
-For a list of JSON-RPC endpoints which are expected to work, see this issue: https://github.com/ethereum/py-evm/issues/178
-
-
+- :ref:`Run Trinity as a light client<cookbook_recipe_running_as_a_light_client>`
+- :ref:`Connect to Mainnet or Ropsten<cookbook_recipe_ropsten_vs_mainnet>`
+- :ref:`Connect to preferred nodes<cookbook_recipe_connecting_to_preferred_nodes>`
+- :ref:`Retrieve chain information via web3<cookbook_recipe_retrieving_chain_information_via_web3>`
+- and many more!
 
 
 .. warning::

--- a/docs/guides/quickstart.rst
+++ b/docs/guides/quickstart.rst
@@ -4,10 +4,10 @@ Quickstart
 Installation
 ~~~~~~~~~~~~
 
-This is the quickstart guide for Trinity. If you only care about running a Trinity node, this
-guide will help you to get things set up. If you plan to develop on top of Py-EVM or contribute
-to the project you may rather want to checkout the :doc:`Contributing Guide </contributing>` which
-explains how to set everything up for development.
+This is the quickstart guide for Trinity. It teaches us how to run a Trinity node as a user.
+
+To develop on top of Trinity or to contribute to the project, check out the
+:doc:`Contributing Guide </contributing>` that explains how to set everything up for development.
 
 Installing on Ubuntu
 --------------------
@@ -97,7 +97,7 @@ Alternatively, we can run a specific image version, following the usual docker v
 
   docker run -it ethereum/trinity:0.1.0-alpha.13
 
-**2. Build your own image**
+**2. Building an image from the source**
 
 Alternatively, we may want to try out a specific (unreleased) version. In that case, we can create
 our very own image directly from the source code.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -16,8 +16,9 @@ Table of contents
    :maxdepth: 1
    :caption: Fundamentals
 
-   guides/index
    api/index
+   cookbook
+   guides/index
 
 .. toctree::
    :maxdepth: 1

--- a/newsfragments/890.doc.rst
+++ b/newsfragments/890.doc.rst
@@ -1,0 +1,1 @@
+Cleanup Quickstart and start a Cookbook with small recipes


### PR DESCRIPTION
### What was wrong?

1. The Quickstart is meant to teach how to *install and run* Trinity and then stop there, giving pointers into deeper parts of the documentation. It became cluttered with other things also burying valuable documentation in a place where people would not expect it.

2. We haven't had a good place to put small recipes which is basically the reason why we just stuffed more and more things into the Quickstart.

3. Some of the grammar used "You" which we typically try to avoid

### How was it fixed?

- I introduced a "Cookbook" section so that the Trinity docs are now structured as follows:

API = Focused on explaining the APIs, mostly generated from source
Cookbook = Short recipes/snippets a la "How do I ..."
Guides = Tutorial style articles

-  Ended the Quickstart right after the point where Trinity is running and syncing and introduced a "Whats next?" section with pointers to guides and the cookbook.

- Rewrote some sentences to avoid "You"

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

[//]: # (See: https://trinity-client.readthedocs.io/en/latest/contributing.html#pull-requests)
- [ ] Add entry to the [release notes](https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcQ0LSsNRZJ1RYvuIORBnVlRPyiybzCz7lgdsuZLz31Y6xtr9Z0K)
