### PR TITLE
Ensure --profile generates profiles of every component process

### DIFF
--- a/docs/cookbook.rst
+++ b/docs/cookbook.rst
@@ -99,3 +99,24 @@ latest block by calling ``w3.eth.getBlock('latest')``.
     'size': 540,
     'transactions': []})
 
+
+Performance profiling
+---------------------
+
+Trinity has builtin support for performance profiling via the ``--profile`` flag. When we run Trinity
+with the ``--profile`` flag it creates a ``cProfile`` of every single process in the current directory.
+
+The files are named ``profile_*`` (e.g. ``profile_discovery``) and can be viewed with any tool that
+supports ``cProfile`` files.
+
+A simple way is through ``cprofilev``
+
+.. code:: sh
+
+  pip install cprofilev
+
+Once installed we can generate a HTML based report and view it in a browser.
+
+.. code:: sh
+
+  cprofilev -f profile_discovery

--- a/newsfragments/891.bugfix.rst
+++ b/newsfragments/891.bugfix.rst
@@ -1,0 +1,1 @@
+Ensure ``--profile`` parameter takes profiles of every process

--- a/newsfragments/891.doc.rst
+++ b/newsfragments/891.doc.rst
@@ -1,0 +1,1 @@
+Cover ``--profile`` parameter in Cookbook

--- a/trinity/extensibility/plugin.py
+++ b/trinity/extensibility/plugin.py
@@ -42,6 +42,9 @@ from trinity._utils.logging import (
 from trinity._utils.os import (
     friendly_filename_or_url,
 )
+from trinity._utils.profiling import (
+    profiler,
+)
 
 
 class PluginStatus(Enum):
@@ -205,11 +208,18 @@ class BaseIsolatedPlugin(BasePlugin):
         """
         self._status = PluginStatus.STARTED
         self._process = ctx.Process(
-            target=self._spawn_start,
+            target=self._prepare_spawn,
         )
 
         self._process.start()
         self.logger.info("Plugin started: %s (pid=%d)", self.name, self._process.pid)
+
+    def _prepare_spawn(self) -> None:
+        if self.boot_info.boot_kwargs.pop('profile', False):
+            with profiler(f'profile_{self.normalized_name}'):
+                self._spawn_start()
+        else:
+            self._spawn_start()
 
     @abstractmethod
     def _spawn_start(self) -> None:

--- a/trinity/main.py
+++ b/trinity/main.py
@@ -90,7 +90,7 @@ def trinity_boot(args: Namespace,
     return (database_server_process,)
 
 
-@setup_cprofiler('run_database_process')
+@setup_cprofiler('profile_db_process')
 @with_queued_logging
 def run_database_process(trinity_config: TrinityConfig, db_class: Type[BaseDB]) -> None:
     with trinity_config.process_id_file('database'):

--- a/trinity/main_beacon.py
+++ b/trinity/main_beacon.py
@@ -101,7 +101,7 @@ def trinity_boot(args: Namespace,
     return (database_server_process,)
 
 
-@setup_cprofiler('run_database_process')
+@setup_cprofiler('profile_db_process')
 @with_queued_logging
 def run_database_process(trinity_config: TrinityConfig, db_class: Type[BaseDB]) -> None:
     with trinity_config.process_id_file('database'):


### PR DESCRIPTION
### What was wrong?

This builds on top of #890 because I wanted to make sure it is documented in the Cookbook.

The `--profile` parameter only profiled the db process. In the beginning, we had manually wired up profiling for the db process and the networking process. Now that all manual wiring is gone except for the db process, that was the only process left.

### How was it fixed?

1. Wire the profiling in the `BaseIsolatedPlugin`.
2. Document functionality in Cookbook

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

[//]: # (See: https://trinity-client.readthedocs.io/en/latest/contributing.html#pull-requests)
- [ ] Add entry to the [release notes](https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](http://img2.chinadaily.com.cn/images/201809/26/5baafc63a310c4ccaa00c76a.jpeg)
