### PR TITLE
getBalance leans on the beam syncer if data is missing

### DIFF
--- a/newsfragments/894.feature.rst
+++ b/newsfragments/894.feature.rst
@@ -1,0 +1,2 @@
+If Trinity is beam syncing and a call to `eth_getBalance` requests data which is not in
+the local database, Trinity asks for the data over the network.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -313,7 +313,7 @@ async def ipc_server(
     the course of all tests. It yields the IPC server only for monkeypatching purposes
     """
     rpc = RPCServer(
-        initialize_eth1_modules(chain_with_block_validation, event_bus)
+        initialize_eth1_modules(chain_with_block_validation, event_bus), event_bus,
     )
     ipc_server = IPCServer(rpc, jsonrpc_ipc_pipe_path, loop=event_loop)
 

--- a/tests/json-fixtures-over-rpc/test_rpc_fixtures.py
+++ b/tests/json-fixtures-over-rpc/test_rpc_fixtures.py
@@ -435,7 +435,7 @@ class MainnetFullChain(FullChain):
 @pytest.mark.asyncio
 async def test_rpc_against_fixtures(event_bus, chain_fixture, fixture_data):
     rpc = RPCServer(
-        initialize_eth1_modules(MainnetFullChain(None), event_bus)
+        initialize_eth1_modules(MainnetFullChain(None), event_bus), event_bus,
     )
 
     setup_result, setup_error = await call_rpc(rpc, 'evm_resetToGenesisFixture', [chain_fixture])

--- a/trinity/rpc/modules/eth.py
+++ b/trinity/rpc/modules/eth.py
@@ -32,10 +32,10 @@ from eth.constants import (
     ZERO_ADDRESS,
 )
 from eth.rlp.blocks import (
-    BaseBlock
+    BaseBlock,
 )
 from eth.rlp.headers import (
-    BlockHeader
+    BlockHeader,
 )
 from eth.vm.spoof import (
     SpoofTransaction,
@@ -56,6 +56,7 @@ from trinity.rpc.format import (
 from trinity.rpc.modules import (
     Eth1ChainRPCModule,
 )
+from trinity.rpc.retry import retryable
 from trinity.sync.common.events import (
     SyncingRequest,
 )
@@ -174,6 +175,7 @@ class Eth(Eth1ChainRPCModule):
     async def gasPrice(self) -> str:
         return hex(int(os.environ.get('TRINITY_GAS_PRICE', to_wei(1, 'gwei'))))
 
+    @retryable
     @format_params(decode_hex, to_int_if_hex)
     async def getBalance(self, address: Address, at_block: Union[str, int]) -> str:
         state = await state_at_block(self.chain, at_block)

--- a/trinity/rpc/retry.py
+++ b/trinity/rpc/retry.py
@@ -1,0 +1,71 @@
+"""
+Tools for retrying failed RPC methods. If we're beam syncing we can fault in missing data
+from remote peers.
+"""
+import itertools
+from typing import (
+    Any,
+    Callable,
+    TypeVar,
+)
+
+from lahja import EndpointAPI
+
+from eth.vm.interrupt import (
+    MissingAccountTrieNode,
+)
+
+from trinity.sync.common.events import (
+    CollectMissingAccount,
+)
+
+
+Func = Callable[..., Any]
+Meth = TypeVar('Meth', bound=Func)
+
+
+RETRYABLE_ATTRIBUTE_NAME = '_is_rpc_retryable'
+MAX_RETRIES = 1000
+
+
+def retryable(func: Meth) -> Meth:
+    setattr(func, RETRYABLE_ATTRIBUTE_NAME, True)
+    return func
+
+
+def is_retryable(func: Func) -> bool:
+    return getattr(func, RETRYABLE_ATTRIBUTE_NAME, False)
+
+
+def should_execute_with_retries(event_bus: EndpointAPI, func: Func) -> bool:
+    return all((
+        is_retryable(func),
+        event_bus.is_any_endpoint_subscribed_to(CollectMissingAccount),
+    ))
+
+
+async def execute_with_retries(event_bus: EndpointAPI, func: Func, params: Any) -> None:
+    """
+    If a beam sync (or anything which responds to CollectMissingAccount) is running then
+    attempt to fetch missing data from it before giving up.
+    """
+    should_retry = should_execute_with_retries(event_bus, func)
+
+    for iteration in itertools.count():
+        try:
+            return await func(*params)
+        except MissingAccountTrieNode as exc:
+            if not should_retry:
+                raise
+
+            if iteration > MAX_RETRIES:
+                raise Exception(
+                    f"Failed to collect missing account after {MAX_RETRIES} attempts"
+                ) from exc
+
+            await event_bus.request(CollectMissingAccount(
+                exc.missing_node_hash,
+                exc.address_hash,
+                exc.state_root_hash,
+                urgent=True,
+            ))


### PR DESCRIPTION
### What was wrong?

Beginning of solution to #893, `eth_getBalance` works during beam sync.

### How was it fixed?

### Future work:

- This also needs to intercept `MissinBytecode` and `MissingStorateTrieNode`.
- This needs to support and be tested with more methods than just `eth_getBalance`
- This needs to generate a friendly error if you ask for a state so old the network won't have it (that's also from before we started beam syncing)
- This needs to return a nice error if the beam syncer can't fetch the state (it shouldn't hang forever)
- It'd be nice to include an integration test that actually runs `RPCServer` and beam sync and verifies that they do the intended thing.

#### Cute Animal Picture

![marmot](https://user-images.githubusercontent.com/466333/62970754-06b14a80-bdc5-11e9-9e9a-fb48aa1cdcd8.jpg)
