### PR TITLE
Handling for PeerConnectionLost during multiplexing

### DIFF
--- a/newsfragments/895.bugfix.rst
+++ b/newsfragments/895.bugfix.rst
@@ -1,0 +1,1 @@
+Handle escaping ``PeerConnectionLost`` exception from ``Multiplexer`` in ``BasePeer`

--- a/p2p/transport.py
+++ b/p2p/transport.py
@@ -229,8 +229,8 @@ class Transport(TransportAPI):
                 self._reader.readexactly(n),
                 timeout=CONN_IDLE_TIMEOUT,
             )
-        except (asyncio.IncompleteReadError, ConnectionResetError, BrokenPipeError) as e:
-            raise PeerConnectionLost(repr(e))
+        except (asyncio.IncompleteReadError, ConnectionResetError, BrokenPipeError) as err:
+            raise PeerConnectionLost from err
 
     def write(self, data: bytes) -> None:
         self._writer.write(data)


### PR DESCRIPTION
fixes https://github.com/ethereum/trinity/issues/871

### What was wrong?

There are `PeerConnectionLost` exceptions coming out of the multiplexer that aren't being handled.

### How was it fixed?

Add error handling for them.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

[//]: # (See: https://trinity-client.readthedocs.io/en/latest/contributing.html#pull-requests)
- [x] Add entry to the [release notes](https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses]()
