### PR TITLE
Beam Sync: Speculative Execution

### DIFF
--- a/newsfragments/899.feature.rst
+++ b/newsfragments/899.feature.rst
@@ -1,0 +1,1 @@
+Speculative Execution in Beam Sync: split block transactions to run them in parallel, for speedup.

--- a/trinity/sync/beam/chain.py
+++ b/trinity/sync/beam/chain.py
@@ -500,12 +500,11 @@ class BeamBlockImporter(BaseBlockImporter, BaseService):
         # This is a hack, so that preview executions can load ancestor block-hashes
         self._db[header.hash] = rlp.encode(header)
 
-        if lagging:
-            # Only broadcast if the current import is lagging, to start running block previews
-            old_state_header = header.copy(state_root=parent_state_root)
-            self._event_bus.broadcast_nowait(
-                DoStatelessBlockPreview(old_state_header, transactions)
-            )
+        # Always broadcast, to start previewing transactions that are further ahead in the block
+        old_state_header = header.copy(state_root=parent_state_root)
+        self._event_bus.broadcast_nowait(
+            DoStatelessBlockPreview(old_state_header, transactions)
+        )
 
     async def _preview_address_load(
             self,

--- a/trinity/sync/beam/constants.py
+++ b/trinity/sync/beam/constants.py
@@ -17,3 +17,9 @@ EMPTY_PEER_RESPONSE_PENALTY = 1
 # previews are possible at a time (given that you have enough CPU cores).
 # The sensitivity of this number is relatively unexplored.
 NUM_PREVIEW_SHARDS = 4
+
+# How many speculative executions should we run concurrently? This is
+#   a global number, not per process or thread. It is necessary to
+#   constrain the I/O, which can become the global bottleneck.
+MAX_CONCURRENT_SPECULATIVE_EXECUTIONS = 40
+MAX_SPECULATIVE_EXECUTIONS_PER_PROCESS = MAX_CONCURRENT_SPECULATIVE_EXECUTIONS // NUM_PREVIEW_SHARDS

--- a/trinity/sync/full/chain.py
+++ b/trinity/sync/full/chain.py
@@ -1141,7 +1141,7 @@ class RegularChainBodySyncer(BaseBodyChainSyncer):
             block = await self.wait(self._import_queue.get())
             if not self._import_active.locked():
                 self.logger.info(
-                    "Paused block import %.1fs, while collecting %s body",
+                    "Waited %.1fs for %s body",
                     waiting_for_next_block.elapsed,
                     block.header,
                 )

--- a/trinity/sync/full/constants.py
+++ b/trinity/sync/full/constants.py
@@ -22,13 +22,9 @@ BLOCK_QUEUE_SIZE_TARGET = 1000
 # This is specifically for blocks where execution happens locally.
 # So each block might have a pretty significant execution time, on
 #   the order of seconds.
-# This is also used during Beam sync (maybe we should have a different constant?)
-# The number is derived by:
-#   - number of parallel processes running (currently 4)
-#   - how many block executions can run comfortably in a single process (~2)
-#       About half the time is spent executing, and the other half waiting on nodes
-#       This might change when we start benchmarking against remote nodes
-#   - how many blocks finish early/quickly, ~half, which doubles capacity (~2)
-#   So we multiply all these together to get 16 parallel executions to permit.
-#   The first block in the queue doesn't get previewed, which brings us to 17.
-BLOCK_IMPORT_QUEUE_SIZE = 17
+# This is also used during Beam sync, to limit how many previews are emitted at once
+# If you increase the number too high, then your I/O latency can skyrocket,
+#   causing a massive slowdown.
+# Every block gets previewed, and a block only enters the queue if another block import
+#   is active. So a queue size of 3 means that up to 4 previews are happening at once.
+BLOCK_IMPORT_QUEUE_SIZE = 7


### PR DESCRIPTION
### What was wrong?

Beam Sync is still too slow, when connected to peers with real-world. There is another angle for execution.

### How was it fixed?

Peek ahead at individual transactions within a block. Execute them as if they were the only transaction in the block. Often, transactions don't depend much on the others bundled before them. So it gives us a chance to look for many more nodes in parallel, without waiting to lag so far behind the chain tip.

I started running into I/O contention, so I had to limit the parallel look-ahead cap. When I tried to run all N transactions at the same time (say 150), it really choked the DB, so I limited it to a total of 40 concurrently running.

I also turned on parallel/preview execution for *all* blocks, and started ignoring the lag. This means we get to look ahead at transactions even for the current block that we are executing.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

[//]: # (See: https://trinity-client.readthedocs.io/en/latest/contributing.html#pull-requests)
- [x] Add entry to the [release notes](https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://static.boredpanda.com/blog/wp-content/uploads/2015/03/cute-animals-hokkaido-ezo-japan-3.jpg)
