### PR TITLE
fix `eth_getBalance` to give correct result when `at_block` of type integer is provided 

### DIFF
--- a/newsfragments/900.bugfix.rst
+++ b/newsfragments/900.bugfix.rst
@@ -1,0 +1,2 @@
+Fix JSON-RPC call `eth_getBalance(address, block_number)` to return balance at the requested block_number.
+Earlier it would always return balance at `block(0)`.

--- a/trinity/rpc/modules/eth.py
+++ b/trinity/rpc/modules/eth.py
@@ -79,7 +79,7 @@ async def get_header(chain: BaseAsyncChain, at_block: Union[str, int]) -> BlockH
     # mypy doesn't have user defined type guards yet
     # https://github.com/python/mypy/issues/5206
     elif is_integer(at_block) and at_block >= 0:  # type: ignore
-        block = await chain.coro_get_canonical_block_by_number(BlockNumber(0))
+        block = await chain.coro_get_canonical_block_by_number(BlockNumber(int(at_block)))
         at_header = block.header
     else:
         raise TypeError("Unrecognized block reference: %r" % at_block)


### PR DESCRIPTION
### What was wrong?
`w3.eth.getBalance('some_address', some_block_number)` would return the same result for 
some_block_number=0. 

### How was it fixed?

fixed `eth_getBalance` to use `at_block` when `at_block` is of type integer.
### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

[//]: # (See: https://trinity-client.readthedocs.io/en/latest/contributing.html#pull-requests)
- [x] Add entry to the [release notes](https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://preview.redd.it/yj4ya52juff31.jpg?width=640&crop=smart&auto=webp&s=b70faa41b0ff9674cd0b4d210942fcf356b7525c)
