### PR TITLE
Modify bcc receive server

### DIFF
--- a/eth2/beacon/chains/base.py
+++ b/eth2/beacon/chains/base.py
@@ -88,7 +88,7 @@ class BaseBeaconChain(Configurable, ABC):
     # State API
     #
     @abstractmethod
-    def get_state_by_slot(self, slot: Slot) -> Hash32:
+    def get_state_by_slot(self, slot: Slot) -> BeaconState:
         ...
 
     #

--- a/tests/libp2p/bcc/conftest.py
+++ b/tests/libp2p/bcc/conftest.py
@@ -2,10 +2,18 @@ import asyncio
 
 import pytest
 
-from trinity.protocol.bcc_libp2p import utils
+from trinity.protocol.bcc_libp2p import servers, utils
 from trinity.tools.bcc_factories import NodeFactory
 
 MOCK_TIME = 0.01
+MOCK_PROCESS_ORPHAN_BLOCKS_PERIOD = 0.1
+
+
+@pytest.fixture
+def mock_process_orphan_blocks_period(monkeypatch):
+    monkeypatch.setattr(
+        servers, "PROCESS_ORPHAN_BLOCKS_PERIOD", MOCK_PROCESS_ORPHAN_BLOCKS_PERIOD
+    )
 
 
 @pytest.fixture

--- a/tests/libp2p/bcc/test_receive_server.py
+++ b/tests/libp2p/bcc/test_receive_server.py
@@ -1,0 +1,171 @@
+import asyncio
+import importlib
+
+from typing import (
+    Tuple,
+)
+
+import pytest
+
+import ssz
+
+from eth_utils import (
+    ValidationError,
+)
+
+from eth2.configs import (
+    Eth2GenesisConfig,
+)
+from eth.exceptions import (
+    BlockNotFound,
+)
+
+from eth2.beacon.typing import (
+    FromBlockParams,
+)
+from eth2.beacon.chains.base import BaseBeaconChain
+from eth2.beacon.chains.testnet import TestnetChain as _TestnetChain
+from eth2.beacon.fork_choice.higher_slot import higher_slot_scoring
+from eth2.beacon.operations.attestation_pool import AttestationPool as TempPool
+from eth2.beacon.types.attestations import Attestation
+from eth2.beacon.types.attestation_data import AttestationData
+from eth2.beacon.types.blocks import (
+    BaseBeaconBlock,
+    BeaconBlock,
+)
+from eth2.beacon.state_machines.forks.serenity.blocks import (
+    SerenityBeaconBlock,
+)
+from eth2.beacon.state_machines.forks.xiao_long_bao.configs import (
+    XIAO_LONG_BAO_CONFIG,
+)
+
+from libp2p.pubsub.pb import rpc_pb2
+
+from trinity.exceptions import (
+    AttestationNotFound,
+)
+from trinity.protocol.bcc_libp2p.servers import (
+    AttestationPool,
+    BCCReceiveServer,
+)
+from trinity.protocol.bcc_libp2p.configs import (
+    PUBSUB_TOPIC_BEACON_BLOCK,
+    PUBSUB_TOPIC_BEACON_ATTESTATION,
+    SSZ_MAX_LIST_SIZE,
+)
+
+
+bcc_helpers = importlib.import_module('tests.core.p2p-proto.bcc.helpers')
+
+
+class FakeChain(_TestnetChain):
+    chaindb_class = bcc_helpers.FakeAsyncBeaconChainDB
+
+    def import_block(
+            self,
+            block: BaseBeaconBlock,
+            perform_validation: bool=True) -> Tuple[
+                BaseBeaconBlock, Tuple[BaseBeaconBlock, ...], Tuple[BaseBeaconBlock, ...]]:
+        """
+        Remove the logics about `state`, because we only need to check a block's parent in
+        `ReceiveServer`.
+        """
+        try:
+            self.get_block_by_root(block.parent_root)
+        except BlockNotFound:
+            raise ValidationError
+        (
+            new_canonical_blocks,
+            old_canonical_blocks,
+        ) = self.chaindb.persist_block(block, block.__class__, higher_slot_scoring)
+        return block, new_canonical_blocks, old_canonical_blocks
+
+
+async def get_fake_chain() -> FakeChain:
+    genesis_config = Eth2GenesisConfig(XIAO_LONG_BAO_CONFIG)
+    chain_db = await bcc_helpers.get_genesis_chain_db(genesis_config=genesis_config)
+    return FakeChain(
+        base_db=chain_db.db,
+        attestation_pool=TempPool(),
+        genesis_config=genesis_config,
+    )
+
+
+def get_blocks(
+        chain: BaseBeaconChain,
+        parent_block: SerenityBeaconBlock = None,
+        num_blocks: int = 3) -> Tuple[SerenityBeaconBlock, ...]:
+    if parent_block is None:
+        parent_block = chain.get_canonical_head()
+    blocks = []
+    for _ in range(num_blocks):
+        block = chain.create_block_from_parent(
+            parent_block=parent_block,
+            block_params=FromBlockParams(),
+        )
+        blocks.append(block)
+        parent_block = block
+    return tuple(blocks)
+
+
+@pytest.fixture
+async def receive_server():
+    topic_msg_queues = {
+        PUBSUB_TOPIC_BEACON_BLOCK: asyncio.Queue(),
+        PUBSUB_TOPIC_BEACON_ATTESTATION: asyncio.Queue(),
+    }
+    chain = await get_fake_chain()
+    server = BCCReceiveServer(
+        chain,
+        topic_msg_queues,
+    )
+    asyncio.ensure_future(server.run())
+    await server.events.started.wait()
+    try:
+        yield server
+    finally:
+        await server.cancel()
+
+
+def test_attestation_pool():
+    pool = AttestationPool()
+    a1 = Attestation()
+    a2 = Attestation(
+        data=a1.data.copy(
+            beacon_block_root=b'\x55' * 32,
+        ),
+    )
+    a3 = Attestation(
+        data=a1.data.copy(
+            beacon_block_root=b'\x66' * 32,
+        ),
+    )
+
+    # test: add
+    pool.add(a1)
+    assert a1 in pool._pool
+    assert len(pool._pool) == 1
+    # test: add: no side effect for adding twice
+    pool.add(a1)
+    assert len(pool._pool) == 1
+    # test: `__contains__`
+    assert a1.hash_tree_root in pool
+    assert a1 in pool
+    assert a2.hash_tree_root not in pool
+    assert a2 not in pool
+    # test: batch_add: two attestations
+    pool.batch_add([a1, a2])
+    assert len(pool._pool) == 2
+    # test: get
+    with pytest.raises(AttestationNotFound):
+        pool.get(a3.hash_tree_root)
+    assert pool.get(a1.hash_tree_root) == a1
+    assert pool.get(a2.hash_tree_root) == a2
+    # test: get_all
+    assert set([a1, a2]) == set(pool.get_all())
+    # test: remove
+    pool.remove(a3)
+    assert len(pool._pool) == 2
+    pool.batch_remove([a2, a1])
+    assert len(pool._pool) == 0

--- a/tests/libp2p/bcc/test_receive_server.py
+++ b/tests/libp2p/bcc/test_receive_server.py
@@ -20,7 +20,6 @@ from eth2.beacon.types.blocks import BaseBeaconBlock, BeaconBlock
 from eth2.beacon.typing import FromBlockParams
 from eth2.configs import Eth2GenesisConfig
 from trinity.db.beacon.chain import AsyncBeaconChainDB
-from trinity.exceptions import AttestationNotFound
 from trinity.protocol.bcc_libp2p.configs import (
     PUBSUB_TOPIC_BEACON_ATTESTATION,
     PUBSUB_TOPIC_BEACON_BLOCK,
@@ -121,11 +120,11 @@ def test_attestation_pool():
 
     # test: add
     pool.add(a1)
-    assert a1 in pool._pool
-    assert len(pool._pool) == 1
+    assert a1.hash_tree_root in pool._pool_storage
+    assert len(pool) == 1
     # test: add: no side effect for adding twice
     pool.add(a1)
-    assert len(pool._pool) == 1
+    assert len(pool) == 1
     # test: `__contains__`
     assert a1.hash_tree_root in pool
     assert a1 in pool
@@ -133,9 +132,9 @@ def test_attestation_pool():
     assert a2 not in pool
     # test: batch_add: two attestations
     pool.batch_add([a1, a2])
-    assert len(pool._pool) == 2
+    assert len(pool) == 2
     # test: get
-    with pytest.raises(AttestationNotFound):
+    with pytest.raises(KeyError):
         pool.get(a3.hash_tree_root)
     assert pool.get(a1.hash_tree_root) == a1
     assert pool.get(a2.hash_tree_root) == a2
@@ -143,9 +142,9 @@ def test_attestation_pool():
     assert set([a1, a2]) == set(pool.get_all())
     # test: remove
     pool.remove(a3)
-    assert len(pool._pool) == 2
+    assert len(pool) == 2
     pool.batch_remove([a2, a1])
-    assert len(pool._pool) == 0
+    assert len(pool) == 0
 
 
 def test_orphan_block_pool():

--- a/tests/libp2p/bcc/test_receive_server.py
+++ b/tests/libp2p/bcc/test_receive_server.py
@@ -23,7 +23,6 @@ from trinity.db.beacon.chain import AsyncBeaconChainDB
 from trinity.protocol.bcc_libp2p.configs import (
     PUBSUB_TOPIC_BEACON_ATTESTATION,
     PUBSUB_TOPIC_BEACON_BLOCK,
-    SSZ_MAX_LIST_SIZE,
 )
 from trinity.protocol.bcc_libp2p.servers import AttestationPool, OrphanBlockPool
 from trinity.tools.bcc_factories import ReceiveServerFactory
@@ -280,13 +279,11 @@ async def test_bcc_receive_server_handle_beacon_blocks(receive_server):
 @pytest.mark.asyncio
 async def test_bcc_receive_server_handle_beacon_attestations(receive_server):
     attestation = Attestation()
-    encoded_attestations = ssz.encode(
-        [attestation], sedes=ssz.List(Attestation, SSZ_MAX_LIST_SIZE)
-    )
+    encoded_attestation = ssz.encode(attestation)
     msg = rpc_pb2.Message(
         from_id=b"my_id",
         seqno=b"\x00" * 8,
-        data=encoded_attestations,
+        data=encoded_attestation,
         topicIDs=[PUBSUB_TOPIC_BEACON_ATTESTATION],
     )
 

--- a/tests/libp2p/bcc/test_receive_server.py
+++ b/tests/libp2p/bcc/test_receive_server.py
@@ -374,7 +374,7 @@ async def test_bcc_receive_server_handle_orphan_block_loop(
         return requested_blocks
 
     with monkeypatch.context() as m:
-        m.setattr(receive_server.p2p_node, "handshaked_peers", fake_peers)
+        m.setattr(receive_server.p2p_node, "handshaked_peers", set(fake_peers))
         m.setattr(
             receive_server.p2p_node,
             "request_recent_beacon_blocks",

--- a/tests/libp2p/bcc/test_receive_server.py
+++ b/tests/libp2p/bcc/test_receive_server.py
@@ -383,19 +383,23 @@ async def test_bcc_receive_server_handle_orphan_block_loop(
 
 
 @pytest.mark.asyncio
-async def test_bcc_receive_server_get_ready_attestations(receive_server, mocker):
+async def test_bcc_receive_server_get_ready_attestations(receive_server, monkeypatch):
     class MockState:
         slot = XIAO_LONG_BAO_CONFIG.GENESIS_SLOT
 
     state = MockState()
 
+    def mock_get_head_state():
+        return state
+
     def mock_get_attestation_data_slot(state, data, config):
         return data.slot
 
-    mocker.patch("eth2.beacon.state_machines.base.BeaconStateMachine.state", state)
-    mocker.patch(
-        "trinity.protocol.bcc_libp2p.servers.get_attestation_data_slot",
-        mock_get_attestation_data_slot,
+    monkeypatch.setattr(receive_server.chain, "get_head_state", mock_get_head_state)
+    from trinity.protocol.bcc_libp2p import servers
+
+    monkeypatch.setattr(
+        servers, "get_attestation_data_slot", mock_get_attestation_data_slot
     )
     attesting_slot = XIAO_LONG_BAO_CONFIG.GENESIS_SLOT
     a1 = Attestation(data=AttestationData())

--- a/tests/libp2p/bcc/test_receive_server.py
+++ b/tests/libp2p/bcc/test_receive_server.py
@@ -1,72 +1,48 @@
 import asyncio
 import importlib
+from typing import Tuple
 
-from typing import (
-    Tuple,
-)
-
+from eth.exceptions import BlockNotFound
+from eth_utils import ValidationError
+from libp2p.pubsub.pb import rpc_pb2
 import pytest
-
 import ssz
 
-from eth_utils import (
-    ValidationError,
-)
-
-from eth2.configs import (
-    Eth2GenesisConfig,
-)
-from eth.exceptions import (
-    BlockNotFound,
-)
-
-from eth2.beacon.typing import (
-    FromBlockParams,
-)
 from eth2.beacon.chains.base import BaseBeaconChain
 from eth2.beacon.chains.testnet import TestnetChain as _TestnetChain
 from eth2.beacon.fork_choice.higher_slot import higher_slot_scoring
 from eth2.beacon.operations.attestation_pool import AttestationPool as TempPool
-from eth2.beacon.types.attestations import Attestation
+from eth2.beacon.state_machines.forks.serenity.blocks import SerenityBeaconBlock
+from eth2.beacon.state_machines.forks.xiao_long_bao.configs import XIAO_LONG_BAO_CONFIG
 from eth2.beacon.types.attestation_data import AttestationData
-from eth2.beacon.types.blocks import (
-    BaseBeaconBlock,
-    BeaconBlock,
-)
-from eth2.beacon.state_machines.forks.serenity.blocks import (
-    SerenityBeaconBlock,
-)
-from eth2.beacon.state_machines.forks.xiao_long_bao.configs import (
-    XIAO_LONG_BAO_CONFIG,
-)
-
-from libp2p.pubsub.pb import rpc_pb2
-
-from trinity.exceptions import (
-    AttestationNotFound,
+from eth2.beacon.types.attestations import Attestation
+from eth2.beacon.types.blocks import BaseBeaconBlock, BeaconBlock
+from eth2.beacon.typing import FromBlockParams
+from eth2.configs import Eth2GenesisConfig
+from trinity.db.beacon.chain import AsyncBeaconChainDB
+from trinity.exceptions import AttestationNotFound
+from trinity.protocol.bcc_libp2p.configs import (
+    PUBSUB_TOPIC_BEACON_ATTESTATION,
+    PUBSUB_TOPIC_BEACON_BLOCK,
+    SSZ_MAX_LIST_SIZE,
 )
 from trinity.protocol.bcc_libp2p.servers import (
     AttestationPool,
     BCCReceiveServer,
-)
-from trinity.protocol.bcc_libp2p.configs import (
-    PUBSUB_TOPIC_BEACON_BLOCK,
-    PUBSUB_TOPIC_BEACON_ATTESTATION,
-    SSZ_MAX_LIST_SIZE,
+    OrphanBlockPool,
 )
 
-
-bcc_helpers = importlib.import_module('tests.core.p2p-proto.bcc.helpers')
+bcc_helpers = importlib.import_module("tests.core.p2p-proto.bcc.helpers")
 
 
 class FakeChain(_TestnetChain):
-    chaindb_class = bcc_helpers.FakeAsyncBeaconChainDB
+    chaindb_class = AsyncBeaconChainDB
 
     def import_block(
-            self,
-            block: BaseBeaconBlock,
-            perform_validation: bool=True) -> Tuple[
-                BaseBeaconBlock, Tuple[BaseBeaconBlock, ...], Tuple[BaseBeaconBlock, ...]]:
+        self, block: BaseBeaconBlock, perform_validation: bool = True
+    ) -> Tuple[
+        BaseBeaconBlock, Tuple[BaseBeaconBlock, ...], Tuple[BaseBeaconBlock, ...]
+    ]:
         """
         Remove the logics about `state`, because we only need to check a block's parent in
         `ReceiveServer`.
@@ -75,10 +51,9 @@ class FakeChain(_TestnetChain):
             self.get_block_by_root(block.parent_root)
         except BlockNotFound:
             raise ValidationError
-        (
-            new_canonical_blocks,
-            old_canonical_blocks,
-        ) = self.chaindb.persist_block(block, block.__class__, higher_slot_scoring)
+        (new_canonical_blocks, old_canonical_blocks) = self.chaindb.persist_block(
+            block, block.__class__, higher_slot_scoring
+        )
         return block, new_canonical_blocks, old_canonical_blocks
 
 
@@ -86,23 +61,21 @@ async def get_fake_chain() -> FakeChain:
     genesis_config = Eth2GenesisConfig(XIAO_LONG_BAO_CONFIG)
     chain_db = await bcc_helpers.get_genesis_chain_db(genesis_config=genesis_config)
     return FakeChain(
-        base_db=chain_db.db,
-        attestation_pool=TempPool(),
-        genesis_config=genesis_config,
+        base_db=chain_db.db, attestation_pool=TempPool(), genesis_config=genesis_config
     )
 
 
 def get_blocks(
-        chain: BaseBeaconChain,
-        parent_block: SerenityBeaconBlock = None,
-        num_blocks: int = 3) -> Tuple[SerenityBeaconBlock, ...]:
+    chain: BaseBeaconChain,
+    parent_block: SerenityBeaconBlock = None,
+    num_blocks: int = 3,
+) -> Tuple[SerenityBeaconBlock, ...]:
     if parent_block is None:
         parent_block = chain.get_canonical_head()
     blocks = []
     for _ in range(num_blocks):
         block = chain.create_block_from_parent(
-            parent_block=parent_block,
-            block_params=FromBlockParams(),
+            parent_block=parent_block, block_params=FromBlockParams()
         )
         blocks.append(block)
         parent_block = block
@@ -110,16 +83,31 @@ def get_blocks(
 
 
 @pytest.fixture
-async def receive_server():
+async def receive_server(nodes):
     topic_msg_queues = {
         PUBSUB_TOPIC_BEACON_BLOCK: asyncio.Queue(),
         PUBSUB_TOPIC_BEACON_ATTESTATION: asyncio.Queue(),
     }
     chain = await get_fake_chain()
-    server = BCCReceiveServer(
-        chain,
-        topic_msg_queues,
-    )
+    server = BCCReceiveServer(chain, nodes[0], topic_msg_queues)
+    asyncio.ensure_future(server.run())
+    await server.events.started.wait()
+    try:
+        yield server
+    finally:
+        await server.cancel()
+
+
+@pytest.fixture
+async def receive_server_with_mock_process_orphan_blocks_period(
+    nodes, mock_process_orphan_blocks_period
+):
+    topic_msg_queues = {
+        PUBSUB_TOPIC_BEACON_BLOCK: asyncio.Queue(),
+        PUBSUB_TOPIC_BEACON_ATTESTATION: asyncio.Queue(),
+    }
+    chain = await get_fake_chain()
+    server = BCCReceiveServer(chain, nodes[0], topic_msg_queues)
     asyncio.ensure_future(server.run())
     await server.events.started.wait()
     try:
@@ -131,16 +119,8 @@ async def receive_server():
 def test_attestation_pool():
     pool = AttestationPool()
     a1 = Attestation()
-    a2 = Attestation(
-        data=a1.data.copy(
-            beacon_block_root=b'\x55' * 32,
-        ),
-    )
-    a3 = Attestation(
-        data=a1.data.copy(
-            beacon_block_root=b'\x66' * 32,
-        ),
-    )
+    a2 = Attestation(data=a1.data.copy(beacon_block_root=b"\x55" * 32))
+    a3 = Attestation(data=a1.data.copy(beacon_block_root=b"\x66" * 32))
 
     # test: add
     pool.add(a1)
@@ -171,6 +151,119 @@ def test_attestation_pool():
     assert len(pool._pool) == 0
 
 
+def test_orphan_block_pool():
+    pool = OrphanBlockPool()
+    b0 = bcc_helpers.create_test_block()
+    b1 = bcc_helpers.create_test_block(parent=b0)
+    b2 = bcc_helpers.create_test_block(parent=b0, state_root=b"\x11" * 32)
+    # test: add
+    pool.add(b1)
+    assert b1 in pool._pool
+    assert len(pool._pool) == 1
+    # test: add: no side effect for adding twice
+    pool.add(b1)
+    assert len(pool._pool) == 1
+    # test: `__contains__`
+    assert b1 in pool
+    assert b1.signing_root in pool
+    assert b2 not in pool
+    assert b2.signing_root not in pool
+    # test: add: two blocks
+    pool.add(b2)
+    assert len(pool._pool) == 2
+    # test: get
+    assert pool.get(b1.signing_root) == b1
+    assert pool.get(b2.signing_root) == b2
+    # test: pop_children
+    b2_children = pool.pop_children(b2.signing_root)
+    assert len(b2_children) == 0
+    assert len(pool._pool) == 2
+    b0_children = pool.pop_children(b0.signing_root)
+    assert len(b0_children) == 2 and (b1 in b0_children) and (b2 in b0_children)
+    assert len(pool._pool) == 0
+
+
+@pytest.mark.parametrize("num_nodes", (1,))
+@pytest.mark.asyncio
+async def test_bcc_receive_server_try_import_orphan_blocks(receive_server):
+    blocks = get_blocks(receive_server.chain, num_blocks=4)
+
+    assert not receive_server._is_block_root_in_db(blocks[0].signing_root)
+    receive_server.chain.import_block(blocks[0])
+    assert receive_server._is_block_root_in_db(blocks[0].signing_root)
+
+    # test: block without its parent in db should not be imported, and it should be put in the
+    # `orphan_block_pool`.
+    receive_server.orphan_block_pool.add(blocks[2])
+    # test: No effect when calling `_try_import_orphan_blocks`
+    # if the `parent_root` is not in db.
+    assert blocks[2].parent_root == blocks[1].signing_root
+    receive_server._try_import_orphan_blocks(blocks[2].parent_root)
+    assert not receive_server._is_block_root_in_db(blocks[2].parent_root)
+    assert not receive_server._is_block_root_in_db(blocks[2].signing_root)
+    assert receive_server._is_block_root_in_orphan_block_pool(blocks[2].signing_root)
+
+    receive_server.orphan_block_pool.add(blocks[3])
+    # test: No effect when calling `_try_import_orphan_blocks` if `parent_root` is in the pool
+    # but not in db.
+    assert blocks[3].parent_root == blocks[2].signing_root
+    receive_server._try_import_orphan_blocks(blocks[2].signing_root)
+    assert not receive_server._is_block_root_in_db(blocks[2].signing_root)
+    assert not receive_server._is_block_root_in_db(blocks[3].signing_root)
+    assert receive_server._is_block_root_in_orphan_block_pool(blocks[3].signing_root)
+
+    # test: a successfully imported parent is present, its children should be processed
+    # recursively.
+    receive_server.chain.import_block(blocks[1])
+    receive_server._try_import_orphan_blocks(blocks[1].signing_root)
+    assert receive_server._is_block_root_in_db(blocks[1].signing_root)
+    assert receive_server._is_block_root_in_db(blocks[2].signing_root)
+    assert receive_server._is_block_root_in_db(blocks[3].signing_root)
+    assert not receive_server._is_block_root_in_orphan_block_pool(
+        blocks[2].signing_root
+    )
+    assert not receive_server._is_block_root_in_orphan_block_pool(
+        blocks[3].signing_root
+    )
+
+
+@pytest.mark.parametrize("num_nodes", (1,))
+@pytest.mark.asyncio
+async def test_bcc_receive_server_process_received_block(receive_server, monkeypatch):
+    block_not_orphan, block_orphan = get_blocks(receive_server.chain, num_blocks=2)
+
+    # test: if the block is an orphan, puts it in the orphan pool
+    receive_server._process_received_block(block_orphan)
+    assert (
+        receive_server.orphan_block_pool.get(block_orphan.signing_root) == block_orphan
+    )
+
+    # test: should returns `False` if `ValidationError` occurs.
+    def import_block_raises_validation_error(block, performa_validation=True):
+        raise ValidationError
+
+    with monkeypatch.context() as m:
+        m.setattr(
+            receive_server.chain, "import_block", import_block_raises_validation_error
+        )
+        receive_server._process_received_block(block_not_orphan)
+        assert not receive_server._is_block_root_in_db(block_not_orphan.signing_root)
+
+    # test: successfully imported the block, calls `self._try_import_orphan_blocks`
+    event = asyncio.Event()
+
+    def _try_import_orphan_blocks(parent_root):
+        event.set()
+
+    with monkeypatch.context() as m:
+        m.setattr(
+            receive_server, "_try_import_orphan_blocks", _try_import_orphan_blocks
+        )
+        receive_server._process_received_block(block_not_orphan)
+        assert event.is_set()
+
+
+@pytest.mark.parametrize("num_nodes", (1,))
 @pytest.mark.asyncio
 async def test_bcc_receive_server_handle_beacon_blocks(receive_server):
     block = get_blocks(receive_server.chain, num_blocks=1)[0]
@@ -179,7 +272,7 @@ async def test_bcc_receive_server_handle_beacon_blocks(receive_server):
         from_id=b"my_id",
         seqno=b"\x00" * 8,
         data=encoded_block,
-        topicIDs=[PUBSUB_TOPIC_BEACON_BLOCK]
+        topicIDs=[PUBSUB_TOPIC_BEACON_BLOCK],
     )
 
     assert receive_server.chain.get_canonical_head() != block
@@ -191,20 +284,25 @@ async def test_bcc_receive_server_handle_beacon_blocks(receive_server):
     assert receive_server.chain.get_canonical_head() == block
 
 
+@pytest.mark.parametrize("num_nodes", (1,))
 @pytest.mark.asyncio
 async def test_bcc_receive_server_handle_beacon_attestations(receive_server):
     attestation = Attestation()
-    encoded_attestations = ssz.encode([attestation], sedes=ssz.List(Attestation, SSZ_MAX_LIST_SIZE))
+    encoded_attestations = ssz.encode(
+        [attestation], sedes=ssz.List(Attestation, SSZ_MAX_LIST_SIZE)
+    )
     msg = rpc_pb2.Message(
         from_id=b"my_id",
         seqno=b"\x00" * 8,
         data=encoded_attestations,
-        topicIDs=[PUBSUB_TOPIC_BEACON_ATTESTATION]
+        topicIDs=[PUBSUB_TOPIC_BEACON_ATTESTATION],
     )
 
     assert attestation not in receive_server.attestation_pool
 
-    beacon_attestation_queue = receive_server.topic_msg_queues[PUBSUB_TOPIC_BEACON_ATTESTATION]
+    beacon_attestation_queue = receive_server.topic_msg_queues[
+        PUBSUB_TOPIC_BEACON_ATTESTATION
+    ]
     await beacon_attestation_queue.put(msg)
     # Wait for receive server to process the new attestation
     await asyncio.sleep(0.5)
@@ -213,17 +311,13 @@ async def test_bcc_receive_server_handle_beacon_attestations(receive_server):
 
     # Put the attestation in the next block
     block = get_blocks(receive_server.chain, num_blocks=1)[0]
-    block = block.copy(
-        body=block.body.copy(
-            attestations=[attestation],
-        )
-    )
+    block = block.copy(body=block.body.copy(attestations=[attestation]))
     encoded_block = ssz.encode(block, BeaconBlock)
     msg = rpc_pb2.Message(
         from_id=b"my_id",
         seqno=b"\x00" * 8,
         data=encoded_block,
-        topicIDs=[PUBSUB_TOPIC_BEACON_BLOCK]
+        topicIDs=[PUBSUB_TOPIC_BEACON_BLOCK],
     )
 
     beacon_block_queue = receive_server.topic_msg_queues[PUBSUB_TOPIC_BEACON_BLOCK]
@@ -234,14 +328,83 @@ async def test_bcc_receive_server_handle_beacon_attestations(receive_server):
     assert attestation not in receive_server.attestation_pool
 
 
+@pytest.mark.parametrize("num_nodes", (1,))
+@pytest.mark.asyncio
+async def test_bcc_receive_server_handle_orphan_block_loop(
+    receive_server_with_mock_process_orphan_blocks_period, monkeypatch
+):
+    receive_server = receive_server_with_mock_process_orphan_blocks_period
+    # block dependency graph
+    # block 1  -- block 2 -- block 3 -- block 4 -- block 5
+    #                 |   \
+    #                 |    block 3'
+    #              block 3''
+    #
+    # block 5, 3' and 3'' are orphan blocks
+    #
+    # First iteration will request block 4 and block 2 and import block 2, block 3' and block 3'',
+    # second iteration will request block 3 and import block 3, block 4 and block 5.
+    blocks = get_blocks(receive_server.chain, num_blocks=5)
+    fork_blocks = (
+        blocks[2].copy(state_root=b"\x01" * 32),
+        blocks[2].copy(state_root=b"\x12" * 32),
+    )
+    mock_peer_1_db = {block.signing_root: block for block in blocks[3:]}
+    mock_peer_2_db = {block.signing_root: block for block in blocks[:3]}
+
+    receive_server.chain.import_block(blocks[0])
+
+    fake_peers = [b"peer_1", b"peer_2"]
+    peer_1_called_event = asyncio.Event()
+    peer_2_called_event = asyncio.Event()
+
+    async def request_recent_beacon_blocks(peer_id, block_roots):
+        requested_blocks = []
+        db = {}
+        if peer_id == fake_peers[0]:
+            db = mock_peer_1_db
+            peer_1_called_event.set()
+        elif peer_id == fake_peers[1]:
+            db = mock_peer_2_db
+            peer_2_called_event.set()
+
+        for block_root in block_roots:
+            if block_root in db:
+                requested_blocks.append(db[block_root])
+        return requested_blocks
+
+    with monkeypatch.context() as m:
+        m.setattr(receive_server.p2p_node, "handshaked_peers", fake_peers)
+        m.setattr(
+            receive_server.p2p_node,
+            "request_recent_beacon_blocks",
+            request_recent_beacon_blocks,
+        )
+
+        for orphan_block in (blocks[4],) + fork_blocks:
+            receive_server.orphan_block_pool.add(orphan_block)
+        # Wait for receive server to process the orphan blocks
+        await asyncio.sleep(0.5)
+        # Check that both peers were requested for blocks
+        assert peer_1_called_event.is_set()
+        assert peer_2_called_event.is_set()
+        # Check that all blocks are processed and no more orphan blocks
+        for block in blocks + fork_blocks:
+            assert receive_server._is_block_root_in_db(block.signing_root)
+        assert len(receive_server.orphan_block_pool) == 0
+
+
+@pytest.mark.parametrize("num_nodes", (1,))
 @pytest.mark.asyncio
 async def test_bcc_receive_server_get_ready_attestations(receive_server, mocker):
     class MockState:
         slot = XIAO_LONG_BAO_CONFIG.GENESIS_SLOT
+
     state = MockState()
 
     def mock_get_attestation_data_slot(state, data, config):
         return data.slot
+
     mocker.patch("eth2.beacon.state_machines.base.BeaconStateMachine.state", state)
     mocker.patch(
         "trinity.protocol.bcc_libp2p.servers.get_attestation_data_slot",
@@ -250,17 +413,21 @@ async def test_bcc_receive_server_get_ready_attestations(receive_server, mocker)
     attesting_slot = XIAO_LONG_BAO_CONFIG.GENESIS_SLOT
     a1 = Attestation(data=AttestationData())
     a1.data.slot = attesting_slot
-    a2 = Attestation(signature=b'\x56' * 96, data=AttestationData())
+    a2 = Attestation(signature=b"\x56" * 96, data=AttestationData())
     a2.data.slot = attesting_slot
-    a3 = Attestation(signature=b'\x78' * 96, data=AttestationData())
+    a3 = Attestation(signature=b"\x78" * 96, data=AttestationData())
     a3.data.slot = attesting_slot + 1
     receive_server.attestation_pool.batch_add([a1, a2, a3])
 
     # Workaround: add a fake head state slot
     # so `get_state_machine` wont's trigger `HeadStateSlotNotFound` exception
-    receive_server.chain.chaindb._add_head_state_slot_lookup(XIAO_LONG_BAO_CONFIG.GENESIS_SLOT)
+    receive_server.chain.chaindb._add_head_state_slot_lookup(
+        XIAO_LONG_BAO_CONFIG.GENESIS_SLOT
+    )
 
-    state.slot = attesting_slot + XIAO_LONG_BAO_CONFIG.MIN_ATTESTATION_INCLUSION_DELAY - 1
+    state.slot = (
+        attesting_slot + XIAO_LONG_BAO_CONFIG.MIN_ATTESTATION_INCLUSION_DELAY - 1
+    )
     ready_attestations = receive_server.get_ready_attestations()
     assert len(ready_attestations) == 0
 
@@ -268,7 +435,9 @@ async def test_bcc_receive_server_get_ready_attestations(receive_server, mocker)
     ready_attestations = receive_server.get_ready_attestations()
     assert set([a1, a2]) == set(ready_attestations)
 
-    state.slot = attesting_slot + XIAO_LONG_BAO_CONFIG.MIN_ATTESTATION_INCLUSION_DELAY + 1
+    state.slot = (
+        attesting_slot + XIAO_LONG_BAO_CONFIG.MIN_ATTESTATION_INCLUSION_DELAY + 1
+    )
     ready_attestations = receive_server.get_ready_attestations()
     assert set([a1, a2, a3]) == set(ready_attestations)
 

--- a/tests/libp2p/bcc/test_topic_validator.py
+++ b/tests/libp2p/bcc/test_topic_validator.py
@@ -1,0 +1,21 @@
+import pytest
+
+from trinity.protocol.bcc_libp2p.configs import (
+    PUBSUB_TOPIC_BEACON_ATTESTATION,
+    PUBSUB_TOPIC_BEACON_BLOCK,
+)
+
+
+@pytest.mark.parametrize(
+    "num_nodes",
+    (
+        1,
+    )
+)
+@pytest.mark.asyncio
+async def test_setup_topic_validators(nodes):
+    node = nodes[0]
+    topic_1 = PUBSUB_TOPIC_BEACON_BLOCK
+    topic_2 = PUBSUB_TOPIC_BEACON_ATTESTATION
+    assert topic_1 in node.pubsub.topic_validators
+    assert topic_2 in node.pubsub.topic_validators

--- a/tests/libp2p/bcc/test_topic_validator.py
+++ b/tests/libp2p/bcc/test_topic_validator.py
@@ -6,12 +6,7 @@ from trinity.protocol.bcc_libp2p.configs import (
 )
 
 
-@pytest.mark.parametrize(
-    "num_nodes",
-    (
-        1,
-    )
-)
+@pytest.mark.parametrize("num_nodes", (1,))
 @pytest.mark.asyncio
 async def test_setup_topic_validators(nodes):
     node = nodes[0]

--- a/tests/plugins/eth2/beacon/test_validator.py
+++ b/tests/plugins/eth2/beacon/test_validator.py
@@ -60,7 +60,7 @@ class FakeNode:
     async def broadcast_beacon_block(self, block):
         self.list_beacon_block.append(block)
 
-    async def broadcast_attestations(self, attestations):
+    async def broadcast_attestation(self, attestation):
         pass
 
 

--- a/trinity/plugins/eth2/beacon/validator.py
+++ b/trinity/plugins/eth2/beacon/validator.py
@@ -366,7 +366,7 @@ class Validator(BaseService):
             for validator_index in attesting_validators_indices:
                 self.latest_attested_epoch[validator_index] = epoch
 
-            self.logger.debug("Brodcasting attestation %s", attestation)
+            self.logger.debug("Broadcasting attestation %s", attestation)
             await self.p2p_node.broadcast_attestation(attestation)
 
             attestations = attestations + (attestation,)

--- a/trinity/plugins/eth2/beacon/validator.py
+++ b/trinity/plugins/eth2/beacon/validator.py
@@ -365,8 +365,11 @@ class Validator(BaseService):
             )
             for validator_index in attesting_validators_indices:
                 self.latest_attested_epoch[validator_index] = epoch
-            attestations = attestations + (attestation,)
 
-        self.logger.debug("Brodcasting attestations %s", attestations)
-        await self.p2p_node.broadcast_attestations(attestations)
+            self.logger.debug("Brodcasting attestation %s", attestation)
+            await self.p2p_node.broadcast_attestation(attestation)
+
+            attestations = attestations + (attestation,)
+        # TODO: Aggregate attestations
+
         return attestations

--- a/trinity/protocol/bcc_libp2p/configs.py
+++ b/trinity/protocol/bcc_libp2p/configs.py
@@ -24,6 +24,7 @@ TTFB_TIMEOUT = 5  # seconds
 # Maximum time for complete response transfer.
 RESP_TIMEOUT = 10  # seconds
 # Maximum number of items in a SSZ List type
+# FIXME: Update this value onec settled in the spec
 SSZ_MAX_LIST_SIZE = 10
 
 #

--- a/trinity/protocol/bcc_libp2p/configs.py
+++ b/trinity/protocol/bcc_libp2p/configs.py
@@ -23,7 +23,8 @@ SHARD_SUBNET_COUNT = None
 TTFB_TIMEOUT = 5  # seconds
 # Maximum time for complete response transfer.
 RESP_TIMEOUT = 10  # seconds
-
+# Maximum number of items in a SSZ List type
+SSZ_MAX_LIST_SIZE = 10
 
 #
 # Gossip domain

--- a/trinity/protocol/bcc_libp2p/node.py
+++ b/trinity/protocol/bcc_libp2p/node.py
@@ -102,6 +102,7 @@ from .configs import (
     REQ_RESP_HELLO,
     REQ_RESP_RECENT_BEACON_BLOCKS,
     ResponseCode,
+    SSZ_MAX_LIST_SIZE,
 )
 from .exceptions import (
     HandshakeFailure,
@@ -270,7 +271,10 @@ class Node(BaseService):
         await self._broadcast_data(PUBSUB_TOPIC_BEACON_BLOCK, ssz.encode(block))
 
     async def broadcast_attestations(self, attestations: Sequence[Attestation]) -> None:
-        await self._broadcast_data(PUBSUB_TOPIC_BEACON_ATTESTATION, ssz.encode(attestations))
+        await self._broadcast_data(
+            PUBSUB_TOPIC_BEACON_ATTESTATION,
+            ssz.encode(list(attestations), sedes=ssz.List(Attestation, SSZ_MAX_LIST_SIZE))
+        )
 
     async def _broadcast_data(self, topic: str, data: bytes) -> None:
         await self.pubsub.publish(topic, data)

--- a/trinity/protocol/bcc_libp2p/node.py
+++ b/trinity/protocol/bcc_libp2p/node.py
@@ -204,9 +204,6 @@ class Node(BaseService):
 
         self.chain = chain
 
-        # Setup topic validators in pubsub
-        self.setup_topic_validators()
-
         self.handshaked_peers = set()
 
     async def _run(self) -> None:
@@ -225,9 +222,9 @@ class Node(BaseService):
         # pubsub
         await self.pubsub.subscribe(PUBSUB_TOPIC_BEACON_BLOCK)
         await self.pubsub.subscribe(PUBSUB_TOPIC_BEACON_ATTESTATION)
-        # TODO: Register topic validators
+        self._setup_topic_validators()
 
-    def setup_topic_validators(self) -> None:
+    def _setup_topic_validators(self) -> None:
         self.pubsub.set_topic_validator(
             PUBSUB_TOPIC_BEACON_BLOCK,
             get_beacon_block_validator(self.chain),

--- a/trinity/protocol/bcc_libp2p/node.py
+++ b/trinity/protocol/bcc_libp2p/node.py
@@ -102,7 +102,6 @@ from .configs import (
     REQ_RESP_HELLO,
     REQ_RESP_RECENT_BEACON_BLOCKS,
     ResponseCode,
-    SSZ_MAX_LIST_SIZE,
 )
 from .exceptions import (
     HandshakeFailure,
@@ -270,11 +269,8 @@ class Node(BaseService):
     async def broadcast_beacon_block(self, block: BaseBeaconBlock) -> None:
         await self._broadcast_data(PUBSUB_TOPIC_BEACON_BLOCK, ssz.encode(block))
 
-    async def broadcast_attestations(self, attestations: Sequence[Attestation]) -> None:
-        await self._broadcast_data(
-            PUBSUB_TOPIC_BEACON_ATTESTATION,
-            ssz.encode(list(attestations), sedes=ssz.List(Attestation, SSZ_MAX_LIST_SIZE))
-        )
+    async def broadcast_attestation(self, attestation: Attestation) -> None:
+        await self._broadcast_data(PUBSUB_TOPIC_BEACON_ATTESTATION, ssz.encode(attestation))
 
     async def _broadcast_data(self, topic: str, data: bytes) -> None:
         await self.pubsub.publish(topic, data)

--- a/trinity/protocol/bcc_libp2p/node.py
+++ b/trinity/protocol/bcc_libp2p/node.py
@@ -116,6 +116,10 @@ from .messages import (
     RecentBeaconBlocksRequest,
     RecentBeaconBlocksResponse,
 )
+from .topic_validators import (
+    get_beacon_attestation_validator,
+    get_beacon_block_validator,
+)
 from .utils import (
     make_rpc_v1_ssz_protocol_id,
     make_tcp_ip_maddr,
@@ -200,6 +204,9 @@ class Node(BaseService):
 
         self.chain = chain
 
+        # Setup topic validators in pubsub
+        self.setup_topic_validators()
+
         self.handshaked_peers = set()
 
     async def _run(self) -> None:
@@ -219,6 +226,18 @@ class Node(BaseService):
         await self.pubsub.subscribe(PUBSUB_TOPIC_BEACON_BLOCK)
         await self.pubsub.subscribe(PUBSUB_TOPIC_BEACON_ATTESTATION)
         # TODO: Register topic validators
+
+    def setup_topic_validators(self) -> None:
+        self.pubsub.set_topic_validator(
+            PUBSUB_TOPIC_BEACON_BLOCK,
+            get_beacon_block_validator(self.chain),
+            False,
+        )
+        self.pubsub.set_topic_validator(
+            PUBSUB_TOPIC_BEACON_ATTESTATION,
+            get_beacon_attestation_validator(self.chain),
+            False,
+        )
 
     async def dial_peer(self, ip: str, port: int, peer_id: ID) -> None:
         """

--- a/trinity/protocol/bcc_libp2p/node.py
+++ b/trinity/protocol/bcc_libp2p/node.py
@@ -588,10 +588,11 @@ class Node(BaseService):
                     yield block
 
     def _validate_start_slot(self, start_slot: Slot) -> None:
-        state_machine = self.chain.get_state_machine()
+        config = self.chain.get_state_machine().config
+        state = self.chain.get_head_state()
         finalized_epoch_start_slot = compute_start_slot_of_epoch(
-            epoch=state_machine.state.finalized_checkpoint.epoch,
-            slots_per_epoch=state_machine.config.SLOTS_PER_EPOCH,
+            epoch=state.finalized_checkpoint.epoch,
+            slots_per_epoch=config.SLOTS_PER_EPOCH,
         )
         if start_slot < finalized_epoch_start_slot:
             raise ValidationError(

--- a/trinity/protocol/bcc_libp2p/servers.py
+++ b/trinity/protocol/bcc_libp2p/servers.py
@@ -201,15 +201,13 @@ class BCCReceiveServer(BaseService):
             await self.sleep(PROCESS_ORPHAN_BLOCKS_PERIOD)
             if len(self.orphan_block_pool) == 0:
                 continue
+            # TODO: Prune Bruce Wayne type of orphan block
+            # (whose parent block seemingly never going to show up)
             orphan_blocks = self.orphan_block_pool.to_list()
-            parent_roots = set([block.parent_root for block in orphan_blocks])
-            block_roots = [block.signing_root for block in orphan_blocks]
-            dependent_block_roots = set()
+            parent_roots = set(block.parent_root for block in orphan_blocks)
+            block_roots = set(block.signing_root for block in orphan_blocks)
             # Remove dependent orphan blocks
-            for parent_root in parent_roots:
-                if parent_root in block_roots:
-                    dependent_block_roots.add(parent_root)
-            parent_roots.difference_update(dependent_block_roots)
+            parent_roots.difference_update(block_roots)
             # Keep requesting parent blocks from all peers
             peers_to_request = list(self.p2p_node.handshaked_peers)
             for peer_id in peers_to_request:

--- a/trinity/protocol/bcc_libp2p/servers.py
+++ b/trinity/protocol/bcc_libp2p/servers.py
@@ -135,14 +135,14 @@ class BCCReceiveServer(BaseService):
     async def _handle_beacon_attestation_loop(self) -> None:
         while True:
             msg = await self.topic_msg_queues[PUBSUB_TOPIC_BEACON_ATTESTATION].get()
-            await self._handle_attestations(msg)
+            await self._handle_beacon_attestations(msg)
 
     async def _handle_beacon_block_loop(self) -> None:
         while True:
             msg = await self.topic_msg_queues[PUBSUB_TOPIC_BEACON_BLOCK].get()
             await self._handle_beacon_block(msg)
 
-    async def _handle_attestations(self, msg: rpc_pb2.Message) -> None:
+    async def _handle_beacon_attestations(self, msg: rpc_pb2.Message) -> None:
         attestations = ssz.decode(msg.data, sedes=ssz.List(Attestation, SSZ_MAX_LIST_SIZE))
 
         self.logger.debug("Received attestations=%s", attestations)

--- a/trinity/protocol/bcc_libp2p/servers.py
+++ b/trinity/protocol/bcc_libp2p/servers.py
@@ -1,10 +1,10 @@
-import asyncio
 from typing import (
     Dict,
     Iterable,
     Set,
     Tuple,
     Union,
+    TYPE_CHECKING,
 )
 
 from cancel_token import (
@@ -54,6 +54,9 @@ from .configs import (
     PUBSUB_TOPIC_BEACON_ATTESTATION,
     SSZ_MAX_LIST_SIZE,
 )
+
+if TYPE_CHECKING:
+    import asyncio  # noqa: F401
 
 
 class AttestationPool:
@@ -111,7 +114,7 @@ class AttestationPool:
 class BCCReceiveServer(BaseService):
 
     chain: BaseBeaconChain
-    topic_msg_queues: Dict[str, "asyncio.Queue[rpc_pb2.Message]"]
+    topic_msg_queues: Dict[str, 'asyncio.Queue[rpc_pb2.Message]']
     attestation_pool: AttestationPool
     # TODO: Add orphan block pool and request parent block function back
     # after RPC for requesting beacon block is built
@@ -119,7 +122,7 @@ class BCCReceiveServer(BaseService):
     def __init__(
             self,
             chain: BaseBeaconChain,
-            topic_msg_queues: Dict[str, asyncio.Queue],
+            topic_msg_queues: Dict[str, 'asyncio.Queue[rpc_pb2.Message]'],
             cancel_token: CancelToken = None) -> None:
         super().__init__(cancel_token)
         self.chain = chain

--- a/trinity/protocol/bcc_libp2p/servers.py
+++ b/trinity/protocol/bcc_libp2p/servers.py
@@ -1,0 +1,226 @@
+import asyncio
+from typing import (
+    Dict,
+    Iterable,
+    Set,
+    Tuple,
+    Union,
+)
+
+from cancel_token import (
+    CancelToken,
+)
+from eth.exceptions import (
+    BlockNotFound,
+)
+from eth_typing import (
+    Hash32,
+)
+from eth_utils import (
+    ValidationError,
+    encode_hex,
+    to_tuple,
+)
+
+import ssz
+
+from libp2p.pubsub.pb import rpc_pb2
+
+from p2p.service import BaseService
+
+from eth2.beacon.attestation_helpers import (
+    get_attestation_data_slot,
+)
+from eth2.beacon.chains.base import (
+    BaseBeaconChain,
+)
+from eth2.beacon.types.attestations import (
+    Attestation,
+)
+from eth2.beacon.types.blocks import (
+    BaseBeaconBlock,
+    BeaconBlock,
+)
+from eth2.beacon.state_machines.forks.serenity.block_validation import (
+    validate_attestation_slot,
+)
+
+from trinity.exceptions import (
+    AttestationNotFound,
+)
+
+from .configs import (
+    PUBSUB_TOPIC_BEACON_BLOCK,
+    PUBSUB_TOPIC_BEACON_ATTESTATION,
+    SSZ_MAX_LIST_SIZE,
+)
+
+
+class AttestationPool:
+    """
+    Stores the attestations not yet included on chain.
+    """
+    # TODO: can probably use lru-cache or even database
+    _pool: Set[Attestation]
+
+    def __init__(self) -> None:
+        self._pool = set()
+
+    def __contains__(self, attestation_or_root: Union[Attestation, Hash32]) -> bool:
+        attestation_root: Hash32
+        if isinstance(attestation_or_root, Attestation):
+            attestation_root = attestation_or_root.hash_tree_root
+        elif isinstance(attestation_or_root, bytes):
+            attestation_root = attestation_or_root
+        else:
+            raise TypeError(
+                f"`attestation_or_root` should be `Attestation` or `Hash32`,"
+                f" got {type(attestation_or_root)}"
+            )
+        try:
+            self.get(attestation_root)
+            return True
+        except AttestationNotFound:
+            return False
+
+    def get(self, attestation_root: Hash32) -> Attestation:
+        for attestation in self._pool:
+            if attestation.hash_tree_root == attestation_root:
+                return attestation
+        raise AttestationNotFound(
+            f"No attestation with root {encode_hex(attestation_root)} is found.")
+
+    def get_all(self) -> Tuple[Attestation, ...]:
+        return tuple(self._pool)
+
+    def add(self, attestation: Attestation) -> None:
+        if attestation not in self._pool:
+            self._pool.add(attestation)
+
+    def batch_add(self, attestations: Iterable[Attestation]) -> None:
+        self._pool = self._pool.union(set(attestations))
+
+    def remove(self, attestation: Attestation) -> None:
+        if attestation in self._pool:
+            self._pool.remove(attestation)
+
+    def batch_remove(self, attestations: Iterable[Attestation]) -> None:
+        self._pool.difference_update(attestations)
+
+
+class BCCReceiveServer(BaseService):
+
+    chain: BaseBeaconChain
+    topic_msg_queues: Dict[str, "asyncio.Queue[rpc_pb2.Message]"]
+    attestation_pool: AttestationPool
+    # TODO: Add orphan block pool and request parent block function back
+    # after RPC for requesting beacon block is built
+
+    def __init__(
+            self,
+            chain: BaseBeaconChain,
+            topic_msg_queues: Dict[str, asyncio.Queue],
+            cancel_token: CancelToken = None) -> None:
+        super().__init__(cancel_token)
+        self.chain = chain
+        self.topic_msg_queues = topic_msg_queues
+        self.attestation_pool = AttestationPool()
+
+    async def _run(self) -> None:
+        self.logger.info(f"BCCReceiveServer up")
+        self.run_daemon_task(self._handle_beacon_attestation_loop())
+        self.run_daemon_task(self._handle_beacon_block_loop())
+        await self.cancellation()
+
+    async def _handle_beacon_attestation_loop(self) -> None:
+        while True:
+            msg = await self.topic_msg_queues[PUBSUB_TOPIC_BEACON_ATTESTATION].get()
+            await self._handle_attestations(msg)
+
+    async def _handle_beacon_block_loop(self) -> None:
+        while True:
+            msg = await self.topic_msg_queues[PUBSUB_TOPIC_BEACON_BLOCK].get()
+            await self._handle_beacon_block(msg)
+
+    async def _handle_attestations(self, msg: rpc_pb2.Message) -> None:
+        attestations = ssz.decode(msg.data, sedes=ssz.List(Attestation, SSZ_MAX_LIST_SIZE))
+
+        self.logger.debug("Received attestations=%s", attestations)
+
+        # Check if attestations has been seen already.
+        # Filter out those seen already.
+        new_attestations = tuple(
+            filter(
+                self._is_attestation_new,
+                attestations,
+            )
+        )
+        if len(new_attestations) == 0:
+            return
+        # Add new attestations to attestation pool.
+        self.attestation_pool.batch_add(new_attestations)
+
+    async def _handle_beacon_block(self, msg: rpc_pb2.Message) -> None:
+        block = ssz.decode(msg.data, BeaconBlock)
+        if self._is_block_seen(block):
+            return
+        self.logger.debug("Received new block=%s", block)
+
+        try:
+            self.chain.import_block(block)
+        # If the block is invalid, we should drop it.
+        except ValidationError:
+            return
+        except Exception:
+            # Unexpected result
+            return
+        else:
+            # Remove attestations in block that are also in the attestation pool.
+            self.attestation_pool.batch_remove(block.body.attestations)
+
+    def _is_attestation_new(self, attestation: Attestation) -> bool:
+        """
+        Check if the attestation is already in the database or the attestion pool.
+        """
+        try:
+            if attestation.hash_tree_root in self.attestation_pool:
+                return True
+            else:
+                return not self.chain.attestation_exists(attestation.hash_tree_root)
+        except AttestationNotFound:
+            return True
+
+    def _is_block_root_in_db(self, block_root: Hash32) -> bool:
+        try:
+            self.chain.get_block_by_root(block_root=block_root)
+            return True
+        except BlockNotFound:
+            return False
+
+    def _is_block_root_seen(self, block_root: Hash32) -> bool:
+        return self._is_block_root_in_db(block_root=block_root)
+
+    def _is_block_seen(self, block: BaseBeaconBlock) -> bool:
+        return self._is_block_root_seen(block_root=block.signing_root)
+
+    @to_tuple
+    def get_ready_attestations(self) -> Iterable[Attestation]:
+        state_machine = self.chain.get_state_machine()
+        config = state_machine.config
+        state = state_machine.state
+        for attestation in self.attestation_pool.get_all():
+            data = attestation.data
+            attestation_slot = get_attestation_data_slot(state, data, config)
+            try:
+                validate_attestation_slot(
+                    attestation_slot,
+                    state.slot,
+                    config.SLOTS_PER_EPOCH,
+                    config.MIN_ATTESTATION_INCLUSION_DELAY,
+                )
+            except ValidationError:
+                # TODO: Should clean up attestations with invalid slot because
+                # they are no longer available for inclusion into block.
+                continue
+            else:
+                yield attestation

--- a/trinity/protocol/bcc_libp2p/servers.py
+++ b/trinity/protocol/bcc_libp2p/servers.py
@@ -224,7 +224,11 @@ class BCCReceiveServer(BaseService):
                     try:
                         parent_roots.remove(block.signing_root)
                     except ValueError:
-                        self.logger.deubg(f"peer={peer_id} sent incorrect block={block}")
+                        self.logger.deubg(
+                            "peer=%s sent incorrect block=%s",
+                            peer_id,
+                            encode_hex(block.signing_root),
+                        )
                         # This should not happen if peers are returning correct blocks
                         continue
                     else:

--- a/trinity/protocol/bcc_libp2p/servers.py
+++ b/trinity/protocol/bcc_libp2p/servers.py
@@ -61,7 +61,7 @@ if TYPE_CHECKING:
 PROCESS_ORPHAN_BLOCKS_PERIOD = 10.0
 
 
-class AttestationPool(OperationPool):
+class AttestationPool(OperationPool[Attestation]):
     """
     Store the attestations not yet included on chain.
     """
@@ -334,9 +334,8 @@ class BCCReceiveServer(BaseService):
 
     @to_tuple
     def get_ready_attestations(self) -> Iterable[Attestation]:
-        state_machine = self.chain.get_state_machine()
-        config = state_machine.config
-        state = state_machine.state
+        config = self.chain.get_state_machine().config
+        state = self.chain.get_head_state()
         for attestation in self.attestation_pool.get_all():
             data = attestation.data
             attestation_slot = get_attestation_data_slot(state, data, config)

--- a/trinity/protocol/bcc_libp2p/servers.py
+++ b/trinity/protocol/bcc_libp2p/servers.py
@@ -1,6 +1,7 @@
 from typing import (
     Dict,
     Iterable,
+    List,
     Set,
     Tuple,
     Union,
@@ -49,6 +50,8 @@ from trinity.exceptions import (
     AttestationNotFound,
 )
 
+from trinity.protocol.bcc_libp2p.node import Node
+
 from .configs import (
     PUBSUB_TOPIC_BEACON_BLOCK,
     PUBSUB_TOPIC_BEACON_ATTESTATION,
@@ -57,6 +60,9 @@ from .configs import (
 
 if TYPE_CHECKING:
     import asyncio  # noqa: F401
+
+
+PROCESS_ORPHAN_BLOCKS_PERIOD = 10.0
 
 
 class AttestationPool:
@@ -111,28 +117,83 @@ class AttestationPool:
         self._pool.difference_update(attestations)
 
 
+class OrphanBlockPool:
+    """
+    Stores the orphan blocks(the blocks who arrive before their parents).
+    """
+    # TODO: can probably use lru-cache or even database
+    _pool: Set[BaseBeaconBlock]
+
+    def __init__(self) -> None:
+        self._pool = set()
+
+    def __len__(self):
+        return len(self._pool)
+
+    def __contains__(self, block_or_block_root: Union[BaseBeaconBlock, Hash32]) -> bool:
+        block_root: Hash32
+        if isinstance(block_or_block_root, BaseBeaconBlock):
+            block_root = block_or_block_root.signing_root
+        elif isinstance(block_or_block_root, bytes):
+            block_root = block_or_block_root
+        else:
+            raise TypeError("`block_or_block_root` should be `BaseBeaconBlock` or `Hash32`")
+        try:
+            self.get(block_root)
+            return True
+        except BlockNotFound:
+            return False
+
+    def to_list(self) -> List[BaseBeaconBlock]:
+        return list(self._pool)
+
+    def get(self, block_root: Hash32) -> BaseBeaconBlock:
+        for block in self._pool:
+            if block.signing_root == block_root:
+                return block
+        raise BlockNotFound(f"No block with signing_root {block_root} is found")
+
+    def add(self, block: BaseBeaconBlock) -> None:
+        if block in self._pool:
+            return
+        self._pool.add(block)
+
+    def pop_children(self, block_root: Hash32) -> Tuple[BaseBeaconBlock, ...]:
+        children = tuple(
+            orphan_block
+            for orphan_block in self._pool
+            if orphan_block.parent_root == block_root
+        )
+        self._pool.difference_update(children)
+        return children
+
+
 class BCCReceiveServer(BaseService):
 
     chain: BaseBeaconChain
+    p2p_node: Node
     topic_msg_queues: Dict[str, 'asyncio.Queue[rpc_pb2.Message]']
     attestation_pool: AttestationPool
-    # TODO: Add orphan block pool and request parent block function back
-    # after RPC for requesting beacon block is built
+    orphan_block_pool: OrphanBlockPool
 
     def __init__(
             self,
             chain: BaseBeaconChain,
+            p2p_node: Node,
             topic_msg_queues: Dict[str, 'asyncio.Queue[rpc_pb2.Message]'],
             cancel_token: CancelToken = None) -> None:
         super().__init__(cancel_token)
         self.chain = chain
         self.topic_msg_queues = topic_msg_queues
+        self.p2p_node = p2p_node
         self.attestation_pool = AttestationPool()
+        self.orphan_block_pool = OrphanBlockPool()
 
     async def _run(self) -> None:
         self.logger.info(f"BCCReceiveServer up")
         self.run_daemon_task(self._handle_beacon_attestation_loop())
         self.run_daemon_task(self._handle_beacon_block_loop())
+        self.run_daemon_task(self._process_orphan_blocks_loop())
         await self.cancellation()
 
     async def _handle_beacon_attestation_loop(self) -> None:
@@ -144,6 +205,40 @@ class BCCReceiveServer(BaseService):
         while True:
             msg = await self.topic_msg_queues[PUBSUB_TOPIC_BEACON_BLOCK].get()
             await self._handle_beacon_block(msg)
+
+    async def _process_orphan_blocks_loop(self) -> None:
+        """
+        Periodically requesting for parent blocks of the
+        orphan blocks in the orphan block pool.
+        """
+        while True:
+            if len(self.orphan_block_pool) == 0:
+                await self.sleep(PROCESS_ORPHAN_BLOCKS_PERIOD)
+                continue
+            orphan_blocks = self.orphan_block_pool.to_list()
+            parent_roots = set([block.parent_root for block in orphan_blocks])
+            block_roots = [block.signing_root for block in orphan_blocks]
+            dependent_block_roots = set()
+            # Remove dependent orphan blocks
+            for parent_root in parent_roots:
+                if parent_root in block_roots:
+                    dependent_block_roots.add(parent_root)
+            parent_roots.difference_update(dependent_block_roots)
+            # Keep requesting parent blocks from all peers
+            peers_to_request = list(self.p2p_node.handshaked_peers)
+            for peer_id in peers_to_request:
+                if len(parent_roots) == 0:
+                    break
+                blocks = await self.p2p_node.request_recent_beacon_blocks(peer_id, parent_roots)
+                for block in blocks:
+                    try:
+                        parent_roots.remove(block.signing_root)
+                    except ValueError:
+                        # This should not happen if peers are returning correct blocks
+                        continue
+                    else:
+                        self._process_received_block(block)
+            await self.sleep(PROCESS_ORPHAN_BLOCKS_PERIOD)
 
     async def _handle_beacon_attestations(self, msg: rpc_pb2.Message) -> None:
         attestations = ssz.decode(msg.data, sedes=ssz.List(Attestation, SSZ_MAX_LIST_SIZE))
@@ -165,21 +260,7 @@ class BCCReceiveServer(BaseService):
 
     async def _handle_beacon_block(self, msg: rpc_pb2.Message) -> None:
         block = ssz.decode(msg.data, BeaconBlock)
-        if self._is_block_seen(block):
-            return
-        self.logger.debug("Received new block=%s", block)
-
-        try:
-            self.chain.import_block(block)
-        # If the block is invalid, we should drop it.
-        except ValidationError:
-            return
-        except Exception:
-            # Unexpected result
-            return
-        else:
-            # Remove attestations in block that are also in the attestation pool.
-            self.attestation_pool.batch_remove(block.body.attestations)
+        self._process_received_block(block)
 
     def _is_attestation_new(self, attestation: Attestation) -> bool:
         """
@@ -193,6 +274,61 @@ class BCCReceiveServer(BaseService):
         except AttestationNotFound:
             return True
 
+    def _process_received_block(self, block: BaseBeaconBlock) -> None:
+        # If the block is an orphan, put it to the orphan pool
+        if not self._is_block_root_in_db(block.parent_root):
+            if block not in self.orphan_block_pool:
+                self.logger.debug("Found orphan_block=%s", block)
+                self.orphan_block_pool.add(block)
+            return
+        try:
+            self.chain.import_block(block)
+            self.logger.debug("Successfully imported block=%s", block)
+        # If the block is invalid, we should drop it.
+        except ValidationError as error:
+            # TODO: Possibly drop all of its descendants in `self.orphan_block_pool`?
+            self.logger.debug("Fail to import block=%s  reason=%s", block, error)
+        else:
+            # Successfully imported the block. See if any blocks in `self.orphan_block_pool`
+            # depend on it. If there are, try to import them.
+            # TODO: should be done asynchronously?
+            self._try_import_orphan_blocks(block.signing_root)
+            # Remove attestations in block that are also in the attestation pool.
+            self.attestation_pool.batch_remove(block.body.attestations)
+
+    def _try_import_orphan_blocks(self, parent_root: Hash32) -> None:
+        """
+        Perform ``chain.import`` on the blocks in ``self.orphan_block_pool`` in breadth-first
+        order, starting from the children of ``parent_root``.
+        """
+        imported_roots: List[Hash32] = []
+
+        imported_roots.append(parent_root)
+        while len(imported_roots) != 0:
+            current_parent_root = imported_roots.pop()
+            # Only process the children if the `current_parent_root` is already in db.
+            if not self._is_block_root_in_db(block_root=current_parent_root):
+                continue
+            # If succeeded, handle the orphan blocks which depend on this block.
+            children = self.orphan_block_pool.pop_children(current_parent_root)
+            if len(children) > 0:
+                self.logger.debug(
+                    "Blocks=%s match their parent block, parent_root=%s",
+                    children,
+                    current_parent_root,
+                )
+            for block in children:
+                try:
+                    self.chain.import_block(block)
+                    self.logger.debug("Successfully imported block=%s", block)
+                    imported_roots.append(block.signing_root)
+                except ValidationError as error:
+                    # TODO: Possibly drop all of its descendants in `self.orphan_block_pool`?
+                    self.logger.debug("Fail to import block=%s  reason=%s", block, error)
+
+    def _is_block_root_in_orphan_block_pool(self, block_root: Hash32) -> bool:
+        return block_root in self.orphan_block_pool
+
     def _is_block_root_in_db(self, block_root: Hash32) -> bool:
         try:
             self.chain.get_block_by_root(block_root=block_root)
@@ -201,6 +337,8 @@ class BCCReceiveServer(BaseService):
             return False
 
     def _is_block_root_seen(self, block_root: Hash32) -> bool:
+        if self._is_block_root_in_orphan_block_pool(block_root=block_root):
+            return True
         return self._is_block_root_in_db(block_root=block_root)
 
     def _is_block_seen(self, block: BaseBeaconBlock) -> bool:

--- a/trinity/protocol/bcc_libp2p/servers.py
+++ b/trinity/protocol/bcc_libp2p/servers.py
@@ -127,7 +127,7 @@ class OrphanBlockPool:
     def __init__(self) -> None:
         self._pool = set()
 
-    def __len__(self):
+    def __len__(self) -> int:
         return len(self._pool)
 
     def __contains__(self, block_or_block_root: Union[BaseBeaconBlock, Hash32]) -> bool:
@@ -229,7 +229,10 @@ class BCCReceiveServer(BaseService):
             for peer_id in peers_to_request:
                 if len(parent_roots) == 0:
                     break
-                blocks = await self.p2p_node.request_recent_beacon_blocks(peer_id, parent_roots)
+                blocks = await self.p2p_node.request_recent_beacon_blocks(
+                    peer_id,
+                    tuple(parent_roots),
+                )
                 for block in blocks:
                     try:
                         parent_roots.remove(block.signing_root)

--- a/trinity/protocol/bcc_libp2p/topic_validators.py
+++ b/trinity/protocol/bcc_libp2p/topic_validators.py
@@ -22,7 +22,7 @@ def get_beacon_block_validator(chain: BaseBeaconChain) -> Callable[..., bool]:
     def beacon_block_validator(msg_forwarder: ID, msg: rpc_pb2.Message) -> bool:
         try:
             block = ssz.decode(msg.data, BaseBeaconBlock)
-        except TypeError:
+        except (TypeError, ssz.DeserializationError):
             return False
 
         state_machine = chain.get_state_machine()
@@ -59,7 +59,7 @@ def get_beacon_attestation_validator(chain: BaseBeaconChain) -> Callable[..., bo
     def beacon_attestation_validator(msg_forwarder: ID, msg: rpc_pb2.Message) -> bool:
         try:
             attestations = ssz.decode(msg.data, sedes=ssz.sedes.CountableList(Attestation))
-        except TypeError:
+        except (TypeError, ssz.DeserializationError):
             # Not correctly encoded
             return False
 

--- a/trinity/protocol/bcc_libp2p/topic_validators.py
+++ b/trinity/protocol/bcc_libp2p/topic_validators.py
@@ -1,0 +1,85 @@
+from typing import (
+    Callable,
+)
+
+import ssz
+
+from eth_utils import ValidationError
+
+from eth2.beacon.types.attestations import Attestation
+from eth2.beacon.exceptions import SignatureError
+from eth2.beacon.helpers import compute_epoch_of_slot
+from eth2.beacon.chains.base import BaseBeaconChain
+from eth2.beacon.types.blocks import BaseBeaconBlock
+from eth2.beacon.state_machines.forks.serenity.block_processing import process_block_header
+from eth2.beacon.state_machines.forks.serenity.block_validation import validate_attestation
+
+from libp2p.peer.id import ID
+from libp2p.pubsub.pb import rpc_pb2
+
+
+def get_beacon_block_validator(chain: BaseBeaconChain) -> Callable[..., bool]:
+    def beacon_block_validator(msg_forwarder: ID, msg: rpc_pb2.Message) -> bool:
+        try:
+            block = ssz.decode(msg.data, BaseBeaconBlock)
+        except TypeError:
+            return False
+
+        state_machine = chain.get_state_machine()
+        config = state_machine.config
+        slots_per_epoch = config.SLOTS_PER_EPOCH
+        head_slot = chain.chaindb.get_head_state_slot()
+        current_epoch = compute_epoch_of_slot(head_slot, slots_per_epoch)
+        block_epoch = compute_epoch_of_slot(block.slot, slots_per_epoch)
+        if block_epoch > current_epoch:
+            # Can not process block in future epoch because
+            # proposer is not predictable.
+            return False
+        elif block_epoch < current_epoch:
+            state_machine = chain.get_state_machine(block.slot)
+
+        state = state_machine.state
+        state_transition = state_machine.state_transition
+        # Fast forward to state in future slot in order to pass
+        # block.slot validity check
+        state = state_transition.apply_state_transition(
+            state,
+            future_slot=block.slot,
+        )
+        try:
+            process_block_header(state, block, config, True)
+        except ValidationError or SignatureError:
+            return False
+        else:
+            return True
+    return beacon_block_validator
+
+
+def get_beacon_attestation_validator(chain: BaseBeaconChain) -> Callable[..., bool]:
+    def beacon_attestation_validator(msg_forwarder: ID, msg: rpc_pb2.Message) -> bool:
+        try:
+            attestations = ssz.decode(msg.data, sedes=ssz.sedes.CountableList(Attestation))
+        except TypeError:
+            # Not correctly encoded
+            return False
+
+        state_machine = chain.get_state_machine()
+        config = state_machine.config
+        state = state_machine.state
+        for attestation in attestations:
+            # Fast forward to state in future slot in order to pass
+            # attestation.data.slot validity check
+            future_state = state_machine.state_transition.apply_state_transition(
+                state,
+                future_slot=attestation.data.slot + config.MIN_ATTESTATION_INCLUSION_DELAY,
+            )
+            try:
+                validate_attestation(
+                    future_state,
+                    attestation,
+                    config,
+                )
+            except ValidationError:
+                return False
+        return True
+    return beacon_attestation_validator

--- a/trinity/protocol/bcc_libp2p/utils.py
+++ b/trinity/protocol/bcc_libp2p/utils.py
@@ -198,7 +198,7 @@ async def _read_ssz_msg(
     payload = await _read_varint_prefixed_bytes(stream, timeout=timeout)
     try:
         return ssz.decode(payload, msg_type)
-    except ssz.DeserializationError as error:
+    except (TypeError, ssz.DeserializationError) as error:
         raise ReadMessageFailure("failed to read the payload") from error
 
 

--- a/trinity/tools/bcc_factories.py
+++ b/trinity/tools/bcc_factories.py
@@ -57,6 +57,7 @@ from trinity.protocol.bcc.peer import (
 )
 
 from trinity.protocol.bcc_libp2p.node import Node
+from trinity.protocol.bcc_libp2p.servers import BCCReceiveServer
 
 from .factories import (
     AtomicDBFactory,
@@ -250,3 +251,19 @@ class BCCPeerPoolFactory(factory.Factory):
         async with run_service(peer_pool):
             peer_pool._add_peer(peer, ())
             yield peer_pool
+
+
+class ReceiveServerFactory(factory.Factory):
+    class Meta:
+        model = BCCReceiveServer
+
+    chain = None
+    p2p_node = factory.SubFactory(NodeFactory)
+    topic_msg_queues = None
+    cancel_token = None
+
+    @classmethod
+    def create_batch(cls, number: int) -> Tuple[Node, ...]:
+        return tuple(
+            cls() for _ in range(number)
+        )


### PR DESCRIPTION
### What was wrong?
As topic validator feature is implemented in https://github.com/libp2p/py-libp2p/pull/226. We can modify `BCCReceiveServer` and add it back to beacon node.


### How was it fixed?
- [x] Add topic validators for topics beacon block and beacon attestation
- [x] Set up topic validators for topics beacon block and beacon attestation after `Pubsub` started
- [x] Copy and modify the original `BCCReceiveServer`
- [x] Add tests for `BCCReceiveServer`
- [ ] Add tests for topic validator?(but it's basically equivalent to block header/attestation verifications)
- [ ] TBD value for `SSZ_MAX_LIST_SIZE`(https://github.com/ethereum/eth2.0-specs/pull/1350)
- [x] Request parent block for orphan block
- [x] Add a loop that constantly requesting parent blocks for orphan blocks

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

[//]: # (See: https://trinity-client.readthedocs.io/en/latest/contributing.html#pull-requests)
- [ ] Add entry to the [release notes](https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses]()