### PR TITLE
Beam Sync: collect 1 more header for uncle validation preparation

### DIFF
--- a/newsfragments/909.bugfix.rst
+++ b/newsfragments/909.bugfix.rst
@@ -1,0 +1,1 @@
+Fix a MissingTrieNode exception when the first imported block has an uncle


### PR DESCRIPTION
### What was wrong?

Off-by-one error when collecting the bodies to validate uncles. This only happens when you happen to have an uncle in the very first block that you beam sync to.

This causes a `MissingTrieNode` exception when looking up key `0x80`.

### How was it fixed?

Add some commentary explaining the situation, and increase the number of bodies collected by one.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

[//]: # (See: https://trinity-client.readthedocs.io/en/latest/contributing.html#pull-requests)
- [x] Add entry to the [release notes](https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://usercontent2.hubstatic.com/13316795_f520.jpg)
