### PR TITLE
Fix eth2-fixtures CI cache

### DIFF
--- a/.circleci/build_geth.sh
+++ b/.circleci/build_geth.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+
+mkdir -p $HOME/.ethash
+pip install --user py-geth>=2.1.0
+export GOROOT=/usr/local/go
+export GETH_BINARY="$HOME/.py-geth/geth-$GETH_VERSION/bin/geth"
+if [ ! -e "$GETH_BINARY" ]; then
+  curl -O https://storage.googleapis.com/golang/go1.10.linux-amd64.tar.gz
+  tar xvf go1.10.linux-amd64.tar.gz
+  sudo chown -R root:root ./go
+  sudo mv go /usr/local
+  sudo ln -s /usr/local/go/bin/go /usr/local/bin/go
+  sudo apt-get update;
+  sudo apt-get install -y build-essential;
+  python -m geth.install $GETH_VERSION;
+fi
+sudo ln -s $GETH_BINARY /usr/local/bin/geth
+geth version

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -52,7 +52,7 @@ geth_steps: &geth_steps
     - checkout
     - restore_cache:
         keys:
-          - cache-v2-{{ arch }}-{{ .Environment.CIRCLE_JOB }}-{{ checksum "setup.py" }}-{{ checksum "tox.ini" }}
+          - cache-v2-{{ arch }}-{{ .Environment.CIRCLE_JOB }}-{{ checksum "setup.py" }}-{{ checksum "tox.ini" }}-{{ checksum "./.circleci/build_geth.sh" }}
     - run:
         name: install libsnappy-dev
         command: sudo apt install -y libsnappy-dev
@@ -64,23 +64,7 @@ geth_steps: &geth_steps
         command: pip install --user tox
     - run:
         name: build geth if missing
-        command: |
-          mkdir -p $HOME/.ethash
-          pip install --user py-geth>=2.1.0
-          export GOROOT=/usr/local/go
-          export GETH_BINARY="$HOME/.py-geth/geth-$GETH_VERSION/bin/geth"
-          if [ ! -e "$GETH_BINARY" ]; then
-            curl -O https://storage.googleapis.com/golang/go1.10.linux-amd64.tar.gz
-            tar xvf go1.10.linux-amd64.tar.gz
-            sudo chown -R root:root ./go
-            sudo mv go /usr/local
-            sudo ln -s /usr/local/go/bin/go /usr/local/bin/go
-            sudo apt-get update;
-            sudo apt-get install -y build-essential;
-            python -m geth.install $GETH_VERSION;
-          fi
-          sudo ln -s $GETH_BINARY /usr/local/bin/geth
-          geth version
+        command: ./.circleci/build_geth.sh
     - run:
         name: run tox
         command: ~/.local/bin/tox -r
@@ -92,7 +76,7 @@ geth_steps: &geth_steps
           - ./eggs
           - ~/.ethash
           - ~/.py-geth
-        key: cache-v2-{{ arch }}-{{ .Environment.CIRCLE_JOB }}-{{ checksum "setup.py" }}-{{ checksum "tox.ini" }}
+        key: cache-v2-{{ arch }}-{{ .Environment.CIRCLE_JOB }}-{{ checksum "setup.py" }}-{{ checksum "tox.ini" }}-{{ checksum "./.circleci/build_geth.sh" }}
 
 eth2_fixtures: &eth2_fixtures
   working_directory: ~/repo
@@ -111,7 +95,7 @@ eth2_fixtures: &eth2_fixtures
         when: on_fail
     - restore_cache:
         keys:
-          - cache-v3-{{ arch }}-{{ .Environment.CIRCLE_JOB }}-{{ checksum "setup.py" }}-{{ checksum "tox.ini" }}-{{ checksum ".circleci/config.yml" }}
+          - cache-v3-{{ arch }}-{{ .Environment.CIRCLE_JOB }}-{{ checksum "setup.py" }}-{{ checksum "tox.ini" }}-{{ checksum "./.circleci/get_eth2_fixtures.sh" }}
     - run:
         name: install libsnappy-dev
         command: sudo apt install -y libsnappy-dev
@@ -119,12 +103,8 @@ eth2_fixtures: &eth2_fixtures
         name: install cmake
         command: sudo apt install -y gcc g++ cmake
     - run:
-        name: download the required yaml files
-        command: |
-          if [ ! -d "./eth2-fixtures/tests" ]; then
-            wget -c https://github.com/hwwhww/eth2.0-spec-tests/releases/download/v0.8.1b/archive.tar.gz
-            tar zxvf archive.tar.gz -C ./eth2-fixtures
-          fi
+        name: download the required yaml files if missing
+        command: ./.circleci/get_eth2_fixtures.sh
     - run:
         name: install dependencies
         command: pip install --user tox
@@ -140,8 +120,7 @@ eth2_fixtures: &eth2_fixtures
           - ./eggs
           - .pytest_cache/v/eth2/bls/key-cache
           - ./eth2-fixtures
-        key: cache-v3-{{ arch }}-{{ .Environment.CIRCLE_JOB }}-{{ checksum "setup.py" }}-{{ checksum "tox.ini" }}-{{ checksum ".circleci/config.yml" }}
-
+        key: cache-v3-{{ arch }}-{{ .Environment.CIRCLE_JOB }}-{{ checksum "setup.py" }}-{{ checksum "tox.ini" }}-{{ checksum "./.circleci/get_eth2_fixtures.sh" }}
 jobs:
   py36-lint:
     <<: *common

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -111,7 +111,7 @@ eth2_fixtures: &eth2_fixtures
         when: on_fail
     - restore_cache:
         keys:
-          - cache-v3-{{ arch }}-{{ .Environment.CIRCLE_JOB }}-{{ checksum "setup.py" }}-{{ checksum "tox.ini" }}
+          - cache-v3-{{ arch }}-{{ .Environment.CIRCLE_JOB }}-{{ checksum "setup.py" }}-{{ checksum "tox.ini" }}-{{ checksum ".circleci/config.yml" }}
     - run:
         name: install libsnappy-dev
         command: sudo apt install -y libsnappy-dev
@@ -121,8 +121,10 @@ eth2_fixtures: &eth2_fixtures
     - run:
         name: download the required yaml files
         command: |
-          wget -c https://github.com/hwwhww/eth2.0-spec-tests/releases/download/v0.8.1b2/archive.tar.gz
-          tar zxvf archive.tar.gz -C ./eth2-fixtures
+          if [ ! -d "./eth2-fixtures/tests" ]; then
+            wget -c https://github.com/hwwhww/eth2.0-spec-tests/releases/download/v0.8.1b/archive.tar.gz
+            tar zxvf archive.tar.gz -C ./eth2-fixtures
+          fi
     - run:
         name: install dependencies
         command: pip install --user tox
@@ -137,7 +139,8 @@ eth2_fixtures: &eth2_fixtures
           - ~/.local
           - ./eggs
           - .pytest_cache/v/eth2/bls/key-cache
-        key: cache-v3-{{ arch }}-{{ .Environment.CIRCLE_JOB }}-{{ checksum "setup.py" }}-{{ checksum "tox.ini" }}
+          - ./eth2-fixtures
+        key: cache-v3-{{ arch }}-{{ .Environment.CIRCLE_JOB }}-{{ checksum "setup.py" }}-{{ checksum "tox.ini" }}-{{ checksum ".circleci/config.yml" }}
 
 jobs:
   py36-lint:

--- a/.circleci/get_eth2_fixtures.sh
+++ b/.circleci/get_eth2_fixtures.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+if [ ! -d "./eth2-fixtures/tests" ]; then
+  wget -c https://github.com/hwwhww/eth2.0-spec-tests/releases/download/v0.8.1b/archive.tar.gz
+  tar zxvf archive.tar.gz -C ./eth2-fixtures
+fi


### PR DESCRIPTION
# What was wrong?

* Per @protolambda 's reminder on eth2 discord, checking if our CI setting is correct...
* Realized that we didn't cache the fixture files properly!!!!
* Since we are uploading `tar.gz` (120 MB) in CI, most overheads were for uncompressing the file.

### How was it fixed?
* Include `.circleci/config.yml` to the cache key
* Check if `.eth2-fixtures/tests` exsits; if not, download the `tar.gz` file
* Add `.eth2-fixtures` to the cache pathes

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

[//]: # (See: https://trinity-client.readthedocs.io/en/latest/contributing.html#pull-requests)
- [ ] Add entry to the [release notes](https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![cute-animal-pictures-animals-eating-watermelon-013](https://user-images.githubusercontent.com/9263930/62938036-c8398100-be00-11e9-917c-64fab82a549c.jpg)
