### PR TITLE
Handle MalformedMessage and TimeoutError during multiplexing

### DIFF
--- a/newsfragments/916.bugfix.rst
+++ b/newsfragments/916.bugfix.rst
@@ -1,0 +1,1 @@
+Handles ``MalformedMessage`` and ``TimeoutError`` exceptions that can occur while multiplexing the devp2p connection


### PR DESCRIPTION
fixes #901 

fixes #903 

### What was wrong?

Exceptions that occur during multiplexing that are not being handled.

### How was it fixed?

Added error handling in the `BasePeer` class.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

[//]: # (See: https://trinity-client.readthedocs.io/en/latest/contributing.html#pull-requests)
- [x] Add entry to the [release notes](https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses]()
