### PR TITLE
[WIP] Prefer low latency in beam sync

### DIFF
--- a/trinity/_utils/regression.py
+++ b/trinity/_utils/regression.py
@@ -1,0 +1,23 @@
+from typing import Tuple
+
+
+def linear_regression(points: Tuple[Tuple[float, float], ...]) -> Tuple[float, float]:
+    """
+    :return: the slope and intercept of the linear regression
+
+    Not convinced? Check:
+    https://www.khanacademy.org/math/statistics-probability/describing-relationships-quantitative-data/more-on-regression/v/regression-line-example  # noqa: E501
+    """
+    xpoints = tuple(point[0] for point in points)
+    ypoints = tuple(point[1] for point in points)
+    num_points = float(len(points))
+
+    xmean = sum(xpoints) / num_points
+    ymean = sum(ypoints) / num_points
+    product_mean = sum(x * y for x, y in points) / num_points
+    x_square_mean = sum(x * x for x in xpoints) / num_points
+
+    slope = (xmean * ymean - product_mean) / ((xmean * xmean) - x_square_mean)
+    intercept = ymean - slope * xmean
+
+    return slope, intercept

--- a/trinity/protocol/common/trackers.py
+++ b/trinity/protocol/common/trackers.py
@@ -1,4 +1,5 @@
 from abc import ABC, abstractmethod
+from collections import defaultdict
 from functools import partial
 from typing import (
     Any,
@@ -13,6 +14,7 @@ from p2p.abc import RequestAPI
 from trinity._utils.ema import EMA
 from trinity._utils.logging import HasExtendedDebugLogger
 from trinity._utils.percentile import Percentile
+from trinity._utils.regression import linear_regression
 from trinity._utils.stddev import StandardDeviation
 from .constants import ROUND_TRIP_TIMEOUT
 from .types import (
@@ -109,7 +111,7 @@ class BasePerformanceTracker(ABC, HasExtendedDebugLogger, Generic[TRequest, TRes
             f"rtt={self.round_trip_ema.value:.2f}/{rt99:.2f}/{rt_stddev:.2f}  "
             f"ips={self.items_per_second_ema.value:.5f}  "
             f"mps={self.messages_per_second_ema.value:.5f}  "
-            f"lat={self.messages_per_second_ema.value:.4f}  "
+            f"lat={self.messages_per_second_ema.value:.4f}s  "
             f"timeouts={self.total_timeouts}  quality={int(self.response_quality_ema.value)}"
         )
 
@@ -168,7 +170,6 @@ class BasePerformanceTracker(ABC, HasExtendedDebugLogger, Generic[TRequest, TRes
             _, self.latency = linear_regression(tuple(
                 (num_items, ema.value) for num_items, ema in self.round_trip_by_items.items()
             ))
-
 
         if elapsed > 0:
             throughput = num_items / elapsed

--- a/trinity/protocol/common/trackers.py
+++ b/trinity/protocol/common/trackers.py
@@ -111,7 +111,7 @@ class BasePerformanceTracker(ABC, HasExtendedDebugLogger, Generic[TRequest, TRes
             f"rtt={self.round_trip_ema.value:.2f}/{rt99:.2f}/{rt_stddev:.2f}  "
             f"ips={self.items_per_second_ema.value:.5f}  "
             f"mps={self.messages_per_second_ema.value:.5f}  "
-            f"lat={self.messages_per_second_ema.value:.4f}s  "
+            f"lat={self.latency:.4f}s  "
             f"timeouts={self.total_timeouts}  quality={int(self.response_quality_ema.value)}"
         )
 

--- a/trinity/sync/beam/state.py
+++ b/trinity/sync/beam/state.py
@@ -94,7 +94,7 @@ class BeamDownloader(BaseService, PeerSubscriber):
         super().__init__(token)
         self._db = db
         self._trie_db = HexaryTrie(db)
-        self._node_data_peers = WaitingPeers[ETHPeer](NodeData)
+        self._node_data_peers = WaitingPeers[ETHPeer](NodeData, latency_focused=True)
         self._event_bus = event_bus
 
         # Track the needed node data that is urgent and important:


### PR DESCRIPTION
### What was wrong?

During Beam Sync, we care about the constant cost of a request much more than the total bandwidth of nodes that we can power through a node. But we're currently aiming at the peer with the highest throughput. (and we don't even know what the constant cost of a request is)

### How was it fixed?

Just a hack job for now:

1. Added in some stats to track and infer the constant cost of a request (called latency in the printout)
2. Also tracking the incremental cost of adding more items in a request (often fairly close to 0, though)
3. Prefer the lowest latency peers
4. Presume the latency is 0 at first, so that we always try sending requests to new peers, and help determine quickly if they have better latency stats
5. At first I was just basing this on messages per second, which is probably a useful metric also, but the latency metric felt more tangible and accessible, and ultimately correct.


### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

[//]: # (See: https://trinity-client.readthedocs.io/en/latest/contributing.html#pull-requests)
- [ ] Add entry to the [release notes](https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses]()
