### PR TITLE
Discv5 Handshake

### DIFF
--- a/p2p/discv5/abc.py
+++ b/p2p/discv5/abc.py
@@ -1,0 +1,89 @@
+from abc import (
+    ABC,
+    abstractmethod,
+)
+from typing import (
+    Type,
+)
+
+from p2p.discv5.enr import (
+    ENR,
+)
+from p2p.discv5.identity_schemes import (
+    IdentityScheme,
+)
+from p2p.discv5.packets import (
+    Packet,
+)
+from p2p.discv5.typing import (
+    NodeID,
+    HandshakeResult,
+    Tag,
+)
+
+
+class HandshakeParticipantAPI(ABC):
+    def __init__(self,
+                 is_initiator: bool,
+                 local_private_key: bytes,
+                 local_enr: ENR,
+                 remote_node_id: NodeID,
+                 ) -> None:
+        ...
+
+    @property
+    @abstractmethod
+    def first_packet_to_send(self) -> Packet:
+        """The first packet we have to send the peer."""
+        ...
+
+    @abstractmethod
+    def is_response_packet(self, packet: Packet) -> bool:
+        """Check if the given packet is the response we need to complete the handshake."""
+        ...
+
+    @abstractmethod
+    def complete_handshake(self, response_packet: Packet) -> HandshakeResult:
+        """Complete the handshake using a response packet received from the peer."""
+        ...
+
+    @property
+    @abstractmethod
+    def is_initiator(self) -> bool:
+        """`True` if the handshake was initiated by us, `False` if it was initiated by the peer."""
+        ...
+
+    @property
+    @abstractmethod
+    def identity_scheme(self) -> Type[IdentityScheme]:
+        """The identity scheme used during the handshake."""
+        ...
+
+    @property
+    @abstractmethod
+    def local_private_key(self) -> bytes:
+        """The static node key of this node."""
+        ...
+
+    @property
+    @abstractmethod
+    def local_enr(self) -> ENR:
+        """The ENR of this node"""
+        ...
+
+    @property
+    @abstractmethod
+    def local_node_id(self) -> NodeID:
+        """The node id of this node."""
+        ...
+
+    @property
+    @abstractmethod
+    def remote_node_id(self) -> NodeID:
+        """The peer's node id."""
+        ...
+
+    @property
+    def tag(self) -> Tag:
+        """The tag used for message packets sent by this node to the peer."""
+        ...

--- a/p2p/discv5/constants.py
+++ b/p2p/discv5/constants.py
@@ -8,6 +8,7 @@ NONCE_SIZE = 12  # size of an AESGCM nonce
 TAG_SIZE = 32  # size of the tag packet prefix
 MAGIC_SIZE = 32  # size of the magic hash in the who are you packet
 ID_NONCE_SIZE = 32  # size of the id nonce in who are you and auth tag packets
+RANDOM_ENCRYPTED_DATA_SIZE = 12  # size of random data we send to initiate a handshake
 
 MAX_PACKET_SIZE = 1280  # maximum allowed size of a packet
 

--- a/p2p/discv5/handshake.py
+++ b/p2p/discv5/handshake.py
@@ -154,7 +154,7 @@ class HandshakeInitiator(BaseHandshakeParticipant):
         if not self.is_response_packet(response_packet):
             raise ValueError("Packet {packet} is not the expected response packet")
         if not isinstance(response_packet, WhoAreYouPacket):
-            raise Exception("Invariant: Only WhoAreYou packets are valid responses")
+            raise TypeError("Invariant: Only WhoAreYou packets are valid responses")
         who_are_you_packet = response_packet
 
         # compute session keys

--- a/p2p/discv5/handshake.py
+++ b/p2p/discv5/handshake.py
@@ -1,9 +1,4 @@
-from abc import (
-    ABC,
-    abstractmethod,
-)
 from typing import (
-    NamedTuple,
     Optional,
     Type,
 )

--- a/p2p/discv5/handshake.py
+++ b/p2p/discv5/handshake.py
@@ -7,6 +7,7 @@ from typing import (
     Optional,
     Type,
 )
+import secrets
 
 from eth_utils import (
     encode_hex,
@@ -147,7 +148,7 @@ class HandshakeInitiator(BaseHandshakeParticipant):
     def is_response_packet(self, packet: Packet) -> bool:
         return (
             isinstance(packet, WhoAreYouPacket) and
-            packet.token == self.initiating_packet.auth_tag
+            secrets.compare_digest(packet.token, self.initiating_packet.auth_tag)
         )
 
     def complete_handshake(self, response_packet: Packet) -> HandshakeResult:

--- a/p2p/discv5/handshake.py
+++ b/p2p/discv5/handshake.py
@@ -1,0 +1,351 @@
+from abc import (
+    ABC,
+    abstractmethod,
+)
+from typing import (
+    NamedTuple,
+    Optional,
+    Type,
+)
+
+from eth_utils import (
+    encode_hex,
+    ValidationError,
+)
+
+from p2p.exceptions import (
+    DecryptionError,
+    HandshakeFailure,
+)
+
+from p2p.discv5.enr import ENR
+from p2p.discv5.identity_schemes import IdentityScheme
+from p2p.discv5.messages import BaseMessage
+from p2p.discv5.packets import (
+    AuthHeaderPacket,
+    AuthTagPacket,
+    get_random_auth_tag,
+    get_random_encrypted_data,
+    get_random_id_nonce,
+    Packet,
+    WhoAreYouPacket,
+)
+from p2p.discv5.tags import (
+    compute_tag,
+    recover_source_id_from_tag,
+)
+from p2p.discv5.typing import (
+    AES128Key,
+    IDNonce,
+    NodeID,
+    Nonce,
+    SessionKeys,
+    Tag,
+)
+
+
+class HandshakeResult(NamedTuple):
+    session_keys: SessionKeys
+    enr: Optional[ENR]
+    message: Optional[BaseMessage]
+    auth_header_packet: Optional[AuthHeaderPacket]
+
+
+class BaseHandshakeParticipant(ABC):
+    def __init__(self,
+                 is_initiator: bool,
+                 our_private_key: bytes,
+                 our_enr: ENR,
+                 their_node_id: Optional[NodeID] = None,
+                 their_enr: Optional[ENR] = None,
+                 ) -> None:
+        self.is_initiator = is_initiator
+
+        self.our_enr = our_enr
+        self.our_private_key = our_private_key
+
+        self.their_enr = their_enr
+        if their_enr is None and their_node_id is None:
+            raise ValueError("Either the peer's ENR or node id must be given")
+        elif their_enr is not None and their_node_id is not None:
+            if not their_node_id == their_enr.node_id:
+                raise ValueError(
+                    f"Node id according to ENR ({encode_hex(their_enr.node_id)}) must match "
+                    f"explicitly given one ({encode_hex(their_node_id)})"
+                )
+            self.their_node_id = their_node_id
+        elif their_enr is None and their_node_id is not None:
+            self.their_node_id = their_node_id
+        elif their_enr is not None and their_node_id is None:
+            self.their_node_id = their_enr.node_id
+        else:
+            raise Exception("Invariant: All cases handled")
+
+    @property
+    @abstractmethod
+    def first_packet_to_send(self) -> Packet:
+        """The first packet we have to send the peer."""
+        ...
+
+    @abstractmethod
+    def is_response_packet(self, packet: Packet) -> bool:
+        """Check if the given packet is the response we need to complete the handshake."""
+        ...
+
+    @abstractmethod
+    def complete_handshake(self, response_packet: Packet) -> HandshakeResult:
+        """Complete the handshake using a response packet received from the peer."""
+        ...
+
+    @property
+    @abstractmethod
+    def identity_scheme(self) -> Type[IdentityScheme]:
+        ...
+
+    @property
+    def our_node_id(self) -> NodeID:
+        return self.our_enr.node_id
+
+    @property
+    def tag(self) -> Tag:
+        return compute_tag(
+            source_node_id=self.our_node_id,
+            destination_node_id=self.their_node_id,
+        )
+
+
+class HandshakeInitiator(BaseHandshakeParticipant):
+    def __init__(self,
+                 *,
+                 our_private_key: bytes,
+                 our_enr: ENR,
+                 their_enr: ENR,
+                 initial_message: BaseMessage,
+                 ) -> None:
+        super().__init__(
+            is_initiator=True,
+            our_enr=our_enr,
+            our_private_key=our_private_key,
+            their_enr=their_enr,
+        )
+        self.initial_message = initial_message
+
+        self.initiating_packet = AuthTagPacket.prepare_random(
+            tag=self.tag,
+            auth_tag=get_random_auth_tag(),
+            random_data=get_random_encrypted_data(),
+        )
+
+    @property
+    def identity_scheme(self) -> Type[IdentityScheme]:
+        return self.their_enr.identity_scheme
+
+    @property
+    def first_packet_to_send(self) -> Packet:
+        return self.initiating_packet
+
+    def is_response_packet(self, packet: Packet) -> bool:
+        return (
+            isinstance(packet, WhoAreYouPacket) and
+            packet.token == self.initiating_packet.auth_tag
+        )
+
+    def complete_handshake(self, response_packet: Packet) -> HandshakeResult:
+        if not self.is_response_packet(response_packet):
+            raise ValueError("Packet {packet} is not the expected response packet")
+        if not isinstance(response_packet, WhoAreYouPacket):
+            raise Exception("Invariant: Only WhoAreYou packets are valid responses")
+        who_are_you_packet = response_packet
+
+        # compute session keys
+        (
+            ephemeral_private_key,
+            ephemeral_public_key,
+        ) = self.identity_scheme.create_handshake_key_pair()
+
+        session_keys = self.identity_scheme.compute_session_keys(
+            local_private_key=ephemeral_private_key,
+            peer_public_key=self.their_enr.public_key,
+            initiator_node_id=self.our_enr.node_id,
+            recipient_node_id=self.their_node_id,
+            id_nonce=who_are_you_packet.id_nonce,
+        )
+
+        # prepare response packet
+        id_nonce_signature = self.identity_scheme.create_id_nonce_signature(
+            id_nonce=who_are_you_packet.id_nonce,
+            private_key=self.our_private_key,
+        )
+
+        if who_are_you_packet.enr_sequence_number < self.our_enr.sequence_number:
+            enr = self.our_enr
+        else:
+            enr = None
+
+        auth_header_packet = AuthHeaderPacket.prepare(
+            tag=self.tag,
+            auth_tag=get_random_auth_tag(),
+            id_nonce=who_are_you_packet.id_nonce,
+            message=self.initial_message,
+            initiator_key=session_keys.initiator_key,
+            id_nonce_signature=id_nonce_signature,
+            auth_response_key=session_keys.auth_response_key,
+            enr=enr,
+            ephemeral_public_key=ephemeral_public_key,
+        )
+
+        return HandshakeResult(
+            session_keys=session_keys,
+            enr=None,
+            message=None,
+            auth_header_packet=auth_header_packet,
+        )
+
+
+class HandshakeRecipient(BaseHandshakeParticipant):
+    def __init__(self,
+                 *,
+                 our_private_key: bytes,
+                 our_enr: ENR,
+                 their_node_id: Optional[NodeID],
+                 their_enr: Optional[ENR],
+                 initiating_packet_auth_tag: Nonce,
+                 ) -> None:
+        super().__init__(
+            is_initiator=False,
+            our_enr=our_enr,
+            our_private_key=our_private_key,
+            their_enr=their_enr,
+            their_node_id=their_node_id,
+        )
+
+        if their_enr is not None:
+            enr_sequence_number = their_enr.sequence_number
+        else:
+            enr_sequence_number = 0
+        self.who_are_you_packet = WhoAreYouPacket.prepare(
+            destination_node_id=self.their_node_id,
+            token=initiating_packet_auth_tag,
+            id_nonce=get_random_id_nonce(),
+            enr_sequence_number=enr_sequence_number,
+        )
+
+    @property
+    def identity_scheme(self) -> Type[IdentityScheme]:
+        return self.our_enr.identity_scheme
+
+    @property
+    def first_packet_to_send(self) -> Packet:
+        return self.who_are_you_packet
+
+    def is_response_packet(self, packet: Packet) -> bool:
+        return (
+            isinstance(packet, AuthHeaderPacket) and
+            recover_source_id_from_tag(
+                packet.tag,
+                self.our_node_id,
+            ) == self.their_node_id
+        )
+
+    def complete_handshake(self, response_packet: Packet) -> HandshakeResult:
+        if not self.is_response_packet(response_packet):
+            raise ValueError("Packet is not the expected response packet")
+        if not isinstance(response_packet, AuthHeaderPacket):
+            raise Exception("Invariant: Only AuthHeader packets are valid responses")
+        auth_header_packet = response_packet
+
+        ephemeral_public_key = auth_header_packet.auth_header.ephemeral_public_key
+        try:
+            self.identity_scheme.validate_handshake_public_key(ephemeral_public_key)
+        except ValidationError as error:
+            raise HandshakeFailure(
+                f"AuthHeader packet from contains invalid ephemeral public key "
+                f"{encode_hex(ephemeral_public_key)}"
+            ) from error
+
+        session_keys = self.identity_scheme.compute_session_keys(
+            local_private_key=self.our_private_key,
+            peer_public_key=ephemeral_public_key,
+            initiator_node_id=self.their_node_id,
+            recipient_node_id=self.our_enr.node_id,
+            id_nonce=self.who_are_you_packet.id_nonce,
+        )
+
+        enr = self.decrypt_and_validate_auth_response(
+            auth_header_packet,
+            session_keys.auth_response_key,
+            self.who_are_you_packet.id_nonce,
+        )
+        message = self.decrypt_and_validate_message(
+            auth_header_packet,
+            session_keys.initiator_key,
+        )
+
+        return HandshakeResult(
+            session_keys=session_keys,
+            enr=enr,
+            message=message,
+            auth_header_packet=None,
+        )
+
+    def decrypt_and_validate_auth_response(self,
+                                           auth_header_packet: AuthHeaderPacket,
+                                           auth_response_key: AES128Key,
+                                           id_nonce: IDNonce,
+                                           ) -> Optional[ENR]:
+        try:
+            id_nonce_signature, enr = auth_header_packet.decrypt_auth_response(auth_response_key)
+        except DecryptionError as error:
+            raise HandshakeFailure("Unable to decrypt auth response") from error
+        except ValidationError as error:
+            raise HandshakeFailure("Invalid auth response content") from error
+
+        # validate ENR if present
+        if enr is None:
+            if self.their_enr is None:
+                raise HandshakeFailure("Peer failed to send their ENR")
+            else:
+                their_current_enr = self.their_enr
+        else:
+            try:
+                enr.validate_signature()
+            except ValidationError as error:
+                raise HandshakeFailure("ENR in auth response contains invalid signature") from error
+
+            if self.their_enr is not None and enr.sequence_number <= self.their_enr.sequence_number:
+                raise HandshakeFailure(
+                    "ENR in auth response is not newer than what we already have"
+                )
+
+            if enr.node_id != self.their_node_id:
+                raise HandshakeFailure(
+                    f"ENR received from peer belongs to different node ({encode_hex(enr.node_id)} "
+                    f"instead of {encode_hex(self.their_node_id)})"
+                )
+
+            their_current_enr = enr
+
+        # validate id nonce signature
+        try:
+            self.identity_scheme.validate_id_nonce_signature(
+                signature=id_nonce_signature,
+                id_nonce=id_nonce,
+                public_key=their_current_enr.public_key,
+            )
+        except ValidationError as error:
+            raise HandshakeFailure("Invalid id nonce signature in auth response") from error
+
+        return enr
+
+    def decrypt_and_validate_message(self,
+                                     auth_header_packet: AuthHeaderPacket,
+                                     initiator_key: AES128Key
+                                     ) -> BaseMessage:
+        try:
+            return auth_header_packet.decrypt_message(initiator_key)
+        except DecryptionError as error:
+            raise HandshakeFailure(
+                "Failed to decrypt message in AuthHeader packet with newly established session keys"
+            ) from error
+        except ValidationError as error:
+            raise HandshakeFailure("Received invalid message") from error

--- a/p2p/discv5/identity_schemes.py
+++ b/p2p/discv5/identity_schemes.py
@@ -5,7 +5,7 @@ from abc import (
 from collections import (
     UserDict,
 )
-import os
+import secrets
 from typing import (
     Tuple,
     Type,
@@ -213,7 +213,7 @@ class V4IdentityScheme(IdentityScheme):
     #
     @classmethod
     def create_handshake_key_pair(cls) -> Tuple[bytes, bytes]:
-        private_key = os.urandom(cls.private_key_size)
+        private_key = secrets.token_bytes(cls.private_key_size)
         public_key = PrivateKey(private_key).public_key.to_compressed_bytes()
         return private_key, public_key
 

--- a/p2p/discv5/identity_schemes.py
+++ b/p2p/discv5/identity_schemes.py
@@ -139,6 +139,8 @@ class IdentityScheme(ABC):
         """Compute the symmetric session keys."""
         ...
 
+    @classmethod
+    @abstractmethod
     def create_id_nonce_signature(cls,
                                   *,
                                   id_nonce: IDNonce,
@@ -147,6 +149,8 @@ class IdentityScheme(ABC):
         """Sign an id nonce received during handshake."""
         ...
 
+    @classmethod
+    @abstractmethod
     def validate_id_nonce_signature(cls,
                                     *,
                                     id_nonce: IDNonce,

--- a/p2p/discv5/packets.py
+++ b/p2p/discv5/packets.py
@@ -1,4 +1,5 @@
 import hashlib
+import os
 
 from typing import (
     cast,
@@ -55,6 +56,8 @@ from p2p.discv5.constants import (
     AUTH_SCHEME_NAME,
     ID_NONCE_SIZE,
     MAX_PACKET_SIZE,
+    NONCE_SIZE,
+    RANDOM_ENCRYPTED_DATA_SIZE,
     TAG_SIZE,
     MAGIC_SIZE,
     ZERO_NONCE,
@@ -559,3 +562,18 @@ def _decrypt_message(key: AES128Key,
         raise ValidationError("Encrypted message does not contain valid RLP") from error
 
     return message
+
+
+#
+# Random packet data
+#
+def get_random_encrypted_data() -> bytes:
+    return os.urandom(RANDOM_ENCRYPTED_DATA_SIZE)
+
+
+def get_random_id_nonce() -> IDNonce:
+    return IDNonce(os.urandom(ID_NONCE_SIZE))
+
+
+def get_random_auth_tag() -> Nonce:
+    return Nonce(os.urandom(NONCE_SIZE))

--- a/p2p/discv5/packets.py
+++ b/p2p/discv5/packets.py
@@ -76,7 +76,7 @@ class AuthHeader(NamedTuple):
     auth_tag: Nonce
     id_nonce: IDNonce
     auth_scheme_name: bytes
-    ephemeral_pubkey: bytes
+    ephemeral_public_key: bytes
     encrypted_auth_response: bytes
 
 
@@ -96,7 +96,7 @@ class AuthHeaderPacket(NamedTuple):
                 id_nonce_signature: bytes,
                 auth_response_key: AES128Key,
                 enr: Optional[ENR],
-                ephemeral_pubkey: bytes,
+                ephemeral_public_key: bytes,
                 ) -> "AuthHeaderPacket":
         encrypted_auth_response = compute_encrypted_auth_response(
             auth_response_key=auth_response_key,
@@ -107,7 +107,7 @@ class AuthHeaderPacket(NamedTuple):
             auth_tag=auth_tag,
             id_nonce=id_nonce,
             auth_scheme_name=AUTH_SCHEME_NAME,
-            ephemeral_pubkey=ephemeral_pubkey,
+            ephemeral_public_key=ephemeral_public_key,
             encrypted_auth_response=encrypted_auth_response,
         )
 
@@ -449,7 +449,7 @@ def _decode_auth(encoded_packet: bytes) -> Tuple[Union[AuthHeader, Nonce], int]:
             auth_tag=decoded_auth[0],
             id_nonce=decoded_auth[1],
             auth_scheme_name=decoded_auth[2],
-            ephemeral_pubkey=decoded_auth[3],
+            ephemeral_public_key=decoded_auth[3],
             encrypted_auth_response=decoded_auth[4],
         )
         validate_auth_header(auth_header)

--- a/p2p/discv5/packets.py
+++ b/p2p/discv5/packets.py
@@ -1,5 +1,5 @@
 import hashlib
-import os
+import secrets
 
 from typing import (
     cast,
@@ -568,12 +568,12 @@ def _decrypt_message(key: AES128Key,
 # Random packet data
 #
 def get_random_encrypted_data() -> bytes:
-    return os.urandom(RANDOM_ENCRYPTED_DATA_SIZE)
+    return secrets.token_bytes(RANDOM_ENCRYPTED_DATA_SIZE)
 
 
 def get_random_id_nonce() -> IDNonce:
-    return IDNonce(os.urandom(ID_NONCE_SIZE))
+    return IDNonce(secrets.token_bytes(ID_NONCE_SIZE))
 
 
 def get_random_auth_tag() -> Nonce:
-    return Nonce(os.urandom(NONCE_SIZE))
+    return Nonce(secrets.token_bytes(NONCE_SIZE))

--- a/p2p/discv5/typing.py
+++ b/p2p/discv5/typing.py
@@ -1,7 +1,20 @@
 from typing import (
     NamedTuple,
     NewType,
+    Optional,
+    TYPE_CHECKING,
 )
+
+if TYPE_CHECKING:
+    from p2p.discv5.enr import (
+        ENR,
+    )
+    from p2p.discv5.messages import (
+        BaseMessage,
+    )
+    from p2p.discv5.packets import (
+        AuthHeaderPacket,
+    )
 
 
 AES128Key = NewType("AES128Key", bytes)
@@ -16,3 +29,10 @@ class SessionKeys(NamedTuple):
     initiator_key: AES128Key
     recipient_key: AES128Key
     auth_response_key: AES128Key
+
+
+class HandshakeResult(NamedTuple):
+    session_keys: SessionKeys
+    enr: Optional["ENR"]
+    message: Optional["BaseMessage"]
+    auth_header_packet: Optional["AuthHeaderPacket"]

--- a/p2p/discv5/typing.py
+++ b/p2p/discv5/typing.py
@@ -6,13 +6,13 @@ from typing import (
 )
 
 if TYPE_CHECKING:
-    from p2p.discv5.enr import (
+    from p2p.discv5.enr import (  # noqa: F401
         ENR,
     )
-    from p2p.discv5.messages import (
+    from p2p.discv5.messages import (  # noqa: F401
         BaseMessage,
     )
-    from p2p.discv5.packets import (
+    from p2p.discv5.packets import (  # noqa: F401
         AuthHeaderPacket,
     )
 

--- a/p2p/tools/factories/discovery.py
+++ b/p2p/tools/factories/discovery.py
@@ -80,7 +80,7 @@ class AuthHeaderFactory(factory.Factory):
     auth_tag = b"\x00" * NONCE_SIZE
     id_nonce = b"\x00" * ID_NONCE_SIZE
     auth_scheme_name = AUTH_SCHEME_NAME
-    ephemeral_pubkey = b"\x00" * 32
+    ephemeral_public_key = b"\x00" * 32
     encrypted_auth_response = b"\x00" * 10
 
 
@@ -152,24 +152,24 @@ class HandshakeInitiatorFactory(factory.Factory):
     class Meta:
         model = HandshakeInitiator
 
-    our_private_key = factory.Faker("binary", length=V4IdentityScheme.private_key_size)
-    our_enr = factory.LazyAttribute(lambda o: ENRFactory(private_key=o.our_private_key))
-    their_enr = factory.LazyAttribute(lambda o: ENRFactory(private_key=o.their_private_key))
+    local_private_key = factory.Faker("binary", length=V4IdentityScheme.private_key_size)
+    local_enr = factory.LazyAttribute(lambda o: ENRFactory(private_key=o.local_private_key))
+    remote_enr = factory.LazyAttribute(lambda o: ENRFactory(private_key=o.remote_private_key))
     initial_message = factory.SubFactory(PingMessageFactory)
 
     class Params:
-        their_private_key = factory.Faker("binary", length=V4IdentityScheme.private_key_size)
+        remote_private_key = factory.Faker("binary", length=V4IdentityScheme.private_key_size)
 
 
 class HandshakeRecipientFactory(factory.Factory):
     class Meta:
         model = HandshakeRecipient
 
-    our_private_key = factory.Faker("binary", length=V4IdentityScheme.private_key_size)
-    our_enr = factory.LazyAttribute(lambda o: ENRFactory(private_key=o.our_private_key))
-    their_enr = factory.LazyAttribute(lambda o: ENRFactory(private_key=o.their_private_key))
-    their_node_id = factory.LazyAttribute(lambda o: o.their_enr.node_id)
+    local_private_key = factory.Faker("binary", length=V4IdentityScheme.private_key_size)
+    local_enr = factory.LazyAttribute(lambda o: ENRFactory(private_key=o.local_private_key))
+    remote_enr = factory.LazyAttribute(lambda o: ENRFactory(private_key=o.remote_private_key))
+    remote_node_id = factory.LazyAttribute(lambda o: o.remote_enr.node_id)
     initiating_packet_auth_tag = factory.Faker("binary", length=NONCE_SIZE)
 
     class Params:
-        their_private_key = factory.Faker("binary", length=V4IdentityScheme.private_key_size)
+        remote_private_key = factory.Faker("binary", length=V4IdentityScheme.private_key_size)

--- a/tests/p2p/discv5/strategies.py
+++ b/tests/p2p/discv5/strategies.py
@@ -24,7 +24,7 @@ nonce_st = st.binary(min_size=NONCE_SIZE, max_size=NONCE_SIZE)
 key_st = st.binary(min_size=AES128_KEY_SIZE, max_size=AES128_KEY_SIZE)
 random_data_st = st.binary(min_size=3, max_size=8)
 # arbitrary size as we're not specifying an identity scheme
-pubkey_st = st.binary(min_size=32, max_size=32)
+public_key_st = st.binary(min_size=32, max_size=32)
 node_id_st = st.binary(min_size=32, max_size=32)
 magic_st = st.binary(min_size=MAGIC_SIZE, max_size=MAGIC_SIZE)
 id_nonce_st = st.binary(min_size=ID_NONCE_SIZE, max_size=ID_NONCE_SIZE)

--- a/tests/p2p/discv5/test_handshake.py
+++ b/tests/p2p/discv5/test_handshake.py
@@ -35,15 +35,15 @@ def test_successful_handshake():
     initial_message = PingMessageFactory()
 
     initiator = HandshakeInitiatorFactory(
-        our_private_key=initiator_private_key,
-        our_enr=initiator_enr,
-        their_enr=recipient_enr,
+        local_private_key=initiator_private_key,
+        local_enr=initiator_enr,
+        remote_enr=recipient_enr,
         initial_message=initial_message,
     )
     recipient = HandshakeRecipientFactory(
-        our_private_key=recipient_private_key,
-        our_enr=recipient_enr,
-        their_enr=initiator_enr,
+        local_private_key=recipient_private_key,
+        local_enr=recipient_enr,
+        remote_enr=initiator_enr,
         initiating_packet_auth_tag=initiator.first_packet_to_send.auth_tag
     )
 
@@ -71,13 +71,13 @@ def test_successful_handshake_with_enr_update():
     )
 
     initiator = HandshakeInitiatorFactory(
-        our_private_key=initiator_private_key,
-        our_enr=new_initiator_enr,
-        their_private_key=recipient_private_key,
+        local_private_key=initiator_private_key,
+        local_enr=new_initiator_enr,
+        remote_private_key=recipient_private_key,
     )
     recipient = HandshakeRecipientFactory(
-        our_private_key=recipient_private_key,
-        their_enr=old_initiator_enr,
+        local_private_key=recipient_private_key,
+        remote_enr=old_initiator_enr,
         initiating_packet_auth_tag=initiator.first_packet_to_send.auth_tag
     )
 
@@ -95,15 +95,15 @@ def test_successful_handshake_with_new_enr():
     recipient_enr = ENRFactory(private_key=recipient_private_key)
 
     initiator = HandshakeInitiatorFactory(
-        our_private_key=initiator_private_key,
-        our_enr=initiator_enr,
-        their_enr=recipient_enr,
+        local_private_key=initiator_private_key,
+        local_enr=initiator_enr,
+        remote_enr=recipient_enr,
     )
     recipient = HandshakeRecipientFactory(
-        our_private_key=recipient_private_key,
-        our_enr=recipient_enr,
-        their_enr=None,
-        their_node_id=initiator_enr.node_id,
+        local_private_key=recipient_private_key,
+        local_enr=recipient_enr,
+        remote_enr=None,
+        remote_node_id=initiator_enr.node_id,
         initiating_packet_auth_tag=initiator.first_packet_to_send.auth_tag
     )
 

--- a/tests/p2p/discv5/test_handshake.py
+++ b/tests/p2p/discv5/test_handshake.py
@@ -2,14 +2,16 @@ from eth_utils import (
     keccak,
 )
 
-from p2p.tools.factories import (
+from p2p.tools.factories.discovery import (
     AuthTagPacketFactory,
     ENRFactory,
     HandshakeInitiatorFactory,
     HandshakeRecipientFactory,
     PingMessageFactory,
-    PrivateKeyFactory,
     WhoAreYouPacketFactory,
+)
+from p2p.tools.factories.keys import (
+    PrivateKeyFactory,
 )
 
 

--- a/tests/p2p/discv5/test_handshake.py
+++ b/tests/p2p/discv5/test_handshake.py
@@ -1,0 +1,114 @@
+from eth_utils import (
+    keccak,
+)
+
+from p2p.tools.factories import (
+    AuthTagPacketFactory,
+    ENRFactory,
+    HandshakeInitiatorFactory,
+    HandshakeRecipientFactory,
+    PingMessageFactory,
+    PrivateKeyFactory,
+    WhoAreYouPacketFactory,
+)
+
+
+def test_initiator_expects_who_are_you_response():
+    handshake_initiator = HandshakeInitiatorFactory()
+    expected_token = handshake_initiator.first_packet_to_send.auth_tag
+    unexpected_token = keccak(expected_token)
+
+    assert not handshake_initiator.is_response_packet(AuthTagPacketFactory())
+    assert not handshake_initiator.is_response_packet(WhoAreYouPacketFactory(
+        token=unexpected_token,
+    ))
+    assert handshake_initiator.is_response_packet(WhoAreYouPacketFactory(
+        token=expected_token,
+    ))
+
+
+def test_successful_handshake():
+    initiator_private_key = PrivateKeyFactory().to_bytes()
+    recipient_private_key = PrivateKeyFactory().to_bytes()
+    initiator_enr = ENRFactory(private_key=initiator_private_key)
+    recipient_enr = ENRFactory(private_key=recipient_private_key)
+    initial_message = PingMessageFactory()
+
+    initiator = HandshakeInitiatorFactory(
+        our_private_key=initiator_private_key,
+        our_enr=initiator_enr,
+        their_enr=recipient_enr,
+        initial_message=initial_message,
+    )
+    recipient = HandshakeRecipientFactory(
+        our_private_key=recipient_private_key,
+        our_enr=recipient_enr,
+        their_enr=initiator_enr,
+        initiating_packet_auth_tag=initiator.first_packet_to_send.auth_tag
+    )
+
+    initiator_result = initiator.complete_handshake(recipient.first_packet_to_send)
+    recipient_result = recipient.complete_handshake(initiator_result.auth_header_packet)
+
+    assert initiator_result.session_keys == recipient_result.session_keys
+
+    assert initiator_result.message is None
+    assert initiator_result.enr is None
+    assert initiator_result.auth_header_packet is not None
+
+    assert recipient_result.message == initial_message
+    assert recipient_result.enr is None
+    assert recipient_result.auth_header_packet is None
+
+
+def test_successful_handshake_with_enr_update():
+    initiator_private_key = PrivateKeyFactory().to_bytes()
+    recipient_private_key = PrivateKeyFactory().to_bytes()
+    old_initiator_enr = ENRFactory(private_key=initiator_private_key)
+    new_initiator_enr = ENRFactory(
+        private_key=initiator_private_key,
+        sequence_number=old_initiator_enr.sequence_number + 1,
+    )
+
+    initiator = HandshakeInitiatorFactory(
+        our_private_key=initiator_private_key,
+        our_enr=new_initiator_enr,
+        their_private_key=recipient_private_key,
+    )
+    recipient = HandshakeRecipientFactory(
+        our_private_key=recipient_private_key,
+        their_enr=old_initiator_enr,
+        initiating_packet_auth_tag=initiator.first_packet_to_send.auth_tag
+    )
+
+    initiator_result = initiator.complete_handshake(recipient.first_packet_to_send)
+    recipient_result = recipient.complete_handshake(initiator_result.auth_header_packet)
+
+    assert initiator_result.enr is None
+    assert recipient_result.enr == new_initiator_enr
+
+
+def test_successful_handshake_with_new_enr():
+    initiator_private_key = PrivateKeyFactory().to_bytes()
+    recipient_private_key = PrivateKeyFactory().to_bytes()
+    initiator_enr = ENRFactory(private_key=initiator_private_key)
+    recipient_enr = ENRFactory(private_key=recipient_private_key)
+
+    initiator = HandshakeInitiatorFactory(
+        our_private_key=initiator_private_key,
+        our_enr=initiator_enr,
+        their_enr=recipient_enr,
+    )
+    recipient = HandshakeRecipientFactory(
+        our_private_key=recipient_private_key,
+        our_enr=recipient_enr,
+        their_enr=None,
+        their_node_id=initiator_enr.node_id,
+        initiating_packet_auth_tag=initiator.first_packet_to_send.auth_tag
+    )
+
+    initiator_result = initiator.complete_handshake(recipient.first_packet_to_send)
+    recipient_result = recipient.complete_handshake(initiator_result.auth_header_packet)
+
+    assert initiator_result.enr is None
+    assert recipient_result.enr == initiator_enr

--- a/tests/p2p/discv5/test_packet_decryption.py
+++ b/tests/p2p/discv5/test_packet_decryption.py
@@ -31,7 +31,7 @@ from tests.p2p.discv5.strategies import (
     tag_st,
     nonce_st,
     key_st,
-    pubkey_st,
+    public_key_st,
 )
 
 
@@ -61,14 +61,14 @@ def message(enr):
     id_nonce=id_nonce_st,
     initiator_key=key_st,
     auth_response_key=key_st,
-    ephemeral_pubkey=pubkey_st,
+    ephemeral_public_key=public_key_st,
 )
 def test_auth_header_message_decryption(tag,
                                         auth_tag,
                                         id_nonce,
                                         initiator_key,
                                         auth_response_key,
-                                        ephemeral_pubkey,
+                                        ephemeral_public_key,
                                         enr,
                                         message):
     id_nonce_signature = b"\x00" * 32
@@ -82,7 +82,7 @@ def test_auth_header_message_decryption(tag,
         id_nonce_signature=id_nonce_signature,
         auth_response_key=auth_response_key,
         enr=enr,
-        ephemeral_pubkey=ephemeral_pubkey
+        ephemeral_public_key=ephemeral_public_key
     )
 
     decrypted_message = packet.decrypt_message(initiator_key)
@@ -95,14 +95,14 @@ def test_auth_header_message_decryption(tag,
     id_nonce=id_nonce_st,
     initiator_key=key_st,
     auth_response_key=key_st,
-    ephemeral_pubkey=pubkey_st,
+    ephemeral_public_key=public_key_st,
 )
 def test_auth_header_decryption_with_enr(tag,
                                          auth_tag,
                                          id_nonce,
                                          initiator_key,
                                          auth_response_key,
-                                         ephemeral_pubkey,
+                                         ephemeral_public_key,
                                          enr,
                                          message):
     id_nonce_signature = b"\x00" * 32
@@ -116,7 +116,7 @@ def test_auth_header_decryption_with_enr(tag,
         id_nonce_signature=id_nonce_signature,
         auth_response_key=auth_response_key,
         enr=enr,
-        ephemeral_pubkey=ephemeral_pubkey
+        ephemeral_public_key=ephemeral_public_key
     )
 
     recovered_id_nonce_signature, recovered_enr = packet.decrypt_auth_response(auth_response_key)
@@ -130,14 +130,14 @@ def test_auth_header_decryption_with_enr(tag,
     id_nonce=id_nonce_st,
     initiator_key=key_st,
     auth_response_key=key_st,
-    ephemeral_pubkey=pubkey_st,
+    ephemeral_public_key=public_key_st,
 )
 def test_auth_header_decryption_without_enr(tag,
                                             auth_tag,
                                             id_nonce,
                                             initiator_key,
                                             auth_response_key,
-                                            ephemeral_pubkey,
+                                            ephemeral_public_key,
                                             message):
     id_nonce_signature = b"\x00" * 32
     packet = AuthHeaderPacket.prepare(
@@ -149,7 +149,7 @@ def test_auth_header_decryption_without_enr(tag,
         id_nonce_signature=id_nonce_signature,
         auth_response_key=auth_response_key,
         enr=None,
-        ephemeral_pubkey=ephemeral_pubkey
+        ephemeral_public_key=ephemeral_public_key
     )
 
     recovered_id_nonce_signature, recovered_enr = packet.decrypt_auth_response(auth_response_key)
@@ -162,13 +162,13 @@ def test_auth_header_decryption_without_enr(tag,
     auth_tag=nonce_st,
     id_nonce=id_nonce_st,
     initiator_key=key_st,
-    ephemeral_pubkey=pubkey_st,
+    ephemeral_public_key=public_key_st,
 )
 def test_invalid_auth_header_decryption_with_wrong_key(tag,
                                                        auth_tag,
                                                        id_nonce,
                                                        initiator_key,
-                                                       ephemeral_pubkey,
+                                                       ephemeral_public_key,
                                                        message):
     id_nonce_signature = b"\x00" * 32
     encryption_key = b"\x00" * AES128_KEY_SIZE
@@ -182,7 +182,7 @@ def test_invalid_auth_header_decryption_with_wrong_key(tag,
         id_nonce_signature=id_nonce_signature,
         auth_response_key=encryption_key,
         enr=None,
-        ephemeral_pubkey=ephemeral_pubkey
+        ephemeral_public_key=ephemeral_public_key
     )
     with pytest.raises(DecryptionError):
         packet.decrypt_auth_response(decryption_key)

--- a/tests/p2p/discv5/test_packet_encoding.py
+++ b/tests/p2p/discv5/test_packet_encoding.py
@@ -44,7 +44,7 @@ from tests.p2p.discv5.strategies import (
 )
 
 # arbitrary as we're not working with a particular identity scheme
-pubkey_st = st.binary(min_size=33, max_size=33)
+public_key_st = st.binary(min_size=33, max_size=33)
 
 
 @given(
@@ -81,7 +81,7 @@ def test_oversize_auth_tag_packet_encoding():
     tag=tag_st,
     auth_tag=nonce_st,
     id_nonce=id_nonce_st,
-    ephemeral_pubkey=pubkey_st,
+    ephemeral_public_key=public_key_st,
     encrypted_auth_response=st.binary(min_size=16, max_size=32),
     encrypted_message_size=st.integers(
         min_value=0,
@@ -91,7 +91,7 @@ def test_oversize_auth_tag_packet_encoding():
             1 + NONCE_SIZE,  # tag
             1 + len(AUTH_SCHEME_NAME),  # auth scheme name
             1 + ID_NONCE_SIZE,  # id nonce
-            1 + 33,  # pubkey
+            1 + 33,  # public_key
             1 + 32,  # encrypted auth response
         ))
     ),
@@ -99,13 +99,13 @@ def test_oversize_auth_tag_packet_encoding():
 def test_auth_header_packet_encoding_decoding(tag,
                                               auth_tag,
                                               id_nonce,
-                                              ephemeral_pubkey,
+                                              ephemeral_public_key,
                                               encrypted_auth_response,
                                               encrypted_message_size):
     auth_header = AuthHeaderFactory(
         auth_tag=auth_tag,
         id_nonce=id_nonce,
-        ephemeral_pubkey=ephemeral_pubkey,
+        ephemeral_public_key=ephemeral_public_key,
         encrypted_auth_response=encrypted_auth_response,
     )
     encrypted_message = b"\x00" * encrypted_message_size

--- a/tests/p2p/discv5/test_packet_preparation.py
+++ b/tests/p2p/discv5/test_packet_preparation.py
@@ -33,7 +33,7 @@ from p2p.discv5.constants import (
 from tests.p2p.discv5.strategies import (
     key_st,
     nonce_st,
-    pubkey_st,
+    public_key_st,
     tag_st,
     node_id_st,
     id_nonce_st,
@@ -48,14 +48,14 @@ from tests.p2p.discv5.strategies import (
     id_nonce=id_nonce_st,
     initiator_key=key_st,
     auth_response_key=key_st,
-    ephemeral_pubkey=pubkey_st,
+    ephemeral_public_key=public_key_st,
 )
 def test_auth_header_preparation(tag,
                                  auth_tag,
                                  id_nonce,
                                  initiator_key,
                                  auth_response_key,
-                                 ephemeral_pubkey):
+                                 ephemeral_public_key):
     enr = ENR(
         sequence_number=1,
         signature=b"",
@@ -79,14 +79,14 @@ def test_auth_header_preparation(tag,
         id_nonce_signature=id_nonce_signature,
         auth_response_key=auth_response_key,
         enr=enr,
-        ephemeral_pubkey=ephemeral_pubkey
+        ephemeral_public_key=ephemeral_public_key
     )
 
     assert packet.tag == tag
     assert packet.auth_header.auth_tag == auth_tag
     assert packet.auth_header.id_nonce == id_nonce
     assert packet.auth_header.auth_scheme_name == AUTH_SCHEME_NAME
-    assert packet.auth_header.ephemeral_pubkey == ephemeral_pubkey
+    assert packet.auth_header.ephemeral_public_key == ephemeral_public_key
 
     decrypted_auth_response = aesgcm_decrypt(
         key=auth_response_key,
@@ -135,14 +135,14 @@ def test_random_packet_preparation(tag, auth_tag, random_data):
     id_nonce=id_nonce_st,
     initiator_key=key_st,
     auth_response_key=key_st,
-    ephemeral_pubkey=pubkey_st,
+    ephemeral_public_key=public_key_st,
 )
 def test_auth_header_preparation_without_enr(tag,
                                              auth_tag,
                                              id_nonce,
                                              initiator_key,
                                              auth_response_key,
-                                             ephemeral_pubkey):
+                                             ephemeral_public_key):
     message = PingMessage(
         request_id=5,
         enr_seq=1,
@@ -158,7 +158,7 @@ def test_auth_header_preparation_without_enr(tag,
         id_nonce_signature=id_nonce_signature,
         auth_response_key=auth_response_key,
         enr=None,
-        ephemeral_pubkey=ephemeral_pubkey
+        ephemeral_public_key=ephemeral_public_key
     )
 
     decrypted_auth_response = aesgcm_decrypt(


### PR DESCRIPTION
This adds two classes that encapsulate the steps necessary to do a handshake. They are fully synchronous and need a service to use them which will come in a follow up PR. The general flow will look like this:

1) Initialize `HandshakeInitiator` (with the initial message we want to send to the peer) or `HandshakeReceiver` (with the `auth_tag` in the `AuthTagPacket` we've received.
2) Send `handshake_participant.first_packet_to_send` to the peer
3) Check all packets received from this point on with `handshake_participant.is_response_packet`
4) If the check succeeds, call `handshake_participant.complete_handshake` to get a `HandshakeResult`
5) The result contains the `SessionKeys`. Additionally, for the handshake initiator, it contains a `AuthHeaderPacket` that we have to send to the peer so that they can complete the handshake on their side. For the handshake recipient, it contains the initial message from the initiator. Optionally, it may also contain an `ENR` of the initiator (if they sent one).

For now I've kept the tests relatively light (only the successful cases). I plan to add more in the future, but would like to wait a bit with that as I hope we'll get some official test vectors at some point.

I've also renamed `pubkey` to `public_key` in the whole discv5 code for consistency with `private_key`, `initiator_key`, etc.

Supersedes #868.

#### Cute Animal Picture


![put a cute animal picture link inside the parentheses](https://user-images.githubusercontent.com/29854669/62385032-428e1980-b554-11e9-91d9-fbcbf54413fe.jpg)
