### PR TITLE
Allow beam sync to start off from a trusted checkpoint

### DIFF
--- a/newsfragments/921.bugfix.rst
+++ b/newsfragments/921.bugfix.rst
@@ -1,0 +1,2 @@
+Fix type hints so that ``max_headers`` is recognized as keyword argument
+to ``get_block_headers``.

--- a/newsfragments/921.feature.rst
+++ b/newsfragments/921.feature.rst
@@ -1,0 +1,8 @@
+Allow beam sync to start from a trusted checkpoint.
+Specify a checkpoint via CLI parameter such as:
+
+``--beam-from-checkpoint="eth://block/byhash/<hash>?score=<score>"``
+
+When given, beam sync will use this as a checkpoint
+to avoid having to download the entire chain of headers
+first.

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 import os
 from setuptools import setup, find_packages
 
-PYEVM_DEPENDENCY = "py-evm==0.3.0a3"
+PYEVM_DEPENDENCY = "py-evm==0.3.0a5"  # noqa: E501
 
 
 deps = {

--- a/tests/core/cli/test_parse_checkpoint_uri.py
+++ b/tests/core/cli/test_parse_checkpoint_uri.py
@@ -1,0 +1,51 @@
+import pytest
+
+from eth_utils import (
+    encode_hex,
+    ValidationError,
+)
+
+from trinity.plugins.builtin.syncer.cli import (
+    parse_checkpoint_uri
+)
+
+
+@pytest.mark.parametrize(
+    'uri, expected',
+    (
+        (
+            'eth://block/byhash/0x113f05289c685eb5b87d433c3e09ec2bfa51d6472cc37108d03b0113b11e3080?score=11',  # noqa: E501
+            ('0x113f05289c685eb5b87d433c3e09ec2bfa51d6472cc37108d03b0113b11e3080', 78, 11),
+        ),
+        (
+            'eth://block/byhash/0x113f05289c685eb5b87d433c3e09ec2bfa51d6472cc37108d03b0113b11e3080?score=1,1',  # noqa: E501
+            ('0x113f05289c685eb5b87d433c3e09ec2bfa51d6472cc37108d03b0113b11e3080', 78, 11),
+        ),
+        (
+            'eth://block/byhash/0x113f05289c685eb5b87d433c3e09ec2bfa51d6472cc37108d03b0113b11e3080?score=1 1',  # noqa: E501
+            ('0x113f05289c685eb5b87d433c3e09ec2bfa51d6472cc37108d03b0113b11e3080', 78, 11),
+        ),
+    )
+)
+def test_parse_checkpoint(uri, expected):
+    block_hash, block_number, block_score = expected
+    checkpoint = parse_checkpoint_uri(uri)
+    assert encode_hex(checkpoint.block_hash) == block_hash
+    assert checkpoint.score == block_score
+
+
+@pytest.mark.parametrize(
+    'uri',
+    (
+        'meh://block/byhash/0x113f05289c685eb5b87d433c3e09ec2bfa51d6472cc37108d03b0113b11e3080?score=11',  # noqa: E501
+        'eth://meh/byhash/0x113f05289c685eb5b87d433c3e09ec2bfa51d6472cc37108d03b0113b11e3080?score=11',  # noqa: E501
+        'eth://block/meh/0x113f05289c685eb5b87d433c3e09ec2bfa51d6472cc37108d03b0113b11e3080?score=11',  # noqa: E501
+        'eth://block/byhash/meh?score=78',
+        'eth://block/meh/0x113f05289c685eb5b87d433c3e09ec2bfa51d6472cc37108d03b0113b11e3080?score=11',  # noqa: E501
+        'eth://block/meh/0x113f05289c685eb5b87d433c3e09ec2bfa51d6472cc37108d03b0113b11e3080?score=meh',  # noqa: E501
+        'eth://block/byhash/0x113f05289c685eb5b87d433c3e09ec2bfa51d6472cc37108d03b0113b11e3080',
+    )
+)
+def test_throws_validation_error(uri):
+    with pytest.raises(ValidationError):
+        parse_checkpoint_uri(uri)

--- a/trinity/db/eth1/chain.py
+++ b/trinity/db/eth1/chain.py
@@ -72,6 +72,7 @@ class AsyncChainDB(BaseAsyncChainDB):
     coro_header_exists = async_method(BaseAsyncChainDB.header_exists)
     coro_get_canonical_block_hash = async_method(BaseAsyncChainDB.get_canonical_block_hash)
     coro_get_canonical_block_header_by_number = async_method(BaseAsyncChainDB.get_canonical_block_header_by_number)  # noqa: E501
+    coro_persist_checkpoint_header = async_method(BaseAsyncChainDB.persist_checkpoint_header)
     coro_persist_header = async_method(BaseAsyncChainDB.persist_header)
     coro_persist_header_chain = async_method(BaseAsyncChainDB.persist_header_chain)
     coro_persist_block = async_method(BaseAsyncChainDB.persist_block)

--- a/trinity/db/eth1/header.py
+++ b/trinity/db/eth1/header.py
@@ -57,9 +57,15 @@ class BaseAsyncHeaderDB(HeaderDB):
         ...
 
     @abstractmethod
-    async def coro_persist_header_chain(self,
-                                        headers: Iterable[BlockHeaderAPI],
-                                        ) -> Tuple[BlockHeaderAPI, ...]:
+    async def coro_persist_checkpoint_header(self, header: BlockHeaderAPI, score: int) -> None:
+        ...
+
+    @abstractmethod
+    async def coro_persist_header_chain(
+        self,
+        headers: Iterable[BlockHeaderAPI],
+        genesis_parent_hash: Hash32=None
+    ) -> Tuple[BlockHeaderAPI, ...]:
         ...
 
 
@@ -71,5 +77,6 @@ class AsyncHeaderDB(BaseAsyncHeaderDB):
     coro_get_score = async_method(BaseAsyncHeaderDB.get_score)
     coro_header_exists = async_method(BaseAsyncHeaderDB.header_exists)
     coro_get_canonical_block_hash = async_method(BaseAsyncHeaderDB.get_canonical_block_hash)
+    coro_persist_checkpoint_header = async_method(BaseAsyncHeaderDB.persist_checkpoint_header)
     coro_persist_header = async_method(BaseAsyncHeaderDB.persist_header)
     coro_persist_header_chain = async_method(BaseAsyncHeaderDB.persist_header_chain)

--- a/trinity/plugins/builtin/syncer/cli.py
+++ b/trinity/plugins/builtin/syncer/cli.py
@@ -1,0 +1,81 @@
+import argparse
+from pathlib import PurePosixPath
+import re
+import urllib
+from typing import (
+    Any,
+)
+
+from eth_typing import (
+    Hash32,
+)
+
+from eth_utils import (
+    is_hex,
+    remove_0x_prefix,
+    decode_hex,
+    ValidationError,
+)
+
+from trinity.sync.common.checkpoint import Checkpoint
+
+
+def is_block_hash(value: str) -> bool:
+    return is_hex(value) and len(remove_0x_prefix(value)) == 64
+
+
+def remove_non_digits(value: str) -> str:
+    return re.sub("\D", "", value)
+
+
+def parse_checkpoint_uri(uri: str) -> Checkpoint:
+    try:
+        parsed = urllib.parse.urlparse(uri)
+    except ValueError as e:
+        raise ValidationError(str(e))
+
+    scheme, netloc, path, query = parsed.scheme, parsed.netloc, parsed.path.lower(), parsed.query
+
+    try:
+        parsed_query = urllib.parse.parse_qsl(query)
+    except ValueError as e:
+        raise ValidationError(str(e))
+
+    query_dict = dict(parsed_query)
+
+    # we allow any kind of separator for a nicer UX. e.g. instead of "11487662456884849810705"
+    # one can use "114 876 624 568 848 498 107 05" or "1,487,662,456,884,849,810,705". This also
+    # allows copying out a value from e.g etherscan.
+    score = remove_non_digits(query_dict.get('score', ''))
+
+    is_by_hash = path.startswith('/byhash')
+    parts = PurePosixPath(parsed.path).parts
+
+    if len(parts) != 3 or scheme != 'eth' or netloc != 'block' or not is_by_hash or not score:
+        raise ValidationError(
+            'checkpoint string must be of the form'
+            '"eth://block/byhash/<hash>?score=<score>"'
+        )
+
+    block_hash = parts[2]
+
+    if not is_block_hash(block_hash):
+        raise ValidationError(f'Block hash must be valid hex string, got: {block_hash}')
+
+    if not score.isdigit():
+        raise ValidationError(f'Score (total difficulty) must be an integer, got: {score}')
+
+    return Checkpoint(Hash32(decode_hex(block_hash)), int(score))
+
+
+class NormalizeCheckpointURI(argparse.Action):
+    """
+    Normalize the URI describing a sync checkpoint.
+    """
+    def __call__(self,
+                 parser: argparse.ArgumentParser,
+                 namespace: argparse.Namespace,
+                 value: Any,
+                 option_string: str=None) -> None:
+        parsed = parse_checkpoint_uri(value)
+        setattr(namespace, self.dest, parsed)

--- a/trinity/plugins/builtin/syncer/plugin.py
+++ b/trinity/plugins/builtin/syncer/plugin.py
@@ -75,6 +75,7 @@ from trinity.sync.light.chain import (
 from trinity._utils.shutdown import (
     exit_with_services,
 )
+from .cli import NormalizeCheckpointURI
 
 
 class BaseSyncStrategy(ABC):
@@ -200,6 +201,16 @@ class BeamSyncStrategy(BaseSyncStrategy):
             default=None,
         )
 
+        arg_parser.add_argument(
+            '--beam-from-checkpoint',
+            action=NormalizeCheckpointURI,
+            help=(
+                "Start beam sync from a trusted checkpoint specified using URI syntax:"
+                "eth://block/byhash/<hash>?score=<score>"
+            ),
+            default=None,
+        )
+
     async def sync(self,
                    args: Namespace,
                    logger: Logger,
@@ -215,6 +226,7 @@ class BeamSyncStrategy(BaseSyncStrategy):
             base_db,
             cast(ETHPeerPool, peer_pool),
             event_bus,
+            args.beam_from_checkpoint,
             args.force_beam_block_number,
             cancel_token,
         )

--- a/trinity/protocol/common/boot.py
+++ b/trinity/protocol/common/boot.py
@@ -86,7 +86,7 @@ class DAOCheckBootManager(BasePeerBootManager):
 
     async def _get_tip_header(self) -> BlockHeader:
         try:
-            headers = await self.peer.requests.get_block_headers(  # type: ignore
+            headers = await self.peer.requests.get_block_headers(
                 self.peer.head_hash,
                 max_headers=1,
                 timeout=CHAIN_SPLIT_CHECK_TIMEOUT,

--- a/trinity/protocol/common/handlers.py
+++ b/trinity/protocol/common/handlers.py
@@ -61,7 +61,7 @@ if TYPE_CHECKING:
         [
             BaseExchangeHandler,
             BlockIdentifier,
-            int,
+            DefaultArg(int, 'max_headers'),
             DefaultArg(int, 'skip'),
             DefaultArg(int, 'reverse'),
             DefaultArg(float, 'timeout')

--- a/trinity/sync/beam/service.py
+++ b/trinity/sync/beam/service.py
@@ -1,5 +1,4 @@
 from lahja import EndpointAPI
-
 from cancel_token import CancelToken
 
 from eth.abc import AtomicDatabaseAPI
@@ -9,6 +8,7 @@ from p2p.service import BaseService
 from trinity.chains.base import AsyncChainAPI
 from trinity.db.eth1.chain import BaseAsyncChainDB
 from trinity.protocol.eth.peer import ETHPeerPool
+from trinity.sync.common.checkpoint import Checkpoint
 
 from .chain import BeamSyncer
 
@@ -22,6 +22,7 @@ class BeamSyncService(BaseService):
             base_db: AtomicDatabaseAPI,
             peer_pool: ETHPeerPool,
             event_bus: EndpointAPI,
+            checkpoint: Checkpoint = None,
             force_beam_block_number: int = None,
             token: CancelToken = None) -> None:
         super().__init__(token)
@@ -30,17 +31,26 @@ class BeamSyncService(BaseService):
         self.base_db = base_db
         self.peer_pool = peer_pool
         self.event_bus = event_bus
+        self.checkpoint = checkpoint
         self.force_beam_block_number = force_beam_block_number
 
     async def _run(self) -> None:
         head = await self.wait(self.chaindb.coro_get_canonical_head())
-        self.logger.info("Starting beam-sync; current head: %s", head)
+
+        if self.checkpoint is not None:
+            self.logger.info(
+                "Starting beam-sync; current head: %s, using checkpoint: %s", head, self.checkpoint
+            )
+        else:
+            self.logger.info("Starting beam-sync; current head: %s", head)
+
         beam_syncer = BeamSyncer(
             self.chain,
             self.base_db,
             self.chaindb,
             self.peer_pool,
             self.event_bus,
+            self.checkpoint,
             self.force_beam_block_number,
             token=self.cancel_token,
         )

--- a/trinity/sync/common/checkpoint.py
+++ b/trinity/sync/common/checkpoint.py
@@ -1,0 +1,23 @@
+from typing import NamedTuple
+
+from eth_typing import (
+    Hash32,
+)
+from eth_utils import (
+    humanize_hash
+)
+
+
+class Checkpoint(NamedTuple):
+    """
+    Represent a checkpoint from where the syncing process can start off
+    when not starting from genesis.
+    """
+    block_hash: Hash32
+    score: int
+
+    def __str__(self) -> str:
+        return (
+            f"<Checkpoint block hash=#{humanize_hash(self.block_hash)}"
+            f" score={self.score}>"
+        )

--- a/trinity/sync/common/strategies.py
+++ b/trinity/sync/common/strategies.py
@@ -1,0 +1,136 @@
+from abc import (
+    ABC,
+    abstractmethod
+)
+import asyncio
+
+from eth_typing import (
+    BlockNumber,
+    Hash32,
+)
+from eth_utils import (
+    ValidationError,
+)
+
+from eth.constants import (
+    GENESIS_BLOCK_NUMBER,
+    GENESIS_PARENT_HASH,
+)
+
+from p2p.disconnect import DisconnectReason
+from p2p.exceptions import (
+    NoConnectedPeers,
+    PeerConnectionLost,
+)
+
+from trinity.chains.base import AsyncChainAPI
+from trinity.db.eth1.header import BaseAsyncHeaderDB
+from trinity.protocol.common.peer import (
+    BaseChainPeerPool,
+)
+from trinity.sync.common.checkpoint import (
+    Checkpoint,
+)
+from trinity.sync.common.constants import (
+    MAX_SKELETON_REORG_DEPTH,
+)
+
+
+class SyncLaunchStrategyAPI(ABC):
+
+    @abstractmethod
+    async def fulfill_prerequisites(self) -> None:
+        ...
+
+    @abstractmethod
+    def get_genesis_parent_hash(self) -> Hash32:
+        ...
+
+    @abstractmethod
+    async def get_starting_block_number(self) -> BlockNumber:
+        ...
+
+
+class FromGenesisLaunchStrategy(SyncLaunchStrategyAPI):
+
+    def __init__(self, db: BaseAsyncHeaderDB, chain: AsyncChainAPI) -> None:
+        self._db = db
+        self._chain = chain
+
+    async def fulfill_prerequisites(self) -> None:
+        pass
+
+    def get_genesis_parent_hash(self) -> Hash32:
+        return GENESIS_PARENT_HASH
+
+    async def get_starting_block_number(self) -> BlockNumber:
+        head = await self._db.coro_get_canonical_head()
+
+        # When we start the sync with a peer, we always request up to MAX_REORG_DEPTH extra
+        # headers before our current head's number, in case there were chain reorgs since the last
+        # time _sync() was called. All of the extra headers that are already present in our DB
+        # will be discarded so we don't unnecessarily process them again.
+        return max(GENESIS_BLOCK_NUMBER, head.block_number - MAX_SKELETON_REORG_DEPTH)
+
+
+class FromCheckpointLaunchStrategy(SyncLaunchStrategyAPI):
+
+    min_block_number = BlockNumber(0)
+
+    def __init__(self,
+                 db: BaseAsyncHeaderDB,
+                 chain: AsyncChainAPI,
+                 checkpoint: Checkpoint,
+                 peer_pool: BaseChainPeerPool) -> None:
+        self._db = db
+        self._chain = chain
+        # We wrap the `FromGenesisLaunchStrategy` because we delegate to it at times and
+        # reaching for inheritance seems wrong in this case.
+        self._genesis_strategy = FromGenesisLaunchStrategy(self._db, self._chain)
+        self._checkpoint = checkpoint
+        self._peer_pool = peer_pool
+
+    async def fulfill_prerequisites(self) -> None:
+        max_attempts = 1000
+
+        for _attempt in range(max_attempts):
+
+            try:
+                peer = self._peer_pool.highest_td_peer
+            except NoConnectedPeers:
+                # Feels appropriate to wait a little longer while we aren't connected
+                # to any peers yet.
+                await asyncio.sleep(2)
+                continue
+
+            try:
+                headers = await peer.requests.get_block_headers(
+                    self._checkpoint.block_hash,
+                    max_headers=1,
+                    skip=0,
+                    reverse=False,
+                )
+            except (TimeoutError, PeerConnectionLost, ValidationError):
+                # Nothing to do here. The ExchangeManager will disconnect if appropriate
+                # and eventually lead us to a better peer.
+                pass
+
+            if not headers:
+                await peer.disconnect(DisconnectReason.useless_peer)
+            elif headers[0].hash != self._checkpoint.block_hash:
+                await peer.disconnect(DisconnectReason.useless_peer)
+            else:
+                self.min_block_number = headers[0].block_number
+                await self._db.coro_persist_checkpoint_header(headers[0], self._checkpoint.score)
+                return
+
+            await asyncio.sleep(0.05)
+
+        raise TimeoutError(f"Failed to get checkpoint header within {max_attempts} attempts")
+
+    def get_genesis_parent_hash(self) -> Hash32:
+        return self._checkpoint.block_hash
+
+    async def get_starting_block_number(self) -> BlockNumber:
+        block_number = await self._genesis_strategy.get_starting_block_number()
+        return block_number if block_number > self.min_block_number else self.min_block_number

--- a/trinity/sync/full/chain.py
+++ b/trinity/sync/full/chain.py
@@ -464,7 +464,7 @@ class FastChainSyncer(BaseService):
                  peer_pool: ETHPeerPool,
                  token: CancelToken = None) -> None:
         super().__init__(token=token)
-        self._header_syncer = ETHHeaderChainSyncer(chain, db, peer_pool, self.cancel_token)
+        self._header_syncer = ETHHeaderChainSyncer(chain, db, peer_pool, token=self.cancel_token)
         self._body_syncer = FastChainBodySyncer(
             chain,
             db,
@@ -947,7 +947,7 @@ class RegularChainSyncer(BaseService):
                  peer_pool: ETHPeerPool,
                  token: CancelToken = None) -> None:
         super().__init__(token=token)
-        self._header_syncer = ETHHeaderChainSyncer(chain, db, peer_pool, self.cancel_token)
+        self._header_syncer = ETHHeaderChainSyncer(chain, db, peer_pool, token=self.cancel_token)
         self._body_syncer = RegularChainBodySyncer(
             chain,
             db,

--- a/trinity/sync/light/chain.py
+++ b/trinity/sync/light/chain.py
@@ -18,7 +18,7 @@ class LightChainSyncer(BaseService):
                  token: CancelToken = None) -> None:
         super().__init__(token=token)
         self._db = db
-        self._header_syncer = LightHeaderChainSyncer(chain, db, peer_pool, self.cancel_token)
+        self._header_syncer = LightHeaderChainSyncer(chain, db, peer_pool, token=self.cancel_token)
 
     async def _run(self) -> None:
         self.run_daemon(self._header_syncer)


### PR DESCRIPTION
### What was wrong?

Relates to #892 

Before beam sync can start of doing its "beam magic", it still needs to download the chain of headers. While that's not the end of the world, it would be much nicer if the user could provide a checkpoint for a header that beam sync would trust (to start with) and build up on top.

This allows beam sync to get to work *immediately* and fill up missing headers (and eventually also blocks) in the background.

### How was it fixed?

1. Add a `SyncLaunchStrategyAPI` with two implementations:

-  created a new class `Checkpoint` that represents a blockhash, a blocknumber as well as a score
- `FromGenesisLaunchStrategy`: Download the full header chain first (same as today)
- `FromCheckpointLaunchStrategy`: Launch from a given checkpoint

2. Added a new parameter `--beam-from-checkpoint` that takes an URI as a form of micro DSL.

This is following what @pipermerriam proposed in #892 but it's been a bit controversial and I'm open to other ideas. However, here's my attempt to defend it:

For the manual checkpoints (e.g. not retrieving one through the etherscan API) there are three parts to a checkpoint, the blockhash, the blocknumber and the score. Creating three different command line parameters for this:

- A. Is hard to remember (I think it's easier to get used to some form of micro DSL)
- B. Makes Trinitys invocation command much longer
- C. Rips apart three things that essentially need to be supplied together

### Seeing it in action:

1. `rm -rf /home/cburgdorf/.local/share/trinity/mainnet/chain-eth1/`

2. `trinity --sync-mode beam  --beam-from-checkpoint="eth://block/byhash/0x113f05289c685eb5b87d433c3e09ec2bfa51d6472cc37108d03b0113b11e3080?number=8360824&score=11,487,662,456,884,849,810,705"` 

Then observe:

```
INFO  08-16 16:54:26       BeamSyncService  Starting beam-sync; using checkpoint: <Checkpoint block hash=#113f..3080 block number=8360824 score=11487662456884849810705>
...
INFO  08-16 16:54:59     HeaderOnlyPersist  Imported 192 headers in 0.21 seconds, new head: <BlockHeader #8361016 b7e740c2>
    INFO  08-16 16:55:01     HeaderOnlyPersist  Imported 388 headers in 0.06 seconds, new head: <BlockHeader #8361404 44c602c9>
    INFO  08-16 16:55:02     HeaderOnlyPersist  Caught up to skeleton peer. Switching to beam mode at <BlockHeader #8362170 e4e1ea7c>
    INFO  08-16 16:55:02            BeamSyncer  Downloading 8 block bodies for uncle validation, before <BlockHeader #8362170 e4e1ea7c>
    INFO  08-16 16:55:02            BeamSyncer  Getting recent block data for uncle validation
    INFO  08-16 16:55:06            BeamSyncer  Have all data needed for Beam validation, continuing...
    INFO  08-16 16:55:06  HeaderCheckpointSyncer  Choosing (<eth.rlp.headers.BlockHeader object at 0x7f6c8effca90>,) as checkpoint headers to sync from
    INFO  08-16 16:55:06        BeamDownloader  Starting beam state sync
    INFO  08-16 16:55:06        BeamDownloader  Beam-Sync: all=0  urgent=0  pred=0  all/sec=0  urgent/sec=0  reqs=0  pred_reqs=0  timeouts=0
    INFO  08-16 16:55:06           ETHPeerPool  Adding ETHPeer <Node(0x1fdd@91.195.52.166)> to pool
    INFO  08-16 16:55:06  RegularChainBodySyncer  Waited 0.6s for <BlockHeader #8362170 e4e1ea7c> body
    INFO  08-16 16:55:06     BeamBlockImporter  Beam importing <BlockHeader #8362170 e4e1ea7c> (69 txns) ...
    INFO  08-16 16:55:16        BeamDownloader  Beam-Sync: all=959  urgent=758  pred=201  all/sec=95  urgent/sec=75  reqs=44  pred_reqs=0  timeouts=1
    INFO  08-16 16:55:23           ETHPeerPool  Adding ETHPeer <Node(0x58dc@23.111.173.234)> to pool
    INFO  08-16 16:55:26        BeamDownloader  Beam-Sync: all=2943  urgent=800  pred=2143  all/sec=145  urgent/sec=39  reqs=86  pred_reqs=0  timeouts=1
    INFO  08-16 16:55:26           ETHPeerPool  Connected peers: 0 inbound, 7 outbound
    INFO  08-16 16:55:36        BeamDownloader  Beam-Sync: all=4693  urgent=838  pred=3855  all/sec=155  urgent/sec=27  reqs=124  pred_reqs=0  timeouts=1
    INFO  08-16 16:55:46        BeamDownloader  Beam-Sync: all=5761  urgent=890  pred=4871  all/sec=143  urgent/sec=22  reqs=176  pred_reqs=0  timeouts=1
    INFO  08-16 16:55:56        BeamDownloader  Beam-Sync: all=8190  urgent=926  pred=7264  all/sec=163  urgent/sec=18  reqs=216  pred_reqs=4  timeouts=1
    INFO  08-16 16:56:06        BeamDownloader  Beam-Sync: all=10329  urgent=967  pred=9362  all/sec=171  urgent/sec=16  reqs=257  pred_reqs=4  timeouts=1
    INFO  08-16 16:56:16        BeamDownloader  Beam-Sync: all=11746  urgent=1010  pred=10736  all/sec=167  urgent/sec=14  reqs=300  pred_reqs=4  timeouts=1
    INFO  08-16 16:56:26        BeamDownloader  Beam-Sync: all=12933  urgent=1051  pred=11882  all/sec=161  urgent/sec=13  reqs=341  pred_reqs=4  timeouts=1
    INFO  08-16 16:56:26           ETHPeerPool  Connected peers: 0 inbound, 7 outbound
    INFO  08-16 16:56:36        BeamDownloader  Beam-Sync: all=14168  urgent=1098  pred=13070  all/sec=156  urgent/sec=12  reqs=388  pred_reqs=4  timeouts=1
    INFO  08-16 16:56:46        BeamDownloader  Beam-Sync: all=15599  urgent=1137  pred=14462  all/sec=155  urgent/sec=11  reqs=427  pred_reqs=4  timeouts=1
    INFO  08-16 16:56:53           ETHPeerPool  Adding ETHPeer <Node(0xf9ae@203.238.15.78)> to pool
    INFO  08-16 16:56:56           ETHPeerPool  Adding ETHPeer <Node(0x0122@47.254.45.126)> to pool
    INFO  08-16 16:56:56           ETHPeerPool  ETHPeer <Node(0x0122@47.254.45.126)> finished[DisconnectReason.subprotocol_error], removing from pool
    INFO  08-16 16:56:56        BeamDownloader  Beam-Sync: all=17160  urgent=1179  pred=15981  all/sec=155  urgent/sec=10  reqs=469  pred_reqs=4  timeouts=1
    INFO  08-16 16:57:01  RegularChainBodySyncer  Imported block 8362170 (69 txs) in 114.37 seconds, with 2m7s lag


```

### To-Do

- [x] Hook it up to the command line (currently uses a hardcoded checkpoint)
- [x] polish local py-evm changes and open up Py-EVM PR
- [x] print out used checkpoint
- [x] switch to proper Py-EVM release
- [x] parse out seperators from block number / score
- [x] Get rid of FIXMEs
- [x] add a test that launches sync from a checkpoint
- [x] Clean up commit history
- [x] Add entry to the [release notes]

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](http://www.awesomelycute.com/gallery/2014/02/cutest-wild-animals-2944.jpg)
