### PR TITLE
ENR DB

### DIFF
--- a/p2p/discv5/abc.py
+++ b/p2p/discv5/abc.py
@@ -97,8 +97,8 @@ class EnrDbApi(ABC):
     def __init__(self, identity_scheme_registry: IdentitySchemeRegistry):
         ...
 
-    @abstractmethod
     @property
+    @abstractmethod
     def identity_scheme_registry(self) -> IdentitySchemeRegistry:
         ...
 

--- a/p2p/discv5/abc.py
+++ b/p2p/discv5/abc.py
@@ -11,6 +11,7 @@ from p2p.discv5.enr import (
 )
 from p2p.discv5.identity_schemes import (
     IdentityScheme,
+    IdentitySchemeRegistry,
 )
 from p2p.discv5.packets import (
     Packet,
@@ -86,4 +87,45 @@ class HandshakeParticipantAPI(ABC):
     @property
     def tag(self) -> Tag:
         """The tag used for message packets sent by this node to the peer."""
+
+
+class EnrDbApi(ABC):
+
+    @abstractmethod
+    def __init__(self, identity_scheme_registry: IdentitySchemeRegistry):
+        ...
+
+    @abstractmethod
+    @property
+    def identity_scheme_registry(self) -> IdentitySchemeRegistry:
+        ...
+
+    @abstractmethod
+    async def insert(self, enr: ENR) -> None:
+        """Insert an ENR into the database."""
+        ...
+
+    @abstractmethod
+    async def update(self, enr: ENR) -> None:
+        """Update an existing ENR if the sequence number is greater."""
+        ...
+
+    @abstractmethod
+    async def remove(self, node_id: NodeID) -> None:
+        """Remove an ENR from the db."""
+        ...
+
+    @abstractmethod
+    async def insert_or_update(self, enr: ENR) -> None:
+        """Insert or update an ENR depending if it is already present already or not."""
+        ...
+
+    @abstractmethod
+    async def get(self, node_id: NodeID) -> ENR:
+        """Get an ENR by its node id."""
+        ...
+
+    @abstractmethod
+    async def contains(self, node_id: NodeID) -> bool:
+        """Check if the db contains an ENR with the given node id."""
         ...

--- a/p2p/discv5/abc.py
+++ b/p2p/discv5/abc.py
@@ -24,6 +24,7 @@ from p2p.discv5.typing import (
 
 
 class HandshakeParticipantAPI(ABC):
+    @abstractmethod
     def __init__(self,
                  is_initiator: bool,
                  local_private_key: bytes,
@@ -85,12 +86,13 @@ class HandshakeParticipantAPI(ABC):
         ...
 
     @property
+    @abstractmethod
     def tag(self) -> Tag:
         """The tag used for message packets sent by this node to the peer."""
+        ...
 
 
 class EnrDbApi(ABC):
-
     @abstractmethod
     def __init__(self, identity_scheme_registry: IdentitySchemeRegistry):
         ...

--- a/p2p/discv5/enr_db.py
+++ b/p2p/discv5/enr_db.py
@@ -1,0 +1,93 @@
+from abc import ABC
+from typing import (
+    Dict,
+)
+
+import trio
+
+from p2p.discv5.enr import ENR
+from p2p.discv5.identity_schemes import IdentitySchemeRegistry
+from p2p.discv5.typing import NodeID
+
+
+class EnrDbApi(ABC):
+
+    def __init__(self, identity_scheme_registry: IdentitySchemeRegistry):
+        self.identity_scheme_registry = identity_scheme_registry
+
+    def validate_identity_scheme(self, enr: ENR) -> None:
+        """Check that we know the identity scheme of the ENR.
+
+        This check should be performed whenever an ENR is inserted or updated in serialized form to
+        make sure retrieving it at a later time will succeed (deserializing the ENR would fail if
+        we don't know the identity scheme).
+        """
+        if enr.identity_scheme.id not in self.identity_scheme_registry:
+            raise ValueError(
+                f"ENRs identity scheme with id {enr.identity_scheme.id} unknown to ENR DBs "
+                f"identity scheme registry"
+            )
+
+    async def insert(self, enr: ENR) -> None:
+        """Insert an ENR into the database."""
+        ...
+
+    async def update(self, enr: ENR) -> None:
+        """Update an existing ENR if the sequence number is greater."""
+        ...
+
+    async def remove(self, node_id: NodeID) -> None:
+        """Remove an ENR from the db."""
+        ...
+
+    async def insert_or_update(self, enr: ENR) -> None:
+        """Insert or update an ENR depending if it is already present already or not."""
+        ...
+
+    async def get(self, node_id: NodeID) -> ENR:
+        """Get an ENR by its node id."""
+        ...
+
+    async def contains(self, node_id: NodeID) -> bool:
+        """Check if the db contains an ENR with the given node id."""
+        ...
+
+
+class MemoryEnrDb(EnrDbApi):
+
+    def __init__(self, identity_scheme_registry: IdentitySchemeRegistry):
+        self.identity_scheme_registry = identity_scheme_registry
+        self.key_value_storage: Dict[NodeID, ENR] = {}
+
+    async def insert(self, enr: ENR) -> None:
+        self.validate_identity_scheme(enr)
+
+        if await self.contains(enr.node_id):
+            raise ValueError(f"ENR with nodeid {enr.node_id} already exists.")
+        else:
+            self.key_value_storage[enr.node_id] = enr
+
+    async def update(self, enr: ENR) -> None:
+        self.validate_identity_scheme(enr)
+        existing_enr = await self.get(enr.node_id)
+        if existing_enr.sequence_number < enr.sequence_number:
+            self.key_value_storage[enr.node_id] = enr
+
+    async def remove(self, node_id: NodeID) -> None:
+        self.key_value_storage.pop(node_id)
+
+        await trio.sleep(0)  # add checkpoint to make this a proper async function
+
+    async def insert_or_update(self, enr: ENR) -> None:
+        try:
+            await self.update(enr)
+        except KeyError:
+            await self.insert(enr)
+
+    async def get(self, node_id: NodeID) -> ENR:
+        await trio.sleep(0)  # add checkpoint to make this a proper async function
+        return self.key_value_storage[node_id]
+
+    async def contains(self, node_id: NodeID) -> bool:
+        await trio.sleep(0)  # add checkpoint to make this a proper async function
+        return node_id in self.key_value_storage

--- a/p2p/discv5/enr_db.py
+++ b/p2p/discv5/enr_db.py
@@ -1,19 +1,23 @@
-from abc import ABC
 from typing import (
     Dict,
 )
 
 import trio
 
+from p2p.discv5.abc import EnrDbApi
 from p2p.discv5.enr import ENR
 from p2p.discv5.identity_schemes import IdentitySchemeRegistry
 from p2p.discv5.typing import NodeID
 
 
-class EnrDbApi(ABC):
+class BaseEnrDb(EnrDbApi):
 
     def __init__(self, identity_scheme_registry: IdentitySchemeRegistry):
-        self.identity_scheme_registry = identity_scheme_registry
+        self._identity_scheme_registry = identity_scheme_registry
+
+    @property
+    def identity_scheme_registry(self) -> IdentitySchemeRegistry:
+        return self._identity_scheme_registry
 
     def validate_identity_scheme(self, enr: ENR) -> None:
         """Check that we know the identity scheme of the ENR.
@@ -28,35 +32,12 @@ class EnrDbApi(ABC):
                 f"identity scheme registry"
             )
 
-    async def insert(self, enr: ENR) -> None:
-        """Insert an ENR into the database."""
-        ...
 
-    async def update(self, enr: ENR) -> None:
-        """Update an existing ENR if the sequence number is greater."""
-        ...
-
-    async def remove(self, node_id: NodeID) -> None:
-        """Remove an ENR from the db."""
-        ...
-
-    async def insert_or_update(self, enr: ENR) -> None:
-        """Insert or update an ENR depending if it is already present already or not."""
-        ...
-
-    async def get(self, node_id: NodeID) -> ENR:
-        """Get an ENR by its node id."""
-        ...
-
-    async def contains(self, node_id: NodeID) -> bool:
-        """Check if the db contains an ENR with the given node id."""
-        ...
-
-
-class MemoryEnrDb(EnrDbApi):
+class MemoryEnrDb(BaseEnrDb):
 
     def __init__(self, identity_scheme_registry: IdentitySchemeRegistry):
-        self.identity_scheme_registry = identity_scheme_registry
+        super().__init__(identity_scheme_registry)
+
         self.key_value_storage: Dict[NodeID, ENR] = {}
 
     async def insert(self, enr: ENR) -> None:

--- a/tests-trio/p2p-trio/test_enr_db.py
+++ b/tests-trio/p2p-trio/test_enr_db.py
@@ -1,0 +1,114 @@
+import pytest
+
+from p2p.discv5.enr_db import (
+    MemoryEnrDb,
+)
+from p2p.discv5.identity_schemes import (
+    default_identity_scheme_registry,
+    IdentitySchemeRegistry,
+)
+from p2p.tools.factories import (
+    ENRFactory,
+    PrivateKeyFactory,
+)
+
+
+@pytest.fixture
+def memory_db():
+    return MemoryEnrDb(default_identity_scheme_registry)
+
+
+@pytest.mark.trio
+async def test_memory_insert(memory_db):
+    private_key = PrivateKeyFactory().to_bytes()
+    enr = ENRFactory(private_key=private_key)
+
+    await memory_db.insert(enr)
+    assert await memory_db.contains(enr.node_id)
+    assert await memory_db.get(enr.node_id) == enr
+
+    with pytest.raises(ValueError):
+        await memory_db.insert(enr)
+
+    updated_enr = ENRFactory(private_key=private_key, sequence_number=enr.sequence_number + 1)
+    with pytest.raises(ValueError):
+        await memory_db.insert(updated_enr)
+
+
+@pytest.mark.trio
+async def test_memory_update(memory_db):
+    private_key = PrivateKeyFactory().to_bytes()
+    enr = ENRFactory(private_key=private_key)
+
+    with pytest.raises(KeyError):
+        await memory_db.update(enr)
+
+    await memory_db.insert(enr)
+
+    await memory_db.update(enr)
+    assert await memory_db.get(enr.node_id) == enr
+
+    updated_enr = ENRFactory(private_key=private_key, sequence_number=enr.sequence_number + 1)
+    await memory_db.update(updated_enr)
+    assert await memory_db.get(enr.node_id) == updated_enr
+
+
+@pytest.mark.trio
+async def test_memory_insert_or_update(memory_db):
+    private_key = PrivateKeyFactory().to_bytes()
+    enr = ENRFactory(private_key=private_key)
+
+    await memory_db.insert_or_update(enr)
+    assert await memory_db.get(enr.node_id) == enr
+
+    await memory_db.insert_or_update(enr)
+    assert await memory_db.get(enr.node_id) == enr
+
+    updated_enr = ENRFactory(private_key=private_key, sequence_number=enr.sequence_number + 1)
+    await memory_db.insert_or_update(updated_enr)
+    assert await memory_db.get(enr.node_id) == updated_enr
+
+
+@pytest.mark.trio
+async def test_memory_remove(memory_db):
+    enr = ENRFactory()
+
+    with pytest.raises(KeyError):
+        await memory_db.remove(enr.node_id)
+
+    await memory_db.insert(enr)
+    await memory_db.remove(enr.node_id)
+
+    assert not await memory_db.contains(enr.node_id)
+
+
+@pytest.mark.trio
+async def test_memory_get(memory_db):
+    enr = ENRFactory()
+
+    with pytest.raises(KeyError):
+        await memory_db.get(enr.node_id)
+
+    await memory_db.insert(enr)
+    assert await memory_db.get(enr.node_id) == enr
+
+
+@pytest.mark.trio
+async def test_memory_contains(memory_db):
+    enr = ENRFactory()
+
+    assert not await memory_db.contains(enr.node_id)
+    await memory_db.insert(enr)
+    assert await memory_db.contains(enr.node_id)
+
+
+@pytest.mark.trio
+async def test_memory_checks_identity_scheme():
+    empty_identity_scheme_registry = IdentitySchemeRegistry()
+    memory_db = MemoryEnrDb(empty_identity_scheme_registry)
+    enr = ENRFactory()
+
+    with pytest.raises(ValueError):
+        await memory_db.insert(enr)
+    with pytest.raises(ValueError):
+        await memory_db.insert_or_update(enr)

--- a/tests-trio/p2p-trio/test_enr_db.py
+++ b/tests-trio/p2p-trio/test_enr_db.py
@@ -7,8 +7,11 @@ from p2p.discv5.identity_schemes import (
     default_identity_scheme_registry,
     IdentitySchemeRegistry,
 )
-from p2p.tools.factories import (
+
+from p2p.tools.factories.discovery import (
     ENRFactory,
+)
+from p2p.tools.factories.keys import (
     PrivateKeyFactory,
 )
 


### PR DESCRIPTION
### What was wrong?

We need to store ENRs somehow.

### How was it fixed?

Define an interface for ENR DBs and provide a simple in-memory implementation.

This PR builds on top of #920 because it uses the `ENRFactory` in the tests added there. Other than that it's independent.

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://user-images.githubusercontent.com/29854669/63022445-3afb3880-bea3-11e9-9286-c940c635aef7.jpg)