### PR TITLE
Expose force-beam-block-number parameter on command line

### DIFF
--- a/newsfragments/923.feature.rst
+++ b/newsfragments/923.feature.rst
@@ -1,0 +1,2 @@
+Expose the `force-beam-block-number` config as a command line parameter.
+The config is useful for testing to force beam sync to activate on a given block number.

--- a/trinity/sync/beam/service.py
+++ b/trinity/sync/beam/service.py
@@ -21,6 +21,7 @@ class BeamSyncService(BaseService):
             base_db: BaseAsyncDB,
             peer_pool: ETHPeerPool,
             event_bus: EndpointAPI,
+            force_beam_block_number: int = None,
             token: CancelToken = None) -> None:
         super().__init__(token)
         self.chain = chain
@@ -28,6 +29,7 @@ class BeamSyncService(BaseService):
         self.base_db = base_db
         self.peer_pool = peer_pool
         self.event_bus = event_bus
+        self.force_beam_block_number = force_beam_block_number
 
     async def _run(self) -> None:
         head = await self.wait(self.chaindb.coro_get_canonical_head())
@@ -38,6 +40,7 @@ class BeamSyncService(BaseService):
             self.chaindb,
             self.peer_pool,
             self.event_bus,
+            self.force_beam_block_number,
             token=self.cancel_token,
         )
         await beam_syncer.run()


### PR DESCRIPTION
### What was wrong?

The `force_beam_block_number` config is very useful for testing. I think it's worth exposing it as a CLI argument.

### How was it fixed?

1. In general, allow sync strategies to make modifications to the parser
2. Have the beam sync strategy add this specific config.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

[//]: # (See: https://trinity-client.readthedocs.io/en/latest/contributing.html#pull-requests)
- [x] Add entry to the [release notes](https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://www.hssv.org/wp-content/uploads/2019/04/Crazy-Kitten-300x300.jpg)
