### PR TITLE
Protocol.__eq__ and Protocol.__hash__

### DIFF
--- a/newsfragments/924.feature.rst
+++ b/newsfragments/924.feature.rst
@@ -1,0 +1,1 @@
+``p2p.protocol.Protocol`` now supports equality checking and is hashable.

--- a/p2p/protocol.py
+++ b/p2p/protocol.py
@@ -2,6 +2,7 @@ import logging
 import operator
 import struct
 from typing import (
+    Any,
     ClassVar,
     Iterable,
     Sequence,
@@ -163,6 +164,12 @@ class Protocol(ProtocolAPI):
         )
         self.cmd_by_type = {type(cmd): cmd for cmd in self.commands}
         self.cmd_by_id = {cmd.cmd_id: cmd for cmd in self.commands}
+
+    def __eq__(self, other: Any) -> bool:
+        return type(self) is type(other)
+
+    def __hash__(self) -> int:
+        return hash(type(self))
 
     @property
     def logger(self) -> logging.Logger:


### PR DESCRIPTION
### What was wrong?

Work in #684 has me needing the `Protocol` class to be hashable and to be able to compare protocol classes.

### How was it fixed?

Added `__eq__` and `__hash__` implementations.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

[//]: # (See: https://trinity-client.readthedocs.io/en/latest/contributing.html#pull-requests)
- [x] Add entry to the [release notes](https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![names-for-big-dogs](https://user-images.githubusercontent.com/824194/63045772-498b2500-be8e-11e9-842e-a385a318d43e.jpeg)

