### PR TITLE
Add MultiplexerAPI.cancel_token

### DIFF
--- a/newsfragments/927.misc.rst
+++ b/newsfragments/927.misc.rst
@@ -1,0 +1,1 @@
+Add ``MultiplexerAPI.cancel_token`` property.

--- a/p2p/abc.py
+++ b/p2p/abc.py
@@ -255,6 +255,8 @@ TProtocol = TypeVar('TProtocol', bound=ProtocolAPI)
 
 
 class MultiplexerAPI(ABC):
+    cancel_token: CancelToken
+
     #
     # Transport API
     #


### PR DESCRIPTION
### What was wrong?

In later work for #684 we need to use the multiplexer's cancel token but the formal API doesn't have a cancel token property.

### How was it fixed?

Added the property to the `MultiplexerAPI`.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

[//]: # (See: https://trinity-client.readthedocs.io/en/latest/contributing.html#pull-requests)
- [x] Add entry to the [release notes](https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![top-10-large-breed-dogs](https://user-images.githubusercontent.com/824194/63045851-76d7d300-be8e-11e9-9d92-8c6669709b61.jpeg)

