### PR TITLE
Remove most received message count from peer stats

### DIFF
--- a/newsfragments/928.misc.rst
+++ b/newsfragments/928.misc.rst
@@ -1,0 +1,1 @@
+Removes the most received message count from the general peer stats (it is still available in the detail data printed about each message type the peer has received)

--- a/p2p/peer_pool.py
+++ b/p2p/peer_pool.py
@@ -484,12 +484,12 @@ class BasePeerPool(BaseService, AsyncIterable[BasePeer]):
                     self.logger.warning(
                         "%s is no longer alive but has not been removed from pool", peer)
                     continue
-                most_received_type, count = max(
-                    peer.received_msgs.items(), key=operator.itemgetter(1))
                 self.logger.debug(
-                    "%s: uptime=%s, received_msgs=%d, most_received=%s(%d)",
-                    peer, humanize_seconds(peer.uptime), peer.received_msgs_count,
-                    most_received_type, count)
+                    "%s: uptime=%s, received_msgs=%d",
+                    peer,
+                    humanize_seconds(peer.uptime),
+                    peer.received_msgs_count,
+                )
                 self.logger.debug("client_version_string='%s'", peer.client_version_string)
                 for line in peer.get_extra_stats():
                     self.logger.debug("    %s", line)


### PR DESCRIPTION
### What was wrong?

In an upcoming PR for #684 I encountered an issue where when there are no stats this code throws an error.

### How was it fixed?

Since the counts are available in the detailed stats printed for each message type I removed this stat as it didn't seem incredibly useful.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

[//]: # (See: https://trinity-client.readthedocs.io/en/latest/contributing.html#pull-requests)
- [x] Add entry to the [release notes](https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![proxy duckduckgo com](https://user-images.githubusercontent.com/824194/63054828-db505d80-bea1-11e9-87cb-2c22d6930613.jpeg)

