### PR TITLE
BaseService cleanup

### DIFF
--- a/newsfragments/929.misc.rst
+++ b/newsfragments/929.misc.rst
@@ -1,0 +1,1 @@
+Additional logging output in ``BaseService`` when cancel token has already been triggered and a small sleep to allow cleanup a little extra time to cancel background tasks.


### PR DESCRIPTION
### What was wrong?

The logging message that `BaseService` outputs when it encounters an attempt to start a service that has already been started doesn't signal how the cancellation token was cancelled.

### How was it fixed?

Added information about where the cancellation came from to the logging output.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

[//]: # (See: https://trinity-client.readthedocs.io/en/latest/contributing.html#pull-requests)
- [x] Add entry to the [release notes](https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![Dogge_Odin](https://user-images.githubusercontent.com/824194/63054637-7eed3e00-bea1-11e9-947e-d26c0b59cb82.jpg)

