### PR TITLE
MemoryTransport logging messages

### DIFF
--- a/newsfragments/930.misc.rst
+++ b/newsfragments/930.misc.rst
@@ -1,0 +1,1 @@
+Add additional logging to ``MemoryTransport`` when sending or waiting on messages.


### PR DESCRIPTION
### What was wrong?

The `MemoryTransport` is primarily used in testing and it helps to have some logging messages about what happens under the hood.

### How was it fixed?

Added logging statements when sending or receiving messages.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

[//]: # (See: https://trinity-client.readthedocs.io/en/latest/contributing.html#pull-requests)
- [x] Add entry to the [release notes](https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![big](https://user-images.githubusercontent.com/824194/63054246-b9a2a680-bea0-11e9-9ffc-6018752923fb.jpg)

