### PR TITLE
Add BasePeerContext.p2p_version

### DIFF
--- a/newsfragments/931.feature.rst
+++ b/newsfragments/931.feature.rst
@@ -1,0 +1,1 @@
+Add ``p2p_version`` to ``p2p.peer.BasePeerContext`` properties and use for handshake.

--- a/p2p/auth.py
+++ b/p2p/auth.py
@@ -40,7 +40,7 @@ from .constants import (
     HASH_LEN,
     PUBKEY_LEN,
     SIGNATURE_LEN,
-    SUPPORTED_RLPX_VERSION,
+    DEVP2P_V4,
 )
 
 
@@ -195,7 +195,7 @@ class HandshakeInitiator(HandshakeBase):
 
         if self.use_eip8:
             data = rlp.encode(
-                [S, self.pubkey.to_bytes(), nonce, SUPPORTED_RLPX_VERSION], sedes=eip8_auth_sedes)
+                [S, self.pubkey.to_bytes(), nonce, DEVP2P_V4], sedes=eip8_auth_sedes)
             return _pad_eip8_data(data)
         else:
             # S || H(ephemeral-pubk) || pubk || nonce || 0x0
@@ -222,7 +222,7 @@ class HandshakeResponder(HandshakeBase):
     def create_auth_ack_message(self, nonce: bytes) -> bytes:
         if self.use_eip8:
             data = rlp.encode(
-                (self.ephemeral_pubkey.to_bytes(), nonce, SUPPORTED_RLPX_VERSION),
+                (self.ephemeral_pubkey.to_bytes(), nonce, DEVP2P_V4),
                 sedes=eip8_ack_sedes)
             msg = _pad_eip8_data(data)
         else:
@@ -279,7 +279,7 @@ def decode_ack_plain(
         raise BadAckMessage(f"Unexpected size for ack message: {len(message)}")
     eph_pubkey = keys.PublicKey(message[:PUBKEY_LEN])
     nonce = message[PUBKEY_LEN: PUBKEY_LEN + HASH_LEN]
-    return eph_pubkey, nonce, SUPPORTED_RLPX_VERSION
+    return eph_pubkey, nonce, DEVP2P_V4
 
 
 def decode_ack_eip8(
@@ -308,7 +308,7 @@ def decode_auth_plain(ciphertext: bytes, privkey: datatypes.PrivateKey) -> Tuple
     pubkey = keys.PublicKey(message[pubkey_start: pubkey_start + PUBKEY_LEN])
     nonce_start = pubkey_start + PUBKEY_LEN
     nonce = message[nonce_start: nonce_start + HASH_LEN]
-    return signature, pubkey, nonce, SUPPORTED_RLPX_VERSION
+    return signature, pubkey, nonce, DEVP2P_V4
 
 
 def decode_auth_eip8(ciphertext: bytes, privkey: datatypes.PrivateKey) -> Tuple[

--- a/p2p/constants.py
+++ b/p2p/constants.py
@@ -1,7 +1,6 @@
-SUPPORTED_RLPX_VERSION = 4
-
-# The p2p protocol version from which Snappy Compression is Enabled
-SNAPPY_PROTOCOL_VERSION = 5
+# DEVP2P Protocol versions
+DEVP2P_V4 = 4
+DEVP2P_V5 = 5
 
 # Overhead added by ECIES encryption
 ENCRYPT_OVERHEAD_LENGTH = 113

--- a/p2p/handshake.py
+++ b/p2p/handshake.py
@@ -23,7 +23,7 @@ from eth.tools.logging import ExtendedDebugLogger
 from p2p._utils import duplicates
 from p2p.abc import TransportAPI, MultiplexerAPI
 from p2p.constants import (
-    SNAPPY_PROTOCOL_VERSION,
+    DEVP2P_V5,
 )
 from p2p.exceptions import (
     HandshakeFailure,
@@ -151,13 +151,8 @@ async def _do_p2p_handshake(transport: TransportAPI,
                             p2p_handshake_params: DevP2PHandshakeParams,
                             base_protocol: BaseP2PProtocol,
                             token: CancelToken) -> Tuple[DevP2PReceipt, BaseP2PProtocol]:
-    client_version_string, listen_port, version = p2p_handshake_params
-    if version != base_protocol.version:
-        raise Exception(
-            f"Protocol class has versin `{base_protocol.version}` but handshake "
-            f"params have version `{version}`"
-        )
-    base_protocol.send_handshake(client_version_string, capabilites, listen_port)
+    client_version_string, listen_port, p2p_version = p2p_handshake_params
+    base_protocol.send_handshake(client_version_string, capabilites, listen_port, p2p_version)
 
     # The base `p2p` protocol handshake directly streams the messages as it has
     # strict requirements about receiving the `Hello` message first.
@@ -172,10 +167,10 @@ async def _do_p2p_handshake(transport: TransportAPI,
 
         protocol: BaseP2PProtocol
 
-        if base_protocol.version >= SNAPPY_PROTOCOL_VERSION:
+        if base_protocol.version >= DEVP2P_V5:
             # Check whether to support Snappy Compression or not
             # based on other peer's p2p protocol version
-            snappy_support = msg['version'] >= SNAPPY_PROTOCOL_VERSION
+            snappy_support = msg['version'] >= DEVP2P_V5
 
             if snappy_support:
                 # Now update the base protocol to support snappy compression

--- a/p2p/p2p_proto.py
+++ b/p2p/p2p_proto.py
@@ -4,6 +4,7 @@ from typing import (
     Dict,
 )
 
+from eth_utils import ValidationError
 from eth_utils.toolz import assoc
 
 import rlp
@@ -87,7 +88,13 @@ class BaseP2PProtocol(Protocol):
             self,
             client_version_string: str,
             capabilities: Capabilities,
-            listen_port: int) -> None:
+            listen_port: int,
+            p2p_version: int) -> None:
+        if p2p_version != self.version:
+            raise ValidationError(
+                f"P2P version mismatch.  Handshake parameters set as "
+                f"v{p2p_version} but protocol class has v{self.version}"
+            )
         self.send_hello(
             version=self.version,
             client_version_string=client_version_string,

--- a/p2p/peer.py
+++ b/p2p/peer.py
@@ -66,7 +66,7 @@ from p2p.tracking.connection import (
 
 from .constants import (
     BLACKLIST_SECONDS_BAD_PROTOCOL,
-    SNAPPY_PROTOCOL_VERSION,
+    DEVP2P_V5,
 )
 
 if TYPE_CHECKING:
@@ -149,10 +149,15 @@ class BasePeerBootManager(BaseService):
 class BasePeerContext:
     client_version_string: str
     listen_port: int
+    p2p_version: int
 
-    def __init__(self, client_version_string: str, listen_port: int) -> None:
+    def __init__(self,
+                 client_version_string: str,
+                 listen_port: int,
+                 p2p_version: int) -> None:
         self.client_version_string = client_version_string
         self.listen_port = listen_port
+        self.p2p_version = p2p_version
 
 
 class BasePeer(BaseService):
@@ -324,6 +329,7 @@ class BasePeer(BaseService):
             client_version_string=self.context.client_version_string,
             capabilities=self.capabilities,
             listen_port=self.context.listen_port,
+            p2p_version=self.context.p2p_version,
         )
 
         cmd, msg = await self.read_msg()
@@ -473,7 +479,7 @@ class BasePeer(BaseService):
 
         # Check whether to support Snappy Compression or not
         # based on other peer's p2p protocol version
-        snappy_support = msg['version'] >= SNAPPY_PROTOCOL_VERSION
+        snappy_support = msg['version'] >= DEVP2P_V5
 
         if snappy_support:
             # Now update the base protocol to support snappy compression

--- a/p2p/tools/factories.py
+++ b/p2p/tools/factories.py
@@ -19,6 +19,7 @@ from eth_keys import keys
 from p2p import auth
 from p2p import discovery
 from p2p.abc import AddressAPI, NodeAPI, ProtocolAPI, TransportAPI, MultiplexerAPI
+from p2p.constants import DEVP2P_V5
 from p2p.ecies import generate_privkey
 from p2p.handshake import DevP2PHandshakeParams
 from p2p.kademlia import Node, Address
@@ -415,7 +416,7 @@ class DevP2PHandshakeParamsFactory(factory.Factory):
 
     listen_port = 30303
     client_version_string = 'test'
-    version = 5
+    version = DEVP2P_V5
 
 
 class AuthTagPacketFactory(factory.Factory):

--- a/p2p/tools/paragon/helpers.py
+++ b/p2p/tools/paragon/helpers.py
@@ -12,9 +12,10 @@ from cancel_token import CancelToken
 
 from p2p import ecies
 from p2p import protocol
+from p2p.constants import DEVP2P_V4
 from p2p.disconnect import DisconnectReason
 from p2p.exceptions import HandshakeFailure
-from p2p.p2p_proto import Hello
+from p2p.p2p_proto import Hello, P2PProtocolV4
 from p2p.peer import (
     BasePeer,
     BasePeerFactory,
@@ -182,7 +183,12 @@ async def get_directly_linked_v4_and_v5_peers(
     )
 
     # Tweaking the P2P Protocol Versions for Alice
-    alice.base_protocol.version = 4  # type: ignore  # mypy doesn't like us overwriting class variables  # noqa: E501
+    alice.base_protocol = P2PProtocolV4(  # type: ignore
+        transport=alice.base_protocol.transport,
+        cmd_id_offset=0,
+        snappy_support=False,
+    )
+    alice.context.p2p_version = DEVP2P_V4
     alice.process_p2p_handshake = MethodType(process_v4_p2p_handshake, alice)  # type: ignore  # mypy still support method overwrites  # noqa: E501
 
     # Perform the base protocol (P2P) handshake.

--- a/p2p/tools/paragon/peer.py
+++ b/p2p/tools/paragon/peer.py
@@ -3,6 +3,7 @@ from typing import (
 )
 
 from p2p.abc import CommandAPI
+from p2p.constants import DEVP2P_V5
 from p2p.peer import (
     BasePeer,
     BasePeerContext,
@@ -36,8 +37,9 @@ class ParagonContext(BasePeerContext):
 
     def __init__(self,
                  client_version_string: str = 'paragon-test',
-                 listen_port: int = 30303) -> None:
-        super().__init__(client_version_string, listen_port)
+                 listen_port: int = 30303,
+                 p2p_version: int = DEVP2P_V5) -> None:
+        super().__init__(client_version_string, listen_port, p2p_version)
 
 
 class ParagonPeerFactory(BasePeerFactory):

--- a/tests/core/p2p-proto/bcc/helpers.py
+++ b/tests/core/p2p-proto/bcc/helpers.py
@@ -32,6 +32,7 @@ from trinity.protocol.bcc.peer import (
 )
 
 from p2p import ecies
+from p2p.constants import DEVP2P_V5
 from p2p.tools.paragon.helpers import (
     get_directly_linked_peers_without_handshake as _get_directly_linked_peers_without_handshake,
     get_directly_linked_peers as _get_directly_linked_peers,
@@ -131,6 +132,7 @@ async def _setup_alice_and_bob_factories(alice_chain_db, bob_chain_db):
         network_id=1,
         client_version_string='alice',
         listen_port=30303,
+        p2p_version=DEVP2P_V5,
     )
 
     alice_factory = BCCPeerFactory(
@@ -147,6 +149,7 @@ async def _setup_alice_and_bob_factories(alice_chain_db, bob_chain_db):
         network_id=1,
         client_version_string='bob',
         listen_port=30304,
+        p2p_version=DEVP2P_V5,
     )
 
     bob_factory = BCCPeerFactory(

--- a/tests/core/peer_helpers.py
+++ b/tests/core/peer_helpers.py
@@ -6,6 +6,7 @@ from eth.chains.mainnet import (
 from eth.db.atomic import AtomicDB
 
 from p2p import ecies
+from p2p.constants import DEVP2P_V5
 from p2p.tools.paragon.helpers import (
     get_directly_linked_peers_without_handshake as _get_directly_linked_peers_without_handshake,
     get_directly_linked_peers as _get_directly_linked_peers,
@@ -54,6 +55,7 @@ async def _setup_alice_and_bob_factories(
         vm_configuration=tuple(),
         client_version_string='alice',
         listen_port=30303,
+        p2p_version=DEVP2P_V5,
     )
 
     if alice_peer_class is ETHPeer:
@@ -81,6 +83,7 @@ async def _setup_alice_and_bob_factories(
         vm_configuration=tuple(),
         client_version_string='bob',
         listen_port=30304,
+        p2p_version=DEVP2P_V5,
     )
 
     if bob_peer_class is ETHPeer:

--- a/tests/integration/test_lightchain_integration.py
+++ b/tests/integration/test_lightchain_integration.py
@@ -22,6 +22,7 @@ from eth.chains.ropsten import (
 from eth.db.atomic import AtomicDB
 
 from p2p import ecies
+from p2p.constants import DEVP2P_V5
 from p2p.kademlia import Node
 
 from trinity.constants import ROPSTEN_NETWORK_ID
@@ -169,6 +170,7 @@ async def test_lightchain_integration(
         vm_configuration=ROPSTEN_VM_CONFIGURATION,
         client_version_string='trinity-test',
         listen_port=30303,
+        p2p_version=DEVP2P_V5,
     )
     peer_pool = LESPeerPool(
         privkey=ecies.generate_privkey(),

--- a/tests/p2p/test_auth.py
+++ b/tests/p2p/test_auth.py
@@ -130,6 +130,7 @@ async def test_handshake():
         client_version_string=initiator_peer.context.client_version_string,
         capabilities=initiator_peer.capabilities,
         listen_port=initiator_peer.context.listen_port,
+        p2p_version=initiator_peer.context.p2p_version,
     )
     responder_transport = Transport(
         remote=responder_remote,
@@ -149,6 +150,7 @@ async def test_handshake():
         client_version_string=responder_peer.context.client_version_string,
         capabilities=responder_peer.capabilities,
         listen_port=responder_peer.context.listen_port,
+        p2p_version=responder_peer.context.p2p_version,
     )
 
     # The handshake msgs sent by each peer (above) are going to be fed directly into their remote's
@@ -248,6 +250,7 @@ async def test_handshake_eip8():
         client_version_string=initiator_peer.context.client_version_string,
         capabilities=initiator_peer.capabilities,
         listen_port=initiator_peer.context.listen_port,
+        p2p_version=initiator_peer.context.p2p_version,
     )
     responder_transport = Transport(
         remote=responder_remote,
@@ -267,6 +270,7 @@ async def test_handshake_eip8():
         client_version_string=responder_peer.context.client_version_string,
         capabilities=responder_peer.capabilities,
         listen_port=responder_peer.context.listen_port,
+        p2p_version=responder_peer.context.p2p_version,
     )
 
     # The handshake msgs sent by each peer (above) are going to be fed directly into their remote's

--- a/trinity/protocol/bcc/context.py
+++ b/trinity/protocol/bcc/context.py
@@ -8,7 +8,8 @@ class BeaconContext(BasePeerContext):
                  chain_db: BaseAsyncBeaconChainDB,
                  network_id: int,
                  client_version_string: str,
-                 listen_port: int) -> None:
-        super().__init__(client_version_string, listen_port)
+                 listen_port: int,
+                 p2p_version: int) -> None:
+        super().__init__(client_version_string, listen_port, p2p_version)
         self.chain_db = chain_db
         self.network_id = network_id

--- a/trinity/protocol/common/context.py
+++ b/trinity/protocol/common/context.py
@@ -17,8 +17,9 @@ class ChainContext(BasePeerContext):
                  vm_configuration: Tuple[Tuple[int, Type[VirtualMachineAPI]], ...],
                  client_version_string: str,
                  listen_port: int,
+                 p2p_version: int,
                  ) -> None:
-        super().__init__(client_version_string, listen_port)
+        super().__init__(client_version_string, listen_port, p2p_version)
         self.headerdb = headerdb
         self.network_id = network_id
         self.vm_configuration = vm_configuration


### PR DESCRIPTION
### What was wrong?

The base protocol version should come from the handshake parameters (this is used in later work under #684 to cleanup how the base protocol is tested).

### How was it fixed?

Changed where the version comes from to allow it to be passed in as part of the handshake parameters.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

[//]: # (See: https://trinity-client.readthedocs.io/en/latest/contributing.html#pull-requests)
- [x] Add entry to the [release notes](https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![bernese-mountain-dog-ap-0t0bvi-590](https://user-images.githubusercontent.com/824194/63053540-2fa60e00-be9f-11e9-853f-24fbc6f3cd68.jpg)

