### PR TITLE
Beam sync fix hang

### DIFF
--- a/newsfragments/932.bugfix.rst
+++ b/newsfragments/932.bugfix.rst
@@ -1,0 +1,2 @@
+Fix a deadlock bug: if you request data from a peer at just the wrong moment, the request would hang
+forever. Now, it correctly raises an :cls:`OperationCancelled`.

--- a/newsfragments/932.misc.rst
+++ b/newsfragments/932.misc.rst
@@ -1,0 +1,1 @@
+Some logging reduction

--- a/newsfragments/932.performance.rst
+++ b/newsfragments/932.performance.rst
@@ -1,0 +1,2 @@
+Previously, we gave up on predicted nodes that were not returned by a peer. Now we retry them,
+which helps make sure we aren't missing any nodes at block import time.

--- a/trinity/protocol/common/managers.py
+++ b/trinity/protocol/common/managers.py
@@ -273,7 +273,7 @@ class ExchangeManager(Generic[TRequestPayload, TResponsePayload, TResult]):
             self._cancel_token,
         )
         self._peer.run_daemon(self._response_stream)
-        await self._response_stream.events.started.wait()
+        await self._peer.wait(self._response_stream.events.started.wait())
 
     @property
     def is_operational(self) -> bool:
@@ -345,7 +345,7 @@ class ExchangeManager(Generic[TRequestPayload, TResponsePayload, TResult]):
                 stream.complete_request()
                 return result
 
-        raise ValidationError("Manager is not pending a response, but no valid response received")
+        raise PeerConnectionLost(f"Response stream of {self._peer} was apparently closed")
 
     @property
     def service(self) -> BaseService:

--- a/trinity/sync/beam/constants.py
+++ b/trinity/sync/beam/constants.py
@@ -10,7 +10,7 @@ REQUEST_BUFFER_MULTIPLIER = 16
 
 # How long should we wait after a peer gives us an empty response for node data,
 # before we ask for some new data from them? Measured in seconds.
-EMPTY_PEER_RESPONSE_PENALTY = 1
+EMPTY_PEER_RESPONSE_PENALTY = 5
 
 # How many different processes are running previews? They will split the
 # block imports equally. A higher number means a slower startup, but more

--- a/trinity/sync/beam/state.py
+++ b/trinity/sync/beam/state.py
@@ -75,7 +75,7 @@ class BeamDownloader(BaseService, PeerSubscriber):
     _total_requests = 0
     _timer = Timer(auto_start=False)
     _report_interval = 10  # Number of seconds between progress reports.
-    _reply_timeout = 20  # seconds
+    _reply_timeout = 1  # seconds
 
     # We are only interested in peers entering or leaving the pool
     subscription_msg_types: FrozenSet[Type[CommandAPI]] = frozenset()

--- a/trinity/sync/beam/state.py
+++ b/trinity/sync/beam/state.py
@@ -397,9 +397,7 @@ class BeamDownloader(BaseService, PeerSubscriber):
             self._node_tasks.complete(urgent_batch_id, tuple(urgent_nodes.keys()))
 
         if predictive_batch_id is not None:
-            # retire all predictions, if the responding node doesn't have them, then we don't
-            # want to keep asking
-            self._maybe_useful_nodes.complete(predictive_batch_id, predictive_node_hashes)
+            self._maybe_useful_nodes.complete(predictive_batch_id, tuple(predictive_nodes.keys()))
 
         self._urgent_processed_nodes += len(urgent_nodes)
         for node_hash in predictive_nodes.keys():

--- a/trinity/sync/beam/state.py
+++ b/trinity/sync/beam/state.py
@@ -386,7 +386,7 @@ class BeamDownloader(BaseService, PeerSubscriber):
             raise ValidationError(f"All nodes must be either urgent or predictive")
 
         if len(urgent_nodes) == 0 and urgent_batch_id is not None:
-            self.logger.info("%s returned no urgent nodes from %r", peer, urgent_node_hashes)
+            self.logger.debug("%s returned no urgent nodes from %r", peer, urgent_node_hashes)
 
         # batch all DB writes into one, for performance
         with self._db.atomic_batch() as batch:
@@ -454,7 +454,7 @@ class BeamDownloader(BaseService, PeerSubscriber):
             return tuple()
         except OperationCancelled:
             self.logger.debug(
-                "Service cancellation while fetching segment, dropping %s from queue",
+                "Service cancellation while fetching nodes, dropping %s from queue",
                 peer,
                 exc_info=True,
             )

--- a/trinity/sync/common/headers.py
+++ b/trinity/sync/common/headers.py
@@ -867,7 +867,7 @@ class BaseHeaderChainSyncer(BaseService, HeaderSyncerAPI, Generic[TChainPeer]):
             try:
                 await self._validate_peer_is_ahead(peer)
             except _PeerBehind:
-                self.logger.info("At or behind peer %s, skipping skeleton sync", peer)
+                self.logger.debug("At or behind peer %s, skipping skeleton sync", peer)
             else:
                 async with self._get_skeleton_syncer(peer) as syncer:
                     await self._full_skeleton_sync(syncer)
@@ -961,7 +961,7 @@ class BaseHeaderChainSyncer(BaseService, HeaderSyncerAPI, Generic[TChainPeer]):
         head = await self.wait(self._db.coro_get_canonical_head())
         head_td = await self.wait(self._db.coro_get_score(head.hash))
         if peer.head_td <= head_td:
-            self.logger.info(
+            self.logger.debug(
                 "Head TD (%d) announced by %s not higher than ours (%d), not syncing",
                 peer.head_td, peer, head_td)
             raise _PeerBehind(f"{peer} is behind us, not a valid target for sync")

--- a/trinity/sync/full/constants.py
+++ b/trinity/sync/full/constants.py
@@ -27,4 +27,4 @@ BLOCK_QUEUE_SIZE_TARGET = 1000
 #   causing a massive slowdown.
 # Every block gets previewed, and a block only enters the queue if another block import
 #   is active. So a queue size of 3 means that up to 4 previews are happening at once.
-BLOCK_IMPORT_QUEUE_SIZE = 7
+BLOCK_IMPORT_QUEUE_SIZE = 15


### PR DESCRIPTION
### What was wrong?

If a peer cancelled at just the right moment, your data request could hang indefinitely. If this is a `GetNodeData` request in Beam Sync, the whole sync service can get stuck.

### How was it fixed?

When waiting for the response stream to launch, wrap it in a call that gets cancelled if the peer is shut down.

Also, some other random Beam Sync fixups.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

[//]: # (See: https://trinity-client.readthedocs.io/en/latest/contributing.html#pull-requests)
- [x] Add entry to the [release notes](https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://usercontent1.hubstatic.com/12725838_f520.jpg)
