### PR TITLE
Beam Sync: preview the nodes needed for trie fixup

### DIFF
--- a/newsfragments/933.performance.rst
+++ b/newsfragments/933.performance.rst
@@ -1,0 +1,2 @@
+During Beam Sync previews, be sure to collect the nodes required to generate the new state root,
+rather than wait until it's time to import the block.

--- a/trinity/sync/beam/importer.py
+++ b/trinity/sync/beam/importer.py
@@ -296,6 +296,9 @@ def pausing_vm_decorator(
         def persist(self) -> Optional[Any]:
             return self._pause_on_missing_data(super().persist)
 
+        def make_state_root(self) -> Optional[Any]:
+            return self._pause_on_missing_data(super().make_state_root)
+
     class PausingVM(original_vm_class):  # type: ignore
         @classmethod
         def get_state_class(cls) -> Type[StateAPI]:
@@ -413,6 +416,7 @@ def partial_trigger_missing_state_downloads(
         # this won't actually save the results, but all we need to do is generate the trie requests
         t = Timer()
         vm.apply_all_transactions(transactions, unused_header)
+        vm.state.make_state_root()
         preview_time = t.elapsed
 
         beam_stats = vm.get_beam_stats()


### PR DESCRIPTION
### What was wrong?

Even when a block was fully previewed, we got stuck asking for trie nodes in real time. Even just a few nodes requested in real-time can really cause you to lag, especially when working with remote peers.

### How was it fixed?

Look for and collect the nodes needed to build the trie, by calling `make_state_root()` at the end of the block preview.

This had the desired effect: in all my testing, when a preview is completed before the real-time import starts, 100% of the required nodes were already collected.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

[//]: # (See: https://trinity-client.readthedocs.io/en/latest/contributing.html#pull-requests)
- [x] Add entry to the [release notes](https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](http://earthporm.com/wp-content/uploads/2015/04/cute-animals-hokkaido-ezo-japan-11.jpg)