### PR TITLE
Fix ETH and LES Handshake receipts to contain protocol instance

### DIFF
--- a/newsfragments/934.bugfix.rst
+++ b/newsfragments/934.bugfix.rst
@@ -1,0 +1,1 @@
+``ETHHandshakeReceipt`` and ``LESHandshakeReceipt`` now properly accept their protocol instances in their constructors.

--- a/trinity/protocol/eth/handshaker.py
+++ b/trinity/protocol/eth/handshaker.py
@@ -21,7 +21,8 @@ from .commands import Status
 class ETHHandshakeReceipt(HandshakeReceipt):
     handshake_params: ETHHandshakeParams
 
-    def __init__(self, handshake_params: ETHHandshakeParams) -> None:
+    def __init__(self, protocol: ETHProtocol, handshake_params: ETHHandshakeParams) -> None:
+        super().__init__(protocol)
         self.handshake_params = handshake_params
 
 
@@ -48,13 +49,14 @@ class ETHHandshaker(Handshaker):
 
             msg = cast(Dict[str, Any], msg)
 
-            receipt = ETHHandshakeReceipt(ETHHandshakeParams(
+            remote_params = ETHHandshakeParams(
                 version=msg['protocol_version'],
                 network_id=msg['network_id'],
                 total_difficulty=msg['td'],
                 head_hash=msg['best_hash'],
                 genesis_hash=msg['genesis_hash'],
-            ))
+            )
+            receipt = ETHHandshakeReceipt(protocol, remote_params)
 
             if receipt.handshake_params.network_id != self.handshake_params.network_id:
                 raise WrongNetworkFailure(


### PR DESCRIPTION
### What was wrong?

The `p2p.handshake.Handshaker` API expects the instance of the `Protocol` to be passed to it in the base constructor.  The `ETH` and `LES` receipt classes were not doing this.

### How was it fixed?

Added the parameter to the constructor.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

[//]: # (See: https://trinity-client.readthedocs.io/en/latest/contributing.html#pull-requests)
- [x] Add entry to the [release notes](https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![big-dog-names-eight--600x600](https://user-images.githubusercontent.com/824194/63114362-ed89d480-bf51-11e9-8cd7-b8afd847eae5.jpg)

