### PR TITLE
LESHandshakeParams.as_payload_dict no longer takes version

### DIFF
--- a/newsfragments/935.misc.rst
+++ b/newsfragments/935.misc.rst
@@ -1,0 +1,1 @@
+``LESHandshakeParams`` no longer takes a ``version`` parameter to ``as_payload_dict``

--- a/trinity/protocol/les/proto.py
+++ b/trinity/protocol/les/proto.py
@@ -77,11 +77,11 @@ class LESHandshakeParams(NamedTuple):
     flow_control_mrr: Optional[int]
     announce_type: Optional[int]
 
-    def as_payload_dict(self, version: int) -> Payload:
-        return self._as_payload_dict(version)
+    def as_payload_dict(self) -> Payload:
+        return self._as_payload_dict()
 
     @to_dict
-    def _as_payload_dict(self, version: int) -> Iterable[Tuple[str, Any]]:
+    def _as_payload_dict(self) -> Iterable[Tuple[str, Any]]:
         yield 'protocolVersion', self.version
         yield 'networkId', self.network_id
         yield 'headTd', self.head_td
@@ -131,7 +131,7 @@ class LESProtocol(Protocol):
                 f"LES protocol version mismatch: "
                 f"params:{handshake_params.version} != proto:{self.version}"
             )
-        resp = handshake_params.as_payload_dict(version=self.version)
+        resp = handshake_params.as_payload_dict()
         cmd = Status(self.cmd_id_offset, self.snappy_support)
         self.transport.send(*cmd.encode(resp))
         self.logger.debug("Sending LES/Status msg: %s", resp)
@@ -253,7 +253,7 @@ class LESProtocolV2(LESProtocol):
                 f"LES protocol version mismatch: "
                 f"params:{handshake_params.version} != proto:{self.version}"
             )
-        resp = handshake_params.as_payload_dict(version=self.version)
+        resp = handshake_params.as_payload_dict()
         cmd = StatusV2(self.cmd_id_offset, self.snappy_support)
         self.logger.debug("Sending LES/Status msg: %s", resp)
         self.transport.send(*cmd.encode(resp))


### PR DESCRIPTION
### What was wrong?

The `LESHandshakeParams` class exposes an `as_payload_dict` which took a parameter to specify the version of the `LES` protocol that should be used.

It was more appropriate to just have this be part of the class parameters.

### How was it fixed?

Added it to the main class parameters.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

[//]: # (See: https://trinity-client.readthedocs.io/en/latest/contributing.html#pull-requests)
- [x] Add entry to the [release notes](https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![landscape-gettyimages-530330473-1](https://user-images.githubusercontent.com/824194/63114771-dc8d9300-bf52-11e9-8c13-9df265117d87.jpg)

