### PR TITLE
Fix CI failing

### DIFF
--- a/newsfragments/936.bugfix.rst
+++ b/newsfragments/936.bugfix.rst
@@ -1,0 +1,1 @@
+Pin ``lahja==0.14.0`` until connection timeout issue is resolved.

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,9 @@ deps = {
         "plyvel==1.0.5",
         PYEVM_DEPENDENCY,
         "web3==4.4.1",
-        "lahja>=0.14.0,<0.15.0",
+        "lahja==0.14.0",
+        # Exact version pin until connection timeout issue is resolved
+        # "lahja>=0.14.0,<0.15.0",
         "termcolor>=1.1.0,<2.0.0",
         "uvloop==0.11.2;platform_system=='Linux' or platform_system=='Darwin' or platform_system=='FreeBSD'",  # noqa: E501
         "websockets==5.0.1",


### PR DESCRIPTION
### What was wrong?

Endpoint connections attempts in CI are timing out for lahja.  This has something to do with `lahja==0.14.1`

### How was it fixed?

Pin to `0.14.0`

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

[//]: # (See: https://trinity-client.readthedocs.io/en/latest/contributing.html#pull-requests)
- [x] Add entry to the [release notes](https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![top-10-large-breed-dogs](https://user-images.githubusercontent.com/824194/63115015-7ead7b00-bf53-11e9-938f-58692091e77a.jpeg)

