### PR TITLE
Negotiate base protocol version based on broadcast p2p version

### DIFF
--- a/newsfragments/942.bugfix.rst
+++ b/newsfragments/942.bugfix.rst
@@ -1,0 +1,1 @@
+Ensure the ``BasePeer`` negotiates the proper base protocol.

--- a/p2p/tools/paragon/helpers.py
+++ b/p2p/tools/paragon/helpers.py
@@ -183,7 +183,7 @@ async def get_directly_linked_v4_and_v5_peers(
     )
 
     # Tweaking the P2P Protocol Versions for Alice
-    alice.base_protocol = P2PProtocolV4(  # type: ignore
+    alice.base_protocol = P2PProtocolV4(
         transport=alice.base_protocol.transport,
         cmd_id_offset=0,
         snappy_support=False,


### PR DESCRIPTION
### What was wrong?

The `BasePeer` unconditionally uses the `v5` version of the `P2PProtocol`.

### How was it fixed?

Change the way we negotiate the base protocol.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

[//]: # (See: https://trinity-client.readthedocs.io/en/latest/contributing.html#pull-requests)
- [x] Add entry to the [release notes](https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![big-dogs-3](https://user-images.githubusercontent.com/824194/63180851-59307800-c00c-11e9-9801-6a89c75d6f9a.jpg)

