### PR TITLE
Prefer lowest RTT for Beam Sync

### DIFF
--- a/newsfragments/943.bugfix.rst
+++ b/newsfragments/943.bugfix.rst
@@ -1,0 +1,1 @@
+Capture :cls:`PeerConnectionLost` in more places, especially sync.

--- a/newsfragments/943.performance.rst
+++ b/newsfragments/943.performance.rst
@@ -1,0 +1,3 @@
+Use round-trip-time when finding the best peer for Beam Sync (instead of node bandwidth).
+Track timeouts as part of RTT now, so that peers with a lot of short responses and timeouts are
+avoided. Increase number of timeouts before peers are kicked.

--- a/trinity/protocol/common/constants.py
+++ b/trinity/protocol/common/constants.py
@@ -19,5 +19,5 @@ NUM_QUEUED_REQUESTS = 3
 
 # Parameters for the token bucket which manages whether a peer should be
 # disconnected from in the event of a TimeoutError during a request/response.
-TIMEOUT_BUCKET_RATE = 1 / 300  # refill 1 token every 5 minutes
+TIMEOUT_BUCKET_RATE = 1 / 60  # refill 1 token every minute
 TIMEOUT_BUCKET_CAPACITY = 3  # max capacity of 3 tokens

--- a/trinity/protocol/common/managers.py
+++ b/trinity/protocol/common/managers.py
@@ -111,7 +111,7 @@ class ResponseCandidateStream(
                 try:
                     yield await self._get_payload(timeout_remaining)
                 except TimeoutError as err:
-                    tracker.record_timeout()
+                    tracker.record_timeout(total_timeout)
 
                     # If the peer has timeoud out too many times, desconnect
                     # and blacklist them

--- a/trinity/protocol/common/trackers.py
+++ b/trinity/protocol/common/trackers.py
@@ -103,10 +103,13 @@ class BasePerformanceTracker(ABC, HasExtendedDebugLogger, Generic[TRequest, TRes
             f"timeouts={self.total_timeouts}  quality={int(self.response_quality_ema.value)}"
         )
 
-    def record_timeout(self) -> None:
+    def record_timeout(self, timeout: float) -> None:
         self.total_msgs += 1
         self.total_timeouts += 1
         self.response_quality_ema.update(0)
+        self.round_trip_ema.update(timeout)
+        self.round_trip_99th.update(timeout)
+        self.round_trip_stddev.update(timeout)
         self.items_per_second_ema.update(0)
 
     def record_response(self,

--- a/trinity/sync/beam/state.py
+++ b/trinity/sync/beam/state.py
@@ -449,6 +449,9 @@ class BeamDownloader(BaseService, PeerSubscriber):
             node_hashes: Tuple[Hash32, ...]) -> NodeDataBundles:
         try:
             completed_nodes = await self._make_node_request(peer, node_hashes)
+        except PeerConnectionLost:
+            self.logger.debug("%s went away, cancelling the nodes request and moving on...", peer)
+            return tuple()
         except BaseP2PError as exc:
             self.logger.warning("Unexpected p2p err while downloading nodes from %s: %s", peer, exc)
             self.logger.debug("Problem downloading nodes from peer, dropping...", exc_info=True)
@@ -459,9 +462,6 @@ class BeamDownloader(BaseService, PeerSubscriber):
                 peer,
                 exc_info=True,
             )
-            return tuple()
-        except PeerConnectionLost:
-            self.logger.debug("%s went away, cancelling the nodes request and moving on...", peer)
             return tuple()
         except CancelledError:
             self.logger.debug("Pending nodes call to %r future cancelled", peer)

--- a/trinity/sync/beam/state.py
+++ b/trinity/sync/beam/state.py
@@ -523,5 +523,9 @@ class BeamDownloader(BaseService, PeerSubscriber):
             msg += "reqs=%d  " % (self._total_requests)
             msg += "pred_reqs=%d  " % (self._predictive_only_requests)
             msg += "timeouts=%d" % self._total_timeouts
+            msg += "  u_pend=%d" % self._node_tasks.num_pending()
+            msg += "  u_prog=%d" % self._node_tasks.num_in_progress()
+            msg += "  p_pend=%d" % self._maybe_useful_nodes.num_pending()
+            msg += "  p_prog=%d" % self._maybe_useful_nodes.num_in_progress()
             self.logger.info("Beam-Sync: %s", msg)
             await self.sleep(self._report_interval)

--- a/trinity/sync/common/headers.py
+++ b/trinity/sync/common/headers.py
@@ -460,6 +460,9 @@ class SkeletonSyncer(BaseService, Generic[TChainPeer]):
             ))
 
             self.logger.debug2('sync received new headers: %s', headers)
+        except PeerConnectionLost:
+            self.logger.debug("Lost connection to %s while retrieving headers, aborting sync", peer)
+            return tuple()
         except OperationCancelled:
             self.logger.info("Skeleteon sync with %s cancelled", peer)
             return tuple()


### PR DESCRIPTION
### What was wrong?

The items per second is not the right thing to optimize for, especially when we might only be asking for a few items at a time from one peer and many items at a time from another peer.

### How was it fixed?

Favor the lowest round-trip time among peers.

Bonus:
- Now that the Beam download timeout is really short, we don't want to ban peers that are slow-ish just a few times in 5 minutes. Increase the threshold a bit
- Track the timeout time as part of the RTT, so that a high variance peer doesn't show up as really low RTT
- Build a subset API for the Performance Tracker that only needs to read out the stats, rather than know how those stats were generated (with request/response typing)
- Show a bit more stats during beam sync
- capture a few more `PeerConnectionLost` exceptions

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

[//]: # (See: https://trinity-client.readthedocs.io/en/latest/contributing.html#pull-requests)
- [x] Add entry to the [release notes](https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://images.boredomfiles.com/wp-content/uploads/2015/04/13-cute-animals-hokkaido-japan.jpg)
