### PR TITLE
eth_getCode fetches data from beam syncer

### DIFF
--- a/tests/core/json-rpc/test_ipc.py
+++ b/tests/core/json-rpc/test_ipc.py
@@ -8,6 +8,7 @@ import uuid
 from eth._utils.address import (
     force_bytes_to_address,
 )
+from eth_hash.auto import keccak
 from eth_utils.toolz import (
     assoc,
 )
@@ -30,9 +31,11 @@ from trinity.protocol.common.events import (
 )
 from trinity.sync.common.events import (
     CollectMissingAccount,
+    CollectMissingBytecode,
     SyncingRequest,
     SyncingResponse,
     MissingAccountCollected,
+    MissingBytecodeCollected,
 )
 from trinity.sync.common.types import (
     SyncProgress
@@ -612,70 +615,6 @@ async def test_admin_addPeer_fires_message(
     assert event.remote.uri() == enode
 
 
-@pytest.fixture
-def ipc_request(jsonrpc_ipc_pipe_path, event_loop, event_bus, ipc_server):
-    async def make_request(*args):
-        request = build_request(*args)
-        return await get_ipc_response(
-            jsonrpc_ipc_pipe_path, request, event_loop, event_bus
-        )
-    return make_request
-
-
-@pytest.mark.asyncio
-async def test_get_balance_works(
-        ipc_request, funded_address, funded_address_initial_balance):
-    """
-    Sanity check, if we call eth_getBalance we get back the expected response.
-    """
-    response = await ipc_request('eth_getBalance', [funded_address.hex(), 'latest'])
-    assert 'error' not in response
-    assert response['result'] == hex(funded_address_initial_balance)
-
-
-@pytest.fixture
-def missing_node(chain_with_block_validation):
-    chain = chain_with_block_validation
-    state_root = chain.get_canonical_head().state_root
-    return chain.chaindb.db.pop(state_root)
-
-
-@pytest.mark.asyncio
-async def test_fails_when_state_is_missing(
-        ipc_request, funded_address, funded_address_initial_balance, missing_node):
-    """
-    If the state root is missing then eth_getBalance throws an error.
-    """
-    response = await ipc_request('eth_getBalance', [funded_address.hex(), 'latest'])
-    assert 'error' in response
-    assert response['error'].startswith('State trie database is missing node for hash')
-
-
-@pytest.mark.asyncio
-async def test_missing_state_is_fetched_if_fetcher_exists(
-        ipc_request, funded_address, funded_address_initial_balance,
-        missing_node, chain_with_block_validation, event_bus):
-    chain = chain_with_block_validation
-
-    # beam sync is not running, so we receive an error
-    response = await ipc_request('eth_getBalance', [funded_address.hex(), 'latest'])
-    assert 'error' in response
-    assert response['error'].startswith('State trie database is missing node for hash')
-
-    # beam sync starts, it fetches requested nodes from remote peers
-    async def find_and_insert_node(event: CollectMissingAccount):
-        state_root = chain.get_canonical_head().state_root
-        chain.chaindb.db[state_root] = missing_node
-        await event_bus.broadcast(MissingAccountCollected(1), event.broadcast_config())
-    event_bus.subscribe(CollectMissingAccount, find_and_insert_node)
-    await event_bus.wait_until_any_endpoint_subscribed_to(CollectMissingAccount)
-
-    # beam sync fetches the missing node so no error is returned
-    response = await ipc_request('eth_getBalance', [funded_address.hex(), 'latest'])
-    assert 'error' not in response
-    assert response['result'] == hex(funded_address_initial_balance)
-
-
 @pytest.mark.asyncio
 async def test_get_balance_works_for_block_number(
         chain_without_block_validation,
@@ -708,3 +647,124 @@ async def test_get_balance_works_for_block_number(
     ))['result']
 
     assert to_int(hexstr=balance_after) < to_int(hexstr=balance_before)
+
+
+@pytest.fixture
+def ipc_request(jsonrpc_ipc_pipe_path, event_loop, event_bus, ipc_server):
+    async def make_request(*args):
+        request = build_request(*args)
+        return await get_ipc_response(
+            jsonrpc_ipc_pipe_path, request, event_loop, event_bus
+        )
+    return make_request
+
+
+# Test that eth_getBalance works during beam sync
+
+
+@pytest.mark.asyncio
+async def test_get_balance_works(
+        ipc_request, funded_address, funded_address_initial_balance):
+    """
+    Sanity check, if we call eth_getBalance we get back the expected response.
+    """
+    response = await ipc_request('eth_getBalance', [funded_address.hex(), 'latest'])
+    assert 'error' not in response
+    assert response['result'] == hex(funded_address_initial_balance)
+
+
+@pytest.fixture
+def missing_node(chain):
+    state_root = chain.get_canonical_head().state_root
+    return chain.chaindb.db.pop(state_root)
+
+
+@pytest.mark.asyncio
+async def test_fails_when_state_is_missing(ipc_request, funded_address, missing_node):
+    """
+    If the state root is missing then eth_getBalance throws an error.
+    """
+    response = await ipc_request('eth_getBalance', [funded_address.hex(), 'latest'])
+    assert 'error' in response
+    assert response['error'].startswith('State trie database is missing node for hash')
+
+
+@pytest.mark.asyncio
+async def test_missing_state_is_fetched_if_fetcher_exists(
+        ipc_request, funded_address, funded_address_initial_balance,
+        missing_node, chain, event_bus):
+
+    # beam sync is not running, so we receive an error
+    response = await ipc_request('eth_getBalance', [funded_address.hex(), 'latest'])
+    assert 'error' in response
+    assert response['error'].startswith('State trie database is missing node for hash')
+
+    # beam sync starts, it fetches requested nodes from remote peers
+    async def find_and_insert_node(event: CollectMissingAccount):
+        state_root = chain.get_canonical_head().state_root
+        chain.chaindb.db[state_root] = missing_node
+        await event_bus.broadcast(MissingAccountCollected(1), event.broadcast_config())
+    event_bus.subscribe(CollectMissingAccount, find_and_insert_node)
+    await event_bus.wait_until_any_endpoint_subscribed_to(CollectMissingAccount)
+
+    # beam sync fetches the missing node so no error is returned
+    response = await ipc_request('eth_getBalance', [funded_address.hex(), 'latest'])
+    assert 'error' not in response
+    assert response['result'] == hex(funded_address_initial_balance)
+
+
+# The same as above, but for eth_getCode
+
+
+@pytest.fixture
+async def contract_code_hash(genesis_state, simple_contract_address):
+    return keccak(genesis_state[simple_contract_address]['code'])
+
+
+@pytest.mark.asyncio
+async def test_getCode(ipc_request, simple_contract_address, contract_code_hash):
+    """
+    Sanity check, if we call eth_getBalance we get back the expected response.
+    """
+    response = await ipc_request('eth_getCode', [simple_contract_address.hex(), 'latest'])
+    assert 'error' not in response
+    assert keccak(decode_hex(response['result'])) == contract_code_hash
+
+
+@pytest.fixture
+def missing_bytecode(chain, contract_code_hash):
+    return chain.chaindb.db.pop(contract_code_hash)
+
+
+@pytest.mark.asyncio
+async def test_getCode_fails_when_state_is_missing(
+        ipc_request, simple_contract_address, missing_bytecode):
+    """
+    If the state root is missing then eth_getBalance throws an error.
+    """
+    response = await ipc_request('eth_getCode', [simple_contract_address.hex(), 'latest'])
+    assert 'error' in response
+    assert response['error'].startswith('Database is missing bytecode for code hash')
+
+
+@pytest.mark.asyncio
+async def test_missing_code_is_fetched_if_fetcher_exists(
+        ipc_request, simple_contract_address, contract_code_hash, missing_bytecode, chain,
+        event_bus):
+
+    # beam sync is not running, so we receive an error
+    response = await ipc_request('eth_getCode', [simple_contract_address.hex(), 'latest'])
+    assert 'error' in response
+    assert response['error'].startswith('Database is missing bytecode for code hash')
+
+    # beam sync starts, it fetches requested nodes from remote peers
+    async def find_and_insert_node(event: CollectMissingBytecode):
+        chain.chaindb.db[contract_code_hash] = missing_bytecode
+        await event_bus.broadcast(MissingBytecodeCollected(), event.broadcast_config())
+    event_bus.subscribe(CollectMissingBytecode, find_and_insert_node)
+    await event_bus.wait_until_any_endpoint_subscribed_to(CollectMissingBytecode)
+
+    # beam sync fetches the missing node so no error is returned
+    response = await ipc_request('eth_getCode', [simple_contract_address.hex(), 'latest'])
+    assert 'error' not in response
+    assert keccak(decode_hex(response['result'])) == contract_code_hash

--- a/trinity/rpc/modules/eth.py
+++ b/trinity/rpc/modules/eth.py
@@ -207,6 +207,7 @@ class Eth(Eth1ChainRPCModule):
         block = await get_block_at_number(self.chain, at_block)
         return hex(len(block.transactions))
 
+    @retryable
     @format_params(decode_hex, to_int_if_hex)
     async def getCode(self, address: Address, at_block: Union[str, int]) -> str:
         state = await state_at_block(self.chain, at_block)


### PR DESCRIPTION
### What was wrong?

Continuing to address #893, this is the next step after #894.

### Future work:

-  This also needs to intercept MissingStorageTrieNode
- This needs to support and be tested with more RPC methods
- This needs to generate a friendly error if you ask for a state so old the network won't have it (that's also from before we started beam syncing)
- This needs to return a nice error if the beam syncer can't fetch the state (it shouldn't hang forever)
- It'd be nice to include an integration test that actually runs RPCServer and beam sync and verifies that they do the intended thing.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

[//]: # (See: https://trinity-client.readthedocs.io/en/latest/contributing.html#pull-requests)
- [ ] Add entry to the [release notes](https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses]()
