### PR TITLE
Add test for eth_getBalance at a specific block_number

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -19,7 +19,10 @@ from eth_utils import (
 from eth_keys import keys
 
 from eth import constants as eth_constants
-from eth.chains.base import Chain
+from eth.chains.base import (
+    Chain,
+    MiningChain
+)
 from eth.db.atomic import AtomicDB
 # TODO: tests should not be locked into one set of VM rules.  Look at expanding
 # to all mainnet vms.
@@ -277,7 +280,7 @@ def chain_without_block_validation(
         'validate_block': lambda self, block: None,
     }
     SpuriousDragonVMForTesting = SpuriousDragonVM.configure(validate_seal=lambda block: None)
-    klass = Chain.configure(
+    klass = MiningChain.configure(
         __name__='TestChainWithoutBlockValidation',
         vm_configuration=(
             (eth_constants.GENESIS_BLOCK_NUMBER, SpuriousDragonVMForTesting),


### PR DESCRIPTION
### What was wrong?
There was a test missing for the bug fixed in #900


### How was it fixed?
 - Made `chain_without_block_validation` fixture use `MiningChain` in order to send eth from one address to another. I've searched for the usage of this fixture in code and it seems like it was stale and not used anywhere, so was safe to modify it. 
- Added test for` eth_getBalance` at a specific block_number by sending eth to an account from `funded_address` and then by comparing the balance at `block_no_before_transfer` and at `block_no_after_transfer `.
### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

[//]: # (See: https://trinity-client.readthedocs.io/en/latest/contributing.html#pull-requests)
- [ ] Add entry to the [release notes](https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://external-preview.redd.it/zWoVJh1X9XTZLgiErlDMa9e1aFBqBWUu_LRtZSIKzvs.png?width=960&crop=smart&auto=webp&s=997681dd6bdd009a183fde1c3c2301381ed86656)
