### PR TITLE
Loosen bounds of token bucket test for a less flaky CI

### DIFF
--- a/tests/p2p/test_token_bucket.py
+++ b/tests/p2p/test_token_bucket.py
@@ -61,8 +61,8 @@ async def test_token_bucket_hits_limit():
     expected_delta = 10 / 1000 + zero
     delta = end_at - start_at
 
-    # allow up to 5% difference in expected time
-    assert_fuzzy_equal(delta, expected_delta, allowed_drift=0.05)
+    # allow up to 10% difference in expected time
+    assert_fuzzy_equal(delta, expected_delta, allowed_drift=0.1)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
### What was wrong?

This test regularly fails in CI and I'm wondering if loosen the bounds a little were acceptable?

### How was it fixed?

Accept 10 % drift instead of the current 5 % drift.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

[//]: # (See: https://trinity-client.readthedocs.io/en/latest/contributing.html#pull-requests)
- [ ] Add entry to the [release notes](https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcSmwndbhDMw_zRir4OwurJ0cAwpHH9H4UloKInq2Y8YXES4JzKH)
