### PR TITLE
Remove "Fake" chain and database objects in favor of real ones.

### DIFF
--- a/newsfragments/949.removal.rst
+++ b/newsfragments/949.removal.rst
@@ -1,0 +1,1 @@
+Remove the ``FakeAsync...`` classes from tests in favor of using the real versions for things like chain and database objects

--- a/scripts/chainsync.py
+++ b/scripts/chainsync.py
@@ -34,7 +34,7 @@ def _test() -> None:
     from eth.chains.mainnet import MainnetChain, MAINNET_GENESIS_HEADER, MAINNET_VM_CONFIGURATION
     from eth.db.backends.level import LevelDB
     from tests.core.integration_test_helpers import (
-        FakeAsyncMainnetChain, FakeAsyncRopstenChain,
+        AsyncMainnetChain, AsyncRopstenChain,
         connect_to_peers_loop)
     from trinity.constants import DEFAULT_PREFERRED_NODES
     from trinity.protocol.common.context import ChainContext
@@ -73,11 +73,11 @@ def _test() -> None:
     if genesis.hash == ROPSTEN_GENESIS_HEADER.hash:
         network_id = RopstenChain.network_id
         vm_config = ROPSTEN_VM_CONFIGURATION  # type: ignore
-        chain_class = FakeAsyncRopstenChain
+        chain_class = AsyncRopstenChain
     elif genesis.hash == MAINNET_GENESIS_HEADER.hash:
         network_id = MainnetChain.network_id
         vm_config = MAINNET_VM_CONFIGURATION  # type: ignore
-        chain_class = FakeAsyncMainnetChain
+        chain_class = AsyncMainnetChain
     else:
         raise RuntimeError("Unknown genesis: %s", genesis)
 

--- a/tests/core/p2p-proto/bcc/helpers.py
+++ b/tests/core/p2p-proto/bcc/helpers.py
@@ -14,17 +14,12 @@ from eth.constants import (
 )
 from eth.db.atomic import AtomicDB
 
-from eth2.beacon.db.chain import BeaconChainDB
 from eth2.beacon.types.blocks import (
     BeaconBlock,
     BeaconBlockBody,
 )
 
-from tests.core.integration_test_helpers import (
-    async_passthrough,
-)
-
-from trinity.db.beacon.chain import BaseAsyncBeaconChainDB
+from trinity.db.beacon.chain import AsyncBeaconChainDB
 from trinity.protocol.bcc.context import BeaconContext
 from trinity.protocol.bcc.peer import (
     BCCPeerFactory,
@@ -47,27 +42,6 @@ from eth2.configs import (
 )
 
 SERENITY_GENESIS_CONFIG = Eth2GenesisConfig(SERENITY_CONFIG)
-
-
-class FakeAsyncBeaconChainDB(BaseAsyncBeaconChainDB, BeaconChainDB):
-
-    coro_persist_block = async_passthrough('persist_block')
-    coro_get_canonical_block_root = async_passthrough('get_canonical_block_root')
-    coro_get_genesis_block_root = async_passthrough('get_genesis_block_root')
-    coro_get_canonical_block_by_slot = async_passthrough('get_canonical_block_by_slot')
-    coro_get_canonical_head = async_passthrough('get_canonical_head')
-    coro_get_canonical_head_root = async_passthrough('get_canonical_head_root')
-    coro_get_finalized_head = async_passthrough('get_finalized_head')
-    coro_get_block_by_root = async_passthrough('get_block_by_root')
-    coro_get_score = async_passthrough('get_score')
-    coro_block_exists = async_passthrough('block_exists')
-    coro_persist_block_chain = async_passthrough('persist_block_chain')
-    coro_get_state_by_root = async_passthrough('get_state_by_root')
-    coro_persist_state = async_passthrough('persist_state')
-    coro_get_attestation_key_by_root = async_passthrough('get_attestation_key_by_root')
-    coro_attestation_exists = async_passthrough('attestation_exists')
-    coro_exists = async_passthrough('exists')
-    coro_get = async_passthrough('get')
 
 
 def create_test_block(parent=None, genesis_config=SERENITY_GENESIS_CONFIG, **kwargs):
@@ -107,7 +81,7 @@ async def get_chain_db(blocks=(),
                        genesis_config=SERENITY_GENESIS_CONFIG,
                        fork_choice_scoring=higher_slot_scoring):
     db = AtomicDB()
-    chain_db = FakeAsyncBeaconChainDB(db=db, genesis_config=genesis_config)
+    chain_db = AsyncBeaconChainDB(db=db, genesis_config=genesis_config)
     await chain_db.coro_persist_block_chain(
         blocks,
         BeaconBlock,

--- a/tests/integration/test_lightchain_integration.py
+++ b/tests/integration/test_lightchain_integration.py
@@ -25,6 +25,7 @@ from p2p import ecies
 from p2p.constants import DEVP2P_V5
 from p2p.kademlia import Node
 
+from trinity._utils.ipc import kill_popen_gracefully
 from trinity.constants import ROPSTEN_NETWORK_ID
 from trinity.db.eth1.chain import AsyncChainDB
 from trinity.db.eth1.header import AsyncHeaderDB
@@ -32,12 +33,9 @@ from trinity.protocol.common.context import ChainContext
 from trinity.protocol.les.peer import LESPeerPool
 from trinity.sync.light.chain import LightChainSyncer
 from trinity.sync.light.service import LightPeerChain
-from trinity._utils.ipc import (
-    kill_popen_gracefully,
-)
+from trinity.tools.chain import AsyncRopstenChain
 
 from tests.core.integration_test_helpers import (
-    FakeAsyncRopstenChain,
     connect_to_peers_loop,
 )
 
@@ -176,7 +174,7 @@ async def test_lightchain_integration(
         privkey=ecies.generate_privkey(),
         context=context,
     )
-    chain = FakeAsyncRopstenChain(base_db)
+    chain = AsyncRopstenChain(base_db)
     syncer = LightChainSyncer(chain, chaindb, peer_pool)
     syncer.min_peers_to_sync = 1
     peer_chain = LightPeerChain(headerdb, peer_pool)

--- a/tests/plugins/eth2/beacon/test_receive_server.py
+++ b/tests/plugins/eth2/beacon/test_receive_server.py
@@ -43,6 +43,7 @@ from eth2.beacon.state_machines.forks.xiao_long_bao.configs import (
     XIAO_LONG_BAO_CONFIG,
 )
 
+from trinity.db.beacon.chain import AsyncBeaconChainDB
 from trinity.exceptions import (
     AttestationNotFound,
 )
@@ -71,7 +72,7 @@ from .helpers import (
 
 
 class FakeChain(_TestnetChain):
-    chaindb_class = bcc_helpers.FakeAsyncBeaconChainDB
+    chaindb_class = AsyncBeaconChainDB
 
     def import_block(
             self,

--- a/trinity/_utils/async_dispatch.py
+++ b/trinity/_utils/async_dispatch.py
@@ -2,17 +2,24 @@ import asyncio
 import functools
 from typing import (
     Any,
-    Awaitable,
-    Callable
+    Coroutine,
+    Callable,
+    TypeVar,
 )
 
+TReturn = TypeVar('TReturn')
 
-def async_method(method_name: str) -> Callable[..., Any]:
-    async def method(self: Any, *args: Any, **kwargs: Any) -> Awaitable[Any]:
+
+def async_method(method: Callable[..., TReturn],
+                 ) -> Callable[..., Coroutine[Any, Any, TReturn]]:
+    @functools.wraps(method)
+    async def wrapper(cls_or_self: Any, *args: Any, **kwargs: Any) -> TReturn:
+        cls_method = getattr(cls_or_self, method.__name__)
         loop = asyncio.get_event_loop()
 
-        func = getattr(self, method_name)
-        pfunc = functools.partial(func, *args, **kwargs)
-
-        return await loop.run_in_executor(None, pfunc)
-    return method
+        return await loop.run_in_executor(
+            None,
+            functools.partial(cls_method, **kwargs),
+            *args
+        )
+    return wrapper

--- a/trinity/chains/base.py
+++ b/trinity/chains/base.py
@@ -1,19 +1,19 @@
-from abc import ABC, abstractmethod
+from abc import abstractmethod
 from typing import Tuple
 
 from eth_typing import BlockNumber, Hash32
 
 from eth.abc import (
     BlockAPI,
+    ChainAPI,
     BlockHeaderAPI,
     ReceiptAPI,
 )
-from eth.chains.base import BaseChain
 
 
 # This class is a work in progress; its main purpose is to define the API of an asyncio-compatible
 # Chain implementation.
-class BaseAsyncChainAPI(ABC):
+class AsyncChainAPI(ChainAPI):
     @abstractmethod
     async def coro_import_block(self,
                                 block: BlockHeaderAPI,
@@ -36,6 +36,10 @@ class BaseAsyncChainAPI(ABC):
         ...
 
     @abstractmethod
+    async def coro_get_ancestors(self, limit: int, header: BlockHeaderAPI) -> Tuple[BlockAPI, ...]:
+        ...
+
+    @abstractmethod
     async def coro_get_block_by_hash(self,
                                      block_hash: Hash32) -> BlockAPI:
         ...
@@ -46,10 +50,14 @@ class BaseAsyncChainAPI(ABC):
         ...
 
     @abstractmethod
+    async def coro_get_block_header_by_hash(self, block_hash: Hash32) -> BlockHeaderAPI:
+        ...
+
+    @abstractmethod
     async def coro_get_canonical_block_by_number(self,
                                                  block_number: BlockNumber) -> BlockAPI:
         ...
 
-
-class BaseAsyncChain(BaseAsyncChainAPI, BaseChain):
-    pass
+    @abstractmethod
+    async def coro_get_canonical_head(self) -> BlockHeaderAPI:
+        ...

--- a/trinity/chains/coro.py
+++ b/trinity/chains/coro.py
@@ -1,17 +1,20 @@
-from trinity._utils.async_dispatch import (
-    async_method,
-)
+from eth.chains import Chain
 
-from .base import BaseAsyncChain
+from trinity._utils.async_dispatch import async_method
+from trinity.db.eth1.chain import AsyncChainDB
+
+from .base import AsyncChainAPI
 
 
-class AsyncChainMixin(BaseAsyncChain):
-    coro_get_ancestors = async_method('get_ancestors')
-    coro_get_ancestor_headers = async_method('get_ancestor_headers')
-    coro_get_block_by_hash = async_method('get_block_by_hash')
-    coro_get_block_by_header = async_method('get_block_by_header')
-    coro_get_block_header_by_hash = async_method('get_block_header_by_hash')
-    coro_get_canonical_block_by_number = async_method('get_canonical_block_by_number')
-    coro_import_block = async_method('import_block')
-    coro_validate_chain = async_method('validate_chain')
-    coro_validate_receipt = async_method('validate_receipt')
+class AsyncChainMixin(AsyncChainAPI):
+    chaindb_class = AsyncChainDB
+
+    coro_get_ancestors = async_method(Chain.get_ancestors)
+    coro_get_block_by_hash = async_method(Chain.get_block_by_hash)
+    coro_get_block_by_header = async_method(Chain.get_block_by_header)
+    coro_get_block_header_by_hash = async_method(Chain.get_block_header_by_hash)
+    coro_get_canonical_block_by_number = async_method(Chain.get_canonical_block_by_number)
+    coro_get_canonical_head = async_method(Chain.get_canonical_head)
+    coro_import_block = async_method(Chain.import_block)
+    coro_validate_chain = async_method(Chain.validate_chain)
+    coro_validate_receipt = async_method(Chain.validate_receipt)

--- a/trinity/db/beacon/chain.py
+++ b/trinity/db/beacon/chain.py
@@ -16,7 +16,7 @@ from eth2.beacon.types.blocks import (
     BaseBeaconBlock,
 )
 
-from trinity._utils.asyncio import async_thread_method
+from trinity._utils.async_dispatch import async_method
 
 
 class BaseAsyncBeaconChainDB(BeaconChainDB):
@@ -123,20 +123,20 @@ class BaseAsyncBeaconChainDB(BeaconChainDB):
 
 
 class AsyncBeaconChainDB(BaseAsyncBeaconChainDB):
-    coro_persist_block = async_thread_method(BaseAsyncBeaconChainDB.persist_block)
-    coro_get_canonical_block_root = async_thread_method(BaseAsyncBeaconChainDB.get_canonical_block_root)  # noqa: E501
-    coro_get_genesis_block_root = async_thread_method(BaseAsyncBeaconChainDB.get_genesis_block_root)
-    coro_get_canonical_block_by_slot = async_thread_method(BaseAsyncBeaconChainDB.get_canonical_block_by_slot)  # noqa: E501
-    coro_get_canonical_head = async_thread_method(BaseAsyncBeaconChainDB.get_canonical_head)
-    coro_get_canonical_head_root = async_thread_method(BaseAsyncBeaconChainDB.get_canonical_head_root)  # noqa: E501
-    coro_get_finalized_head = async_thread_method(BaseAsyncBeaconChainDB.get_finalized_head)
-    coro_get_block_by_root = async_thread_method(BaseAsyncBeaconChainDB.get_block_by_root)
-    coro_get_score = async_thread_method(BaseAsyncBeaconChainDB.get_score)
-    coro_block_exists = async_thread_method(BaseAsyncBeaconChainDB.block_exists)
-    coro_persist_block_chain = async_thread_method(BaseAsyncBeaconChainDB.persist_block_chain)
-    coro_get_state_by_root = async_thread_method(BaseAsyncBeaconChainDB.get_state_by_root)
-    coro_persist_state = async_thread_method(BaseAsyncBeaconChainDB.persist_state)
-    coro_get_attestation_key_by_root = async_thread_method(BaseAsyncBeaconChainDB.get_attestation_key_by_root)  # noqa: E501
-    coro_attestation_exists = async_thread_method(BaseAsyncBeaconChainDB.attestation_exists)
-    coro_exists = async_thread_method(BaseAsyncBeaconChainDB.exists)
-    coro_get = async_thread_method(BaseAsyncBeaconChainDB.get)
+    coro_persist_block = async_method(BaseAsyncBeaconChainDB.persist_block)
+    coro_get_canonical_block_root = async_method(BaseAsyncBeaconChainDB.get_canonical_block_root)  # noqa: E501
+    coro_get_genesis_block_root = async_method(BaseAsyncBeaconChainDB.get_genesis_block_root)
+    coro_get_canonical_block_by_slot = async_method(BaseAsyncBeaconChainDB.get_canonical_block_by_slot)  # noqa: E501
+    coro_get_canonical_head = async_method(BaseAsyncBeaconChainDB.get_canonical_head)
+    coro_get_canonical_head_root = async_method(BaseAsyncBeaconChainDB.get_canonical_head_root)  # noqa: E501
+    coro_get_finalized_head = async_method(BaseAsyncBeaconChainDB.get_finalized_head)
+    coro_get_block_by_root = async_method(BaseAsyncBeaconChainDB.get_block_by_root)
+    coro_get_score = async_method(BaseAsyncBeaconChainDB.get_score)
+    coro_block_exists = async_method(BaseAsyncBeaconChainDB.block_exists)
+    coro_persist_block_chain = async_method(BaseAsyncBeaconChainDB.persist_block_chain)
+    coro_get_state_by_root = async_method(BaseAsyncBeaconChainDB.get_state_by_root)
+    coro_persist_state = async_method(BaseAsyncBeaconChainDB.persist_state)
+    coro_get_attestation_key_by_root = async_method(BaseAsyncBeaconChainDB.get_attestation_key_by_root)  # noqa: E501
+    coro_attestation_exists = async_method(BaseAsyncBeaconChainDB.attestation_exists)
+    coro_exists = async_method(BaseAsyncBeaconChainDB.exists)
+    coro_get = async_method(BaseAsyncBeaconChainDB.get)

--- a/trinity/db/eth1/chain.py
+++ b/trinity/db/eth1/chain.py
@@ -17,7 +17,7 @@ from eth.abc import (
 )
 from eth.db.chain import ChainDB
 
-from trinity._utils.asyncio import async_thread_method
+from trinity._utils.async_dispatch import async_method
 from trinity.db.eth1.header import BaseAsyncHeaderDB
 
 
@@ -64,20 +64,20 @@ class BaseAsyncChainDB(BaseAsyncHeaderDB, ChainDB):
 
 
 class AsyncChainDB(BaseAsyncChainDB):
-    coro_exists = async_thread_method(BaseAsyncChainDB.exists)
-    coro_get = async_thread_method(BaseAsyncChainDB.get)
-    coro_get_block_header_by_hash = async_thread_method(BaseAsyncChainDB.get_block_header_by_hash)
-    coro_get_canonical_head = async_thread_method(BaseAsyncChainDB.get_canonical_head)
-    coro_get_score = async_thread_method(BaseAsyncChainDB.get_score)
-    coro_header_exists = async_thread_method(BaseAsyncChainDB.header_exists)
-    coro_get_canonical_block_hash = async_thread_method(BaseAsyncChainDB.get_canonical_block_hash)
-    coro_get_canonical_block_header_by_number = async_thread_method(BaseAsyncChainDB.get_canonical_block_header_by_number)  # noqa: E501
-    coro_persist_header = async_thread_method(BaseAsyncChainDB.persist_header)
-    coro_persist_header_chain = async_thread_method(BaseAsyncChainDB.persist_header_chain)
-    coro_persist_block = async_thread_method(BaseAsyncChainDB.persist_block)
-    coro_persist_header_chain = async_thread_method(BaseAsyncChainDB.persist_header_chain)
-    coro_persist_uncles = async_thread_method(BaseAsyncChainDB.persist_uncles)
-    coro_persist_trie_data_dict = async_thread_method(BaseAsyncChainDB.persist_trie_data_dict)
-    coro_get_block_transactions = async_thread_method(BaseAsyncChainDB.get_block_transactions)
-    coro_get_block_uncles = async_thread_method(BaseAsyncChainDB.get_block_uncles)
-    coro_get_receipts = async_thread_method(BaseAsyncChainDB.get_receipts)
+    coro_exists = async_method(BaseAsyncChainDB.exists)
+    coro_get = async_method(BaseAsyncChainDB.get)
+    coro_get_block_header_by_hash = async_method(BaseAsyncChainDB.get_block_header_by_hash)
+    coro_get_canonical_head = async_method(BaseAsyncChainDB.get_canonical_head)
+    coro_get_score = async_method(BaseAsyncChainDB.get_score)
+    coro_header_exists = async_method(BaseAsyncChainDB.header_exists)
+    coro_get_canonical_block_hash = async_method(BaseAsyncChainDB.get_canonical_block_hash)
+    coro_get_canonical_block_header_by_number = async_method(BaseAsyncChainDB.get_canonical_block_header_by_number)  # noqa: E501
+    coro_persist_header = async_method(BaseAsyncChainDB.persist_header)
+    coro_persist_header_chain = async_method(BaseAsyncChainDB.persist_header_chain)
+    coro_persist_block = async_method(BaseAsyncChainDB.persist_block)
+    coro_persist_header_chain = async_method(BaseAsyncChainDB.persist_header_chain)
+    coro_persist_uncles = async_method(BaseAsyncChainDB.persist_uncles)
+    coro_persist_trie_data_dict = async_method(BaseAsyncChainDB.persist_trie_data_dict)
+    coro_get_block_transactions = async_method(BaseAsyncChainDB.get_block_transactions)
+    coro_get_block_uncles = async_method(BaseAsyncChainDB.get_block_uncles)
+    coro_get_receipts = async_method(BaseAsyncChainDB.get_receipts)

--- a/trinity/db/eth1/header.py
+++ b/trinity/db/eth1/header.py
@@ -15,7 +15,7 @@ from eth.abc import (
 )
 from eth.db.header import HeaderDB
 
-from trinity._utils.asyncio import async_thread_method
+from trinity._utils.async_dispatch import async_method
 
 
 TReturn = TypeVar('TReturn')
@@ -64,12 +64,12 @@ class BaseAsyncHeaderDB(HeaderDB):
 
 
 class AsyncHeaderDB(BaseAsyncHeaderDB):
-    coro_get_block_header_by_hash = async_thread_method(BaseAsyncHeaderDB.get_block_header_by_hash)
-    coro_get_canonical_block_hash = async_thread_method(BaseAsyncHeaderDB.get_canonical_block_hash)
-    coro_get_canonical_block_header_by_number = async_thread_method(BaseAsyncHeaderDB.get_canonical_block_header_by_number)  # noqa: E501
-    coro_get_canonical_head = async_thread_method(BaseAsyncHeaderDB.get_canonical_head)
-    coro_get_score = async_thread_method(BaseAsyncHeaderDB.get_score)
-    coro_header_exists = async_thread_method(BaseAsyncHeaderDB.header_exists)
-    coro_get_canonical_block_hash = async_thread_method(BaseAsyncHeaderDB.get_canonical_block_hash)
-    coro_persist_header = async_thread_method(BaseAsyncHeaderDB.persist_header)
-    coro_persist_header_chain = async_thread_method(BaseAsyncHeaderDB.persist_header_chain)
+    coro_get_block_header_by_hash = async_method(BaseAsyncHeaderDB.get_block_header_by_hash)
+    coro_get_canonical_block_hash = async_method(BaseAsyncHeaderDB.get_canonical_block_hash)
+    coro_get_canonical_block_header_by_number = async_method(BaseAsyncHeaderDB.get_canonical_block_header_by_number)  # noqa: E501
+    coro_get_canonical_head = async_method(BaseAsyncHeaderDB.get_canonical_head)
+    coro_get_score = async_method(BaseAsyncHeaderDB.get_score)
+    coro_header_exists = async_method(BaseAsyncHeaderDB.header_exists)
+    coro_get_canonical_block_hash = async_method(BaseAsyncHeaderDB.get_canonical_block_hash)
+    coro_persist_header = async_method(BaseAsyncHeaderDB.persist_header)
+    coro_persist_header_chain = async_method(BaseAsyncHeaderDB.persist_header_chain)

--- a/trinity/plugins/builtin/json_rpc/plugin.py
+++ b/trinity/plugins/builtin/json_rpc/plugin.py
@@ -19,7 +19,7 @@ from trinity.config import (
     BeaconAppConfig,
     TrinityConfig
 )
-from trinity.chains.base import BaseAsyncChain
+from trinity.chains.base import AsyncChainAPI
 from trinity.chains.light_eventbus import (
     EventBusLightPeerChain,
 )
@@ -65,7 +65,7 @@ class JsonRpcServerPlugin(AsyncioIsolatedPlugin):
         eth1_app_config = trinity_config.get_app_config(Eth1AppConfig)
         chain_config = eth1_app_config.get_chain_config()
 
-        chain: BaseAsyncChain
+        chain: AsyncChainAPI
         db = DBClient.connect(trinity_config.database_ipc_path)
 
         if eth1_app_config.database_mode is Eth1DbMode.LIGHT:

--- a/trinity/rpc/format.py
+++ b/trinity/rpc/format.py
@@ -32,7 +32,7 @@ from eth.constants import (
     CREATE_CONTRACT_ADDRESS,
 )
 
-from trinity.chains.base import BaseAsyncChain
+from trinity.chains.base import AsyncChainAPI
 
 
 def transaction_to_dict(transaction: SignedTransactionAPI) -> Dict[str, str]:
@@ -105,7 +105,7 @@ def header_to_dict(header: BlockHeaderAPI) -> Dict[str, str]:
 
 
 def block_to_dict(block: BlockAPI,
-                  chain: BaseAsyncChain,
+                  chain: AsyncChainAPI,
                   include_transactions: bool) -> Dict[str, Union[str, List[str]]]:
 
     header_dict = header_to_dict(block.header)

--- a/trinity/rpc/modules/__init__.py
+++ b/trinity/rpc/modules/__init__.py
@@ -9,9 +9,7 @@ from eth_utils import (
     to_tuple,
 )
 
-from trinity.chains.base import (
-    BaseAsyncChain
-)
+from trinity.chains.base import AsyncChainAPI
 
 from .main import (  # noqa: F401
     BaseRPCModule,
@@ -30,7 +28,7 @@ from .web3 import Web3  # noqa: F401
 
 
 @to_tuple
-def initialize_eth1_modules(chain: BaseAsyncChain,
+def initialize_eth1_modules(chain: AsyncChainAPI,
                             event_bus: EndpointAPI) -> Iterable[BaseRPCModule]:
     yield Eth(chain, event_bus)
     yield EVM(chain, event_bus)

--- a/trinity/rpc/modules/eth.py
+++ b/trinity/rpc/modules/eth.py
@@ -44,7 +44,7 @@ from eth.vm.spoof import (
 from trinity.constants import (
     TO_NETWORKING_BROADCAST_CONFIG,
 )
-from trinity.chains.base import BaseAsyncChain
+from trinity.chains.base import AsyncChainAPI
 from trinity.rpc.format import (
     block_to_dict,
     header_to_dict,
@@ -66,7 +66,7 @@ from trinity._utils.validation import (
 )
 
 
-async def get_header(chain: BaseAsyncChain, at_block: Union[str, int]) -> BlockHeader:
+async def get_header(chain: AsyncChainAPI, at_block: Union[str, int]) -> BlockHeader:
     if at_block == 'pending':
         raise NotImplementedError("RPC interface does not support the 'pending' block at this time")
     elif at_block == 'latest':
@@ -87,7 +87,7 @@ async def get_header(chain: BaseAsyncChain, at_block: Union[str, int]) -> BlockH
 
 
 async def state_at_block(
-        chain: BaseAsyncChain,
+        chain: AsyncChainAPI,
         at_block: Union[str, int],
         read_only: bool=True) -> AccountDatabaseAPI:
     at_header = await get_header(chain, at_block)
@@ -95,7 +95,7 @@ async def state_at_block(
     return vm.state
 
 
-async def get_block_at_number(chain: BaseAsyncChain, at_block: Union[str, int]) -> BaseBlock:
+async def get_block_at_number(chain: AsyncChainAPI, at_block: Union[str, int]) -> BaseBlock:
     # mypy doesn't have user defined type guards yet
     # https://github.com/python/mypy/issues/5206
     if is_integer(at_block) and at_block >= 0:  # type: ignore
@@ -107,7 +107,7 @@ async def get_block_at_number(chain: BaseAsyncChain, at_block: Union[str, int]) 
 
 
 def dict_to_spoof_transaction(
-        chain: BaseAsyncChain,
+        chain: AsyncChainAPI,
         header: BlockHeader,
         transaction_dict: Dict[str, Any]) -> SpoofTransaction:
     """

--- a/trinity/rpc/modules/main.py
+++ b/trinity/rpc/modules/main.py
@@ -5,7 +5,6 @@ from typing import (
     Any,
     Generic,
     TypeVar,
-    TYPE_CHECKING,
 )
 
 from lahja import (
@@ -13,8 +12,7 @@ from lahja import (
     EndpointAPI
 )
 
-if TYPE_CHECKING:
-    from trinity.chains.base import BaseAsyncChain  # noqa: F401
+from trinity.chains.base import AsyncChainAPI
 
 
 TChain = TypeVar('TChain')
@@ -51,5 +49,5 @@ class ChainBasedRPCModule(BaseRPCModule, Generic[TChain]):
         self.chain = chain
 
 
-Eth1ChainRPCModule = ChainBasedRPCModule['BaseAsyncChain']
+Eth1ChainRPCModule = ChainBasedRPCModule[AsyncChainAPI]
 BeaconChainRPCModule = ChainBasedRPCModule[Any]

--- a/trinity/server.py
+++ b/trinity/server.py
@@ -30,7 +30,7 @@ from p2p.service import BaseService
 from eth2.beacon.chains.base import BeaconChain
 
 from trinity._utils.version import construct_trinity_client_identifier
-from trinity.chains.base import BaseAsyncChain
+from trinity.chains.base import AsyncChainAPI
 from trinity.constants import DEFAULT_PREFERRED_NODES
 from trinity.db.eth1.chain import BaseAsyncChainDB
 from trinity.db.eth1.header import BaseAsyncHeaderDB
@@ -59,7 +59,7 @@ class BaseServer(BaseService, Generic[TPeerPool]):
     def __init__(self,
                  privkey: datatypes.PrivateKey,
                  port: int,
-                 chain: BaseAsyncChain,
+                 chain: AsyncChainAPI,
                  chaindb: BaseAsyncChainDB,
                  headerdb: BaseAsyncHeaderDB,
                  base_db: AtomicDatabaseAPI,
@@ -237,7 +237,7 @@ class BCCServer(BaseServer[BCCPeerPool]):
     def __init__(self,
                  privkey: datatypes.PrivateKey,
                  port: int,
-                 chain: BaseAsyncChain,
+                 chain: AsyncChainAPI,
                  chaindb: BaseAsyncChainDB,
                  headerdb: BaseAsyncHeaderDB,
                  base_db: AtomicDatabaseAPI,

--- a/trinity/sync/beam/chain.py
+++ b/trinity/sync/beam/chain.py
@@ -28,7 +28,7 @@ import rlp
 
 from p2p.service import BaseService
 
-from trinity.chains.base import BaseAsyncChain
+from trinity.chains.base import AsyncChainAPI
 from trinity.db.eth1.chain import BaseAsyncChainDB
 from trinity.db.eth1.header import BaseAsyncHeaderDB
 from trinity.protocol.eth.peer import ETHPeerPool
@@ -86,7 +86,7 @@ class BeamSyncer(BaseService):
     """
     def __init__(
             self,
-            chain: BaseAsyncChain,
+            chain: AsyncChainAPI,
             db: BaseAtomicDB,
             chain_db: BaseAsyncChainDB,
             peer_pool: ETHPeerPool,
@@ -440,7 +440,7 @@ class BeamBlockImporter(BaseBlockImporter, BaseService):
     """
     def __init__(
             self,
-            chain: BaseAsyncChain,
+            chain: AsyncChainAPI,
             db: DatabaseAPI,
             state_getter: BeamDownloader,
             event_bus: EndpointAPI,

--- a/trinity/sync/beam/importer.py
+++ b/trinity/sync/beam/importer.py
@@ -42,7 +42,7 @@ from lahja.common import BroadcastConfig
 from p2p.service import BaseService
 
 from trinity._utils.timer import Timer
-from trinity.chains.base import BaseAsyncChain
+from trinity.chains.base import AsyncChainAPI
 from trinity.chains.full import FullChain
 from trinity.sync.beam.constants import (
     MAX_SPECULATIVE_EXECUTIONS_PER_PROCESS,
@@ -327,7 +327,7 @@ def _broadcast_import_complete(
     )
 
 
-def partial_import_block(beam_chain: BaseAsyncChain, block: BlockAPI) -> Callable[[], None]:
+def partial_import_block(beam_chain: AsyncChainAPI, block: BlockAPI) -> Callable[[], None]:
     """
     Get an argument-free function that will import the given block.
     """
@@ -356,7 +356,7 @@ class BlockImportServer(BaseService):
     def __init__(
             self,
             event_bus: EndpointAPI,
-            beam_chain: BaseAsyncChain,
+            beam_chain: AsyncChainAPI,
             token: CancelToken=None) -> None:
         super().__init__(token=token)
         self._event_bus = event_bus
@@ -369,7 +369,7 @@ class BlockImportServer(BaseService):
     async def serve(
             self,
             event_bus: EndpointAPI,
-            beam_chain: BaseAsyncChain) -> None:
+            beam_chain: AsyncChainAPI) -> None:
         """
         Listen to DoStatelessBlockImport events, and import block when received.
         Reply with StatelessBlockImportDone when import is complete.
@@ -402,7 +402,7 @@ class BlockImportServer(BaseService):
 
 
 def partial_trigger_missing_state_downloads(
-        beam_chain: BaseAsyncChain,
+        beam_chain: AsyncChainAPI,
         header: BlockHeaderAPI,
         transactions: Tuple[SignedTransactionAPI, ...]) -> Callable[[], None]:
     """
@@ -433,7 +433,7 @@ def partial_trigger_missing_state_downloads(
 
 
 def partial_speculative_execute(
-        beam_chain: BaseAsyncChain,
+        beam_chain: AsyncChainAPI,
         header: BlockHeaderAPI,
         transactions: Tuple[SignedTransactionAPI, ...]) -> Callable[[], None]:
     """
@@ -478,7 +478,7 @@ class BlockPreviewServer(BaseService):
     def __init__(
             self,
             event_bus: EndpointAPI,
-            beam_chain: BaseAsyncChain,
+            beam_chain: AsyncChainAPI,
             shard_num: int,
             token: CancelToken=None) -> None:
         super().__init__(token=token)
@@ -499,7 +499,7 @@ class BlockPreviewServer(BaseService):
     async def serve(
             self,
             event_bus: EndpointAPI,
-            beam_chain: BaseAsyncChain) -> None:
+            beam_chain: AsyncChainAPI) -> None:
         """
         Listen to DoStatelessBlockPreview events, and execute the transactions to prefill
         all the needed state data.

--- a/trinity/sync/beam/service.py
+++ b/trinity/sync/beam/service.py
@@ -2,11 +2,11 @@ from lahja import EndpointAPI
 
 from cancel_token import CancelToken
 
-from eth.db.backends.base import BaseAtomicDB
+from eth.abc import AtomicDatabaseAPI
 
 from p2p.service import BaseService
 
-from trinity.chains.base import BaseAsyncChain
+from trinity.chains.base import AsyncChainAPI
 from trinity.db.eth1.chain import BaseAsyncChainDB
 from trinity.protocol.eth.peer import ETHPeerPool
 
@@ -17,9 +17,9 @@ class BeamSyncService(BaseService):
 
     def __init__(
             self,
-            chain: BaseAsyncChain,
+            chain: AsyncChainAPI,
             chaindb: BaseAsyncChainDB,
-            base_db: BaseAtomicDB,
+            base_db: AtomicDatabaseAPI,
             peer_pool: ETHPeerPool,
             event_bus: EndpointAPI,
             force_beam_block_number: int = None,

--- a/trinity/sync/common/chain.py
+++ b/trinity/sync/common/chain.py
@@ -43,7 +43,7 @@ from trinity._utils.headers import (
 from trinity._utils.humanize import (
     humanize_integer_sequence,
 )
-from trinity.chains.base import BaseAsyncChain
+from trinity.chains.base import AsyncChainAPI
 from trinity.db.eth1.header import BaseAsyncHeaderDB
 from trinity.protocol.common.peer import (
     BaseChainPeer,
@@ -66,7 +66,7 @@ class PeerHeaderSyncer(BaseService):
     _seal_check_random_sample_rate = SEAL_CHECK_RANDOM_SAMPLE_RATE
 
     def __init__(self,
-                 chain: BaseAsyncChain,
+                 chain: AsyncChainAPI,
                  db: BaseAsyncHeaderDB,
                  peer: BaseChainPeer,
                  token: CancelToken = None) -> None:
@@ -283,7 +283,7 @@ class BaseBlockImporter(ABC):
 
 
 class SimpleBlockImporter(BaseBlockImporter):
-    def __init__(self, chain: BaseAsyncChain) -> None:
+    def __init__(self, chain: AsyncChainAPI) -> None:
         self._chain = chain
 
     async def import_block(

--- a/trinity/sync/common/headers.py
+++ b/trinity/sync/common/headers.py
@@ -47,7 +47,7 @@ from p2p.exceptions import BaseP2PError, PeerConnectionLost
 from p2p.peer import BasePeer, PeerSubscriber
 from p2p.service import BaseService
 
-from trinity.chains.base import BaseAsyncChain
+from trinity.chains.base import AsyncChainAPI
 from trinity.db.eth1.header import BaseAsyncHeaderDB
 from trinity.protocol.common.commands import (
     BaseBlockHeaders,
@@ -84,7 +84,7 @@ class SkeletonSyncer(BaseService, Generic[TChainPeer]):
     _fetched_headers: 'asyncio.Queue[Tuple[BlockHeader, ...]]'
 
     def __init__(self,
-                 chain: BaseAsyncChain,
+                 chain: AsyncChainAPI,
                  db: BaseAsyncHeaderDB,
                  peer: TChainPeer,
                  token: CancelToken) -> None:
@@ -564,7 +564,7 @@ class HeaderMeatSyncer(BaseService, PeerSubscriber, Generic[TChainPeer]):
 
     def __init__(
             self,
-            chain: BaseAsyncChain,
+            chain: AsyncChainAPI,
             peer_pool: BaseChainPeerPool,
             stitcher: HeaderStitcher,
             token: CancelToken) -> None:
@@ -780,7 +780,7 @@ class BaseHeaderChainSyncer(BaseService, HeaderSyncerAPI, Generic[TChainPeer]):
     _meat: HeaderMeatSyncer[TChainPeer]
 
     def __init__(self,
-                 chain: BaseAsyncChain,
+                 chain: AsyncChainAPI,
                  db: BaseAsyncHeaderDB,
                  peer_pool: BaseChainPeerPool,
                  token: CancelToken = None) -> None:

--- a/trinity/sync/full/chain.py
+++ b/trinity/sync/full/chain.py
@@ -55,7 +55,7 @@ from p2p.peer import BasePeer, PeerSubscriber
 from p2p.service import BaseService
 from p2p.token_bucket import TokenBucket
 
-from trinity.chains.base import BaseAsyncChain
+from trinity.chains.base import AsyncChainAPI
 from trinity.db.eth1.chain import BaseAsyncChainDB
 from trinity.protocol.eth.monitors import ETHChainTipMonitor
 from trinity.protocol.eth import commands
@@ -126,7 +126,7 @@ class BaseBodyChainSyncer(BaseService, PeerSubscriber):
     _pending_bodies: Dict[BlockHeaderAPI, BlockBody]
 
     def __init__(self,
-                 chain: BaseAsyncChain,
+                 chain: AsyncChainAPI,
                  db: BaseAsyncChainDB,
                  peer_pool: ETHPeerPool,
                  header_syncer: HeaderSyncerAPI,
@@ -459,7 +459,7 @@ class BaseBodyChainSyncer(BaseService, PeerSubscriber):
 
 class FastChainSyncer(BaseService):
     def __init__(self,
-                 chain: BaseAsyncChain,
+                 chain: AsyncChainAPI,
                  db: BaseAsyncChainDB,
                  peer_pool: ETHPeerPool,
                  token: CancelToken = None) -> None:
@@ -563,7 +563,7 @@ class FastChainBodySyncer(BaseBodyChainSyncer):
     head.
     """
     def __init__(self,
-                 chain: BaseAsyncChain,
+                 chain: AsyncChainAPI,
                  db: BaseAsyncChainDB,
                  peer_pool: ETHPeerPool,
                  header_syncer: HeaderSyncerAPI,
@@ -942,7 +942,7 @@ class FastChainBodySyncer(BaseBodyChainSyncer):
 
 class RegularChainSyncer(BaseService):
     def __init__(self,
-                 chain: BaseAsyncChain,
+                 chain: AsyncChainAPI,
                  db: BaseAsyncChainDB,
                  peer_pool: ETHPeerPool,
                  token: CancelToken = None) -> None:
@@ -976,7 +976,7 @@ class RegularChainBodySyncer(BaseBodyChainSyncer):
     """
 
     def __init__(self,
-                 chain: BaseAsyncChain,
+                 chain: AsyncChainAPI,
                  db: BaseAsyncChainDB,
                  peer_pool: ETHPeerPool,
                  header_syncer: HeaderSyncerAPI,

--- a/trinity/sync/full/service.py
+++ b/trinity/sync/full/service.py
@@ -9,7 +9,7 @@ from eth.rlp.headers import BlockHeader
 
 from p2p.service import BaseService
 
-from trinity.chains.base import BaseAsyncChain
+from trinity.chains.base import AsyncChainAPI
 from trinity.db.eth1.chain import BaseAsyncChainDB
 from trinity.protocol.eth.peer import ETHPeerPool
 
@@ -22,7 +22,7 @@ async def ensure_state_then_sync_full(logger: logging.Logger,
                                       head: BlockHeader,
                                       base_db: BaseAtomicDB,
                                       chaindb: BaseAsyncChainDB,
-                                      chain: BaseAsyncChain,
+                                      chain: AsyncChainAPI,
                                       peer_pool: ETHPeerPool,
                                       cancel_token: CancelToken) -> None:
     # Ensure we have the state for our current head.
@@ -47,7 +47,7 @@ async def ensure_state_then_sync_full(logger: logging.Logger,
 class FullChainSyncer(BaseService):
 
     def __init__(self,
-                 chain: BaseAsyncChain,
+                 chain: AsyncChainAPI,
                  chaindb: BaseAsyncChainDB,
                  base_db: BaseAtomicDB,
                  peer_pool: ETHPeerPool,
@@ -78,7 +78,7 @@ class FullChainSyncer(BaseService):
 class FastThenFullChainSyncer(BaseService):
 
     def __init__(self,
-                 chain: BaseAsyncChain,
+                 chain: AsyncChainAPI,
                  chaindb: BaseAsyncChainDB,
                  base_db: BaseAtomicDB,
                  peer_pool: ETHPeerPool,

--- a/trinity/sync/full/state.py
+++ b/trinity/sync/full/state.py
@@ -28,11 +28,11 @@ from eth_typing import (
 
 from cancel_token import CancelToken
 
+from eth.abc import AtomicDatabaseAPI
 from eth.constants import (
     BLANK_ROOT_HASH,
     EMPTY_SHA3,
 )
-from eth.db.backends.base import BaseAtomicDB
 from eth.db.backends.level import LevelDB
 from eth.rlp.accounts import Account
 from eth.tools.logging import ExtendedDebugLogger
@@ -72,7 +72,7 @@ class StateDownloader(BaseService, PeerSubscriber):
 
     def __init__(self,
                  chaindb: BaseAsyncChainDB,
-                 account_db: BaseAtomicDB,
+                 account_db: AtomicDatabaseAPI,
                  root_hash: Hash32,
                  peer_pool: ETHPeerPool,
                  token: CancelToken = None) -> None:

--- a/trinity/sync/light/chain.py
+++ b/trinity/sync/light/chain.py
@@ -3,7 +3,7 @@ from cancel_token import CancelToken
 
 from p2p.service import BaseService
 
-from trinity.chains.base import BaseAsyncChain
+from trinity.chains.base import AsyncChainAPI
 from trinity.db.eth1.header import BaseAsyncHeaderDB
 from trinity.protocol.les.peer import LESPeerPool
 from trinity.protocol.les.sync import LightHeaderChainSyncer
@@ -12,7 +12,7 @@ from trinity._utils.timer import Timer
 
 class LightChainSyncer(BaseService):
     def __init__(self,
-                 chain: BaseAsyncChain,
+                 chain: AsyncChainAPI,
                  db: BaseAsyncHeaderDB,
                  peer_pool: LESPeerPool,
                  token: CancelToken = None) -> None:

--- a/trinity/tools/chain.py
+++ b/trinity/tools/chain.py
@@ -1,0 +1,35 @@
+from eth import MainnetChain, RopstenChain
+from eth.chains.base import (
+    MiningChain,
+)
+from eth.vm.forks.byzantium import ByzantiumVM
+from eth.vm.forks.petersburg import PetersburgVM
+
+from trinity.chains.coro import AsyncChainMixin
+from trinity.chains.full import FullChain
+
+
+class AsyncRopstenChain(AsyncChainMixin, RopstenChain):
+    pass
+
+
+class AsyncMainnetChain(AsyncChainMixin, MainnetChain):
+    pass
+
+
+class AsyncMiningChain(AsyncChainMixin, MiningChain):
+    pass
+
+
+class LatestTestChain(FullChain):
+    """
+    A test chain that uses the most recent mainnet VM from block 0.
+    That means the VM will explicitly change when a new network upgrade is locked in.
+    """
+    vm_configuration = ((0, PetersburgVM),)
+    network_id = 999
+
+
+class ByzantiumTestChain(FullChain):
+    vm_configuration = ((0, ByzantiumVM),)
+    network_id = 999


### PR DESCRIPTION
This should be merged before #937 

### What was wrong?

With #859 merged we no longer need "fake" versions of our async chain and database objects in our tests.

### How was it fixed?

This removes the various `FakeAsync...` objects that are used in testing in favor of the real deal.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

[//]: # (See: https://trinity-client.readthedocs.io/en/latest/contributing.html#pull-requests)
- [x] Add entry to the [release notes](https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![Big-Dog-Sulley-Mastiff](https://user-images.githubusercontent.com/824194/63286132-85e6c880-c274-11e9-9cdc-b00193812a67.jpg)
