### PR TITLE
fix flakey test using msg buffer API

### DIFF
--- a/newsfragments/950.misc.rst
+++ b/newsfragments/950.misc.rst
@@ -1,0 +1,1 @@
+Fix flakey test

--- a/tests/core/p2p-proto/test_les_protocol_commands.py
+++ b/tests/core/p2p-proto/test_les_protocol_commands.py
@@ -48,7 +48,14 @@ async def test_les_protocol_methods_request_id(
         generated_request_id = peer.sub_proto.send_get_block_headers(
             b'1234', 1, 0, False, request_id=request_id
         )
-        await asyncio.sleep(0.1)
+
+        # yield to let remote and peer transmit messages.  This can take a
+        # small amount of time so we give it a few rounds of the event loop to
+        # finish transmitting.
+        for _ in range(10):
+            await asyncio.sleep(0.01)
+            if buffer.msg_queue.qsize() >= 1:
+                break
 
     messages = buffer.get_messages()
     assert len(messages) == 1


### PR DESCRIPTION
### What was wrong?

One of the LES command tests was flaky due to underlying changes to how subscriptions work.

### How was it fixed?

Changed to use a more precise waiting condition.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

[//]: # (See: https://trinity-client.readthedocs.io/en/latest/contributing.html#pull-requests)
- [x] Add entry to the [release notes](https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![s-l1000](https://user-images.githubusercontent.com/824194/63295491-02d06d00-c28a-11e9-8ef0-06b81780f18a.jpg)

