### PR TITLE
Add run_service helper for legacy BaseService

### DIFF
--- a/newsfragments/955.feature.rst
+++ b/newsfragments/955.feature.rst
@@ -1,0 +1,1 @@
+Add ``p2p.service.run_service`` which implements a context manager API for running a ``p2p.service.BaseService``.


### PR DESCRIPTION
### What was wrong?

In some cases, we want to run a service for a more constrained period with control over the lifecycle.

### How was it fixed?

Add a `run_service` that works for the legacy `p2p.service.BaseService` and use it in the various places where it can cleanup the code.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

[//]: # (See: https://trinity-client.readthedocs.io/en/latest/contributing.html#pull-requests)
- [x] Add entry to the [release notes](https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![mastiff-AP-VZGHOK-590sm12913](https://user-images.githubusercontent.com/824194/63366593-59e04b80-c337-11e9-920e-1ae1bbce0dc2.jpg)

