### PR TITLE
Add connection abstraction to devp2p networking

### DIFF
--- a/newsfragments/956.feature.rst
+++ b/newsfragments/956.feature.rst
@@ -1,0 +1,1 @@
+Add ``p2p.connection.Connection`` service which actively manages the ``p2p.multiplexer.Multiplexer`` exposing an API for registering handler callbacks for individuall protocol commands or entire protocols, as well as access to general metadata about the p2p connection.

--- a/newsfragments/964.bugfix.rst
+++ b/newsfragments/964.bugfix.rst
@@ -1,0 +1,1 @@
+Fix ``p2p.tools.factories.MultiplexerPairFactory`` negotiation of ``p2p`` protocol version.

--- a/p2p/abc.py
+++ b/p2p/abc.py
@@ -23,7 +23,6 @@ from cancel_token import CancelToken
 
 from eth_keys import datatypes
 
-from p2p.disconnect import DisconnectReason
 from p2p.typing import Capability, Capabilities, Payload, Structure
 
 if TYPE_CHECKING:
@@ -333,8 +332,6 @@ class HandlerSubscriptionAPI:
 
 
 class ConnectionAPI(ABC):
-    disconnect_reason: DisconnectReason = None
-
     #
     # Primary properties of the connection
     #

--- a/p2p/connection.py
+++ b/p2p/connection.py
@@ -1,7 +1,7 @@
 import asyncio
 import collections
 import functools
-from typing import Any, Awaitable, Callable, DefaultDict, Set, Tuple, TypeVar, Type
+from typing import Any, Awaitable, Callable, DefaultDict, Set, Tuple, Type
 
 from eth_keys import keys
 
@@ -13,7 +13,6 @@ from p2p.abc import (
     ProtocolAPI,
     ConnectionAPI,
 )
-from p2p.disconnect import DisconnectReason
 from p2p.exceptions import (
     UnknownProtocol,
     UnknownProtocolCommand,
@@ -29,10 +28,6 @@ from p2p.p2p_proto import (
 from p2p.typing import Capabilities, Payload
 
 
-TProtocol = TypeVar('TProtocol', bound=ProtocolAPI)
-TReceipt = TypeVar('TReceipt', bound=HandshakeReceipt)
-
-
 class HandlerSubscription(HandlerSubscriptionAPI):
     def __init__(self, remove_fn: Callable[[], Any]) -> None:
         self._remove_fn = remove_fn
@@ -42,8 +37,6 @@ class HandlerSubscription(HandlerSubscriptionAPI):
 
 
 class Connection(ConnectionAPI, BaseService):
-    disconnect_reason: DisconnectReason = None
-
     _protocol_handlers: DefaultDict[
         Type[ProtocolAPI],
         Set[Callable[[CommandAPI, Payload], Awaitable[Any]]]

--- a/p2p/connection.py
+++ b/p2p/connection.py
@@ -1,0 +1,214 @@
+import asyncio
+import collections
+import functools
+from typing import Any, Awaitable, Callable, DefaultDict, Set, Tuple, TypeVar, Type
+
+from eth_keys import keys
+
+from p2p.abc import (
+    CommandAPI,
+    HandlerSubscriptionAPI,
+    MultiplexerAPI,
+    NodeAPI,
+    ProtocolAPI,
+    ConnectionAPI,
+)
+from p2p.disconnect import DisconnectReason
+from p2p.exceptions import (
+    UnknownProtocol,
+    UnknownProtocolCommand,
+)
+from p2p.handshake import (
+    DevP2PReceipt,
+    HandshakeReceipt,
+)
+from p2p.service import BaseService
+from p2p.p2p_proto import (
+    BaseP2PProtocol,
+)
+from p2p.typing import Capabilities, Payload
+
+
+TProtocol = TypeVar('TProtocol', bound=ProtocolAPI)
+TReceipt = TypeVar('TReceipt', bound=HandshakeReceipt)
+
+
+class HandlerSubscription(HandlerSubscriptionAPI):
+    def __init__(self, remove_fn: Callable[[], Any]) -> None:
+        self._remove_fn = remove_fn
+
+    def cancel(self) -> None:
+        self._remove_fn()
+
+
+class Connection(ConnectionAPI, BaseService):
+    disconnect_reason: DisconnectReason = None
+
+    _protocol_handlers: DefaultDict[
+        Type[ProtocolAPI],
+        Set[Callable[[CommandAPI, Payload], Awaitable[Any]]]
+    ]
+    _command_handlers: DefaultDict[
+        Type[CommandAPI],
+        Set[Callable[[Payload], Awaitable[Any]]]
+    ]
+
+    def __init__(self,
+                 multiplexer: MultiplexerAPI,
+                 devp2p_receipt: DevP2PReceipt,
+                 protocol_receipts: Tuple[HandshakeReceipt, ...],
+                 is_dial_out: bool) -> None:
+        super().__init__(token=multiplexer.cancel_token, loop=multiplexer.cancel_token.loop)
+        self._multiplexer = multiplexer
+        self._devp2p_receipt = devp2p_receipt
+        self._protocol_receipts = protocol_receipts
+        self.is_dial_out = is_dial_out
+
+        self._protocol_handlers = collections.defaultdict(set)
+        self._command_handlers = collections.defaultdict(set)
+
+        # An event that controls when the connection will start reading from
+        # the individual multiplexed protocol streams and feeding handlers.
+        # This ensures that the connection does not start consuming messages
+        # before all necessary handlers have been added
+        self._handlers_ready = asyncio.Event()
+
+    def start_protocol_streams(self) -> None:
+        self._handlers_ready.set()
+
+    #
+    # Primary properties of the connection
+    #
+    @property
+    def is_dial_in(self) -> bool:
+        return not self.is_dial_out
+
+    @property
+    def remote(self) -> NodeAPI:
+        return self._multiplexer.remote
+
+    async def _run(self) -> None:
+        async with self._multiplexer.multiplex():
+            for protocol in self._multiplexer.get_protocols():
+                self.run_daemon_task(self._feed_protocol_handlers(protocol))
+
+            await self.cancellation()
+
+    #
+    # Subscriptions/Handler API
+    #
+    async def _feed_protocol_handlers(self, protocol: ProtocolAPI) -> None:
+        # do not start consuming from the protocol stream until
+        # `start_protocol_streams` has been called and the multiplexer is
+        # active.
+        try:
+            await asyncio.wait_for(asyncio.gather(self._handlers_ready.wait()), timeout=10)
+        except asyncio.TimeoutError as err:
+            self.logger.info('Timedout waiting for handler ready signal')
+            raise asyncio.TimeoutError(
+                "The handlers ready event was never set.  Ensure that "
+                "`Connection.start_protocol_streams()` is being called"
+            ) from err
+
+        # we don't need to use wait_iter here because the multiplexer does it
+        # for us.
+        async for cmd, msg in self._multiplexer.stream_protocol_messages(protocol):
+            self.logger.debug2('Handling command: %s', type(cmd))
+            # local copy to prevent multation while iterating
+            protocol_handlers = set(self._protocol_handlers[type(protocol)])
+            for proto_handler_fn in protocol_handlers:
+                self.logger.debug2(
+                    'Running protocol handler %s for protocol=%s command=%s',
+                    proto_handler_fn,
+                    protocol,
+                    type(cmd),
+                )
+                self.run_task(proto_handler_fn(cmd, msg))
+            command_handlers = set(self._command_handlers[type(cmd)])
+            for cmd_handler_fn in command_handlers:
+                self.logger.debug2(
+                    'Running command handler %s for protocol=%s command=%s',
+                    cmd_handler_fn,
+                    protocol,
+                    type(cmd),
+                )
+                self.run_task(cmd_handler_fn(msg))
+
+    def add_protocol_handler(self,
+                             protocol_class: Type[ProtocolAPI],
+                             handler_fn: Callable[[CommandAPI, Payload], Awaitable[Any]],
+                             ) -> HandlerSubscription:
+        if not self._multiplexer.has_protocol(protocol_class):
+            raise UnknownProtocol(
+                f"Protocol {protocol_class} was not found int he connected "
+                f"protocols: {self._multiplexer.get_protocols()}"
+            )
+        self._protocol_handlers[protocol_class].add(handler_fn)
+        remove_fn = functools.partial(
+            self._protocol_handlers[protocol_class].remove,
+            handler_fn,
+        )
+        return HandlerSubscription(remove_fn)
+
+    def add_command_handler(self,
+                            command_type: Type[CommandAPI],
+                            handler_fn: Callable[[Payload], Awaitable[Any]],
+                            ) -> HandlerSubscription:
+        for protocol in self._multiplexer.get_protocols():
+            if protocol.supports_command(command_type):
+                self._command_handlers[command_type].add(handler_fn)
+                remove_fn = functools.partial(
+                    self._command_handlers[command_type].remove,
+                    handler_fn,
+                )
+                return HandlerSubscription(remove_fn)
+        else:
+            raise UnknownProtocolCommand(
+                f"Command {command_type} was not found in the connected "
+                f"protocols: {self._multiplexer.get_protocols()}"
+            )
+
+    #
+    # Access to underlying Multiplexer
+    #
+    def get_multiplexer(self) -> MultiplexerAPI:
+        return self._multiplexer
+
+    #
+    # Base Protocol shortcuts
+    #
+    def get_base_protocol(self) -> BaseP2PProtocol:
+        return self._multiplexer.get_base_protocol()
+
+    @property
+    def remote_capabilities(self) -> Capabilities:
+        return self._devp2p_receipt.capabilities
+
+    @property
+    def remote_p2p_version(self) -> int:
+        return self._devp2p_receipt.version
+
+    @property
+    def negotiated_p2p_version(self) -> int:
+        return self.get_base_protocol().version
+
+    @property
+    def remote_public_key(self) -> keys.PublicKey:
+        return keys.PublicKey(self._devp2p_receipt.remote_public_key)
+
+    @property
+    def client_version_string(self) -> str:
+        return self._devp2p_receipt.client_version_string
+
+    @property
+    def safe_client_version_string(self) -> str:
+        # limit number of chars to be displayed, and try to keep printable ones only
+        # MAGIC 256: arbitrary, "should be enough for everybody"
+        if len(self.client_version_string) <= 256:
+            return self.client_version_string
+
+        truncated_client_version_string = self.client_version_string[:253] + '...'
+        if truncated_client_version_string.isprintable():
+            return truncated_client_version_string
+        else:
+            return repr(truncated_client_version_string)

--- a/p2p/handshake.py
+++ b/p2p/handshake.py
@@ -21,7 +21,7 @@ from eth_utils.toolz import groupby, valmap
 from eth.tools.logging import ExtendedDebugLogger
 
 from p2p._utils import duplicates
-from p2p.abc import TransportAPI, MultiplexerAPI
+from p2p.abc import TransportAPI, MultiplexerAPI, ProtocolAPI
 from p2p.constants import (
     DEVP2P_V5,
 )
@@ -39,10 +39,7 @@ from p2p.p2p_proto import (
     P2PProtocol,
     P2PProtocolV4,
 )
-from p2p.protocol import (
-    get_cmd_offsets,
-    Protocol,
-)
+from p2p.protocol import get_cmd_offsets
 from p2p.typing import (
     Capabilities,
     Capability,
@@ -54,9 +51,9 @@ class HandshakeReceipt:
     Data storage object for ephemeral data exchanged during protocol
     handshakes.
     """
-    protocol: Protocol
+    protocol: ProtocolAPI
 
-    def __init__(self, protocol: Protocol) -> None:
+    def __init__(self, protocol: ProtocolAPI) -> None:
         self.protocol = protocol
 
 
@@ -68,12 +65,12 @@ class Handshaker(ABC):
     """
     logger = cast(ExtendedDebugLogger, logging.getLogger('p2p.connection.ProtocolHandler'))
 
-    protocol_class: Type[Protocol]
+    protocol_class: Type[ProtocolAPI]
 
     @abstractmethod
     async def do_handshake(self,
                            multiplexer: MultiplexerAPI,
-                           protocol: Protocol) -> HandshakeReceipt:
+                           protocol: ProtocolAPI) -> HandshakeReceipt:
         """
         Perform the actual handshake for the protocol.
         """

--- a/p2p/tools/connection.py
+++ b/p2p/tools/connection.py
@@ -1,0 +1,25 @@
+import asyncio
+from typing import Any
+
+from p2p.abc import ConnectionAPI
+from p2p.p2p_proto import Ping, Pong
+
+
+async def do_ping_pong_test(alice_connection: ConnectionAPI, bob_connection: ConnectionAPI) -> None:
+    got_ping = asyncio.Event()
+    got_pong = asyncio.Event()
+
+    async def _handle_ping(msg: Any) -> None:
+        got_ping.set()
+        bob_connection.get_base_protocol().send_pong()
+
+    async def _handle_pong(msg: Any) -> None:
+        got_pong.set()
+
+    alice_connection.add_command_handler(Pong, _handle_pong)
+    bob_connection.add_command_handler(Ping, _handle_ping)
+
+    alice_connection.get_base_protocol().send_ping()
+
+    await asyncio.wait_for(got_ping.wait(), timeout=1)
+    await asyncio.wait_for(got_pong.wait(), timeout=1)

--- a/p2p/tools/factories/__init__.py
+++ b/p2p/tools/factories/__init__.py
@@ -3,6 +3,7 @@ try:
 except ImportError:
     raise ImportError("The `p2p.tools.factories` module requires the `factory-boy` library")
 from .cancel_token import CancelTokenFactory  # noqa: F401
+from .connection import ConnectionPairFactory  # noqa: F401
 from .discovery import (  # noqa: F401
     AuthHeaderFactory,
     AuthHeaderPacketFactory,

--- a/p2p/tools/factories/connection.py
+++ b/p2p/tools/factories/connection.py
@@ -1,0 +1,131 @@
+import asyncio
+from typing import AsyncIterator, Tuple
+
+from async_generator import asynccontextmanager
+
+from cancel_token import CancelToken
+
+from eth_keys import keys
+
+from p2p.abc import ConnectionAPI, NodeAPI
+from p2p.connection import Connection
+from p2p.constants import DEVP2P_V5
+from p2p.handshake import (
+    DevP2PReceipt,
+    Handshaker,
+    negotiate_protocol_handshakes,
+)
+from p2p.service import run_service
+
+from .cancel_token import CancelTokenFactory
+from .multiplexer import MultiplexerPairFactory
+from .p2p_proto import DevP2PHandshakeParamsFactory
+from .transport import MemoryTransportPairFactory
+
+
+@asynccontextmanager
+async def ConnectionPairFactory(*,
+                                alice_handshakers: Tuple[Handshaker, ...] = (),
+                                bob_handshakers: Tuple[Handshaker, ...] = (),
+                                alice_remote: NodeAPI = None,
+                                alice_private_key: keys.PrivateKey = None,
+                                alice_client_version: str = 'alice',
+                                alice_p2p_version: int = DEVP2P_V5,
+                                bob_remote: NodeAPI = None,
+                                bob_private_key: keys.PrivateKey = None,
+                                bob_client_version: str = 'bob',
+                                bob_p2p_version: int = DEVP2P_V5,
+                                cancel_token: CancelToken = None,
+                                start_streams: bool = True,
+                                ) -> AsyncIterator[Tuple[ConnectionAPI, ConnectionAPI]]:
+
+    if alice_handshakers or bob_handshakers:
+        # We only leverage `negotiate_protocol_handshakes` if we have actual
+        # protocol handshakers since it raises `NoMatchingPeerCapabilities` if
+        # there are no matching capabilities.
+        alice_transport, bob_transport = MemoryTransportPairFactory(
+            alice_remote=alice_remote,
+            alice_private_key=alice_private_key,
+            bob_remote=bob_remote,
+            bob_private_key=bob_private_key,
+        )
+        alice_devp2p_params = DevP2PHandshakeParamsFactory(
+            client_version_string=alice_client_version,
+            listen_port=alice_transport.remote.address.tcp_port,
+            version=alice_p2p_version,
+        )
+        bob_devp2p_params = DevP2PHandshakeParamsFactory(
+            client_version_string=bob_client_version,
+            listen_port=bob_transport.remote.address.tcp_port,
+            version=bob_p2p_version,
+        )
+
+        if cancel_token is None:
+            cancel_token = CancelTokenFactory()
+
+        (
+            (alice_multiplexer, alice_p2p_receipt, alice_protocol_receipts),
+            (bob_multiplexer, bob_p2p_receipt, bob_protocol_receipts),
+        ) = await asyncio.gather(
+            negotiate_protocol_handshakes(
+                alice_transport,
+                alice_devp2p_params,
+                alice_handshakers,
+                cancel_token,
+            ),
+            negotiate_protocol_handshakes(
+                bob_transport,
+                bob_devp2p_params,
+                bob_handshakers,
+                cancel_token,
+            ),
+        )
+    else:
+        # This path is just for testing to allow us to establish a `Connection`
+        # without any protocols beyond the base p2p protocol.
+        alice_multiplexer, bob_multiplexer = MultiplexerPairFactory(
+            alice_remote=alice_remote,
+            alice_private_key=alice_private_key,
+            alice_p2p_version=alice_p2p_version,
+            bob_remote=bob_remote,
+            bob_private_key=bob_private_key,
+            bob_p2p_version=bob_p2p_version,
+            cancel_token=cancel_token,
+        )
+        alice_p2p_receipt = DevP2PReceipt(
+            protocol=alice_multiplexer.get_base_protocol(),
+            version=bob_p2p_version,
+            client_version_string=bob_client_version,
+            capabilities=(),
+            listen_port=bob_multiplexer.remote.address.tcp_port,
+            remote_public_key=bob_multiplexer.remote.pubkey,
+        )
+        bob_p2p_receipt = DevP2PReceipt(
+            protocol=bob_multiplexer.get_base_protocol(),
+            version=alice_p2p_version,
+            client_version_string=alice_client_version,
+            capabilities=(),
+            listen_port=alice_multiplexer.remote.address.tcp_port,
+            remote_public_key=alice_multiplexer.remote.pubkey,
+        )
+        alice_protocol_receipts = ()
+        bob_protocol_receipts = ()
+
+    alice_connection = Connection(
+        multiplexer=alice_multiplexer,
+        devp2p_receipt=alice_p2p_receipt,
+        protocol_receipts=alice_protocol_receipts,
+        is_dial_out=True,
+    )
+    bob_connection = Connection(
+        multiplexer=bob_multiplexer,
+        devp2p_receipt=bob_p2p_receipt,
+        protocol_receipts=bob_protocol_receipts,
+        is_dial_out=False,
+    )
+
+    async with run_service(alice_connection), run_service(bob_connection):
+        if start_streams:
+            alice_connection.start_protocol_streams()
+            bob_connection.start_protocol_streams()
+        yield alice_connection, bob_connection

--- a/p2p/tools/handshake.py
+++ b/p2p/tools/handshake.py
@@ -1,0 +1,14 @@
+from typing import Type
+
+from p2p.abc import MultiplexerAPI, ProtocolAPI
+from p2p.handshake import Handshaker, HandshakeReceipt
+
+
+class NoopHandshaker(Handshaker):
+    def __init__(self, protocol_class: Type[ProtocolAPI]) -> None:
+        self.protocol_class = protocol_class
+
+    async def do_handshake(self,
+                           multiplexer: MultiplexerAPI,
+                           protocol: ProtocolAPI) -> HandshakeReceipt:
+        return HandshakeReceipt(protocol)

--- a/p2p/tools/paragon/peer.py
+++ b/p2p/tools/paragon/peer.py
@@ -9,6 +9,7 @@ from p2p.handshake import (
     HandshakeReceipt,
 )
 
+from p2p.abc import ProtocolAPI
 from p2p.constants import DEVP2P_V5
 from p2p.peer import (
     BasePeer,
@@ -16,7 +17,6 @@ from p2p.peer import (
     BasePeerFactory,
 )
 from p2p.peer_pool import BasePeerPool
-from p2p.protocol import Protocol
 
 from .proto import ParagonProtocol
 
@@ -43,7 +43,7 @@ class ParagonHandshaker(Handshaker):
 
     async def do_handshake(self,
                            multiplexer: MultiplexerAPI,
-                           protocol: Protocol) -> HandshakeReceipt:
+                           protocol: ProtocolAPI) -> HandshakeReceipt:
         return HandshakeReceipt(protocol)
 
 

--- a/tests/p2p/test_connection.py
+++ b/tests/p2p/test_connection.py
@@ -1,0 +1,183 @@
+import asyncio
+
+import pytest
+
+from p2p.constants import DEVP2P_V4, DEVP2P_V5
+from p2p.p2p_proto import P2PProtocolV4, Ping
+from p2p.protocol import Command, Protocol
+from p2p.tools.connection import do_ping_pong_test
+from p2p.tools.handshake import NoopHandshaker
+from p2p.tools.factories import (
+    ConnectionPairFactory,
+    NodeFactory,
+    PrivateKeyFactory,
+    ProtocolFactory,
+)
+
+
+@pytest.mark.asyncio
+async def test_connection_ping_and_pong():
+    async with ConnectionPairFactory() as (alice_connection, bob_connection):
+        await do_ping_pong_test(alice_connection, bob_connection)
+
+
+@pytest.mark.asyncio
+async def test_connection_waits_to_feed_protocol_streams():
+    async with ConnectionPairFactory(start_streams=False) as (alice_connection, bob_connection):
+        got_ping = asyncio.Event()
+
+        async def _handle_ping(msg):
+            got_ping.set()
+
+        alice_connection.add_command_handler(Ping, _handle_ping)
+
+        bob_base_protocol = bob_connection.get_base_protocol()
+        bob_base_protocol.send_ping()
+
+        with pytest.raises(asyncio.TimeoutError):
+            await asyncio.wait_for(got_ping.wait(), timeout=0.1)
+
+        alice_connection.start_protocol_streams()
+
+        await asyncio.wait_for(got_ping.wait(), timeout=1)
+
+
+@pytest.mark.asyncio
+async def test_connection_properties():
+    Protocol_A = ProtocolFactory()
+    Protocol_B = ProtocolFactory()
+
+    alice_handshakers = (NoopHandshaker(Protocol_A),)
+    bob_handshakers = (NoopHandshaker(Protocol_A), NoopHandshaker(Protocol_B))
+    bob_capabilities = (Protocol_A.as_capability(), Protocol_B.as_capability())
+
+    bob_remote = NodeFactory()
+    bob_private_key = PrivateKeyFactory()
+
+    pair_factory = ConnectionPairFactory(
+        alice_handshakers=alice_handshakers,
+        bob_handshakers=bob_handshakers,
+        alice_p2p_version=DEVP2P_V4,
+        bob_client_version='bob-client',
+        bob_p2p_version=DEVP2P_V5,
+        bob_private_key=bob_private_key,
+        bob_remote=bob_remote,
+    )
+    async with pair_factory as (connection, _):
+        assert type(connection.get_base_protocol()) is P2PProtocolV4
+        assert connection.remote_capabilities == bob_capabilities
+        assert connection.remote_p2p_version == DEVP2P_V5
+        assert connection.negotiated_p2p_version == DEVP2P_V4
+        assert connection.remote_public_key == bob_private_key.public_key
+        assert connection.client_version_string == 'bob-client'
+        assert connection.safe_client_version_string == 'bob-client'
+
+
+@pytest.mark.asyncio
+async def test_connection_safe_client_version_string():
+    long_client_version_string = 'unicornsandrainbows' * 100
+    pair_factory = ConnectionPairFactory(
+        bob_client_version=long_client_version_string,
+    )
+    async with pair_factory as (connection, _):
+        assert connection.client_version_string == long_client_version_string
+        assert len(connection.safe_client_version_string) == 256
+        assert connection.safe_client_version_string.endswith('...')
+        assert long_client_version_string.startswith(connection.safe_client_version_string[:-3])
+
+
+class CommandA(Command):
+    _cmd_id = 0
+    structure = ()
+
+
+class CommandB(Command):
+    _cmd_id = 1
+    structure = ()
+
+
+class SecondProtocol(Protocol):
+    name = 'second'
+    version = 1
+    _commands = (CommandA, CommandB)
+    cmd_length = 2
+
+    def send_cmd(self, cmd_type) -> None:
+        header, body = self.cmd_by_type[cmd_type].encode({})
+        self.transport.send(header, body)
+
+
+class CommandC(Command):
+    _cmd_id = 0
+    structure = ()
+
+
+class CommandD(Command):
+    _cmd_id = 1
+    structure = ()
+
+
+class ThirdProtocol(Protocol):
+    name = 'third'
+    version = 1
+    _commands = (CommandC, CommandD)
+    cmd_length = 2
+
+    def send_cmd(self, cmd_type) -> None:
+        header, body = self.cmd_by_type[cmd_type].encode({})
+        self.transport.send(header, body)
+
+
+@pytest.mark.asyncio
+async def test_connection_protocol_and_command_handlers():
+    alice_handshakers = (NoopHandshaker(SecondProtocol), NoopHandshaker(ThirdProtocol))
+    bob_handshakers = (NoopHandshaker(SecondProtocol), NoopHandshaker(ThirdProtocol))
+    pair_factory = ConnectionPairFactory(
+        alice_handshakers=alice_handshakers,
+        bob_handshakers=bob_handshakers,
+    )
+    async with pair_factory as (alice_connection, bob_connection):
+        messages_cmd_A = []
+        messages_cmd_D = []
+        messages_second_protocol = []
+
+        done = asyncio.Event()
+
+        async def _handler_second_protocol(cmd, msg):
+            messages_second_protocol.append((cmd, msg))
+
+        async def _handler_cmd_A(msg):
+            messages_cmd_A.append(msg)
+
+        async def _handler_cmd_D(msg):
+            messages_cmd_D.append(msg)
+
+        async def _handler_cmd_C(msg):
+            done.set()
+
+        alice_connection.add_protocol_handler(SecondProtocol, _handler_second_protocol)
+        alice_connection.add_command_handler(CommandA, _handler_cmd_A)
+        alice_connection.add_command_handler(CommandC, _handler_cmd_C)
+        alice_connection.add_command_handler(CommandD, _handler_cmd_D)
+
+        alice_connection.start_protocol_streams()
+        bob_connection.start_protocol_streams()
+
+        bob_second_protocol = bob_connection.get_multiplexer().get_protocol_by_type(SecondProtocol)
+        bob_third_protocol = bob_connection.get_multiplexer().get_protocol_by_type(ThirdProtocol)
+
+        bob_second_protocol.send_cmd(CommandA)
+        bob_second_protocol.send_cmd(CommandB)
+        bob_third_protocol.send_cmd(CommandD)
+        bob_second_protocol.send_cmd(CommandB)
+        bob_third_protocol.send_cmd(CommandD)
+        bob_second_protocol.send_cmd(CommandA)
+        bob_second_protocol.send_cmd(CommandB)
+        bob_third_protocol.send_cmd(CommandD)
+        bob_third_protocol.send_cmd(CommandC)
+
+        await asyncio.wait_for(done.wait(), timeout=1)
+
+        assert len(messages_second_protocol) == 5
+        assert len(messages_cmd_A) == 2
+        assert len(messages_cmd_D) == 3

--- a/tests/p2p/test_connection.py
+++ b/tests/p2p/test_connection.py
@@ -75,15 +75,14 @@ async def test_connection_properties():
 
 @pytest.mark.asyncio
 async def test_connection_safe_client_version_string():
-    long_client_version_string = 'unicornsandrainbows' * 100
+    long_client_version_string = 'unicorns\nand\nrainbows\n' * 100
     pair_factory = ConnectionPairFactory(
         bob_client_version=long_client_version_string,
     )
     async with pair_factory as (connection, _):
         assert connection.client_version_string == long_client_version_string
-        assert len(connection.safe_client_version_string) == 256
-        assert connection.safe_client_version_string.endswith('...')
-        assert long_client_version_string.startswith(connection.safe_client_version_string[:-3])
+        assert len(connection.safe_client_version_string) < len(long_client_version_string)
+        assert '...' in connection.safe_client_version_string
 
 
 class CommandA(Command):

--- a/tests/p2p/test_connection_pair_factory.py
+++ b/tests/p2p/test_connection_pair_factory.py
@@ -1,0 +1,105 @@
+import pytest
+
+from p2p.constants import DEVP2P_V4, DEVP2P_V5
+from p2p.p2p_proto import P2PProtocol, P2PProtocolV4
+from p2p.tools.factories import ConnectionPairFactory, ProtocolFactory
+from p2p.tools.connection import do_ping_pong_test
+from p2p.tools.handshake import NoopHandshaker
+
+
+@pytest.mark.asyncio
+async def test_connection_pair_factory_with_no_protocols():
+    async with ConnectionPairFactory() as (alice_connection, bob_connection):
+        assert alice_connection.remote_capabilities == ()
+        assert bob_connection.remote_capabilities == ()
+
+        await do_ping_pong_test(alice_connection, bob_connection)
+
+
+@pytest.mark.parametrize(
+    'alice_p2p_version,bob_p2p_version',
+    (
+        (DEVP2P_V4, DEVP2P_V4),
+        (DEVP2P_V4, DEVP2P_V5),
+        (DEVP2P_V5, DEVP2P_V4),
+        (DEVP2P_V5, DEVP2P_V5),
+    ),
+)
+@pytest.mark.asyncio
+async def test_connection_pair_factory_no_protocols_with_different_p2p_versions(
+    alice_p2p_version,
+    bob_p2p_version,
+):
+    pair_factory = ConnectionPairFactory(
+        alice_p2p_version=alice_p2p_version,
+        bob_p2p_version=bob_p2p_version,
+    )
+    async with pair_factory as (alice_connection, bob_connection):
+        expected_base_protocol_version = min(alice_p2p_version, bob_p2p_version)
+        if expected_base_protocol_version == DEVP2P_V4:
+            expected_base_protocol_class = P2PProtocolV4
+        elif expected_base_protocol_version == DEVP2P_V5:
+            expected_base_protocol_class = P2PProtocol
+        else:
+            raise Exception(f"unrecognized version: {expected_base_protocol_version}")
+
+        alice_base_protocol = alice_connection.get_base_protocol()
+        bob_base_protocol = bob_connection.get_base_protocol()
+
+        assert type(alice_base_protocol) is expected_base_protocol_class
+        assert type(bob_base_protocol) is expected_base_protocol_class
+
+        assert alice_base_protocol.version == expected_base_protocol_version
+        assert bob_base_protocol.version == expected_base_protocol_version
+
+        assert alice_connection.remote_p2p_version == bob_p2p_version
+        assert bob_connection.remote_p2p_version == alice_p2p_version
+
+        await do_ping_pong_test(alice_connection, bob_connection)
+
+
+@pytest.mark.asyncio
+async def test_connection_pair_factory_with_single_protocol():
+    protocol_class = ProtocolFactory()
+
+    alice_handshaker = NoopHandshaker(protocol_class)
+    bob_handshaker = NoopHandshaker(protocol_class)
+
+    pair_factory = ConnectionPairFactory(
+        alice_handshakers=(alice_handshaker,),
+        bob_handshakers=(bob_handshaker,),
+    )
+
+    async with pair_factory as (alice_connection, bob_connection):
+        expected_caps = (protocol_class.as_capability(),)
+
+        assert alice_connection.remote_capabilities == expected_caps
+        assert bob_connection.remote_capabilities == expected_caps
+
+        await do_ping_pong_test(alice_connection, bob_connection)
+
+
+@pytest.mark.asyncio
+async def test_connection_pair_factory_with_multiple_protocols():
+    protocol_class_a = ProtocolFactory()
+    protocol_class_b = ProtocolFactory()
+
+    alice_handshaker_a = NoopHandshaker(protocol_class_a)
+    alice_handshaker_b = NoopHandshaker(protocol_class_b)
+    bob_handshaker_a = NoopHandshaker(protocol_class_a)
+    bob_handshaker_b = NoopHandshaker(protocol_class_b)
+
+    pair_factory = ConnectionPairFactory(
+        alice_handshakers=(alice_handshaker_a, alice_handshaker_b),
+        bob_handshakers=(bob_handshaker_a, bob_handshaker_b),
+    )
+
+    async with pair_factory as (alice_connection, bob_connection):
+        expected_caps = (
+            protocol_class_a.as_capability(),
+            protocol_class_b.as_capability(),
+        )
+        assert alice_connection.remote_capabilities == expected_caps
+        assert bob_connection.remote_capabilities == expected_caps
+
+        await do_ping_pong_test(alice_connection, bob_connection)

--- a/tests/p2p/test_handshake.py
+++ b/tests/p2p/test_handshake.py
@@ -11,17 +11,8 @@ from p2p.p2p_proto import P2PProtocol, P2PProtocolV4
 from p2p.handshake import (
     negotiate_protocol_handshakes,
     DevP2PHandshakeParams,
-    Handshaker,
-    HandshakeReceipt,
 )
-
-
-class NoopHandshaker(Handshaker):
-    def __init__(self, protocol_class):
-        self.protocol_class = protocol_class
-
-    async def do_handshake(self, multiplexer, protocol):
-        return HandshakeReceipt(protocol)
+from p2p.tools.handshake import NoopHandshaker
 
 
 @pytest.mark.asyncio

--- a/tests/p2p/test_multiplexer_pair_factory.py
+++ b/tests/p2p/test_multiplexer_pair_factory.py
@@ -1,0 +1,54 @@
+import pytest
+
+from p2p.constants import DEVP2P_V4, DEVP2P_V5
+from p2p.p2p_proto import P2PProtocol, P2PProtocolV4
+from p2p.tools.factories import MultiplexerPairFactory, NodeFactory
+
+
+def test_multiplexer_pair_factory():
+    alice_remote, bob_remote = NodeFactory.create_batch(2)
+    alice_multiplexer, bob_multiplexer = MultiplexerPairFactory(
+        alice_remote=alice_remote,
+        bob_remote=bob_remote,
+    )
+    assert alice_multiplexer.remote == bob_remote
+    assert bob_multiplexer.remote == alice_remote
+
+    assert alice_multiplexer.get_base_protocol().version == DEVP2P_V5
+    assert bob_multiplexer.get_base_protocol().version == DEVP2P_V5
+
+
+@pytest.mark.parametrize(
+    'alice_p2p_version,bob_p2p_version',
+    (
+        (DEVP2P_V4, DEVP2P_V4),
+        (DEVP2P_V4, DEVP2P_V5),
+        (DEVP2P_V5, DEVP2P_V4),
+        (DEVP2P_V5, DEVP2P_V5),
+    ),
+)
+@pytest.mark.asyncio
+async def test_multiplexer_pair_factory_with_different_p2p_versions(
+    alice_p2p_version,
+    bob_p2p_version,
+):
+    alice_multiplexer, bob_multiplexer = MultiplexerPairFactory(
+        alice_p2p_version=alice_p2p_version,
+        bob_p2p_version=bob_p2p_version,
+    )
+    expected_base_protocol_version = min(alice_p2p_version, bob_p2p_version)
+    if expected_base_protocol_version == DEVP2P_V4:
+        expected_base_protocol_class = P2PProtocolV4
+    elif expected_base_protocol_version == DEVP2P_V5:
+        expected_base_protocol_class = P2PProtocol
+    else:
+        raise Exception(f"unrecognized version: {expected_base_protocol_version}")
+
+    alice_base_protocol = alice_multiplexer.get_base_protocol()
+    bob_base_protocol = bob_multiplexer.get_base_protocol()
+
+    assert type(alice_base_protocol) is expected_base_protocol_class
+    assert type(bob_base_protocol) is expected_base_protocol_class
+
+    assert alice_base_protocol.version == expected_base_protocol_version
+    assert bob_base_protocol.version == expected_base_protocol_version

--- a/trinity/protocol/bcc/handshaker.py
+++ b/trinity/protocol/bcc/handshaker.py
@@ -3,7 +3,7 @@ from typing import cast
 from eth_typing import Hash32
 from eth_utils import encode_hex
 
-from p2p.abc import MultiplexerAPI
+from p2p.abc import MultiplexerAPI, ProtocolAPI
 from p2p.exceptions import (
     HandshakeFailure,
 )
@@ -11,7 +11,6 @@ from p2p.handshake import (
     HandshakeReceipt,
     Handshaker,
 )
-from p2p.protocol import Protocol
 
 from .commands import (
     Status,
@@ -45,7 +44,7 @@ class BCCHandshaker(Handshaker):
 
     async def do_handshake(self,
                            multiplexer: MultiplexerAPI,
-                           protocol: Protocol) -> BCCHandshakeReceipt:
+                           protocol: ProtocolAPI) -> BCCHandshakeReceipt:
         """Perform the handshake for the sub-protocol agreed with the remote peer.
 
         Raises HandshakeFailure if the handshake is not successful.

--- a/trinity/protocol/eth/handshaker.py
+++ b/trinity/protocol/eth/handshaker.py
@@ -2,7 +2,7 @@ from typing import cast, Any, Dict
 
 from eth_utils import encode_hex
 
-from p2p.abc import MultiplexerAPI
+from p2p.abc import MultiplexerAPI, ProtocolAPI
 from p2p.exceptions import (
     HandshakeFailure,
 )
@@ -10,7 +10,6 @@ from p2p.handshake import (
     HandshakeReceipt,
     Handshaker,
 )
-from p2p.protocol import Protocol
 
 from trinity.exceptions import WrongGenesisFailure, WrongNetworkFailure
 
@@ -35,7 +34,7 @@ class ETHHandshaker(Handshaker):
 
     async def do_handshake(self,
                            multiplexer: MultiplexerAPI,
-                           protocol: Protocol) -> ETHHandshakeReceipt:
+                           protocol: ProtocolAPI) -> ETHHandshakeReceipt:
         """Perform the handshake for the sub-protocol agreed with the remote peer.
 
         Raises HandshakeFailure if the handshake is not successful.

--- a/trinity/protocol/les/handshaker.py
+++ b/trinity/protocol/les/handshaker.py
@@ -8,7 +8,7 @@ from typing import (
 
 from eth_utils import encode_hex
 
-from p2p.abc import MultiplexerAPI
+from p2p.abc import MultiplexerAPI, ProtocolAPI
 from p2p.exceptions import (
     HandshakeFailure,
 )
@@ -16,7 +16,6 @@ from p2p.handshake import (
     HandshakeReceipt,
     Handshaker,
 )
-from p2p.protocol import Protocol
 
 from trinity.exceptions import WrongGenesisFailure, WrongNetworkFailure
 
@@ -50,7 +49,7 @@ class BaseLESHandshaker(Handshaker):
 
     async def do_handshake(self,
                            multiplexer: MultiplexerAPI,
-                           protocol: Protocol) -> LESHandshakeReceipt:
+                           protocol: ProtocolAPI) -> LESHandshakeReceipt:
         """Perform the handshake for the sub-protocol agreed with the remote peer.
 
         Raises HandshakeFailure if the handshake is not successful.


### PR DESCRIPTION
Extracted from #684 

Builds on #887

### What was wrong?

As a continuation of #684 we previously implemented the `Multiplexer` and new facilities to handle the P2P handshake under `p2p.handshake`.  Now we need something *active* (aka a Service) to manage the multiplexed connection and allow multiple consumers for each protocol or command.

### How was it fixed?

The implements a `Connection` service (which is implemented but not yet used by the `p2p.BasePeer`.  This service houses a `Multiplexer` and exposes the following APIs.

1. Mirrors access to the base `p2p` protocol from the `Multiplexer`.
2. Mirrors access to the `remote` from the `Multiplexer`
3. Meta-data about the remote connection like their public key, client version string, listen port, etc.
4. Meta-data about the handshake via the handshake receipts.
5. APIs for registering handlers for individual Commands or full Protocols.  This can be thought of as similar to the existing peer subscription API.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

[//]: # (See: https://trinity-client.readthedocs.io/en/latest/contributing.html#pull-requests)
- [x] Add entry to the [release notes](https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![extra-large-dog-breeds-great-dane](https://user-images.githubusercontent.com/824194/63452999-e86ece80-c404-11e9-9328-a09aad7b9c20.jpg)

