### PR TITLE
Beam backfill

### DIFF
--- a/trinity/sync/beam/backfill.py
+++ b/trinity/sync/beam/backfill.py
@@ -166,12 +166,12 @@ class BeamStateBackfill(BaseService, PeerSubscriber, QueenTrackerAPI):
             old_queen = self._queen_peer
             self._update_queen(peer)
             if peer == self._queen_peer:
-                self.logger.warning("Switching queen peer from %s to %s", old_queen, peer)
+                self.logger.debug("Switching queen peer from %s to %s", old_queen, peer)
                 continue
 
             if peer.requests.get_node_data.is_requesting:
                 # skip the peer if there's an active request
-                self.logger.warning("Skipping active peer %s", peer)
+                self.logger.debug("Backfill is skipping active peer %s", peer)
                 self.call_later(10, self._waiting_peers.put_nowait, peer)
                 continue
 
@@ -183,7 +183,7 @@ class BeamStateBackfill(BaseService, PeerSubscriber, QueenTrackerAPI):
             if len(on_deck) == 0:
                 # Nothing left to request, break and wait for new data to come in
                 self._waiting_peers.put_nowait(peer)
-                self.logger.warning("Backfill is waiting for more hashes to arrive")
+                self.logger.debug("Backfill is waiting for more hashes to arrive")
                 await self.sleep(2)
                 continue
 
@@ -317,14 +317,14 @@ class BeamStateBackfill(BaseService, PeerSubscriber, QueenTrackerAPI):
             msg += "  new=%d" % self._num_added
             msg += "  missed=%d" % self._num_missed
             msg += "  queen=%s" % self._queen_peer
-            self.logger.info("Beam-Backfill: %s", msg)
+            self.logger.debug("Beam-Backfill: %s", msg)
 
             self._num_added = 0
             self._num_missed = 0
 
             # log peer counts
             show_top_n_peers = 3
-            self.logger.info(
+            self.logger.debug(
                 "Beam-Backfill-Peer-Usage-Top-%d: %s",
                 show_top_n_peers,
                 self._num_requests_by_peer.most_common(show_top_n_peers),

--- a/trinity/sync/beam/backfill.py
+++ b/trinity/sync/beam/backfill.py
@@ -1,0 +1,284 @@
+import asyncio
+from collections import Counter
+import typing
+from typing import (
+    FrozenSet,
+    Iterable,
+    List,
+    Set,
+    Tuple,
+    Type,
+)
+
+from cancel_token import CancelToken, OperationCancelled
+from eth.abc import AtomicDatabaseAPI
+from eth_typing import Hash32
+import rlp
+
+from p2p.abc import CommandAPI
+from p2p.exceptions import BaseP2PError, PeerConnectionLost
+from p2p.peer import BasePeer, PeerSubscriber
+from p2p.service import BaseService
+
+from trinity.protocol.eth.commands import (
+    NodeData,
+)
+from trinity.protocol.eth.peer import ETHPeer, ETHPeerPool
+from trinity.protocol.common.abc import (
+    PerformanceAPI,
+)
+from trinity.sync.beam.constants import (
+    GAP_BETWEEN_TESTS,
+)
+from trinity.sync.common.peers import WaitingPeers
+
+REQUEST_SIZE = 16
+
+
+def _get_items_per_second(tracker: PerformanceAPI) -> float:
+    return -1 * tracker.items_per_second_ema.value
+
+
+def _peer_sort_key(peer: ETHPeer) -> float:
+    return _get_items_per_second(peer.requests.get_node_data.tracker)
+
+
+class BeamStateBackfill(BaseService, PeerSubscriber):
+    """
+    Use a very simple strategy to fill in state in the background.
+
+    Ask each peer in sequence for some nodes, ignoring the lowest RTT node.
+    Reduce memory pressure by using a depth-first strategy.
+
+    An intended side-effect is to build & maintain an accurate measurement of
+    the round-trip-time that peers take to respond to GetNodeData commands.
+    """
+    # We are only interested in peers entering or leaving the pool
+    subscription_msg_types: FrozenSet[Type[CommandAPI]] = frozenset()
+
+    # This is a rather arbitrary value, but when the sync is operating normally we never see
+    # the msg queue grow past a few hundred items, so this should be a reasonable limit for
+    # now.
+    msg_queue_maxsize: int = 2000
+
+    _total_processed_nodes = 0
+    _num_added = 0
+    _num_missed = 0
+    _report_interval = 10
+
+    _num_requests_by_peer: typing.Counter[ETHPeer]
+
+    def __init__(
+            self,
+            db: AtomicDatabaseAPI,
+            peer_pool: ETHPeerPool,
+            token: CancelToken = None) -> None:
+
+        # in case there is no token set, make sure this gets cancelled when the peer pool does
+        if token is None:
+            token = peer_pool.cancel_token
+
+        super().__init__(token=token)
+        self._db = db
+
+        # Pending nodes to download
+        self._node_hashes: List[Hash32] = []
+
+        self._peer_pool = peer_pool
+        self._available_peers = asyncio.Event()
+        # The best peer gets skipped for backfill, because we prefer to use it for
+        #   urgent beam sync nodes
+        self._queen_peer: ETHPeer = None
+        self._waiting_peers = WaitingPeers[ETHPeer](NodeData, sort_key=_get_items_per_second)
+
+        self._is_missing: Set[Hash32] = set()
+
+        self._num_requests_by_peer = Counter()
+
+    def _update_queen(self, peer: ETHPeer) -> None:
+        if self._queen_peer is None:
+            self._queen_peer = peer
+        elif _peer_sort_key(peer) < _peer_sort_key(self._queen_peer):
+            self._waiting_peers.put_nowait(self._queen_peer)
+            self._queen_peer = peer
+
+    async def _run(self) -> None:
+        self.run_daemon_task(self._periodically_report_progress())
+
+        with self.subscribe(self._peer_pool):
+            await self.wait(self._run_backfill())
+
+    async def _run_backfill(self) -> None:
+        while self.is_operational:
+
+            # collect node hashes that might be missing
+            await self._walk()
+
+            peer = await self._waiting_peers.get_fastest()
+            old_queen = self._queen_peer
+            self._update_queen(peer)
+            if peer == self._queen_peer:
+                self.logger.warning("Switching queen peer from %s to %s", old_queen, peer)
+                continue
+
+            if peer.requests.get_node_data.is_requesting:
+                # skip the peer if there's an active request
+                self.logger.warning("Skipping active peer %s", peer)
+                self.call_later(10, self._waiting_peers.put_nowait, peer)
+                continue
+
+            self._node_hashes, on_deck = (
+                self._node_hashes[:-1 * REQUEST_SIZE],
+                tuple(self._node_hashes[-1 * REQUEST_SIZE:]),
+            )
+
+            if len(on_deck) == 0:
+                # Nothing left to request, break and wait for new data to come in
+                self._waiting_peers.put_nowait(peer)
+                self.logger.warning("Backfill is waiting for more hashes to arrive")
+                await self.sleep(2)
+                continue
+
+            self.run_task(self._make_request(peer, on_deck))
+
+    async def _make_request(self, peer: ETHPeer, request_hashes: Tuple[Hash32, ...]) -> None:
+        self._num_requests_by_peer[peer] += 1
+        try:
+            nodes = await peer.requests.get_node_data(request_hashes)
+        except asyncio.TimeoutError:
+            self._node_hashes.extend(request_hashes)
+            self.call_later(GAP_BETWEEN_TESTS * 2, self._waiting_peers.put_nowait, peer)
+        except (PeerConnectionLost, OperationCancelled):
+            # Something unhappy, but we don't really care, peer will be gone by next loop
+            self._node_hashes.extend(request_hashes)
+        except (BaseP2PError, Exception) as exc:
+            self.logger.info("Unexpected err while getting background nodes from %s: %s", peer, exc)
+            self.logger.debug("Problem downloading background nodes from peer...", exc_info=True)
+            self._node_hashes.extend(request_hashes)
+            self.call_later(GAP_BETWEEN_TESTS * 2, self._waiting_peers.put_nowait, peer)
+        else:
+            self.call_later(GAP_BETWEEN_TESTS, self._waiting_peers.put_nowait, peer)
+            self._insert_results(request_hashes, nodes)
+
+    def _insert_results(
+            self,
+            requested_hashes: Tuple[Hash32, ...],
+            nodes: Tuple[Tuple[Hash32, bytes], ...]) -> None:
+
+        returned_nodes = dict(nodes)
+        with self._db.atomic_batch() as write_batch:
+            for requested_hash in requested_hashes:
+                if requested_hash in returned_nodes:
+                    self._num_added += 1
+                    self._total_processed_nodes += 1
+                    encoded_node = returned_nodes[requested_hash]
+                    write_batch[requested_hash] = encoded_node
+                    self._is_missing.discard(requested_hash)
+                    self._node_hashes.extend(self._get_children(encoded_node))
+                else:
+                    self._num_missed += 1
+                    self._node_hashes.append(requested_hash)
+
+    def _has_full_request_worth_of_queued_hashes(self) -> bool:
+        if len(self._node_hashes) < REQUEST_SIZE:
+            # there are too few hashes available
+            return False
+
+        next_request_preview = self._node_hashes[-1 * REQUEST_SIZE:]
+
+        # confirm that all queued hashes are missing from the database
+        # self._is_missing is cached to avoid excessive I/O of checking repeatedly
+        return all(node_hash not in self._is_missing for node_hash in next_request_preview)
+
+    async def _walk(self) -> None:
+        """
+        Evaluate queued node hashes, checking which ones are locally available. For
+        anything that is locally available, load it up and put its children on the queue.
+        """
+        while not self._has_full_request_worth_of_queued_hashes():
+            for reversed_idx, node_hash in enumerate(reversed(self._node_hashes)):
+                if node_hash in self._is_missing:
+                    continue
+
+                try:
+                    encoded_node = self._db[node_hash]
+                except KeyError:
+                    self._is_missing.add(node_hash)
+                    # release the event loop, because doing a bunch of db reads is slow
+                    await self.sleep(0)
+                    continue
+                else:
+                    # found a node to expand out
+                    remove_idx = len(self._node_hashes) - reversed_idx - 1
+                    break
+            else:
+                # Didn't find any nodes to expand. Give up the walk
+                return
+
+            # remove the already-present node hash
+            del self._node_hashes[remove_idx]
+
+            # Expand out the node that's already present
+            self._node_hashes.extend(self._get_children(encoded_node))
+
+            # Release the event loop, because this could be long
+            await self.sleep(0)
+
+            # Continue until the pending stack is big enough
+
+    def _get_children(self, encoded_node: bytes) -> Iterable[Hash32]:
+        try:
+            decoded_node = rlp.decode(encoded_node)
+        except rlp.DecodingError:
+            # Could not decode rlp, it's probably a bytecode, carry on...
+            return set()
+
+        if len(decoded_node) == 17:
+            # branch node
+            return set(node_hash for node_hash in decoded_node[:16] if len(node_hash) == 32)
+        elif len(decoded_node) == 2 and len(decoded_node[1]) == 32:
+            # leaf or extension node
+            return {decoded_node[1]}
+        else:
+            # final value, ignore
+            return set()
+
+    def set_root_hash(self, root_hash: Hash32) -> None:
+        if len(self._node_hashes) < REQUEST_SIZE:
+            self._node_hashes.append(root_hash)
+
+    def register_peer(self, peer: BasePeer) -> None:
+        super().register_peer(peer)
+        # when a new peer is added to the pool, add it to the idle peer list
+        self._waiting_peers.put_nowait(peer)  # type: ignore
+
+    def deregister_peer(self, peer: BasePeer) -> None:
+        super().deregister_peer(peer)
+        if self._queen_peer == peer:
+            self._queen_peer = None
+
+    async def _periodically_report_progress(self) -> None:
+        while self.is_operational:
+            await self.sleep(self._report_interval)
+
+            if len(self._node_hashes) == 0:
+                self.logger.debug("Beam-Backfill: waiting for new state root")
+                continue
+
+            msg = "all=%d" % self._total_processed_nodes
+            msg += "  new=%d" % self._num_added
+            msg += "  missed=%d" % self._num_missed
+            msg += "  queen=%s" % self._queen_peer
+            self.logger.info("Beam-Backfill: %s", msg)
+
+            self._num_added = 0
+            self._num_missed = 0
+
+            # log peer counts
+            show_top_n_peers = 3
+            self.logger.info(
+                "Beam-Backfill-Peer-Usage-Top-%d: %s",
+                show_top_n_peers,
+                self._num_requests_by_peer.most_common(show_top_n_peers),
+            )
+            self._num_requests_by_peer.clear()

--- a/trinity/sync/beam/chain.py
+++ b/trinity/sync/beam/chain.py
@@ -132,14 +132,21 @@ class BeamSyncer(BaseService):
             self._launch_strategy,
             self.cancel_token,
         )
-        self._state_downloader = BeamDownloader(db, peer_pool, event_bus, self.cancel_token)
+
+        self._backfiller = BeamStateBackfill(db, peer_pool, token=self.cancel_token)
+
+        self._state_downloader = BeamDownloader(
+            db,
+            peer_pool,
+            self._backfiller,
+            event_bus,
+            self.cancel_token,
+        )
         self._data_hunter = MissingDataEventHandler(
             self._state_downloader,
             event_bus,
             token=self.cancel_token,
         )
-
-        self._backfiller = BeamStateBackfill(db, peer_pool, token=self.cancel_token)
 
         self._block_importer = BeamBlockImporter(
             chain,

--- a/trinity/sync/beam/constants.py
+++ b/trinity/sync/beam/constants.py
@@ -2,7 +2,7 @@
 #   so it's reasonable to ask for all-predictive nodes from a peer.
 # Urgent node requests usually come in pretty fast, so
 #   even at a small value (like 1ms), this timeout is rarely triggered.
-DELAY_BEFORE_NON_URGENT_REQUEST = 0.001
+DELAY_BEFORE_NON_URGENT_REQUEST = 0.05
 
 # How much large should our buffer be? This is a multiplier on how many
 # nodes we can request at once from a single peer.

--- a/trinity/sync/beam/constants.py
+++ b/trinity/sync/beam/constants.py
@@ -24,3 +24,17 @@ MAX_SPECULATIVE_EXECUTIONS_PER_PROCESS = MAX_CONCURRENT_SPECULATIVE_EXECUTIONS /
 # and maybe to try out another peeer. Then reinsert it relatively soon.
 # Measured in seconds.
 NON_IDEAL_RESPONSE_PENALTY = 0.5
+
+# How many seconds should we leave the backfill peer idle, in between
+# backfill requests? This is called "tests" because we are importantly
+# checking how fast a peer is.
+GAP_BETWEEN_TESTS = 0.25
+# One reason to leave this as non-zero is: if we are regularly switching
+# the "queen peer" then we want to improve the chances that the new queen
+# (formerly backfill) is idle and ready to serve urgent nodes.
+# Another reason to leave this as non-zero: we don't want to overload the
+# database with reads/writes, but there are probably better ways to acheive
+# that goal.
+# One reason to make it relatively short, is that we want to find out quickly
+# when a new peer has excellent service stats. It might take several requests
+# to establish it (partially because we measure using an exponential average).

--- a/trinity/sync/beam/state.py
+++ b/trinity/sync/beam/state.py
@@ -490,6 +490,7 @@ class BeamDownloader(BaseService, PeerSubscriber):
                 pass
             else:
                 # peer didn't return enough results, wait a while before trying again
+                self.logger.debug("%s returned 0 state trie nodes, penalize...", peer)
                 self._queen_tracker.penalize_queen(peer)
             return completed_nodes
 
@@ -533,12 +534,12 @@ class BeamDownloader(BaseService, PeerSubscriber):
             msg += "  u_prog=%d" % self._node_tasks.num_in_progress()
             msg += "  p_pend=%d" % self._maybe_useful_nodes.num_pending()
             msg += "  p_prog=%d" % self._maybe_useful_nodes.num_in_progress()
-            self.logger.info("Beam-Sync: %s", msg)
+            self.logger.debug("Beam-Sync: %s", msg)
 
             # log peer counts
             show_top_n_peers = 3
             self.logger.debug(
-                "Beam-Peer-Usage-Top-%d: urgent=%s, predictive=%s",
+                "Beam-Sync-Peer-Usage-Top-%d: urgent=%s, predictive=%s",
                 show_top_n_peers,
                 self._num_urgent_requests_by_peer.most_common(show_top_n_peers),
                 self._num_predictive_requests_by_peer.most_common(show_top_n_peers),

--- a/trinity/sync/beam/state.py
+++ b/trinity/sync/beam/state.py
@@ -466,7 +466,7 @@ class BeamDownloader(BaseService, PeerSubscriber):
             return tuple()
         except CancelledError:
             self.logger.debug("Pending nodes call to %r future cancelled", peer)
-            return tuple()
+            raise
         except Exception as exc:
             self.logger.info("Unexpected err while downloading nodes from %s: %s", peer, exc)
             delay = NON_IDEAL_RESPONSE_PENALTY

--- a/trinity/sync/common/headers.py
+++ b/trinity/sync/common/headers.py
@@ -456,13 +456,13 @@ class SkeletonSyncer(BaseService, Generic[TChainPeer]):
 
             self.logger.debug2('sync received new headers: %s', headers)
         except PeerConnectionLost:
-            self.logger.debug("Lost connection to %s while retrieving headers, aborting sync", peer)
+            self.logger.debug("Lost connection to %s while retrieving headers", peer)
             return tuple()
         except OperationCancelled:
             self.logger.info("Skeleteon sync with %s cancelled", peer)
             return tuple()
         except asyncio.TimeoutError:
-            self.logger.warning("Timeout waiting for header batch from %s, aborting sync", peer)
+            self.logger.debug("Timeout waiting for headers (skip=%d) from %s", skip, peer)
             return tuple()
         except ValidationError as err:
             self.logger.warning(


### PR DESCRIPTION
### What was wrong?

Fix #951 

### How was it fixed?

Pretty much as planned.

Some stuff came up. Seems like the lock approach to make sure we don't ask the same peer for data twice is pretty finicky. It was triggering timeouts, even validation failures. So there's a hack to prevent asking for backfill nodes from a peer that already has an outstanding `GetNodeData` request.

### To-Do

- [x] Stop interfering with the primary beam sync, maybe maintaining a blacklist of peers that have recently been used by the beam sync importer. Currently, backfill is causing beam sync to have growing lag
- [x] Still getting some timeout errors on the lock itself, which assumes all requesters use the same timeout.
- [x] ~~Maybe a more robust locking solution that doesn't break so easily~~ :football: to later
- [x] It's not finding out data as quickly as I'd like, track down why. (First guess is ~~the sleep when there are outstanding requests to all the peers~~ the code was asking each peer in series and waiting for the previous one to finish :man_facepalming: )
- [x] ~~A better story for what happens when we finish backfill. Right now it just keeps scanning the DB over and over~~ :football: to later

[//]: # (Stay ahead of things, add list items here!)
- [ ] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

[//]: # (See: https://trinity-client.readthedocs.io/en/latest/contributing.html#pull-requests)
- [ ] Add entry to the [release notes](https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](http://earthporm.com/wp-content/uploads/2015/04/cute-animals-hokkaido-ezo-japan-20.jpg)