### PR TITLE
Rename session key members

### DIFF
--- a/p2p/discv5/identity_schemes.py
+++ b/p2p/discv5/identity_schemes.py
@@ -131,10 +131,11 @@ class IdentityScheme(ABC):
     def compute_session_keys(cls,
                              *,
                              local_private_key: bytes,
-                             peer_public_key: bytes,
-                             initiator_node_id: NodeID,
-                             recipient_node_id: NodeID,
+                             remote_public_key: bytes,
+                             local_node_id: NodeID,
+                             remote_node_id: NodeID,
                              id_nonce: IDNonce,
+                             is_locally_initiated: bool,
                              ) -> SessionKeys:
         """Compute the symmetric session keys."""
         ...
@@ -225,15 +226,24 @@ class V4IdentityScheme(IdentityScheme):
     def compute_session_keys(cls,
                              *,
                              local_private_key: bytes,
-                             peer_public_key: bytes,
-                             initiator_node_id: NodeID,
-                             recipient_node_id: NodeID,
+                             remote_public_key: bytes,
+                             local_node_id: NodeID,
+                             remote_node_id: NodeID,
                              id_nonce: IDNonce,
+                             is_locally_initiated: bool
                              ) -> SessionKeys:
         # TODO: do it properly
+        initiator_key = AES128Key(b"\x00" * AES128_KEY_SIZE)
+        recipient_key = AES128Key(b"\x11" * AES128_KEY_SIZE)
+
+        if is_locally_initiated:
+            encryption_key, decryption_key = initiator_key, recipient_key
+        else:
+            encryption_key, decryption_key = recipient_key, initiator_key
+
         return SessionKeys(
-            initiator_key=AES128Key(b"\x00" * AES128_KEY_SIZE),
-            recipient_key=AES128Key(b"\x11" * AES128_KEY_SIZE),
+            encryption_key=encryption_key,
+            decryption_key=decryption_key,
             auth_response_key=AES128Key(b"\x22" * AES128_KEY_SIZE),
         )
 

--- a/p2p/discv5/typing.py
+++ b/p2p/discv5/typing.py
@@ -26,8 +26,8 @@ NodeID = NewType("NodeID", bytes)
 
 
 class SessionKeys(NamedTuple):
-    initiator_key: AES128Key
-    recipient_key: AES128Key
+    encryption_key: AES128Key
+    decryption_key: AES128Key
     auth_response_key: AES128Key
 
 

--- a/tests/p2p/discv5/test_handshake.py
+++ b/tests/p2p/discv5/test_handshake.py
@@ -15,6 +15,12 @@ from p2p.tools.factories.keys import (
 )
 
 
+def assert_session_keys_equal(initiator_session_keys, recipient_session_keys):
+    assert initiator_session_keys.auth_response_key == recipient_session_keys.auth_response_key
+    assert initiator_session_keys.encryption_key == recipient_session_keys.decryption_key
+    assert initiator_session_keys.decryption_key == recipient_session_keys.encryption_key
+
+
 def test_initiator_expects_who_are_you_response():
     handshake_initiator = HandshakeInitiatorFactory()
     expected_token = handshake_initiator.first_packet_to_send.auth_tag
@@ -52,7 +58,7 @@ def test_successful_handshake():
     initiator_result = initiator.complete_handshake(recipient.first_packet_to_send)
     recipient_result = recipient.complete_handshake(initiator_result.auth_header_packet)
 
-    assert initiator_result.session_keys == recipient_result.session_keys
+    assert_session_keys_equal(initiator_result.session_keys, recipient_result.session_keys)
 
     assert initiator_result.message is None
     assert initiator_result.enr is None


### PR DESCRIPTION
### What was wrong?

We stored the initiator_key and the recipient_key, which has the advantage that it's symmetric in the sense that we get the same result on both sides of the handshake. However, it requires us to remember who's the initiator and who's the recipient, otherwise we don't know which key to use to encrypt or decrypt a particular message.

### How was it fixed?

Use `encryption_key` and `decryption_key` instead and pass `is_locally_initiated` to the `compute_handshake` function, so that it can make the distinction once and we can forget about it immediately after the handshake.

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://user-images.githubusercontent.com/29854669/63439571-9d69b100-c42e-11e9-95f1-657737b02000.jpg)