### PR TITLE
Peer Packer

### DIFF
--- a/p2p/discv5/channel_services.py
+++ b/p2p/discv5/channel_services.py
@@ -20,12 +20,18 @@ from p2p.trio_service import (
     ManagerAPI,
 )
 
+from p2p.discv5.constants import (
+    DATAGRAM_BUFFER_SIZE,
+)
+from p2p.discv5.messages import (
+    BaseMessage,
+)
 from p2p.discv5.packets import (
     decode_packet,
     Packet,
 )
-from p2p.discv5.constants import (
-    DATAGRAM_BUFFER_SIZE,
+from p2p.discv5.typing import (
+    NodeID,
 )
 
 
@@ -55,6 +61,18 @@ class IncomingPacket(NamedTuple):
 class OutgoingPacket(NamedTuple):
     packet: Packet
     receiver_endpoint: Endpoint
+
+
+class IncomingMessage(NamedTuple):
+    message: BaseMessage
+    sender_endpoint: Endpoint
+    sender_node_id: NodeID
+
+
+class OutgoingMessage(NamedTuple):
+    message: BaseMessage
+    receiver_endpoint: Endpoint
+    receiver_node_id: NodeID
 
 
 #

--- a/p2p/discv5/channel_services.py
+++ b/p2p/discv5/channel_services.py
@@ -57,10 +57,16 @@ class IncomingPacket(NamedTuple):
     packet: Packet
     sender_endpoint: Endpoint
 
+    def __str__(self) -> str:
+        return f"{self.__class__.__name__}[{self.packet.__class__.__name__}]"
+
 
 class OutgoingPacket(NamedTuple):
     packet: Packet
     receiver_endpoint: Endpoint
+
+    def __str__(self) -> str:
+        return f"{self.__class__.__name__}[{self.packet.__class__.__name__}]"
 
 
 class IncomingMessage(NamedTuple):
@@ -68,11 +74,17 @@ class IncomingMessage(NamedTuple):
     sender_endpoint: Endpoint
     sender_node_id: NodeID
 
+    def __str__(self) -> str:
+        return f"{self.__class__.__name__}[{self.message.__class__.__name__}]"
+
 
 class OutgoingMessage(NamedTuple):
     message: BaseMessage
     receiver_endpoint: Endpoint
     receiver_node_id: NodeID
+
+    def __str__(self) -> str:
+        return f"{self.__class__.__name__}[{self.message.__class__.__name__}]"
 
 
 #

--- a/p2p/discv5/packer.py
+++ b/p2p/discv5/packer.py
@@ -1,0 +1,445 @@
+import logging
+from typing import (
+    List,
+    Optional,
+)
+
+from eth_utils import (
+    encode_hex,
+    ValidationError,
+)
+
+import trio
+from trio.abc import (
+    ReceiveChannel,
+    SendChannel,
+)
+
+from p2p.trio_service import Service
+
+from p2p.discv5.abc import (
+    EnrDbApi,
+    HandshakeParticipantAPI,
+)
+from p2p.discv5.channel_services import (
+    Endpoint,
+    IncomingMessage,
+    IncomingPacket,
+    OutgoingMessage,
+    OutgoingPacket,
+)
+from p2p.discv5.enr import (
+    ENR,
+)
+from p2p.discv5.handshake import (
+    HandshakeInitiator,
+    HandshakeRecipient,
+)
+from p2p.discv5.messages import (
+    BaseMessage,
+    MessageTypeRegistry,
+)
+from p2p.discv5.packets import (
+    AuthTagPacket,
+    get_random_auth_tag,
+)
+from p2p.discv5.tags import (
+    compute_tag,
+)
+from p2p.discv5.typing import (
+    NodeID,
+    Nonce,
+    SessionKeys,
+)
+
+from p2p.exceptions import (
+    DecryptionError,
+    HandshakeFailure,
+)
+
+
+class PeerPacker(Service):
+    handshake_participant: Optional[HandshakeParticipantAPI] = None
+    session_keys: Optional[SessionKeys] = None
+
+    def __init__(self,
+                 local_private_key: bytes,
+                 local_node_id: NodeID,
+                 remote_node_id: NodeID,
+                 enr_db: EnrDbApi,
+                 message_type_registry: MessageTypeRegistry,
+                 incoming_packet_receive_channel: ReceiveChannel[IncomingPacket],
+                 incoming_message_send_channel: SendChannel[IncomingMessage],
+                 outgoing_message_receive_channel: ReceiveChannel[OutgoingMessage],
+                 outgoing_packet_send_channel: SendChannel[OutgoingPacket],
+                 ) -> None:
+        self.local_private_key = local_private_key
+        self.local_node_id = local_node_id
+        self.remote_node_id = remote_node_id
+        self.enr_db = enr_db
+        self.message_type_registry = message_type_registry
+
+        self.incoming_packet_receive_channel = incoming_packet_receive_channel
+        self.incoming_message_send_channel = incoming_message_send_channel
+        self.outgoing_message_receive_channel = outgoing_message_receive_channel
+        self.outgoing_packet_send_channel = outgoing_packet_send_channel
+
+        self.logger = logging.getLogger(
+            f"p2p.discv5.packer.PeerPacker[{encode_hex(remote_node_id)[2:10]}]"
+        )
+
+        self.outgoing_message_backlog: List[OutgoingMessage] = []
+
+    async def run(self) -> None:
+        async with self.incoming_packet_receive_channel, self.incoming_message_send_channel,  \
+                self.outgoing_message_receive_channel, self.outgoing_packet_send_channel:
+            self.manager.run_task(self.handle_incoming_packets, daemon=True)
+            self.manager.run_task(self.handle_outgoing_messages, daemon=True)
+            await self.manager.wait_stopped()
+
+    async def handle_incoming_packets(self) -> None:
+        async for incoming_packet in self.incoming_packet_receive_channel:
+            # Handle packets sequentially, so that the rest of the code doesn't have to deal
+            # with multiple packets being processed at the same time.
+            await self.handle_incoming_packet(incoming_packet)
+
+    async def handle_incoming_packet(self, incoming_packet: IncomingPacket) -> None:
+        if self.is_pre_handshake:
+            await self.handle_incoming_packet_pre_handshake(incoming_packet)
+        elif self.is_during_handshake:
+            await self.handle_incoming_packet_during_handshake(incoming_packet)
+        elif self.is_post_handshake:
+            await self.handle_incoming_packet_post_handshake(incoming_packet)
+        else:
+            raise Exception("Invariant: All states handled")
+
+    async def handle_outgoing_messages(self) -> None:
+        async for outgoing_message in self.outgoing_message_receive_channel:
+            # Similar to the incoming packets outgoing messages are processed in sequence, even
+            # though it's not that critical here
+            await self.handle_outgoing_message(outgoing_message)
+
+    async def handle_outgoing_message(self, outgoing_message: OutgoingMessage) -> None:
+        if self.is_pre_handshake:
+            await self.handle_outgoing_message_pre_handshake(outgoing_message)
+        elif self.is_during_handshake:
+            await self.handle_outgoing_message_during_handshake(outgoing_message)
+        elif self.is_post_handshake:
+            await self.handle_outgoing_message_post_handshake(outgoing_message)
+        else:
+            raise Exception("Invariant: All states handled")
+
+    #
+    # Incoming packet handlers
+    #
+    async def handle_incoming_packet_pre_handshake(self, incoming_packet: IncomingPacket) -> None:
+        if not self.is_pre_handshake:
+            raise ValueError("Can only handle packets pre handshake")
+
+        if isinstance(incoming_packet.packet, AuthTagPacket):
+            try:
+                remote_enr = await self.enr_db.get(self.remote_node_id)
+            except KeyError:
+                remote_enr = None
+            try:
+                local_enr = await self.enr_db.get(self.local_node_id)
+            except KeyError:
+                raise ValueError(
+                    f"Unable to find local ENR in DB by node id {encode_hex(self.local_node_id)}"
+                )
+
+            # There's a minimal chance that while we were looking up the ENRs in the db, we've
+            # initiated a handshake ourselves. Therefore, we check that we are still in the pre
+            # handshake state, if not we just drop the packet (which is what we always do with
+            # AuthTag packets received after we have initiated a handshake).
+            if self.is_pre_handshake:
+                self.logger.debug("Received handshake initiating packet")
+                self.start_handshake_as_recipient(
+                    auth_tag=incoming_packet.packet.auth_tag,
+                    local_enr=local_enr,
+                    remote_enr=remote_enr,
+                )
+            else:
+                self.logger.warning(
+                    "Dropping AuthTag packet previously thought to initiate handshake as we have "
+                    "initiated handshake ourselves in the meantime"
+                )
+
+            self.logger.debug("Responding with WhoAreYou packet")
+            await self.send_first_handshake_packet(incoming_packet.sender_endpoint)
+        else:
+            self.logger.debug(
+                "Dropping %s as handshake has not been started yet",
+                incoming_packet.packet.__class__.__name__,
+            )
+
+    async def handle_incoming_packet_during_handshake(self,
+                                                      incoming_packet: IncomingPacket,
+                                                      ) -> None:
+        if not self.is_during_handshake:
+            raise ValueError("Can only handle packets during handshake")
+        if self.handshake_participant is None:
+            raise TypeError("handshake_participant is None even though handshake is in progress")
+
+        packet = incoming_packet.packet
+
+        if self.handshake_participant.is_response_packet(packet):
+            self.logger.debug("Received %s as handshake response", packet.__class__.__name__)
+        else:
+            self.logger.debug(
+                "Dropping %s unexpectedly received during handshake",
+                packet.__class__.__name__,
+            )
+            return
+
+        try:
+            handshake_result = self.handshake_participant.complete_handshake(packet)
+        except HandshakeFailure as handshake_failure:
+            self.logger.warning(
+                "Handshake with %s has failed: %s",
+                encode_hex(self.remote_node_id),
+                handshake_failure,
+            )
+            raise  # let the service fail
+        else:
+            self.logger.info("Handshake with %s was successful", encode_hex(self.remote_node_id))
+
+            # copy message backlog before we reset it
+            outgoing_message_backlog = tuple(self.outgoing_message_backlog)
+            self.reset_handshake_state()
+            self.session_keys = handshake_result.session_keys
+            if not self.is_post_handshake:
+                raise Exception(
+                    "Invariant: As session_keys are set now, peer packer is in post handshake state"
+                )
+
+            if handshake_result.enr is not None:
+                self.logger.debug("Updating ENR in DB with %r", handshake_result.enr)
+                await self.enr_db.insert_or_update(handshake_result.enr)
+
+            if handshake_result.auth_header_packet is not None:
+                outgoing_packet = OutgoingPacket(
+                    handshake_result.auth_header_packet,
+                    incoming_packet.sender_endpoint,
+                )
+                self.logger.debug("Sending AuthHeader packet to let peer complete handshake")
+                await self.outgoing_packet_send_channel.send(outgoing_packet)
+
+            if handshake_result.message:
+                incoming_message = IncomingMessage(
+                    handshake_result.message,
+                    incoming_packet.sender_endpoint,
+                    self.remote_node_id,
+                )
+                self.logger.debug(
+                    "Received %s message during handshake",
+                    handshake_result.message.__class__.__name__,
+                )
+                await self.incoming_message_send_channel.send(incoming_message)
+
+            self.logger.debug("Sending %d messages from backlog", len(outgoing_message_backlog))
+            for outgoing_message in outgoing_message_backlog:
+                await self.handle_outgoing_message(outgoing_message)
+
+    async def handle_incoming_packet_post_handshake(self, incoming_packet: IncomingPacket) -> None:
+        if not self.is_post_handshake:
+            raise ValueError("Can only handle packets post handshake")
+        if self.session_keys is None:
+            raise TypeError("session_keys are None even though handshake has been completed")
+
+        if isinstance(incoming_packet.packet, AuthTagPacket):
+            try:
+                message = incoming_packet.packet.decrypt_message(
+                    self.session_keys.decryption_key,
+                    self.message_type_registry,
+                )
+            except DecryptionError:
+                self.logger.info(
+                    "Failed to decrypt message from peer, starting another handshake as recipient"
+                )
+                self.reset_handshake_state()
+                await self.handle_incoming_packet_pre_handshake(incoming_packet)
+            except ValidationError as validation_error:
+                self.logger.warning("Received invalid packet: %s", validation_error)
+                raise  # let the service fail
+            else:
+                self.logger.debug("Received %s in AuthTag packet", message.__class__.__name__)
+                incoming_message = IncomingMessage(
+                    message,
+                    incoming_packet.sender_endpoint,
+                    self.remote_node_id,
+                )
+                await self.incoming_message_send_channel.send(incoming_message)
+        else:
+            self.logger.debug(
+                "Dropping %s as handshake has already been completed",
+                incoming_packet.packet.__class__.__name__,
+            )
+
+    #
+    # Outgoing message handlers
+    #
+    async def handle_outgoing_message_pre_handshake(self,
+                                                    outgoing_message: OutgoingMessage,
+                                                    ) -> None:
+        if not self.is_pre_handshake:
+            raise ValueError("Can only handle message pre handshake")
+
+        try:
+            local_enr = await self.enr_db.get(self.local_node_id)
+        except KeyError:
+            raise ValueError(
+                f"Unable to find local ENR in DB by node id {encode_hex(self.local_node_id)}"
+            )
+        try:
+            remote_enr = await self.enr_db.get(self.remote_node_id)
+        except KeyError:
+            self.logger.warning(
+                "Unable to initiate handshake with %s as their ENR is not present in the DB",
+                encode_hex(self.remote_node_id),
+            )
+            raise HandshakeFailure()
+
+        # There is a minimal chance that while we were looking up the ENRs in the db, the peer has
+        # initiated a handshake by themselves. Therefore, we check that we are still in the pre
+        # handshake state, if not we just handle the packet again (which will most likely result in
+        # the message being put on the backlog).
+        if self.is_pre_handshake:
+            self.logger.info(
+                "Initiating handshake to send %s",
+                outgoing_message.message.__class__.__name__,
+            )
+            self.start_handshake_as_initiator(
+                local_enr=local_enr,
+                remote_enr=remote_enr,
+                message=outgoing_message.message,
+            )
+            self.logger.debug("Sending initiating packet")
+            await self.send_first_handshake_packet(outgoing_message.receiver_endpoint)
+        else:
+            await self.handle_outgoing_message(outgoing_message)
+
+    async def handle_outgoing_message_during_handshake(self,
+                                                       outgoing_message: OutgoingMessage
+                                                       ) -> None:
+        if not self.is_during_handshake:
+            raise ValueError("Can only handle message during handshake")
+
+        self.logger.debug(
+            "Putting %s on message backlog as handshake is in progress already",
+            outgoing_message.message.__class__.__name__,
+        )
+        self.outgoing_message_backlog.append(outgoing_message)
+        await trio.sleep(0)
+
+    async def handle_outgoing_message_post_handshake(self,
+                                                     outgoing_message: OutgoingMessage,
+                                                     ) -> None:
+        if not self.is_post_handshake:
+            raise ValueError("Can only handle message post handshake")
+        if self.session_keys is None:
+            raise TypeError("session_keys are None even though handshake has been completed")
+
+        packet = AuthTagPacket.prepare(
+            tag=compute_tag(self.local_node_id, self.remote_node_id),
+            auth_tag=get_random_auth_tag(),
+            message=outgoing_message.message,
+            key=self.session_keys.encryption_key,
+        )
+        outgoing_packet = OutgoingPacket(
+            packet,
+            outgoing_message.receiver_endpoint,
+        )
+        self.logger.debug(
+            "Sending %s in AuthTag packet",
+            outgoing_message.message.__class__.__name__,
+        )
+        await self.outgoing_packet_send_channel.send(outgoing_packet)
+
+    #
+    # Start Handshake Methods
+    #
+    def start_handshake_as_initiator(self,
+                                     local_enr: ENR,
+                                     remote_enr: ENR,
+                                     message: BaseMessage,
+                                     ) -> None:
+        if not self.is_pre_handshake:
+            raise ValueError("Can only register handshake when its not started yet")
+
+        self.handshake_participant = HandshakeInitiator(
+            local_private_key=self.local_private_key,
+            local_enr=local_enr,
+            remote_enr=remote_enr,
+            initial_message=message,
+        )
+
+        if not self.is_during_handshake:
+            raise Exception("Invariant: After a handshake is started, the handshake is in progress")
+
+    def start_handshake_as_recipient(self,
+                                     auth_tag: Nonce,
+                                     local_enr: ENR,
+                                     remote_enr: Optional[ENR],
+                                     ) -> None:
+        if not self.is_pre_handshake:
+            raise ValueError("Can only register handshake when its not started yet")
+
+        self.handshake_participant = HandshakeRecipient(
+            local_private_key=self.local_private_key,
+            local_enr=local_enr,
+            remote_node_id=self.remote_node_id,
+            remote_enr=remote_enr,
+            initiating_packet_auth_tag=auth_tag,
+        )
+
+        if not self.is_during_handshake:
+            raise Exception("Invariant: After a handshake is started, the handshake is in progress")
+
+    #
+    # Handshake states
+    #
+    @property
+    def is_pre_handshake(self) -> bool:
+        """True if neither session keys are available nor a handshake is in progress."""
+        return self.handshake_participant is None and self.session_keys is None
+
+    @property
+    def is_during_handshake(self) -> bool:
+        """True if a handshake is in progress, but not completed yet."""
+        return self.handshake_participant is not None
+
+    @property
+    def is_post_handshake(self) -> bool:
+        """True if session keys from a preceding handshake are available."""
+        return self.handshake_participant is None and self.session_keys is not None
+
+    def reset_handshake_state(self) -> None:
+        """Return to the pre handshake state.
+
+        This deletes the session keys, the handshake participant instance, and all messages on the
+        message backlog. After this method is called, a new handshake can be initiated.
+        """
+        if self.is_pre_handshake:
+            raise ValueError("Handshake is already in pre state")
+        self.handshake_participant = None
+        self.session_keys = None
+        self.outgoing_message_backlog.clear()
+
+    def is_expecting_handshake_packet(self, incoming_packet: IncomingPacket) -> bool:
+        """Check if the peer packer is waiting for the given packet to complete a handshake.
+
+        This should be called before putting the packet in question on the peer's incoming packet
+        channel.
+        """
+        return (
+            self.is_during_handshake and
+            self.handshake_participant.is_response_packet(incoming_packet.packet)
+        )
+
+    async def send_first_handshake_packet(self, receiver_endpoint: Endpoint) -> None:
+        outgoing_packet = OutgoingPacket(
+            self.handshake_participant.first_packet_to_send,
+            receiver_endpoint,
+        )
+        await self.outgoing_packet_send_channel.send(outgoing_packet)

--- a/p2p/trio_service.py
+++ b/p2p/trio_service.py
@@ -5,8 +5,6 @@ import sys
 from types import TracebackType
 from typing import Any, Callable, Awaitable, Optional, Tuple, Type, AsyncIterator
 
-from mypy_extensions import VarArg
-
 from async_generator import asynccontextmanager
 
 import trio
@@ -156,7 +154,7 @@ class ManagerAPI(ABC):
     @trio_typing.takes_callable_and_args
     @abstractmethod
     async def run_task(self,
-                       async_fn: Callable[[VarArg()], Awaitable[Any]],
+                       async_fn: Callable[..., Awaitable[Any]],
                        *args: Any,
                        daemon: bool = False,
                        name: str = None) -> None:

--- a/tests-trio/p2p-trio/test_packer.py
+++ b/tests-trio/p2p-trio/test_packer.py
@@ -1,0 +1,335 @@
+import pytest
+
+import trio
+
+import pytest_trio
+
+from p2p.trio_service import (
+    background_service,
+)
+
+from p2p.discv5.channel_services import (
+    IncomingPacket,
+    OutgoingMessage,
+)
+from p2p.discv5.enr_db import (
+    MemoryEnrDb,
+)
+from p2p.discv5.messages import (
+    default_message_type_registry,
+)
+from p2p.discv5.identity_schemes import (
+    default_identity_scheme_registry,
+)
+from p2p.discv5.packer import (
+    PeerPacker,
+)
+from p2p.discv5.packets import (
+    AuthHeaderPacket,
+    AuthTagPacket,
+    WhoAreYouPacket,
+)
+
+from p2p.tools.factories.discovery import (
+    AuthTagPacketFactory,
+    ENRFactory,
+    EndpointFactory,
+    HandshakeRecipientFactory,
+    PingMessageFactory,
+)
+from p2p.tools.factories.keys import (
+    PrivateKeyFactory,
+)
+
+
+@pytest.fixture
+def private_key():
+    return PrivateKeyFactory().to_bytes()
+
+
+@pytest.fixture
+def remote_private_key():
+    return PrivateKeyFactory().to_bytes()
+
+
+@pytest.fixture
+def enr(private_key):
+    return ENRFactory(private_key=private_key)
+
+
+@pytest.fixture
+def remote_enr(remote_private_key):
+    return ENRFactory(private_key=remote_private_key)
+
+
+@pytest.fixture
+def endpoint():
+    return EndpointFactory()
+
+
+@pytest.fixture
+def remote_endpoint():
+    return EndpointFactory()
+
+
+@pytest_trio.trio_fixture
+async def enr_db(enr, remote_enr):
+    db = MemoryEnrDb(default_identity_scheme_registry)
+    await db.insert(enr)
+    await db.insert(remote_enr)
+    return db
+
+
+@pytest.fixture
+def incoming_packet_channels():
+    return trio.open_memory_channel(0)
+
+
+@pytest.fixture
+def incoming_message_channels():
+    return trio.open_memory_channel(0)
+
+
+@pytest.fixture
+def outgoing_packet_channels():
+    return trio.open_memory_channel(0)
+
+
+@pytest.fixture
+def outgoing_message_channels():
+    return trio.open_memory_channel(0)
+
+
+@pytest.fixture
+def remote_incoming_packet_channels():
+    return trio.open_memory_channel(0)
+
+
+@pytest.fixture
+def remote_incoming_message_channels():
+    return trio.open_memory_channel(0)
+
+
+@pytest.fixture
+def remote_outgoing_packet_channels():
+    return trio.open_memory_channel(0)
+
+
+@pytest.fixture
+def remote_outgoing_message_channels():
+    return trio.open_memory_channel(0)
+
+
+@pytest_trio.trio_fixture
+async def bridged_channels(nursery,
+                           endpoint,
+                           remote_endpoint,
+                           outgoing_packet_channels,
+                           remote_outgoing_packet_channels,
+                           incoming_packet_channels,
+                           remote_incoming_packet_channels,
+                           ):
+    async def bridge_channels(outgoing_packet_receive_channel, incoming_packet_send_channel):
+        async for outgoing_packet in outgoing_packet_receive_channel:
+            receiver = outgoing_packet.receiver_endpoint
+            sender = endpoint if receiver == remote_endpoint else remote_endpoint
+            incoming_packet = IncomingPacket(
+                packet=outgoing_packet.packet,
+                sender_endpoint=sender,
+            )
+            await incoming_packet_send_channel.send(incoming_packet)
+
+    nursery.start_soon(
+        bridge_channels,
+        outgoing_packet_channels[1],
+        remote_incoming_packet_channels[0],
+    )
+    nursery.start_soon(
+        bridge_channels,
+        remote_outgoing_packet_channels[1],
+        incoming_packet_channels[0],
+    )
+
+
+@pytest_trio.trio_fixture
+async def peer_packer(enr_db,
+                      private_key,
+                      enr,
+                      remote_enr,
+                      incoming_packet_channels,
+                      incoming_message_channels,
+                      outgoing_message_channels,
+                      outgoing_packet_channels):
+    peer_packer = PeerPacker(
+        local_private_key=private_key,
+        local_node_id=enr.node_id,
+        remote_node_id=remote_enr.node_id,
+        enr_db=enr_db,
+        message_type_registry=default_message_type_registry,
+        incoming_packet_receive_channel=incoming_packet_channels[1],
+        incoming_message_send_channel=incoming_message_channels[0],
+        outgoing_message_receive_channel=outgoing_message_channels[1],
+        outgoing_packet_send_channel=outgoing_packet_channels[0],
+    )
+    async with background_service(peer_packer):
+        yield peer_packer
+
+
+@pytest_trio.trio_fixture
+async def remote_peer_packer(enr_db,
+                             remote_private_key,
+                             enr,
+                             remote_enr,
+                             remote_incoming_packet_channels,
+                             remote_incoming_message_channels,
+                             remote_outgoing_message_channels,
+                             remote_outgoing_packet_channels):
+    peer_packer = PeerPacker(
+        local_private_key=remote_private_key,
+        local_node_id=remote_enr.node_id,
+        remote_node_id=enr.node_id,
+        enr_db=enr_db,
+        message_type_registry=default_message_type_registry,
+        incoming_packet_receive_channel=remote_incoming_packet_channels[1],
+        incoming_message_send_channel=remote_incoming_message_channels[0],
+        outgoing_message_receive_channel=remote_outgoing_message_channels[1],
+        outgoing_packet_send_channel=remote_outgoing_packet_channels[0],
+    )
+    async with background_service(peer_packer):
+        yield peer_packer
+
+
+#
+# Peer packer tests
+#
+@pytest.mark.trio
+async def test_peer_packer_initiates_handshake(peer_packer,
+                                               outgoing_message_channels,
+                                               outgoing_packet_channels,
+                                               nursery):
+    outgoing_message = OutgoingMessage(
+        PingMessageFactory(),
+        EndpointFactory(),
+        peer_packer.remote_node_id,
+    )
+
+    await outgoing_message_channels[0].send(outgoing_message)
+    with trio.fail_after(0.5):
+        outgoing_packet = await outgoing_packet_channels[1].receive()
+
+    assert peer_packer.is_during_handshake
+    assert outgoing_packet.receiver_endpoint == outgoing_message.receiver_endpoint
+    assert isinstance(outgoing_packet.packet, AuthTagPacket)
+
+
+@pytest.mark.trio
+async def test_peer_packer_sends_who_are_you(peer_packer,
+                                             incoming_packet_channels,
+                                             outgoing_packet_channels,
+                                             nursery):
+    incoming_packet = IncomingPacket(
+        AuthTagPacketFactory(),
+        EndpointFactory(),
+    )
+
+    await incoming_packet_channels[0].send(incoming_packet)
+    with trio.fail_after(0.5):
+        outgoing_packet = await outgoing_packet_channels[1].receive()
+
+    assert peer_packer.is_during_handshake
+    assert outgoing_packet.receiver_endpoint == incoming_packet.sender_endpoint
+    assert isinstance(outgoing_packet.packet, WhoAreYouPacket)
+    assert outgoing_packet.packet.token == incoming_packet.packet.auth_tag
+
+
+@pytest.mark.trio
+async def test_peer_packer_sends_auth_header(peer_packer,
+                                             enr,
+                                             remote_enr,
+                                             remote_endpoint,
+                                             incoming_packet_channels,
+                                             outgoing_packet_channels,
+                                             outgoing_message_channels,
+                                             nursery,
+                                             ):
+    outgoing_message = OutgoingMessage(
+        PingMessageFactory(),
+        remote_endpoint,
+        peer_packer.remote_node_id,
+    )
+    await outgoing_message_channels[0].send(outgoing_message)
+    with trio.fail_after(0.5):
+        outgoing_auth_tag_packet = await outgoing_packet_channels[1].receive()
+
+    handshake_recipient = HandshakeRecipientFactory(
+        local_private_key=remote_private_key,
+        local_enr=remote_enr,
+        remote_private_key=peer_packer.local_private_key,
+        remote_enr=enr,
+        remote_node_id=peer_packer.local_node_id,
+        initiating_packet_auth_tag=outgoing_auth_tag_packet.packet.auth_tag,
+    )
+    incoming_packet = IncomingPacket(
+        handshake_recipient.first_packet_to_send,
+        sender_endpoint=remote_endpoint,
+    )
+    await incoming_packet_channels[0].send(incoming_packet)
+    with trio.fail_after(0.5):
+        outgoing_auth_header_packet = await outgoing_packet_channels[1].receive()
+
+    assert peer_packer.is_post_handshake
+    assert isinstance(outgoing_auth_header_packet.packet, AuthHeaderPacket)
+    assert outgoing_auth_header_packet.receiver_endpoint == remote_endpoint
+
+    handshake_result = handshake_recipient.complete_handshake(
+        outgoing_auth_header_packet.packet,
+    )
+    initiator_keys = peer_packer.session_keys
+    recipient_keys = handshake_result.session_keys
+    assert initiator_keys.auth_response_key == recipient_keys.auth_response_key
+    assert initiator_keys.encryption_key == recipient_keys.decryption_key
+    assert initiator_keys.decryption_key == recipient_keys.encryption_key
+
+
+@pytest.mark.trio
+async def test_full_peer_packer_handshake(peer_packer,
+                                          remote_peer_packer,
+                                          endpoint,
+                                          remote_endpoint,
+                                          enr,
+                                          remote_enr,
+                                          outgoing_message_channels,
+                                          remote_outgoing_message_channels,
+                                          incoming_message_channels,
+                                          remote_incoming_message_channels,
+                                          bridged_channels,
+                                          nursery):
+    # to remote
+    outgoing_message = OutgoingMessage(
+        message=PingMessageFactory(),
+        receiver_endpoint=remote_endpoint,
+        receiver_node_id=remote_enr.node_id,
+    )
+    await outgoing_message_channels[0].send(outgoing_message)
+
+    with trio.fail_after(0.5):
+        incoming_message = await remote_incoming_message_channels[1].receive()
+
+    assert incoming_message.message == outgoing_message.message
+    assert incoming_message.sender_endpoint == endpoint
+    assert incoming_message.sender_node_id == enr.node_id
+
+    # from remote
+    outgoing_message = OutgoingMessage(
+        message=PingMessageFactory(),
+        receiver_endpoint=endpoint,
+        receiver_node_id=enr.node_id,
+    )
+    await remote_outgoing_message_channels[0].send(outgoing_message)
+
+    with trio.fail_after(0.5):
+        incoming_message = await incoming_message_channels[1].receive()
+
+    assert incoming_message.message == outgoing_message.message
+    assert incoming_message.sender_endpoint == remote_endpoint
+    assert incoming_message.sender_node_id == remote_enr.node_id


### PR DESCRIPTION
This PR adds the `PeerPacker`, the class responsible for packing messages into packets and unpacking packets to messages for a single peer. Unfortunately, it's rather big, even after a few iterations of stripping it down. I thought about making it even smaller by separating handshake related stuff from normal operation, but this wouldn't help much (because normal operation is pretty trivial) and increase complexity (because you have now two components that are strongly linked and have to communicate with each other). Fortunately, it's not that complex because most of what it has to do is feed the `HandshakeInitiator` and `HandshakeRecipient` class with the packets it received on some channel.

### External interface

The `PeerPacker` is supposed to be created and owned by a `Packer` class that manages one `PeerPacker` for every peer. The `Packer` sends incoming packets to the peer's `incoming_packet_receive_channel` if they come from the right sender, or if `PeerPacker.is_expecting_handshake_packet` returns `True` (we need this because `WhoAreYou` packets don't have an explicit sender). The `PeerPacker` also receives messages it should pack and send to the peer in the `outgoing_messages_receive_channel`. Encrypted packets that should be sent over the wire go to the `outgoing_packet_send_channel`, decrypted messages go to the `incoming_message_send_channel`.

The handshake can fail in a couple of ways with a `HandshakeFailure` exception which the packer should catch.

### Internals

There's some internal state:
- `handshake_participant` which is either `None` (before or after the handshake), a `HandshakeInitiator`, or a `HandshakeRecipient`
- `session_keys` which is `None` before or during the handshake, or set after the handshake
- `outgoing_message_backlog`: a list of messages we have to send to the peer, but we haven't yet because the handshake is still ongoing

At all times, the peer packer is either `is_pre_handshake`, `is_during_handshake`, or `is_post_handshake`, depending on which of `handshake_participant` and `session_keys` is set. Incoming packets and outgoing messages are dispatched to three different methods each based on this state. Incoming packets/outgoing messages generally change the state.

We don't store our or the peer ENR directly, but get it from the db instead, because it might change over time (e.g. if we get a new IP).

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://user-images.githubusercontent.com/29854669/63449710-e62a6580-c440-11e9-87d8-0a786813a689.jpg)
