### PR TITLE
Add support for etherscan resolved checkpoints

### DIFF
--- a/newsfragments/963.feature.rst
+++ b/newsfragments/963.feature.rst
@@ -1,0 +1,2 @@
+Allow Trinity to automatically resolve a checkpoint through the etherscan API
+using this syntax: ``--beam-from-checkpoint="eth://block/byetherscan/latest"``

--- a/tests/integration/test_etherscan_checkpoint_resolver.py
+++ b/tests/integration/test_etherscan_checkpoint_resolver.py
@@ -1,0 +1,23 @@
+import pytest
+
+from eth_utils import encode_hex
+from trinity.plugins.builtin.syncer.cli import (
+    parse_checkpoint_uri,
+    is_block_hash,
+)
+
+# This is just the score at the tip as it was at some point on August 26th 2019
+# It serves as anchor so that we have *some* minimal expected score to test against.
+MIN_EXPECTED_SCORE = 11631608640717612820968
+
+
+@pytest.mark.parametrize(
+    'uri',
+    (
+        'eth://block/byetherscan/latest',
+    )
+)
+def test_parse_checkpoint(uri):
+    checkpoint = parse_checkpoint_uri(uri)
+    assert checkpoint.score >= MIN_EXPECTED_SCORE
+    assert is_block_hash(encode_hex(checkpoint.block_hash))

--- a/trinity/plugins/builtin/syncer/etherscan_api.py
+++ b/trinity/plugins/builtin/syncer/etherscan_api.py
@@ -1,0 +1,54 @@
+from typing import (
+    Any,
+    Dict,
+)
+from eth_utils import (
+    to_hex,
+    to_int,
+)
+
+import requests
+
+from trinity.exceptions import BaseTrinityError
+
+
+ETHERSCAN_API_URL = "https://api.etherscan.io/api"
+ETHERSCAN_PROXY_API_URL = f"{ETHERSCAN_API_URL}?module=proxy"
+
+
+class EtherscanAPIError(BaseTrinityError):
+    pass
+
+
+def etherscan_post(action: str) -> Any:
+    response = requests.post(f"{ETHERSCAN_PROXY_API_URL}&action={action}")
+
+    if response.status_code not in [200, 201]:
+        raise EtherscanAPIError(
+            f"Invalid status code: {response.status_code}, {response.reason}"
+        )
+
+    try:
+        value = response.json()
+    except ValueError as err:
+        raise EtherscanAPIError(f"Invalid response: {response.text}") from err
+
+    message = value.get('message', '')
+    result = value['result']
+
+    api_error = message == 'NOTOK' or result == 'Error!'
+
+    if api_error:
+        raise EtherscanAPIError(f"API error: {message}, result: {result}")
+
+    return value['result']
+
+
+def get_latest_block() -> int:
+    response = etherscan_post("eth_blockNumber")
+    return to_int(hexstr=response)
+
+
+def get_block_by_number(block_number: int) -> Dict[str, Any]:
+    num = to_hex(primitive=block_number)
+    return etherscan_post(f"eth_getBlockByNumber&tag={num}&boolean=false")

--- a/trinity/plugins/builtin/syncer/plugin.py
+++ b/trinity/plugins/builtin/syncer/plugin.py
@@ -206,7 +206,8 @@ class BeamSyncStrategy(BaseSyncStrategy):
             action=NormalizeCheckpointURI,
             help=(
                 "Start beam sync from a trusted checkpoint specified using URI syntax:"
-                "eth://block/byhash/<hash>?score=<score>"
+                "By specific block, eth://block/byhash/<hash>?score=<score>"
+                "Let etherscan pick a block near the tip, eth://block/byetherscan/latest"
             ),
             default=None,
         )


### PR DESCRIPTION
### What was wrong?

This adds support for a checkpoint URI that automatically resolves a trusted checkpoint via the etherscan API.

Relates to #892 

### How was it fixed?

I considered a different design for this initially, one that would have consulted the etherscan API in an async fashion at a later stage of the boot. But here's why I went for this instead:

1. Trinity already depends against the `request` library and that library is entirely synchronous

2. Making synchronous requests at this super early stage (it's pretty much the very first thing that happens) will only delay the boot a bit but doesn't cause trouble anywhere else so that might be acceptable

3. It's very simple. The whole change only happens on the argument parsing stage and is otherwise transparent (uses the existing checkpoint processing pipeline)

Usage: `-beam-from-checkpoint="eth://block/byetherscan/latest"`

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

[//]: # (See: https://trinity-client.readthedocs.io/en/latest/contributing.html#pull-requests)
- [x] Add entry to the [release notes](https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://i.pinimg.com/originals/81/41/db/8141db7fdbec49d9e54188b8e37bdf6b.jpg)
