### PR TITLE
Fix base protocol selection in MultiplexerPairFactory

### DIFF
--- a/newsfragments/964.bugfix.rst
+++ b/newsfragments/964.bugfix.rst
@@ -1,0 +1,1 @@
+Fix ``p2p.tools.factories.MultiplexerPairFactory`` negotiation of ``p2p`` protocol version.

--- a/tests/p2p/test_multiplexer_pair_factory.py
+++ b/tests/p2p/test_multiplexer_pair_factory.py
@@ -19,36 +19,29 @@ def test_multiplexer_pair_factory():
 
 
 @pytest.mark.parametrize(
-    'alice_p2p_version,bob_p2p_version',
+    'alice_p2p_version,bob_p2p_version,expected_base_protocol_class',
     (
-        (DEVP2P_V4, DEVP2P_V4),
-        (DEVP2P_V4, DEVP2P_V5),
-        (DEVP2P_V5, DEVP2P_V4),
-        (DEVP2P_V5, DEVP2P_V5),
+        (DEVP2P_V4, DEVP2P_V4, P2PProtocolV4),
+        (DEVP2P_V4, DEVP2P_V5, P2PProtocolV4),
+        (DEVP2P_V5, DEVP2P_V4, P2PProtocolV4),
+        (DEVP2P_V5, DEVP2P_V5, P2PProtocol),
     ),
 )
 @pytest.mark.asyncio
 async def test_multiplexer_pair_factory_with_different_p2p_versions(
     alice_p2p_version,
     bob_p2p_version,
+    expected_base_protocol_class,
 ):
     alice_multiplexer, bob_multiplexer = MultiplexerPairFactory(
         alice_p2p_version=alice_p2p_version,
         bob_p2p_version=bob_p2p_version,
     )
-    expected_base_protocol_version = min(alice_p2p_version, bob_p2p_version)
-    if expected_base_protocol_version == DEVP2P_V4:
-        expected_base_protocol_class = P2PProtocolV4
-    elif expected_base_protocol_version == DEVP2P_V5:
-        expected_base_protocol_class = P2PProtocol
-    else:
-        raise Exception(f"unrecognized version: {expected_base_protocol_version}")
-
     alice_base_protocol = alice_multiplexer.get_base_protocol()
     bob_base_protocol = bob_multiplexer.get_base_protocol()
 
     assert type(alice_base_protocol) is expected_base_protocol_class
     assert type(bob_base_protocol) is expected_base_protocol_class
 
-    assert alice_base_protocol.version == expected_base_protocol_version
-    assert bob_base_protocol.version == expected_base_protocol_version
+    assert alice_base_protocol.version == expected_base_protocol_class.version
+    assert bob_base_protocol.version == expected_base_protocol_class.version

--- a/tests/p2p/test_multiplexer_pair_factory.py
+++ b/tests/p2p/test_multiplexer_pair_factory.py
@@ -1,0 +1,54 @@
+import pytest
+
+from p2p.constants import DEVP2P_V4, DEVP2P_V5
+from p2p.p2p_proto import P2PProtocol, P2PProtocolV4
+from p2p.tools.factories import MultiplexerPairFactory, NodeFactory
+
+
+def test_multiplexer_pair_factory():
+    alice_remote, bob_remote = NodeFactory.create_batch(2)
+    alice_multiplexer, bob_multiplexer = MultiplexerPairFactory(
+        alice_remote=alice_remote,
+        bob_remote=bob_remote,
+    )
+    assert alice_multiplexer.remote == bob_remote
+    assert bob_multiplexer.remote == alice_remote
+
+    assert alice_multiplexer.get_base_protocol().version == DEVP2P_V5
+    assert bob_multiplexer.get_base_protocol().version == DEVP2P_V5
+
+
+@pytest.mark.parametrize(
+    'alice_p2p_version,bob_p2p_version',
+    (
+        (DEVP2P_V4, DEVP2P_V4),
+        (DEVP2P_V4, DEVP2P_V5),
+        (DEVP2P_V5, DEVP2P_V4),
+        (DEVP2P_V5, DEVP2P_V5),
+    ),
+)
+@pytest.mark.asyncio
+async def test_multiplexer_pair_factory_with_different_p2p_versions(
+    alice_p2p_version,
+    bob_p2p_version,
+):
+    alice_multiplexer, bob_multiplexer = MultiplexerPairFactory(
+        alice_p2p_version=alice_p2p_version,
+        bob_p2p_version=bob_p2p_version,
+    )
+    expected_base_protocol_version = min(alice_p2p_version, bob_p2p_version)
+    if expected_base_protocol_version == DEVP2P_V4:
+        expected_base_protocol_class = P2PProtocolV4
+    elif expected_base_protocol_version == DEVP2P_V5:
+        expected_base_protocol_class = P2PProtocol
+    else:
+        raise Exception(f"unrecognized version: {expected_base_protocol_version}")
+
+    alice_base_protocol = alice_multiplexer.get_base_protocol()
+    bob_base_protocol = bob_multiplexer.get_base_protocol()
+
+    assert type(alice_base_protocol) is expected_base_protocol_class
+    assert type(bob_base_protocol) is expected_base_protocol_class
+
+    assert alice_base_protocol.version == expected_base_protocol_version
+    assert bob_base_protocol.version == expected_base_protocol_version


### PR DESCRIPTION
### What was wrong?

The `MultiplexerPairFactory` did not properly negotiate the proper version of the base protocol.

### How was it fixed?

Added code to negotiate the base protocol version based on the `p2p_version` supplied for each peer.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

[//]: # (See: https://trinity-client.readthedocs.io/en/latest/contributing.html#pull-requests)
- [x] Add entry to the [release notes](https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![Newfoundland_dog_Smoky](https://user-images.githubusercontent.com/824194/63545779-6b675600-c4e5-11e9-9fa5-fad630d4ccd7.jpg)

