### PR TITLE
Remove superfluous noqa comments

### DIFF
--- a/p2p/discovery.py
+++ b/p2p/discovery.py
@@ -441,7 +441,7 @@ class DiscoveryProtocol(asyncio.DatagramProtocol):
         ip_address, udp_port = addr
         address = Address(ip_address, udp_port)
         # The prefix below is what geth uses to identify discv5 msgs.
-        # https://github.com/ethereum/go-ethereum/blob/c4712bf96bc1bae4a5ad4600e9719e4a74bde7d5/p2p/discv5/udp.go#L149  # noqa: E501
+        # https://github.com/ethereum/go-ethereum/blob/c4712bf96bc1bae4a5ad4600e9719e4a74bde7d5/p2p/discv5/udp.go#L149
         if text_if_str(to_bytes, data).startswith(V5_ID_STRING):
             self.receive_v5(address, cast(bytes, data))
         else:

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 import os
 from setuptools import setup, find_packages
 
-PYEVM_DEPENDENCY = "py-evm==0.3.0a5"  # noqa: E501
+PYEVM_DEPENDENCY = "py-evm==0.3.0a5"
 
 
 deps = {

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -214,7 +214,7 @@ def _chain_with_block_validation(base_db, genesis_state, chain_cls=Chain):
         "extra_data": b"B",
         "gas_limit": 3141592,
         "gas_used": 0,
-        "mix_hash": decode_hex("56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421"),  # noqa: E501
+        "mix_hash": decode_hex("56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421"),
         "nonce": decode_hex("0102030405060708"),
         "block_number": 0,
         "parent_hash": decode_hex("0000000000000000000000000000000000000000000000000000000000000000"),  # noqa: E501

--- a/trinity/__init__.py
+++ b/trinity/__init__.py
@@ -18,11 +18,11 @@ def is_uvloop_supported() -> bool:
 
 if is_uvloop_supported():
     # Set `uvloop` as the default event loop
-    import asyncio  # noqa: E402
+    import asyncio
 
     from eth._warnings import catch_and_ignore_import_warning
     with catch_and_ignore_import_warning():
-        import uvloop  # noqa: E402
+        import uvloop
 
     asyncio.set_event_loop_policy(uvloop.EventLoopPolicy())
 


### PR DESCRIPTION
### What was wrong?

We have a bunch of `noqa` comments that aren't needed.

### How was it fixed?

Removed them.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

[//]: # (See: https://trinity-client.readthedocs.io/en/latest/contributing.html#pull-requests)
- [x] ~~Add entry to the [release notes](https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)~~

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://cdn.cnn.com/cnnnext/dam/assets/130819142015-cutest-animal-1-fennec-fox-horizontal-large-gallery.jpg)
