### PR TITLE
Message Dispatcher

### DIFF
--- a/p2p/discv5/constants.py
+++ b/p2p/discv5/constants.py
@@ -22,8 +22,13 @@ IP_V6_SIZE = 16  # size of an IPv6 address
 
 ENR_REPR_PREFIX = "enr:"  # prefix used when printing an ENR
 MAX_ENR_SIZE = 300  # maximum allowed size of an ENR
+IP_V4_ADDRESS_ENR_KEY = b"ip"
+UDP_PORT_ENR_KEY = b"udp"
 
 WHO_ARE_YOU_MAGIC_SUFFIX = b"WHOAREYOU"
 
 # buffer size used for incoming UDP datagrams (should be larger than MAX_PACKET_SIZE)
 DATAGRAM_BUFFER_SIZE = 2048
+
+MAX_REQUEST_ID = 2**32 - 1  # highest request id used for outgoing requests
+MAX_REQUEST_ID_ATTEMPTS = 100  # number of attempts we take to guess a available request id

--- a/p2p/discv5/message_dispatcher.py
+++ b/p2p/discv5/message_dispatcher.py
@@ -1,0 +1,319 @@
+import logging
+import random
+from types import (
+    TracebackType,
+)
+from typing import (
+    AsyncIterator,
+    Callable,
+    Dict,
+    Optional,
+    Tuple,
+    Type,
+    TypeVar,
+)
+
+import trio
+from trio.abc import (
+    ReceiveChannel,
+    SendChannel,
+)
+from trio.hazmat import (
+    checkpoint,
+)
+
+from eth_utils import (
+    encode_hex,
+)
+
+from p2p.trio_service import Service
+
+from p2p.discv5.channel_services import (
+    Endpoint,
+    IncomingMessage,
+    OutgoingMessage,
+)
+from p2p.discv5.abc import (
+    ChannelHandlerSubscriptionAPI,
+    EnrDbApi,
+    MessageDispatcherAPI,
+)
+from p2p.discv5.constants import (
+    IP_V4_ADDRESS_ENR_KEY,
+    MAX_REQUEST_ID,
+    MAX_REQUEST_ID_ATTEMPTS,
+    UDP_PORT_ENR_KEY,
+)
+from p2p.discv5.messages import (
+    BaseMessage,
+)
+from p2p.discv5.typing import (
+    NodeID,
+)
+
+
+def get_random_request_id() -> int:
+    return random.randint(0, MAX_REQUEST_ID)
+
+
+ChannelContentType = TypeVar("ChannelContentType")
+
+
+class ChannelHandlerSubscription(ChannelHandlerSubscriptionAPI[ChannelContentType]):
+    def __init__(self,
+                 send_channel: SendChannel[ChannelContentType],
+                 receive_channel: ReceiveChannel[ChannelContentType],
+                 remove_fn: Callable[[], None],
+                 ) -> None:
+        self._send_channel = send_channel
+        self.receive_channel = receive_channel
+        self.remove_fn = remove_fn
+
+    def cancel(self) -> None:
+        self.remove_fn()
+
+    async def __aenter__(self) -> "ChannelHandlerSubscription[ChannelContentType]":
+        await self._send_channel.__aenter__()
+        await self.receive_channel.__aenter__()
+        return self
+
+    async def __aexit__(self,
+                        exc_type: Optional[Type[BaseException]],
+                        exc_value: Optional[BaseException],
+                        traceback: Optional[TracebackType],
+                        ) -> None:
+        self.remove_fn()
+        await self._send_channel.__aexit__()
+        await self.receive_channel.__aexit__()
+
+    async def receive(self) -> ChannelContentType:
+        return await self.receive_channel.receive()
+
+    def __aiter__(self) -> AsyncIterator[ChannelContentType]:
+        return self
+
+    async def __anext__(self) -> ChannelContentType:
+        try:
+            return await self.receive()
+        except trio.EndOfChannel:
+            raise StopAsyncIteration
+
+
+class MessageDispatcher(Service, MessageDispatcherAPI):
+    logger = logging.getLogger("p2p.discv5.message_dispatcher.MessageDispatcher")
+
+    def __init__(self,
+                 enr_db: EnrDbApi,
+                 incoming_message_receive_channel: ReceiveChannel[IncomingMessage],
+                 outgoing_message_send_channel: SendChannel[OutgoingMessage],
+                 ) -> None:
+        self.enr_db = enr_db
+
+        self.incoming_message_receive_channel = incoming_message_receive_channel
+        self.outgoing_message_send_channel = outgoing_message_send_channel
+
+        self.request_handler_send_channels: Dict[int, SendChannel[IncomingMessage]] = {}
+        self.response_handler_send_channels: Dict[
+            Tuple[NodeID, int],
+            SendChannel[IncomingMessage],
+        ] = {}
+
+    async def run(self) -> None:
+        async with self.incoming_message_receive_channel, self.outgoing_message_send_channel:
+            async for incoming_message in self.incoming_message_receive_channel:
+                await self.handle_incoming_message(incoming_message)
+
+    async def handle_incoming_message(self, incoming_message: IncomingMessage) -> None:
+        sender_node_id = incoming_message.sender_node_id
+        message_type = incoming_message.message.message_type
+        request_id = incoming_message.message.request_id
+
+        is_request = message_type in self.request_handler_send_channels
+        is_response = (sender_node_id, request_id) in self.response_handler_send_channels
+
+        if is_request and is_response:
+            self.logger.warning(
+                f"%s from %s is both a response to an earlier request (id %d) and a request a "
+                f"handler is present for (message type %d). Message will be handled twice.",
+                incoming_message,
+                encode_hex(sender_node_id),
+                request_id,
+                message_type,
+            )
+        if not is_request and not is_response:
+            self.logger.warning(
+                f"Dropping %s from %s (request id %d, message type %d) as neither a request nor a "
+                f"response handler is present",
+                incoming_message,
+                encode_hex(sender_node_id),
+                request_id,
+                message_type,
+            )
+            await checkpoint()
+
+        if is_request:
+            self.logger.debug(
+                "Received request %s with id %d from %s",
+                incoming_message,
+                request_id,
+                encode_hex(sender_node_id),
+            )
+            send_channel = self.request_handler_send_channels[message_type]
+            await send_channel.send(incoming_message)
+
+        if is_response:
+            self.logger.debug(
+                "Received response %s for request with id %d from %s",
+                incoming_message,
+                request_id,
+                encode_hex(sender_node_id),
+            )
+            send_channel = self.response_handler_send_channels[sender_node_id, request_id]
+            await send_channel.send(incoming_message)
+
+    def get_free_request_id(self, node_id: NodeID) -> int:
+        for _ in range(MAX_REQUEST_ID_ATTEMPTS):
+            request_id = get_random_request_id()
+            if (node_id, request_id) not in self.response_handler_send_channels:
+                return request_id
+        else:
+            # this should be extremely unlikely to happen
+            raise ValueError(
+                f"Failed to get free request id ({len(self.response_handler_send_channels)} "
+                f"handlers added right now)"
+            )
+
+    def add_request_handler(self,
+                            message_type: int,
+                            ) -> ChannelHandlerSubscription[IncomingMessage]:
+        if message_type in self.request_handler_send_channels:
+            raise ValueError(f"Request handler for type {message_type} is already added")
+
+        request_channels: Tuple[
+            SendChannel[IncomingMessage],
+            ReceiveChannel[IncomingMessage],
+        ] = trio.open_memory_channel(0)
+        self.request_handler_send_channels[message_type] = request_channels[0]
+
+        self.logger.debug("Adding request handler for message type %d", message_type)
+
+        def remove() -> None:
+            try:
+                self.request_handler_send_channels.pop(message_type)
+            except KeyError:
+                raise ValueError(
+                    f"Request handler for type {message_type} has already been removed"
+                )
+            else:
+                self.logger.debug("Removing request handler for message type %d", message_type)
+
+        return ChannelHandlerSubscription(
+            send_channel=request_channels[0],
+            receive_channel=request_channels[1],
+            remove_fn=remove,
+        )
+
+    def add_response_handler(self,
+                             remote_node_id: NodeID,
+                             request_id: int,
+                             ) -> ChannelHandlerSubscription[IncomingMessage]:
+        if (remote_node_id, request_id) in self.response_handler_send_channels:
+            raise ValueError(
+                f"Response handler for node id {encode_hex(remote_node_id)} and request id "
+                f"{request_id} has already been added"
+            )
+
+        self.logger.debug(
+            "Adding response handler for peer %s and request id %d",
+            encode_hex(remote_node_id),
+            request_id,
+        )
+
+        response_channels: Tuple[
+            SendChannel[IncomingMessage],
+            ReceiveChannel[IncomingMessage],
+        ] = trio.open_memory_channel(0)
+        self.response_handler_send_channels[(remote_node_id, request_id)] = response_channels[0]
+
+        def remove() -> None:
+            try:
+                self.response_handler_send_channels.pop((remote_node_id, request_id))
+            except KeyError:
+                raise ValueError(
+                    f"Response handler for node id {encode_hex(remote_node_id)} and request id "
+                    f"{request_id} has already been removed"
+                )
+            else:
+                self.logger.debug(
+                    "Removing response handler for peer %s and request id %d",
+                    encode_hex(remote_node_id),
+                    request_id,
+                )
+
+        return ChannelHandlerSubscription(
+            send_channel=response_channels[0],
+            receive_channel=response_channels[1],
+            remove_fn=remove,
+        )
+
+    async def prepare_outgoing_message(self,
+                                       receiver_node_id: NodeID,
+                                       message: BaseMessage,
+                                       ) -> OutgoingMessage:
+        try:
+            enr = await self.enr_db.get(receiver_node_id)
+        except KeyError:
+            raise ValueError(f"No ENR for peer {encode_hex(receiver_node_id)} known")
+
+        try:
+            ip_address = enr[IP_V4_ADDRESS_ENR_KEY]
+        except KeyError:
+            raise ValueError(
+                f"ENR for peer {encode_hex(receiver_node_id)} does not contain an IP address"
+            )
+
+        try:
+            udp_port = enr[UDP_PORT_ENR_KEY]
+        except KeyError:
+            raise ValueError(
+                f"ENR for peer {encode_hex(receiver_node_id)} does not contain a UDP port"
+            )
+
+        outgoing_message = OutgoingMessage(
+            message=message,
+            receiver_endpoint=Endpoint(
+                ip_address,
+                udp_port,
+            ),
+            receiver_node_id=receiver_node_id,
+        )
+        return outgoing_message
+
+    async def request(self, receiver_node_id: NodeID, message: BaseMessage) -> IncomingMessage:
+        response_channels: Tuple[
+            SendChannel[IncomingMessage],
+            ReceiveChannel[IncomingMessage],
+        ] = trio.open_memory_channel(0)
+        response_send_channel, response_receive_channel = response_channels
+
+        async with self.add_response_handler(
+            receiver_node_id,
+            message.request_id,
+        ) as response_subscription:
+            outgoing_message = await self.prepare_outgoing_message(receiver_node_id, message)
+            self.logger.debug(
+                "Sending %s to %s with request id %d",
+                outgoing_message,
+                encode_hex(receiver_node_id),
+                message.request_id,
+            )
+            await self.outgoing_message_send_channel.send(outgoing_message)
+            response = await response_subscription.receive()
+            self.logger.debug(
+                "Received %s from %s with request id %d as response to %s",
+                response,
+                outgoing_message,
+                encode_hex(receiver_node_id),
+                message.request_id,
+            )
+            return response

--- a/p2p/tools/factories/discovery.py
+++ b/p2p/tools/factories/discovery.py
@@ -1,3 +1,4 @@
+import socket
 from typing import (
     Any,
     Dict,
@@ -107,7 +108,7 @@ class EndpointFactory(factory.Factory):
     class Meta:
         model = Endpoint
 
-    ip_address = factory.Faker("ipv4")
+    ip_address = factory.LazyFunction(lambda: socket.inet_aton(factory.Faker("ipv4").generate({})))
     port = factory.Faker("pyint", min_value=0, max_value=65535)
 
 

--- a/tests-trio/p2p-trio/test_channel_services.py
+++ b/tests-trio/p2p-trio/test_channel_services.py
@@ -1,4 +1,8 @@
 import trio
+from socket import (
+    inet_aton,
+    inet_ntoa,
+)
 
 import pytest
 import pytest_trio
@@ -10,6 +14,7 @@ from p2p.trio_service import (
 from p2p.discv5.channel_services import (
     DatagramReceiver,
     DatagramSender,
+    Endpoint,
     IncomingDatagram,
     OutgoingDatagram,
     OutgoingPacket,
@@ -54,7 +59,7 @@ async def test_datagram_receiver(socket_pair):
             received_datagram = await receive_channel.receive()
 
         assert received_datagram.datagram == data
-        assert received_datagram.sender_endpoint.ip_address == sender_address[0]
+        assert received_datagram.sender_endpoint.ip_address == inet_aton(sender_address[0])
         assert received_datagram.sender_endpoint.port == sender_address[1]
 
 
@@ -66,7 +71,10 @@ async def test_datagram_sender(socket_pair):
 
     send_channel, receive_channel = trio.open_memory_channel(1)
     async with background_service(DatagramSender(receive_channel, sending_socket)):
-        outgoing_datagram = OutgoingDatagram(b"some packet", receiver_endpoint)
+        outgoing_datagram = OutgoingDatagram(
+            b"some packet",
+            Endpoint(inet_aton(receiver_endpoint[0]), receiver_endpoint[1]),
+        )
         await send_channel.send(outgoing_datagram)
 
         with trio.fail_after(0.5):

--- a/tests-trio/p2p-trio/test_channel_services.py
+++ b/tests-trio/p2p-trio/test_channel_services.py
@@ -1,7 +1,6 @@
 import trio
 from socket import (
     inet_aton,
-    inet_ntoa,
 )
 
 import pytest

--- a/tests-trio/p2p-trio/test_message_dispatcher.py
+++ b/tests-trio/p2p-trio/test_message_dispatcher.py
@@ -1,0 +1,181 @@
+import pytest
+
+import pytest_trio
+
+import trio
+
+from p2p.trio_service import (
+    background_service,
+)
+
+from p2p.tools.factories.discovery import (
+    EndpointFactory,
+    ENRFactory,
+    PingMessageFactory,
+)
+from p2p.tools.factories.keys import (
+    PrivateKeyFactory,
+)
+
+from p2p.discv5.enr_db import MemoryEnrDb
+from p2p.discv5.channel_services import (
+    IncomingMessage,
+)
+from p2p.discv5.identity_schemes import (
+    default_identity_scheme_registry,
+)
+from p2p.discv5.messages import (
+    PingMessage,
+)
+from p2p.discv5.message_dispatcher import (
+    MessageDispatcher,
+)
+
+
+@pytest.fixture
+def private_key():
+    return PrivateKeyFactory().to_bytes()
+
+
+@pytest.fixture
+def remote_private_key():
+    return PrivateKeyFactory().to_bytes()
+
+
+@pytest.fixture
+def endpoint():
+    return EndpointFactory()
+
+
+@pytest.fixture
+def remote_endpoint():
+    return EndpointFactory()
+
+
+@pytest.fixture
+def enr(private_key, endpoint):
+    return ENRFactory(
+        private_key=private_key,
+        custom_kv_pairs={
+            b"ip": endpoint.ip_address,
+            b"udp": endpoint.port,
+        }
+    )
+
+
+@pytest.fixture
+def remote_enr(remote_private_key, remote_endpoint):
+    return ENRFactory(
+        private_key=remote_private_key,
+        custom_kv_pairs={
+            b"ip": remote_endpoint.ip_address,
+            b"udp": remote_endpoint.port,
+        }
+    )
+
+
+@pytest_trio.trio_fixture
+async def enr_db(enr, remote_enr):
+    db = MemoryEnrDb(default_identity_scheme_registry)
+    await db.insert(enr)
+    await db.insert(remote_enr)
+    return db
+
+
+@pytest.fixture
+def incoming_message_channels():
+    return trio.open_memory_channel(0)
+
+
+@pytest.fixture
+def outgoing_message_channels():
+    return trio.open_memory_channel(0)
+
+
+@pytest_trio.trio_fixture
+async def message_dispatcher(enr_db, incoming_message_channels, outgoing_message_channels):
+    message_dispatcher = MessageDispatcher(
+        enr_db=enr_db,
+        incoming_message_receive_channel=incoming_message_channels[1],
+        outgoing_message_send_channel=outgoing_message_channels[0],
+    )
+    async with background_service(message_dispatcher):
+        yield message_dispatcher
+
+
+@pytest.mark.trio
+async def test_request_handling(message_dispatcher,
+                                incoming_message_channels,
+                                remote_enr,
+                                remote_endpoint):
+    ping_send_channel, ping_receive_channel = trio.open_memory_channel(0)
+
+    async with message_dispatcher.add_request_handler(
+        PingMessage.message_type,
+    ) as request_subscription:
+
+        incoming_message = IncomingMessage(
+            message=PingMessageFactory(),
+            sender_endpoint=remote_endpoint,
+            sender_node_id=remote_enr.node_id,
+        )
+        await incoming_message_channels[0].send(incoming_message)
+
+        with trio.fail_after(1):
+            handled_incoming_message = await request_subscription.receive()
+        assert handled_incoming_message == incoming_message
+
+
+@pytest.mark.trio
+async def test_response_handling(message_dispatcher, remote_enr, incoming_message_channels):
+    request_id = message_dispatcher.get_free_request_id(remote_enr.node_id)
+    async with message_dispatcher.add_response_handler(
+        remote_enr.node_id,
+        request_id,
+    ) as response_subscription:
+
+        incoming_message = IncomingMessage(
+            message=PingMessageFactory(
+                request_id=request_id,
+            ),
+            sender_endpoint=remote_endpoint,
+            sender_node_id=remote_enr.node_id,
+        )
+        await incoming_message_channels[0].send(incoming_message)
+
+        with trio.fail_after(1):
+            handled_response = await response_subscription.receive()
+        assert handled_response == incoming_message
+
+
+@pytest.mark.trio
+async def test_request(message_dispatcher,
+                       remote_enr,
+                       remote_endpoint,
+                       incoming_message_channels,
+                       outgoing_message_channels,
+                       nursery,
+                       ):
+    request_id = message_dispatcher.get_free_request_id(remote_enr.node_id)
+    request = PingMessageFactory(request_id=request_id)
+    response = PingMessageFactory(request_id=request_id)
+
+    async def handle_request_on_remote():
+        outgoing_message = await outgoing_message_channels[1].receive()
+        assert outgoing_message.message == request
+        assert outgoing_message.receiver_endpoint == remote_endpoint
+        assert outgoing_message.receiver_node_id == remote_enr.node_id
+
+        await incoming_message_channels[0].send(IncomingMessage(
+            message=response,
+            sender_endpoint=remote_endpoint,
+            sender_node_id=remote_enr.node_id,
+        ))
+
+    nursery.start_soon(handle_request_on_remote)
+
+    received_response = await message_dispatcher.request(remote_enr.node_id, request)
+
+    assert received_response.message == response
+    assert received_response.sender_endpoint == remote_endpoint
+    assert received_response.sender_node_id == remote_enr.node_id


### PR DESCRIPTION
The message dispatcher is the interface that the business logic will use to communicate with peers. They can register handlers at the dispatcher, which will then pass the corresponding messages to the handler via channels. For convenience, there's also a `request` method that one can await to get the response, which will automatically register and deregister handlers and look up ip address and udp port from the ENR db.

I also unified how we handle IP addresses: In ENRs they are `bytes`, in the `Endpoint` tuple they used to be .-delimited `str`s (now everything is `bytes`).

Some request-responses will consist of multiple messages (in particular, `Nodes` messages). Those cannot be nicely handled with `requests` at the moment. I'll probably add a `request_nodes` method for that when I need it.

It might be necessary in the future to move some of the functionality down to the packer in order to handle timeouts and failed handshakes properly. But the interface of the message dispatcher hopefully shouldn't be affected by this, so I just wrote the simple version for now.

#### Cute Animal Picture

![animal-animal-world-bird-portrait-54103](https://user-images.githubusercontent.com/29854669/63636440-a9908100-c66f-11e9-883b-1bed7c357324.jpg)
