### PR TITLE
Finish `Hello`, `BeaconBlocks`, `RecentBeaconBlocks` req/resp

### DIFF
--- a/tests/libp2p/bcc/test_req_resp.py
+++ b/tests/libp2p/bcc/test_req_resp.py
@@ -165,3 +165,160 @@ async def test_request_beacon_blocks_on_canonical_chain(nodes_with_chain, monkey
     ]
     assert len(requested_blocks) == len(expected_blocks)
     assert set(requested_blocks) == set(expected_blocks)
+
+
+@pytest.mark.parametrize(
+    "num_nodes",
+    (2,),
+)
+@pytest.mark.asyncio
+async def test_request_beacon_blocks_invalid_request(nodes_with_chain, monkeypatch):
+    nodes = nodes_with_chain
+    await nodes[0].dial_peer_maddr(nodes[1].listen_maddr_with_peer_id)
+    await nodes[0].say_hello(nodes[1].peer_id)
+    await asyncio.sleep(0.01)
+    assert nodes[1].peer_id in nodes[0].handshaked_peers
+    assert nodes[0].peer_id in nodes[1].handshaked_peers
+
+    head_slot = 5
+    request_head_block_root = b'\x56' * 32
+    head_block = BeaconBlock(
+        slot=head_slot,
+        parent_root=ZERO_HASH32,
+        state_root=ZERO_HASH32,
+        signature=EMPTY_SIGNATURE,
+        body=BeaconBlockBody(),
+    )
+
+    def get_block_by_root(root):
+        return head_block
+    monkeypatch.setattr(nodes[1].chain, "get_block_by_root", get_block_by_root)
+
+    # Test: Can not request blocks with `start_slot` greater than head block slot
+    start_slot = 6
+    count = 5
+    step = 1
+    with pytest.raises(RequestFailure):
+        await nodes[0].request_beacon_blocks(
+            peer_id=nodes[1].peer_id,
+            head_block_root=request_head_block_root,
+            start_slot=start_slot,
+            count=count,
+            step=step,
+        )
+
+
+@pytest.mark.parametrize(
+    "num_nodes",
+    (2,),
+)
+@pytest.mark.parametrize(
+    "fork_chain_block_slots, start_slot, count, step, expected_block_slots",
+    (
+        (range(10), 0, 5, 1, range(5)),
+        (range(10), 1, 2, 3, [1, 4]),
+        ([0, 2, 3, 7, 8], 0, 4, 2, [0, 2]),
+        ([0, 4, 5], 4, 2, 2, [4]),
+    ),
+)
+@pytest.mark.asyncio
+async def test_request_beacon_blocks_on_fork_chain(nodes_with_chain,
+                                                   monkeypatch,
+                                                   fork_chain_block_slots,
+                                                   start_slot,
+                                                   count,
+                                                   step,
+                                                   expected_block_slots):
+    nodes = nodes_with_chain
+    await nodes[0].dial_peer_maddr(nodes[1].listen_maddr_with_peer_id)
+    await nodes[0].say_hello(nodes[1].peer_id)
+    await asyncio.sleep(0.01)
+    assert nodes[1].peer_id in nodes[0].handshaked_peers
+    assert nodes[0].peer_id in nodes[1].handshaked_peers
+
+    canonical_head_slot = fork_chain_block_slots[-1] + 1
+    mock_block = BeaconBlock(
+        slot=canonical_head_slot,
+        parent_root=ZERO_HASH32,
+        state_root=ZERO_HASH32,
+        signature=EMPTY_SIGNATURE,
+        body=BeaconBlockBody(),
+    )
+    canonical_head = mock_block
+
+    # Mock up fork chain block database
+    fork_chain_blocks = []
+    for slot in fork_chain_block_slots:
+        if len(fork_chain_blocks) == 0:
+            fork_chain_blocks.append(mock_block.copy(
+                slot=slot,
+            ))
+        else:
+            fork_chain_blocks.append(mock_block.copy(
+                slot=slot,
+                parent_root=fork_chain_blocks[-1].signing_root,
+            ))
+    mock_root_to_block_db = {
+        block.signing_root: block
+        for block in fork_chain_blocks
+    }
+
+    def get_block_by_root(root):
+        if root in mock_root_to_block_db:
+            return mock_root_to_block_db[root]
+        else:
+            raise BlockNotFound
+    monkeypatch.setattr(nodes[1].chain, "get_block_by_root", get_block_by_root)
+
+    def get_canonical_block_by_slot(slot):
+        return canonical_head
+    monkeypatch.setattr(nodes[1].chain, "get_canonical_block_by_slot", get_canonical_block_by_slot)
+
+    requested_blocks = await nodes[0].request_beacon_blocks(
+        peer_id=nodes[1].peer_id,
+        head_block_root=fork_chain_blocks[-1].signing_root,
+        start_slot=start_slot,
+        count=count,
+        step=step,
+    )
+
+    expected_blocks = [
+        block
+        for block in fork_chain_blocks
+        if block.slot in expected_block_slots
+    ]
+    assert len(requested_blocks) == len(expected_blocks)
+    assert set(requested_blocks) == set(expected_blocks)
+
+
+@pytest.mark.parametrize(
+    "num_nodes",
+    (2,),
+)
+@pytest.mark.asyncio
+async def test_request_beacon_blocks_on_nonexist_chain(nodes_with_chain, monkeypatch):
+    nodes = nodes_with_chain
+    await nodes[0].dial_peer_maddr(nodes[1].listen_maddr_with_peer_id)
+    await nodes[0].say_hello(nodes[1].peer_id)
+    await asyncio.sleep(0.01)
+    assert nodes[1].peer_id in nodes[0].handshaked_peers
+    assert nodes[0].peer_id in nodes[1].handshaked_peers
+
+    request_head_block_root = b'\x56' * 32
+
+    def get_block_by_root(root):
+        raise BlockNotFound
+    monkeypatch.setattr(nodes[1].chain, "get_block_by_root", get_block_by_root)
+
+    start_slot = 0
+    count = 5
+    step = 1
+    requested_blocks = await nodes[0].request_beacon_blocks(
+        peer_id=nodes[1].peer_id,
+        head_block_root=request_head_block_root,
+        start_slot=start_slot,
+        count=count,
+        step=step,
+    )
+
+    assert len(requested_blocks) == 0

--- a/tests/libp2p/bcc/test_req_resp.py
+++ b/tests/libp2p/bcc/test_req_resp.py
@@ -1,18 +1,16 @@
 import asyncio
 
-import pytest
-
 from eth.constants import ZERO_HASH32
 from eth.exceptions import BlockNotFound
 from eth.validation import validate_word
+import pytest
 
 from eth2.beacon.constants import EMPTY_SIGNATURE
 from eth2.beacon.types.blocks import BeaconBlock, BeaconBlockBody
-
-from trinity.protocol.bcc_libp2p.node import REQ_RESP_HELLO_SSZ
 from trinity.protocol.bcc_libp2p.configs import ResponseCode
 from trinity.protocol.bcc_libp2p.exceptions import HandshakeFailure, RequestFailure
 from trinity.protocol.bcc_libp2p.messages import HelloRequest
+from trinity.protocol.bcc_libp2p.node import REQ_RESP_HELLO_SSZ
 from trinity.protocol.bcc_libp2p.utils import read_req, write_resp
 
 

--- a/tests/libp2p/bcc/test_req_resp.py
+++ b/tests/libp2p/bcc/test_req_resp.py
@@ -196,12 +196,20 @@ async def test_request_beacon_blocks_invalid_request(nodes_with_chain, monkeypat
             step=step,
         )
 
-    # TEST: Can not request blocks with `start_slot` lower than peer's latest finalized slot
+    # TEST: Can not request fork chain blocks with `start_slot`
+    # lower than peer's latest finalized slot
     start_slot = head_slot
     state_machine = nodes[1].chain.get_state_machine()
     old_state = state_machine.state
     new_checkpoint = old_state.finalized_checkpoint.copy(
         epoch=old_state.finalized_checkpoint.epoch + 1
+    )
+
+    def get_canonical_block_by_slot(slot):
+        raise BlockNotFound
+
+    monkeypatch.setattr(
+        nodes[1].chain, "get_canonical_block_by_slot", get_canonical_block_by_slot
     )
 
     def get_state_machine(at_slot=None):

--- a/tests/libp2p/bcc/test_req_resp.py
+++ b/tests/libp2p/bcc/test_req_resp.py
@@ -2,10 +2,16 @@ import asyncio
 
 import pytest
 
-from trinity.protocol.bcc_libp2p.configs import ResponseCode
-from trinity.protocol.bcc_libp2p.exceptions import HandshakeFailure
-from trinity.protocol.bcc_libp2p.messages import HelloRequest
+from eth.constants import ZERO_HASH32
+from eth.exceptions import BlockNotFound
+
+from eth2.beacon.constants import EMPTY_SIGNATURE
+from eth2.beacon.types.blocks import BeaconBlock, BeaconBlockBody
+
 from trinity.protocol.bcc_libp2p.node import REQ_RESP_HELLO_SSZ
+from trinity.protocol.bcc_libp2p.configs import ResponseCode
+from trinity.protocol.bcc_libp2p.exceptions import HandshakeFailure, RequestFailure
+from trinity.protocol.bcc_libp2p.messages import HelloRequest
 from trinity.protocol.bcc_libp2p.utils import read_req, write_resp
 
 
@@ -33,7 +39,9 @@ async def test_hello_failure_invalid_hello_packet(
             fork_version=b"\x12\x34\x56\x78"  # version different from another node.
         )
 
-    monkeypatch.setattr(nodes[0], "_make_hello_packet", _make_hello_packet_with_wrong_fork_version)
+    monkeypatch.setattr(
+        nodes[0], "_make_hello_packet", _make_hello_packet_with_wrong_fork_version
+    )
     # Test: Handshake fails when sending invalid hello packet.
     with pytest.raises(HandshakeFailure):
         await nodes[0].say_hello(nodes[1].peer_id)
@@ -43,9 +51,12 @@ async def test_hello_failure_invalid_hello_packet(
 
     def _make_hello_packet_with_wrong_checkpoint():
         return HelloRequest(
-            finalized_root=b"\x78" * 32,  # finalized root different from another node.
+            finalized_root=b"\x78" * 32  # finalized root different from another node.
         )
-    monkeypatch.setattr(nodes[0], "_make_hello_packet", _make_hello_packet_with_wrong_checkpoint)
+
+    monkeypatch.setattr(
+        nodes[0], "_make_hello_packet", _make_hello_packet_with_wrong_checkpoint
+    )
     # Test: Handshake fails when sending invalid hello packet.
     with pytest.raises(HandshakeFailure):
         await nodes[0].say_hello(nodes[1].peer_id)
@@ -72,3 +83,85 @@ async def test_hello_failure_failure_response(nodes_with_chain):
         await nodes[0].say_hello(nodes[1].peer_id)
     await asyncio.sleep(0.01)
     assert nodes[0].peer_id not in nodes[1].handshaked_peers
+
+
+@pytest.mark.parametrize("num_nodes", (2,))
+@pytest.mark.asyncio
+async def test_request_beacon_blocks_fail(nodes_with_chain, monkeypatch):
+    nodes = nodes_with_chain
+    await nodes[0].dial_peer_maddr(nodes[1].listen_maddr_with_peer_id)
+
+    # Test: Can not request beacon block before handshake
+    with pytest.raises(RequestFailure):
+        await nodes[0].request_beacon_blocks(
+            peer_id=nodes[1].peer_id,
+            head_block_root=ZERO_HASH32,
+            start_slot=0,
+            count=1,
+            step=1,
+        )
+
+
+@pytest.mark.parametrize("num_nodes", (2,))
+@pytest.mark.asyncio
+async def test_request_beacon_blocks_on_canonical_chain(nodes_with_chain, monkeypatch):
+    nodes = nodes_with_chain
+    await nodes[0].dial_peer_maddr(nodes[1].listen_maddr_with_peer_id)
+    await nodes[0].say_hello(nodes[1].peer_id)
+    await asyncio.sleep(0.01)
+    assert nodes[1].peer_id in nodes[0].handshaked_peers
+    assert nodes[0].peer_id in nodes[1].handshaked_peers
+
+    # Mock up block database
+    head_slot = 5
+    request_head_block_root = b"\x56" * 32
+    head_block = BeaconBlock(
+        slot=head_slot,
+        parent_root=ZERO_HASH32,
+        state_root=ZERO_HASH32,
+        signature=EMPTY_SIGNATURE,
+        body=BeaconBlockBody(),
+    )
+    blocks = [head_block.copy(slot=slot) for slot in range(5)]
+    mock_slot_to_block_db = {
+        5: head_block,
+        4: blocks[4],
+        3: blocks[3],
+        2: blocks[2],
+        1: blocks[1],
+        0: blocks[0],
+    }
+
+    def get_block_by_root(root):
+        return head_block
+
+    monkeypatch.setattr(nodes[1].chain, "get_block_by_root", get_block_by_root)
+
+    def get_canonical_block_by_slot(slot):
+        if slot in mock_slot_to_block_db:
+            return mock_slot_to_block_db[slot]
+        else:
+            raise BlockNotFound
+
+    monkeypatch.setattr(
+        nodes[1].chain, "get_canonical_block_by_slot", get_canonical_block_by_slot
+    )
+
+    start_slot = 0
+    count = 5
+    step = 3
+    requested_blocks = await nodes[0].request_beacon_blocks(
+        peer_id=nodes[1].peer_id,
+        head_block_root=request_head_block_root,
+        start_slot=start_slot,
+        count=count,
+        step=step,
+    )
+
+    expected_blocks = [
+        blocks[start_slot + i * step]
+        for i in range(count)
+        if start_slot + i * step < len(blocks)
+    ]
+    assert len(requested_blocks) == len(expected_blocks)
+    assert set(requested_blocks) == set(expected_blocks)

--- a/trinity/protocol/bcc_libp2p/exceptions.py
+++ b/trinity/protocol/bcc_libp2p/exceptions.py
@@ -16,3 +16,7 @@ class WriteMessageFailure(BaseLibp2pError):
 
 class ValidationError(BaseLibp2pError):
     pass
+
+
+class RequestFailure(BaseLibp2pError):
+    pass

--- a/trinity/protocol/bcc_libp2p/messages.py
+++ b/trinity/protocol/bcc_libp2p/messages.py
@@ -1,3 +1,7 @@
+from typing import (
+    Sequence,
+)
+
 import ssz
 from ssz.sedes import (
     List,
@@ -86,16 +90,23 @@ class BeaconBlocksResponse(ssz.Serializable):
         ('blocks', List(BeaconBlock, 1)),
     ]
 
-    def __init__(self, blocks: int) -> None:
+    def __init__(self, blocks: Sequence[BeaconBlock]) -> None:
         super().__init__(blocks)
 
 
-# # TODO: RecentBeaconBlocksRequest
-# (
-#   block_roots: []HashTreeRoot
-# )
+class RecentBeaconBlocksRequest(ssz.Serializable):
+    fields = [
+        ('block_roots', List(bytes32, 1)),
+    ]
 
-# # RecentBeaconBlocksResponse
-# (
-#   blocks: []BeaconBlock
-# )
+    def __init__(self, block_roots: Sequence[Hash32]) -> None:
+        super().__init__(block_roots)
+
+
+class RecentBeaconBlocksResponse(ssz.Serializable):
+    fields = [
+        ('blocks', List(BeaconBlock, 1)),
+    ]
+
+    def __init__(self, blocks: Sequence[BeaconBlock]) -> None:
+        super().__init__(blocks)

--- a/trinity/protocol/bcc_libp2p/messages.py
+++ b/trinity/protocol/bcc_libp2p/messages.py
@@ -1,5 +1,6 @@
 import ssz
 from ssz.sedes import (
+    List,
     bytes4,
     bytes32,
     uint64,
@@ -19,6 +20,7 @@ from eth2.beacon.typing import (
     default_slot,
     default_version,
 )
+from eth2.beacon.types.blocks import BeaconBlock
 
 
 class HelloRequest(ssz.Serializable):
@@ -79,10 +81,13 @@ class BeaconBlocksRequest(ssz.Serializable):
         )
 
 
-# # TODO: BeaconBlocksResponse
-# (
-#   blocks: []BeaconBlock
-# )
+class BeaconBlocksResponse(ssz.Serializable):
+    fields = [
+        ('blocks', List(BeaconBlock, 1)),
+    ]
+
+    def __init__(self, blocks: int) -> None:
+        super().__init__(blocks)
 
 
 # # TODO: RecentBeaconBlocksRequest

--- a/trinity/protocol/bcc_libp2p/node.py
+++ b/trinity/protocol/bcc_libp2p/node.py
@@ -535,7 +535,7 @@ class Node(BaseService):
     @to_tuple
     def _get_blocks_from_canonical_chain_by_slot(
         self,
-        slot_of_requested_blocks: Sequence[BaseBeaconBlock],
+        slot_of_requested_blocks: Sequence[Slot],
     ) -> Iterable[BaseBeaconBlock]:
         # If peer's head block is on our canonical chain,
         # start getting the requested blocks by slots.

--- a/trinity/protocol/bcc_libp2p/node.py
+++ b/trinity/protocol/bcc_libp2p/node.py
@@ -478,9 +478,8 @@ class Node(BaseService):
             # FIXME: Use `Stream.reset()` when `NetStream` has this API.
             # await stream.reset()
             # TODO: Disconnect
-            error_msg = "fail to read the response"
-            self.logger.info("Handshake failed: %s", error_msg)
-            raise HandshakeFailure(error_msg) from error
+            self.logger.info("Handshake failed: fail to read the response")
+            raise HandshakeFailure("fail to read the response") from error
 
         self.logger.debug(
             "Received the hello message %s, resp_code=%s",
@@ -654,18 +653,6 @@ class Node(BaseService):
             peer_id,
         )
 
-    def _make_beacon_blocks_packet(self,
-                                   head_block_root: Hash32,
-                                   start_slot: Slot,
-                                   count: int,
-                                   step: int) -> BeaconBlocksRequest:
-        return BeaconBlocksRequest(
-            head_block_root=head_block_root,
-            start_slot=start_slot,
-            count=count,
-            step=step,
-        )
-
     async def request_beacon_blocks(self,
                                     peer_id: ID,
                                     head_block_root: Hash32,
@@ -678,11 +665,11 @@ class Node(BaseService):
             self.logger.info("Request beacon block failed: %s", error_msg)
             raise RequestFailure(error_msg)
 
-        beacon_blocks_request = self._make_beacon_blocks_packet(
-            head_block_root,
-            start_slot,
-            count,
-            step,
+        beacon_blocks_request = BeaconBlocksRequest(
+            head_block_root=head_block_root,
+            start_slot=start_slot,
+            count=count,
+            step=step,
         )
 
         self.logger.debug(
@@ -707,9 +694,8 @@ class Node(BaseService):
         except ReadMessageFailure as error:
             # FIXME: Use `Stream.reset()` when `NetStream` has this API.
             # await stream.reset()
-            error_msg = "fail to read the response"
-            self.logger.info("Request beacon blocks failed: %s", error_msg)
-            raise RequestFailure(error_msg) from error
+            self.logger.info("Request beacon blocks failed: fail to read the response")
+            raise RequestFailure("fail to read the response") from error
 
         self.logger.debug(
             "Received beacon blocks response %s, resp_code=%s",
@@ -782,11 +768,6 @@ class Node(BaseService):
             peer_id,
         )
 
-    def _make_recent_beacon_blocks_packet(
-            self,
-            block_roots: Sequence[Hash32]) -> RecentBeaconBlocksRequest:
-        return RecentBeaconBlocksRequest(block_roots=block_roots)
-
     async def request_recent_beacon_blocks(
             self,
             peer_id: ID,
@@ -797,7 +778,7 @@ class Node(BaseService):
             self.logger.info("Request recent beacon block failed: %s", error_msg)
             raise RequestFailure(error_msg)
 
-        recent_beacon_blocks_request = self._make_recent_beacon_blocks_packet(block_roots)
+        recent_beacon_blocks_request = RecentBeaconBlocksRequest(block_roots=block_roots)
 
         self.logger.debug(
             "Opening new stream to peer=%s with protocols=%s",
@@ -824,9 +805,8 @@ class Node(BaseService):
         except ReadMessageFailure as error:
             # FIXME: Use `Stream.reset()` when `NetStream` has this API.
             # await stream.reset()
-            error_msg = "fail to read the response"
-            self.logger.info("Request recent beacon blocks failed: %s", error_msg)
-            raise RequestFailure(error_msg) from error
+            self.logger.info("Request recent beacon blocks failed: fail to read the response")
+            raise RequestFailure("fail to read the response") from error
 
         self.logger.debug(
             "Received recent beacon blocks response %s, resp_code=%s",

--- a/trinity/protocol/bcc_libp2p/node.py
+++ b/trinity/protocol/bcc_libp2p/node.py
@@ -552,7 +552,7 @@ class Node(BaseService):
         self,
         start_slot: Slot,
         peer_head_block: BaseBeaconBlock,
-        slot_of_requested_blocks: Sequence[BaseBeaconBlock],
+        slot_of_requested_blocks: Sequence[Slot],
     ) -> Iterable[BaseBeaconBlock]:
         # Peer's head block is on a fork chain,
         # start getting the requested blocks by

--- a/trinity/protocol/bcc_libp2p/node.py
+++ b/trinity/protocol/bcc_libp2p/node.py
@@ -5,6 +5,7 @@ from typing import (
     Set,
     Sequence,
     Tuple,
+    cast,
 )
 
 from cancel_token import (
@@ -488,6 +489,7 @@ class Node(BaseService):
             # TODO: Disconnect
             raise HandshakeFailure(error_msg)
 
+        hello_other_side = cast(HelloRequest, hello_other_side)
         try:
             await self._validate_hello_req(hello_other_side)
         except ValidationError as error:
@@ -719,6 +721,7 @@ class Node(BaseService):
             # await stream.reset()
             raise RequestFailure(error_msg)
 
+        beacon_blocks_response = cast(BeaconBlocksResponse, beacon_blocks_response)
         asyncio.ensure_future(stream.close())
 
         return beacon_blocks_response.blocks
@@ -836,6 +839,10 @@ class Node(BaseService):
             # await stream.reset()
             raise RequestFailure(error_msg)
 
+        recent_beacon_blocks_response = cast(
+            RecentBeaconBlocksResponse,
+            recent_beacon_blocks_response,
+        )
         asyncio.ensure_future(stream.close())
 
         return recent_beacon_blocks_response.blocks

--- a/trinity/protocol/bcc_libp2p/node.py
+++ b/trinity/protocol/bcc_libp2p/node.py
@@ -333,8 +333,8 @@ class Node(BaseService):
             hello_other_side.finalized_epoch,
             config.SLOTS_PER_EPOCH,
         )
-        finalized_root = self.chain.get_canonical_block_by_slot(
-            finalized_epoch_start_slot).block.signing_root
+        finalized_root = self.chain.get_canonical_block_root(
+            finalized_epoch_start_slot)
 
         if hello_other_side.finalized_root != finalized_root:
             raise ValidationError(


### PR DESCRIPTION
### What was wrong?
Finish `Hello`, `BeaconBlocks`, `RecentBeaconBlocks` request/response
- spec for `Hello`: https://github.com/ethereum/eth2.0-specs/blob/dev/specs/networking/p2p-interface.md#hello
- spec for `BeaconBlocks`: https://github.com/ethereum/eth2.0-specs/blob/dev/specs/networking/p2p-interface.md#beaconblocks
- spec for `RecentBeaconBlocks`: https://github.com/ethereum/eth2.0-specs/blob/dev/specs/networking/p2p-interface.md#recentbeaconblocks


### How was it fixed?
Add handler for these requests and functions to make these requests

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

[//]: # (See: https://trinity-client.readthedocs.io/en/latest/contributing.html#pull-requests)
- [ ] Add entry to the [release notes](https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![](https://pixnio.com/free-images/2018/11/21/2018-11-21-13-06-25-1200x800.jpg)
