### PR TITLE
eth2 v0.8.{2,3} update

### DIFF
--- a/eth2/beacon/fork_choice/lmd_ghost.py
+++ b/eth2/beacon/fork_choice/lmd_ghost.py
@@ -166,12 +166,12 @@ class Store:
         Return the block in the chain that is a
         predecessor of ``block`` at the requested ``slot``.
         """
-        if block.slot == slot:
-            return block
-        elif block.slot < slot:
-            return None
-        else:
+        if block.slot > slot:
             return self.get_ancestor(self._get_parent_block(block), slot)
+        elif block.slot == slot:
+            return block
+        else:
+            return None
 
 
 AttestationTarget = Tuple[ValidatorIndex, Optional[BaseBeaconBlock]]

--- a/eth2/beacon/state_machines/forks/serenity/epoch_processing.py
+++ b/eth2/beacon/state_machines/forks/serenity/epoch_processing.py
@@ -834,19 +834,17 @@ def _compute_next_historical_roots(state: BeaconState, config: Eth2Config) -> Tu
 def process_final_updates(state: BeaconState, config: Eth2Config) -> BeaconState:
     new_eth1_data_votes = _determine_next_eth1_votes(state, config)
     new_validators = _update_effective_balances(state, config)
-    new_start_shard = _compute_next_start_shard(state, config)
     new_active_index_roots = _compute_next_active_index_roots(state, config)
     new_compact_committees_roots = _compute_next_compact_committees_roots(
         state.copy(
             validators=new_validators,
-            start_shard=new_start_shard,
         ),
         config,
     )
     new_slashings = _compute_next_slashings(state, config)
     new_randao_mixes = _compute_next_randao_mixes(state, config)
     new_historical_roots = _compute_next_historical_roots(state, config)
-
+    new_start_shard = _compute_next_start_shard(state, config)
     return state.copy(
         eth1_data_votes=new_eth1_data_votes,
         validators=new_validators,


### PR DESCRIPTION
### What was wrong?


### How was it fixed?
* Fix start shard for compact committees root (ethereum/eth2.0-specs#1319)
* Properly check attestation bitlist lengths (ethereum/eth2.0-specs#1317)
* Ignore latest messages in fork choice prior to latest justified (ethereum/eth2.0-specs#1306)
    - Our implementation has already optimized it! I synced it as the spec format anyway.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

[//]: # (See: https://trinity-client.readthedocs.io/en/latest/contributing.html#pull-requests)
- [ ] Add entry to the [release notes](https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

need the new fixture format parser.

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses]()
