### PR TITLE
Add `black` and `isort` to eth2 code.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -134,6 +134,18 @@ jobs:
       - image: circleci/python:3.7
         environment:
           TOXENV: py37-lint
+  py36-lint-eth2:
+    <<: *common
+    docker:
+      - image: circleci/python:3.6
+        environment:
+          TOXENV: py36-lint-eth2
+  py37-lint-eth2:
+    <<: *common
+    docker:
+      - image: circleci/python:3.7
+        environment:
+          TOXENV: py37-lint-eth2
 
   py36-docs:
     <<: *common
@@ -418,6 +430,8 @@ workflows:
       - py36-long_run_integration
 
       - py36-lint
+      - py36-lint-eth2
       - py37-lint
+      - py37-lint-eth2
 
       - docker-image-build-test

--- a/.flake8-eth2
+++ b/.flake8-eth2
@@ -1,0 +1,4 @@
+[flake8]
+max-line-length= 100
+exclude=
+ignore=W503,E203

--- a/Makefile
+++ b/Makefile
@@ -25,6 +25,9 @@ clean-pyc:
 lint:
 	tox -epy3{6,5}-lint
 
+lint-eth2:
+	tox -epy37-lint-eth2
+
 test:
 	py.test --tb native tests
 

--- a/eth2/_utils/bitfield.py
+++ b/eth2/_utils/bitfield.py
@@ -1,6 +1,4 @@
-from cytoolz import (
-    curry,
-)
+from cytoolz import curry
 from eth2.beacon.typing import Bitfield
 from .tuple import update_tuple_item
 
@@ -12,13 +10,7 @@ def has_voted(bitfield: Bitfield, index: int) -> bool:
 
 @curry
 def set_voted(bitfield: Bitfield, index: int) -> Bitfield:
-    return Bitfield(
-        update_tuple_item(
-            bitfield,
-            index,
-            True,
-        )
-    )
+    return Bitfield(update_tuple_item(bitfield, index, True))
 
 
 def get_bitfield_length(bit_count: int) -> int:
@@ -32,9 +24,5 @@ def get_empty_bitfield(bit_count: int) -> Bitfield:
 
 def get_vote_count(bitfield: Bitfield) -> int:
     return len(
-        tuple(
-            index
-            for index in range(len(bitfield))
-            if has_voted(bitfield, index)
-        )
+        tuple(index for index in range(len(bitfield)) if has_voted(bitfield, index))
     )

--- a/eth2/_utils/bitfield.py
+++ b/eth2/_utils/bitfield.py
@@ -1,5 +1,7 @@
 from cytoolz import curry
+
 from eth2.beacon.typing import Bitfield
+
 from .tuple import update_tuple_item
 
 

--- a/eth2/_utils/bls/__init__.py
+++ b/eth2/_utils/bls/__init__.py
@@ -1,27 +1,13 @@
-from typing import (
-    Sequence,
-    Type,
-)
+from typing import Sequence, Type
 
-from eth_typing import (
-    BLSPubkey,
-    BLSSignature,
-    Hash32,
-)
+from eth_typing import BLSPubkey, BLSSignature, Hash32
 
 from py_ecc.bls.typing import Domain
 
-from eth2.beacon.exceptions import (
-    SignatureError,
-)
+from eth2.beacon.exceptions import SignatureError
 
-from .backends import (
-    DEFAULT_BACKEND,
-    NoOpBackend,
-)
-from .backends.base import (
-    BaseBLSBackend,
-)
+from .backends import DEFAULT_BACKEND, NoOpBackend
+from .backends.base import BaseBLSBackend
 from .validation import (
     validate_private_key,
     validate_signature,
@@ -49,51 +35,51 @@ class Eth2BLS:
         cls.use(NoOpBackend)
 
     @classmethod
-    def privtopub(cls,
-                  privkey: int) -> BLSPubkey:
+    def privtopub(cls, privkey: int) -> BLSPubkey:
         validate_private_key(privkey)
         return cls.backend.privtopub(privkey)
 
     @classmethod
-    def sign(cls,
-             message_hash: Hash32,
-             privkey: int,
-             domain: Domain) -> BLSSignature:
+    def sign(cls, message_hash: Hash32, privkey: int, domain: Domain) -> BLSSignature:
         validate_private_key(privkey)
         return cls.backend.sign(message_hash, privkey, domain)
 
     @classmethod
-    def aggregate_signatures(cls,
-                             signatures: Sequence[BLSSignature]) -> BLSSignature:
+    def aggregate_signatures(cls, signatures: Sequence[BLSSignature]) -> BLSSignature:
         return cls.backend.aggregate_signatures(signatures)
 
     @classmethod
-    def aggregate_pubkeys(cls,
-                          pubkeys: Sequence[BLSPubkey]) -> BLSPubkey:
+    def aggregate_pubkeys(cls, pubkeys: Sequence[BLSPubkey]) -> BLSPubkey:
         return cls.backend.aggregate_pubkeys(pubkeys)
 
     @classmethod
-    def verify(cls,
-               message_hash: Hash32,
-               pubkey: BLSPubkey,
-               signature: BLSSignature,
-               domain: Domain) -> bool:
+    def verify(
+        cls,
+        message_hash: Hash32,
+        pubkey: BLSPubkey,
+        signature: BLSSignature,
+        domain: Domain,
+    ) -> bool:
         return cls.backend.verify(message_hash, pubkey, signature, domain)
 
     @classmethod
-    def verify_multiple(cls,
-                        pubkeys: Sequence[BLSPubkey],
-                        message_hashes: Sequence[Hash32],
-                        signature: BLSSignature,
-                        domain: Domain) -> bool:
+    def verify_multiple(
+        cls,
+        pubkeys: Sequence[BLSPubkey],
+        message_hashes: Sequence[Hash32],
+        signature: BLSSignature,
+        domain: Domain,
+    ) -> bool:
         return cls.backend.verify_multiple(pubkeys, message_hashes, signature, domain)
 
     @classmethod
-    def validate(cls,
-                 message_hash: Hash32,
-                 pubkey: BLSPubkey,
-                 signature: BLSSignature,
-                 domain: Domain) -> None:
+    def validate(
+        cls,
+        message_hash: Hash32,
+        pubkey: BLSPubkey,
+        signature: BLSSignature,
+        domain: Domain,
+    ) -> None:
         if cls.backend != NoOpBackend:
             validate_signature(signature)
             validate_public_key(pubkey)
@@ -108,11 +94,13 @@ class Eth2BLS:
             )
 
     @classmethod
-    def validate_multiple(cls,
-                          pubkeys: Sequence[BLSPubkey],
-                          message_hashes: Sequence[Hash32],
-                          signature: BLSSignature,
-                          domain: Domain) -> None:
+    def validate_multiple(
+        cls,
+        pubkeys: Sequence[BLSPubkey],
+        message_hashes: Sequence[Hash32],
+        signature: BLSSignature,
+        domain: Domain,
+    ) -> None:
         if cls.backend != NoOpBackend:
             validate_signature(signature)
             validate_many_public_keys(pubkeys)

--- a/eth2/_utils/bls/__init__.py
+++ b/eth2/_utils/bls/__init__.py
@@ -1,7 +1,6 @@
 from typing import Sequence, Type
 
 from eth_typing import BLSPubkey, BLSSignature, Hash32
-
 from py_ecc.bls.typing import Domain
 
 from eth2.beacon.exceptions import SignatureError
@@ -9,10 +8,10 @@ from eth2.beacon.exceptions import SignatureError
 from .backends import DEFAULT_BACKEND, NoOpBackend
 from .backends.base import BaseBLSBackend
 from .validation import (
-    validate_private_key,
-    validate_signature,
-    validate_public_key,
     validate_many_public_keys,
+    validate_private_key,
+    validate_public_key,
+    validate_signature,
 )
 
 

--- a/eth2/_utils/bls/backends/__init__.py
+++ b/eth2/_utils/bls/backends/__init__.py
@@ -1,8 +1,8 @@
+from typing import Tuple, Type  # noqa: F401
+
+from .base import BaseBLSBackend  # noqa: F401
 from .noop import NoOpBackend
 from .py_ecc import PyECCBackend
-from .base import BaseBLSBackend  # noqa: F401
-from typing import Type, Tuple  # noqa: F401
-
 
 AVAILABLE_BACKENDS = (
     NoOpBackend,

--- a/eth2/_utils/bls/backends/__init__.py
+++ b/eth2/_utils/bls/backends/__init__.py
@@ -1,11 +1,7 @@
-
 from .noop import NoOpBackend
 from .py_ecc import PyECCBackend
 from .base import BaseBLSBackend  # noqa: F401
-from typing import (  # noqa: F401
-    Type,
-    Tuple,
-)
+from typing import Type, Tuple  # noqa: F401
 
 
 AVAILABLE_BACKENDS = (
@@ -18,6 +14,7 @@ DEFAULT_BACKEND = PyECCBackend  # type: Type[BaseBLSBackend]
 
 try:
     from .milagro import MilagroBackend
+
     DEFAULT_BACKEND = MilagroBackend
     AVAILABLE_BACKENDS += (MilagroBackend,)
 except ImportError:
@@ -25,6 +22,7 @@ except ImportError:
 
 try:
     from .chia import ChiaBackend
+
     AVAILABLE_BACKENDS += (ChiaBackend,)
 except ImportError:
     pass

--- a/eth2/_utils/bls/backends/base.py
+++ b/eth2/_utils/bls/backends/base.py
@@ -2,7 +2,6 @@ from abc import ABC, abstractmethod
 from typing import Sequence
 
 from eth_typing import BLSPubkey, BLSSignature, Hash32
-
 from py_ecc.bls.typing import Domain
 
 

--- a/eth2/_utils/bls/backends/base.py
+++ b/eth2/_utils/bls/backends/base.py
@@ -1,16 +1,7 @@
-from abc import (
-    ABC,
-    abstractmethod,
-)
-from typing import (
-    Sequence,
-)
+from abc import ABC, abstractmethod
+from typing import Sequence
 
-from eth_typing import (
-    BLSPubkey,
-    BLSSignature,
-    Hash32,
-)
+from eth_typing import BLSPubkey, BLSSignature, Hash32
 
 from py_ecc.bls.typing import Domain
 
@@ -23,17 +14,14 @@ class BaseBLSBackend(ABC):
 
     @staticmethod
     @abstractmethod
-    def sign(message_hash: Hash32,
-             privkey: int,
-             domain: Domain) -> BLSSignature:
+    def sign(message_hash: Hash32, privkey: int, domain: Domain) -> BLSSignature:
         ...
 
     @staticmethod
     @abstractmethod
-    def verify(message_hash: Hash32,
-               pubkey: BLSPubkey,
-               signature: BLSSignature,
-               domain: Domain) -> bool:
+    def verify(
+        message_hash: Hash32, pubkey: BLSPubkey, signature: BLSSignature, domain: Domain
+    ) -> bool:
         ...
 
     @staticmethod
@@ -48,8 +36,10 @@ class BaseBLSBackend(ABC):
 
     @staticmethod
     @abstractmethod
-    def verify_multiple(pubkeys: Sequence[BLSPubkey],
-                        message_hashes: Sequence[Hash32],
-                        signature: BLSSignature,
-                        domain: Domain) -> bool:
+    def verify_multiple(
+        pubkeys: Sequence[BLSPubkey],
+        message_hashes: Sequence[Hash32],
+        signature: BLSSignature,
+        domain: Domain,
+    ) -> bool:
         ...

--- a/eth2/_utils/bls/backends/chia/__init__.py
+++ b/eth2/_utils/bls/backends/chia/__init__.py
@@ -1,18 +1,10 @@
-from typing import (
-    Sequence,
-)
+from typing import Sequence
 
-from eth_typing import (
-    BLSPubkey,
-    BLSSignature,
-    Hash32,
-)
+from eth_typing import BLSPubkey, BLSSignature, Hash32
 
 from py_ecc.bls.typing import Domain
 
-from eth2._utils.bls.backends.base import (
-    BaseBLSBackend,
-)
+from eth2._utils.bls.backends.base import BaseBLSBackend
 
 from .api import (
     aggregate_pubkeys,
@@ -30,16 +22,13 @@ class ChiaBackend(BaseBLSBackend):
         return privtopub(k)
 
     @staticmethod
-    def sign(message_hash: Hash32,
-             privkey: int,
-             domain: Domain) -> BLSSignature:
+    def sign(message_hash: Hash32, privkey: int, domain: Domain) -> BLSSignature:
         return sign(message_hash, privkey, domain)
 
     @staticmethod
-    def verify(message_hash: Hash32,
-               pubkey: BLSPubkey,
-               signature: BLSSignature,
-               domain: Domain) -> bool:
+    def verify(
+        message_hash: Hash32, pubkey: BLSPubkey, signature: BLSSignature, domain: Domain
+    ) -> bool:
         return verify(message_hash, pubkey, signature, domain)
 
     @staticmethod
@@ -51,8 +40,10 @@ class ChiaBackend(BaseBLSBackend):
         return aggregate_pubkeys(pubkeys)
 
     @staticmethod
-    def verify_multiple(pubkeys: Sequence[BLSPubkey],
-                        message_hashes: Sequence[Hash32],
-                        signature: BLSSignature,
-                        domain: Domain) -> bool:
+    def verify_multiple(
+        pubkeys: Sequence[BLSPubkey],
+        message_hashes: Sequence[Hash32],
+        signature: BLSSignature,
+        domain: Domain,
+    ) -> bool:
         return verify_multiple(pubkeys, message_hashes, signature, domain)

--- a/eth2/_utils/bls/backends/chia/__init__.py
+++ b/eth2/_utils/bls/backends/chia/__init__.py
@@ -1,7 +1,6 @@
 from typing import Sequence
 
 from eth_typing import BLSPubkey, BLSSignature, Hash32
-
 from py_ecc.bls.typing import Domain
 
 from eth2._utils.bls.backends.base import BaseBLSBackend

--- a/eth2/_utils/bls/backends/chia/api.py
+++ b/eth2/_utils/bls/backends/chia/api.py
@@ -3,8 +3,6 @@ from typing import Sequence, cast
 from blspy import AggregationInfo, InsecureSignature, PrivateKey, PublicKey, Signature
 from eth_typing import BLSPubkey, BLSSignature, Hash32
 from eth_utils import ValidationError
-
-
 from py_ecc.bls.typing import Domain
 
 from eth2.beacon.constants import EMPTY_PUBKEY, EMPTY_SIGNATURE

--- a/eth2/_utils/bls/backends/noop.py
+++ b/eth2/_utils/bls/backends/noop.py
@@ -1,41 +1,27 @@
-from typing import (
-    Sequence,
-)
+from typing import Sequence
 
-from eth_typing import (
-    BLSPubkey,
-    BLSSignature,
-    Hash32,
-)
+from eth_typing import BLSPubkey, BLSSignature, Hash32
 
 from py_ecc.bls.typing import Domain
 
-from eth2.beacon.constants import (
-    EMPTY_PUBKEY,
-    EMPTY_SIGNATURE,
-)
+from eth2.beacon.constants import EMPTY_PUBKEY, EMPTY_SIGNATURE
 
-from .base import (
-    BaseBLSBackend,
-)
+from .base import BaseBLSBackend
 
 
 class NoOpBackend(BaseBLSBackend):
     @staticmethod
     def privtopub(k: int) -> BLSPubkey:
-        return BLSPubkey(k.to_bytes(48, 'little'))
+        return BLSPubkey(k.to_bytes(48, "little"))
 
     @staticmethod
-    def sign(message_hash: Hash32,
-             privkey: int,
-             domain: Domain) -> BLSSignature:
+    def sign(message_hash: Hash32, privkey: int, domain: Domain) -> BLSSignature:
         return EMPTY_SIGNATURE
 
     @staticmethod
-    def verify(message_hash: Hash32,
-               pubkey: BLSPubkey,
-               signature: BLSSignature,
-               domain: Domain) -> bool:
+    def verify(
+        message_hash: Hash32, pubkey: BLSPubkey, signature: BLSSignature, domain: Domain
+    ) -> bool:
         return True
 
     @staticmethod
@@ -47,8 +33,10 @@ class NoOpBackend(BaseBLSBackend):
         return EMPTY_PUBKEY
 
     @staticmethod
-    def verify_multiple(pubkeys: Sequence[BLSPubkey],
-                        message_hashes: Sequence[Hash32],
-                        signature: BLSSignature,
-                        domain: Domain) -> bool:
+    def verify_multiple(
+        pubkeys: Sequence[BLSPubkey],
+        message_hashes: Sequence[Hash32],
+        signature: BLSSignature,
+        domain: Domain,
+    ) -> bool:
         return True

--- a/eth2/_utils/bls/backends/noop.py
+++ b/eth2/_utils/bls/backends/noop.py
@@ -1,7 +1,6 @@
 from typing import Sequence
 
 from eth_typing import BLSPubkey, BLSSignature, Hash32
-
 from py_ecc.bls.typing import Domain
 
 from eth2.beacon.constants import EMPTY_PUBKEY, EMPTY_SIGNATURE

--- a/eth2/_utils/bls/backends/py_ecc.py
+++ b/eth2/_utils/bls/backends/py_ecc.py
@@ -1,17 +1,9 @@
-from typing import (
-    Sequence,
-)
+from typing import Sequence
 
-from eth_typing import (
-    BLSPubkey,
-    BLSSignature,
-    Hash32,
-)
+from eth_typing import BLSPubkey, BLSSignature, Hash32
 
 
-from eth2._utils.bls.backends.base import (
-    BaseBLSBackend,
-)
+from eth2._utils.bls.backends.base import BaseBLSBackend
 from py_ecc.bls import (
     aggregate_pubkeys,
     aggregate_signatures,
@@ -22,10 +14,7 @@ from py_ecc.bls import (
 )
 from py_ecc.bls.typing import Domain
 
-from eth2.beacon.constants import (
-    EMPTY_PUBKEY,
-    EMPTY_SIGNATURE,
-)
+from eth2.beacon.constants import EMPTY_PUBKEY, EMPTY_SIGNATURE
 
 
 class PyECCBackend(BaseBLSBackend):
@@ -34,16 +23,13 @@ class PyECCBackend(BaseBLSBackend):
         return privtopub(k)
 
     @staticmethod
-    def sign(message_hash: Hash32,
-             privkey: int,
-             domain: Domain) -> BLSSignature:
+    def sign(message_hash: Hash32, privkey: int, domain: Domain) -> BLSSignature:
         return sign(message_hash, privkey, domain)
 
     @staticmethod
-    def verify(message_hash: Hash32,
-               pubkey: BLSPubkey,
-               signature: BLSSignature,
-               domain: Domain) -> bool:
+    def verify(
+        message_hash: Hash32, pubkey: BLSPubkey, signature: BLSSignature, domain: Domain
+    ) -> bool:
         return verify(message_hash, pubkey, signature, domain)
 
     @staticmethod
@@ -61,8 +47,10 @@ class PyECCBackend(BaseBLSBackend):
         return aggregate_pubkeys(pubkeys)
 
     @staticmethod
-    def verify_multiple(pubkeys: Sequence[BLSPubkey],
-                        message_hashes: Sequence[Hash32],
-                        signature: BLSSignature,
-                        domain: Domain) -> bool:
+    def verify_multiple(
+        pubkeys: Sequence[BLSPubkey],
+        message_hashes: Sequence[Hash32],
+        signature: BLSSignature,
+        domain: Domain,
+    ) -> bool:
         return verify_multiple(pubkeys, message_hashes, signature, domain)

--- a/eth2/_utils/bls/backends/py_ecc.py
+++ b/eth2/_utils/bls/backends/py_ecc.py
@@ -1,9 +1,6 @@
 from typing import Sequence
 
 from eth_typing import BLSPubkey, BLSSignature, Hash32
-
-
-from eth2._utils.bls.backends.base import BaseBLSBackend
 from py_ecc.bls import (
     aggregate_pubkeys,
     aggregate_signatures,
@@ -14,6 +11,7 @@ from py_ecc.bls import (
 )
 from py_ecc.bls.typing import Domain
 
+from eth2._utils.bls.backends.base import BaseBLSBackend
 from eth2.beacon.constants import EMPTY_PUBKEY, EMPTY_SIGNATURE
 
 

--- a/eth2/_utils/bls/validation.py
+++ b/eth2/_utils/bls/validation.py
@@ -1,18 +1,7 @@
-from py_ecc.optimized_bls12_381 import (
-    curve_order,
-)
-from eth_typing import (
-    BLSSignature,
-    BLSPubkey,
-)
-from eth2.beacon.constants import (
-    EMPTY_PUBKEY,
-    EMPTY_SIGNATURE,
-)
-from eth2.beacon.exceptions import (
-    SignatureError,
-    PublicKeyError,
-)
+from py_ecc.optimized_bls12_381 import curve_order
+from eth_typing import BLSSignature, BLSPubkey
+from eth2.beacon.constants import EMPTY_PUBKEY, EMPTY_SIGNATURE
+from eth2.beacon.exceptions import SignatureError, PublicKeyError
 from typing import Sequence
 
 
@@ -23,7 +12,7 @@ def validate_private_key(privkey: int) -> None:
         )
 
 
-def validate_public_key(pubkey: BLSPubkey, allow_empty: bool =False) -> None:
+def validate_public_key(pubkey: BLSPubkey, allow_empty: bool = False) -> None:
     if len(pubkey) != 48:
         raise PublicKeyError(
             f"Invalid public key length, expect 48 got {len(pubkey)}. pubkey: {pubkey}"
@@ -43,6 +32,4 @@ def validate_signature(signature: BLSSignature) -> None:
             f"Invalid signaute length, expect 96 got {len(signature)}. Signature: {signature}"
         )
     if signature == EMPTY_SIGNATURE:
-        raise SignatureError(
-            f"Signature should not be empty. Signature: {signature}"
-        )
+        raise SignatureError(f"Signature should not be empty. Signature: {signature}")

--- a/eth2/_utils/bls/validation.py
+++ b/eth2/_utils/bls/validation.py
@@ -1,8 +1,10 @@
-from py_ecc.optimized_bls12_381 import curve_order
-from eth_typing import BLSSignature, BLSPubkey
-from eth2.beacon.constants import EMPTY_PUBKEY, EMPTY_SIGNATURE
-from eth2.beacon.exceptions import SignatureError, PublicKeyError
 from typing import Sequence
+
+from eth_typing import BLSPubkey, BLSSignature
+from py_ecc.optimized_bls12_381 import curve_order
+
+from eth2.beacon.constants import EMPTY_PUBKEY, EMPTY_SIGNATURE
+from eth2.beacon.exceptions import PublicKeyError, SignatureError
 
 
 def validate_private_key(privkey: int) -> None:

--- a/eth2/_utils/funcs.py
+++ b/eth2/_utils/funcs.py
@@ -9,8 +9,10 @@ def constantly(x: Any) -> Any:
     """
     Return a function that returns ``x`` given any arguments.
     """
+
     def f(*args: Any, **kwargs: Any) -> Any:
         return x
+
     return f
 
 

--- a/eth2/_utils/hash.py
+++ b/eth2/_utils/hash.py
@@ -1,7 +1,5 @@
 from hashlib import sha256
-from typing import (
-    Union,
-)
+from typing import Union
 
 from eth_typing import Hash32
 

--- a/eth2/_utils/merkle/common.py
+++ b/eth2/_utils/merkle/common.py
@@ -1,26 +1,12 @@
-from typing import (
-    Iterable,
-    NewType,
-    Sequence,
-)
+from typing import Iterable, NewType, Sequence
 
-from cytoolz import (
-    iterate,
-    partition,
-    take,
-)
+from cytoolz import iterate, partition, take
 
 from eth_utils import to_tuple
 
-from eth2._utils.hash import (
-    hash_eth2,
-)
-from eth_typing import (
-    Hash32,
-)
-from eth_utils import (
-    ValidationError,
-)
+from eth2._utils.hash import hash_eth2
+from eth_typing import Hash32
+from eth_utils import ValidationError
 
 
 MerkleTree = NewType("MerkleTree", Sequence[Sequence[Hash32]])
@@ -71,22 +57,22 @@ def get_merkle_proof(tree: MerkleTree, item_index: int) -> Iterable[Hash32]:
         return ()
 
     branch_indices = get_branch_indices(item_index, len(tree))
-    proof_indices = [i ^ 1 for i in branch_indices][:-1]  # get sibling by flipping rightmost bit
+    proof_indices = [i ^ 1 for i in branch_indices][
+        :-1
+    ]  # get sibling by flipping rightmost bit
     for layer, proof_index in zip(reversed(tree), proof_indices):
         yield layer[proof_index]
 
 
-def verify_merkle_branch(leaf: Hash32,
-                         proof: Sequence[Hash32],
-                         depth: int,
-                         index: int,
-                         root: Hash32) -> bool:
+def verify_merkle_branch(
+    leaf: Hash32, proof: Sequence[Hash32], depth: int, index: int, root: Hash32
+) -> bool:
     """
     Verify that the given ``leaf`` is on the merkle branch ``proof``.
     """
     value = leaf
     for i in range(depth):
-        if index // (2**i) % 2:
+        if index // (2 ** i) % 2:
             value = hash_eth2(proof[i] + value)
         else:
             value = hash_eth2(value + proof[i])

--- a/eth2/_utils/merkle/common.py
+++ b/eth2/_utils/merkle/common.py
@@ -1,13 +1,10 @@
 from typing import Iterable, NewType, Sequence
 
 from cytoolz import iterate, partition, take
-
-from eth_utils import to_tuple
+from eth_typing import Hash32
+from eth_utils import ValidationError, to_tuple
 
 from eth2._utils.hash import hash_eth2
-from eth_typing import Hash32
-from eth_utils import ValidationError
-
 
 MerkleTree = NewType("MerkleTree", Sequence[Sequence[Hash32]])
 MerkleProof = NewType("MerkleProof", Sequence[Hash32])

--- a/eth2/_utils/merkle/normal.py
+++ b/eth2/_utils/merkle/normal.py
@@ -6,25 +6,13 @@ not considered to be part of the tree.
 """
 
 import math
-from typing import (
-    Sequence,
-    Union,
-)
+from typing import Sequence, Union
 
-from cytoolz import (
-    identity,
-    iterate,
-    reduce,
-    take,
-)
+from cytoolz import identity, iterate, reduce, take
 
-from eth_typing import (
-    Hash32,
-)
+from eth_typing import Hash32
 
-from eth2._utils.hash import (
-    hash_eth2,
-)
+from eth2._utils.hash import hash_eth2
 from .common import (  # noqa: F401
     _calc_parent_hash,
     _hash_layer,
@@ -36,10 +24,9 @@ from .common import (  # noqa: F401
 )
 
 
-def verify_merkle_proof(root: Hash32,
-                        item: Union[bytes, bytearray],
-                        item_index: int,
-                        proof: MerkleProof) -> bool:
+def verify_merkle_proof(
+    root: Hash32, item: Union[bytes, bytearray], item_index: int, proof: MerkleProof
+) -> bool:
     """
     Verify a Merkle proof against a root hash.
     """
@@ -50,7 +37,9 @@ def verify_merkle_proof(root: Hash32,
         for branch_index in branch_indices
     ]
     proof_root = reduce(
-        lambda n1, n2_and_order: _calc_parent_hash(*n2_and_order[1]([n1, n2_and_order[0]])),
+        lambda n1, n2_and_order: _calc_parent_hash(
+            *n2_and_order[1]([n1, n2_and_order[0]])
+        ),
         zip(proof, node_orderers),
         leaf,
     )

--- a/eth2/_utils/merkle/normal.py
+++ b/eth2/_utils/merkle/normal.py
@@ -9,18 +9,18 @@ import math
 from typing import Sequence, Union
 
 from cytoolz import identity, iterate, reduce, take
-
 from eth_typing import Hash32
 
 from eth2._utils.hash import hash_eth2
+
 from .common import (  # noqa: F401
+    MerkleProof,
+    MerkleTree,
     _calc_parent_hash,
     _hash_layer,
     get_branch_indices,
     get_merkle_proof,
     get_root,
-    MerkleTree,
-    MerkleProof,
 )
 
 

--- a/eth2/_utils/merkle/sparse.py
+++ b/eth2/_utils/merkle/sparse.py
@@ -5,24 +5,12 @@ only a single element, the leaves as many as there are data items in the tree. T
 not considered to be part of the tree.
 """
 
-from typing import (
-    Sequence,
-    Union,
-    TYPE_CHECKING,
-)
+from typing import Sequence, Union, TYPE_CHECKING
 
-from eth_utils.toolz import (
-    cons,
-    iterate,
-    take,
-)
-from eth2._utils.hash import (
-    hash_eth2,
-)
+from eth_utils.toolz import cons, iterate, take
+from eth2._utils.hash import hash_eth2
 from eth2._utils.tuple import update_tuple_item
-from eth_typing import (
-    Hash32,
-)
+from eth_typing import Hash32
 
 from .common import (  # noqa: F401
     _calc_parent_hash,
@@ -39,14 +27,16 @@ if TYPE_CHECKING:
 
 TreeDepth = 32
 EmptyNodeHashes = tuple(
-    take(TreeDepth, iterate(lambda node_hash: hash_eth2(node_hash + node_hash), b'\x00' * 32))
+    take(
+        TreeDepth,
+        iterate(lambda node_hash: hash_eth2(node_hash + node_hash), b"\x00" * 32),
+    )
 )
 
 
-def verify_merkle_proof(root: Hash32,
-                        leaf: Hash32,
-                        index: int,
-                        proof: MerkleProof) -> bool:
+def verify_merkle_proof(
+    root: Hash32, leaf: Hash32, index: int, proof: MerkleProof
+) -> bool:
     """
     Verify that the given ``item`` is on the merkle branch ``proof``
     starting with the given ``root``.
@@ -54,7 +44,7 @@ def verify_merkle_proof(root: Hash32,
     assert len(proof) == TreeDepth
     value = leaf
     for i in range(TreeDepth):
-        if index // (2**i) % 2:
+        if index // (2 ** i) % 2:
             value = hash_eth2(proof[i] + value)
         else:
             value = hash_eth2(value + proof[i])
@@ -82,11 +72,7 @@ def calc_merkle_tree_from_leaves(leaves: Sequence[Hash32]) -> MerkleTree:
     tree: Tuple[Sequence[Hash32], ...] = (leaves,)
     for i in range(TreeDepth):
         if len(tree[0]) % 2 == 1:
-            tree = update_tuple_item(
-                tree,
-                0,
-                tuple(tree[0]) + (EmptyNodeHashes[i],),
-            )
+            tree = update_tuple_item(tree, 0, tuple(tree[0]) + (EmptyNodeHashes[i],))
         tree = tuple(cons(_hash_layer(tree[0]), tree))
     return MerkleTree(tree)
 

--- a/eth2/_utils/merkle/sparse.py
+++ b/eth2/_utils/merkle/sparse.py
@@ -5,21 +5,22 @@ only a single element, the leaves as many as there are data items in the tree. T
 not considered to be part of the tree.
 """
 
-from typing import Sequence, Union, TYPE_CHECKING
+from typing import TYPE_CHECKING, Sequence, Union
 
+from eth_typing import Hash32
 from eth_utils.toolz import cons, iterate, take
+
 from eth2._utils.hash import hash_eth2
 from eth2._utils.tuple import update_tuple_item
-from eth_typing import Hash32
 
 from .common import (  # noqa: F401
+    MerkleProof,
+    MerkleTree,
     _calc_parent_hash,
     _hash_layer,
     get_branch_indices,
     get_merkle_proof,
     get_root,
-    MerkleTree,
-    MerkleProof,
 )
 
 if TYPE_CHECKING:

--- a/eth2/_utils/numeric.py
+++ b/eth2/_utils/numeric.py
@@ -1,8 +1,6 @@
 import decimal
 
-from eth_typing import (
-    Hash32,
-)
+from eth_typing import Hash32
 
 
 def bitwise_xor(a: Hash32, b: Hash32) -> Hash32:
@@ -22,17 +20,9 @@ def integer_squareroot(value: int) -> int:
     root of a 256-bit integer is a 128-bit integer.
     """
     if not isinstance(value, int) or isinstance(value, bool):
-        raise ValueError(
-            "Value must be an integer: Got: {0}".format(
-                type(value),
-            )
-        )
+        raise ValueError("Value must be an integer: Got: {0}".format(type(value)))
     if value < 0:
-        raise ValueError(
-            "Value cannot be negative: Got: {0}".format(
-                value,
-            )
-        )
+        raise ValueError("Value cannot be negative: Got: {0}".format(value))
 
     with decimal.localcontext() as ctx:
         ctx.prec = 128

--- a/eth2/_utils/ssz.py
+++ b/eth2/_utils/ssz.py
@@ -1,32 +1,26 @@
-from typing import (
-    Iterable,
-    Optional,
-    Tuple,
-)
+from typing import Iterable, Optional, Tuple
 
 import ssz
 
-from eth_utils import (
-    to_tuple,
-    ValidationError,
-)
-from eth_utils.toolz import (
-    curry,
-)
+from eth_utils import to_tuple, ValidationError
+from eth_utils.toolz import curry
 
 from eth2.beacon.types.blocks import BaseBeaconBlock
 
 
 @to_tuple
-def diff_ssz_object(left: BaseBeaconBlock,
-                    right: BaseBeaconBlock) -> Optional[Iterable[Tuple[str, str, str]]]:
+def diff_ssz_object(
+    left: BaseBeaconBlock, right: BaseBeaconBlock
+) -> Optional[Iterable[Tuple[str, str, str]]]:
     if left != right:
         ssz_type = type(left)
 
         for field_name, field_type in ssz_type._meta.fields:
             left_value = getattr(left, field_name)
             right_value = getattr(right, field_name)
-            if isinstance(field_type, type) and issubclass(field_type, ssz.Serializable):
+            if isinstance(field_type, type) and issubclass(
+                field_type, ssz.Serializable
+            ):
                 sub_diff = diff_ssz_object(left_value, right_value)
                 for sub_field_name, sub_left_value, sub_right_value in sub_diff:
                     yield (
@@ -36,33 +30,27 @@ def diff_ssz_object(left: BaseBeaconBlock,
                     )
             elif isinstance(field_type, ssz.sedes.List):
                 if tuple(left_value) != tuple(right_value):
-                    yield (
-                        field_name,
-                        left_value,
-                        right_value,
-                    )
+                    yield (field_name, left_value, right_value)
             elif left_value != right_value:
-                yield (
-                    field_name,
-                    left_value,
-                    right_value,
-                )
+                yield (field_name, left_value, right_value)
             else:
                 continue
 
 
 @curry
-def validate_ssz_equal(obj_a: BaseBeaconBlock,
-                       obj_b: BaseBeaconBlock,
-                       obj_a_name: str=None,
-                       obj_b_name: str=None) -> None:
+def validate_ssz_equal(
+    obj_a: BaseBeaconBlock,
+    obj_b: BaseBeaconBlock,
+    obj_a_name: str = None,
+    obj_b_name: str = None,
+) -> None:
     if obj_a == obj_b:
         return
 
     if obj_a_name is None:
-        obj_a_name = obj_a.__class__.__name__ + '_a'
+        obj_a_name = obj_a.__class__.__name__ + "_a"
     if obj_b_name is None:
-        obj_b_name = obj_b.__class__.__name__ + '_b'
+        obj_b_name = obj_b.__class__.__name__ + "_b"
 
     diff = diff_ssz_object(obj_a, obj_b)
     if len(diff) == 0:
@@ -73,8 +61,7 @@ def validate_ssz_equal(obj_a: BaseBeaconBlock,
     diff_error_message = "\n - ".join(
         f"{field_name.ljust(longest_field_name, ' ')}:\n    "
         f"(actual)  : {actual}\n    (expected): {expected}"
-        for field_name, actual, expected
-        in diff
+        for field_name, actual, expected in diff
     )
     error_message = (
         f"Mismatch between {obj_a_name} and {obj_b_name} "
@@ -84,6 +71,5 @@ def validate_ssz_equal(obj_a: BaseBeaconBlock,
 
 
 validate_imported_block_unchanged = validate_ssz_equal(
-    obj_a_name="block",
-    obj_b_name="imported block",
+    obj_a_name="block", obj_b_name="imported block"
 )

--- a/eth2/_utils/ssz.py
+++ b/eth2/_utils/ssz.py
@@ -1,9 +1,8 @@
 from typing import Iterable, Optional, Tuple
 
-import ssz
-
-from eth_utils import to_tuple, ValidationError
+from eth_utils import ValidationError, to_tuple
 from eth_utils.toolz import curry
+import ssz
 
 from eth2.beacon.types.blocks import BaseBeaconBlock
 

--- a/eth2/_utils/tuple.py
+++ b/eth2/_utils/tuple.py
@@ -1,22 +1,17 @@
-from typing import (
-    Any,
-    Callable,
-    Tuple,
-    TypeVar,
-)
+from typing import Any, Callable, Tuple, TypeVar
 
-from eth_utils import (
-    ValidationError,
-)
+from eth_utils import ValidationError
 
 
-VType = TypeVar('VType')
+VType = TypeVar("VType")
 
 
-def update_tuple_item_with_fn(tuple_data: Tuple[VType, ...],
-                              index: int,
-                              fn: Callable[[VType, Any], VType],
-                              *args: Any) -> Tuple[VType, ...]:
+def update_tuple_item_with_fn(
+    tuple_data: Tuple[VType, ...],
+    index: int,
+    fn: Callable[[VType, Any], VType],
+    *args: Any
+) -> Tuple[VType, ...]:
     """
     Update the ``index``th item of ``tuple_data`` to the result of calling ``fn`` on the existing
     value.
@@ -29,22 +24,17 @@ def update_tuple_item_with_fn(tuple_data: Tuple[VType, ...],
     except IndexError:
         raise ValidationError(
             "the length of the given tuple_data is {}, the given index {} is out of index".format(
-                len(tuple_data),
-                index,
+                len(tuple_data), index
             )
         )
     else:
         return tuple(list_data)
 
 
-def update_tuple_item(tuple_data: Tuple[VType, ...],
-                      index: int,
-                      new_value: VType) -> Tuple[VType, ...]:
+def update_tuple_item(
+    tuple_data: Tuple[VType, ...], index: int, new_value: VType
+) -> Tuple[VType, ...]:
     """
     Update the ``index``th item of ``tuple_data`` to ``new_value``
     """
-    return update_tuple_item_with_fn(
-        tuple_data,
-        index,
-        lambda *_: new_value
-    )
+    return update_tuple_item_with_fn(tuple_data, index, lambda *_: new_value)

--- a/eth2/_utils/tuple.py
+++ b/eth2/_utils/tuple.py
@@ -2,7 +2,6 @@ from typing import Any, Callable, Tuple, TypeVar
 
 from eth_utils import ValidationError
 
-
 VType = TypeVar("VType")
 
 

--- a/eth2/beacon/attestation_helpers.py
+++ b/eth2/beacon/attestation_helpers.py
@@ -1,43 +1,30 @@
-from eth2._utils.bls import (
-    bls,
-)
+from eth2._utils.bls import bls
 
-from eth_utils import (
-    ValidationError,
-)
+from eth_utils import ValidationError
 
 from eth2.beacon.helpers import (
     get_active_validator_indices,
     get_domain,
     compute_start_slot_of_epoch,
 )
-from eth2.beacon.committee_helpers import (
-    get_committee_count,
-    get_start_shard,
-)
+from eth2.beacon.committee_helpers import get_committee_count, get_start_shard
 from eth2.beacon.signature_domain import SignatureDomain
 from eth2.beacon.types.attestations import IndexedAttestation
 from eth2.beacon.types.attestation_data import AttestationData
-from eth2.beacon.types.attestation_data_and_custody_bits import AttestationDataAndCustodyBit
+from eth2.beacon.types.attestation_data_and_custody_bits import (
+    AttestationDataAndCustodyBit,
+)
 from eth2.beacon.types.states import BeaconState
-from eth2.beacon.typing import (
-    Slot,
-)
-from eth2.configs import (
-    CommitteeConfig,
-    Eth2Config,
-)
-from eth2.beacon.exceptions import (
-    SignatureError,
-)
+from eth2.beacon.typing import Slot
+from eth2.configs import CommitteeConfig, Eth2Config
+from eth2.beacon.exceptions import SignatureError
 
 
-def get_attestation_data_slot(state: BeaconState,
-                              data: AttestationData,
-                              config: Eth2Config) -> Slot:
+def get_attestation_data_slot(
+    state: BeaconState, data: AttestationData, config: Eth2Config
+) -> Slot:
     active_validator_indices = get_active_validator_indices(
-        state.validators,
-        data.target.epoch,
+        state.validators, data.target.epoch
     )
     committee_count = get_committee_count(
         len(active_validator_indices),
@@ -46,42 +33,34 @@ def get_attestation_data_slot(state: BeaconState,
         config.TARGET_COMMITTEE_SIZE,
     )
     offset = (
-        data.crosslink.shard + config.SHARD_COUNT - get_start_shard(
-            state,
-            data.target.epoch,
-            CommitteeConfig(config),
-        )
+        data.crosslink.shard
+        + config.SHARD_COUNT
+        - get_start_shard(state, data.target.epoch, CommitteeConfig(config))
     ) % config.SHARD_COUNT
     committees_per_slot = committee_count // config.SLOTS_PER_EPOCH
-    return compute_start_slot_of_epoch(
-        data.target.epoch,
-        config.SLOTS_PER_EPOCH,
-    ) + offset // committees_per_slot
+    return (
+        compute_start_slot_of_epoch(data.target.epoch, config.SLOTS_PER_EPOCH)
+        + offset // committees_per_slot
+    )
 
 
-def validate_indexed_attestation_aggregate_signature(state: BeaconState,
-                                                     indexed_attestation: IndexedAttestation,
-                                                     slots_per_epoch: int) -> None:
+def validate_indexed_attestation_aggregate_signature(
+    state: BeaconState, indexed_attestation: IndexedAttestation, slots_per_epoch: int
+) -> None:
     bit_0_indices = indexed_attestation.custody_bit_0_indices
     bit_1_indices = indexed_attestation.custody_bit_1_indices
 
     pubkeys = (
-        bls.aggregate_pubkeys(
-            tuple(state.validators[i].pubkey for i in bit_0_indices)
-        ),
-        bls.aggregate_pubkeys(
-            tuple(state.validators[i].pubkey for i in bit_1_indices)
-        ),
+        bls.aggregate_pubkeys(tuple(state.validators[i].pubkey for i in bit_0_indices)),
+        bls.aggregate_pubkeys(tuple(state.validators[i].pubkey for i in bit_1_indices)),
     )
 
     message_hashes = (
         AttestationDataAndCustodyBit(
-            data=indexed_attestation.data,
-            custody_bit=False
+            data=indexed_attestation.data, custody_bit=False
         ).hash_tree_root,
         AttestationDataAndCustodyBit(
-            data=indexed_attestation.data,
-            custody_bit=True,
+            data=indexed_attestation.data, custody_bit=True
         ).hash_tree_root,
     )
 
@@ -99,10 +78,12 @@ def validate_indexed_attestation_aggregate_signature(state: BeaconState,
     )
 
 
-def validate_indexed_attestation(state: BeaconState,
-                                 indexed_attestation: IndexedAttestation,
-                                 max_validators_per_committee: int,
-                                 slots_per_epoch: int) -> None:
+def validate_indexed_attestation(
+    state: BeaconState,
+    indexed_attestation: IndexedAttestation,
+    max_validators_per_committee: int,
+    slots_per_epoch: int,
+) -> None:
     """
     Derived from spec: `is_valid_indexed_attestation`.
     """
@@ -139,23 +120,28 @@ def validate_indexed_attestation(state: BeaconState,
         )
 
     try:
-        validate_indexed_attestation_aggregate_signature(state,
-                                                         indexed_attestation,
-                                                         slots_per_epoch)
+        validate_indexed_attestation_aggregate_signature(
+            state, indexed_attestation, slots_per_epoch
+        )
     except SignatureError as error:
         raise ValidationError(
-            f"Incorrect aggregate signature on the {indexed_attestation}",
-            error,
+            f"Incorrect aggregate signature on the {indexed_attestation}", error
         )
 
 
-def is_slashable_attestation_data(data_1: AttestationData, data_2: AttestationData) -> bool:
+def is_slashable_attestation_data(
+    data_1: AttestationData, data_2: AttestationData
+) -> bool:
     """
     Check if ``data_1`` and ``data_2`` are slashable according to Casper FFG rules.
     """
     return (
         # Double vote
-        (data_1 != data_2 and data_1.target.epoch == data_2.target.epoch) or
+        (data_1 != data_2 and data_1.target.epoch == data_2.target.epoch)
+        or
         # Surround vote
-        (data_1.source.epoch < data_2.source.epoch and data_2.target.epoch < data_1.target.epoch)
+        (
+            data_1.source.epoch < data_2.source.epoch
+            and data_2.target.epoch < data_1.target.epoch
+        )
     )

--- a/eth2/beacon/attestation_helpers.py
+++ b/eth2/beacon/attestation_helpers.py
@@ -1,23 +1,22 @@
-from eth2._utils.bls import bls
-
 from eth_utils import ValidationError
 
+from eth2._utils.bls import bls
+from eth2.beacon.committee_helpers import get_committee_count, get_start_shard
+from eth2.beacon.exceptions import SignatureError
 from eth2.beacon.helpers import (
+    compute_start_slot_of_epoch,
     get_active_validator_indices,
     get_domain,
-    compute_start_slot_of_epoch,
 )
-from eth2.beacon.committee_helpers import get_committee_count, get_start_shard
 from eth2.beacon.signature_domain import SignatureDomain
-from eth2.beacon.types.attestations import IndexedAttestation
 from eth2.beacon.types.attestation_data import AttestationData
 from eth2.beacon.types.attestation_data_and_custody_bits import (
     AttestationDataAndCustodyBit,
 )
+from eth2.beacon.types.attestations import IndexedAttestation
 from eth2.beacon.types.states import BeaconState
 from eth2.beacon.typing import Slot
 from eth2.configs import CommitteeConfig, Eth2Config
-from eth2.beacon.exceptions import SignatureError
 
 
 def get_attestation_data_slot(

--- a/eth2/beacon/chains/base.py
+++ b/eth2/beacon/chains/base.py
@@ -1,77 +1,39 @@
-from abc import (
-    ABC,
-    abstractmethod,
-)
+from abc import ABC, abstractmethod
 import logging
-from typing import (
-    TYPE_CHECKING,
-    Tuple,
-    Type,
-)
+from typing import TYPE_CHECKING, Tuple, Type
 
-from eth._utils.datatypes import (
-    Configurable,
-)
-from eth.abc import (
-    AtomicDatabaseAPI,
-)
-from eth.exceptions import (
-    BlockNotFound,
-)
-from eth.validation import (
-    validate_word,
-)
-from eth_typing import (
-    Hash32,
-)
-from eth_utils import (
-    ValidationError,
-    encode_hex,
-)
+from eth._utils.datatypes import Configurable
+from eth.abc import AtomicDatabaseAPI
+from eth.exceptions import BlockNotFound
+from eth.validation import validate_word
+from eth_typing import Hash32
+from eth_utils import ValidationError, encode_hex
 
 from eth2._utils.funcs import constantly
-from eth2._utils.ssz import (
-    validate_imported_block_unchanged,
-)
-from eth2.beacon.db.chain import (
-    BaseBeaconChainDB,
-    BeaconChainDB,
-)
-from eth2.beacon.exceptions import (
-    BlockClassError,
-    StateMachineNotFound,
-)
+from eth2._utils.ssz import validate_imported_block_unchanged
+from eth2.beacon.db.chain import BaseBeaconChainDB, BeaconChainDB
+from eth2.beacon.exceptions import BlockClassError, StateMachineNotFound
 from eth2.beacon.operations.attestation_pool import AttestationPool
-from eth2.beacon.types.attestations import (
-    Attestation,
-)
-from eth2.beacon.types.blocks import (
-    BaseBeaconBlock,
-)
-from eth2.beacon.types.states import (
-    BeaconState,
-)
-from eth2.beacon.typing import (
-    FromBlockParams,
-    Slot,
-)
-from eth2.configs import (
-    Eth2GenesisConfig,
-)
+from eth2.beacon.types.attestations import Attestation
+from eth2.beacon.types.blocks import BaseBeaconBlock
+from eth2.beacon.types.states import BeaconState
+from eth2.beacon.typing import FromBlockParams, Slot
+from eth2.configs import Eth2GenesisConfig
 
 if TYPE_CHECKING:
-    from eth2.beacon.state_machines.base import (  # noqa: F401
-        BaseBeaconStateMachine,
-    )
+    from eth2.beacon.state_machines.base import BaseBeaconStateMachine  # noqa: F401
 
 
 class BaseBeaconChain(Configurable, ABC):
     """
     The base class for all BeaconChain objects
     """
+
     chaindb = None  # type: BaseBeaconChainDB
     chaindb_class = None  # type: Type[BaseBeaconChainDB]
-    sm_configuration = None  # type: Tuple[Tuple[Slot, Type[BaseBeaconStateMachine]], ...]
+    sm_configuration = (
+        None
+    )  # type: Tuple[Tuple[Slot, Type[BaseBeaconStateMachine]], ...]
     chain_id = None  # type: int
 
     #
@@ -87,11 +49,13 @@ class BaseBeaconChain(Configurable, ABC):
     #
     @classmethod
     @abstractmethod
-    def from_genesis(cls,
-                     base_db: AtomicDatabaseAPI,
-                     genesis_state: BeaconState,
-                     genesis_block: BaseBeaconBlock,
-                     genesis_config: Eth2GenesisConfig) -> 'BaseBeaconChain':
+    def from_genesis(
+        cls,
+        base_db: AtomicDatabaseAPI,
+        genesis_state: BeaconState,
+        genesis_block: BaseBeaconBlock,
+        genesis_config: Eth2GenesisConfig,
+    ) -> "BaseBeaconChain":
         ...
 
     #
@@ -100,24 +64,24 @@ class BaseBeaconChain(Configurable, ABC):
     @classmethod
     @abstractmethod
     def get_state_machine_class(
-            cls,
-            block: BaseBeaconBlock) -> Type['BaseBeaconStateMachine']:
+        cls, block: BaseBeaconBlock
+    ) -> Type["BaseBeaconStateMachine"]:
         ...
 
     @abstractmethod
-    def get_state_machine(self, at_slot: Slot=None) -> 'BaseBeaconStateMachine':
+    def get_state_machine(self, at_slot: Slot = None) -> "BaseBeaconStateMachine":
         ...
 
     @classmethod
     @abstractmethod
     def get_state_machine_class_for_block_slot(
-            cls,
-            slot: Slot) -> Type['BaseBeaconStateMachine']:
+        cls, slot: Slot
+    ) -> Type["BaseBeaconStateMachine"]:
         ...
 
     @classmethod
     @abstractmethod
-    def get_genesis_state_machine_class(self) -> Type['BaseBeaconStateMachine']:
+    def get_genesis_state_machine_class(self) -> Type["BaseBeaconStateMachine"]:
         ...
 
     #
@@ -135,9 +99,9 @@ class BaseBeaconChain(Configurable, ABC):
         ...
 
     @abstractmethod
-    def create_block_from_parent(self,
-                                 parent_block: BaseBeaconBlock,
-                                 block_params: FromBlockParams) -> BaseBeaconBlock:
+    def create_block_from_parent(
+        self, parent_block: BaseBeaconBlock, block_params: FromBlockParams
+    ) -> BaseBeaconBlock:
         ...
 
     @abstractmethod
@@ -162,17 +126,17 @@ class BaseBeaconChain(Configurable, ABC):
 
     @abstractmethod
     def import_block(
-            self,
-            block: BaseBeaconBlock,
-            perform_validation: bool=True
-    ) -> Tuple[BaseBeaconBlock, Tuple[BaseBeaconBlock, ...], Tuple[BaseBeaconBlock, ...]]:
+        self, block: BaseBeaconBlock, perform_validation: bool = True
+    ) -> Tuple[
+        BaseBeaconBlock, Tuple[BaseBeaconBlock, ...], Tuple[BaseBeaconBlock, ...]
+    ]:
         ...
 
     #
     # Attestation API
     #
     @abstractmethod
-    def get_attestation_by_root(self, attestation_root: Hash32)-> Attestation:
+    def get_attestation_by_root(self, attestation_root: Hash32) -> Attestation:
         ...
 
     @abstractmethod
@@ -187,14 +151,17 @@ class BeaconChain(BaseBeaconChain):
     StateMachine classes, delegating operations to the appropriate StateMachine depending on the
     current block slot number.
     """
+
     logger = logging.getLogger("eth2.beacon.chains.BeaconChain")
 
     chaindb_class = BeaconChainDB  # type: Type[BaseBeaconChainDB]
 
-    def __init__(self,
-                 base_db: AtomicDatabaseAPI,
-                 attestation_pool: AttestationPool,
-                 genesis_config: Eth2GenesisConfig) -> None:
+    def __init__(
+        self,
+        base_db: AtomicDatabaseAPI,
+        attestation_pool: AttestationPool,
+        genesis_config: Eth2GenesisConfig,
+    ) -> None:
         if not self.sm_configuration:
             raise ValueError(
                 "The Chain class cannot be instantiated with an empty `sm_configuration`"
@@ -211,7 +178,7 @@ class BeaconChain(BaseBeaconChain):
     # Helpers
     #
     @classmethod
-    def get_chaindb_class(cls) -> Type['BaseBeaconChainDB']:
+    def get_chaindb_class(cls) -> Type["BaseBeaconChainDB"]:
         if cls.chaindb_class is None:
             raise AttributeError("`chaindb_class` not set")
         return cls.chaindb_class
@@ -220,11 +187,13 @@ class BeaconChain(BaseBeaconChain):
     # Chain API
     #
     @classmethod
-    def from_genesis(cls,
-                     base_db: AtomicDatabaseAPI,
-                     genesis_state: BeaconState,
-                     genesis_block: BaseBeaconBlock,
-                     genesis_config: Eth2GenesisConfig) -> 'BaseBeaconChain':
+    def from_genesis(
+        cls,
+        base_db: AtomicDatabaseAPI,
+        genesis_state: BeaconState,
+        genesis_block: BaseBeaconBlock,
+        genesis_config: Eth2GenesisConfig,
+    ) -> "BaseBeaconChain":
         """
         Initialize the ``BeaconChain`` from a genesis state.
         """
@@ -232,8 +201,7 @@ class BeaconChain(BaseBeaconChain):
         if type(genesis_block) != sm_class.block_class:
             raise BlockClassError(
                 "Given genesis block class: {}, StateMachine.block_class: {}".format(
-                    type(genesis_block),
-                    sm_class.block_class
+                    type(genesis_block), sm_class.block_class
                 )
             )
 
@@ -241,18 +209,17 @@ class BeaconChain(BaseBeaconChain):
         chaindb.persist_state(genesis_state)
         attestation_pool = AttestationPool()
         return cls._from_genesis_block(
-            base_db,
-            attestation_pool,
-            genesis_block,
-            genesis_config,
+            base_db, attestation_pool, genesis_block, genesis_config
         )
 
     @classmethod
-    def _from_genesis_block(cls,
-                            base_db: AtomicDatabaseAPI,
-                            attestation_pool: AttestationPool,
-                            genesis_block: BaseBeaconBlock,
-                            genesis_config: Eth2GenesisConfig) -> 'BaseBeaconChain':
+    def _from_genesis_block(
+        cls,
+        base_db: AtomicDatabaseAPI,
+        attestation_pool: AttestationPool,
+        genesis_block: BaseBeaconBlock,
+        genesis_config: Eth2GenesisConfig,
+    ) -> "BaseBeaconChain":
         """
         Initialize the ``BeaconChain`` from the genesis block.
         """
@@ -265,7 +232,9 @@ class BeaconChain(BaseBeaconChain):
     # StateMachine API
     #
     @classmethod
-    def get_state_machine_class(cls, block: BaseBeaconBlock) -> Type['BaseBeaconStateMachine']:
+    def get_state_machine_class(
+        cls, block: BaseBeaconBlock
+    ) -> Type["BaseBeaconStateMachine"]:
         """
         Returns the ``StateMachine`` instance for the given block slot number.
         """
@@ -273,20 +242,24 @@ class BeaconChain(BaseBeaconChain):
 
     @classmethod
     def get_state_machine_class_for_block_slot(
-            cls,
-            slot: Slot) -> Type['BaseBeaconStateMachine']:
+        cls, slot: Slot
+    ) -> Type["BaseBeaconStateMachine"]:
         """
         Return the ``StateMachine`` class for the given block slot number.
         """
         if cls.sm_configuration is None:
-            raise AttributeError("Chain classes must define the StateMachines in sm_configuration")
+            raise AttributeError(
+                "Chain classes must define the StateMachines in sm_configuration"
+            )
 
         for start_slot, sm_class in reversed(cls.sm_configuration):
             if slot >= start_slot:
                 return sm_class
-        raise StateMachineNotFound("No StateMachine available for block slot: #{0}".format(slot))
+        raise StateMachineNotFound(
+            "No StateMachine available for block slot: #{0}".format(slot)
+        )
 
-    def get_state_machine(self, at_slot: Slot=None) -> 'BaseBeaconStateMachine':
+    def get_state_machine(self, at_slot: Slot = None) -> "BaseBeaconStateMachine":
         """
         Return the ``StateMachine`` instance for the given slot number.
         """
@@ -297,13 +270,11 @@ class BeaconChain(BaseBeaconChain):
         sm_class = self.get_state_machine_class_for_block_slot(slot)
 
         return sm_class(
-            chaindb=self.chaindb,
-            attestation_pool=self.attestation_pool,
-            slot=slot,
+            chaindb=self.chaindb, attestation_pool=self.attestation_pool, slot=slot
         )
 
     @classmethod
-    def get_genesis_state_machine_class(cls) -> Type['BaseBeaconStateMachine']:
+    def get_genesis_state_machine_class(cls) -> Type["BaseBeaconStateMachine"]:
         return cls.sm_configuration[0][1]
 
     #
@@ -328,16 +299,16 @@ class BeaconChain(BaseBeaconChain):
         block_class = sm_class.block_class
         return block_class
 
-    def create_block_from_parent(self,
-                                 parent_block: BaseBeaconBlock,
-                                 block_params: FromBlockParams) -> BaseBeaconBlock:
+    def create_block_from_parent(
+        self, parent_block: BaseBeaconBlock, block_params: FromBlockParams
+    ) -> BaseBeaconBlock:
         """
         Passthrough helper to the ``StateMachine`` class of the block descending from the
         given block.
         """
         slot = parent_block.slot + 1 if block_params.slot is None else block_params.slot
         return self.get_state_machine_class_for_block_slot(
-            slot=slot,
+            slot=slot
         ).create_block_from_parent(parent_block, block_params)
 
     def get_block_by_root(self, block_root: Hash32) -> BaseBeaconBlock:
@@ -389,10 +360,10 @@ class BeaconChain(BaseBeaconChain):
         return self.chaindb.get_canonical_block_root(slot)
 
     def import_block(
-            self,
-            block: BaseBeaconBlock,
-            perform_validation: bool=True
-    ) -> Tuple[BaseBeaconBlock, Tuple[BaseBeaconBlock, ...], Tuple[BaseBeaconBlock, ...]]:
+        self, block: BaseBeaconBlock, perform_validation: bool = True
+    ) -> Tuple[
+        BaseBeaconBlock, Tuple[BaseBeaconBlock, ...], Tuple[BaseBeaconBlock, ...]
+    ]:
         """
         Import a complete block and returns a 3-tuple
 
@@ -407,9 +378,7 @@ class BeaconChain(BaseBeaconChain):
             raise ValidationError(
                 "Attempt to import block #{}.  Cannot import block {} before importing "
                 "its parent block at {}".format(
-                    block.slot,
-                    block.signing_root,
-                    block.parent_root,
+                    block.slot, block.signing_root, block.parent_root
                 )
             )
 
@@ -433,17 +402,12 @@ class BeaconChain(BaseBeaconChain):
         self.chaindb.persist_state(state)
 
         fork_choice_scoring = state_machine.get_fork_choice_scoring()
-        (
-            new_canonical_blocks,
-            old_canonical_blocks,
-        ) = self.chaindb.persist_block(
-            imported_block,
-            imported_block.__class__,
-            fork_choice_scoring,
+        (new_canonical_blocks, old_canonical_blocks) = self.chaindb.persist_block(
+            imported_block, imported_block.__class__, fork_choice_scoring
         )
 
         self.logger.debug(
-            'IMPORTED_BLOCK: slot %s | signed root %s',
+            "IMPORTED_BLOCK: slot %s | signed root %s",
             imported_block.slot,
             encode_hex(imported_block.signing_root),
         )
@@ -453,7 +417,7 @@ class BeaconChain(BaseBeaconChain):
     #
     # Attestation API
     #
-    def get_attestation_by_root(self, attestation_root: Hash32)-> Attestation:
+    def get_attestation_by_root(self, attestation_root: Hash32) -> Attestation:
         block_root, index = self.chaindb.get_attestation_key_by_root(attestation_root)
         block = self.get_block_by_root(block_root)
         return block.body.attestations[index]

--- a/eth2/beacon/chains/testnet/__init__.py
+++ b/eth2/beacon/chains/testnet/__init__.py
@@ -1,27 +1,12 @@
-from typing import (
-    TYPE_CHECKING,
-)
-from eth2.beacon.chains.base import (
-    BeaconChain,
-)
-from eth2.beacon.state_machines.forks.xiao_long_bao import (
-    XiaoLongBaoStateMachine,
-)
-from .constants import (
-    TESTNET_CHAIN_ID,
-)
+from typing import TYPE_CHECKING
+from eth2.beacon.chains.base import BeaconChain
+from eth2.beacon.state_machines.forks.xiao_long_bao import XiaoLongBaoStateMachine
+from .constants import TESTNET_CHAIN_ID
 
 if TYPE_CHECKING:
-    from eth2.beacon.typing import (  # noqa: F401
-        Slot,
-    )
-    from eth2.beacon.state_machines.base import (  # noqa: F401
-        BaseBeaconStateMachine,
-    )
-    from typing import (  # noqa: F401
-        Tuple,
-        Type,
-    )
+    from eth2.beacon.typing import Slot  # noqa: F401
+    from eth2.beacon.state_machines.base import BaseBeaconStateMachine  # noqa: F401
+    from typing import Tuple, Type  # noqa: F401
 
 state_machine_class = XiaoLongBaoStateMachine
 

--- a/eth2/beacon/chains/testnet/__init__.py
+++ b/eth2/beacon/chains/testnet/__init__.py
@@ -1,6 +1,8 @@
 from typing import TYPE_CHECKING
+
 from eth2.beacon.chains.base import BeaconChain
 from eth2.beacon.state_machines.forks.xiao_long_bao import XiaoLongBaoStateMachine
+
 from .constants import TESTNET_CHAIN_ID
 
 if TYPE_CHECKING:

--- a/eth2/beacon/chains/testnet/constants.py
+++ b/eth2/beacon/chains/testnet/constants.py
@@ -1,3 +1,1 @@
-
-
 TESTNET_CHAIN_ID = 5566

--- a/eth2/beacon/committee_helpers.py
+++ b/eth2/beacon/committee_helpers.py
@@ -1,77 +1,51 @@
-from typing import (
-    Iterable,
-    Sequence,
-    Tuple,
-)
+from typing import Iterable, Sequence, Tuple
 
-from eth_utils import (
-    to_tuple,
-    ValidationError,
-)
-from eth_typing import (
-    Hash32,
-    BLSPubkey,
-)
+from eth_utils import to_tuple, ValidationError
+from eth_typing import Hash32, BLSPubkey
 
 import ssz
 
-from eth2._utils.hash import (
-    hash_eth2,
-)
-from eth2._utils.tuple import (
-    update_tuple_item,
-)
-from eth2.configs import (
-    CommitteeConfig,
-)
-from eth2.beacon.constants import (
-    MAX_RANDOM_BYTE,
-    MAX_INDEX_COUNT,
-)
-from eth2.beacon.helpers import (
-    get_seed,
-    get_active_validator_indices,
-)
-from eth2.beacon.typing import (
-    Epoch,
-    Gwei,
-    Shard,
-    Slot,
-    ValidatorIndex,
-)
+from eth2._utils.hash import hash_eth2
+from eth2._utils.tuple import update_tuple_item
+from eth2.configs import CommitteeConfig
+from eth2.beacon.constants import MAX_RANDOM_BYTE, MAX_INDEX_COUNT
+from eth2.beacon.helpers import get_seed, get_active_validator_indices
+from eth2.beacon.typing import Epoch, Gwei, Shard, Slot, ValidatorIndex
 from eth2.beacon.types.compact_committees import CompactCommittee
 from eth2.beacon.types.states import BeaconState
 from eth2.beacon.types.validators import Validator
 
 
-def get_committees_per_slot(active_validator_count: int,
-                            shard_count: int,
-                            slots_per_epoch: int,
-                            target_committee_size: int) -> int:
+def get_committees_per_slot(
+    active_validator_count: int,
+    shard_count: int,
+    slots_per_epoch: int,
+    target_committee_size: int,
+) -> int:
     return max(
         1,
         min(
             shard_count // slots_per_epoch,
             active_validator_count // slots_per_epoch // target_committee_size,
-        )
+        ),
     )
 
 
-def get_committee_count(active_validator_count: int,
-                        shard_count: int,
-                        slots_per_epoch: int,
-                        target_committee_size: int) -> int:
-    return get_committees_per_slot(
-        active_validator_count,
-        shard_count,
-        slots_per_epoch,
-        target_committee_size,
-    ) * slots_per_epoch
+def get_committee_count(
+    active_validator_count: int,
+    shard_count: int,
+    slots_per_epoch: int,
+    target_committee_size: int,
+) -> int:
+    return (
+        get_committees_per_slot(
+            active_validator_count, shard_count, slots_per_epoch, target_committee_size
+        )
+        * slots_per_epoch
+    )
 
 
-def get_shard_delta(state: BeaconState,
-                    epoch: Epoch,
-                    config: CommitteeConfig) -> int:
+def get_shard_delta(state: BeaconState, epoch: Epoch, config: CommitteeConfig) -> int:
     shard_count = config.SHARD_COUNT
     slots_per_epoch = config.SLOTS_PER_EPOCH
 
@@ -88,9 +62,7 @@ def get_shard_delta(state: BeaconState,
     )
 
 
-def get_start_shard(state: BeaconState,
-                    epoch: Epoch,
-                    config: CommitteeConfig) -> Shard:
+def get_start_shard(state: BeaconState, epoch: Epoch, config: CommitteeConfig) -> Shard:
     current_epoch = state.current_epoch(config.SLOTS_PER_EPOCH)
     next_epoch = state.next_epoch(config.SLOTS_PER_EPOCH)
     if epoch > next_epoch:
@@ -103,16 +75,20 @@ def get_start_shard(state: BeaconState,
     while check_epoch > epoch:
         check_epoch -= 1
         shard = (
-            shard + config.SHARD_COUNT - get_shard_delta(state, Epoch(check_epoch), config)
+            shard
+            + config.SHARD_COUNT
+            - get_shard_delta(state, Epoch(check_epoch), config)
         ) % config.SHARD_COUNT
     return shard
 
 
-def _find_proposer_in_committee(validators: Sequence[Validator],
-                                committee: Sequence[ValidatorIndex],
-                                epoch: Epoch,
-                                seed: Hash32,
-                                max_effective_balance: Gwei) -> ValidatorIndex:
+def _find_proposer_in_committee(
+    validators: Sequence[Validator],
+    committee: Sequence[ValidatorIndex],
+    epoch: Epoch,
+    seed: Hash32,
+    max_effective_balance: Gwei,
+) -> ValidatorIndex:
     base = int(epoch)
     i = 0
     committee_len = len(committee)
@@ -125,16 +101,18 @@ def _find_proposer_in_committee(validators: Sequence[Validator],
         i += 1
 
 
-def _calculate_first_committee_at_slot(state: BeaconState,
-                                       slot: Slot,
-                                       config: CommitteeConfig) -> Tuple[ValidatorIndex, ...]:
+def _calculate_first_committee_at_slot(
+    state: BeaconState, slot: Slot, config: CommitteeConfig
+) -> Tuple[ValidatorIndex, ...]:
     slots_per_epoch = config.SLOTS_PER_EPOCH
     shard_count = config.SHARD_COUNT
     target_committee_size = config.TARGET_COMMITTEE_SIZE
 
     current_epoch = state.current_epoch(slots_per_epoch)
 
-    active_validator_indices = get_active_validator_indices(state.validators, current_epoch)
+    active_validator_indices = get_active_validator_indices(
+        state.validators, current_epoch
+    )
 
     committees_per_slot = get_committees_per_slot(
         len(active_validator_indices),
@@ -144,28 +122,20 @@ def _calculate_first_committee_at_slot(state: BeaconState,
     )
 
     offset = committees_per_slot * (slot % slots_per_epoch)
-    shard = (
-        get_start_shard(state, current_epoch, config) + offset
-    ) % shard_count
+    shard = (get_start_shard(state, current_epoch, config) + offset) % shard_count
 
-    return get_crosslink_committee(
-        state,
-        current_epoch,
-        shard,
-        config,
-    )
+    return get_crosslink_committee(state, current_epoch, shard, config)
 
 
-def get_beacon_proposer_index(state: BeaconState,
-                              committee_config: CommitteeConfig) -> ValidatorIndex:
+def get_beacon_proposer_index(
+    state: BeaconState, committee_config: CommitteeConfig
+) -> ValidatorIndex:
     """
     Return the current beacon proposer index.
     """
 
     first_committee = _calculate_first_committee_at_slot(
-        state,
-        state.slot,
-        committee_config,
+        state, state.slot, committee_config
     )
 
     current_epoch = state.current_epoch(committee_config.SLOTS_PER_EPOCH)
@@ -181,10 +151,9 @@ def get_beacon_proposer_index(state: BeaconState,
     )
 
 
-def compute_shuffled_index(index: int,
-                           index_count: int,
-                           seed: Hash32,
-                           shuffle_round_count: int) -> int:
+def compute_shuffled_index(
+    index: int, index_count: int, seed: Hash32, shuffle_round_count: int
+) -> int:
     """
     Return `p(index)` in a pseudorandom permutation `p` of `0...index_count-1`
     with ``seed`` as entropy.
@@ -206,17 +175,19 @@ def compute_shuffled_index(index: int,
 
     new_index = index
     for current_round in range(shuffle_round_count):
-        pivot = int.from_bytes(
-            hash_eth2(seed + current_round.to_bytes(1, 'little'))[0:8],
-            'little',
-        ) % index_count
+        pivot = (
+            int.from_bytes(
+                hash_eth2(seed + current_round.to_bytes(1, "little"))[0:8], "little"
+            )
+            % index_count
+        )
 
         flip = (pivot + index_count - new_index) % index_count
         position = max(new_index, flip)
         source = hash_eth2(
-            seed +
-            current_round.to_bytes(1, 'little') +
-            (position // 256).to_bytes(4, 'little')
+            seed
+            + current_round.to_bytes(1, "little")
+            + (position // 256).to_bytes(4, "little")
         )
         byte = source[(position % 256) // 8]
         bit = (byte >> (position % 8)) % 2
@@ -225,31 +196,31 @@ def compute_shuffled_index(index: int,
     return new_index
 
 
-def _compute_committee(indices: Sequence[ValidatorIndex],
-                       seed: Hash32,
-                       index: int,
-                       count: int,
-                       shuffle_round_count: int) -> Iterable[ValidatorIndex]:
+def _compute_committee(
+    indices: Sequence[ValidatorIndex],
+    seed: Hash32,
+    index: int,
+    count: int,
+    shuffle_round_count: int,
+) -> Iterable[ValidatorIndex]:
     start = (len(indices) * index) // count
     end = (len(indices) * (index + 1)) // count
     for i in range(start, end):
-        shuffled_index = compute_shuffled_index(i, len(indices), seed, shuffle_round_count)
+        shuffled_index = compute_shuffled_index(
+            i, len(indices), seed, shuffle_round_count
+        )
         yield indices[shuffled_index]
 
 
 @to_tuple
-def get_crosslink_committee(state: BeaconState,
-                            epoch: Epoch,
-                            shard: Shard,
-                            config: CommitteeConfig) -> Iterable[ValidatorIndex]:
+def get_crosslink_committee(
+    state: BeaconState, epoch: Epoch, shard: Shard, config: CommitteeConfig
+) -> Iterable[ValidatorIndex]:
     target_shard = (
         shard + config.SHARD_COUNT - get_start_shard(state, epoch, config)
     ) % config.SHARD_COUNT
 
-    active_validator_indices = get_active_validator_indices(
-        state.validators,
-        epoch,
-    )
+    active_validator_indices = get_active_validator_indices(state.validators, epoch)
 
     return _compute_committee(
         indices=active_validator_indices,
@@ -265,10 +236,9 @@ def get_crosslink_committee(state: BeaconState,
     )
 
 
-def _compute_compact_committee_for_shard_in_epoch(state: BeaconState,
-                                                  epoch: Epoch,
-                                                  shard: Shard,
-                                                  config: CommitteeConfig) -> CompactCommittee:
+def _compute_compact_committee_for_shard_in_epoch(
+    state: BeaconState, epoch: Epoch, shard: Shard, config: CommitteeConfig
+) -> CompactCommittee:
     effective_balance_increment = config.EFFECTIVE_BALANCE_INCREMENT
 
     pubkeys: Tuple[BLSPubkey, ...] = tuple()
@@ -281,23 +251,17 @@ def _compute_compact_committee_for_shard_in_epoch(state: BeaconState,
         compact_validator = (index << 16) + (validator.slashed << 15) + compact_balance
         compact_validators += (compact_validator,)
 
-    return CompactCommittee(
-        pubkeys=pubkeys,
-        compact_validators=compact_validators,
-    )
+    return CompactCommittee(pubkeys=pubkeys, compact_validators=compact_validators)
 
 
-def get_compact_committees_root(state: BeaconState,
-                                epoch: Epoch,
-                                config: CommitteeConfig) -> Hash32:
+def get_compact_committees_root(
+    state: BeaconState, epoch: Epoch, config: CommitteeConfig
+) -> Hash32:
     shard_count = config.SHARD_COUNT
 
     committees = (CompactCommittee(),) * shard_count
     start_shard = get_start_shard(state, epoch, config)
-    active_validator_indices = get_active_validator_indices(
-        state.validators,
-        epoch,
-    )
+    active_validator_indices = get_active_validator_indices(state.validators, epoch)
     committee_count = get_committee_count(
         len(active_validator_indices),
         config.SHARD_COUNT,
@@ -307,14 +271,9 @@ def get_compact_committees_root(state: BeaconState,
     for committee_number in range(committee_count):
         shard = Shard((start_shard + committee_number) % shard_count)
         compact_committee = _compute_compact_committee_for_shard_in_epoch(
-            state,
-            epoch,
-            shard,
-            config,
+            state, epoch, shard, config
         )
-        committees = update_tuple_item(
-            committees,
-            shard,
-            compact_committee,
-        )
-    return ssz.get_hash_tree_root(committees, sedes=ssz.sedes.Vector(CompactCommittee, shard_count))
+        committees = update_tuple_item(committees, shard, compact_committee)
+    return ssz.get_hash_tree_root(
+        committees, sedes=ssz.sedes.Vector(CompactCommittee, shard_count)
+    )

--- a/eth2/beacon/committee_helpers.py
+++ b/eth2/beacon/committee_helpers.py
@@ -1,19 +1,18 @@
 from typing import Iterable, Sequence, Tuple
 
-from eth_utils import to_tuple, ValidationError
-from eth_typing import Hash32, BLSPubkey
-
+from eth_typing import BLSPubkey, Hash32
+from eth_utils import ValidationError, to_tuple
 import ssz
 
 from eth2._utils.hash import hash_eth2
 from eth2._utils.tuple import update_tuple_item
-from eth2.configs import CommitteeConfig
-from eth2.beacon.constants import MAX_RANDOM_BYTE, MAX_INDEX_COUNT
-from eth2.beacon.helpers import get_seed, get_active_validator_indices
-from eth2.beacon.typing import Epoch, Gwei, Shard, Slot, ValidatorIndex
+from eth2.beacon.constants import MAX_INDEX_COUNT, MAX_RANDOM_BYTE
+from eth2.beacon.helpers import get_active_validator_indices, get_seed
 from eth2.beacon.types.compact_committees import CompactCommittee
 from eth2.beacon.types.states import BeaconState
 from eth2.beacon.types.validators import Validator
+from eth2.beacon.typing import Epoch, Gwei, Shard, Slot, ValidatorIndex
+from eth2.configs import CommitteeConfig
 
 
 def get_committees_per_slot(

--- a/eth2/beacon/constants.py
+++ b/eth2/beacon/constants.py
@@ -1,32 +1,24 @@
-from eth.constants import (
-    ZERO_HASH32,
-)
-from eth_typing import (
-    BLSSignature,
-    BLSPubkey,
-)
-from eth2.beacon.typing import (
-    Epoch,
-    Timestamp,
-)
+from eth.constants import ZERO_HASH32
+from eth_typing import BLSSignature, BLSPubkey
+from eth2.beacon.typing import Epoch, Timestamp
 
 
-EMPTY_SIGNATURE = BLSSignature(b'\x00' * 96)
-EMPTY_PUBKEY = BLSPubkey(b'\x00' * 48)
-GWEI_PER_ETH = 10**9
-FAR_FUTURE_EPOCH = Epoch(2**64 - 1)
+EMPTY_SIGNATURE = BLSSignature(b"\x00" * 96)
+EMPTY_PUBKEY = BLSPubkey(b"\x00" * 48)
+GWEI_PER_ETH = 10 ** 9
+FAR_FUTURE_EPOCH = Epoch(2 ** 64 - 1)
 
 GENESIS_PARENT_ROOT = ZERO_HASH32
 
 ZERO_TIMESTAMP = Timestamp(0)
 
-MAX_INDEX_COUNT = 2**40
+MAX_INDEX_COUNT = 2 ** 40
 
-MAX_RANDOM_BYTE = 2**8 - 1
+MAX_RANDOM_BYTE = 2 ** 8 - 1
 
 BASE_REWARDS_PER_EPOCH = 5
 
-DEPOSIT_CONTRACT_TREE_DEPTH = 2**5
+DEPOSIT_CONTRACT_TREE_DEPTH = 2 ** 5
 
 SECONDS_PER_DAY = 86400
 

--- a/eth2/beacon/constants.py
+++ b/eth2/beacon/constants.py
@@ -1,7 +1,7 @@
 from eth.constants import ZERO_HASH32
-from eth_typing import BLSSignature, BLSPubkey
-from eth2.beacon.typing import Epoch, Timestamp
+from eth_typing import BLSPubkey, BLSSignature
 
+from eth2.beacon.typing import Epoch, Timestamp
 
 EMPTY_SIGNATURE = BLSSignature(b"\x00" * 96)
 EMPTY_PUBKEY = BLSPubkey(b"\x00" * 48)

--- a/eth2/beacon/db/chain.py
+++ b/eth2/beacon/db/chain.py
@@ -1,57 +1,27 @@
 from abc import ABC, abstractmethod
 import functools
 
-from typing import (
-    Iterable,
-    Optional,
-    Tuple,
-    Type,
-)
-from cytoolz import (
-    concat,
-    first,
-    sliding_window,
-)
+from typing import Iterable, Optional, Tuple, Type
+from cytoolz import concat, first, sliding_window
 
 import ssz
-from eth_typing import (
-    Hash32,
-)
-from eth_utils import (
-    encode_hex,
-    to_tuple,
-    ValidationError,
-)
+from eth_typing import Hash32
+from eth_utils import encode_hex, to_tuple, ValidationError
 
-from eth.abc import (
-    DatabaseAPI,
-    AtomicDatabaseAPI,
-)
-from eth.constants import (
-    ZERO_HASH32,
-)
+from eth.abc import DatabaseAPI, AtomicDatabaseAPI
+from eth.constants import ZERO_HASH32
 from eth.exceptions import (
     BlockNotFound,
     CanonicalHeadNotFound,
     ParentNotFound,
     StateRootNotFound,
 )
-from eth.validation import (
-    validate_word,
-)
+from eth.validation import validate_word
 from eth2.beacon.fork_choice.scoring import ScoringFn as ForkChoiceScoringFn
-from eth2.beacon.helpers import (
-    compute_epoch_of_slot,
-)
-from eth2.beacon.typing import (
-    Epoch,
-    Slot,
-)
+from eth2.beacon.helpers import compute_epoch_of_slot
+from eth2.beacon.typing import Epoch, Slot
 from eth2.beacon.types.states import BeaconState  # noqa: F401
-from eth2.beacon.types.blocks import (  # noqa: F401
-    BaseBeaconBlock,
-    BeaconBlock,
-)
+from eth2.beacon.types.blocks import BaseBeaconBlock, BeaconBlock  # noqa: F401
 
 from eth2.beacon.db.exceptions import (
     AttestationRootNotFound,
@@ -63,23 +33,20 @@ from eth2.beacon.db.exceptions import (
 )
 from eth2.beacon.db.schema import SchemaV1
 
-from eth2.configs import (
-    Eth2GenesisConfig,
-)
+from eth2.configs import Eth2GenesisConfig
 
 
 class AttestationKey(ssz.Serializable):
-    fields = [
-        ('block_root', ssz.sedes.bytes32),
-        ('index', ssz.sedes.uint8),
-    ]
+    fields = [("block_root", ssz.sedes.bytes32), ("index", ssz.sedes.uint8)]
 
 
 class BaseBeaconChainDB(ABC):
     db: AtomicDatabaseAPI = None
 
     @abstractmethod
-    def __init__(self, db: AtomicDatabaseAPI, genesis_config: Eth2GenesisConfig) -> None:
+    def __init__(
+        self, db: AtomicDatabaseAPI, genesis_config: Eth2GenesisConfig
+    ) -> None:
         pass
 
     #
@@ -87,10 +54,10 @@ class BaseBeaconChainDB(ABC):
     #
     @abstractmethod
     def persist_block(
-            self,
-            block: BaseBeaconBlock,
-            block_class: Type[BaseBeaconBlock],
-            fork_choice_scoring: ForkChoiceScoringFn,
+        self,
+        block: BaseBeaconBlock,
+        block_class: Type[BaseBeaconBlock],
+        fork_choice_scoring: ForkChoiceScoringFn,
     ) -> Tuple[Tuple[BaseBeaconBlock, ...], Tuple[BaseBeaconBlock, ...]]:
         pass
 
@@ -103,9 +70,9 @@ class BaseBeaconChainDB(ABC):
         pass
 
     @abstractmethod
-    def get_canonical_block_by_slot(self,
-                                    slot: Slot,
-                                    block_class: Type[BaseBeaconBlock]) -> BaseBeaconBlock:
+    def get_canonical_block_by_slot(
+        self, slot: Slot, block_class: Type[BaseBeaconBlock]
+    ) -> BaseBeaconBlock:
         pass
 
     @abstractmethod
@@ -125,14 +92,13 @@ class BaseBeaconChainDB(ABC):
         pass
 
     @abstractmethod
-    def get_block_by_root(self,
-                          block_root: Hash32,
-                          block_class: Type[BaseBeaconBlock]) -> BaseBeaconBlock:
+    def get_block_by_root(
+        self, block_root: Hash32, block_class: Type[BaseBeaconBlock]
+    ) -> BaseBeaconBlock:
         pass
 
     @abstractmethod
-    def get_slot_by_root(self,
-                         block_root: Hash32) -> Slot:
+    def get_slot_by_root(self, block_root: Hash32) -> Slot:
         pass
 
     @abstractmethod
@@ -145,15 +111,15 @@ class BaseBeaconChainDB(ABC):
 
     @abstractmethod
     def persist_block_chain(
-            self,
-            blocks: Iterable[BaseBeaconBlock],
-            block_class: Type[BaseBeaconBlock],
-            fork_choice_scoring: Iterable[ForkChoiceScoringFn],
+        self,
+        blocks: Iterable[BaseBeaconBlock],
+        block_class: Type[BaseBeaconBlock],
+        fork_choice_scoring: Iterable[ForkChoiceScoringFn],
     ) -> Tuple[Tuple[BaseBeaconBlock, ...], Tuple[BaseBeaconBlock, ...]]:
         pass
 
     @abstractmethod
-    def set_score(self, block: BaseBeaconBlock, score: int)-> None:
+    def set_score(self, block: BaseBeaconBlock, score: int) -> None:
         pass
 
     #
@@ -164,23 +130,28 @@ class BaseBeaconChainDB(ABC):
         pass
 
     @abstractmethod
-    def get_state_by_slot(self, slot: Slot, state_class: Type[BeaconState]) -> BeaconState:
+    def get_state_by_slot(
+        self, slot: Slot, state_class: Type[BeaconState]
+    ) -> BeaconState:
         pass
 
     @abstractmethod
-    def get_state_by_root(self, state_root: Hash32, state_class: Type[BeaconState]) -> BeaconState:
+    def get_state_by_root(
+        self, state_root: Hash32, state_class: Type[BeaconState]
+    ) -> BeaconState:
         pass
 
     @abstractmethod
-    def persist_state(self,
-                      state: BeaconState) -> None:
+    def persist_state(self, state: BeaconState) -> None:
         pass
 
     #
     # Attestation API
     #
     @abstractmethod
-    def get_attestation_key_by_root(self, attestation_root: Hash32)-> Tuple[Hash32, int]:
+    def get_attestation_key_by_root(
+        self, attestation_root: Hash32
+    ) -> Tuple[Hash32, int]:
         pass
 
     @abstractmethod
@@ -200,7 +171,9 @@ class BaseBeaconChainDB(ABC):
 
 
 class BeaconChainDB(BaseBeaconChainDB):
-    def __init__(self, db: AtomicDatabaseAPI, genesis_config: Eth2GenesisConfig) -> None:
+    def __init__(
+        self, db: AtomicDatabaseAPI, genesis_config: Eth2GenesisConfig
+    ) -> None:
         self.db = db
         self.genesis_config = genesis_config
 
@@ -222,10 +195,10 @@ class BeaconChainDB(BaseBeaconChainDB):
             return self.genesis_config.GENESIS_EPOCH
 
     def persist_block(
-            self,
-            block: BaseBeaconBlock,
-            block_class: Type[BaseBeaconBlock],
-            fork_choice_scoring: ForkChoiceScoringFn,
+        self,
+        block: BaseBeaconBlock,
+        block_class: Type[BaseBeaconBlock],
+        fork_choice_scoring: ForkChoiceScoringFn,
     ) -> Tuple[Tuple[BaseBeaconBlock, ...], Tuple[BaseBeaconBlock, ...]]:
         """
         Persist the given block.
@@ -238,19 +211,16 @@ class BeaconChainDB(BaseBeaconChainDB):
 
     @classmethod
     def _persist_block(
-            cls,
-            db: DatabaseAPI,
-            block: BaseBeaconBlock,
-            block_class: Type[BaseBeaconBlock],
-            fork_choice_scoring: ForkChoiceScoringFn,
+        cls,
+        db: DatabaseAPI,
+        block: BaseBeaconBlock,
+        block_class: Type[BaseBeaconBlock],
+        fork_choice_scoring: ForkChoiceScoringFn,
     ) -> Tuple[Tuple[BaseBeaconBlock, ...], Tuple[BaseBeaconBlock, ...]]:
-        block_chain = (block, )
-        scorings = (fork_choice_scoring, )
+        block_chain = (block,)
+        scorings = (fork_choice_scoring,)
         new_canonical_blocks, old_canonical_blocks = cls._persist_block_chain(
-            db,
-            block_chain,
-            block_class,
-            scorings,
+            db, block_chain, block_class, scorings
         )
 
         return new_canonical_blocks, old_canonical_blocks
@@ -282,15 +252,13 @@ class BeaconChainDB(BaseBeaconChainDB):
         try:
             encoded_key = db[slot_to_root_key]
         except KeyError:
-            raise BlockNotFound(
-                "No canonical block for block slot #{0}".format(slot)
-            )
+            raise BlockNotFound("No canonical block for block slot #{0}".format(slot))
         else:
             return ssz.decode(encoded_key, sedes=ssz.sedes.bytes32)
 
-    def get_canonical_block_by_slot(self,
-                                    slot: Slot,
-                                    block_class: Type[BaseBeaconBlock]) -> BaseBeaconBlock:
+    def get_canonical_block_by_slot(
+        self, slot: Slot, block_class: Type[BaseBeaconBlock]
+    ) -> BaseBeaconBlock:
         """
         Return the block with the given slot in the canonical chain.
 
@@ -301,10 +269,8 @@ class BeaconChainDB(BaseBeaconChainDB):
 
     @classmethod
     def _get_canonical_block_by_slot(
-            cls,
-            db: DatabaseAPI,
-            slot: Slot,
-            block_class: Type[BaseBeaconBlock]) -> BaseBeaconBlock:
+        cls, db: DatabaseAPI, slot: Slot, block_class: Type[BaseBeaconBlock]
+    ) -> BaseBeaconBlock:
         canonical_block_root = cls._get_canonical_block_root(db, slot)
         return cls._get_block_by_root(db, canonical_block_root, block_class)
 
@@ -315,9 +281,9 @@ class BeaconChainDB(BaseBeaconChainDB):
         return self._get_canonical_head(self.db, block_class)
 
     @classmethod
-    def _get_canonical_head(cls,
-                            db: DatabaseAPI,
-                            block_class: Type[BaseBeaconBlock]) -> BaseBeaconBlock:
+    def _get_canonical_head(
+        cls, db: DatabaseAPI, block_class: Type[BaseBeaconBlock]
+    ) -> BaseBeaconBlock:
         canonical_head_root = cls._get_canonical_head_root(db)
         return cls._get_block_by_root(db, Hash32(canonical_head_root), block_class)
 
@@ -342,9 +308,9 @@ class BeaconChainDB(BaseBeaconChainDB):
         return self._get_finalized_head(self.db, block_class)
 
     @classmethod
-    def _get_finalized_head(cls,
-                            db: DatabaseAPI,
-                            block_class: Type[BaseBeaconBlock]) -> BaseBeaconBlock:
+    def _get_finalized_head(
+        cls, db: DatabaseAPI, block_class: Type[BaseBeaconBlock]
+    ) -> BaseBeaconBlock:
         finalized_head_root = cls._get_finalized_head_root(db)
         return cls._get_block_by_root(db, Hash32(finalized_head_root), block_class)
 
@@ -363,9 +329,9 @@ class BeaconChainDB(BaseBeaconChainDB):
         return self._get_justified_head(self.db, block_class)
 
     @classmethod
-    def _get_justified_head(cls,
-                            db: DatabaseAPI,
-                            block_class: Type[BaseBeaconBlock]) -> BaseBeaconBlock:
+    def _get_justified_head(
+        cls, db: DatabaseAPI, block_class: Type[BaseBeaconBlock]
+    ) -> BaseBeaconBlock:
         justified_head_root = cls._get_justified_head_root(db)
         return cls._get_block_by_root(db, Hash32(justified_head_root), block_class)
 
@@ -377,15 +343,15 @@ class BeaconChainDB(BaseBeaconChainDB):
             raise JustifiedHeadNotFound("No justified head set for this chain")
         return justified_head_root
 
-    def get_block_by_root(self,
-                          block_root: Hash32,
-                          block_class: Type[BaseBeaconBlock]) -> BaseBeaconBlock:
+    def get_block_by_root(
+        self, block_root: Hash32, block_class: Type[BaseBeaconBlock]
+    ) -> BaseBeaconBlock:
         return self._get_block_by_root(self.db, block_root, block_class)
 
     @staticmethod
-    def _get_block_by_root(db: DatabaseAPI,
-                           block_root: Hash32,
-                           block_class: Type[BaseBeaconBlock]) -> BaseBeaconBlock:
+    def _get_block_by_root(
+        db: DatabaseAPI, block_root: Hash32, block_class: Type[BaseBeaconBlock]
+    ) -> BaseBeaconBlock:
         """
         Return the requested block header as specified by block root.
 
@@ -395,12 +361,12 @@ class BeaconChainDB(BaseBeaconChainDB):
         try:
             block_ssz = db[block_root]
         except KeyError:
-            raise BlockNotFound("No block with root {0} found".format(
-                encode_hex(block_root)))
+            raise BlockNotFound(
+                "No block with root {0} found".format(encode_hex(block_root))
+            )
         return _decode_block(block_ssz, block_class)
 
-    def get_slot_by_root(self,
-                         block_root: Hash32) -> Slot:
+    def get_slot_by_root(self, block_root: Hash32) -> Slot:
         """
         Return the requested block header as specified by block root.
 
@@ -409,14 +375,14 @@ class BeaconChainDB(BaseBeaconChainDB):
         return self._get_slot_by_root(self.db, block_root)
 
     @staticmethod
-    def _get_slot_by_root(db: DatabaseAPI,
-                          block_root: Hash32) -> Slot:
+    def _get_slot_by_root(db: DatabaseAPI, block_root: Hash32) -> Slot:
         validate_word(block_root, title="block root")
         try:
             encoded_slot = db[SchemaV1.make_block_root_to_slot_lookup_key(block_root)]
         except KeyError:
-            raise BlockNotFound("No block with root {0} found".format(
-                encode_hex(block_root)))
+            raise BlockNotFound(
+                "No block with root {0} found".format(encode_hex(block_root))
+            )
         return Slot(ssz.decode(encoded_slot, sedes=ssz.sedes.uint64))
 
     def get_score(self, block_root: Hash32) -> int:
@@ -427,8 +393,9 @@ class BeaconChainDB(BaseBeaconChainDB):
         try:
             encoded_score = db[SchemaV1.make_block_root_to_score_lookup_key(block_root)]
         except KeyError:
-            raise BlockNotFound("No block with hash {0} found".format(
-                encode_hex(block_root)))
+            raise BlockNotFound(
+                "No block with hash {0} found".format(encode_hex(block_root))
+            )
         return ssz.decode(encoded_score, sedes=ssz.sedes.uint64)
 
     def block_exists(self, block_root: Hash32) -> bool:
@@ -440,23 +407,23 @@ class BeaconChainDB(BaseBeaconChainDB):
         return block_root in db
 
     def persist_block_chain(
-            self,
-            blocks: Iterable[BaseBeaconBlock],
-            block_class: Type[BaseBeaconBlock],
-            fork_choice_scorings: Iterable[ForkChoiceScoringFn],
+        self,
+        blocks: Iterable[BaseBeaconBlock],
+        block_class: Type[BaseBeaconBlock],
+        fork_choice_scorings: Iterable[ForkChoiceScoringFn],
     ) -> Tuple[Tuple[BaseBeaconBlock, ...], Tuple[BaseBeaconBlock, ...]]:
         """
         Return two iterable of blocks, the first containing the new canonical blocks,
         the second containing the old canonical headers
         """
         with self.db.atomic_batch() as db:
-            return self._persist_block_chain(db, blocks, block_class, fork_choice_scorings)
+            return self._persist_block_chain(
+                db, blocks, block_class, fork_choice_scorings
+            )
 
     @staticmethod
     def _set_block_score_to_db(
-            db: DatabaseAPI,
-            block: BaseBeaconBlock,
-            score: int,
+        db: DatabaseAPI, block: BaseBeaconBlock, score: int
     ) -> int:
         # NOTE if we change the score serialization, we will likely need to
         # patch up the fork choice logic.
@@ -468,19 +435,15 @@ class BeaconChainDB(BaseBeaconChainDB):
         return score
 
     def set_score(self, block: BaseBeaconBlock, score: int) -> None:
-        self.__class__._set_block_score_to_db(
-            self.db,
-            block,
-            score,
-        )
+        self.__class__._set_block_score_to_db(self.db, block, score)
 
     @classmethod
     def _persist_block_chain(
-            cls,
-            db: DatabaseAPI,
-            blocks: Iterable[BaseBeaconBlock],
-            block_class: Type[BaseBeaconBlock],
-            fork_choice_scorings: Iterable[ForkChoiceScoringFn],
+        cls,
+        db: DatabaseAPI,
+        blocks: Iterable[BaseBeaconBlock],
+        block_class: Type[BaseBeaconBlock],
+        fork_choice_scorings: Iterable[ForkChoiceScoringFn],
     ) -> Tuple[Tuple[BaseBeaconBlock, ...], Tuple[BaseBeaconBlock, ...]]:
         blocks_iterator = iter(blocks)
         scorings_iterator = iter(fork_choice_scorings)
@@ -492,7 +455,9 @@ class BeaconChainDB(BaseBeaconChainDB):
             return tuple(), tuple()
 
         try:
-            previous_canonical_head = cls._get_canonical_head(db, block_class).signing_root
+            previous_canonical_head = cls._get_canonical_head(
+                db, block_class
+            ).signing_root
             head_score = cls._get_score(db, previous_canonical_head)
         except CanonicalHeadNotFound:
             no_canonical_head = True
@@ -511,10 +476,7 @@ class BeaconChainDB(BaseBeaconChainDB):
         score = first_scoring(first_block)
 
         curr_block_head = first_block
-        db.set(
-            curr_block_head.signing_root,
-            ssz.encode(curr_block_head),
-        )
+        db.set(curr_block_head.signing_root, ssz.encode(curr_block_head))
         cls._add_block_root_to_slot_lookup(db, curr_block_head)
         cls._set_block_score_to_db(db, curr_block_head, score)
         cls._add_attestations_root_to_block_lookup(db, curr_block_head)
@@ -532,10 +494,7 @@ class BeaconChainDB(BaseBeaconChainDB):
                 )
 
             curr_block_head = child
-            db.set(
-                curr_block_head.signing_root,
-                ssz.encode(curr_block_head),
-            )
+            db.set(curr_block_head.signing_root, ssz.encode(curr_block_head))
             cls._add_block_root_to_slot_lookup(db, curr_block_head)
             cls._add_attestations_root_to_block_lookup(db, curr_block_head)
 
@@ -549,19 +508,20 @@ class BeaconChainDB(BaseBeaconChainDB):
             cls._set_block_score_to_db(db, curr_block_head, score)
 
         if no_canonical_head:
-            return cls._set_as_canonical_chain_head(db, curr_block_head.signing_root, block_class)
+            return cls._set_as_canonical_chain_head(
+                db, curr_block_head.signing_root, block_class
+            )
 
         if score > head_score:
-            return cls._set_as_canonical_chain_head(db, curr_block_head.signing_root, block_class)
+            return cls._set_as_canonical_chain_head(
+                db, curr_block_head.signing_root, block_class
+            )
         else:
             return tuple(), tuple()
 
     @classmethod
     def _set_as_canonical_chain_head(
-            cls,
-            db: DatabaseAPI,
-            block_root: Hash32,
-            block_class: Type[BaseBeaconBlock]
+        cls, db: DatabaseAPI, block_root: Hash32, block_class: Type[BaseBeaconBlock]
     ) -> Tuple[Tuple[BaseBeaconBlock, ...], Tuple[BaseBeaconBlock, ...]]:
         """
         Set the canonical chain HEAD to the block as specified by the
@@ -577,7 +537,9 @@ class BeaconChainDB(BaseBeaconChainDB):
                 "Cannot use unknown block root as canonical head: {}".format(block_root)
             )
 
-        new_canonical_blocks = tuple(reversed(cls._find_new_ancestors(db, block, block_class)))
+        new_canonical_blocks = tuple(
+            reversed(cls._find_new_ancestors(db, block, block_class))
+        )
         old_canonical_blocks = []
 
         for block in new_canonical_blocks:
@@ -587,7 +549,9 @@ class BeaconChainDB(BaseBeaconChainDB):
                 # no old_canonical block, and no more possible
                 break
             else:
-                old_canonical_block = cls._get_block_by_root(db, old_canonical_root, block_class)
+                old_canonical_block = cls._get_block_by_root(
+                    db, old_canonical_root, block_class
+                )
                 old_canonical_blocks.append(old_canonical_block)
 
         for block in new_canonical_blocks:
@@ -600,10 +564,8 @@ class BeaconChainDB(BaseBeaconChainDB):
     @classmethod
     @to_tuple
     def _find_new_ancestors(
-            cls,
-            db: DatabaseAPI,
-            block: BaseBeaconBlock,
-            block_class: Type[BaseBeaconBlock]) -> Iterable[BaseBeaconBlock]:
+        cls, db: DatabaseAPI, block: BaseBeaconBlock, block_class: Type[BaseBeaconBlock]
+    ) -> Iterable[BaseBeaconBlock]:
         """
         Return the chain leading up from the given block until (but not including)
         the first ancestor it has in common with our canonical chain.
@@ -640,9 +602,7 @@ class BeaconChainDB(BaseBeaconChainDB):
         Set a record in the database to allow looking up this block by its
         block slot.
         """
-        block_slot_to_root_key = SchemaV1.make_block_slot_to_root_lookup_key(
-            block.slot
-        )
+        block_slot_to_root_key = SchemaV1.make_block_slot_to_root_lookup_key(block.slot)
         db.set(
             block_slot_to_root_key,
             ssz.encode(block.signing_root, sedes=ssz.sedes.bytes32),
@@ -657,10 +617,7 @@ class BeaconChainDB(BaseBeaconChainDB):
         block_root_to_slot_key = SchemaV1.make_block_root_to_slot_lookup_key(
             block.signing_root
         )
-        db.set(
-            block_root_to_slot_key,
-            ssz.encode(block.slot, sedes=ssz.sedes.uint64),
-        )
+        db.set(block_root_to_slot_key, ssz.encode(block.slot, sedes=ssz.sedes.uint64))
 
     #
     # Beacon State API
@@ -681,8 +638,7 @@ class BeaconChainDB(BaseBeaconChainDB):
         """
         slot_to_state_root_key = SchemaV1.make_slot_to_state_root_lookup_key(slot)
         self.db.set(
-            slot_to_state_root_key,
-            ssz.encode(state_root, sedes=ssz.sedes.bytes32),
+            slot_to_state_root_key, ssz.encode(state_root, sedes=ssz.sedes.bytes32)
         )
 
     def get_head_state_slot(self) -> Slot:
@@ -692,18 +648,22 @@ class BeaconChainDB(BaseBeaconChainDB):
     def _get_head_state_slot(db: DatabaseAPI) -> Slot:
         try:
             encoded_head_state_slot = db[SchemaV1.make_head_state_slot_lookup_key()]
-            head_state_slot = ssz.decode(encoded_head_state_slot, sedes=ssz.sedes.uint64)
+            head_state_slot = ssz.decode(
+                encoded_head_state_slot, sedes=ssz.sedes.uint64
+            )
         except KeyError:
             raise HeadStateSlotNotFound("No head state slot found")
         return head_state_slot
 
-    def get_state_by_slot(self, slot: Slot, state_class: Type[BeaconState]) -> BeaconState:
+    def get_state_by_slot(
+        self, slot: Slot, state_class: Type[BeaconState]
+    ) -> BeaconState:
         return self._get_state_by_slot(self.db, slot, state_class)
 
     @staticmethod
-    def _get_state_by_slot(db: DatabaseAPI,
-                           slot: Slot,
-                           state_class: Type[BeaconState]) -> BeaconState:
+    def _get_state_by_slot(
+        db: DatabaseAPI, slot: Slot, state_class: Type[BeaconState]
+    ) -> BeaconState:
         """
         Return the requested beacon state as specified by slot.
 
@@ -713,24 +673,26 @@ class BeaconChainDB(BaseBeaconChainDB):
         try:
             state_root_ssz = db[slot_to_state_root_key]
         except KeyError:
-            raise StateSlotNotFound(
-                "No state root for slot #{0}".format(slot)
-            )
+            raise StateSlotNotFound("No state root for slot #{0}".format(slot))
 
         state_root = ssz.decode(state_root_ssz, sedes=ssz.sedes.bytes32)
         try:
             state_ssz = db[state_root]
         except KeyError:
-            raise StateRootNotFound(f"No state with root {encode_hex(state_root)} found")
+            raise StateRootNotFound(
+                f"No state with root {encode_hex(state_root)} found"
+            )
         return _decode_state(state_ssz, state_class)
 
-    def get_state_by_root(self, state_root: Hash32, state_class: Type[BeaconState]) -> BeaconState:
+    def get_state_by_root(
+        self, state_root: Hash32, state_class: Type[BeaconState]
+    ) -> BeaconState:
         return self._get_state_by_root(self.db, state_root, state_class)
 
     @staticmethod
-    def _get_state_by_root(db: DatabaseAPI,
-                           state_root: Hash32,
-                           state_class: Type[BeaconState]) -> BeaconState:
+    def _get_state_by_root(
+        db: DatabaseAPI, state_root: Hash32, state_class: Type[BeaconState]
+    ) -> BeaconState:
         """
         Return the requested beacon state as specified by state hash.
 
@@ -740,11 +702,12 @@ class BeaconChainDB(BaseBeaconChainDB):
         try:
             state_ssz = db[state_root]
         except KeyError:
-            raise StateRootNotFound(f"No state with root {encode_hex(state_root)} found")
+            raise StateRootNotFound(
+                f"No state with root {encode_hex(state_root)} found"
+            )
         return _decode_state(state_ssz, state_class)
 
-    def persist_state(self,
-                      state: BeaconState) -> None:
+    def persist_state(self, state: BeaconState) -> None:
         """
         Persist the given BeaconState.
 
@@ -753,10 +716,7 @@ class BeaconChainDB(BaseBeaconChainDB):
         return self._persist_state(state)
 
     def _persist_state(self, state: BeaconState) -> None:
-        self.db.set(
-            state.hash_tree_root,
-            ssz.encode(state),
-        )
+        self.db.set(state.hash_tree_root, ssz.encode(state))
         self._add_slot_to_state_root_lookup(state.slot, state.hash_tree_root)
 
         self._persist_finalized_head(state)
@@ -777,10 +737,7 @@ class BeaconChainDB(BaseBeaconChainDB):
         Unconditionally write the ``finalized_root`` as the root of the currently
         finalized block.
         """
-        self.db.set(
-            SchemaV1.make_finalized_head_root_lookup_key(),
-            finalized_root,
-        )
+        self.db.set(SchemaV1.make_finalized_head_root_lookup_key(), finalized_root)
         self._finalized_root = finalized_root
 
     def _persist_finalized_head(self, state: BeaconState) -> None:
@@ -801,13 +758,12 @@ class BeaconChainDB(BaseBeaconChainDB):
         Unconditionally write the ``justified_root`` as the root of the highest
         justified block.
         """
-        self.db.set(
-            SchemaV1.make_justified_head_root_lookup_key(),
-            justified_root,
-        )
+        self.db.set(SchemaV1.make_justified_head_root_lookup_key(), justified_root)
         self._highest_justified_epoch = epoch
 
-    def _find_updated_justified_root(self, state: BeaconState) -> Optional[Tuple[Hash32, Epoch]]:
+    def _find_updated_justified_root(
+        self, state: BeaconState
+    ) -> Optional[Tuple[Hash32, Epoch]]:
         """
         Find the highest epoch that has been justified so far.
 
@@ -820,16 +776,10 @@ class BeaconChainDB(BaseBeaconChainDB):
         """
         if state.current_justified_checkpoint.epoch > self._highest_justified_epoch:
             checkpoint = state.current_justified_checkpoint
-            return (
-                checkpoint.root,
-                checkpoint.epoch,
-            )
+            return (checkpoint.root, checkpoint.epoch)
         elif state.previous_justified_checkpoint.epoch > self._highest_justified_epoch:
             checkpoint = state.previous_justified_checkpoint
-            return (
-                checkpoint.root,
-                checkpoint.epoch,
-            )
+            return (checkpoint.root, checkpoint.epoch)
         return None
 
     def _persist_justified_head(self, state: BeaconState) -> None:
@@ -843,9 +793,9 @@ class BeaconChainDB(BaseBeaconChainDB):
         if result:
             self._update_justified_head(*result)
 
-    def _handle_exceptional_justification_and_finality(self,
-                                                       db: DatabaseAPI,
-                                                       genesis_block: BaseBeaconBlock) -> None:
+    def _handle_exceptional_justification_and_finality(
+        self, db: DatabaseAPI, genesis_block: BaseBeaconBlock
+    ) -> None:
         """
         The genesis ``BeaconState`` lacks the correct justification and finality
         data in the early epochs. The invariants of this class require an exceptional
@@ -861,24 +811,32 @@ class BeaconChainDB(BaseBeaconChainDB):
     #
 
     @staticmethod
-    def _add_attestations_root_to_block_lookup(db: DatabaseAPI,
-                                               block: BaseBeaconBlock) -> None:
+    def _add_attestations_root_to_block_lookup(
+        db: DatabaseAPI, block: BaseBeaconBlock
+    ) -> None:
         root = block.signing_root
         for index, attestation in enumerate(block.body.attestations):
             attestation_key = AttestationKey(root, index)
             db.set(
-                SchemaV1.make_attestation_root_to_block_lookup_key(attestation.hash_tree_root),
+                SchemaV1.make_attestation_root_to_block_lookup_key(
+                    attestation.hash_tree_root
+                ),
                 ssz.encode(attestation_key),
             )
 
-    def get_attestation_key_by_root(self, attestation_root: Hash32)-> Tuple[Hash32, int]:
+    def get_attestation_key_by_root(
+        self, attestation_root: Hash32
+    ) -> Tuple[Hash32, int]:
         return self._get_attestation_key_by_root(self.db, attestation_root)
 
     @staticmethod
-    def _get_attestation_key_by_root(db: DatabaseAPI,
-                                     attestation_root: Hash32) -> Tuple[Hash32, int]:
+    def _get_attestation_key_by_root(
+        db: DatabaseAPI, attestation_root: Hash32
+    ) -> Tuple[Hash32, int]:
         try:
-            encoded_key = db[SchemaV1.make_attestation_root_to_block_lookup_key(attestation_root)]
+            encoded_key = db[
+                SchemaV1.make_attestation_root_to_block_lookup_key(attestation_root)
+            ]
         except KeyError:
             raise AttestationRootNotFound(
                 "Attestation root {0} not found".format(encode_hex(attestation_root))
@@ -887,7 +845,9 @@ class BeaconChainDB(BaseBeaconChainDB):
         return attestation_key.block_root, attestation_key.index
 
     def attestation_exists(self, attestation_root: Hash32) -> bool:
-        lookup_key = SchemaV1.make_attestation_root_to_block_lookup_key(attestation_root)
+        lookup_key = SchemaV1.make_attestation_root_to_block_lookup_key(
+            attestation_root
+        )
         return self.exists(lookup_key)
 
     #

--- a/eth2/beacon/db/chain.py
+++ b/eth2/beacon/db/chain.py
@@ -1,14 +1,9 @@
 from abc import ABC, abstractmethod
 import functools
-
 from typing import Iterable, Optional, Tuple, Type
+
 from cytoolz import concat, first, sliding_window
-
-import ssz
-from eth_typing import Hash32
-from eth_utils import encode_hex, to_tuple, ValidationError
-
-from eth.abc import DatabaseAPI, AtomicDatabaseAPI
+from eth.abc import AtomicDatabaseAPI, DatabaseAPI
 from eth.constants import ZERO_HASH32
 from eth.exceptions import (
     BlockNotFound,
@@ -17,11 +12,9 @@ from eth.exceptions import (
     StateRootNotFound,
 )
 from eth.validation import validate_word
-from eth2.beacon.fork_choice.scoring import ScoringFn as ForkChoiceScoringFn
-from eth2.beacon.helpers import compute_epoch_of_slot
-from eth2.beacon.typing import Epoch, Slot
-from eth2.beacon.types.states import BeaconState  # noqa: F401
-from eth2.beacon.types.blocks import BaseBeaconBlock, BeaconBlock  # noqa: F401
+from eth_typing import Hash32
+from eth_utils import ValidationError, encode_hex, to_tuple
+import ssz
 
 from eth2.beacon.db.exceptions import (
     AttestationRootNotFound,
@@ -32,7 +25,11 @@ from eth2.beacon.db.exceptions import (
     StateSlotNotFound,
 )
 from eth2.beacon.db.schema import SchemaV1
-
+from eth2.beacon.fork_choice.scoring import ScoringFn as ForkChoiceScoringFn
+from eth2.beacon.helpers import compute_epoch_of_slot
+from eth2.beacon.types.blocks import BaseBeaconBlock, BeaconBlock  # noqa: F401
+from eth2.beacon.types.states import BeaconState  # noqa: F401
+from eth2.beacon.typing import Epoch, Slot
 from eth2.configs import Eth2GenesisConfig
 
 

--- a/eth2/beacon/db/exceptions.py
+++ b/eth2/beacon/db/exceptions.py
@@ -2,6 +2,7 @@ class BeaconDBException(Exception):
     """
     Base class for exceptions raised by this package.
     """
+
     pass
 
 
@@ -9,6 +10,7 @@ class HeadStateSlotNotFound(BeaconDBException):
     """
     Exception raised if head state slot does not exist.
     """
+
     pass
 
 
@@ -16,6 +18,7 @@ class StateSlotNotFound(BeaconDBException):
     """
     Exception raised if state root with the given slot number does not exist.
     """
+
     pass
 
 
@@ -23,6 +26,7 @@ class FinalizedHeadNotFound(BeaconDBException):
     """
     Exception raised if no finalized head is set in this database.
     """
+
     pass
 
 
@@ -30,6 +34,7 @@ class JustifiedHeadNotFound(BeaconDBException):
     """
     Exception raised if no justified head is set in this database.
     """
+
     pass
 
 
@@ -37,6 +42,7 @@ class AttestationRootNotFound(BeaconDBException):
     """
     Exception raised if no attestation root is set in this database.
     """
+
     pass
 
 
@@ -45,4 +51,5 @@ class MissingForkChoiceScoringFns(BeaconDBException):
     Exception raised if a client tries to score a block without providing
     the ability to generate a score via a ``scoring``.
     """
+
     pass

--- a/eth2/beacon/db/schema.py
+++ b/eth2/beacon/db/schema.py
@@ -1,8 +1,6 @@
 from abc import ABC, abstractmethod
 
-from eth_typing import (
-    Hash32,
-)
+from eth_typing import Hash32
 
 
 class BaseSchema(ABC):
@@ -67,43 +65,43 @@ class SchemaV1(BaseSchema):
     #
     @staticmethod
     def make_head_state_slot_lookup_key() -> bytes:
-        return b'v1:beacon:head-state-slot'
+        return b"v1:beacon:head-state-slot"
 
     @staticmethod
     def make_slot_to_state_root_lookup_key(slot: int) -> bytes:
-        return b'v1:beacon:slot-to-state-root%d' % slot
+        return b"v1:beacon:slot-to-state-root%d" % slot
 
     #
     # Block
     #
     @staticmethod
     def make_canonical_head_root_lookup_key() -> bytes:
-        return b'v1:beacon:canonical-head-root'
+        return b"v1:beacon:canonical-head-root"
 
     @staticmethod
     def make_finalized_head_root_lookup_key() -> bytes:
-        return b'v1:beacon:finalized-head-root'
+        return b"v1:beacon:finalized-head-root"
 
     @staticmethod
     def make_justified_head_root_lookup_key() -> bytes:
-        return b'v1:beacon:justified-head-root'
+        return b"v1:beacon:justified-head-root"
 
     @staticmethod
     def make_block_slot_to_root_lookup_key(slot: int) -> bytes:
-        slot_to_root_key = b'v1:beacon:block-slot-to-root:%d' % slot
+        slot_to_root_key = b"v1:beacon:block-slot-to-root:%d" % slot
         return slot_to_root_key
 
     @staticmethod
     def make_block_root_to_score_lookup_key(block_root: Hash32) -> bytes:
-        return b'v1:beacon:block-root-to-score:%s' % block_root
+        return b"v1:beacon:block-root-to-score:%s" % block_root
 
     @staticmethod
     def make_block_root_to_slot_lookup_key(block_root: Hash32) -> bytes:
-        return b'v1:beacon:block-root-to-slot:%s' % block_root
+        return b"v1:beacon:block-root-to-slot:%s" % block_root
 
     #
     # Attestaion
     #
     @staticmethod
     def make_attestation_root_to_block_lookup_key(attestaton_root: Hash32) -> bytes:
-        return b'v1:beacon:attestation-root-to-block:%s' % attestaton_root
+        return b"v1:beacon:attestation-root-to-block:%s" % attestaton_root

--- a/eth2/beacon/deposit_helpers.py
+++ b/eth2/beacon/deposit_helpers.py
@@ -1,36 +1,21 @@
-from eth_utils import (
-    encode_hex,
-    ValidationError,
-)
+from eth_utils import encode_hex, ValidationError
 from eth2._utils.bls import bls
 
-from eth2._utils.merkle.common import (
-    verify_merkle_branch,
-)
-from eth2.beacon.constants import (
-    DEPOSIT_CONTRACT_TREE_DEPTH,
-)
-from eth2.beacon.signature_domain import (
-    SignatureDomain,
-)
-from eth2.beacon.helpers import (
-    compute_domain,
-)
-from eth2.beacon.epoch_processing_helpers import (
-    increase_balance,
-)
+from eth2._utils.merkle.common import verify_merkle_branch
+from eth2.beacon.constants import DEPOSIT_CONTRACT_TREE_DEPTH
+from eth2.beacon.signature_domain import SignatureDomain
+from eth2.beacon.helpers import compute_domain
+from eth2.beacon.epoch_processing_helpers import increase_balance
 from eth2.beacon.types.deposits import Deposit
 from eth2.beacon.types.states import BeaconState
 from eth2.beacon.types.validators import Validator
-from eth2.beacon.typing import (
-    ValidatorIndex,
-)
+from eth2.beacon.typing import ValidatorIndex
 from eth2.configs import Eth2Config
 
 
-def validate_deposit_proof(state: BeaconState,
-                           deposit: Deposit,
-                           deposit_contract_tree_depth: int) -> None:
+def validate_deposit_proof(
+    state: BeaconState, deposit: Deposit, deposit_contract_tree_depth: int
+) -> None:
     """
     Validate if deposit branch proof is valid.
     """
@@ -51,9 +36,9 @@ def validate_deposit_proof(state: BeaconState,
         )
 
 
-def process_deposit(state: BeaconState,
-                    deposit: Deposit,
-                    config: Eth2Config) -> BeaconState:
+def process_deposit(
+    state: BeaconState, deposit: Deposit, config: Eth2Config
+) -> BeaconState:
     """
     Process a deposit from Ethereum 1.0.
     """
@@ -63,9 +48,7 @@ def process_deposit(state: BeaconState,
     # needs to be done here because while the deposit contract will never
     # create an invalid Merkle branch, it may admit an invalid deposit
     # object, and we need to be able to skip over it
-    state = state.copy(
-        eth1_deposit_index=state.eth1_deposit_index + 1,
-    )
+    state = state.copy(eth1_deposit_index=state.eth1_deposit_index + 1)
 
     pubkey = deposit.data.pubkey
     amount = deposit.data.amount
@@ -79,29 +62,20 @@ def process_deposit(state: BeaconState,
             message_hash=deposit.data.signing_root,
             pubkey=pubkey,
             signature=deposit.data.signature,
-            domain=compute_domain(
-                SignatureDomain.DOMAIN_DEPOSIT,
-            ),
+            domain=compute_domain(SignatureDomain.DOMAIN_DEPOSIT),
         )
         if not is_valid_proof_of_possession:
             return state
 
         withdrawal_credentials = deposit.data.withdrawal_credentials
         validator = Validator.create_pending_validator(
-            pubkey,
-            withdrawal_credentials,
-            amount,
-            config,
+            pubkey, withdrawal_credentials, amount, config
         )
 
         return state.copy(
             validators=state.validators + (validator,),
-            balances=state.balances + (amount, ),
+            balances=state.balances + (amount,),
         )
     else:
         index = ValidatorIndex(validator_pubkeys.index(pubkey))
-        return increase_balance(
-            state,
-            index,
-            amount,
-        )
+        return increase_balance(state, index, amount)

--- a/eth2/beacon/deposit_helpers.py
+++ b/eth2/beacon/deposit_helpers.py
@@ -1,11 +1,11 @@
-from eth_utils import encode_hex, ValidationError
-from eth2._utils.bls import bls
+from eth_utils import ValidationError, encode_hex
 
+from eth2._utils.bls import bls
 from eth2._utils.merkle.common import verify_merkle_branch
 from eth2.beacon.constants import DEPOSIT_CONTRACT_TREE_DEPTH
-from eth2.beacon.signature_domain import SignatureDomain
-from eth2.beacon.helpers import compute_domain
 from eth2.beacon.epoch_processing_helpers import increase_balance
+from eth2.beacon.helpers import compute_domain
+from eth2.beacon.signature_domain import SignatureDomain
 from eth2.beacon.types.deposits import Deposit
 from eth2.beacon.types.states import BeaconState
 from eth2.beacon.types.validators import Validator

--- a/eth2/beacon/epoch_processing_helpers.py
+++ b/eth2/beacon/epoch_processing_helpers.py
@@ -1,8 +1,7 @@
 from typing import Iterable, Sequence, Set, Tuple
 
 from eth_typing import Hash32
-
-from eth_utils import to_tuple, ValidationError
+from eth_utils import ValidationError, to_tuple
 from eth_utils.toolz import curry, groupby, thread_first
 
 from eth2._utils.bitfield import Bitfield, has_voted
@@ -11,7 +10,6 @@ from eth2._utils.tuple import update_tuple_item_with_fn
 from eth2.beacon.attestation_helpers import get_attestation_data_slot
 from eth2.beacon.committee_helpers import get_crosslink_committee
 from eth2.beacon.constants import BASE_REWARDS_PER_EPOCH
-from eth2.configs import Eth2Config, CommitteeConfig
 from eth2.beacon.exceptions import InvalidEpochError
 from eth2.beacon.helpers import (
     get_active_validator_indices,
@@ -19,13 +17,13 @@ from eth2.beacon.helpers import (
     get_block_root_at_slot,
     get_total_balance,
 )
-from eth2.beacon.typing import Epoch, Gwei, Shard, ValidatorIndex
-
+from eth2.beacon.types.attestation_data import AttestationData
+from eth2.beacon.types.attestations import Attestation, IndexedAttestation
 from eth2.beacon.types.crosslinks import Crosslink
 from eth2.beacon.types.pending_attestations import PendingAttestation
-from eth2.beacon.types.attestations import Attestation, IndexedAttestation
-from eth2.beacon.types.attestation_data import AttestationData
 from eth2.beacon.types.states import BeaconState
+from eth2.beacon.typing import Epoch, Gwei, Shard, ValidatorIndex
+from eth2.configs import CommitteeConfig, Eth2Config
 
 
 def increase_balance(

--- a/eth2/beacon/exceptions.py
+++ b/eth2/beacon/exceptions.py
@@ -1,5 +1,4 @@
 from eth.exceptions import PyEVMError
-
 from eth_utils import ValidationError
 
 

--- a/eth2/beacon/exceptions.py
+++ b/eth2/beacon/exceptions.py
@@ -1,16 +1,13 @@
-from eth.exceptions import (
-    PyEVMError,
-)
+from eth.exceptions import PyEVMError
 
-from eth_utils import (
-    ValidationError,
-)
+from eth_utils import ValidationError
 
 
 class StateMachineNotFound(PyEVMError):
     """
     Raised when no ``StateMachine`` is available for the provided block slot number.
     """
+
     pass
 
 
@@ -18,6 +15,7 @@ class BlockClassError(PyEVMError):
     """
     Raised when the given ``block`` doesn't match the block class version
     """
+
     pass
 
 
@@ -26,6 +24,7 @@ class ProposerIndexError(PyEVMError):
     Raised when the given ``validator_index`` doesn't match the ``validator_index``
     of proposer of the given ``slot``
     """
+
     pass
 
 
@@ -33,6 +32,7 @@ class NoCommitteeAssignment(PyEVMError):
     """
     Raised when no potential crosslink committee assignment.
     """
+
     pass
 
 
@@ -42,6 +42,7 @@ class InvalidEpochError(ValidationError):
 
     Example: asking the ``BeaconState`` about an epoch that is not derivable given the current data.
     """
+
     pass
 
 
@@ -49,6 +50,7 @@ class BLSValidationError(ValidationError):
     """
     Raised when a verification of public keys, messages, and signature fails.
     """
+
     pass
 
 
@@ -56,6 +58,7 @@ class SignatureError(BLSValidationError):
     """
     Signature is ill-formed
     """
+
     pass
 
 
@@ -63,4 +66,5 @@ class PublicKeyError(BLSValidationError):
     """
     Public Key is ill-formed
     """
+
     pass

--- a/eth2/beacon/fork_choice/lmd_ghost.py
+++ b/eth2/beacon/fork_choice/lmd_ghost.py
@@ -5,18 +5,17 @@ from eth_utils import to_tuple
 from eth_utils.toolz import curry, first, mapcat, merge, merge_with, second, valmap
 
 from eth2.beacon.attestation_helpers import get_attestation_data_slot
-from eth2.beacon.epoch_processing_helpers import get_attesting_indices
-from eth2.beacon.helpers import get_active_validator_indices, compute_epoch_of_slot
 from eth2.beacon.db.chain import BeaconChainDB
+from eth2.beacon.epoch_processing_helpers import get_attesting_indices
+from eth2.beacon.helpers import compute_epoch_of_slot, get_active_validator_indices
 from eth2.beacon.operations.attestation_pool import AttestationPool
-from eth2.beacon.types.attestations import Attestation
 from eth2.beacon.types.attestation_data import AttestationData
+from eth2.beacon.types.attestations import Attestation
 from eth2.beacon.types.blocks import BaseBeaconBlock
 from eth2.beacon.types.pending_attestations import PendingAttestation
 from eth2.beacon.types.states import BeaconState
 from eth2.beacon.typing import Gwei, Slot, ValidatorIndex
-from eth2.configs import Eth2Config, CommitteeConfig
-
+from eth2.configs import CommitteeConfig, Eth2Config
 
 # TODO(ralexstokes) integrate `AttestationPool` once it has been merged
 AttestationIndex = Dict[ValidatorIndex, AttestationData]

--- a/eth2/beacon/genesis.py
+++ b/eth2/beacon/genesis.py
@@ -1,54 +1,29 @@
-from typing import (
-    Sequence,
-    Type,
-)
+from typing import Sequence, Type
 
-from eth_typing import (
-    Hash32,
-)
+from eth_typing import Hash32
 
 import ssz
 
-from eth2.beacon.constants import (
-    SECONDS_PER_DAY,
-    DEPOSIT_CONTRACT_TREE_DEPTH,
-)
-from eth2.beacon.committee_helpers import (
-    get_compact_committees_root,
-)
-from eth2.beacon.deposit_helpers import (
-    process_deposit,
-)
-from eth2.beacon.helpers import (
-    get_active_validator_indices,
-)
+from eth2.beacon.constants import SECONDS_PER_DAY, DEPOSIT_CONTRACT_TREE_DEPTH
+from eth2.beacon.committee_helpers import get_compact_committees_root
+from eth2.beacon.deposit_helpers import process_deposit
+from eth2.beacon.helpers import get_active_validator_indices
 
-from eth2.beacon.types.blocks import (
-    BaseBeaconBlock,
-    BeaconBlockBody,
-)
-from eth2.beacon.types.block_headers import (
-    BeaconBlockHeader,
-)
+from eth2.beacon.types.blocks import BaseBeaconBlock, BeaconBlockBody
+from eth2.beacon.types.block_headers import BeaconBlockHeader
 from eth2.beacon.types.deposits import Deposit
 from eth2.beacon.types.deposit_data import DepositData
 from eth2.beacon.types.eth1_data import Eth1Data
 from eth2.beacon.types.states import BeaconState
 from eth2.beacon.types.validators import calculate_effective_balance
-from eth2.beacon.typing import (
-    Timestamp,
-    ValidatorIndex,
-)
-from eth2.beacon.validator_status_helpers import (
-    activate_validator,
-)
-from eth2.configs import (
-    Eth2Config,
-    CommitteeConfig,
-)
+from eth2.beacon.typing import Timestamp, ValidatorIndex
+from eth2.beacon.validator_status_helpers import activate_validator
+from eth2.configs import Eth2Config, CommitteeConfig
 
 
-def is_genesis_trigger(deposits: Sequence[Deposit], timestamp: int, config: Eth2Config) -> bool:
+def is_genesis_trigger(
+    deposits: Sequence[Deposit], timestamp: int, config: Eth2Config
+) -> bool:
     state = BeaconState(config=config)
 
     for deposit in deposits:
@@ -64,24 +39,16 @@ def is_genesis_trigger(deposits: Sequence[Deposit], timestamp: int, config: Eth2
 
 def state_with_validator_digests(state: BeaconState, config: Eth2Config) -> BeaconState:
     active_validator_indices = get_active_validator_indices(
-        state.validators,
-        config.GENESIS_EPOCH,
+        state.validators, config.GENESIS_EPOCH
     )
     active_index_root = ssz.get_hash_tree_root(
-        active_validator_indices,
-        ssz.List(ssz.uint64, config.VALIDATOR_REGISTRY_LIMIT),
+        active_validator_indices, ssz.List(ssz.uint64, config.VALIDATOR_REGISTRY_LIMIT)
     )
-    active_index_roots = (
-        (active_index_root,) * config.EPOCHS_PER_HISTORICAL_VECTOR
-    )
+    active_index_roots = (active_index_root,) * config.EPOCHS_PER_HISTORICAL_VECTOR
     committee_root = get_compact_committees_root(
-        state,
-        config.GENESIS_EPOCH,
-        CommitteeConfig(config),
+        state, config.GENESIS_EPOCH, CommitteeConfig(config)
     )
-    compact_committees_roots = (
-        (committee_root,) * config.EPOCHS_PER_HISTORICAL_VECTOR
-    )
+    compact_committees_roots = (committee_root,) * config.EPOCHS_PER_HISTORICAL_VECTOR
     return state.copy(
         active_index_roots=active_index_roots,
         compact_committees_roots=compact_committees_roots,
@@ -90,89 +57,71 @@ def state_with_validator_digests(state: BeaconState, config: Eth2Config) -> Beac
 
 def _genesis_time_from_eth1_timestamp(eth1_timestamp: Timestamp) -> Timestamp:
     return Timestamp(
-        eth1_timestamp - eth1_timestamp % SECONDS_PER_DAY + 2 * SECONDS_PER_DAY,
+        eth1_timestamp - eth1_timestamp % SECONDS_PER_DAY + 2 * SECONDS_PER_DAY
     )
 
 
-def initialize_beacon_state_from_eth1(*,
-                                      eth1_block_hash: Hash32,
-                                      eth1_timestamp: Timestamp,
-                                      deposits: Sequence[Deposit],
-                                      config: Eth2Config) -> BeaconState:
+def initialize_beacon_state_from_eth1(
+    *,
+    eth1_block_hash: Hash32,
+    eth1_timestamp: Timestamp,
+    deposits: Sequence[Deposit],
+    config: Eth2Config
+) -> BeaconState:
     state = BeaconState(
         genesis_time=_genesis_time_from_eth1_timestamp(eth1_timestamp),
-        eth1_data=Eth1Data(
-            block_hash=eth1_block_hash,
-            deposit_count=len(deposits),
-        ),
+        eth1_data=Eth1Data(block_hash=eth1_block_hash, deposit_count=len(deposits)),
         latest_block_header=BeaconBlockHeader(
-            body_root=BeaconBlockBody().hash_tree_root,
+            body_root=BeaconBlockBody().hash_tree_root
         ),
         config=config,
     )
 
     # Process genesis deposits
     for index, deposit in enumerate(deposits):
-        deposit_data_list = tuple(
-            deposit.data
-            for deposit in deposits[:index + 1]
-        )
+        deposit_data_list = tuple(deposit.data for deposit in deposits[: index + 1])
         state = state.copy(
             eth1_data=state.eth1_data.copy(
                 deposit_root=ssz.get_hash_tree_root(
                     deposit_data_list,
-                    ssz.List(DepositData, 2**DEPOSIT_CONTRACT_TREE_DEPTH),
-                ),
-            ),
+                    ssz.List(DepositData, 2 ** DEPOSIT_CONTRACT_TREE_DEPTH),
+                )
+            )
         )
-        state = process_deposit(
-            state=state,
-            deposit=deposit,
-            config=config,
-        )
+        state = process_deposit(state=state, deposit=deposit, config=config)
 
     # Process genesis activations
     for validator_index in range(len(state.validators)):
         validator_index = ValidatorIndex(validator_index)
         balance = state.balances[validator_index]
-        effective_balance = calculate_effective_balance(
-            balance,
-            config,
-        )
+        effective_balance = calculate_effective_balance(balance, config)
 
         state = state.update_validator_with_fn(
-            validator_index,
-            lambda v, *_: v.copy(
-                effective_balance=effective_balance,
-            ),
+            validator_index, lambda v, *_: v.copy(effective_balance=effective_balance)
         )
 
         if effective_balance == config.MAX_EFFECTIVE_BALANCE:
             state = state.update_validator_with_fn(
-                validator_index,
-                activate_validator,
-                config.GENESIS_EPOCH,
+                validator_index, activate_validator, config.GENESIS_EPOCH
             )
 
-    return state_with_validator_digests(
-        state,
-        config,
-    )
+    return state_with_validator_digests(state, config)
 
 
 def is_valid_genesis_state(state: BeaconState, config: Eth2Config) -> bool:
     if state.genesis_time < config.MIN_GENESIS_TIME:
         return False
 
-    validator_count = len(get_active_validator_indices(state.validators, config.GENESIS_EPOCH))
+    validator_count = len(
+        get_active_validator_indices(state.validators, config.GENESIS_EPOCH)
+    )
     if validator_count < config.MIN_GENESIS_ACTIVE_VALIDATOR_COUNT:
         return False
 
     return True
 
 
-def get_genesis_block(genesis_state_root: Hash32,
-                      block_class: Type[BaseBeaconBlock]) -> BaseBeaconBlock:
-    return block_class(
-        state_root=genesis_state_root,
-    )
+def get_genesis_block(
+    genesis_state_root: Hash32, block_class: Type[BaseBeaconBlock]
+) -> BaseBeaconBlock:
+    return block_class(state_root=genesis_state_root)

--- a/eth2/beacon/genesis.py
+++ b/eth2/beacon/genesis.py
@@ -1,24 +1,22 @@
 from typing import Sequence, Type
 
 from eth_typing import Hash32
-
 import ssz
 
-from eth2.beacon.constants import SECONDS_PER_DAY, DEPOSIT_CONTRACT_TREE_DEPTH
 from eth2.beacon.committee_helpers import get_compact_committees_root
+from eth2.beacon.constants import DEPOSIT_CONTRACT_TREE_DEPTH, SECONDS_PER_DAY
 from eth2.beacon.deposit_helpers import process_deposit
 from eth2.beacon.helpers import get_active_validator_indices
-
-from eth2.beacon.types.blocks import BaseBeaconBlock, BeaconBlockBody
 from eth2.beacon.types.block_headers import BeaconBlockHeader
-from eth2.beacon.types.deposits import Deposit
+from eth2.beacon.types.blocks import BaseBeaconBlock, BeaconBlockBody
 from eth2.beacon.types.deposit_data import DepositData
+from eth2.beacon.types.deposits import Deposit
 from eth2.beacon.types.eth1_data import Eth1Data
 from eth2.beacon.types.states import BeaconState
 from eth2.beacon.types.validators import calculate_effective_balance
 from eth2.beacon.typing import Timestamp, ValidatorIndex
 from eth2.beacon.validator_status_helpers import activate_validator
-from eth2.configs import Eth2Config, CommitteeConfig
+from eth2.configs import CommitteeConfig, Eth2Config
 
 
 def is_genesis_trigger(

--- a/eth2/beacon/helpers.py
+++ b/eth2/beacon/helpers.py
@@ -1,25 +1,23 @@
-from typing import Callable, Sequence, Set, Tuple, TYPE_CHECKING
+from typing import TYPE_CHECKING, Callable, Sequence, Set, Tuple
 
-from eth_utils import ValidationError
 from eth_typing import Hash32
-
+from eth_utils import ValidationError
 from py_ecc.bls.typing import Domain
 
 from eth2._utils.hash import hash_eth2
 from eth2.beacon.signature_domain import SignatureDomain
+from eth2.beacon.types.forks import Fork
+from eth2.beacon.types.validators import Validator
 from eth2.beacon.typing import (
+    DomainType,
     Epoch,
     Gwei,
     Slot,
     ValidatorIndex,
     Version,
     default_version,
-    DomainType,
 )
 from eth2.configs import CommitteeConfig
-
-from eth2.beacon.types.forks import Fork
-from eth2.beacon.types.validators import Validator
 
 if TYPE_CHECKING:
     from eth2.beacon.types.states import BeaconState  # noqa: F401

--- a/eth2/beacon/operations/attestation_pool.py
+++ b/eth2/beacon/operations/attestation_pool.py
@@ -1,6 +1,6 @@
-from .pool import OperationPool
-
 from eth2.beacon.types.attestations import Attestation
+
+from .pool import OperationPool
 
 
 class AttestationPool(OperationPool[Attestation]):

--- a/eth2/beacon/operations/pool.py
+++ b/eth2/beacon/operations/pool.py
@@ -11,7 +11,7 @@ class Operation(Protocol):
     hash_tree_root: HashTreeRoot
 
 
-T = TypeVar('T', bound='Operation')
+T = TypeVar("T", bound="Operation")
 
 
 class OperationPool(Generic[T]):

--- a/eth2/beacon/operations/pool.py
+++ b/eth2/beacon/operations/pool.py
@@ -1,8 +1,7 @@
 from typing import Dict, Generic, Iterator, Tuple, TypeVar
-from typing_extensions import Protocol
 
 from eth_typing import Hash32
-
+from typing_extensions import Protocol
 
 HashTreeRoot = Hash32
 

--- a/eth2/beacon/scripts/run_beacon_nodes.py
+++ b/eth2/beacon/scripts/run_beacon_nodes.py
@@ -3,19 +3,15 @@
 import asyncio
 from collections import defaultdict
 import logging
+from pathlib import Path
 import signal
 import sys
 import time
 from typing import ClassVar, Dict, List, MutableSet, NamedTuple, Optional, Tuple
 
-from pathlib import Path
-
-from libp2p.peer.id import ID
-
 from eth_keys.datatypes import PrivateKey
-
 from eth_utils import remove_0x_prefix
-
+from libp2p.peer.id import ID
 from multiaddr import Multiaddr
 
 from trinity.protocol.bcc_libp2p.utils import peer_id_from_pubkey

--- a/eth2/beacon/state_machines/base.py
+++ b/eth2/beacon/state_machines/base.py
@@ -1,32 +1,17 @@
-from abc import (
-    ABC,
-    abstractmethod,
-)
-from typing import (
-    Tuple,
-    Type,
-)
+from abc import ABC, abstractmethod
+from typing import Tuple, Type
 
-from eth._utils.datatypes import (
-    Configurable,
-)
+from eth._utils.datatypes import Configurable
 
-from eth2.configs import (  # noqa: F401
-    Eth2Config,
-)
+from eth2.configs import Eth2Config  # noqa: F401
 from eth2.beacon.db.chain import BaseBeaconChainDB
 from eth2.beacon.fork_choice.scoring import ScoringFn as ForkChoiceScoringFn
 from eth2.beacon.operations.attestation_pool import AttestationPool
 from eth2.beacon.types.blocks import BaseBeaconBlock
 from eth2.beacon.types.states import BeaconState
-from eth2.beacon.typing import (
-    FromBlockParams,
-    Slot,
-)
+from eth2.beacon.typing import FromBlockParams, Slot
 
-from .state_transitions import (
-    BaseStateTransition,
-)
+from .state_transitions import BaseStateTransition
 
 
 class BaseBeaconStateMachine(Configurable, ABC):
@@ -42,11 +27,13 @@ class BaseBeaconStateMachine(Configurable, ABC):
     state_transition_class = None  # type: Type[BaseStateTransition]
 
     @abstractmethod
-    def __init__(self,
-                 chaindb: BaseBeaconChainDB,
-                 attestation_pool: AttestationPool,
-                 slot: Slot,
-                 state: BeaconState=None) -> None:
+    def __init__(
+        self,
+        chaindb: BaseBeaconChainDB,
+        attestation_pool: AttestationPool,
+        slot: Slot,
+        state: BeaconState = None,
+    ) -> None:
         ...
 
     @classmethod
@@ -77,24 +64,27 @@ class BaseBeaconStateMachine(Configurable, ABC):
     # Import block API
     #
     @abstractmethod
-    def import_block(self,
-                     block: BaseBeaconBlock,
-                     check_proposer_signature: bool=True) -> Tuple[BeaconState, BaseBeaconBlock]:
+    def import_block(
+        self, block: BaseBeaconBlock, check_proposer_signature: bool = True
+    ) -> Tuple[BeaconState, BaseBeaconBlock]:
         ...
 
     @staticmethod
     @abstractmethod
-    def create_block_from_parent(parent_block: BaseBeaconBlock,
-                                 block_params: FromBlockParams) -> BaseBeaconBlock:
+    def create_block_from_parent(
+        parent_block: BaseBeaconBlock, block_params: FromBlockParams
+    ) -> BaseBeaconBlock:
         ...
 
 
 class BeaconStateMachine(BaseBeaconStateMachine):
-    def __init__(self,
-                 chaindb: BaseBeaconChainDB,
-                 attestation_pool: AttestationPool,
-                 slot: Slot,
-                 state: BeaconState=None) -> None:
+    def __init__(
+        self,
+        chaindb: BaseBeaconChainDB,
+        attestation_pool: AttestationPool,
+        slot: Slot,
+        state: BeaconState = None,
+    ) -> None:
         self.chaindb = chaindb
         self.attestation_pool = attestation_pool
         if state is not None:
@@ -106,8 +96,7 @@ class BeaconStateMachine(BaseBeaconStateMachine):
     def state(self) -> BeaconState:
         if self._state is None:
             self._state = self.chaindb.get_state_by_slot(
-                self.slot,
-                self.get_state_class()
+                self.slot, self.get_state_class()
             )
         return self._state
 
@@ -140,7 +129,9 @@ class BeaconStateMachine(BaseBeaconStateMachine):
         class that this StateTransition uses for StateTransition.
         """
         if cls.state_transition_class is None:
-            raise AttributeError("No `state_transition_class` has been set for this StateMachine")
+            raise AttributeError(
+                "No `state_transition_class` has been set for this StateMachine"
+            )
         else:
             return cls.state_transition_class
 
@@ -151,17 +142,13 @@ class BeaconStateMachine(BaseBeaconStateMachine):
     #
     # Import block API
     #
-    def import_block(self,
-                     block: BaseBeaconBlock,
-                     check_proposer_signature: bool=True) -> Tuple[BeaconState, BaseBeaconBlock]:
+    def import_block(
+        self, block: BaseBeaconBlock, check_proposer_signature: bool = True
+    ) -> Tuple[BeaconState, BaseBeaconBlock]:
         state = self.state_transition.apply_state_transition(
-            self.state,
-            block=block,
-            check_proposer_signature=check_proposer_signature,
+            self.state, block=block, check_proposer_signature=check_proposer_signature
         )
 
-        block = block.copy(
-            state_root=state.hash_tree_root,
-        )
+        block = block.copy(state_root=state.hash_tree_root)
 
         return state, block

--- a/eth2/beacon/state_machines/base.py
+++ b/eth2/beacon/state_machines/base.py
@@ -3,13 +3,13 @@ from typing import Tuple, Type
 
 from eth._utils.datatypes import Configurable
 
-from eth2.configs import Eth2Config  # noqa: F401
 from eth2.beacon.db.chain import BaseBeaconChainDB
 from eth2.beacon.fork_choice.scoring import ScoringFn as ForkChoiceScoringFn
 from eth2.beacon.operations.attestation_pool import AttestationPool
 from eth2.beacon.types.blocks import BaseBeaconBlock
 from eth2.beacon.types.states import BeaconState
 from eth2.beacon.typing import FromBlockParams, Slot
+from eth2.configs import Eth2Config  # noqa: F401
 
 from .state_transitions import BaseStateTransition
 

--- a/eth2/beacon/state_machines/forks/serenity/__init__.py
+++ b/eth2/beacon/state_machines/forks/serenity/__init__.py
@@ -1,31 +1,26 @@
 from typing import Type  # noqa: F401
 
 from eth2.beacon.fork_choice.scoring import ScoringFn as ForkChoiceScoringFn
-from eth2.beacon.fork_choice.lmd_ghost import (
-    lmd_ghost_scoring,
-)
-from eth2.beacon.typing import (
-    FromBlockParams,
-)
+from eth2.beacon.fork_choice.lmd_ghost import lmd_ghost_scoring
+from eth2.beacon.typing import FromBlockParams
 
 from eth2.beacon.types.blocks import BaseBeaconBlock  # noqa: F401
 from eth2.beacon.types.states import BeaconState  # noqa: F401
 
 from eth2.beacon.state_machines.base import BeaconStateMachine
-from eth2.beacon.state_machines.state_transitions import BaseStateTransition  # noqa: F401
+from eth2.beacon.state_machines.state_transitions import (
+    BaseStateTransition,
+)  # noqa: F401
 
 from .configs import SERENITY_CONFIG
-from .blocks import (
-    create_serenity_block_from_parent,
-    SerenityBeaconBlock,
-)
+from .blocks import create_serenity_block_from_parent, SerenityBeaconBlock
 from .states import SerenityBeaconState
 from .state_transitions import SerenityStateTransition
 
 
 class SerenityStateMachine(BeaconStateMachine):
     # fork name
-    fork = 'serenity'  # type: str
+    fork = "serenity"  # type: str
     config = SERENITY_CONFIG
 
     # classes
@@ -35,20 +30,19 @@ class SerenityStateMachine(BeaconStateMachine):
 
     # methods
     @staticmethod
-    def create_block_from_parent(parent_block: BaseBeaconBlock,
-                                 block_params: FromBlockParams) -> BaseBeaconBlock:
+    def create_block_from_parent(
+        parent_block: BaseBeaconBlock, block_params: FromBlockParams
+    ) -> BaseBeaconBlock:
         return create_serenity_block_from_parent(parent_block, block_params)
 
     def _get_justified_head_state(self) -> BeaconState:
         justified_head = self.chaindb.get_justified_head(self.block_class)
-        return self.chaindb.get_state_by_root(justified_head.state_root, self.state_class)
+        return self.chaindb.get_state_by_root(
+            justified_head.state_root, self.state_class
+        )
 
     def get_fork_choice_scoring(self) -> ForkChoiceScoringFn:
         state = self._get_justified_head_state()
         return lmd_ghost_scoring(
-            self.chaindb,
-            self.attestation_pool,
-            state,
-            self.config,
-            self.block_class
+            self.chaindb, self.attestation_pool, state, self.config, self.block_class
         )

--- a/eth2/beacon/state_machines/forks/serenity/__init__.py
+++ b/eth2/beacon/state_machines/forks/serenity/__init__.py
@@ -1,21 +1,19 @@
 from typing import Type  # noqa: F401
 
-from eth2.beacon.fork_choice.scoring import ScoringFn as ForkChoiceScoringFn
 from eth2.beacon.fork_choice.lmd_ghost import lmd_ghost_scoring
-from eth2.beacon.typing import FromBlockParams
-
+from eth2.beacon.fork_choice.scoring import ScoringFn as ForkChoiceScoringFn
+from eth2.beacon.state_machines.base import BeaconStateMachine
+from eth2.beacon.state_machines.state_transitions import (  # noqa: F401
+    BaseStateTransition,
+)
 from eth2.beacon.types.blocks import BaseBeaconBlock  # noqa: F401
 from eth2.beacon.types.states import BeaconState  # noqa: F401
+from eth2.beacon.typing import FromBlockParams
 
-from eth2.beacon.state_machines.base import BeaconStateMachine
-from eth2.beacon.state_machines.state_transitions import (
-    BaseStateTransition,
-)  # noqa: F401
-
+from .blocks import SerenityBeaconBlock, create_serenity_block_from_parent
 from .configs import SERENITY_CONFIG
-from .blocks import create_serenity_block_from_parent, SerenityBeaconBlock
-from .states import SerenityBeaconState
 from .state_transitions import SerenityStateTransition
+from .states import SerenityBeaconState
 
 
 class SerenityStateMachine(BeaconStateMachine):

--- a/eth2/beacon/state_machines/forks/serenity/block_processing.py
+++ b/eth2/beacon/state_machines/forks/serenity/block_processing.py
@@ -1,13 +1,8 @@
 from eth2._utils.hash import hash_eth2
 from eth2._utils.tuple import update_tuple_item
-from eth2._utils.numeric import (
-    bitwise_xor,
-)
+from eth2._utils.numeric import bitwise_xor
 
-from eth2.configs import (
-    Eth2Config,
-    CommitteeConfig,
-)
+from eth2.configs import Eth2Config, CommitteeConfig
 from eth2.beacon.types.states import BeaconState
 from eth2.beacon.types.blocks import BaseBeaconBlock
 from eth2.beacon.types.block_headers import BeaconBlockHeader
@@ -16,12 +11,8 @@ from eth2.beacon.state_machines.forks.serenity.block_validation import (
     validate_randao_reveal,
 )
 
-from eth2.beacon.helpers import (
-    get_randao_mix,
-)
-from eth2.beacon.committee_helpers import (
-    get_beacon_proposer_index,
-)
+from eth2.beacon.helpers import get_randao_mix
+from eth2.beacon.committee_helpers import get_beacon_proposer_index
 
 from .block_validation import (
     validate_block_slot,
@@ -30,28 +21,22 @@ from .block_validation import (
     validate_proposer_is_not_slashed,
 )
 
-from .operation_processing import (
-    process_operations,
-)
+from .operation_processing import process_operations
 
 
-def process_block_header(state: BeaconState,
-                         block: BaseBeaconBlock,
-                         config: Eth2Config,
-                         check_proposer_signature: bool) -> BeaconState:
+def process_block_header(
+    state: BeaconState,
+    block: BaseBeaconBlock,
+    config: Eth2Config,
+    check_proposer_signature: bool,
+) -> BeaconState:
     validate_block_slot(state, block)
     validate_block_parent_root(state, block)
-    validate_proposer_is_not_slashed(
-        state,
-        block.signing_root,
-        CommitteeConfig(config),
-    )
+    validate_proposer_is_not_slashed(state, block.signing_root, CommitteeConfig(config))
 
     if check_proposer_signature:
         validate_proposer_signature(
-            state,
-            block,
-            committee_config=CommitteeConfig(config),
+            state, block, committee_config=CommitteeConfig(config)
         )
 
     return state.copy(
@@ -59,16 +44,15 @@ def process_block_header(state: BeaconState,
             slot=block.slot,
             parent_root=block.parent_root,
             body_root=block.body.hash_tree_root,
-        ),
+        )
     )
 
 
-def process_randao(state: BeaconState,
-                   block: BaseBeaconBlock,
-                   config: Eth2Config) -> BeaconState:
+def process_randao(
+    state: BeaconState, block: BaseBeaconBlock, config: Eth2Config
+) -> BeaconState:
     proposer_index = get_beacon_proposer_index(
-        state=state,
-        committee_config=CommitteeConfig(config),
+        state=state, committee_config=CommitteeConfig(config)
     )
 
     epoch = state.current_epoch(config.SLOTS_PER_EPOCH)
@@ -93,34 +77,34 @@ def process_randao(state: BeaconState,
 
     return state.copy(
         randao_mixes=update_tuple_item(
-            state.randao_mixes,
-            randao_mix_index,
-            new_randao_mix,
-        ),
+            state.randao_mixes, randao_mix_index, new_randao_mix
+        )
     )
 
 
-def process_eth1_data(state: BeaconState,
-                      block: BaseBeaconBlock,
-                      config: Eth2Config) -> BeaconState:
+def process_eth1_data(
+    state: BeaconState, block: BaseBeaconBlock, config: Eth2Config
+) -> BeaconState:
     body = block.body
 
     new_eth1_data_votes = state.eth1_data_votes + (body.eth1_data,)
 
     new_eth1_data = state.eth1_data
-    if new_eth1_data_votes.count(body.eth1_data) * 2 > config.SLOTS_PER_ETH1_VOTING_PERIOD:
+    if (
+        new_eth1_data_votes.count(body.eth1_data) * 2
+        > config.SLOTS_PER_ETH1_VOTING_PERIOD
+    ):
         new_eth1_data = body.eth1_data
 
-    return state.copy(
-        eth1_data=new_eth1_data,
-        eth1_data_votes=new_eth1_data_votes,
-    )
+    return state.copy(eth1_data=new_eth1_data, eth1_data_votes=new_eth1_data_votes)
 
 
-def process_block(state: BeaconState,
-                  block: BaseBeaconBlock,
-                  config: Eth2Config,
-                  check_proposer_signature: bool=True) -> BeaconState:
+def process_block(
+    state: BeaconState,
+    block: BaseBeaconBlock,
+    config: Eth2Config,
+    check_proposer_signature: bool = True,
+) -> BeaconState:
     state = process_block_header(state, block, config, check_proposer_signature)
     state = process_randao(state, block, config)
     state = process_eth1_data(state, block, config)

--- a/eth2/beacon/state_machines/forks/serenity/block_processing.py
+++ b/eth2/beacon/state_machines/forks/serenity/block_processing.py
@@ -1,26 +1,22 @@
 from eth2._utils.hash import hash_eth2
-from eth2._utils.tuple import update_tuple_item
 from eth2._utils.numeric import bitwise_xor
-
-from eth2.configs import Eth2Config, CommitteeConfig
-from eth2.beacon.types.states import BeaconState
-from eth2.beacon.types.blocks import BaseBeaconBlock
-from eth2.beacon.types.block_headers import BeaconBlockHeader
-
+from eth2._utils.tuple import update_tuple_item
+from eth2.beacon.committee_helpers import get_beacon_proposer_index
+from eth2.beacon.helpers import get_randao_mix
 from eth2.beacon.state_machines.forks.serenity.block_validation import (
     validate_randao_reveal,
 )
-
-from eth2.beacon.helpers import get_randao_mix
-from eth2.beacon.committee_helpers import get_beacon_proposer_index
+from eth2.beacon.types.block_headers import BeaconBlockHeader
+from eth2.beacon.types.blocks import BaseBeaconBlock
+from eth2.beacon.types.states import BeaconState
+from eth2.configs import CommitteeConfig, Eth2Config
 
 from .block_validation import (
-    validate_block_slot,
     validate_block_parent_root,
-    validate_proposer_signature,
+    validate_block_slot,
     validate_proposer_is_not_slashed,
+    validate_proposer_signature,
 )
-
 from .operation_processing import process_operations
 
 

--- a/eth2/beacon/state_machines/forks/serenity/block_validation.py
+++ b/eth2/beacon/state_machines/forks/serenity/block_validation.py
@@ -1,26 +1,25 @@
-from typing import cast, Iterable, Sequence, Tuple  # noqa: F401
-
-from eth_typing import BLSPubkey, BLSSignature, Hash32
-from eth_utils import encode_hex, ValidationError
-import ssz
+from typing import Iterable, Sequence, Tuple, cast  # noqa: F401
 
 from eth.constants import ZERO_HASH32
-from eth2._utils.hash import hash_eth2
-from eth2._utils.bls import bls
+from eth_typing import BLSPubkey, BLSSignature, Hash32
+from eth_utils import ValidationError, encode_hex
+import ssz
 
-from eth2.configs import CommitteeConfig
+from eth2._utils.bls import bls
+from eth2._utils.hash import hash_eth2
 from eth2.beacon.attestation_helpers import (
     get_attestation_data_slot,
-    validate_indexed_attestation,
     is_slashable_attestation_data,
+    validate_indexed_attestation,
 )
 from eth2.beacon.committee_helpers import get_beacon_proposer_index
-from eth2.beacon.epoch_processing_helpers import get_indexed_attestation
 from eth2.beacon.constants import FAR_FUTURE_EPOCH
+from eth2.beacon.epoch_processing_helpers import get_indexed_attestation
+from eth2.beacon.exceptions import SignatureError
+from eth2.beacon.helpers import compute_epoch_of_slot, get_domain
 from eth2.beacon.signature_domain import SignatureDomain
-from eth2.beacon.helpers import get_domain, compute_epoch_of_slot
-from eth2.beacon.types.attestations import Attestation, IndexedAttestation
 from eth2.beacon.types.attestation_data import AttestationData
+from eth2.beacon.types.attestations import Attestation, IndexedAttestation
 from eth2.beacon.types.attester_slashings import AttesterSlashing
 from eth2.beacon.types.blocks import BaseBeaconBlock, BeaconBlockHeader
 from eth2.beacon.types.checkpoints import Checkpoint
@@ -28,11 +27,10 @@ from eth2.beacon.types.crosslinks import Crosslink
 from eth2.beacon.types.proposer_slashings import ProposerSlashing
 from eth2.beacon.types.states import BeaconState
 from eth2.beacon.types.transfers import Transfer
-from eth2.beacon.types.voluntary_exits import VoluntaryExit
 from eth2.beacon.types.validators import Validator
+from eth2.beacon.types.voluntary_exits import VoluntaryExit
 from eth2.beacon.typing import Epoch, Shard, Slot
-from eth2.configs import Eth2Config
-from eth2.beacon.exceptions import SignatureError
+from eth2.configs import CommitteeConfig, Eth2Config
 
 
 def validate_correct_number_of_deposits(

--- a/eth2/beacon/state_machines/forks/serenity/blocks.py
+++ b/eth2/beacon/state_machines/forks/serenity/blocks.py
@@ -1,19 +1,15 @@
-from eth2.beacon.typing import (
-    FromBlockParams,
-)
+from eth2.beacon.typing import FromBlockParams
 
-from eth2.beacon.types.blocks import (
-    BaseBeaconBlock,
-    BeaconBlock,
-)
+from eth2.beacon.types.blocks import BaseBeaconBlock, BeaconBlock
 
 
 class SerenityBeaconBlock(BeaconBlock):
     pass
 
 
-def create_serenity_block_from_parent(parent_block: BaseBeaconBlock,
-                                      block_params: FromBlockParams) -> BaseBeaconBlock:
+def create_serenity_block_from_parent(
+    parent_block: BaseBeaconBlock, block_params: FromBlockParams
+) -> BaseBeaconBlock:
     block = SerenityBeaconBlock.from_parent(parent_block, block_params)
 
     return block

--- a/eth2/beacon/state_machines/forks/serenity/blocks.py
+++ b/eth2/beacon/state_machines/forks/serenity/blocks.py
@@ -1,6 +1,5 @@
-from eth2.beacon.typing import FromBlockParams
-
 from eth2.beacon.types.blocks import BaseBeaconBlock, BeaconBlock
+from eth2.beacon.typing import FromBlockParams
 
 
 class SerenityBeaconBlock(BeaconBlock):

--- a/eth2/beacon/state_machines/forks/serenity/configs.py
+++ b/eth2/beacon/state_machines/forks/serenity/configs.py
@@ -1,68 +1,61 @@
-from eth_utils import (
-    decode_hex,
-)
+from eth_utils import decode_hex
 from eth2.configs import Eth2Config
-from eth2.beacon.constants import (
-    GWEI_PER_ETH,
-)
-from eth2.beacon.typing import (
-    Epoch,
-    Gwei,
-    Second,
-    Slot,
-)
+from eth2.beacon.constants import GWEI_PER_ETH
+from eth2.beacon.typing import Epoch, Gwei, Second, Slot
 
 
 SERENITY_CONFIG = Eth2Config(
     # Misc
-    SHARD_COUNT=2**10,  # (= 1,024) shards
-    TARGET_COMMITTEE_SIZE=2**7,  # (= 128) validators
-    MAX_VALIDATORS_PER_COMMITTEE=2**12,  # (= 4,096) validators
-    MIN_PER_EPOCH_CHURN_LIMIT=2**2,
-    CHURN_LIMIT_QUOTIENT=2**16,
+    SHARD_COUNT=2 ** 10,  # (= 1,024) shards
+    TARGET_COMMITTEE_SIZE=2 ** 7,  # (= 128) validators
+    MAX_VALIDATORS_PER_COMMITTEE=2 ** 12,  # (= 4,096) validators
+    MIN_PER_EPOCH_CHURN_LIMIT=2 ** 2,
+    CHURN_LIMIT_QUOTIENT=2 ** 16,
     SHUFFLE_ROUND_COUNT=90,
     # Genesis
-    MIN_GENESIS_ACTIVE_VALIDATOR_COUNT=2**16,
+    MIN_GENESIS_ACTIVE_VALIDATOR_COUNT=2 ** 16,
     MIN_GENESIS_TIME=1578009600,  # (= Jan 3, 2020)
     # Gwei values
-    MIN_DEPOSIT_AMOUNT=Gwei(2**0 * GWEI_PER_ETH),  # (= 1,000,000,000) Gwei
-    MAX_EFFECTIVE_BALANCE=Gwei(2**5 * GWEI_PER_ETH),  # (= 32,000,000,00) Gwei
-    EJECTION_BALANCE=Gwei(2**4 * GWEI_PER_ETH),  # (= 16,000,000,000) Gwei
-    EFFECTIVE_BALANCE_INCREMENT=Gwei(2**0 * GWEI_PER_ETH),  # (= 1,000,000,000) Gwei
+    MIN_DEPOSIT_AMOUNT=Gwei(2 ** 0 * GWEI_PER_ETH),  # (= 1,000,000,000) Gwei
+    MAX_EFFECTIVE_BALANCE=Gwei(2 ** 5 * GWEI_PER_ETH),  # (= 32,000,000,00) Gwei
+    EJECTION_BALANCE=Gwei(2 ** 4 * GWEI_PER_ETH),  # (= 16,000,000,000) Gwei
+    EFFECTIVE_BALANCE_INCREMENT=Gwei(2 ** 0 * GWEI_PER_ETH),  # (= 1,000,000,000) Gwei
     # Initial values
     GENESIS_SLOT=Slot(0),
     GENESIS_EPOCH=Epoch(0),
     BLS_WITHDRAWAL_PREFIX=0,
     # Time parameters
     SECONDS_PER_SLOT=Second(6),  # seconds
-    MIN_ATTESTATION_INCLUSION_DELAY=2**0,  # (= 1) slots
-    SLOTS_PER_EPOCH=2**6,  # (= 64) slots
-    MIN_SEED_LOOKAHEAD=2**0,  # (= 1) epochs
-    ACTIVATION_EXIT_DELAY=2**2,  # (= 4) epochs
-    SLOTS_PER_ETH1_VOTING_PERIOD=2**10,  # (= 16) epochs
-    SLOTS_PER_HISTORICAL_ROOT=2**13,  # (= 8,192) slots
-    MIN_VALIDATOR_WITHDRAWABILITY_DELAY=2**8,  # (= 256) epochs
-    PERSISTENT_COMMITTEE_PERIOD=2**11,  # (= 2,048) epochs
-    MAX_EPOCHS_PER_CROSSLINK=2**6,
-    MIN_EPOCHS_TO_INACTIVITY_PENALTY=2**2,
+    MIN_ATTESTATION_INCLUSION_DELAY=2 ** 0,  # (= 1) slots
+    SLOTS_PER_EPOCH=2 ** 6,  # (= 64) slots
+    MIN_SEED_LOOKAHEAD=2 ** 0,  # (= 1) epochs
+    ACTIVATION_EXIT_DELAY=2 ** 2,  # (= 4) epochs
+    SLOTS_PER_ETH1_VOTING_PERIOD=2 ** 10,  # (= 16) epochs
+    SLOTS_PER_HISTORICAL_ROOT=2 ** 13,  # (= 8,192) slots
+    MIN_VALIDATOR_WITHDRAWABILITY_DELAY=2 ** 8,  # (= 256) epochs
+    PERSISTENT_COMMITTEE_PERIOD=2 ** 11,  # (= 2,048) epochs
+    MAX_EPOCHS_PER_CROSSLINK=2 ** 6,
+    MIN_EPOCHS_TO_INACTIVITY_PENALTY=2 ** 2,
     # State list lengths
-    EPOCHS_PER_HISTORICAL_VECTOR=2**16,
-    EPOCHS_PER_SLASHINGS_VECTOR=2**13,
-    HISTORICAL_ROOTS_LIMIT=2**24,
-    VALIDATOR_REGISTRY_LIMIT=2**40,
+    EPOCHS_PER_HISTORICAL_VECTOR=2 ** 16,
+    EPOCHS_PER_SLASHINGS_VECTOR=2 ** 13,
+    HISTORICAL_ROOTS_LIMIT=2 ** 24,
+    VALIDATOR_REGISTRY_LIMIT=2 ** 40,
     # Reward and penalty quotients
-    BASE_REWARD_FACTOR=2**6,  # (= 64)
-    WHISTLEBLOWER_REWARD_QUOTIENT=2**9,  # (= 512)
-    PROPOSER_REWARD_QUOTIENT=2**3,
-    INACTIVITY_PENALTY_QUOTIENT=2**25,  # (= 33,554,432)
-    MIN_SLASHING_PENALTY_QUOTIENT=2**5,
+    BASE_REWARD_FACTOR=2 ** 6,  # (= 64)
+    WHISTLEBLOWER_REWARD_QUOTIENT=2 ** 9,  # (= 512)
+    PROPOSER_REWARD_QUOTIENT=2 ** 3,
+    INACTIVITY_PENALTY_QUOTIENT=2 ** 25,  # (= 33,554,432)
+    MIN_SLASHING_PENALTY_QUOTIENT=2 ** 5,
     # Max operations per block
-    MAX_PROPOSER_SLASHINGS=2**4,  # (= 16)
-    MAX_ATTESTER_SLASHINGS=2**0,  # (= 1)
-    MAX_ATTESTATIONS=2**7,  # (= 128)
-    MAX_DEPOSITS=2**4,  # (= 16)
-    MAX_VOLUNTARY_EXITS=2**4,  # (= 16)
+    MAX_PROPOSER_SLASHINGS=2 ** 4,  # (= 16)
+    MAX_ATTESTER_SLASHINGS=2 ** 0,  # (= 1)
+    MAX_ATTESTATIONS=2 ** 7,  # (= 128)
+    MAX_DEPOSITS=2 ** 4,  # (= 16)
+    MAX_VOLUNTARY_EXITS=2 ** 4,  # (= 16)
     MAX_TRANSFERS=0,
     # Deposit contract
-    DEPOSIT_CONTRACT_ADDRESS=decode_hex('0x1234567890123456789012345678901234567890'),  # TBD
+    DEPOSIT_CONTRACT_ADDRESS=decode_hex(
+        "0x1234567890123456789012345678901234567890"
+    ),  # TBD
 )

--- a/eth2/beacon/state_machines/forks/serenity/configs.py
+++ b/eth2/beacon/state_machines/forks/serenity/configs.py
@@ -1,8 +1,8 @@
 from eth_utils import decode_hex
-from eth2.configs import Eth2Config
+
 from eth2.beacon.constants import GWEI_PER_ETH
 from eth2.beacon.typing import Epoch, Gwei, Second, Slot
-
+from eth2.configs import Eth2Config
 
 SERENITY_CONFIG = Eth2Config(
     # Misc

--- a/eth2/beacon/state_machines/forks/serenity/epoch_processing.py
+++ b/eth2/beacon/state_machines/forks/serenity/epoch_processing.py
@@ -1,30 +1,13 @@
-from typing import (
-    Sequence,
-    Set,
-    Tuple,
-)
+from typing import Sequence, Set, Tuple
 
-from eth_utils.toolz import (
-    curry,
-)
+from eth_utils.toolz import curry
 import ssz
 
-from eth_typing import (
-    Hash32,
-)
+from eth_typing import Hash32
 
-from eth2._utils.tuple import (
-    update_tuple_item,
-    update_tuple_item_with_fn,
-)
-from eth2.configs import (
-    Eth2Config,
-    CommitteeConfig,
-)
-from eth2.beacon.constants import (
-    BASE_REWARDS_PER_EPOCH,
-    FAR_FUTURE_EPOCH,
-)
+from eth2._utils.tuple import update_tuple_item, update_tuple_item_with_fn
+from eth2.configs import Eth2Config, CommitteeConfig
+from eth2.beacon.constants import BASE_REWARDS_PER_EPOCH, FAR_FUTURE_EPOCH
 from eth2.beacon.committee_helpers import (
     get_crosslink_committee,
     get_compact_committees_root,
@@ -53,96 +36,64 @@ from eth2.beacon.helpers import (
     get_block_root,
     get_randao_mix,
 )
-from eth2.beacon.validator_status_helpers import (
-    initiate_exit_for_validator,
-)
+from eth2.beacon.validator_status_helpers import initiate_exit_for_validator
 from eth2.beacon.types.checkpoints import Checkpoint
 from eth2.beacon.types.eth1_data import Eth1Data
 from eth2.beacon.types.historical_batch import HistoricalBatch
 from eth2.beacon.types.pending_attestations import PendingAttestation
 from eth2.beacon.types.states import BeaconState
 from eth2.beacon.types.validators import Validator
-from eth2.beacon.typing import (
-    Bitfield,
-    Epoch,
-    Gwei,
-    Shard,
-    ValidatorIndex,
-)
+from eth2.beacon.typing import Bitfield, Epoch, Gwei, Shard, ValidatorIndex
 
 
 def _bft_threshold_met(participation: Gwei, total: Gwei) -> bool:
     return 3 * participation >= 2 * total
 
 
-def _is_threshold_met_against_active_set(state: BeaconState,
-                                         attestations: Sequence[PendingAttestation],
-                                         config: Eth2Config) -> bool:
+def _is_threshold_met_against_active_set(
+    state: BeaconState, attestations: Sequence[PendingAttestation], config: Eth2Config
+) -> bool:
     """
     Predicate indicating if the balance at risk of validators making an attestation
     in ``attestations`` is greater than the fault tolerance threshold of the total balance.
     """
-    attesting_balance = get_attesting_balance(
-        state,
-        attestations,
-        config
-    )
+    attesting_balance = get_attesting_balance(state, attestations, config)
 
     total_balance = get_total_active_balance(state, config)
 
-    return _bft_threshold_met(
-        attesting_balance,
-        total_balance,
-    )
+    return _bft_threshold_met(attesting_balance, total_balance)
 
 
 def _is_epoch_justifiable(state: BeaconState, epoch: Epoch, config: Eth2Config) -> bool:
-    attestations = get_matching_target_attestations(
-        state,
-        epoch,
-        config,
-    )
-    return _is_threshold_met_against_active_set(
-        state,
-        attestations,
-        config,
-    )
+    attestations = get_matching_target_attestations(state, epoch, config)
+    return _is_threshold_met_against_active_set(state, attestations, config)
 
 
-def _determine_updated_justification_data(justified_epoch: Epoch,
-                                          bitfield: Bitfield,
-                                          is_epoch_justifiable: bool,
-                                          candidate_epoch: Epoch,
-                                          bit_offset: int) -> Tuple[Epoch, Bitfield]:
+def _determine_updated_justification_data(
+    justified_epoch: Epoch,
+    bitfield: Bitfield,
+    is_epoch_justifiable: bool,
+    candidate_epoch: Epoch,
+    bit_offset: int,
+) -> Tuple[Epoch, Bitfield]:
     if is_epoch_justifiable:
         return (
             candidate_epoch,
-            Bitfield(
-                update_tuple_item(
-                    bitfield,
-                    bit_offset,
-                    True,
-                )
-            )
+            Bitfield(update_tuple_item(bitfield, bit_offset, True)),
         )
     else:
-        return (
-            justified_epoch,
-            bitfield,
-        )
+        return (justified_epoch, bitfield)
 
 
 def _determine_updated_justifications(
-        previous_epoch_justifiable: bool,
-        previous_epoch: Epoch,
-        current_epoch_justifiable: bool,
-        current_epoch: Epoch,
-        justified_epoch: Epoch,
-        justification_bits: Bitfield) -> Tuple[Epoch, Bitfield]:
-    (
-        justified_epoch,
-        justification_bits,
-    ) = _determine_updated_justification_data(
+    previous_epoch_justifiable: bool,
+    previous_epoch: Epoch,
+    current_epoch_justifiable: bool,
+    current_epoch: Epoch,
+    justified_epoch: Epoch,
+    justification_bits: Bitfield,
+) -> Tuple[Epoch, Bitfield]:
+    (justified_epoch, justification_bits) = _determine_updated_justification_data(
         justified_epoch,
         justification_bits,
         previous_epoch_justifiable,
@@ -150,39 +101,22 @@ def _determine_updated_justifications(
         1,
     )
 
-    (
-        justified_epoch,
-        justification_bits,
-    ) = _determine_updated_justification_data(
-        justified_epoch,
-        justification_bits,
-        current_epoch_justifiable,
-        current_epoch,
-        0,
+    (justified_epoch, justification_bits) = _determine_updated_justification_data(
+        justified_epoch, justification_bits, current_epoch_justifiable, current_epoch, 0
     )
 
-    return (
-        justified_epoch,
-        justification_bits,
-    )
+    return (justified_epoch, justification_bits)
 
 
-def _determine_new_justified_epoch_and_bitfield(state: BeaconState,
-                                                config: Eth2Config) -> Tuple[Epoch, Bitfield]:
+def _determine_new_justified_epoch_and_bitfield(
+    state: BeaconState, config: Eth2Config
+) -> Tuple[Epoch, Bitfield]:
     genesis_epoch = config.GENESIS_EPOCH
     previous_epoch = state.previous_epoch(config.SLOTS_PER_EPOCH, genesis_epoch)
     current_epoch = state.current_epoch(config.SLOTS_PER_EPOCH)
 
-    previous_epoch_justifiable = _is_epoch_justifiable(
-        state,
-        previous_epoch,
-        config,
-    )
-    current_epoch_justifiable = _is_epoch_justifiable(
-        state,
-        current_epoch,
-        config,
-    )
+    previous_epoch_justifiable = _is_epoch_justifiable(state, previous_epoch, config)
+    current_epoch_justifiable = _is_epoch_justifiable(state, current_epoch, config)
 
     (
         new_current_justified_epoch,
@@ -196,22 +130,16 @@ def _determine_new_justified_epoch_and_bitfield(state: BeaconState,
         (False,) + state.justification_bits[:-1],
     )
 
-    return (
-        new_current_justified_epoch,
-        justification_bits,
-    )
+    return (new_current_justified_epoch, justification_bits)
 
 
 def _determine_new_justified_checkpoint_and_bitfield(
-        state: BeaconState,
-        config: Eth2Config) -> Tuple[Checkpoint, Bitfield]:
+    state: BeaconState, config: Eth2Config
+) -> Tuple[Checkpoint, Bitfield]:
     (
         new_current_justified_epoch,
         justification_bits,
-    ) = _determine_new_justified_epoch_and_bitfield(
-        state,
-        config,
-    )
+    ) = _determine_new_justified_epoch_and_bitfield(state, config)
 
     if new_current_justified_epoch != state.current_justified_checkpoint.epoch:
         new_current_justified_root = get_block_root(
@@ -224,56 +152,54 @@ def _determine_new_justified_checkpoint_and_bitfield(
         new_current_justified_root = state.current_justified_checkpoint.root
 
     return (
-        Checkpoint(
-            epoch=new_current_justified_epoch,
-            root=new_current_justified_root,
-        ),
+        Checkpoint(epoch=new_current_justified_epoch, root=new_current_justified_root),
         justification_bits,
     )
 
 
-def _bitfield_matches(bitfield: Bitfield,
-                      offset: slice) -> bool:
+def _bitfield_matches(bitfield: Bitfield, offset: slice) -> bool:
     return all(bitfield[offset])
 
 
-def _determine_new_finalized_epoch(last_finalized_epoch: Epoch,
-                                   previous_justified_epoch: Epoch,
-                                   current_justified_epoch: Epoch,
-                                   current_epoch: Epoch,
-                                   justification_bits: Bitfield) -> Epoch:
+def _determine_new_finalized_epoch(
+    last_finalized_epoch: Epoch,
+    previous_justified_epoch: Epoch,
+    current_justified_epoch: Epoch,
+    current_epoch: Epoch,
+    justification_bits: Bitfield,
+) -> Epoch:
     new_finalized_epoch = last_finalized_epoch
 
     if (
-        _bitfield_matches(justification_bits, slice(1, 4)) and
-        previous_justified_epoch + 3 == current_epoch
+        _bitfield_matches(justification_bits, slice(1, 4))
+        and previous_justified_epoch + 3 == current_epoch
     ):
         new_finalized_epoch = previous_justified_epoch
 
     if (
-        _bitfield_matches(justification_bits, slice(1, 3)) and
-        previous_justified_epoch + 2 == current_epoch
+        _bitfield_matches(justification_bits, slice(1, 3))
+        and previous_justified_epoch + 2 == current_epoch
     ):
         new_finalized_epoch = previous_justified_epoch
 
     if (
-        _bitfield_matches(justification_bits, slice(0, 3)) and
-        current_justified_epoch + 2 == current_epoch
+        _bitfield_matches(justification_bits, slice(0, 3))
+        and current_justified_epoch + 2 == current_epoch
     ):
         new_finalized_epoch = current_justified_epoch
 
     if (
-        _bitfield_matches(justification_bits, slice(0, 2)) and
-        current_justified_epoch + 1 == current_epoch
+        _bitfield_matches(justification_bits, slice(0, 2))
+        and current_justified_epoch + 1 == current_epoch
     ):
         new_finalized_epoch = current_justified_epoch
 
     return new_finalized_epoch
 
 
-def _determine_new_finalized_checkpoint(state: BeaconState,
-                                        justification_bits: Bitfield,
-                                        config: Eth2Config) -> Checkpoint:
+def _determine_new_finalized_checkpoint(
+    state: BeaconState, justification_bits: Bitfield, config: Eth2Config
+) -> Checkpoint:
     current_epoch = state.current_epoch(config.SLOTS_PER_EPOCH)
 
     new_finalized_epoch = _determine_new_finalized_epoch(
@@ -298,13 +224,12 @@ def _determine_new_finalized_checkpoint(state: BeaconState,
     else:
         new_finalized_root = state.finalized_checkpoint.root
 
-    return Checkpoint(
-        epoch=new_finalized_epoch,
-        root=new_finalized_root,
-    )
+    return Checkpoint(epoch=new_finalized_epoch, root=new_finalized_root)
 
 
-def process_justification_and_finalization(state: BeaconState, config: Eth2Config) -> BeaconState:
+def process_justification_and_finalization(
+    state: BeaconState, config: Eth2Config
+) -> BeaconState:
     current_epoch = state.current_epoch(config.SLOTS_PER_EPOCH)
     genesis_epoch = config.GENESIS_EPOCH
 
@@ -314,15 +239,10 @@ def process_justification_and_finalization(state: BeaconState, config: Eth2Confi
     (
         new_current_justified_checkpoint,
         justification_bits,
-    ) = _determine_new_justified_checkpoint_and_bitfield(
-        state,
-        config,
-    )
+    ) = _determine_new_justified_checkpoint_and_bitfield(state, config)
 
     new_finalized_checkpoint = _determine_new_finalized_checkpoint(
-        state,
-        justification_bits,
-        config,
+        state, justification_bits, config
     )
 
     return state.copy(
@@ -333,17 +253,13 @@ def process_justification_and_finalization(state: BeaconState, config: Eth2Confi
     )
 
 
-def _is_threshold_met_against_committee(state: BeaconState,
-                                        attesting_indices: Set[ValidatorIndex],
-                                        committee: Set[ValidatorIndex]) -> bool:
-    total_attesting_balance = get_total_balance(
-        state,
-        attesting_indices,
-    )
-    total_committee_balance = get_total_balance(
-        state,
-        committee,
-    )
+def _is_threshold_met_against_committee(
+    state: BeaconState,
+    attesting_indices: Set[ValidatorIndex],
+    committee: Set[ValidatorIndex],
+) -> bool:
+    total_attesting_balance = get_total_balance(state, attesting_indices)
+    total_committee_balance = get_total_balance(state, committee)
     return _bft_threshold_met(total_attesting_balance, total_committee_balance)
 
 
@@ -354,47 +270,35 @@ def process_crosslinks(state: BeaconState, config: Eth2Config) -> BeaconState:
     new_current_crosslinks = state.current_crosslinks
 
     for epoch in (previous_epoch, current_epoch):
-        active_validators_indices = get_active_validator_indices(state.validators, epoch)
+        active_validators_indices = get_active_validator_indices(
+            state.validators, epoch
+        )
         epoch_committee_count = get_committee_count(
             len(active_validators_indices),
             config.SHARD_COUNT,
             config.SLOTS_PER_EPOCH,
             config.TARGET_COMMITTEE_SIZE,
         )
-        epoch_start_shard = get_start_shard(
-            state,
-            epoch,
-            CommitteeConfig(config),
-        )
+        epoch_start_shard = get_start_shard(state, epoch, CommitteeConfig(config))
         for shard_offset in range(epoch_committee_count):
             shard = Shard((epoch_start_shard + shard_offset) % config.SHARD_COUNT)
-            crosslink_committee = set(get_crosslink_committee(
-                state,
-                epoch,
-                shard,
-                CommitteeConfig(config),
-            ))
+            crosslink_committee = set(
+                get_crosslink_committee(state, epoch, shard, CommitteeConfig(config))
+            )
 
             if not crosslink_committee:
                 # empty crosslink committee this epoch
                 continue
 
             winning_crosslink, attesting_indices = get_winning_crosslink_and_attesting_indices(
-                state=state,
-                epoch=epoch,
-                shard=shard,
-                config=config,
+                state=state, epoch=epoch, shard=shard, config=config
             )
             threshold_met = _is_threshold_met_against_committee(
-                state,
-                attesting_indices,
-                crosslink_committee,
+                state, attesting_indices, crosslink_committee
             )
             if threshold_met:
                 new_current_crosslinks = update_tuple_item(
-                    new_current_crosslinks,
-                    shard,
-                    winning_crosslink,
+                    new_current_crosslinks, shard, winning_crosslink
                 )
 
     return state.copy(
@@ -403,49 +307,38 @@ def process_crosslinks(state: BeaconState, config: Eth2Config) -> BeaconState:
     )
 
 
-def get_attestation_deltas(state: BeaconState,
-                           config: Eth2Config) -> Tuple[Sequence[Gwei], Sequence[Gwei]]:
+def get_attestation_deltas(
+    state: BeaconState, config: Eth2Config
+) -> Tuple[Sequence[Gwei], Sequence[Gwei]]:
     committee_config = CommitteeConfig(config)
-    rewards = tuple(
-        0 for _ in range(len(state.validators))
-    )
-    penalties = tuple(
-        0 for _ in range(len(state.validators))
-    )
+    rewards = tuple(0 for _ in range(len(state.validators)))
+    penalties = tuple(0 for _ in range(len(state.validators)))
     previous_epoch = state.previous_epoch(config.SLOTS_PER_EPOCH, config.GENESIS_EPOCH)
     total_balance = get_total_active_balance(state, config)
     eligible_validator_indices = tuple(
-        ValidatorIndex(index) for index, v in enumerate(state.validators)
-        if v.is_active(previous_epoch) or (
-            v.slashed and previous_epoch + 1 < v.withdrawable_epoch
-        )
+        ValidatorIndex(index)
+        for index, v in enumerate(state.validators)
+        if v.is_active(previous_epoch)
+        or (v.slashed and previous_epoch + 1 < v.withdrawable_epoch)
     )
 
     matching_source_attestations = get_matching_source_attestations(
-        state,
-        previous_epoch,
-        config,
+        state, previous_epoch, config
     )
     matching_target_attestations = get_matching_target_attestations(
-        state,
-        previous_epoch,
-        config,
+        state, previous_epoch, config
     )
     matching_head_attestations = get_matching_head_attestations(
-        state,
-        previous_epoch,
-        config,
+        state, previous_epoch, config
     )
 
     for attestations in (
-            matching_source_attestations,
-            matching_target_attestations,
-            matching_head_attestations
+        matching_source_attestations,
+        matching_target_attestations,
+        matching_head_attestations,
     ):
         unslashed_attesting_indices = get_unslashed_attesting_indices(
-            state,
-            attestations,
-            committee_config,
+            state, attestations, committee_config
         )
         attesting_balance = get_total_balance(state, unslashed_attesting_indices)
         for index in eligible_validator_indices:
@@ -454,37 +347,28 @@ def get_attestation_deltas(state: BeaconState,
                     rewards,
                     index,
                     lambda balance, delta: balance + delta,
-                    get_base_reward(
-                        state,
-                        index,
-                        config,
-                    ) * attesting_balance // total_balance,
+                    get_base_reward(state, index, config)
+                    * attesting_balance
+                    // total_balance,
                 )
             else:
                 penalties = update_tuple_item_with_fn(
                     penalties,
                     index,
                     lambda balance, delta: balance + delta,
-                    get_base_reward(
-                        state,
-                        index,
-                        config,
-                    ),
+                    get_base_reward(state, index, config),
                 )
 
     for index in get_unslashed_attesting_indices(
-            state,
-            matching_source_attestations,
-            committee_config,
+        state, matching_source_attestations, committee_config
     ):
         attestation = min(
             (
-                a for a in matching_source_attestations
-                if index in get_attesting_indices(
-                    state,
-                    a.data,
-                    a.aggregation_bits,
-                    committee_config,
+                a
+                for a in matching_source_attestations
+                if index
+                in get_attesting_indices(
+                    state, a.data, a.aggregation_bits, committee_config
                 )
             ),
             key=lambda a: a.inclusion_delay,
@@ -503,31 +387,27 @@ def get_attestation_deltas(state: BeaconState,
             index,
             lambda balance, delta: balance + delta,
             (
-                max_attester_reward * (
-                    config.SLOTS_PER_EPOCH +
-                    config.MIN_ATTESTATION_INCLUSION_DELAY -
-                    attestation.inclusion_delay
-                ) // config.SLOTS_PER_EPOCH
-            )
+                max_attester_reward
+                * (
+                    config.SLOTS_PER_EPOCH
+                    + config.MIN_ATTESTATION_INCLUSION_DELAY
+                    - attestation.inclusion_delay
+                )
+                // config.SLOTS_PER_EPOCH
+            ),
         )
 
     finality_delay = previous_epoch - state.finalized_checkpoint.epoch
     if finality_delay > config.MIN_EPOCHS_TO_INACTIVITY_PENALTY:
         matching_target_attesting_indices = get_unslashed_attesting_indices(
-            state,
-            matching_target_attestations,
-            committee_config,
+            state, matching_target_attestations, committee_config
         )
         for index in eligible_validator_indices:
             penalties = update_tuple_item_with_fn(
                 penalties,
                 index,
                 lambda balance, delta: balance + delta,
-                BASE_REWARDS_PER_EPOCH * get_base_reward(
-                    state,
-                    index,
-                    config,
-                ),
+                BASE_REWARDS_PER_EPOCH * get_base_reward(state, index, config),
             )
             if index not in matching_target_attesting_indices:
                 effective_balance = state.validators[index].effective_balance
@@ -535,23 +415,21 @@ def get_attestation_deltas(state: BeaconState,
                     penalties,
                     index,
                     lambda balance, delta: balance + delta,
-                    effective_balance * finality_delay // config.INACTIVITY_PENALTY_QUOTIENT,
+                    effective_balance
+                    * finality_delay
+                    // config.INACTIVITY_PENALTY_QUOTIENT,
                 )
-    return tuple(
-        Gwei(reward) for reward in rewards
-    ), tuple(
-        Gwei(penalty) for penalty in penalties
+    return (
+        tuple(Gwei(reward) for reward in rewards),
+        tuple(Gwei(penalty) for penalty in penalties),
     )
 
 
-def get_crosslink_deltas(state: BeaconState,
-                         config: Eth2Config) -> Tuple[Sequence[Gwei], Sequence[Gwei]]:
-    rewards = tuple(
-        0 for _ in range(len(state.validators))
-    )
-    penalties = tuple(
-        0 for _ in range(len(state.validators))
-    )
+def get_crosslink_deltas(
+    state: BeaconState, config: Eth2Config
+) -> Tuple[Sequence[Gwei], Sequence[Gwei]]:
+    rewards = tuple(0 for _ in range(len(state.validators)))
+    penalties = tuple(0 for _ in range(len(state.validators)))
     epoch = state.previous_epoch(config.SLOTS_PER_EPOCH, config.GENESIS_EPOCH)
     active_validators_indices = get_active_validator_indices(state.validators, epoch)
     epoch_committee_count = get_committee_count(
@@ -560,33 +438,17 @@ def get_crosslink_deltas(state: BeaconState,
         config.SLOTS_PER_EPOCH,
         config.TARGET_COMMITTEE_SIZE,
     )
-    epoch_start_shard = get_start_shard(
-        state,
-        epoch,
-        CommitteeConfig(config),
-    )
+    epoch_start_shard = get_start_shard(state, epoch, CommitteeConfig(config))
     for shard_offset in range(epoch_committee_count):
         shard = Shard((epoch_start_shard + shard_offset) % config.SHARD_COUNT)
-        crosslink_committee = set(get_crosslink_committee(
-            state,
-            epoch,
-            shard,
-            CommitteeConfig(config),
-        ))
+        crosslink_committee = set(
+            get_crosslink_committee(state, epoch, shard, CommitteeConfig(config))
+        )
         _, attesting_indices = get_winning_crosslink_and_attesting_indices(
-            state=state,
-            epoch=epoch,
-            shard=shard,
-            config=config,
+            state=state, epoch=epoch, shard=shard, config=config
         )
-        total_attesting_balance = get_total_balance(
-            state,
-            attesting_indices,
-        )
-        total_committee_balance = get_total_balance(
-            state,
-            crosslink_committee,
-        )
+        total_attesting_balance = get_total_balance(state, attesting_indices)
+        total_committee_balance = get_total_balance(state, crosslink_committee)
         for index in crosslink_committee:
             base_reward = get_base_reward(state, index, config)
             if index in attesting_indices:
@@ -594,7 +456,7 @@ def get_crosslink_deltas(state: BeaconState,
                     rewards,
                     index,
                     lambda balance, delta: balance + delta,
-                    base_reward * total_attesting_balance // total_committee_balance
+                    base_reward * total_attesting_balance // total_committee_balance,
                 )
             else:
                 penalties = update_tuple_item_with_fn(
@@ -603,50 +465,57 @@ def get_crosslink_deltas(state: BeaconState,
                     lambda balance, delta: balance + delta,
                     base_reward,
                 )
-    return tuple(
-        Gwei(reward) for reward in rewards
-    ), tuple(
-        Gwei(penalty) for penalty in penalties
+    return (
+        tuple(Gwei(reward) for reward in rewards),
+        tuple(Gwei(penalty) for penalty in penalties),
     )
 
 
-def process_rewards_and_penalties(state: BeaconState, config: Eth2Config) -> BeaconState:
+def process_rewards_and_penalties(
+    state: BeaconState, config: Eth2Config
+) -> BeaconState:
     current_epoch = state.current_epoch(config.SLOTS_PER_EPOCH)
     if current_epoch == config.GENESIS_EPOCH:
         return state
 
-    rewards_for_attestations, penalties_for_attestations = get_attestation_deltas(state, config)
-    rewards_for_crosslinks, penalties_for_crosslinks = get_crosslink_deltas(state, config)
+    rewards_for_attestations, penalties_for_attestations = get_attestation_deltas(
+        state, config
+    )
+    rewards_for_crosslinks, penalties_for_crosslinks = get_crosslink_deltas(
+        state, config
+    )
 
     for index in range(len(state.validators)):
         index = ValidatorIndex(index)
-        state = increase_balance(state, index, Gwei(
-            rewards_for_attestations[index] + rewards_for_crosslinks[index]
-        ))
-        state = decrease_balance(state, index, Gwei(
-            penalties_for_attestations[index] + penalties_for_crosslinks[index]
-        ))
+        state = increase_balance(
+            state,
+            index,
+            Gwei(rewards_for_attestations[index] + rewards_for_crosslinks[index]),
+        )
+        state = decrease_balance(
+            state,
+            index,
+            Gwei(penalties_for_attestations[index] + penalties_for_crosslinks[index]),
+        )
 
     return state
 
 
 @curry
-def _process_activation_eligibility_or_ejections(state: BeaconState,
-                                                 validator: Validator,
-                                                 config: Eth2Config) -> Validator:
+def _process_activation_eligibility_or_ejections(
+    state: BeaconState, validator: Validator, config: Eth2Config
+) -> Validator:
     current_epoch = state.current_epoch(config.SLOTS_PER_EPOCH)
 
     if (
-        validator.activation_eligibility_epoch == FAR_FUTURE_EPOCH and
-        validator.effective_balance == config.MAX_EFFECTIVE_BALANCE
+        validator.activation_eligibility_epoch == FAR_FUTURE_EPOCH
+        and validator.effective_balance == config.MAX_EFFECTIVE_BALANCE
     ):
-        validator = validator.copy(
-            activation_eligibility_epoch=current_epoch,
-        )
+        validator = validator.copy(activation_eligibility_epoch=current_epoch)
 
     if (
-        validator.is_active(current_epoch) and
-        validator.effective_balance <= config.EJECTION_BALANCE
+        validator.is_active(current_epoch)
+        and validator.effective_balance <= config.EJECTION_BALANCE
     ):
         validator = initiate_exit_for_validator(validator, state, config)
 
@@ -654,9 +523,9 @@ def _process_activation_eligibility_or_ejections(state: BeaconState,
 
 
 @curry
-def _update_validator_activation_epoch(state: BeaconState,
-                                       config: Eth2Config,
-                                       validator: Validator) -> Validator:
+def _update_validator_activation_epoch(
+    state: BeaconState, config: Eth2Config, validator: Validator
+) -> Validator:
     if validator.activation_epoch == FAR_FUTURE_EPOCH:
         return validator.copy(
             activation_epoch=compute_activation_exit_epoch(
@@ -675,34 +544,29 @@ def process_registry_updates(state: BeaconState, config: Eth2Config) -> BeaconSt
     )
 
     activation_exit_epoch = compute_activation_exit_epoch(
-        state.finalized_checkpoint.epoch,
-        config.ACTIVATION_EXIT_DELAY,
+        state.finalized_checkpoint.epoch, config.ACTIVATION_EXIT_DELAY
     )
     activation_queue = sorted(
         (
-            index for index, validator in enumerate(new_validators) if
-            validator.activation_eligibility_epoch != FAR_FUTURE_EPOCH and
-            validator.activation_epoch >= activation_exit_epoch
+            index
+            for index, validator in enumerate(new_validators)
+            if validator.activation_eligibility_epoch != FAR_FUTURE_EPOCH
+            and validator.activation_epoch >= activation_exit_epoch
         ),
         key=lambda index: new_validators[index].activation_eligibility_epoch,
     )
 
-    for index in activation_queue[:get_validator_churn_limit(state, config)]:
+    for index in activation_queue[: get_validator_churn_limit(state, config)]:
         new_validators = update_tuple_item_with_fn(
-            new_validators,
-            index,
-            _update_validator_activation_epoch(state, config),
+            new_validators, index, _update_validator_activation_epoch(state, config)
         )
 
-    return state.copy(
-        validators=new_validators,
-    )
+    return state.copy(validators=new_validators)
 
 
-def _determine_slashing_penalty(total_penalties: Gwei,
-                                total_balance: Gwei,
-                                balance: Gwei,
-                                increment: Gwei) -> Gwei:
+def _determine_slashing_penalty(
+    total_penalties: Gwei, total_balance: Gwei, balance: Gwei, increment: Gwei
+) -> Gwei:
     penalty_numerator = balance // increment * min(total_penalties * 3, total_balance)
     penalty = penalty_numerator // total_balance * increment
     return Gwei(penalty)
@@ -715,7 +579,10 @@ def process_slashings(state: BeaconState, config: Eth2Config) -> BeaconState:
     slashing_period = config.EPOCHS_PER_SLASHINGS_VECTOR // 2
     for index, validator in enumerate(state.validators):
         index = ValidatorIndex(index)
-        if validator.slashed and current_epoch + slashing_period == validator.withdrawable_epoch:
+        if (
+            validator.slashed
+            and current_epoch + slashing_period == validator.withdrawable_epoch
+        ):
             penalty = _determine_slashing_penalty(
                 Gwei(sum(state.slashings)),
                 total_balance,
@@ -726,14 +593,18 @@ def process_slashings(state: BeaconState, config: Eth2Config) -> BeaconState:
     return state
 
 
-def _determine_next_eth1_votes(state: BeaconState, config: Eth2Config) -> Tuple[Eth1Data, ...]:
+def _determine_next_eth1_votes(
+    state: BeaconState, config: Eth2Config
+) -> Tuple[Eth1Data, ...]:
     if (state.slot + 1) % config.SLOTS_PER_ETH1_VOTING_PERIOD == 0:
         return tuple()
     else:
         return state.eth1_data_votes
 
 
-def _update_effective_balances(state: BeaconState, config: Eth2Config) -> Tuple[Validator, ...]:
+def _update_effective_balances(
+    state: BeaconState, config: Eth2Config
+) -> Tuple[Validator, ...]:
     half_increment = config.EFFECTIVE_BALANCE_INCREMENT // 2
     new_validators = state.validators
     for index, validator in enumerate(state.validators):
@@ -748,9 +619,7 @@ def _update_effective_balances(state: BeaconState, config: Eth2Config) -> Tuple[
             new_validators = update_tuple_item_with_fn(
                 new_validators,
                 index,
-                lambda v, new_balance: v.copy(
-                    effective_balance=new_balance,
-                ),
+                lambda v, new_balance: v.copy(effective_balance=new_balance),
                 new_effective_balance,
             )
     return new_validators
@@ -758,35 +627,34 @@ def _update_effective_balances(state: BeaconState, config: Eth2Config) -> Tuple[
 
 def _compute_next_start_shard(state: BeaconState, config: Eth2Config) -> Shard:
     current_epoch = state.current_epoch(config.SLOTS_PER_EPOCH)
-    return (state.start_shard + get_shard_delta(
-        state,
-        current_epoch,
-        CommitteeConfig(config),
-    )) % config.SHARD_COUNT
+    return (
+        state.start_shard
+        + get_shard_delta(state, current_epoch, CommitteeConfig(config))
+    ) % config.SHARD_COUNT
 
 
-def _compute_next_active_index_roots(state: BeaconState, config: Eth2Config) -> Tuple[Hash32, ...]:
+def _compute_next_active_index_roots(
+    state: BeaconState, config: Eth2Config
+) -> Tuple[Hash32, ...]:
     next_epoch = state.next_epoch(config.SLOTS_PER_EPOCH)
     index_root_position = (
         next_epoch + config.ACTIVATION_EXIT_DELAY
     ) % config.EPOCHS_PER_HISTORICAL_VECTOR
     validator_indices_for_new_active_index_root = get_active_validator_indices(
-        state.validators,
-        Epoch(next_epoch + config.ACTIVATION_EXIT_DELAY),
+        state.validators, Epoch(next_epoch + config.ACTIVATION_EXIT_DELAY)
     )
     new_active_index_root = ssz.get_hash_tree_root(
         validator_indices_for_new_active_index_root,
         ssz.sedes.List(ssz.uint64, config.VALIDATOR_REGISTRY_LIMIT),
     )
     return update_tuple_item(
-        state.active_index_roots,
-        index_root_position,
-        new_active_index_root,
+        state.active_index_roots, index_root_position, new_active_index_root
     )
 
 
-def _compute_next_compact_committees_roots(state: BeaconState,
-                                           config: Eth2Config) -> Tuple[Hash32, ...]:
+def _compute_next_compact_committees_roots(
+    state: BeaconState, config: Eth2Config
+) -> Tuple[Hash32, ...]:
     next_epoch = state.next_epoch(config.SLOTS_PER_EPOCH)
     committee_root_position = next_epoch % config.EPOCHS_PER_HISTORICAL_VECTOR
     return update_tuple_item(
@@ -799,33 +667,30 @@ def _compute_next_compact_committees_roots(state: BeaconState,
 def _compute_next_slashings(state: BeaconState, config: Eth2Config) -> Tuple[Gwei, ...]:
     next_epoch = state.next_epoch(config.SLOTS_PER_EPOCH)
     return update_tuple_item(
-        state.slashings,
-        next_epoch % config.EPOCHS_PER_SLASHINGS_VECTOR,
-        Gwei(0),
+        state.slashings, next_epoch % config.EPOCHS_PER_SLASHINGS_VECTOR, Gwei(0)
     )
 
 
-def _compute_next_randao_mixes(state: BeaconState, config: Eth2Config) -> Tuple[Hash32, ...]:
+def _compute_next_randao_mixes(
+    state: BeaconState, config: Eth2Config
+) -> Tuple[Hash32, ...]:
     current_epoch = state.current_epoch(config.SLOTS_PER_EPOCH)
     next_epoch = state.next_epoch(config.SLOTS_PER_EPOCH)
     return update_tuple_item(
         state.randao_mixes,
         next_epoch % config.EPOCHS_PER_HISTORICAL_VECTOR,
-        get_randao_mix(
-            state,
-            current_epoch,
-            config.EPOCHS_PER_HISTORICAL_VECTOR,
-        ),
+        get_randao_mix(state, current_epoch, config.EPOCHS_PER_HISTORICAL_VECTOR),
     )
 
 
-def _compute_next_historical_roots(state: BeaconState, config: Eth2Config) -> Tuple[Hash32, ...]:
+def _compute_next_historical_roots(
+    state: BeaconState, config: Eth2Config
+) -> Tuple[Hash32, ...]:
     next_epoch = state.next_epoch(config.SLOTS_PER_EPOCH)
     new_historical_roots = state.historical_roots
     if next_epoch % (config.SLOTS_PER_HISTORICAL_ROOT // config.SLOTS_PER_EPOCH) == 0:
         historical_batch = HistoricalBatch(
-            block_roots=state.block_roots,
-            state_roots=state.state_roots,
+            block_roots=state.block_roots, state_roots=state.state_roots
         )
         new_historical_roots += (historical_batch.hash_tree_root,)
     return new_historical_roots
@@ -837,11 +702,7 @@ def process_final_updates(state: BeaconState, config: Eth2Config) -> BeaconState
     new_start_shard = _compute_next_start_shard(state, config)
     new_active_index_roots = _compute_next_active_index_roots(state, config)
     new_compact_committees_roots = _compute_next_compact_committees_roots(
-        state.copy(
-            validators=new_validators,
-            start_shard=new_start_shard,
-        ),
-        config,
+        state.copy(validators=new_validators, start_shard=new_start_shard), config
     )
     new_slashings = _compute_next_slashings(state, config)
     new_randao_mixes = _compute_next_randao_mixes(state, config)

--- a/eth2/beacon/state_machines/forks/serenity/epoch_processing.py
+++ b/eth2/beacon/state_machines/forks/serenity/epoch_processing.py
@@ -1,33 +1,31 @@
 from typing import Sequence, Set, Tuple
 
+from eth_typing import Hash32
 from eth_utils.toolz import curry
 import ssz
 
-from eth_typing import Hash32
-
 from eth2._utils.tuple import update_tuple_item, update_tuple_item_with_fn
-from eth2.configs import Eth2Config, CommitteeConfig
-from eth2.beacon.constants import BASE_REWARDS_PER_EPOCH, FAR_FUTURE_EPOCH
 from eth2.beacon.committee_helpers import (
-    get_crosslink_committee,
-    get_compact_committees_root,
     get_committee_count,
-    get_start_shard,
+    get_compact_committees_root,
+    get_crosslink_committee,
     get_shard_delta,
+    get_start_shard,
 )
+from eth2.beacon.constants import BASE_REWARDS_PER_EPOCH, FAR_FUTURE_EPOCH
 from eth2.beacon.epoch_processing_helpers import (
+    compute_activation_exit_epoch,
     decrease_balance,
     get_attesting_balance,
     get_attesting_indices,
     get_base_reward,
-    get_validator_churn_limit,
-    compute_activation_exit_epoch,
     get_matching_head_attestations,
     get_matching_source_attestations,
     get_matching_target_attestations,
     get_total_active_balance,
     get_total_balance,
     get_unslashed_attesting_indices,
+    get_validator_churn_limit,
     get_winning_crosslink_and_attesting_indices,
     increase_balance,
 )
@@ -36,7 +34,6 @@ from eth2.beacon.helpers import (
     get_block_root,
     get_randao_mix,
 )
-from eth2.beacon.validator_status_helpers import initiate_exit_for_validator
 from eth2.beacon.types.checkpoints import Checkpoint
 from eth2.beacon.types.eth1_data import Eth1Data
 from eth2.beacon.types.historical_batch import HistoricalBatch
@@ -44,6 +41,8 @@ from eth2.beacon.types.pending_attestations import PendingAttestation
 from eth2.beacon.types.states import BeaconState
 from eth2.beacon.types.validators import Validator
 from eth2.beacon.typing import Bitfield, Epoch, Gwei, Shard, ValidatorIndex
+from eth2.beacon.validator_status_helpers import initiate_exit_for_validator
+from eth2.configs import CommitteeConfig, Eth2Config
 
 
 def _bft_threshold_met(participation: Gwei, total: Gwei) -> bool:

--- a/eth2/beacon/state_machines/forks/serenity/operation_processing.py
+++ b/eth2/beacon/state_machines/forks/serenity/operation_processing.py
@@ -1,35 +1,19 @@
-from typing import (
-    Tuple,
-)
+from typing import Tuple
 
-from eth_utils import (
-    ValidationError,
-)
+from eth_utils import ValidationError
 
-from eth2.configs import (
-    Eth2Config,
-    CommitteeConfig,
-)
+from eth2.configs import Eth2Config, CommitteeConfig
 from eth2.beacon.validator_status_helpers import (
     initiate_validator_exit,
     slash_validator,
 )
-from eth2.beacon.attestation_helpers import (
-    get_attestation_data_slot,
-)
-from eth2.beacon.committee_helpers import (
-    get_beacon_proposer_index,
-)
-from eth2.beacon.epoch_processing_helpers import (
-    increase_balance,
-    decrease_balance,
-)
+from eth2.beacon.attestation_helpers import get_attestation_data_slot
+from eth2.beacon.committee_helpers import get_beacon_proposer_index
+from eth2.beacon.epoch_processing_helpers import increase_balance, decrease_balance
 from eth2.beacon.types.blocks import BaseBeaconBlock
 from eth2.beacon.types.pending_attestations import PendingAttestation
 from eth2.beacon.types.states import BeaconState
-from eth2.beacon.deposit_helpers import (
-    process_deposit,
-)
+from eth2.beacon.deposit_helpers import process_deposit
 
 from .block_validation import (
     validate_attestation,
@@ -43,9 +27,9 @@ from .block_validation import (
 )
 
 
-def process_proposer_slashings(state: BeaconState,
-                               block: BaseBeaconBlock,
-                               config: Eth2Config) -> BeaconState:
+def process_proposer_slashings(
+    state: BeaconState, block: BaseBeaconBlock, config: Eth2Config
+) -> BeaconState:
     if len(block.body.proposer_slashings) > config.MAX_PROPOSER_SLASHINGS:
         raise ValidationError(
             f"The block ({block}) has too many proposer slashings:\n"
@@ -56,18 +40,14 @@ def process_proposer_slashings(state: BeaconState,
     for proposer_slashing in block.body.proposer_slashings:
         validate_proposer_slashing(state, proposer_slashing, config.SLOTS_PER_EPOCH)
 
-        state = slash_validator(
-            state,
-            proposer_slashing.proposer_index,
-            config,
-        )
+        state = slash_validator(state, proposer_slashing.proposer_index, config)
 
     return state
 
 
-def process_attester_slashings(state: BeaconState,
-                               block: BaseBeaconBlock,
-                               config: Eth2Config) -> BeaconState:
+def process_attester_slashings(
+    state: BeaconState, block: BaseBeaconBlock, config: Eth2Config
+) -> BeaconState:
     if len(block.body.attester_slashings) > config.MAX_ATTESTER_SLASHINGS:
         raise ValidationError(
             f"The block ({block}) has too many attester slashings:\n"
@@ -95,24 +75,22 @@ def process_attester_slashings(state: BeaconState,
             attestation_2.custody_bit_0_indices + attestation_2.custody_bit_1_indices
         )
 
-        eligible_indices = sorted(set(attesting_indices_1).intersection(attesting_indices_2))
+        eligible_indices = sorted(
+            set(attesting_indices_1).intersection(attesting_indices_2)
+        )
         for index in eligible_indices:
             validator = state.validators[index]
             if validator.is_slashable(current_epoch):
-                state = slash_validator(
-                    state,
-                    index,
-                    config,
-                )
+                state = slash_validator(state, index, config)
                 slashed_any = True
         validate_some_slashing(slashed_any, attester_slashing)
 
     return state
 
 
-def process_attestations(state: BeaconState,
-                         block: BaseBeaconBlock,
-                         config: Eth2Config) -> BeaconState:
+def process_attestations(
+    state: BeaconState, block: BaseBeaconBlock, config: Eth2Config
+) -> BeaconState:
     if len(block.body.attestations) > config.MAX_ATTESTATIONS:
         raise ValidationError(
             f"The block has too many attestations:\n"
@@ -124,21 +102,10 @@ def process_attestations(state: BeaconState,
     new_current_epoch_attestations: Tuple[PendingAttestation, ...] = tuple()
     new_previous_epoch_attestations: Tuple[PendingAttestation, ...] = tuple()
     for attestation in block.body.attestations:
-        validate_attestation(
-            state,
-            attestation,
-            config,
-        )
+        validate_attestation(state, attestation, config)
 
-        attestation_slot = get_attestation_data_slot(
-            state,
-            attestation.data,
-            config,
-        )
-        proposer_index = get_beacon_proposer_index(
-            state,
-            CommitteeConfig(config),
-        )
+        attestation_slot = get_attestation_data_slot(state, attestation.data, config)
+        proposer_index = get_beacon_proposer_index(state, CommitteeConfig(config))
         pending_attestation = PendingAttestation(
             aggregation_bits=attestation.aggregation_bits,
             data=attestation.data,
@@ -161,9 +128,9 @@ def process_attestations(state: BeaconState,
     )
 
 
-def process_deposits(state: BeaconState,
-                     block: BaseBeaconBlock,
-                     config: Eth2Config) -> BeaconState:
+def process_deposits(
+    state: BeaconState, block: BaseBeaconBlock, config: Eth2Config
+) -> BeaconState:
     if len(block.body.deposits) > config.MAX_DEPOSITS:
         raise ValidationError(
             f"The block ({block}) has too many deposits:\n"
@@ -172,18 +139,14 @@ def process_deposits(state: BeaconState,
         )
 
     for deposit in block.body.deposits:
-        state = process_deposit(
-            state,
-            deposit,
-            config,
-        )
+        state = process_deposit(state, deposit, config)
 
     return state
 
 
-def process_voluntary_exits(state: BeaconState,
-                            block: BaseBeaconBlock,
-                            config: Eth2Config) -> BeaconState:
+def process_voluntary_exits(
+    state: BeaconState, block: BaseBeaconBlock, config: Eth2Config
+) -> BeaconState:
     if len(block.body.voluntary_exits) > config.MAX_VOLUNTARY_EXITS:
         raise ValidationError(
             f"The block ({block}) has too many voluntary exits:\n"
@@ -203,9 +166,9 @@ def process_voluntary_exits(state: BeaconState,
     return state
 
 
-def process_transfers(state: BeaconState,
-                      block: BaseBeaconBlock,
-                      config: Eth2Config) -> BeaconState:
+def process_transfers(
+    state: BeaconState, block: BaseBeaconBlock, config: Eth2Config
+) -> BeaconState:
     if len(block.body.transfers) > config.MAX_TRANSFERS:
         raise ValidationError(
             f"The block ({block}) has too many transfers:\n"
@@ -214,36 +177,21 @@ def process_transfers(state: BeaconState,
         )
 
     for transfer in block.body.transfers:
-        validate_transfer(
-            state,
-            transfer,
-            config,
-        )
-        state = decrease_balance(
-            state,
-            transfer.sender,
-            transfer.amount + transfer.fee,
-        )
+        validate_transfer(state, transfer, config)
+        state = decrease_balance(state, transfer.sender, transfer.amount + transfer.fee)
+        state = increase_balance(state, transfer.recipient, transfer.amount)
         state = increase_balance(
             state,
-            transfer.recipient,
-            transfer.amount,
-        )
-        state = increase_balance(
-            state,
-            get_beacon_proposer_index(
-                state,
-                CommitteeConfig(config),
-            ),
+            get_beacon_proposer_index(state, CommitteeConfig(config)),
             transfer.fee,
         )
 
     return state
 
 
-def process_operations(state: BeaconState,
-                       block: BaseBeaconBlock,
-                       config: Eth2Config) -> BeaconState:
+def process_operations(
+    state: BeaconState, block: BaseBeaconBlock, config: Eth2Config
+) -> BeaconState:
     validate_correct_number_of_deposits(state, block, config)
     validate_unique_transfers(state, block, config)
 

--- a/eth2/beacon/state_machines/forks/serenity/operation_processing.py
+++ b/eth2/beacon/state_machines/forks/serenity/operation_processing.py
@@ -2,28 +2,28 @@ from typing import Tuple
 
 from eth_utils import ValidationError
 
-from eth2.configs import Eth2Config, CommitteeConfig
+from eth2.beacon.attestation_helpers import get_attestation_data_slot
+from eth2.beacon.committee_helpers import get_beacon_proposer_index
+from eth2.beacon.deposit_helpers import process_deposit
+from eth2.beacon.epoch_processing_helpers import decrease_balance, increase_balance
+from eth2.beacon.types.blocks import BaseBeaconBlock
+from eth2.beacon.types.pending_attestations import PendingAttestation
+from eth2.beacon.types.states import BeaconState
 from eth2.beacon.validator_status_helpers import (
     initiate_validator_exit,
     slash_validator,
 )
-from eth2.beacon.attestation_helpers import get_attestation_data_slot
-from eth2.beacon.committee_helpers import get_beacon_proposer_index
-from eth2.beacon.epoch_processing_helpers import increase_balance, decrease_balance
-from eth2.beacon.types.blocks import BaseBeaconBlock
-from eth2.beacon.types.pending_attestations import PendingAttestation
-from eth2.beacon.types.states import BeaconState
-from eth2.beacon.deposit_helpers import process_deposit
+from eth2.configs import CommitteeConfig, Eth2Config
 
 from .block_validation import (
     validate_attestation,
     validate_attester_slashing,
-    validate_proposer_slashing,
-    validate_voluntary_exit,
     validate_correct_number_of_deposits,
+    validate_proposer_slashing,
     validate_some_slashing,
     validate_transfer,
     validate_unique_transfers,
+    validate_voluntary_exit,
 )
 
 

--- a/eth2/beacon/state_machines/forks/serenity/slot_processing.py
+++ b/eth2/beacon/state_machines/forks/serenity/slot_processing.py
@@ -1,42 +1,25 @@
-from typing import (
-    Sequence,
-    Tuple,
-)
+from typing import Sequence, Tuple
 
-from eth.constants import (
-    ZERO_HASH32,
-)
+from eth.constants import ZERO_HASH32
 
-from eth_typing import (
-    Hash32,
-)
-from eth_utils import (
-    ValidationError,
-)
+from eth_typing import Hash32
+from eth_utils import ValidationError
 
 from eth2._utils.tuple import update_tuple_item
-from eth2.configs import (
-    Eth2Config,
-)
-from eth2.beacon.typing import (
-    Slot,
-)
+from eth2.configs import Eth2Config
+from eth2.beacon.typing import Slot
 from eth2.beacon.types.states import BeaconState
 
-from .epoch_processing import (
-    process_epoch,
-)
+from .epoch_processing import process_epoch
 
 
-def _update_historical_root(roots: Tuple[Hash32, ...],
-                            index: Slot,
-                            slots_per_historical_root: int,
-                            new_root: Hash32) -> Sequence[Hash32]:
-    return update_tuple_item(
-        roots,
-        index % slots_per_historical_root,
-        new_root,
-    )
+def _update_historical_root(
+    roots: Tuple[Hash32, ...],
+    index: Slot,
+    slots_per_historical_root: int,
+    new_root: Hash32,
+) -> Sequence[Hash32]:
+    return update_tuple_item(roots, index % slots_per_historical_root, new_root)
 
 
 def _process_slot(state: BeaconState, config: Eth2Config) -> BeaconState:
@@ -44,18 +27,13 @@ def _process_slot(state: BeaconState, config: Eth2Config) -> BeaconState:
 
     previous_state_root = state.hash_tree_root
     updated_state_roots = _update_historical_root(
-        state.state_roots,
-        state.slot,
-        slots_per_historical_root,
-        previous_state_root,
+        state.state_roots, state.slot, slots_per_historical_root, previous_state_root
     )
 
     if state.latest_block_header.state_root == ZERO_HASH32:
         latest_block_header = state.latest_block_header
         state = state.copy(
-            latest_block_header=latest_block_header.copy(
-                state_root=previous_state_root,
-            ),
+            latest_block_header=latest_block_header.copy(state_root=previous_state_root)
         )
 
     updated_block_roots = _update_historical_root(
@@ -65,16 +43,11 @@ def _process_slot(state: BeaconState, config: Eth2Config) -> BeaconState:
         state.latest_block_header.signing_root,
     )
 
-    return state.copy(
-        block_roots=updated_block_roots,
-        state_roots=updated_state_roots,
-    )
+    return state.copy(block_roots=updated_block_roots, state_roots=updated_state_roots)
 
 
 def _increment_slot(state: BeaconState) -> BeaconState:
-    return state.copy(
-        slot=state.slot + 1,
-    )
+    return state.copy(slot=state.slot + 1)
 
 
 def process_slots(state: BeaconState, slot: Slot, config: Eth2Config) -> BeaconState:

--- a/eth2/beacon/state_machines/forks/serenity/slot_processing.py
+++ b/eth2/beacon/state_machines/forks/serenity/slot_processing.py
@@ -1,14 +1,13 @@
 from typing import Sequence, Tuple
 
 from eth.constants import ZERO_HASH32
-
 from eth_typing import Hash32
 from eth_utils import ValidationError
 
 from eth2._utils.tuple import update_tuple_item
-from eth2.configs import Eth2Config
-from eth2.beacon.typing import Slot
 from eth2.beacon.types.states import BeaconState
+from eth2.beacon.typing import Slot
+from eth2.configs import Eth2Config
 
 from .epoch_processing import process_epoch
 

--- a/eth2/beacon/state_machines/forks/serenity/state_transitions.py
+++ b/eth2/beacon/state_machines/forks/serenity/state_transitions.py
@@ -1,17 +1,11 @@
-from eth2.configs import (
-    Eth2Config,
-)
+from eth2.configs import Eth2Config
 from eth2.beacon.state_machines.state_transitions import BaseStateTransition
 from eth2.beacon.types.blocks import BaseBeaconBlock
 from eth2.beacon.types.states import BeaconState
 from eth2.beacon.typing import Slot
 
-from .block_processing import (
-    process_block,
-)
-from .slot_processing import (
-    process_slots,
-)
+from .block_processing import process_block
+from .slot_processing import process_slots
 
 
 class SerenityStateTransition(BaseStateTransition):
@@ -20,11 +14,13 @@ class SerenityStateTransition(BaseStateTransition):
     def __init__(self, config: Eth2Config):
         self.config = config
 
-    def apply_state_transition(self,
-                               state: BeaconState,
-                               block: BaseBeaconBlock=None,
-                               future_slot: Slot=None,
-                               check_proposer_signature: bool=True) -> BeaconState:
+    def apply_state_transition(
+        self,
+        state: BeaconState,
+        block: BaseBeaconBlock = None,
+        future_slot: Slot = None,
+        check_proposer_signature: bool = True,
+    ) -> BeaconState:
         # NOTE: Callers should request a transition to some slot past the ``state.slot``.
         # This can be done by providing either a ``block`` *or* a ``future_slot``.
         # We enforce this invariant with the assertion on ``target_slot``.

--- a/eth2/beacon/state_machines/forks/serenity/state_transitions.py
+++ b/eth2/beacon/state_machines/forks/serenity/state_transitions.py
@@ -1,8 +1,8 @@
-from eth2.configs import Eth2Config
 from eth2.beacon.state_machines.state_transitions import BaseStateTransition
 from eth2.beacon.types.blocks import BaseBeaconBlock
 from eth2.beacon.types.states import BeaconState
 from eth2.beacon.typing import Slot
+from eth2.configs import Eth2Config
 
 from .block_processing import process_block
 from .slot_processing import process_slots

--- a/eth2/beacon/state_machines/forks/xiao_long_bao/__init__.py
+++ b/eth2/beacon/state_machines/forks/xiao_long_bao/__init__.py
@@ -1,10 +1,6 @@
 from eth2.beacon.fork_choice.scoring import ScoringFn as ForkChoiceScoringFn
-from eth2.beacon.fork_choice.higher_slot import (
-    higher_slot_scoring,
-)
-from eth2.beacon.state_machines.base import (
-    BeaconStateMachine,
-)
+from eth2.beacon.fork_choice.higher_slot import higher_slot_scoring
+from eth2.beacon.state_machines.base import BeaconStateMachine
 from eth2.beacon.state_machines.forks.serenity.blocks import (
     SerenityBeaconBlock,
     create_serenity_block_from_parent,
@@ -12,24 +8,16 @@ from eth2.beacon.state_machines.forks.serenity.blocks import (
 from eth2.beacon.state_machines.forks.serenity.state_transitions import (
     SerenityStateTransition,
 )
-from eth2.beacon.state_machines.forks.serenity.states import (
-    SerenityBeaconState,
-)
-from eth2.beacon.types.blocks import (
-    BaseBeaconBlock,
-)
-from eth2.beacon.typing import (
-    FromBlockParams,
-)
+from eth2.beacon.state_machines.forks.serenity.states import SerenityBeaconState
+from eth2.beacon.types.blocks import BaseBeaconBlock
+from eth2.beacon.typing import FromBlockParams
 
-from .configs import (
-    XIAO_LONG_BAO_CONFIG,
-)
+from .configs import XIAO_LONG_BAO_CONFIG
 
 
 class XiaoLongBaoStateMachine(BeaconStateMachine):
     # fork name
-    fork = 'xiao_long_bao'
+    fork = "xiao_long_bao"
     config = XIAO_LONG_BAO_CONFIG
 
     # classes
@@ -39,8 +27,9 @@ class XiaoLongBaoStateMachine(BeaconStateMachine):
 
     # methods
     @staticmethod
-    def create_block_from_parent(parent_block: BaseBeaconBlock,
-                                 block_params: FromBlockParams) -> BaseBeaconBlock:
+    def create_block_from_parent(
+        parent_block: BaseBeaconBlock, block_params: FromBlockParams
+    ) -> BaseBeaconBlock:
         return create_serenity_block_from_parent(parent_block, block_params)
 
     def get_fork_choice_scoring(self) -> ForkChoiceScoringFn:

--- a/eth2/beacon/state_machines/forks/xiao_long_bao/__init__.py
+++ b/eth2/beacon/state_machines/forks/xiao_long_bao/__init__.py
@@ -1,5 +1,5 @@
-from eth2.beacon.fork_choice.scoring import ScoringFn as ForkChoiceScoringFn
 from eth2.beacon.fork_choice.higher_slot import higher_slot_scoring
+from eth2.beacon.fork_choice.scoring import ScoringFn as ForkChoiceScoringFn
 from eth2.beacon.state_machines.base import BeaconStateMachine
 from eth2.beacon.state_machines.forks.serenity.blocks import (
     SerenityBeaconBlock,

--- a/eth2/beacon/state_machines/forks/xiao_long_bao/configs.py
+++ b/eth2/beacon/state_machines/forks/xiao_long_bao/configs.py
@@ -1,6 +1,4 @@
-from eth2.beacon.state_machines.forks.serenity.configs import (
-    SERENITY_CONFIG,
-)
+from eth2.beacon.state_machines.forks.serenity.configs import SERENITY_CONFIG
 
 
 XIAO_LONG_BAO_CONFIG = SERENITY_CONFIG._replace(
@@ -9,7 +7,7 @@ XIAO_LONG_BAO_CONFIG = SERENITY_CONFIG._replace(
     SHARD_COUNT=4,
     MIN_ATTESTATION_INCLUSION_DELAY=2,
     # Shorten the HISTORICAL lengths to make genesis yaml lighter
-    EPOCHS_PER_HISTORICAL_VECTOR=2**7,
-    SLOTS_PER_HISTORICAL_ROOT=2**4,
-    EPOCHS_PER_SLASHINGS_VECTOR=2**4,
+    EPOCHS_PER_HISTORICAL_VECTOR=2 ** 7,
+    SLOTS_PER_HISTORICAL_ROOT=2 ** 4,
+    EPOCHS_PER_SLASHINGS_VECTOR=2 ** 4,
 )

--- a/eth2/beacon/state_machines/forks/xiao_long_bao/configs.py
+++ b/eth2/beacon/state_machines/forks/xiao_long_bao/configs.py
@@ -1,6 +1,5 @@
 from eth2.beacon.state_machines.forks.serenity.configs import SERENITY_CONFIG
 
-
 XIAO_LONG_BAO_CONFIG = SERENITY_CONFIG._replace(
     SLOTS_PER_EPOCH=4,
     TARGET_COMMITTEE_SIZE=2,

--- a/eth2/beacon/state_machines/state_transitions.py
+++ b/eth2/beacon/state_machines/state_transitions.py
@@ -1,11 +1,6 @@
-from abc import (
-    ABC,
-    abstractmethod,
-)
+from abc import ABC, abstractmethod
 
-from eth._utils.datatypes import (
-    Configurable,
-)
+from eth._utils.datatypes import Configurable
 
 from eth2.configs import Eth2Config
 from eth2.beacon.types.blocks import BaseBeaconBlock
@@ -20,11 +15,13 @@ class BaseStateTransition(Configurable, ABC):
         self.config = config
 
     @abstractmethod
-    def apply_state_transition(self,
-                               state: BeaconState,
-                               block: BaseBeaconBlock=None,
-                               future_slot: Slot=None,
-                               check_proposer_signature: bool=True) -> BeaconState:
+    def apply_state_transition(
+        self,
+        state: BeaconState,
+        block: BaseBeaconBlock = None,
+        future_slot: Slot = None,
+        check_proposer_signature: bool = True,
+    ) -> BeaconState:
         """
         Applies the state transition function to ``state`` based on data in
         ``block`` or ``future_slot``. The ``block.slot`` or the ``future_slot``

--- a/eth2/beacon/state_machines/state_transitions.py
+++ b/eth2/beacon/state_machines/state_transitions.py
@@ -2,10 +2,10 @@ from abc import ABC, abstractmethod
 
 from eth._utils.datatypes import Configurable
 
-from eth2.configs import Eth2Config
 from eth2.beacon.types.blocks import BaseBeaconBlock
 from eth2.beacon.types.states import BeaconState
 from eth2.beacon.typing import Slot
+from eth2.configs import Eth2Config
 
 
 class BaseStateTransition(Configurable, ABC):

--- a/eth2/beacon/tools/builder/committee_assignment.py
+++ b/eth2/beacon/tools/builder/committee_assignment.py
@@ -1,22 +1,21 @@
-from typing import Tuple, NamedTuple
+from typing import NamedTuple, Tuple
 
 from eth_utils import ValidationError
 
-from eth2.configs import CommitteeConfig, Eth2Config
 from eth2.beacon.committee_helpers import (
     get_beacon_proposer_index,
-    get_crosslink_committee,
     get_committee_count,
+    get_crosslink_committee,
     get_start_shard,
 )
+from eth2.beacon.exceptions import NoCommitteeAssignment
 from eth2.beacon.helpers import (
-    get_active_validator_indices,
     compute_start_slot_of_epoch,
+    get_active_validator_indices,
 )
 from eth2.beacon.types.states import BeaconState
-from eth2.beacon.typing import Shard, Slot, ValidatorIndex, Epoch
-from eth2.beacon.exceptions import NoCommitteeAssignment
-
+from eth2.beacon.typing import Epoch, Shard, Slot, ValidatorIndex
+from eth2.configs import CommitteeConfig, Eth2Config
 
 CommitteeAssignment = NamedTuple(
     "CommitteeAssignment",

--- a/eth2/beacon/tools/builder/initializer.py
+++ b/eth2/beacon/tools/builder/initializer.py
@@ -1,25 +1,23 @@
-from typing import cast, Dict, Sequence, Tuple, Type
-
-from eth_typing import BLSPubkey, Hash32
+from typing import Dict, Sequence, Tuple, Type, cast
 
 from eth.constants import ZERO_HASH32
+from eth_typing import BLSPubkey, Hash32
 
 from eth2._utils.hash import hash_eth2
 from eth2._utils.merkle.common import get_merkle_proof
 from eth2._utils.merkle.sparse import calc_merkle_tree_from_leaves, get_root
-from eth2.configs import Eth2Config
 from eth2.beacon.constants import ZERO_TIMESTAMP
 from eth2.beacon.genesis import get_genesis_block, initialize_beacon_state_from_eth1
+from eth2.beacon.tools.builder.validator import create_mock_deposit_data
 from eth2.beacon.types.blocks import BaseBeaconBlock
-from eth2.beacon.types.deposits import Deposit
 from eth2.beacon.types.deposit_data import DepositData  # noqa: F401
+from eth2.beacon.types.deposits import Deposit
 from eth2.beacon.types.eth1_data import Eth1Data
 from eth2.beacon.types.states import BeaconState
 from eth2.beacon.types.validators import Validator
 from eth2.beacon.typing import Timestamp
 from eth2.beacon.validator_status_helpers import activate_validator
-
-from eth2.beacon.tools.builder.validator import create_mock_deposit_data
+from eth2.configs import Eth2Config
 
 
 def create_mock_deposits_and_root(

--- a/eth2/beacon/tools/builder/proposer.py
+++ b/eth2/beacon/tools/builder/proposer.py
@@ -1,21 +1,19 @@
 from typing import Dict, Sequence, Type
+
 from eth_typing import BLSPubkey, BLSSignature
 import ssz
 
-
-from eth2.configs import CommitteeConfig, Eth2Config
-from eth2.beacon.signature_domain import SignatureDomain
 from eth2.beacon.committee_helpers import get_beacon_proposer_index
 from eth2.beacon.exceptions import ProposerIndexError
 from eth2.beacon.helpers import compute_epoch_of_slot
+from eth2.beacon.signature_domain import SignatureDomain
 from eth2.beacon.state_machines.base import BaseBeaconStateMachine
-
+from eth2.beacon.tools.builder.validator import sign_transaction
 from eth2.beacon.types.attestations import Attestation
 from eth2.beacon.types.blocks import BaseBeaconBlock, BeaconBlockBody
 from eth2.beacon.types.states import BeaconState
 from eth2.beacon.typing import FromBlockParams, Slot, ValidatorIndex
-
-from eth2.beacon.tools.builder.validator import sign_transaction
+from eth2.configs import CommitteeConfig, Eth2Config
 
 
 def _generate_randao_reveal(

--- a/eth2/beacon/tools/builder/state.py
+++ b/eth2/beacon/tools/builder/state.py
@@ -1,6 +1,4 @@
-from typing import (
-    Sequence,
-)
+from typing import Sequence
 
 from eth2.configs import Eth2Config
 from eth2.beacon.genesis import (
@@ -10,11 +8,7 @@ from eth2.beacon.genesis import (
 from eth2.beacon.types.eth1_data import Eth1Data
 from eth2.beacon.types.states import BeaconState
 from eth2.beacon.types.validators import Validator
-from eth2.beacon.typing import (
-    Epoch,
-    Gwei,
-    Timestamp,
-)
+from eth2.beacon.typing import Epoch, Gwei, Timestamp
 
 
 def _check_distinct_pubkeys(validators: Sequence[Validator]) -> None:
@@ -22,8 +16,9 @@ def _check_distinct_pubkeys(validators: Sequence[Validator]) -> None:
     assert len(set(pubkeys)) == len(pubkeys)
 
 
-def _check_no_missing_balances(validators: Sequence[Validator],
-                               balances: Sequence[Gwei]) -> None:
+def _check_no_missing_balances(
+    validators: Sequence[Validator], balances: Sequence[Gwei]
+) -> None:
     assert len(validators) == len(balances)
 
 
@@ -33,23 +28,27 @@ def _check_sufficient_balance(balances: Sequence[Gwei], threshold: Gwei) -> None
             assert False
 
 
-def _check_activated_validators(validators: Sequence[Validator],
-                                genesis_epoch: Epoch) -> None:
+def _check_activated_validators(
+    validators: Sequence[Validator], genesis_epoch: Epoch
+) -> None:
     for validator in validators:
         assert validator.activation_eligibility_epoch == genesis_epoch
         assert validator.activation_epoch == genesis_epoch
 
 
-def _check_correct_eth1_data(eth1_data: Eth1Data,
-                             validators: Sequence[Validator]) -> None:
+def _check_correct_eth1_data(
+    eth1_data: Eth1Data, validators: Sequence[Validator]
+) -> None:
     assert eth1_data.deposit_count == len(validators)
 
 
-def create_mock_genesis_state_from_validators(genesis_time: Timestamp,
-                                              genesis_eth1_data: Eth1Data,
-                                              genesis_validators: Sequence[Validator],
-                                              genesis_balances: Sequence[Gwei],
-                                              config: Eth2Config) -> BeaconState:
+def create_mock_genesis_state_from_validators(
+    genesis_time: Timestamp,
+    genesis_eth1_data: Eth1Data,
+    genesis_validators: Sequence[Validator],
+    genesis_balances: Sequence[Gwei],
+    config: Eth2Config,
+) -> BeaconState:
     """
     Produce a valid genesis state without creating the
     corresponding deposits.
@@ -73,13 +72,10 @@ def create_mock_genesis_state_from_validators(genesis_time: Timestamp,
     state_with_validators = empty_state.copy(
         eth1_deposit_index=empty_state.eth1_deposit_index + len(genesis_validators),
         eth1_data=empty_state.eth1_data.copy(
-            deposit_count=empty_state.eth1_data.deposit_count + len(genesis_validators),
+            deposit_count=empty_state.eth1_data.deposit_count + len(genesis_validators)
         ),
         validators=genesis_validators,
         balances=genesis_balances,
     )
 
-    return state_with_validator_digests(
-        state_with_validators,
-        config,
-    )
+    return state_with_validator_digests(state_with_validators, config)

--- a/eth2/beacon/tools/builder/state.py
+++ b/eth2/beacon/tools/builder/state.py
@@ -1,14 +1,14 @@
 from typing import Sequence
 
-from eth2.configs import Eth2Config
 from eth2.beacon.genesis import (
-    state_with_validator_digests,
     initialize_beacon_state_from_eth1,
+    state_with_validator_digests,
 )
 from eth2.beacon.types.eth1_data import Eth1Data
 from eth2.beacon.types.states import BeaconState
 from eth2.beacon.types.validators import Validator
 from eth2.beacon.typing import Epoch, Gwei, Timestamp
+from eth2.configs import Eth2Config
 
 
 def _check_distinct_pubkeys(validators: Sequence[Validator]) -> None:

--- a/eth2/beacon/tools/builder/validator.py
+++ b/eth2/beacon/tools/builder/validator.py
@@ -1,38 +1,37 @@
 import math
 import random
-
 from typing import Dict, Iterable, Sequence, Tuple
 
-from eth_typing import BLSPubkey, BLSSignature, Hash32
-
 from eth.constants import ZERO_HASH32
+from eth_typing import BLSPubkey, BLSSignature, Hash32
 from eth_utils import to_tuple
-from eth_utils.toolz import pipe, keymap as keymapper
-from eth2._utils.bls import bls, Domain
+from eth_utils.toolz import keymap as keymapper
+from eth_utils.toolz import pipe
 
 from eth2._utils.bitfield import get_empty_bitfield, set_voted
-from eth2.configs import CommitteeConfig, Eth2Config
-from eth2.beacon.signature_domain import SignatureDomain
+from eth2._utils.bls import Domain, bls
 from eth2.beacon.committee_helpers import (
-    get_crosslink_committee,
     get_committee_count,
-    get_start_shard,
+    get_crosslink_committee,
     get_shard_delta,
+    get_start_shard,
 )
 from eth2.beacon.helpers import (
     compute_domain,
-    get_block_root_at_slot,
-    get_block_root,
-    get_domain,
-    compute_start_slot_of_epoch,
     compute_epoch_of_slot,
+    compute_start_slot_of_epoch,
     get_active_validator_indices,
+    get_block_root,
+    get_block_root_at_slot,
+    get_domain,
 )
-from eth2.beacon.types.attestations import Attestation, IndexedAttestation
+from eth2.beacon.signature_domain import SignatureDomain
+from eth2.beacon.state_machines.base import BaseBeaconStateMachine
 from eth2.beacon.types.attestation_data import AttestationData
 from eth2.beacon.types.attestation_data_and_custody_bits import (
     AttestationDataAndCustodyBit,
 )
+from eth2.beacon.types.attestations import Attestation, IndexedAttestation
 from eth2.beacon.types.attester_slashings import AttesterSlashing
 from eth2.beacon.types.blocks import BeaconBlockHeader
 from eth2.beacon.types.checkpoints import Checkpoint
@@ -54,7 +53,7 @@ from eth2.beacon.typing import (
     default_epoch,
     default_shard,
 )
-from eth2.beacon.state_machines.base import BaseBeaconStateMachine
+from eth2.configs import CommitteeConfig, Eth2Config
 
 
 # TODO(ralexstokes) merge w/ below

--- a/eth2/beacon/tools/factories.py
+++ b/eth2/beacon/tools/factories.py
@@ -1,20 +1,18 @@
 import time
-import factory
 from typing import Any, Type, TypeVar
 
-from eth2._utils.bls import bls
+from eth.db.atomic import AtomicDB
+import factory
 
+from eth2._utils.bls import bls
 from eth2._utils.hash import hash_eth2
+from eth2.beacon.chains.base import BaseBeaconChain
+from eth2.beacon.chains.testnet import TestnetChain
 from eth2.beacon.state_machines.forks.serenity.blocks import SerenityBeaconBlock
 from eth2.beacon.state_machines.forks.xiao_long_bao.configs import XIAO_LONG_BAO_CONFIG
 from eth2.beacon.tools.builder.initializer import create_mock_genesis
-
-from eth.db.atomic import AtomicDB
 from eth2.beacon.typing import Timestamp
-from eth2.beacon.chains.base import BaseBeaconChain
-from eth2.beacon.chains.testnet import TestnetChain
 from eth2.configs import Eth2GenesisConfig
-
 
 NUM_VALIDATORS = 8
 

--- a/eth2/beacon/tools/factories.py
+++ b/eth2/beacon/tools/factories.py
@@ -1,46 +1,26 @@
 import time
 import factory
-from typing import (
-    Any,
-    Type,
-    TypeVar,
-)
+from typing import Any, Type, TypeVar
 
 from eth2._utils.bls import bls
 
-from eth2._utils.hash import (
-    hash_eth2,
-)
-from eth2.beacon.state_machines.forks.serenity.blocks import (
-    SerenityBeaconBlock,
-)
-from eth2.beacon.state_machines.forks.xiao_long_bao.configs import (
-    XIAO_LONG_BAO_CONFIG,
-)
-from eth2.beacon.tools.builder.initializer import (
-    create_mock_genesis,
-)
+from eth2._utils.hash import hash_eth2
+from eth2.beacon.state_machines.forks.serenity.blocks import SerenityBeaconBlock
+from eth2.beacon.state_machines.forks.xiao_long_bao.configs import XIAO_LONG_BAO_CONFIG
+from eth2.beacon.tools.builder.initializer import create_mock_genesis
 
 from eth.db.atomic import AtomicDB
-from eth2.beacon.typing import (
-    Timestamp,
-)
-from eth2.beacon.chains.base import (
-    BaseBeaconChain,
-)
-from eth2.beacon.chains.testnet import (
-    TestnetChain,
-)
-from eth2.configs import (
-    Eth2GenesisConfig,
-)
+from eth2.beacon.typing import Timestamp
+from eth2.beacon.chains.base import BaseBeaconChain
+from eth2.beacon.chains.testnet import TestnetChain
+from eth2.configs import Eth2GenesisConfig
 
 
 NUM_VALIDATORS = 8
 
 
-privkeys = tuple(int.from_bytes(
-    hash_eth2(str(i).encode('utf-8'))[:4], 'big')
+privkeys = tuple(
+    int.from_bytes(hash_eth2(str(i).encode("utf-8"))[:4], "big")
     for i in range(NUM_VALIDATORS)
 )
 index_to_pubkey = {}

--- a/eth2/beacon/tools/fixtures/config_name.py
+++ b/eth2/beacon/tools/fixtures/config_name.py
@@ -1,9 +1,7 @@
-from typing import (
-    NewType,
-)
+from typing import NewType
 
 
-ConfigName = NewType('ConfigName', str)
+ConfigName = NewType("ConfigName", str)
 
 Mainnet = "mainnet"
 Minimal = "minimal"

--- a/eth2/beacon/tools/fixtures/config_name.py
+++ b/eth2/beacon/tools/fixtures/config_name.py
@@ -1,6 +1,5 @@
 from typing import NewType
 
-
 ConfigName = NewType("ConfigName", str)
 
 Mainnet = "mainnet"

--- a/eth2/beacon/tools/fixtures/helpers.py
+++ b/eth2/beacon/tools/fixtures/helpers.py
@@ -1,59 +1,41 @@
-from typing import (
-    Tuple,
-    Type,
-)
+from typing import Tuple, Type
 
-from eth_utils import (
-    encode_hex,
-    ValidationError,
-)
-from ssz.tools import (
-    to_formatted_dict,
-)
+from eth_utils import encode_hex, ValidationError
+from ssz.tools import to_formatted_dict
 
 from eth2.beacon.db.chain import BeaconChainDB
-from eth2.beacon.tools.builder.proposer import (
-    advance_to_slot,
-)
+from eth2.beacon.tools.builder.proposer import advance_to_slot
 from eth2.beacon.operations.attestation_pool import AttestationPool
-from eth2.beacon.state_machines.forks.serenity import (
-    SerenityStateMachine,
-)
-from eth2.beacon.tools.fixtures.test_case import (
-    StateTestCase,
-)
+from eth2.beacon.state_machines.forks.serenity import SerenityStateMachine
+from eth2.beacon.tools.fixtures.test_case import StateTestCase
 from eth2.beacon.types.states import BeaconState
 
 
-def run_state_execution(test_case: StateTestCase,
-                        sm_class: Type[SerenityStateMachine],
-                        chaindb: BeaconChainDB,
-                        attestation_pool: AttestationPool,
-                        state: BeaconState) -> BeaconState:
+def run_state_execution(
+    test_case: StateTestCase,
+    sm_class: Type[SerenityStateMachine],
+    chaindb: BeaconChainDB,
+    attestation_pool: AttestationPool,
+    state: BeaconState,
+) -> BeaconState:
     chaindb.persist_state(state)
     post_state = state
     post_state, chaindb = apply_advance_to_slot(
-        test_case,
-        sm_class,
-        chaindb,
-        attestation_pool,
-        post_state,
+        test_case, sm_class, chaindb, attestation_pool, post_state
     )
     post_state, chaindb = apply_blocks(
-        test_case,
-        sm_class,
-        chaindb,
-        attestation_pool,
-        post_state,
+        test_case, sm_class, chaindb, attestation_pool, post_state
     )
     return post_state
 
 
-def apply_advance_to_slot(test_case: StateTestCase,
-                          sm_class: Type[SerenityStateMachine],
-                          chaindb: BeaconChainDB,
-                          attestation_pool: AttestationPool,
-                          state: BeaconState) -> Tuple[BeaconState, BeaconChainDB]:
+def apply_advance_to_slot(
+    test_case: StateTestCase,
+    sm_class: Type[SerenityStateMachine],
+    chaindb: BeaconChainDB,
+    attestation_pool: AttestationPool,
+    state: BeaconState,
+) -> Tuple[BeaconState, BeaconChainDB]:
     post_state = state.copy()
     sm = sm_class(chaindb, attestation_pool, None, post_state)
     slot = test_case.pre.slot + test_case.slots
@@ -61,11 +43,13 @@ def apply_advance_to_slot(test_case: StateTestCase,
     return advance_to_slot(sm, post_state, slot), chaindb
 
 
-def apply_blocks(test_case: StateTestCase,
-                 sm_class: Type[SerenityStateMachine],
-                 chaindb: BeaconChainDB,
-                 attestation_pool: AttestationPool,
-                 state: BeaconState) -> Tuple[BeaconState, BeaconChainDB]:
+def apply_blocks(
+    test_case: StateTestCase,
+    sm_class: Type[SerenityStateMachine],
+    chaindb: BeaconChainDB,
+    attestation_pool: AttestationPool,
+    state: BeaconState,
+) -> Tuple[BeaconState, BeaconChainDB]:
     post_state = state.copy()
     for block in test_case.blocks:
         sm = sm_class(chaindb, attestation_pool, None, post_state)

--- a/eth2/beacon/tools/fixtures/helpers.py
+++ b/eth2/beacon/tools/fixtures/helpers.py
@@ -1,12 +1,12 @@
 from typing import Tuple, Type
 
-from eth_utils import encode_hex, ValidationError
+from eth_utils import ValidationError, encode_hex
 from ssz.tools import to_formatted_dict
 
 from eth2.beacon.db.chain import BeaconChainDB
-from eth2.beacon.tools.builder.proposer import advance_to_slot
 from eth2.beacon.operations.attestation_pool import AttestationPool
 from eth2.beacon.state_machines.forks.serenity import SerenityStateMachine
+from eth2.beacon.tools.builder.proposer import advance_to_slot
 from eth2.beacon.tools.fixtures.test_case import StateTestCase
 from eth2.beacon.types.states import BeaconState
 

--- a/eth2/beacon/tools/fixtures/loading.py
+++ b/eth2/beacon/tools/fixtures/loading.py
@@ -1,22 +1,21 @@
 import os
 from pathlib import Path
 from typing import Any, Callable, Dict, Iterable, Sequence, Tuple, Type, Union
-from ruamel.yaml import YAML
 
-from eth_utils import decode_hex, to_tuple
 from eth_typing import BLSPubkey, BLSSignature
+from eth_utils import decode_hex, to_tuple
 from eth_utils.toolz import assoc, keyfilter
+from ruamel.yaml import YAML
 from ssz.tools import from_formatted_dict
 
 from eth2.beacon.helpers import compute_epoch_of_slot
+from eth2.beacon.tools.fixtures.config_name import ALL_CONFIG_NAMES, ConfigName
+from eth2.beacon.tools.fixtures.test_case import OperationOrBlockHeader
+from eth2.beacon.tools.fixtures.test_file import TestFile
 from eth2.beacon.types.blocks import BaseBeaconBlock
 from eth2.beacon.types.deposits import Deposit
 from eth2.beacon.types.states import BeaconState
 from eth2.configs import Eth2Config
-
-from eth2.beacon.tools.fixtures.config_name import ALL_CONFIG_NAMES, ConfigName
-from eth2.beacon.tools.fixtures.test_case import OperationOrBlockHeader
-from eth2.beacon.tools.fixtures.test_file import TestFile
 
 
 #

--- a/eth2/beacon/tools/fixtures/loading.py
+++ b/eth2/beacon/tools/fixtures/loading.py
@@ -1,55 +1,22 @@
 import os
 from pathlib import Path
-from typing import (
-    Any,
-    Callable,
-    Dict,
-    Iterable,
-    Sequence,
-    Tuple,
-    Type,
-    Union,
-)
-from ruamel.yaml import (
-    YAML,
-)
+from typing import Any, Callable, Dict, Iterable, Sequence, Tuple, Type, Union
+from ruamel.yaml import YAML
 
-from eth_utils import (
-    decode_hex,
-    to_tuple,
-)
-from eth_typing import (
-    BLSPubkey,
-    BLSSignature,
-)
-from eth_utils.toolz import (
-    assoc,
-    keyfilter,
-)
-from ssz.tools import (
-    from_formatted_dict,
-)
+from eth_utils import decode_hex, to_tuple
+from eth_typing import BLSPubkey, BLSSignature
+from eth_utils.toolz import assoc, keyfilter
+from ssz.tools import from_formatted_dict
 
-from eth2.beacon.helpers import (
-    compute_epoch_of_slot,
-)
+from eth2.beacon.helpers import compute_epoch_of_slot
 from eth2.beacon.types.blocks import BaseBeaconBlock
 from eth2.beacon.types.deposits import Deposit
 from eth2.beacon.types.states import BeaconState
-from eth2.configs import (
-    Eth2Config,
-)
+from eth2.configs import Eth2Config
 
-from eth2.beacon.tools.fixtures.config_name import (
-    ALL_CONFIG_NAMES,
-    ConfigName,
-)
-from eth2.beacon.tools.fixtures.test_case import (
-    OperationOrBlockHeader,
-)
-from eth2.beacon.tools.fixtures.test_file import (
-    TestFile,
-)
+from eth2.beacon.tools.fixtures.config_name import ALL_CONFIG_NAMES, ConfigName
+from eth2.beacon.tools.fixtures.test_case import OperationOrBlockHeader
+from eth2.beacon.tools.fixtures.test_file import TestFile
 
 
 #
@@ -67,9 +34,8 @@ def generate_config_by_dict(dict_config: Dict[str, Any]) -> Eth2Config:
             config_without_phase_1,
             "GENESIS_EPOCH",
             compute_epoch_of_slot(
-                dict_config['GENESIS_SLOT'],
-                dict_config['SLOTS_PER_EPOCH'],
-            )
+                dict_config["GENESIS_SLOT"], dict_config["SLOTS_PER_EPOCH"]
+            ),
         )
     )
 
@@ -82,11 +48,11 @@ def get_config(root_project_dir: Path, config_name: ConfigName) -> Eth2Config:
         return config_cache[config_name]
 
     # TODO: change the path after the constants presets are copied to submodule
-    path = root_project_dir / 'tests/eth2/fixtures'
+    path = root_project_dir / "tests/eth2/fixtures"
     yaml = YAML(typ="unsafe")
-    file_name = config_name + '.yaml'
+    file_name = config_name + ".yaml"
     file_to_open = path / file_name
-    with open(file_to_open, 'U') as f:
+    with open(file_to_open, "U") as f:
         new_text = f.read()
         data = yaml.load(new_text)
     config = generate_config_by_dict(data)
@@ -94,24 +60,22 @@ def get_config(root_project_dir: Path, config_name: ConfigName) -> Eth2Config:
     return config
 
 
-def get_test_file_from_dict(data: Dict[str, Any],
-                            root_project_dir: Path,
-                            file_name: str,
-                            parse_test_case_fn: Callable[..., Any]) -> TestFile:
-    config_name = data['config']
+def get_test_file_from_dict(
+    data: Dict[str, Any],
+    root_project_dir: Path,
+    file_name: str,
+    parse_test_case_fn: Callable[..., Any],
+) -> TestFile:
+    config_name = data["config"]
     assert config_name in ALL_CONFIG_NAMES
     config_name = ConfigName(config_name)
     config = get_config(root_project_dir, config_name)
-    handler = data['handler']
+    handler = data["handler"]
     parsed_test_cases = tuple(
         parse_test_case_fn(test_case, handler, index, config)
-        for index, test_case in enumerate(data['test_cases'])
+        for index, test_case in enumerate(data["test_cases"])
     )
-    return TestFile(
-        file_name=file_name,
-        config=config,
-        test_cases=parsed_test_cases,
-    )
+    return TestFile(file_name=file_name, config=config, test_cases=parsed_test_cases)
 
 
 @to_tuple
@@ -122,49 +86,53 @@ def get_yaml_files_pathes(dir_path: Path) -> Iterable[str]:
 
 
 @to_tuple
-def load_from_yaml_files(root_project_dir: Path,
-                         dir_path: Path,
-                         config_names: Sequence[ConfigName],
-                         parse_test_case_fn: Callable[..., Any]) -> Iterable[TestFile]:
+def load_from_yaml_files(
+    root_project_dir: Path,
+    dir_path: Path,
+    config_names: Sequence[ConfigName],
+    parse_test_case_fn: Callable[..., Any],
+) -> Iterable[TestFile]:
     entries = get_yaml_files_pathes(dir_path)
     for file_path in entries:
         file_name = os.path.basename(file_path)
         if len(config_names) == 0:
-            yield load_from_yaml_file(root_project_dir, file_path, file_name, parse_test_case_fn)
+            yield load_from_yaml_file(
+                root_project_dir, file_path, file_name, parse_test_case_fn
+            )
         for config_name in config_names:
             if config_name in file_name:
                 yield load_from_yaml_file(
-                    root_project_dir,
-                    file_path,
-                    file_name,
-                    parse_test_case_fn,
+                    root_project_dir, file_path, file_name, parse_test_case_fn
                 )
 
 
-def load_from_yaml_file(root_project_dir: Path,
-                        file_path: str,
-                        file_name: str,
-                        parse_test_case_fn: Callable[..., Any]) -> TestFile:
+def load_from_yaml_file(
+    root_project_dir: Path,
+    file_path: str,
+    file_name: str,
+    parse_test_case_fn: Callable[..., Any],
+) -> TestFile:
     yaml = YAML(typ="unsafe")
-    with open(file_path, 'U') as f:
+    with open(file_path, "U") as f:
         new_text = f.read()
         data = yaml.load(new_text)
         test_file = get_test_file_from_dict(
-            data,
-            root_project_dir,
-            file_name,
-            parse_test_case_fn,
+            data, root_project_dir, file_name, parse_test_case_fn
         )
         return test_file
 
 
 @to_tuple
-def get_all_test_files(root_project_dir: Path,
-                       fixture_pathes: Tuple[Path, ...],
-                       config_names: Sequence[ConfigName],
-                       parse_test_case_fn: Callable[..., Any]) -> Iterable[TestFile]:
+def get_all_test_files(
+    root_project_dir: Path,
+    fixture_pathes: Tuple[Path, ...],
+    config_names: Sequence[ConfigName],
+    parse_test_case_fn: Callable[..., Any],
+) -> Iterable[TestFile]:
     for path in fixture_pathes:
-        yield from load_from_yaml_files(root_project_dir, path, config_names, parse_test_case_fn)
+        yield from load_from_yaml_files(
+            root_project_dir, path, config_names, parse_test_case_fn
+        )
 
 
 #
@@ -172,17 +140,18 @@ def get_all_test_files(root_project_dir: Path,
 #
 def get_bls_setting(test_case: Dict[str, Any]) -> bool:
     # Default is free to choose, so we choose OFF.
-    if 'bls_setting' not in test_case or test_case['bls_setting'] == 2:
+    if "bls_setting" not in test_case or test_case["bls_setting"] == 2:
         return False
     else:
         return True
 
 
-def get_states(test_case: Dict[str, Any],
-               cls_state: Type[BeaconState]) -> Tuple[BeaconState, BeaconState, bool]:
-    pre = from_formatted_dict(test_case['pre'], cls_state)
-    if test_case['post'] is not None:
-        post = from_formatted_dict(test_case['post'], cls_state)
+def get_states(
+    test_case: Dict[str, Any], cls_state: Type[BeaconState]
+) -> Tuple[BeaconState, BeaconState, bool]:
+    pre = from_formatted_dict(test_case["pre"], cls_state)
+    if test_case["post"] is not None:
+        post = from_formatted_dict(test_case["post"], cls_state)
         is_valid = True
     else:
         post = None
@@ -192,56 +161,74 @@ def get_states(test_case: Dict[str, Any],
 
 
 def get_slots(test_case: Dict[str, Any]) -> int:
-    return test_case['slots'] if 'slots' in test_case else 0
+    return test_case["slots"] if "slots" in test_case else 0
 
 
-def get_blocks(test_case: Dict[str, Any],
-               cls_block: Type[BaseBeaconBlock]) -> Tuple[BaseBeaconBlock, ...]:
-    if 'blocks' in test_case:
-        return tuple(from_formatted_dict(block, cls_block) for block in test_case['blocks'])
+def get_blocks(
+    test_case: Dict[str, Any], cls_block: Type[BaseBeaconBlock]
+) -> Tuple[BaseBeaconBlock, ...]:
+    if "blocks" in test_case:
+        return tuple(
+            from_formatted_dict(block, cls_block) for block in test_case["blocks"]
+        )
     else:
         return ()
 
 
-def get_deposits(test_case: Dict[str, Any],
-                 cls_deposit: Type[Deposit]) -> Tuple[Deposit, ...]:
-    return tuple(from_formatted_dict(deposit, cls_deposit) for deposit in test_case['deposits'])
+def get_deposits(
+    test_case: Dict[str, Any], cls_deposit: Type[Deposit]
+) -> Tuple[Deposit, ...]:
+    return tuple(
+        from_formatted_dict(deposit, cls_deposit) for deposit in test_case["deposits"]
+    )
 
 
-def get_operation_or_header(test_case: Dict[str, Any],
-                            cls_operation_or_header: Type[OperationOrBlockHeader],
-                            handler: str) -> Tuple[OperationOrBlockHeader, ...]:
+def get_operation_or_header(
+    test_case: Dict[str, Any],
+    cls_operation_or_header: Type[OperationOrBlockHeader],
+    handler: str,
+) -> Tuple[OperationOrBlockHeader, ...]:
     if handler in test_case:
         return from_formatted_dict(test_case[handler], cls_operation_or_header)
     else:
-        raise NameError(
-            f"Operation {handler} is not supported."
+        raise NameError(f"Operation {handler} is not supported.")
+
+
+def get_input_bls_pubkeys(
+    test_case: Dict[str, Any]
+) -> Dict[str, Tuple[BLSPubkey, ...]]:
+    return {
+        "pubkeys": tuple(BLSPubkey(decode_hex(item)) for item in test_case["input"])
+    }
+
+
+def get_input_bls_signatures(
+    test_case: Dict[str, Any]
+) -> Dict[str, Tuple[BLSSignature, ...]]:
+    return {
+        "signatures": tuple(
+            BLSSignature(decode_hex(item)) for item in test_case["input"]
         )
-
-
-def get_input_bls_pubkeys(test_case: Dict[str, Any]) -> Dict[str, Tuple[BLSPubkey, ...]]:
-    return {'pubkeys': tuple(BLSPubkey(decode_hex(item)) for item in test_case['input'])}
-
-
-def get_input_bls_signatures(test_case: Dict[str, Any]) -> Dict[str, Tuple[BLSSignature, ...]]:
-    return {'signatures': tuple(BLSSignature(decode_hex(item)) for item in test_case['input'])}
+    }
 
 
 def get_input_bls_privkey(test_case: Dict[str, Any]) -> Dict[str, int]:
-    return {'privkey': int.from_bytes(decode_hex(test_case['input']), 'big')}
+    return {"privkey": int.from_bytes(decode_hex(test_case["input"]), "big")}
 
 
-def get_input_sign_message(test_case: Dict[str, Any]) -> Dict[str, Union[int, bytes, bytes]]:
+def get_input_sign_message(
+    test_case: Dict[str, Any]
+) -> Dict[str, Union[int, bytes, bytes]]:
     return {
-        'privkey': int.from_bytes(decode_hex(test_case['input']['privkey']), 'big'),
-        'message_hash': decode_hex(test_case['input']['message']),
-        'domain': decode_hex(test_case['input']['domain']),
+        "privkey": int.from_bytes(decode_hex(test_case["input"]["privkey"]), "big"),
+        "message_hash": decode_hex(test_case["input"]["message"]),
+        "domain": decode_hex(test_case["input"]["domain"]),
     }
 
 
 def get_output_bls_pubkey(test_case: Dict[str, Any]) -> BLSPubkey:
-    return BLSPubkey(decode_hex(test_case['output']))
+    return BLSPubkey(decode_hex(test_case["output"]))
 
 
 def get_output_bls_signature(test_case: Dict[str, Any]) -> BLSSignature:
-    return BLSSignature(decode_hex(test_case['output']))
+    return BLSSignature(decode_hex(test_case["output"]))

--- a/eth2/beacon/tools/fixtures/test_case.py
+++ b/eth2/beacon/tools/fixtures/test_case.py
@@ -1,12 +1,6 @@
-from typing import (
-    Tuple,
-    Union,
-)
+from typing import Tuple, Union
 
-from dataclasses import (
-    dataclass,
-    field,
-)
+from dataclasses import dataclass, field
 
 
 from eth2.beacon.types.attestations import Attestation
@@ -20,12 +14,12 @@ from eth2.beacon.types.voluntary_exits import VoluntaryExit
 
 
 from eth2.beacon.types.states import BeaconState
-from eth2.beacon.typing import (
-    Slot,
-)
+from eth2.beacon.typing import Slot
 
 
-Operation = Union[ProposerSlashing, AttesterSlashing, Attestation, Deposit, VoluntaryExit, Transfer]
+Operation = Union[
+    ProposerSlashing, AttesterSlashing, Attestation, Deposit, VoluntaryExit, Transfer
+]
 OperationOrBlockHeader = Union[Operation, BeaconBlockHeader]
 
 

--- a/eth2/beacon/tools/fixtures/test_case.py
+++ b/eth2/beacon/tools/fixtures/test_case.py
@@ -1,21 +1,16 @@
-from typing import Tuple, Union
-
 from dataclasses import dataclass, field
-
+from typing import Tuple, Union
 
 from eth2.beacon.types.attestations import Attestation
 from eth2.beacon.types.attester_slashings import AttesterSlashing
-from eth2.beacon.types.blocks import BeaconBlock
 from eth2.beacon.types.block_headers import BeaconBlockHeader
+from eth2.beacon.types.blocks import BeaconBlock
 from eth2.beacon.types.deposits import Deposit
 from eth2.beacon.types.proposer_slashings import ProposerSlashing
+from eth2.beacon.types.states import BeaconState
 from eth2.beacon.types.transfers import Transfer
 from eth2.beacon.types.voluntary_exits import VoluntaryExit
-
-
-from eth2.beacon.types.states import BeaconState
 from eth2.beacon.typing import Slot
-
 
 Operation = Union[
     ProposerSlashing, AttesterSlashing, Attestation, Deposit, VoluntaryExit, Transfer

--- a/eth2/beacon/tools/fixtures/test_file.py
+++ b/eth2/beacon/tools/fixtures/test_file.py
@@ -1,13 +1,7 @@
-from typing import (
-    Sequence,
-)
-from dataclasses import (
-    dataclass,
-)
+from typing import Sequence
+from dataclasses import dataclass
 
-from eth2.configs import (
-    Eth2Config,
-)
+from eth2.configs import Eth2Config
 from eth2.beacon.tools.fixtures.test_case import BaseTestCase
 
 

--- a/eth2/beacon/tools/fixtures/test_file.py
+++ b/eth2/beacon/tools/fixtures/test_file.py
@@ -1,8 +1,8 @@
-from typing import Sequence
 from dataclasses import dataclass
+from typing import Sequence
 
-from eth2.configs import Eth2Config
 from eth2.beacon.tools.fixtures.test_case import BaseTestCase
+from eth2.configs import Eth2Config
 
 
 @dataclass

--- a/eth2/beacon/tools/misc/ssz_vector.py
+++ b/eth2/beacon/tools/misc/ssz_vector.py
@@ -3,9 +3,7 @@ from typing import Dict
 import ssz
 import ssz.sedes as sedes
 
-from eth2.configs import (
-    Eth2Config,
-)
+from eth2.configs import Eth2Config
 
 from eth2.beacon.types.attestations import Attestation, IndexedAttestation
 from eth2.beacon.types.blocks import BeaconBlockBody
@@ -40,8 +38,10 @@ def _mk_overrides(config: Eth2Config) -> Dict[ssz.Serializable, Dict[str, int]]:
             "active_index_roots": config.EPOCHS_PER_HISTORICAL_VECTOR,
             "compact_committees_roots": config.EPOCHS_PER_HISTORICAL_VECTOR,
             "slashings": config.EPOCHS_PER_SLASHINGS_VECTOR,
-            "previous_epoch_attestations": config.MAX_ATTESTATIONS * config.SLOTS_PER_EPOCH,
-            "current_epoch_attestations": config.MAX_ATTESTATIONS * config.SLOTS_PER_EPOCH,
+            "previous_epoch_attestations": config.MAX_ATTESTATIONS
+            * config.SLOTS_PER_EPOCH,
+            "current_epoch_attestations": config.MAX_ATTESTATIONS
+            * config.SLOTS_PER_EPOCH,
             "previous_crosslinks": config.SHARD_COUNT,
             "current_crosslinks": config.SHARD_COUNT,
         },
@@ -57,9 +57,7 @@ def _mk_overrides(config: Eth2Config) -> Dict[ssz.Serializable, Dict[str, int]]:
             "custody_bit_0_indices": config.MAX_VALIDATORS_PER_COMMITTEE,
             "custody_bit_1_indices": config.MAX_VALIDATORS_PER_COMMITTEE,
         },
-        PendingAttestation: {
-            "aggregation_bits": config.MAX_VALIDATORS_PER_COMMITTEE,
-        },
+        PendingAttestation: {"aggregation_bits": config.MAX_VALIDATORS_PER_COMMITTEE},
     }
 
 

--- a/eth2/beacon/tools/misc/ssz_vector.py
+++ b/eth2/beacon/tools/misc/ssz_vector.py
@@ -3,14 +3,13 @@ from typing import Dict
 import ssz
 import ssz.sedes as sedes
 
-from eth2.configs import Eth2Config
-
 from eth2.beacon.types.attestations import Attestation, IndexedAttestation
 from eth2.beacon.types.blocks import BeaconBlockBody
 from eth2.beacon.types.compact_committees import CompactCommittee
 from eth2.beacon.types.historical_batch import HistoricalBatch
 from eth2.beacon.types.pending_attestations import PendingAttestation
 from eth2.beacon.types.states import BeaconState
+from eth2.configs import Eth2Config
 
 
 def _mk_overrides(config: Eth2Config) -> Dict[ssz.Serializable, Dict[str, int]]:

--- a/eth2/beacon/types/attestation_data.py
+++ b/eth2/beacon/types/attestation_data.py
@@ -1,48 +1,34 @@
-from eth.constants import (
-    ZERO_HASH32,
-)
+from eth.constants import ZERO_HASH32
 
-from eth_typing import (
-    Hash32,
-)
+from eth_typing import Hash32
 
 import ssz
-from ssz.sedes import (
-    bytes32,
-)
+from ssz.sedes import bytes32
 
-from eth2.beacon.types.checkpoints import (
-    Checkpoint,
-    default_checkpoint,
-)
-from eth2.beacon.types.crosslinks import (
-    Crosslink,
-    default_crosslink,
-)
-from eth_utils import (
-    humanize_hash,
-)
+from eth2.beacon.types.checkpoints import Checkpoint, default_checkpoint
+from eth2.beacon.types.crosslinks import Crosslink, default_crosslink
+from eth_utils import humanize_hash
 
 
 class AttestationData(ssz.Serializable):
 
     fields = [
         # LMD GHOST vote
-        ('beacon_block_root', bytes32),
-
+        ("beacon_block_root", bytes32),
         # FFG vote
-        ('source', Checkpoint),
-        ('target', Checkpoint),
-
+        ("source", Checkpoint),
+        ("target", Checkpoint),
         # Crosslink vote
-        ('crosslink', Crosslink),
+        ("crosslink", Crosslink),
     ]
 
-    def __init__(self,
-                 beacon_block_root: Hash32=ZERO_HASH32,
-                 source: Checkpoint=default_checkpoint,
-                 target: Checkpoint=default_checkpoint,
-                 crosslink: Crosslink=default_crosslink) -> None:
+    def __init__(
+        self,
+        beacon_block_root: Hash32 = ZERO_HASH32,
+        source: Checkpoint = default_checkpoint,
+        target: Checkpoint = default_checkpoint,
+        crosslink: Crosslink = default_crosslink,
+    ) -> None:
         super().__init__(
             beacon_block_root=beacon_block_root,
             source=source,

--- a/eth2/beacon/types/attestation_data.py
+++ b/eth2/beacon/types/attestation_data.py
@@ -1,13 +1,11 @@
 from eth.constants import ZERO_HASH32
-
 from eth_typing import Hash32
-
+from eth_utils import humanize_hash
 import ssz
 from ssz.sedes import bytes32
 
 from eth2.beacon.types.checkpoints import Checkpoint, default_checkpoint
 from eth2.beacon.types.crosslinks import Crosslink, default_crosslink
-from eth_utils import humanize_hash
 
 
 class AttestationData(ssz.Serializable):

--- a/eth2/beacon/types/attestation_data_and_custody_bits.py
+++ b/eth2/beacon/types/attestation_data_and_custody_bits.py
@@ -1,27 +1,21 @@
 import ssz
-from ssz.sedes import (
-    boolean,
-)
+from ssz.sedes import boolean
 
-from .attestation_data import (
-    AttestationData,
-    default_attestation_data,
-)
+from .attestation_data import AttestationData, default_attestation_data
 
 
 class AttestationDataAndCustodyBit(ssz.Serializable):
 
     fields = [
         # Attestation data
-        ('data', AttestationData),
+        ("data", AttestationData),
         # Custody bit
-        ('custody_bit', boolean),
+        ("custody_bit", boolean),
     ]
 
-    def __init__(self,
-                 data: AttestationData=default_attestation_data,
-                 custody_bit: bool=False)-> None:
-        super().__init__(
-            data=data,
-            custody_bit=custody_bit,
-        )
+    def __init__(
+        self,
+        data: AttestationData = default_attestation_data,
+        custody_bit: bool = False,
+    ) -> None:
+        super().__init__(data=data, custody_bit=custody_bit)

--- a/eth2/beacon/types/attestations.py
+++ b/eth2/beacon/types/attestations.py
@@ -1,54 +1,34 @@
-from typing import (
-    Sequence,
-)
+from typing import Sequence
 
 import ssz
-from ssz.sedes import (
-    Bitlist,
-    bytes96,
-    List,
-    uint64,
-)
+from ssz.sedes import Bitlist, bytes96, List, uint64
 
-from .attestation_data import (
-    AttestationData,
-    default_attestation_data,
-)
+from .attestation_data import AttestationData, default_attestation_data
 
-from eth2.beacon.typing import (
-    Bitfield,
-    ValidatorIndex,
-)
+from eth2.beacon.typing import Bitfield, ValidatorIndex
 from eth2.beacon.constants import EMPTY_SIGNATURE
-from eth_typing import (
-    BLSSignature,
-)
+from eth_typing import BLSSignature
 
-from .defaults import (
-    default_bitfield,
-    default_tuple,
-)
+from .defaults import default_bitfield, default_tuple
 
 
 class Attestation(ssz.Serializable):
 
     fields = [
-        ('aggregation_bits', Bitlist(1)),
-        ('data', AttestationData),
-        ('custody_bits', Bitlist(1)),
-        ('signature', bytes96),
+        ("aggregation_bits", Bitlist(1)),
+        ("data", AttestationData),
+        ("custody_bits", Bitlist(1)),
+        ("signature", bytes96),
     ]
 
-    def __init__(self, aggregation_bits: Bitfield=default_bitfield,
-                 data: AttestationData=default_attestation_data,
-                 custody_bits: Bitfield=default_bitfield,
-                 signature: BLSSignature=EMPTY_SIGNATURE) -> None:
-        super().__init__(
-            aggregation_bits,
-            data,
-            custody_bits,
-            signature,
-        )
+    def __init__(
+        self,
+        aggregation_bits: Bitfield = default_bitfield,
+        data: AttestationData = default_attestation_data,
+        custody_bits: Bitfield = default_bitfield,
+        signature: BLSSignature = EMPTY_SIGNATURE,
+    ) -> None:
+        super().__init__(aggregation_bits, data, custody_bits, signature)
 
     def __repr__(self) -> str:
         return f"<Attestation {self.data} >"
@@ -58,25 +38,22 @@ class IndexedAttestation(ssz.Serializable):
 
     fields = [
         # Validator indices
-        ('custody_bit_0_indices', List(uint64, 1)),
-        ('custody_bit_1_indices', List(uint64, 1)),
+        ("custody_bit_0_indices", List(uint64, 1)),
+        ("custody_bit_1_indices", List(uint64, 1)),
         # Attestation data
-        ('data', AttestationData),
+        ("data", AttestationData),
         # Aggregate signature
-        ('signature', bytes96),
+        ("signature", bytes96),
     ]
 
-    def __init__(self,
-                 custody_bit_0_indices: Sequence[ValidatorIndex]=default_tuple,
-                 custody_bit_1_indices: Sequence[ValidatorIndex]=default_tuple,
-                 data: AttestationData=default_attestation_data,
-                 signature: BLSSignature=EMPTY_SIGNATURE) -> None:
-        super().__init__(
-            custody_bit_0_indices,
-            custody_bit_1_indices,
-            data,
-            signature,
-        )
+    def __init__(
+        self,
+        custody_bit_0_indices: Sequence[ValidatorIndex] = default_tuple,
+        custody_bit_1_indices: Sequence[ValidatorIndex] = default_tuple,
+        data: AttestationData = default_attestation_data,
+        signature: BLSSignature = EMPTY_SIGNATURE,
+    ) -> None:
+        super().__init__(custody_bit_0_indices, custody_bit_1_indices, data, signature)
 
     def __repr__(self) -> str:
         return f"<IndexedAttestation {self.data}>"

--- a/eth2/beacon/types/attestations.py
+++ b/eth2/beacon/types/attestations.py
@@ -1,14 +1,13 @@
 from typing import Sequence
 
+from eth_typing import BLSSignature
 import ssz
-from ssz.sedes import Bitlist, bytes96, List, uint64
+from ssz.sedes import Bitlist, List, bytes96, uint64
+
+from eth2.beacon.constants import EMPTY_SIGNATURE
+from eth2.beacon.typing import Bitfield, ValidatorIndex
 
 from .attestation_data import AttestationData, default_attestation_data
-
-from eth2.beacon.typing import Bitfield, ValidatorIndex
-from eth2.beacon.constants import EMPTY_SIGNATURE
-from eth_typing import BLSSignature
-
 from .defaults import default_bitfield, default_tuple
 
 

--- a/eth2/beacon/types/attester_slashings.py
+++ b/eth2/beacon/types/attester_slashings.py
@@ -1,24 +1,20 @@
 import ssz
 
-from .attestations import (
-    IndexedAttestation,
-    default_indexed_attestation,
-)
+from .attestations import IndexedAttestation, default_indexed_attestation
 
 
 class AttesterSlashing(ssz.Serializable):
 
     fields = [
         # First attestation
-        ('attestation_1', IndexedAttestation),
+        ("attestation_1", IndexedAttestation),
         # Second attestation
-        ('attestation_2', IndexedAttestation),
+        ("attestation_2", IndexedAttestation),
     ]
 
-    def __init__(self,
-                 attestation_1: IndexedAttestation=default_indexed_attestation,
-                 attestation_2: IndexedAttestation=default_indexed_attestation)-> None:
-        super().__init__(
-            attestation_1,
-            attestation_2,
-        )
+    def __init__(
+        self,
+        attestation_1: IndexedAttestation = default_indexed_attestation,
+        attestation_2: IndexedAttestation = default_indexed_attestation,
+    ) -> None:
+        super().__init__(attestation_1, attestation_2)

--- a/eth2/beacon/types/block_headers.py
+++ b/eth2/beacon/types/block_headers.py
@@ -1,49 +1,36 @@
-from eth.constants import (
-    ZERO_HASH32,
-)
+from eth.constants import ZERO_HASH32
 
-from eth_typing import (
-    BLSSignature,
-    Hash32,
-)
-from eth_utils import (
-    encode_hex,
-)
+from eth_typing import BLSSignature, Hash32
+from eth_utils import encode_hex
 
 import ssz
-from ssz.sedes import (
-    bytes32,
-    bytes96,
-    uint64,
-)
+from ssz.sedes import bytes32, bytes96, uint64
 
 from eth2.beacon.constants import EMPTY_SIGNATURE
-from eth2.beacon.typing import (
-    Slot,
-)
+from eth2.beacon.typing import Slot
 
-from .defaults import (
-    default_slot,
-)
+from .defaults import default_slot
 
 
 class BeaconBlockHeader(ssz.SignedSerializable):
 
     fields = [
-        ('slot', uint64),
-        ('parent_root', bytes32),
-        ('state_root', bytes32),
-        ('body_root', bytes32),
-        ('signature', bytes96),
+        ("slot", uint64),
+        ("parent_root", bytes32),
+        ("state_root", bytes32),
+        ("body_root", bytes32),
+        ("signature", bytes96),
     ]
 
-    def __init__(self,
-                 *,
-                 slot: Slot=default_slot,
-                 parent_root: Hash32=ZERO_HASH32,
-                 state_root: Hash32=ZERO_HASH32,
-                 body_root: Hash32=ZERO_HASH32,
-                 signature: BLSSignature=EMPTY_SIGNATURE):
+    def __init__(
+        self,
+        *,
+        slot: Slot = default_slot,
+        parent_root: Hash32 = ZERO_HASH32,
+        state_root: Hash32 = ZERO_HASH32,
+        body_root: Hash32 = ZERO_HASH32,
+        signature: BLSSignature = EMPTY_SIGNATURE,
+    ):
         super().__init__(
             slot=slot,
             parent_root=parent_root,
@@ -54,9 +41,9 @@ class BeaconBlockHeader(ssz.SignedSerializable):
 
     def __repr__(self) -> str:
         return (
-            f'<Block #{self.slot} '
-            f'signing_root={encode_hex(self.signing_root)[2:10]} '
-            f'hash_tree_root={encode_hex(self.hash_tree_root)[2:10]}>'
+            f"<Block #{self.slot} "
+            f"signing_root={encode_hex(self.signing_root)[2:10]} "
+            f"hash_tree_root={encode_hex(self.hash_tree_root)[2:10]}>"
         )
 
 

--- a/eth2/beacon/types/block_headers.py
+++ b/eth2/beacon/types/block_headers.py
@@ -1,8 +1,6 @@
 from eth.constants import ZERO_HASH32
-
 from eth_typing import BLSSignature, Hash32
 from eth_utils import encode_hex
-
 import ssz
 from ssz.sedes import bytes32, bytes96, uint64
 

--- a/eth2/beacon/types/blocks.py
+++ b/eth2/beacon/types/blocks.py
@@ -1,59 +1,27 @@
-from abc import (
-    ABC,
-    abstractmethod,
-)
+from abc import ABC, abstractmethod
 
-from typing import (
-    Sequence,
-    TYPE_CHECKING,
-)
+from typing import Sequence, TYPE_CHECKING
 
-from eth.constants import (
-    ZERO_HASH32,
-)
+from eth.constants import ZERO_HASH32
 
-from eth_typing import (
-    BLSSignature,
-    Hash32,
-)
-from eth_utils import (
-    encode_hex,
-)
+from eth_typing import BLSSignature, Hash32
+from eth_utils import encode_hex
 import ssz
-from ssz.sedes import (
-    List,
-    bytes32,
-    bytes96,
-    uint64,
-)
+from ssz.sedes import List, bytes32, bytes96, uint64
 
 
-from eth._utils.datatypes import (
-    Configurable,
-)
+from eth._utils.datatypes import Configurable
 
-from eth2.beacon.constants import (
-    EMPTY_SIGNATURE,
-    GENESIS_PARENT_ROOT,
-)
-from eth2.beacon.typing import (
-    Slot,
-    FromBlockParams,
-)
+from eth2.beacon.constants import EMPTY_SIGNATURE, GENESIS_PARENT_ROOT
+from eth2.beacon.typing import Slot, FromBlockParams
 
 
 from .attestations import Attestation
 from .attester_slashings import AttesterSlashing
 from .block_headers import BeaconBlockHeader
-from .defaults import (
-    default_tuple,
-    default_slot,
-)
+from .defaults import default_tuple, default_slot
 from .deposits import Deposit
-from .eth1_data import (
-    Eth1Data,
-    default_eth1_data,
-)
+from .eth1_data import Eth1Data, default_eth1_data
 from .proposer_slashings import ProposerSlashing
 from .transfers import Transfer
 from .voluntary_exits import VoluntaryExit
@@ -66,28 +34,30 @@ if TYPE_CHECKING:
 class BeaconBlockBody(ssz.Serializable):
 
     fields = [
-        ('randao_reveal', bytes96),
-        ('eth1_data', Eth1Data),
-        ('graffiti', bytes32),
-        ('proposer_slashings', List(ProposerSlashing, 1)),
-        ('attester_slashings', List(AttesterSlashing, 1)),
-        ('attestations', List(Attestation, 1)),
-        ('deposits', List(Deposit, 1)),
-        ('voluntary_exits', List(VoluntaryExit, 1)),
-        ('transfers', List(Transfer, 1)),
+        ("randao_reveal", bytes96),
+        ("eth1_data", Eth1Data),
+        ("graffiti", bytes32),
+        ("proposer_slashings", List(ProposerSlashing, 1)),
+        ("attester_slashings", List(AttesterSlashing, 1)),
+        ("attestations", List(Attestation, 1)),
+        ("deposits", List(Deposit, 1)),
+        ("voluntary_exits", List(VoluntaryExit, 1)),
+        ("transfers", List(Transfer, 1)),
     ]
 
-    def __init__(self,
-                 *,
-                 randao_reveal: bytes96=EMPTY_SIGNATURE,
-                 eth1_data: Eth1Data=default_eth1_data,
-                 graffiti: Hash32=ZERO_HASH32,
-                 proposer_slashings: Sequence[ProposerSlashing]=default_tuple,
-                 attester_slashings: Sequence[AttesterSlashing]=default_tuple,
-                 attestations: Sequence[Attestation]=default_tuple,
-                 deposits: Sequence[Deposit]=default_tuple,
-                 voluntary_exits: Sequence[VoluntaryExit]=default_tuple,
-                 transfers: Sequence[Transfer]=default_tuple)-> None:
+    def __init__(
+        self,
+        *,
+        randao_reveal: bytes96 = EMPTY_SIGNATURE,
+        eth1_data: Eth1Data = default_eth1_data,
+        graffiti: Hash32 = ZERO_HASH32,
+        proposer_slashings: Sequence[ProposerSlashing] = default_tuple,
+        attester_slashings: Sequence[AttesterSlashing] = default_tuple,
+        attestations: Sequence[Attestation] = default_tuple,
+        deposits: Sequence[Deposit] = default_tuple,
+        voluntary_exits: Sequence[VoluntaryExit] = default_tuple,
+        transfers: Sequence[Transfer] = default_tuple,
+    ) -> None:
         super().__init__(
             randao_reveal=randao_reveal,
             eth1_data=eth1_data,
@@ -110,20 +80,22 @@ default_beacon_block_body = BeaconBlockBody()
 
 class BaseBeaconBlock(ssz.SignedSerializable, Configurable, ABC):
     fields = [
-        ('slot', uint64),
-        ('parent_root', bytes32),
-        ('state_root', bytes32),
-        ('body', BeaconBlockBody),
-        ('signature', bytes96),
+        ("slot", uint64),
+        ("parent_root", bytes32),
+        ("state_root", bytes32),
+        ("body", BeaconBlockBody),
+        ("signature", bytes96),
     ]
 
-    def __init__(self,
-                 *,
-                 slot: Slot=default_slot,
-                 parent_root: Hash32=ZERO_HASH32,
-                 state_root: Hash32=ZERO_HASH32,
-                 body: BeaconBlockBody=default_beacon_block_body,
-                 signature: BLSSignature=EMPTY_SIGNATURE) -> None:
+    def __init__(
+        self,
+        *,
+        slot: Slot = default_slot,
+        parent_root: Hash32 = ZERO_HASH32,
+        state_root: Hash32 = ZERO_HASH32,
+        body: BeaconBlockBody = default_beacon_block_body,
+        signature: BLSSignature = EMPTY_SIGNATURE,
+    ) -> None:
         super().__init__(
             slot=slot,
             parent_root=parent_root,
@@ -134,12 +106,12 @@ class BaseBeaconBlock(ssz.SignedSerializable, Configurable, ABC):
 
     def __repr__(self) -> str:
         return (
-            f'<Block #{self.slot} '
-            f'parent_root={encode_hex(self.parent_root)[2:10]} '
-            f'signing_root={encode_hex(self.signing_root)[2:10]} '
-            f'state_root={encode_hex(self.state_root)[2:10]} '
-            f'attestations={self.body.attestations} '
-            '>'
+            f"<Block #{self.slot} "
+            f"parent_root={encode_hex(self.parent_root)[2:10]} "
+            f"signing_root={encode_hex(self.signing_root)[2:10]} "
+            f"state_root={encode_hex(self.state_root)[2:10]} "
+            f"attestations={self.body.attestations} "
+            ">"
         )
 
     @property
@@ -158,7 +130,7 @@ class BaseBeaconBlock(ssz.SignedSerializable, Configurable, ABC):
 
     @classmethod
     @abstractmethod
-    def from_root(cls, root: Hash32, chaindb: 'BaseBeaconChainDB') -> 'BaseBeaconBlock':
+    def from_root(cls, root: Hash32, chaindb: "BaseBeaconChainDB") -> "BaseBeaconBlock":
         """
         Return the block denoted by the given block root.
         """
@@ -169,7 +141,7 @@ class BeaconBlock(BaseBeaconBlock):
     block_body_class = BeaconBlockBody
 
     @classmethod
-    def from_root(cls, root: Hash32, chaindb: 'BaseBeaconChainDB') -> 'BeaconBlock':
+    def from_root(cls, root: Hash32, chaindb: "BaseBeaconChainDB") -> "BeaconBlock":
         """
         Return the block denoted by the given block ``root``.
         """
@@ -195,9 +167,9 @@ class BeaconBlock(BaseBeaconBlock):
         )
 
     @classmethod
-    def from_parent(cls,
-                    parent_block: 'BaseBeaconBlock',
-                    block_params: FromBlockParams) -> 'BaseBeaconBlock':
+    def from_parent(
+        cls, parent_block: "BaseBeaconBlock", block_params: FromBlockParams
+    ) -> "BaseBeaconBlock":
         """
         Initialize a new block with the ``parent_block`` as the block's
         previous block root.
@@ -215,8 +187,7 @@ class BeaconBlock(BaseBeaconBlock):
         )
 
     @classmethod
-    def convert_block(cls,
-                      block: 'BaseBeaconBlock') -> 'BeaconBlock':
+    def convert_block(cls, block: "BaseBeaconBlock") -> "BeaconBlock":
         return cls(
             slot=block.slot,
             parent_root=block.parent_root,
@@ -226,7 +197,7 @@ class BeaconBlock(BaseBeaconBlock):
         )
 
     @classmethod
-    def from_header(cls, header: BeaconBlockHeader) -> 'BeaconBlock':
+    def from_header(cls, header: BeaconBlockHeader) -> "BeaconBlock":
         return cls(
             slot=header.slot,
             parent_root=header.parent_root,

--- a/eth2/beacon/types/blocks.py
+++ b/eth2/beacon/types/blocks.py
@@ -1,31 +1,25 @@
 from abc import ABC, abstractmethod
+from typing import TYPE_CHECKING, Sequence
 
-from typing import Sequence, TYPE_CHECKING
-
+from eth._utils.datatypes import Configurable
 from eth.constants import ZERO_HASH32
-
 from eth_typing import BLSSignature, Hash32
 from eth_utils import encode_hex
 import ssz
 from ssz.sedes import List, bytes32, bytes96, uint64
 
-
-from eth._utils.datatypes import Configurable
-
 from eth2.beacon.constants import EMPTY_SIGNATURE, GENESIS_PARENT_ROOT
-from eth2.beacon.typing import Slot, FromBlockParams
-
+from eth2.beacon.typing import FromBlockParams, Slot
 
 from .attestations import Attestation
 from .attester_slashings import AttesterSlashing
 from .block_headers import BeaconBlockHeader
-from .defaults import default_tuple, default_slot
+from .defaults import default_slot, default_tuple
 from .deposits import Deposit
 from .eth1_data import Eth1Data, default_eth1_data
 from .proposer_slashings import ProposerSlashing
 from .transfers import Transfer
 from .voluntary_exits import VoluntaryExit
-
 
 if TYPE_CHECKING:
     from eth2.beacon.db.chain import BaseBeaconChainDB  # noqa: F401

--- a/eth2/beacon/types/checkpoints.py
+++ b/eth2/beacon/types/checkpoints.py
@@ -1,43 +1,24 @@
-from eth_typing import (
-    Hash32,
-)
-from eth_utils import (
-    encode_hex,
-)
+from eth_typing import Hash32
+from eth_utils import encode_hex
 
-from eth.constants import (
-    ZERO_HASH32,
-)
+from eth.constants import ZERO_HASH32
 
 import ssz
-from ssz.sedes import (
-    bytes32,
-    uint64,
-)
+from ssz.sedes import bytes32, uint64
 
-from eth2.beacon.typing import (
-    Epoch,
-)
+from eth2.beacon.typing import Epoch
 
-from .defaults import (
-    default_epoch,
-)
+from .defaults import default_epoch
 
 
 class Checkpoint(ssz.Serializable):
 
-    fields = [
-        ('epoch', uint64),
-        ('root', bytes32)
-    ]
+    fields = [("epoch", uint64), ("root", bytes32)]
 
-    def __init__(self,
-                 epoch: Epoch=default_epoch,
-                 root: Hash32=ZERO_HASH32) -> None:
-        super().__init__(
-            epoch=epoch,
-            root=root,
-        )
+    def __init__(
+        self, epoch: Epoch = default_epoch, root: Hash32 = ZERO_HASH32
+    ) -> None:
+        super().__init__(epoch=epoch, root=root)
 
     def __str__(self) -> str:
         return f"({self.epoch}, {encode_hex(self.root)[0:8]})"

--- a/eth2/beacon/types/checkpoints.py
+++ b/eth2/beacon/types/checkpoints.py
@@ -1,8 +1,6 @@
+from eth.constants import ZERO_HASH32
 from eth_typing import Hash32
 from eth_utils import encode_hex
-
-from eth.constants import ZERO_HASH32
-
 import ssz
 from ssz.sedes import bytes32, uint64
 

--- a/eth2/beacon/types/compact_committees.py
+++ b/eth2/beacon/types/compact_committees.py
@@ -1,37 +1,23 @@
-from typing import (
-    Sequence,
-)
+from typing import Sequence
 
-from eth_typing import (
-    BLSPubkey,
-)
+from eth_typing import BLSPubkey
 
 import ssz
-from ssz.sedes import (
-    bytes48,
-    List,
-    uint64,
-)
+from ssz.sedes import bytes48, List, uint64
 
-from .defaults import (
-    default_tuple,
-)
+from .defaults import default_tuple
 
 
 class CompactCommittee(ssz.Serializable):
 
-    fields = [
-        ('pubkeys', List(bytes48, 1)),
-        ('compact_validators', List(uint64, 1)),
-    ]
+    fields = [("pubkeys", List(bytes48, 1)), ("compact_validators", List(uint64, 1))]
 
-    def __init__(self,
-                 pubkeys: Sequence[BLSPubkey]=default_tuple,
-                 compact_validators: Sequence[int]=default_tuple) -> None:
-        super().__init__(
-            pubkeys=pubkeys,
-            compact_validators=compact_validators,
-        )
+    def __init__(
+        self,
+        pubkeys: Sequence[BLSPubkey] = default_tuple,
+        compact_validators: Sequence[int] = default_tuple,
+    ) -> None:
+        super().__init__(pubkeys=pubkeys, compact_validators=compact_validators)
 
 
 default_compact_committee = CompactCommittee()

--- a/eth2/beacon/types/compact_committees.py
+++ b/eth2/beacon/types/compact_committees.py
@@ -1,9 +1,8 @@
 from typing import Sequence
 
 from eth_typing import BLSPubkey
-
 import ssz
-from ssz.sedes import bytes48, List, uint64
+from ssz.sedes import List, bytes48, uint64
 
 from .defaults import default_tuple
 

--- a/eth2/beacon/types/crosslinks.py
+++ b/eth2/beacon/types/crosslinks.py
@@ -1,49 +1,35 @@
-from eth_typing import (
-    Hash32,
-)
+from eth_typing import Hash32
 
 import ssz
-from ssz.sedes import (
-    uint64,
-    bytes32,
-)
+from ssz.sedes import uint64, bytes32
 
-from eth2.beacon.constants import (
-    ZERO_HASH32,
-)
-from eth2.beacon.typing import (
-    Epoch,
-    Shard,
-)
-from eth_utils import (
-    encode_hex,
-    humanize_hash,
-)
+from eth2.beacon.constants import ZERO_HASH32
+from eth2.beacon.typing import Epoch, Shard
+from eth_utils import encode_hex, humanize_hash
 
-from .defaults import (
-    default_shard,
-    default_epoch,
-)
+from .defaults import default_shard, default_epoch
 
 
 class Crosslink(ssz.Serializable):
 
     fields = [
-        ('shard', uint64),
-        ('parent_root', bytes32),
+        ("shard", uint64),
+        ("parent_root", bytes32),
         # Crosslinking data from epochs [start....end-1]
-        ('start_epoch', uint64),
-        ('end_epoch', uint64),
+        ("start_epoch", uint64),
+        ("end_epoch", uint64),
         # Root of the crosslinked shard data since the previous crosslink
-        ('data_root', bytes32),
+        ("data_root", bytes32),
     ]
 
-    def __init__(self,
-                 shard: Shard=default_shard,
-                 parent_root: Hash32=ZERO_HASH32,
-                 start_epoch: Epoch=default_epoch,
-                 end_epoch: Epoch=default_epoch,
-                 data_root: Hash32=ZERO_HASH32) -> None:
+    def __init__(
+        self,
+        shard: Shard = default_shard,
+        parent_root: Hash32 = ZERO_HASH32,
+        start_epoch: Epoch = default_epoch,
+        end_epoch: Epoch = default_epoch,
+        data_root: Hash32 = ZERO_HASH32,
+    ) -> None:
         super().__init__(
             shard=shard,
             parent_root=parent_root,

--- a/eth2/beacon/types/crosslinks.py
+++ b/eth2/beacon/types/crosslinks.py
@@ -1,13 +1,12 @@
 from eth_typing import Hash32
-
+from eth_utils import encode_hex, humanize_hash
 import ssz
-from ssz.sedes import uint64, bytes32
+from ssz.sedes import bytes32, uint64
 
 from eth2.beacon.constants import ZERO_HASH32
 from eth2.beacon.typing import Epoch, Shard
-from eth_utils import encode_hex, humanize_hash
 
-from .defaults import default_shard, default_epoch
+from .defaults import default_epoch, default_shard
 
 
 class Crosslink(ssz.Serializable):

--- a/eth2/beacon/types/defaults.py
+++ b/eth2/beacon/types/defaults.py
@@ -1,15 +1,9 @@
 """
 This module contains default values to be shared across types in the parent module.
 """
-from typing import (
-    Tuple,
-    TypeVar,
-    TYPE_CHECKING,
-)
+from typing import Tuple, TypeVar, TYPE_CHECKING
 
-from eth2.beacon.constants import (
-    EMPTY_PUBKEY,
-)
+from eth2.beacon.constants import EMPTY_PUBKEY
 from eth2.beacon.typing import (  # noqa: F401
     default_epoch,
     default_slot,
@@ -35,12 +29,12 @@ default_bls_pubkey = EMPTY_PUBKEY
 #
 # for more info, see: https://stackoverflow.com/q/51885518
 # updating to ``flake8==3.7.7`` fixes this bug but introduces many other breaking changes.
-SomeElement = TypeVar('SomeElement')
+SomeElement = TypeVar("SomeElement")
 
 default_tuple = tuple()  # type: Tuple[Any, ...]
 
 
 def default_tuple_of_size(
-        size: int,
-        default_element: SomeElement) -> Tuple[SomeElement, ...]:
+    size: int, default_element: SomeElement
+) -> Tuple[SomeElement, ...]:
     return (default_element,) * size

--- a/eth2/beacon/types/defaults.py
+++ b/eth2/beacon/types/defaults.py
@@ -1,18 +1,18 @@
 """
 This module contains default values to be shared across types in the parent module.
 """
-from typing import Tuple, TypeVar, TYPE_CHECKING
+from typing import TYPE_CHECKING, Tuple, TypeVar
 
 from eth2.beacon.constants import EMPTY_PUBKEY
 from eth2.beacon.typing import (  # noqa: F401
-    default_epoch,
-    default_slot,
-    default_shard,
-    default_validator_index,
-    default_gwei,
-    default_timestamp,
-    default_second,
     default_bitfield,
+    default_epoch,
+    default_gwei,
+    default_second,
+    default_shard,
+    default_slot,
+    default_timestamp,
+    default_validator_index,
     default_version,
 )
 

--- a/eth2/beacon/types/deposit_data.py
+++ b/eth2/beacon/types/deposit_data.py
@@ -1,31 +1,13 @@
-from eth.constants import (
-    ZERO_HASH32,
-)
-from eth_typing import (
-    BLSPubkey,
-    BLSSignature,
-    Hash32,
-)
-from eth_utils import (
-    encode_hex,
-)
+from eth.constants import ZERO_HASH32
+from eth_typing import BLSPubkey, BLSSignature, Hash32
+from eth_utils import encode_hex
 import ssz
-from ssz.sedes import (
-    uint64,
-    bytes32,
-    bytes48,
-    bytes96,
-)
+from ssz.sedes import uint64, bytes32, bytes48, bytes96
 
 from eth2.beacon.constants import EMPTY_SIGNATURE
-from eth2.beacon.typing import (
-    Gwei,
-)
+from eth2.beacon.typing import Gwei
 
-from .defaults import (
-    default_bls_pubkey,
-    default_gwei,
-)
+from .defaults import default_bls_pubkey, default_gwei
 
 
 class DepositData(ssz.SignedSerializable):
@@ -34,19 +16,22 @@ class DepositData(ssz.SignedSerializable):
     Ethereum 1.0 deposit contract after a successful call to the ``deposit`` function on that
     contract.
     """
+
     fields = [
-        ('pubkey', bytes48),
-        ('withdrawal_credentials', bytes32),
-        ('amount', uint64),
+        ("pubkey", bytes48),
+        ("withdrawal_credentials", bytes32),
+        ("amount", uint64),
         # BLS proof of possession (a BLS signature)
-        ('signature', bytes96),
+        ("signature", bytes96),
     ]
 
-    def __init__(self,
-                 pubkey: BLSPubkey=default_bls_pubkey,
-                 withdrawal_credentials: Hash32=ZERO_HASH32,
-                 amount: Gwei=default_gwei,
-                 signature: BLSSignature=EMPTY_SIGNATURE) -> None:
+    def __init__(
+        self,
+        pubkey: BLSPubkey = default_bls_pubkey,
+        withdrawal_credentials: Hash32 = ZERO_HASH32,
+        amount: Gwei = default_gwei,
+        signature: BLSSignature = EMPTY_SIGNATURE,
+    ) -> None:
         super().__init__(
             pubkey=pubkey,
             withdrawal_credentials=withdrawal_credentials,

--- a/eth2/beacon/types/deposit_data.py
+++ b/eth2/beacon/types/deposit_data.py
@@ -2,7 +2,7 @@ from eth.constants import ZERO_HASH32
 from eth_typing import BLSPubkey, BLSSignature, Hash32
 from eth_utils import encode_hex
 import ssz
-from ssz.sedes import uint64, bytes32, bytes48, bytes96
+from ssz.sedes import bytes32, bytes48, bytes96, uint64
 
 from eth2.beacon.constants import EMPTY_SIGNATURE
 from eth2.beacon.typing import Gwei

--- a/eth2/beacon/types/deposits.py
+++ b/eth2/beacon/types/deposits.py
@@ -1,34 +1,16 @@
-from typing import (
-    Sequence,
-)
+from typing import Sequence
 
-from eth.constants import (
-    ZERO_HASH32,
-)
-from eth_utils import (
-    encode_hex,
-)
-from eth_typing import (
-    Hash32,
-)
+from eth.constants import ZERO_HASH32
+from eth_utils import encode_hex
+from eth_typing import Hash32
 import ssz
-from ssz.sedes import (
-    Vector,
-    bytes32,
-)
+from ssz.sedes import Vector, bytes32
 
-from eth2.beacon.constants import (
-    DEPOSIT_CONTRACT_TREE_DEPTH,
-)
+from eth2.beacon.constants import DEPOSIT_CONTRACT_TREE_DEPTH
 
-from .deposit_data import (
-    DepositData,
-    default_deposit_data,
-)
+from .deposit_data import DepositData, default_deposit_data
 
-from .defaults import (
-    default_tuple_of_size,
-)
+from .defaults import default_tuple_of_size
 
 DEPOSIT_PROOF_VECTOR_SIZE = DEPOSIT_CONTRACT_TREE_DEPTH + 1
 
@@ -44,17 +26,16 @@ class Deposit(ssz.Serializable):
 
     fields = [
         # Merkle path to deposit root
-        ('proof', Vector(bytes32, DEPOSIT_PROOF_VECTOR_SIZE)),
-        ('data', DepositData),
+        ("proof", Vector(bytes32, DEPOSIT_PROOF_VECTOR_SIZE)),
+        ("data", DepositData),
     ]
 
-    def __init__(self,
-                 proof: Sequence[Hash32]=default_proof_tuple,
-                 data: DepositData=default_deposit_data)-> None:
-        super().__init__(
-            proof,
-            data,
-        )
+    def __init__(
+        self,
+        proof: Sequence[Hash32] = default_proof_tuple,
+        data: DepositData = default_deposit_data,
+    ) -> None:
+        super().__init__(proof, data)
 
     def __repr__(self) -> str:
         return f"<Deposit hash_tree_root: {encode_hex(self.hash_tree_root)[0:8]} data: {self.data}>"

--- a/eth2/beacon/types/deposits.py
+++ b/eth2/beacon/types/deposits.py
@@ -1,16 +1,15 @@
 from typing import Sequence
 
 from eth.constants import ZERO_HASH32
-from eth_utils import encode_hex
 from eth_typing import Hash32
+from eth_utils import encode_hex
 import ssz
 from ssz.sedes import Vector, bytes32
 
 from eth2.beacon.constants import DEPOSIT_CONTRACT_TREE_DEPTH
 
-from .deposit_data import DepositData, default_deposit_data
-
 from .defaults import default_tuple_of_size
+from .deposit_data import DepositData, default_deposit_data
 
 DEPOSIT_PROOF_VECTOR_SIZE = DEPOSIT_CONTRACT_TREE_DEPTH + 1
 

--- a/eth2/beacon/types/eth1_data.py
+++ b/eth2/beacon/types/eth1_data.py
@@ -1,30 +1,25 @@
-from eth_typing import (
-    Hash32,
-)
+from eth_typing import Hash32
 
 import ssz
-from ssz.sedes import (
-    bytes32,
-    uint64,
-)
+from ssz.sedes import bytes32, uint64
 
-from eth.constants import (
-    ZERO_HASH32,
-)
+from eth.constants import ZERO_HASH32
 
 
 class Eth1Data(ssz.Serializable):
 
     fields = [
-        ('deposit_root', bytes32),
-        ('deposit_count', uint64),
-        ('block_hash', bytes32),
+        ("deposit_root", bytes32),
+        ("deposit_count", uint64),
+        ("block_hash", bytes32),
     ]
 
-    def __init__(self,
-                 deposit_root: Hash32=ZERO_HASH32,
-                 deposit_count: int=0,
-                 block_hash: Hash32=ZERO_HASH32) -> None:
+    def __init__(
+        self,
+        deposit_root: Hash32 = ZERO_HASH32,
+        deposit_count: int = 0,
+        block_hash: Hash32 = ZERO_HASH32,
+    ) -> None:
         super().__init__(
             deposit_root=deposit_root,
             deposit_count=deposit_count,

--- a/eth2/beacon/types/eth1_data.py
+++ b/eth2/beacon/types/eth1_data.py
@@ -1,9 +1,7 @@
+from eth.constants import ZERO_HASH32
 from eth_typing import Hash32
-
 import ssz
 from ssz.sedes import bytes32, uint64
-
-from eth.constants import ZERO_HASH32
 
 
 class Eth1Data(ssz.Serializable):

--- a/eth2/beacon/types/forks.py
+++ b/eth2/beacon/types/forks.py
@@ -1,33 +1,26 @@
 import ssz
-from ssz.sedes import (
-    bytes4,
-    uint64,
-)
+from ssz.sedes import bytes4, uint64
 
-from eth2.beacon.typing import (
-    Epoch,
-    Version,
-)
+from eth2.beacon.typing import Epoch, Version
 
-from .defaults import (
-    default_epoch,
-    default_version,
-)
+from .defaults import default_epoch, default_version
 
 
 class Fork(ssz.Serializable):
 
     fields = [
-        ('previous_version', bytes4),
-        ('current_version', bytes4),
+        ("previous_version", bytes4),
+        ("current_version", bytes4),
         # Epoch of latest fork
-        ('epoch', uint64)
+        ("epoch", uint64),
     ]
 
-    def __init__(self,
-                 previous_version: Version=default_version,
-                 current_version: Version=default_version,
-                 epoch: Epoch=default_epoch) -> None:
+    def __init__(
+        self,
+        previous_version: Version = default_version,
+        current_version: Version = default_version,
+        epoch: Epoch = default_epoch,
+    ) -> None:
         super().__init__(
             previous_version=previous_version,
             current_version=current_version,

--- a/eth2/beacon/types/historical_batch.py
+++ b/eth2/beacon/types/historical_batch.py
@@ -1,50 +1,36 @@
-from typing import (
-    Sequence,
-)
+from typing import Sequence
 
-from eth.constants import (
-    ZERO_HASH32,
-)
-from eth_typing import (
-    Hash32,
-)
+from eth.constants import ZERO_HASH32
+from eth_typing import Hash32
 
 import ssz
-from ssz.sedes import (
-    bytes32,
-    Vector,
-)
+from ssz.sedes import bytes32, Vector
 
-from eth2.configs import (
-    Eth2Config,
-)
+from eth2.configs import Eth2Config
 
-from .defaults import (
-    default_tuple,
-    default_tuple_of_size,
-)
+from .defaults import default_tuple, default_tuple_of_size
 
 
 class HistoricalBatch(ssz.Serializable):
 
-    fields = [
-        ('block_roots', Vector(bytes32, 1)),
-        ('state_roots', Vector(bytes32, 1)),
-    ]
+    fields = [("block_roots", Vector(bytes32, 1)), ("state_roots", Vector(bytes32, 1))]
 
-    def __init__(self,
-                 *,
-                 block_roots: Sequence[Hash32]=default_tuple,
-                 state_roots: Sequence[Hash32]=default_tuple,
-                 config: Eth2Config=None) -> None:
+    def __init__(
+        self,
+        *,
+        block_roots: Sequence[Hash32] = default_tuple,
+        state_roots: Sequence[Hash32] = default_tuple,
+        config: Eth2Config = None
+    ) -> None:
         if config:
             # try to provide sane defaults
             if block_roots == default_tuple:
-                block_roots = default_tuple_of_size(config.SLOTS_PER_HISTORICAL_ROOT, ZERO_HASH32)
+                block_roots = default_tuple_of_size(
+                    config.SLOTS_PER_HISTORICAL_ROOT, ZERO_HASH32
+                )
             if state_roots == default_tuple:
-                state_roots = default_tuple_of_size(config.SLOTS_PER_HISTORICAL_ROOT, ZERO_HASH32)
+                state_roots = default_tuple_of_size(
+                    config.SLOTS_PER_HISTORICAL_ROOT, ZERO_HASH32
+                )
 
-        super().__init__(
-            block_roots=block_roots,
-            state_roots=state_roots,
-        )
+        super().__init__(block_roots=block_roots, state_roots=state_roots)

--- a/eth2/beacon/types/historical_batch.py
+++ b/eth2/beacon/types/historical_batch.py
@@ -2,9 +2,8 @@ from typing import Sequence
 
 from eth.constants import ZERO_HASH32
 from eth_typing import Hash32
-
 import ssz
-from ssz.sedes import bytes32, Vector
+from ssz.sedes import Vector, bytes32
 
 from eth2.configs import Eth2Config
 

--- a/eth2/beacon/types/pending_attestations.py
+++ b/eth2/beacon/types/pending_attestations.py
@@ -1,39 +1,29 @@
 import ssz
-from ssz.sedes import (
-    Bitlist,
-    uint64,
-)
+from ssz.sedes import Bitlist, uint64
 
-from eth2.beacon.typing import (
-    Bitfield,
-    ValidatorIndex,
-)
+from eth2.beacon.typing import Bitfield, ValidatorIndex
 
-from .attestation_data import (
-    AttestationData,
-    default_attestation_data,
-)
+from .attestation_data import AttestationData, default_attestation_data
 
-from .defaults import (
-    default_bitfield,
-    default_validator_index,
-)
+from .defaults import default_bitfield, default_validator_index
 
 
 class PendingAttestation(ssz.Serializable):
 
     fields = [
-        ('aggregation_bits', Bitlist(1)),
-        ('data', AttestationData),
-        ('inclusion_delay', uint64),
-        ('proposer_index', uint64),
+        ("aggregation_bits", Bitlist(1)),
+        ("data", AttestationData),
+        ("inclusion_delay", uint64),
+        ("proposer_index", uint64),
     ]
 
-    def __init__(self,
-                 aggregation_bits: Bitfield=default_bitfield,
-                 data: AttestationData=default_attestation_data,
-                 inclusion_delay: int=0,
-                 proposer_index: ValidatorIndex=default_validator_index) -> None:
+    def __init__(
+        self,
+        aggregation_bits: Bitfield = default_bitfield,
+        data: AttestationData = default_attestation_data,
+        inclusion_delay: int = 0,
+        proposer_index: ValidatorIndex = default_validator_index,
+    ) -> None:
         super().__init__(
             aggregation_bits=aggregation_bits,
             data=data,

--- a/eth2/beacon/types/pending_attestations.py
+++ b/eth2/beacon/types/pending_attestations.py
@@ -4,7 +4,6 @@ from ssz.sedes import Bitlist, uint64
 from eth2.beacon.typing import Bitfield, ValidatorIndex
 
 from .attestation_data import AttestationData, default_attestation_data
-
 from .defaults import default_bitfield, default_validator_index
 
 

--- a/eth2/beacon/types/proposer_slashings.py
+++ b/eth2/beacon/types/proposer_slashings.py
@@ -1,38 +1,29 @@
 import ssz
-from ssz.sedes import (
-    uint64,
-)
+from ssz.sedes import uint64
 
-from .block_headers import (
-    BeaconBlockHeader,
-    default_beacon_block_header,
-)
-from eth2.beacon.typing import (
-    ValidatorIndex,
-)
+from .block_headers import BeaconBlockHeader, default_beacon_block_header
+from eth2.beacon.typing import ValidatorIndex
 
-from .defaults import (
-    default_validator_index,
-)
+from .defaults import default_validator_index
 
 
 class ProposerSlashing(ssz.Serializable):
 
     fields = [
         # Proposer index
-        ('proposer_index', uint64),
+        ("proposer_index", uint64),
         # First block header
-        ('header_1', BeaconBlockHeader),
+        ("header_1", BeaconBlockHeader),
         # Second block header
-        ('header_2', BeaconBlockHeader),
+        ("header_2", BeaconBlockHeader),
     ]
 
-    def __init__(self,
-                 proposer_index: ValidatorIndex=default_validator_index,
-                 header_1: BeaconBlockHeader=default_beacon_block_header,
-                 header_2: BeaconBlockHeader=default_beacon_block_header) -> None:
+    def __init__(
+        self,
+        proposer_index: ValidatorIndex = default_validator_index,
+        header_1: BeaconBlockHeader = default_beacon_block_header,
+        header_2: BeaconBlockHeader = default_beacon_block_header,
+    ) -> None:
         super().__init__(
-            proposer_index=proposer_index,
-            header_1=header_1,
-            header_2=header_2,
+            proposer_index=proposer_index, header_1=header_1, header_2=header_2
         )

--- a/eth2/beacon/types/proposer_slashings.py
+++ b/eth2/beacon/types/proposer_slashings.py
@@ -1,9 +1,9 @@
 import ssz
 from ssz.sedes import uint64
 
-from .block_headers import BeaconBlockHeader, default_beacon_block_header
 from eth2.beacon.typing import ValidatorIndex
 
+from .block_headers import BeaconBlockHeader, default_beacon_block_header
 from .defaults import default_validator_index
 
 

--- a/eth2/beacon/types/states.py
+++ b/eth2/beacon/types/states.py
@@ -1,40 +1,17 @@
-from typing import (
-    Any,
-    Callable,
-    Sequence,
-)
+from typing import Any, Callable, Sequence
 
-from eth_typing import (
-    Hash32,
-)
-from eth_utils import (
-    encode_hex,
-)
+from eth_typing import Hash32
+from eth_utils import encode_hex
 
 import ssz
-from ssz.sedes import (
-    Bitvector,
-    List,
-    Vector,
-    bytes32,
-    uint64,
-)
+from ssz.sedes import Bitvector, List, Vector, bytes32, uint64
 
-from eth.constants import (
-    ZERO_HASH32,
-)
+from eth.constants import ZERO_HASH32
 
-from eth2._utils.tuple import (
-    update_tuple_item,
-    update_tuple_item_with_fn,
-)
+from eth2._utils.tuple import update_tuple_item, update_tuple_item_with_fn
 from eth2.configs import Eth2Config
-from eth2.beacon.constants import (
-    JUSTIFICATION_BITS_LENGTH,
-)
-from eth2.beacon.helpers import (
-    compute_epoch_of_slot,
-)
+from eth2.beacon.constants import JUSTIFICATION_BITS_LENGTH
+from eth2.beacon.helpers import compute_epoch_of_slot
 from eth2.beacon.typing import (
     Epoch,
     Gwei,
@@ -45,26 +22,11 @@ from eth2.beacon.typing import (
     Bitfield,
 )
 
-from .block_headers import (
-    BeaconBlockHeader,
-    default_beacon_block_header,
-)
-from .eth1_data import (
-    Eth1Data,
-    default_eth1_data,
-)
-from .checkpoints import (
-    Checkpoint,
-    default_checkpoint,
-)
-from .crosslinks import (
-    Crosslink,
-    default_crosslink,
-)
-from .forks import (
-    Fork,
-    default_fork,
-)
+from .block_headers import BeaconBlockHeader, default_beacon_block_header
+from .eth1_data import Eth1Data, default_eth1_data
+from .checkpoints import Checkpoint, default_checkpoint
+from .crosslinks import Crosslink, default_crosslink
+from .forks import Fork, default_fork
 from .pending_attestations import PendingAttestation
 from .validators import Validator
 
@@ -84,80 +46,81 @@ class BeaconState(ssz.Serializable):
 
     fields = [
         # Versioning
-        ('genesis_time', uint64),
-        ('slot', uint64),
-        ('fork', Fork),
-
+        ("genesis_time", uint64),
+        ("slot", uint64),
+        ("fork", Fork),
         # History
-        ('latest_block_header', BeaconBlockHeader),
-        ('block_roots', Vector(bytes32, 1)),  # Needed to process attestations, older to newer  # noqa: E501
-        ('state_roots', Vector(bytes32, 1)),
-        ('historical_roots', List(bytes32, 1)),  # allow for a log-sized Merkle proof from any block to any historical block root  # noqa: E501
-
+        ("latest_block_header", BeaconBlockHeader),
+        (
+            "block_roots",
+            Vector(bytes32, 1),
+        ),  # Needed to process attestations, older to newer  # noqa: E501
+        ("state_roots", Vector(bytes32, 1)),
+        (
+            "historical_roots",
+            List(bytes32, 1),
+        ),  # allow for a log-sized Merkle proof from any block to any historical block root  # noqa: E501
         # Ethereum 1.0 chain
-        ('eth1_data', Eth1Data),
-        ('eth1_data_votes', List(Eth1Data, 1)),
-        ('eth1_deposit_index', uint64),
-
+        ("eth1_data", Eth1Data),
+        ("eth1_data_votes", List(Eth1Data, 1)),
+        ("eth1_deposit_index", uint64),
         # Validator registry
-        ('validators', List(Validator, 1)),
-        ('balances', List(uint64, 1)),
-
+        ("validators", List(Validator, 1)),
+        ("balances", List(uint64, 1)),
         # Shuffling
-        ('start_shard', uint64),
-        ('randao_mixes', Vector(bytes32, 1)),
-        ('active_index_roots', Vector(bytes32, 1)),
-        ('compact_committees_roots', Vector(bytes32, 1)),
-
+        ("start_shard", uint64),
+        ("randao_mixes", Vector(bytes32, 1)),
+        ("active_index_roots", Vector(bytes32, 1)),
+        ("compact_committees_roots", Vector(bytes32, 1)),
         # Slashings
-        ('slashings', Vector(uint64, 1)),  # Balances slashed at every withdrawal period  # noqa: E501
-
+        (
+            "slashings",
+            Vector(uint64, 1),
+        ),  # Balances slashed at every withdrawal period  # noqa: E501
         # Attestations
-        ('previous_epoch_attestations', List(PendingAttestation, 1)),
-        ('current_epoch_attestations', List(PendingAttestation, 1)),
-
+        ("previous_epoch_attestations", List(PendingAttestation, 1)),
+        ("current_epoch_attestations", List(PendingAttestation, 1)),
         # Crosslinks
-        ('previous_crosslinks', Vector(Crosslink, 1)),
-        ('current_crosslinks', Vector(Crosslink, 1)),
-
+        ("previous_crosslinks", Vector(Crosslink, 1)),
+        ("current_crosslinks", Vector(Crosslink, 1)),
         # Justification
-        ('justification_bits', Bitvector(JUSTIFICATION_BITS_LENGTH)),
-        ('previous_justified_checkpoint', Checkpoint),
-        ('current_justified_checkpoint', Checkpoint),
-
+        ("justification_bits", Bitvector(JUSTIFICATION_BITS_LENGTH)),
+        ("previous_justified_checkpoint", Checkpoint),
+        ("current_justified_checkpoint", Checkpoint),
         # Finality
-        ('finalized_checkpoint', Checkpoint),
+        ("finalized_checkpoint", Checkpoint),
     ]
 
     def __init__(
-            self,
-            *,
-            genesis_time: Timestamp=default_timestamp,
-            slot: Slot=default_slot,
-            fork: Fork=default_fork,
-            latest_block_header: BeaconBlockHeader=default_beacon_block_header,
-            block_roots: Sequence[Hash32]=default_tuple,
-            state_roots: Sequence[Hash32]=default_tuple,
-            historical_roots: Sequence[Hash32]=default_tuple,
-            eth1_data: Eth1Data=default_eth1_data,
-            eth1_data_votes: Sequence[Eth1Data]=default_tuple,
-            eth1_deposit_index: int=0,
-            validators: Sequence[Validator]=default_tuple,
-            balances: Sequence[Gwei]=default_tuple,
-            start_shard: Shard=default_shard,
-            randao_mixes: Sequence[Hash32]=default_tuple,
-            active_index_roots: Sequence[Hash32]=default_tuple,
-            compact_committees_roots: Sequence[Hash32]=default_tuple,
-            slashings: Sequence[Gwei]=default_tuple,
-            previous_epoch_attestations: Sequence[PendingAttestation]=default_tuple,
-            current_epoch_attestations: Sequence[PendingAttestation]=default_tuple,
-            previous_crosslinks: Sequence[Crosslink]=default_tuple,
-            current_crosslinks: Sequence[Crosslink]=default_tuple,
-            justification_bits: Bitfield=default_justification_bits,
-            previous_justified_checkpoint: Checkpoint=default_checkpoint,
-            current_justified_checkpoint: Checkpoint=default_checkpoint,
-            finalized_checkpoint: Checkpoint=default_checkpoint,
-            config: Eth2Config=None) -> None:
+        self,
+        *,
+        genesis_time: Timestamp = default_timestamp,
+        slot: Slot = default_slot,
+        fork: Fork = default_fork,
+        latest_block_header: BeaconBlockHeader = default_beacon_block_header,
+        block_roots: Sequence[Hash32] = default_tuple,
+        state_roots: Sequence[Hash32] = default_tuple,
+        historical_roots: Sequence[Hash32] = default_tuple,
+        eth1_data: Eth1Data = default_eth1_data,
+        eth1_data_votes: Sequence[Eth1Data] = default_tuple,
+        eth1_deposit_index: int = 0,
+        validators: Sequence[Validator] = default_tuple,
+        balances: Sequence[Gwei] = default_tuple,
+        start_shard: Shard = default_shard,
+        randao_mixes: Sequence[Hash32] = default_tuple,
+        active_index_roots: Sequence[Hash32] = default_tuple,
+        compact_committees_roots: Sequence[Hash32] = default_tuple,
+        slashings: Sequence[Gwei] = default_tuple,
+        previous_epoch_attestations: Sequence[PendingAttestation] = default_tuple,
+        current_epoch_attestations: Sequence[PendingAttestation] = default_tuple,
+        previous_crosslinks: Sequence[Crosslink] = default_tuple,
+        current_crosslinks: Sequence[Crosslink] = default_tuple,
+        justification_bits: Bitfield = default_justification_bits,
+        previous_justified_checkpoint: Checkpoint = default_checkpoint,
+        current_justified_checkpoint: Checkpoint = default_checkpoint,
+        finalized_checkpoint: Checkpoint = default_checkpoint,
+        config: Eth2Config = None,
+    ) -> None:
         if len(validators) != len(balances):
             raise ValueError(
                 "The length of validators and balances lists should be the same."
@@ -166,38 +129,36 @@ class BeaconState(ssz.Serializable):
         if config:
             # try to provide sane defaults
             if block_roots == default_tuple:
-                block_roots = default_tuple_of_size(config.SLOTS_PER_HISTORICAL_ROOT, ZERO_HASH32)
+                block_roots = default_tuple_of_size(
+                    config.SLOTS_PER_HISTORICAL_ROOT, ZERO_HASH32
+                )
             if state_roots == default_tuple:
-                state_roots = default_tuple_of_size(config.SLOTS_PER_HISTORICAL_ROOT, ZERO_HASH32)
+                state_roots = default_tuple_of_size(
+                    config.SLOTS_PER_HISTORICAL_ROOT, ZERO_HASH32
+                )
             if randao_mixes == default_tuple:
                 randao_mixes = default_tuple_of_size(
-                    config.EPOCHS_PER_HISTORICAL_VECTOR,
-                    ZERO_HASH32
+                    config.EPOCHS_PER_HISTORICAL_VECTOR, ZERO_HASH32
                 )
             if active_index_roots == default_tuple:
                 active_index_roots = default_tuple_of_size(
-                    config.EPOCHS_PER_HISTORICAL_VECTOR,
-                    ZERO_HASH32
+                    config.EPOCHS_PER_HISTORICAL_VECTOR, ZERO_HASH32
                 )
             if compact_committees_roots == default_tuple:
                 compact_committees_roots = default_tuple_of_size(
-                    config.EPOCHS_PER_HISTORICAL_VECTOR,
-                    ZERO_HASH32
+                    config.EPOCHS_PER_HISTORICAL_VECTOR, ZERO_HASH32
                 )
             if slashings == default_tuple:
                 slashings = default_tuple_of_size(
-                    config.EPOCHS_PER_SLASHINGS_VECTOR,
-                    Gwei(0),
+                    config.EPOCHS_PER_SLASHINGS_VECTOR, Gwei(0)
                 )
             if previous_crosslinks == default_tuple:
                 previous_crosslinks = default_tuple_of_size(
-                    config.SHARD_COUNT,
-                    default_crosslink,
+                    config.SHARD_COUNT, default_crosslink
                 )
             if current_crosslinks == default_tuple:
                 current_crosslinks = default_tuple_of_size(
-                    config.SHARD_COUNT,
-                    default_crosslink,
+                    config.SHARD_COUNT, default_crosslink
                 )
 
         super().__init__(
@@ -235,10 +196,12 @@ class BeaconState(ssz.Serializable):
     def validator_count(self) -> int:
         return len(self.validators)
 
-    def update_validator(self,
-                         validator_index: ValidatorIndex,
-                         validator: Validator,
-                         balance: Gwei=None) -> 'BeaconState':
+    def update_validator(
+        self,
+        validator_index: ValidatorIndex,
+        validator: Validator,
+        balance: Gwei = None,
+    ) -> "BeaconState":
         """
         Replace ``self.validators[validator_index]`` with ``validator``.
 
@@ -246,28 +209,24 @@ class BeaconState(ssz.Serializable):
         ``self.balances[validator_index] with ``balance``.
         """
         if (
-                validator_index >= len(self.validators) or
-                validator_index >= len(self.balances) or
-                validator_index < 0
+            validator_index >= len(self.validators)
+            or validator_index >= len(self.balances)
+            or validator_index < 0
         ):
             raise IndexError("Incorrect validator index")
 
-        state = self.update_validator_with_fn(
-            validator_index,
-            lambda *_: validator,
-        )
+        state = self.update_validator_with_fn(validator_index, lambda *_: validator)
         if balance:
-            return state._update_validator_balance(
-                validator_index,
-                balance,
-            )
+            return state._update_validator_balance(validator_index, balance)
         else:
             return state
 
-    def update_validator_with_fn(self,
-                                 validator_index: ValidatorIndex,
-                                 fn: Callable[[Validator, Any], Validator],
-                                 *args: Any) -> 'BeaconState':
+    def update_validator_with_fn(
+        self,
+        validator_index: ValidatorIndex,
+        fn: Callable[[Validator, Any], Validator],
+        *args: Any,
+    ) -> "BeaconState":
         """
         Replace ``self.validators[validator_index]`` with
         the result of calling ``fn`` on the existing ``validator``.
@@ -279,16 +238,13 @@ class BeaconState(ssz.Serializable):
 
         return self.copy(
             validators=update_tuple_item_with_fn(
-                self.validators,
-                validator_index,
-                fn,
-                *args,
-            ),
+                self.validators, validator_index, fn, *args
+            )
         )
 
-    def _update_validator_balance(self,
-                                  validator_index: ValidatorIndex,
-                                  balance: Gwei) -> 'BeaconState':
+    def _update_validator_balance(
+        self, validator_index: ValidatorIndex, balance: Gwei
+    ) -> "BeaconState":
         """
         Update the balance of validator of the given ``validator_index``.
         """
@@ -296,11 +252,7 @@ class BeaconState(ssz.Serializable):
             raise IndexError("Incorrect validator index")
 
         return self.copy(
-            balances=update_tuple_item(
-                self.balances,
-                validator_index,
-                balance,
-            )
+            balances=update_tuple_item(self.balances, validator_index, balance)
         )
 
     def current_epoch(self, slots_per_epoch: int) -> Epoch:

--- a/eth2/beacon/types/states.py
+++ b/eth2/beacon/types/states.py
@@ -1,43 +1,39 @@
 from typing import Any, Callable, Sequence
 
+from eth.constants import ZERO_HASH32
 from eth_typing import Hash32
 from eth_utils import encode_hex
-
 import ssz
 from ssz.sedes import Bitvector, List, Vector, bytes32, uint64
 
-from eth.constants import ZERO_HASH32
-
 from eth2._utils.tuple import update_tuple_item, update_tuple_item_with_fn
-from eth2.configs import Eth2Config
 from eth2.beacon.constants import JUSTIFICATION_BITS_LENGTH
 from eth2.beacon.helpers import compute_epoch_of_slot
 from eth2.beacon.typing import (
+    Bitfield,
     Epoch,
     Gwei,
     Shard,
     Slot,
     Timestamp,
     ValidatorIndex,
-    Bitfield,
 )
+from eth2.configs import Eth2Config
 
 from .block_headers import BeaconBlockHeader, default_beacon_block_header
-from .eth1_data import Eth1Data, default_eth1_data
 from .checkpoints import Checkpoint, default_checkpoint
 from .crosslinks import Crosslink, default_crosslink
+from .defaults import (
+    default_shard,
+    default_slot,
+    default_timestamp,
+    default_tuple,
+    default_tuple_of_size,
+)
+from .eth1_data import Eth1Data, default_eth1_data
 from .forks import Fork, default_fork
 from .pending_attestations import PendingAttestation
 from .validators import Validator
-
-from .defaults import (
-    default_timestamp,
-    default_slot,
-    default_tuple,
-    default_tuple_of_size,
-    default_shard,
-)
-
 
 default_justification_bits = Bitfield((False,) * JUSTIFICATION_BITS_LENGTH)
 

--- a/eth2/beacon/types/transfers.py
+++ b/eth2/beacon/types/transfers.py
@@ -1,21 +1,10 @@
-from eth_typing import (
-    BLSPubkey,
-    BLSSignature,
-)
+from eth_typing import BLSPubkey, BLSSignature
 import ssz
-from ssz.sedes import (
-    bytes48,
-    bytes96,
-    uint64
-)
+from ssz.sedes import bytes48, bytes96, uint64
 
 from eth2.beacon.constants import EMPTY_SIGNATURE
 
-from eth2.beacon.typing import (
-    Gwei,
-    Slot,
-    ValidatorIndex,
-)
+from eth2.beacon.typing import Gwei, Slot, ValidatorIndex
 
 from .defaults import (
     default_validator_index,
@@ -27,26 +16,28 @@ from .defaults import (
 
 class Transfer(ssz.SignedSerializable):
     fields = [
-        ('sender', uint64),
-        ('recipient', uint64),
-        ('amount', uint64),
-        ('fee', uint64),
+        ("sender", uint64),
+        ("recipient", uint64),
+        ("amount", uint64),
+        ("fee", uint64),
         # Inclusion slot
-        ('slot', uint64),
+        ("slot", uint64),
         # Sender withdrawal pubkey
-        ('pubkey', bytes48),
+        ("pubkey", bytes48),
         # Sender signature
-        ('signature', bytes96),
+        ("signature", bytes96),
     ]
 
-    def __init__(self,
-                 sender: ValidatorIndex=default_validator_index,
-                 recipient: ValidatorIndex=default_validator_index,
-                 amount: Gwei=default_gwei,
-                 fee: Gwei=default_gwei,
-                 slot: Slot=default_slot,
-                 pubkey: BLSPubkey=default_bls_pubkey,
-                 signature: BLSSignature=EMPTY_SIGNATURE) -> None:
+    def __init__(
+        self,
+        sender: ValidatorIndex = default_validator_index,
+        recipient: ValidatorIndex = default_validator_index,
+        amount: Gwei = default_gwei,
+        fee: Gwei = default_gwei,
+        slot: Slot = default_slot,
+        pubkey: BLSPubkey = default_bls_pubkey,
+        signature: BLSSignature = EMPTY_SIGNATURE,
+    ) -> None:
         super().__init__(
             sender=sender,
             recipient=recipient,

--- a/eth2/beacon/types/transfers.py
+++ b/eth2/beacon/types/transfers.py
@@ -3,14 +3,13 @@ import ssz
 from ssz.sedes import bytes48, bytes96, uint64
 
 from eth2.beacon.constants import EMPTY_SIGNATURE
-
 from eth2.beacon.typing import Gwei, Slot, ValidatorIndex
 
 from .defaults import (
-    default_validator_index,
+    default_bls_pubkey,
     default_gwei,
     default_slot,
-    default_bls_pubkey,
+    default_validator_index,
 )
 
 

--- a/eth2/beacon/types/validators.py
+++ b/eth2/beacon/types/validators.py
@@ -1,30 +1,12 @@
-from eth_typing import (
-    BLSPubkey,
-    Hash32,
-)
+from eth_typing import BLSPubkey, Hash32
 import ssz
-from ssz.sedes import (
-    boolean,
-    bytes32,
-    bytes48,
-    uint64,
-)
+from ssz.sedes import boolean, bytes32, bytes48, uint64
 
 from eth2.configs import Eth2Config
-from eth2.beacon.constants import (
-    FAR_FUTURE_EPOCH,
-    ZERO_HASH32,
-)
-from eth2.beacon.typing import (
-    Epoch,
-    Gwei,
-)
+from eth2.beacon.constants import FAR_FUTURE_EPOCH, ZERO_HASH32
+from eth2.beacon.typing import Epoch, Gwei
 
-from .defaults import (
-    default_bls_pubkey,
-    default_epoch,
-    default_gwei,
-)
+from .defaults import default_bls_pubkey, default_epoch, default_gwei
 
 
 def _round_down_to_previous_multiple(amount: int, increment: int) -> int:
@@ -35,8 +17,7 @@ def calculate_effective_balance(amount: Gwei, config: Eth2Config) -> Gwei:
     return Gwei(
         min(
             _round_down_to_previous_multiple(
-                amount,
-                config.EFFECTIVE_BALANCE_INCREMENT,
+                amount, config.EFFECTIVE_BALANCE_INCREMENT
             ),
             config.MAX_EFFECTIVE_BALANCE,
         )
@@ -46,30 +27,32 @@ def calculate_effective_balance(amount: Gwei, config: Eth2Config) -> Gwei:
 class Validator(ssz.Serializable):
 
     fields = [
-        ('pubkey', bytes48),
-        ('withdrawal_credentials', bytes32),
-        ('effective_balance', uint64),
-        ('slashed', boolean),
+        ("pubkey", bytes48),
+        ("withdrawal_credentials", bytes32),
+        ("effective_balance", uint64),
+        ("slashed", boolean),
         # Epoch when validator became eligible for activation
-        ('activation_eligibility_epoch', uint64),
+        ("activation_eligibility_epoch", uint64),
         # Epoch when validator activated
-        ('activation_epoch', uint64),
+        ("activation_epoch", uint64),
         # Epoch when validator exited
-        ('exit_epoch', uint64),
+        ("exit_epoch", uint64),
         # Epoch when validator withdrew
-        ('withdrawable_epoch', uint64),
+        ("withdrawable_epoch", uint64),
     ]
 
-    def __init__(self,
-                 *,
-                 pubkey: BLSPubkey=default_bls_pubkey,
-                 withdrawal_credentials: Hash32=ZERO_HASH32,
-                 effective_balance: Gwei=default_gwei,
-                 slashed: bool=False,
-                 activation_eligibility_epoch: Epoch=default_epoch,
-                 activation_epoch: Epoch=default_epoch,
-                 exit_epoch: Epoch=default_epoch,
-                 withdrawable_epoch: Epoch=default_epoch) -> None:
+    def __init__(
+        self,
+        *,
+        pubkey: BLSPubkey = default_bls_pubkey,
+        withdrawal_credentials: Hash32 = ZERO_HASH32,
+        effective_balance: Gwei = default_gwei,
+        slashed: bool = False,
+        activation_eligibility_epoch: Epoch = default_epoch,
+        activation_epoch: Epoch = default_epoch,
+        exit_epoch: Epoch = default_epoch,
+        withdrawable_epoch: Epoch = default_epoch
+    ) -> None:
         super().__init__(
             pubkey=pubkey,
             withdrawal_credentials=withdrawal_credentials,
@@ -94,25 +77,26 @@ class Validator(ssz.Serializable):
         From `is_slashable_validator` in the spec.
         """
         not_slashed = self.slashed is False
-        active_but_not_withdrawable = self.activation_epoch <= epoch < self.withdrawable_epoch
+        active_but_not_withdrawable = (
+            self.activation_epoch <= epoch < self.withdrawable_epoch
+        )
         return not_slashed and active_but_not_withdrawable
 
     @classmethod
-    def create_pending_validator(cls,
-                                 pubkey: BLSPubkey,
-                                 withdrawal_credentials: Hash32,
-                                 amount: Gwei,
-                                 config: Eth2Config) -> 'Validator':
+    def create_pending_validator(
+        cls,
+        pubkey: BLSPubkey,
+        withdrawal_credentials: Hash32,
+        amount: Gwei,
+        config: Eth2Config,
+    ) -> "Validator":
         """
         Return a new pending ``Validator`` with the given fields.
         """
         return cls(
             pubkey=pubkey,
             withdrawal_credentials=withdrawal_credentials,
-            effective_balance=calculate_effective_balance(
-                amount,
-                config,
-            ),
+            effective_balance=calculate_effective_balance(amount, config),
             activation_eligibility_epoch=FAR_FUTURE_EPOCH,
             activation_epoch=FAR_FUTURE_EPOCH,
             exit_epoch=FAR_FUTURE_EPOCH,

--- a/eth2/beacon/types/validators.py
+++ b/eth2/beacon/types/validators.py
@@ -2,9 +2,9 @@ from eth_typing import BLSPubkey, Hash32
 import ssz
 from ssz.sedes import boolean, bytes32, bytes48, uint64
 
-from eth2.configs import Eth2Config
 from eth2.beacon.constants import FAR_FUTURE_EPOCH, ZERO_HASH32
 from eth2.beacon.typing import Epoch, Gwei
+from eth2.configs import Eth2Config
 
 from .defaults import default_bls_pubkey, default_epoch, default_gwei
 

--- a/eth2/beacon/types/voluntary_exits.py
+++ b/eth2/beacon/types/voluntary_exits.py
@@ -1,39 +1,26 @@
-from eth_typing import (
-    BLSSignature,
-)
+from eth_typing import BLSSignature
 import ssz
-from ssz.sedes import (
-    bytes96,
-    uint64,
-)
+from ssz.sedes import bytes96, uint64
 
-from eth2.beacon.typing import (
-    Epoch,
-    ValidatorIndex,
-)
+from eth2.beacon.typing import Epoch, ValidatorIndex
 from eth2.beacon.constants import EMPTY_SIGNATURE
 
-from .defaults import (
-    default_validator_index,
-    default_epoch,
-)
+from .defaults import default_validator_index, default_epoch
 
 
 class VoluntaryExit(ssz.SignedSerializable):
 
     fields = [
         # Minimum epoch for processing exit
-        ('epoch', uint64),
-        ('validator_index', uint64),
-        ('signature', bytes96),
+        ("epoch", uint64),
+        ("validator_index", uint64),
+        ("signature", bytes96),
     ]
 
-    def __init__(self,
-                 epoch: Epoch=default_epoch,
-                 validator_index: ValidatorIndex=default_validator_index,
-                 signature: BLSSignature=EMPTY_SIGNATURE) -> None:
-        super().__init__(
-            epoch,
-            validator_index,
-            signature,
-        )
+    def __init__(
+        self,
+        epoch: Epoch = default_epoch,
+        validator_index: ValidatorIndex = default_validator_index,
+        signature: BLSSignature = EMPTY_SIGNATURE,
+    ) -> None:
+        super().__init__(epoch, validator_index, signature)

--- a/eth2/beacon/types/voluntary_exits.py
+++ b/eth2/beacon/types/voluntary_exits.py
@@ -2,10 +2,10 @@ from eth_typing import BLSSignature
 import ssz
 from ssz.sedes import bytes96, uint64
 
-from eth2.beacon.typing import Epoch, ValidatorIndex
 from eth2.beacon.constants import EMPTY_SIGNATURE
+from eth2.beacon.typing import Epoch, ValidatorIndex
 
-from .defaults import default_validator_index, default_epoch
+from .defaults import default_epoch, default_validator_index
 
 
 class VoluntaryExit(ssz.SignedSerializable):

--- a/eth2/beacon/typing.py
+++ b/eth2/beacon/typing.py
@@ -1,28 +1,26 @@
-from typing import (
-    NamedTuple,
-    NewType,
-    Tuple,
-)
+from typing import NamedTuple, NewType, Tuple
 
 
-Slot = NewType('Slot', int)  # uint64
-Epoch = NewType('Epoch', int)  # uint64
-Shard = NewType('Shard', int)  # uint64
+Slot = NewType("Slot", int)  # uint64
+Epoch = NewType("Epoch", int)  # uint64
+Shard = NewType("Shard", int)  # uint64
 
-Bitfield = NewType('Bitfield', Tuple[bool, ...])
+Bitfield = NewType("Bitfield", Tuple[bool, ...])
 
 
-ValidatorIndex = NewType('ValidatorIndex', int)  # uint64
-CommitteeIndex = NewType('CommitteeIndex', int)  # uint64 The i-th position in a committee tuple
+ValidatorIndex = NewType("ValidatorIndex", int)  # uint64
+CommitteeIndex = NewType(
+    "CommitteeIndex", int
+)  # uint64 The i-th position in a committee tuple
 
-Gwei = NewType('Gwei', int)  # uint64
+Gwei = NewType("Gwei", int)  # uint64
 
-Timestamp = NewType('Timestamp', int)
-Second = NewType('Second', int)
+Timestamp = NewType("Timestamp", int)
+Second = NewType("Second", int)
 
-Version = NewType('Version', bytes)
+Version = NewType("Version", bytes)
 
-DomainType = NewType('DomainType', bytes)  # bytes of length 4
+DomainType = NewType("DomainType", bytes)  # bytes of length 4
 
 
 class FromBlockParams(NamedTuple):
@@ -38,4 +36,4 @@ default_gwei = Gwei(0)
 default_timestamp = Timestamp(0)
 default_second = Second(0)
 default_bitfield = Bitfield(tuple())
-default_version = Version(b'\x00' * 4)
+default_version = Version(b"\x00" * 4)

--- a/eth2/beacon/typing.py
+++ b/eth2/beacon/typing.py
@@ -1,6 +1,5 @@
 from typing import NamedTuple, NewType, Tuple
 
-
 Slot = NewType("Slot", int)  # uint64
 Epoch = NewType("Epoch", int)  # uint64
 Shard = NewType("Shard", int)  # uint64

--- a/eth2/beacon/validator_status_helpers.py
+++ b/eth2/beacon/validator_status_helpers.py
@@ -1,17 +1,8 @@
-from eth_utils.toolz import (
-    curry,
-)
+from eth_utils.toolz import curry
 
-from eth2._utils.tuple import (
-    update_tuple_item_with_fn,
-)
-from eth2.configs import (
-    CommitteeConfig,
-    Eth2Config,
-)
-from eth2.beacon.committee_helpers import (
-    get_beacon_proposer_index,
-)
+from eth2._utils.tuple import update_tuple_item_with_fn
+from eth2.configs import CommitteeConfig, Eth2Config
+from eth2.beacon.committee_helpers import get_beacon_proposer_index
 from eth2.beacon.constants import FAR_FUTURE_EPOCH
 from eth2.beacon.epoch_processing_helpers import (
     decrease_balance,
@@ -21,37 +12,34 @@ from eth2.beacon.epoch_processing_helpers import (
 )
 from eth2.beacon.types.states import BeaconState
 from eth2.beacon.types.validators import Validator
-from eth2.beacon.typing import (
-    Epoch,
-    Gwei,
-    ValidatorIndex,
-)
+from eth2.beacon.typing import Epoch, Gwei, ValidatorIndex
 
 
 def activate_validator(validator: Validator, activation_epoch: Epoch) -> Validator:
     return validator.copy(
-        activation_eligibility_epoch=activation_epoch,
-        activation_epoch=activation_epoch,
+        activation_eligibility_epoch=activation_epoch, activation_epoch=activation_epoch
     )
 
 
-def _compute_exit_queue_epoch(state: BeaconState, churn_limit: int, config: Eth2Config) -> Epoch:
+def _compute_exit_queue_epoch(
+    state: BeaconState, churn_limit: int, config: Eth2Config
+) -> Epoch:
     slots_per_epoch = config.SLOTS_PER_EPOCH
 
     exit_epochs = tuple(
-        v.exit_epoch for v in state.validators
-        if v.exit_epoch != FAR_FUTURE_EPOCH
+        v.exit_epoch for v in state.validators if v.exit_epoch != FAR_FUTURE_EPOCH
     )
     exit_queue_epoch = max(
-        exit_epochs + (compute_activation_exit_epoch(
-            state.current_epoch(slots_per_epoch),
-            config.ACTIVATION_EXIT_DELAY,
-        ),)
+        exit_epochs
+        + (
+            compute_activation_exit_epoch(
+                state.current_epoch(slots_per_epoch), config.ACTIVATION_EXIT_DELAY
+            ),
+        )
     )
-    exit_queue_churn = len(tuple(
-        v for v in state.validators
-        if v.exit_epoch == exit_queue_epoch
-    ))
+    exit_queue_churn = len(
+        tuple(v for v in state.validators if v.exit_epoch == exit_queue_epoch)
+    )
     if exit_queue_churn >= churn_limit:
         exit_queue_epoch += 1
     return Epoch(exit_queue_epoch)
@@ -59,9 +47,9 @@ def _compute_exit_queue_epoch(state: BeaconState, churn_limit: int, config: Eth2
 
 # NOTE: adding ``curry`` here gets mypy to allow use of this elsewhere.
 @curry
-def initiate_exit_for_validator(validator: Validator,
-                                state: BeaconState,
-                                config: Eth2Config) -> Validator:
+def initiate_exit_for_validator(
+    validator: Validator, state: BeaconState, config: Eth2Config
+) -> Validator:
     """
     Performs the mutations to ``validator`` used to initiate an exit.
     More convenient given our immutability patterns compared to ``initiate_validator_exit``.
@@ -74,42 +62,42 @@ def initiate_exit_for_validator(validator: Validator,
 
     return validator.copy(
         exit_epoch=exit_queue_epoch,
-        withdrawable_epoch=Epoch(exit_queue_epoch + config.MIN_VALIDATOR_WITHDRAWABILITY_DELAY),
+        withdrawable_epoch=Epoch(
+            exit_queue_epoch + config.MIN_VALIDATOR_WITHDRAWABILITY_DELAY
+        ),
     )
 
 
-def initiate_validator_exit(state: BeaconState,
-                            index: ValidatorIndex,
-                            config: Eth2Config) -> BeaconState:
+def initiate_validator_exit(
+    state: BeaconState, index: ValidatorIndex, config: Eth2Config
+) -> BeaconState:
     """
     Initiate exit for the validator with the given ``index``.
     Return the updated state (immutable).
     """
     return state.update_validator_with_fn(
-        index,
-        initiate_exit_for_validator,
-        state,
-        config,
+        index, initiate_exit_for_validator, state, config
     )
 
 
 @curry
-def _set_validator_slashed(v: Validator,
-                           current_epoch: Epoch,
-                           epochs_per_slashings_vector: int) -> Validator:
+def _set_validator_slashed(
+    v: Validator, current_epoch: Epoch, epochs_per_slashings_vector: int
+) -> Validator:
     return v.copy(
         slashed=True,
         withdrawable_epoch=max(
-            v.withdrawable_epoch,
-            Epoch(current_epoch + epochs_per_slashings_vector),
+            v.withdrawable_epoch, Epoch(current_epoch + epochs_per_slashings_vector)
         ),
     )
 
 
-def slash_validator(state: BeaconState,
-                    index: ValidatorIndex,
-                    config: Eth2Config,
-                    whistleblower_index: ValidatorIndex=None) -> BeaconState:
+def slash_validator(
+    state: BeaconState,
+    index: ValidatorIndex,
+    config: Eth2Config,
+    whistleblower_index: ValidatorIndex = None,
+) -> BeaconState:
     """
     Slash the validator with index ``index``.
 
@@ -124,10 +112,7 @@ def slash_validator(state: BeaconState,
 
     state = initiate_validator_exit(state, index, config)
     state = state.update_validator_with_fn(
-        index,
-        _set_validator_slashed,
-        current_epoch,
-        config.EPOCHS_PER_SLASHINGS_VECTOR,
+        index, _set_validator_slashed, current_epoch, config.EPOCHS_PER_SLASHINGS_VECTOR
     )
 
     slashed_balance = state.validators[index].effective_balance
@@ -140,7 +125,9 @@ def slash_validator(state: BeaconState,
             slashed_balance,
         )
     )
-    state = decrease_balance(state, index, slashed_balance // config.MIN_SLASHING_PENALTY_QUOTIENT)
+    state = decrease_balance(
+        state, index, slashed_balance // config.MIN_SLASHING_PENALTY_QUOTIENT
+    )
 
     proposer_index = get_beacon_proposer_index(state, CommitteeConfig(config))
     if whistleblower_index is None:
@@ -149,9 +136,7 @@ def slash_validator(state: BeaconState,
     proposer_reward = Gwei(whistleblower_reward // config.PROPOSER_REWARD_QUOTIENT)
     state = increase_balance(state, proposer_index, proposer_reward)
     state = increase_balance(
-        state,
-        whistleblower_index,
-        Gwei(whistleblower_reward - proposer_reward),
+        state, whistleblower_index, Gwei(whistleblower_reward - proposer_reward)
     )
 
     return state

--- a/eth2/beacon/validator_status_helpers.py
+++ b/eth2/beacon/validator_status_helpers.py
@@ -1,18 +1,18 @@
 from eth_utils.toolz import curry
 
 from eth2._utils.tuple import update_tuple_item_with_fn
-from eth2.configs import CommitteeConfig, Eth2Config
 from eth2.beacon.committee_helpers import get_beacon_proposer_index
 from eth2.beacon.constants import FAR_FUTURE_EPOCH
 from eth2.beacon.epoch_processing_helpers import (
+    compute_activation_exit_epoch,
     decrease_balance,
     get_validator_churn_limit,
-    compute_activation_exit_epoch,
     increase_balance,
 )
 from eth2.beacon.types.states import BeaconState
 from eth2.beacon.types.validators import Validator
 from eth2.beacon.typing import Epoch, Gwei, ValidatorIndex
+from eth2.configs import CommitteeConfig, Eth2Config
 
 
 def activate_validator(validator: Validator, activation_epoch: Epoch) -> Validator:

--- a/eth2/configs.py
+++ b/eth2/configs.py
@@ -1,70 +1,63 @@
-from typing import (
-    NamedTuple,
-)
+from typing import NamedTuple
 
-from eth2.beacon.typing import (
-    Epoch,
-    Gwei,
-    Second,
-    Slot,
-)
+from eth2.beacon.typing import Epoch, Gwei, Second, Slot
 
 
 Eth2Config = NamedTuple(
-    'Eth2Config',
+    "Eth2Config",
     (
         # Misc
-        ('SHARD_COUNT', int),
-        ('TARGET_COMMITTEE_SIZE', int),
-        ('MAX_VALIDATORS_PER_COMMITTEE', int),
-        ('MIN_PER_EPOCH_CHURN_LIMIT', int),
-        ('CHURN_LIMIT_QUOTIENT', int),
-        ('SHUFFLE_ROUND_COUNT', int),
+        ("SHARD_COUNT", int),
+        ("TARGET_COMMITTEE_SIZE", int),
+        ("MAX_VALIDATORS_PER_COMMITTEE", int),
+        ("MIN_PER_EPOCH_CHURN_LIMIT", int),
+        ("CHURN_LIMIT_QUOTIENT", int),
+        ("SHUFFLE_ROUND_COUNT", int),
         # Genesis
-        ('MIN_GENESIS_ACTIVE_VALIDATOR_COUNT', int),
-        ('MIN_GENESIS_TIME', int),
+        ("MIN_GENESIS_ACTIVE_VALIDATOR_COUNT", int),
+        ("MIN_GENESIS_TIME", int),
         # Gwei values,
-        ('MIN_DEPOSIT_AMOUNT', Gwei),
-        ('MAX_EFFECTIVE_BALANCE', Gwei),
-        ('EJECTION_BALANCE', Gwei),
-        ('EFFECTIVE_BALANCE_INCREMENT', Gwei),
+        ("MIN_DEPOSIT_AMOUNT", Gwei),
+        ("MAX_EFFECTIVE_BALANCE", Gwei),
+        ("EJECTION_BALANCE", Gwei),
+        ("EFFECTIVE_BALANCE_INCREMENT", Gwei),
         # Initial values
-        ('GENESIS_SLOT', Slot),
-        ('GENESIS_EPOCH', Epoch),
-        ('BLS_WITHDRAWAL_PREFIX', int),
+        ("GENESIS_SLOT", Slot),
+        ("GENESIS_EPOCH", Epoch),
+        ("BLS_WITHDRAWAL_PREFIX", int),
         # Time parameters
-        ('SECONDS_PER_SLOT', Second),
-        ('MIN_ATTESTATION_INCLUSION_DELAY', int),
-        ('SLOTS_PER_EPOCH', int),
-        ('MIN_SEED_LOOKAHEAD', int),
-        ('ACTIVATION_EXIT_DELAY', int),
-        ('SLOTS_PER_ETH1_VOTING_PERIOD', int),
-        ('SLOTS_PER_HISTORICAL_ROOT', int),
-        ('MIN_VALIDATOR_WITHDRAWABILITY_DELAY', int),
-        ('PERSISTENT_COMMITTEE_PERIOD', int),
-        ('MAX_EPOCHS_PER_CROSSLINK', int),
-        ('MIN_EPOCHS_TO_INACTIVITY_PENALTY', int),
+        ("SECONDS_PER_SLOT", Second),
+        ("MIN_ATTESTATION_INCLUSION_DELAY", int),
+        ("SLOTS_PER_EPOCH", int),
+        ("MIN_SEED_LOOKAHEAD", int),
+        ("ACTIVATION_EXIT_DELAY", int),
+        ("SLOTS_PER_ETH1_VOTING_PERIOD", int),
+        ("SLOTS_PER_HISTORICAL_ROOT", int),
+        ("MIN_VALIDATOR_WITHDRAWABILITY_DELAY", int),
+        ("PERSISTENT_COMMITTEE_PERIOD", int),
+        ("MAX_EPOCHS_PER_CROSSLINK", int),
+        ("MIN_EPOCHS_TO_INACTIVITY_PENALTY", int),
         # State list lengths
-        ('EPOCHS_PER_HISTORICAL_VECTOR', int),
-        ('EPOCHS_PER_SLASHINGS_VECTOR', int),
-        ('HISTORICAL_ROOTS_LIMIT', int),
-        ('VALIDATOR_REGISTRY_LIMIT', int),
+        ("EPOCHS_PER_HISTORICAL_VECTOR", int),
+        ("EPOCHS_PER_SLASHINGS_VECTOR", int),
+        ("HISTORICAL_ROOTS_LIMIT", int),
+        ("VALIDATOR_REGISTRY_LIMIT", int),
         # Rewards and penalties
-        ('BASE_REWARD_FACTOR', int),
-        ('WHISTLEBLOWER_REWARD_QUOTIENT', int),
-        ('PROPOSER_REWARD_QUOTIENT', int),
-        ('INACTIVITY_PENALTY_QUOTIENT', int),
-        ('MIN_SLASHING_PENALTY_QUOTIENT', int),
+        ("BASE_REWARD_FACTOR", int),
+        ("WHISTLEBLOWER_REWARD_QUOTIENT", int),
+        ("PROPOSER_REWARD_QUOTIENT", int),
+        ("INACTIVITY_PENALTY_QUOTIENT", int),
+        ("MIN_SLASHING_PENALTY_QUOTIENT", int),
         # Max operations per block
-        ('MAX_PROPOSER_SLASHINGS', int),
-        ('MAX_ATTESTER_SLASHINGS', int),
-        ('MAX_ATTESTATIONS', int),
-        ('MAX_DEPOSITS', int),
-        ('MAX_VOLUNTARY_EXITS', int),
-        ('MAX_TRANSFERS', int),
+        ("MAX_PROPOSER_SLASHINGS", int),
+        ("MAX_ATTESTER_SLASHINGS", int),
+        ("MAX_ATTESTATIONS", int),
+        ("MAX_DEPOSITS", int),
+        ("MAX_VOLUNTARY_EXITS", int),
+        ("MAX_TRANSFERS", int),
         # Deposit contract
-        ('DEPOSIT_CONTRACT_ADDRESS', bytes),
-    )
+        ("DEPOSIT_CONTRACT_ADDRESS", bytes),
+    ),
 )
 
 

--- a/eth2/configs.py
+++ b/eth2/configs.py
@@ -2,7 +2,6 @@ from typing import NamedTuple
 
 from eth2.beacon.typing import Epoch, Gwei, Second, Slot
 
-
 Eth2Config = NamedTuple(
     "Eth2Config",
     (

--- a/setup.py
+++ b/setup.py
@@ -114,6 +114,10 @@ deps = {
         "milagro-bls-binding==0.1.3",
         "blspy>=0.1.8,<1",  # for `bls_chia`
     ],
+    'eth2-lint': [
+        "black==19.3b0",
+        "isort==4.3.21",
+    ],
 }
 
 # NOTE: Snappy breaks RTD builds. Until we have a more mature solution
@@ -129,7 +133,8 @@ deps['dev'] = (
     deps['test'] +
     deps['doc'] +
     deps['lint'] +
-    deps['eth2']
+    deps['eth2'] +
+    deps['eth2-lint']
 )
 
 

--- a/tests/eth2/conftest.py
+++ b/tests/eth2/conftest.py
@@ -5,9 +5,7 @@ import eth_utils.toolz as toolz
 import pytest
 
 from eth2._utils.bls import bls
-from eth2._utils.hash import (
-    hash_eth2,
-)
+from eth2._utils.hash import hash_eth2
 
 
 def _serialize_bls_pubkeys(key):
@@ -24,10 +22,7 @@ def _deserialize_bls_pubkey(key_data):
 
 def _deserialize_pair(pair):
     index, pubkey = pair
-    return (
-        int(index),
-        _deserialize_bls_pubkey(pubkey),
-    )
+    return (int(index), _deserialize_bls_pubkey(pubkey))
 
 
 class privkey_view:
@@ -47,10 +42,7 @@ class pubkey_view:
 
     def __getitem__(self, index):
         if isinstance(index, slice):
-            return list(
-                self.key_cache._get_pubkey_at(i)
-                for i in range(index.stop)
-            )
+            return list(self.key_cache._get_pubkey_at(i) for i in range(index.stop))
         return self.key_cache._get_pubkey_at(index)
 
 
@@ -69,8 +61,7 @@ class BLSKeyCache:
 
     def _restore_from_cache(self, cached_data):
         self.all_pubkeys_by_index = toolz.itemmap(
-            _deserialize_pair,
-            cached_data["pubkeys_by_index"],
+            _deserialize_pair, cached_data["pubkeys_by_index"]
         )
         for index, pubkey in self.all_pubkeys_by_index.items():
             privkey = self._get_privkey_for(index)
@@ -86,9 +77,8 @@ class BLSKeyCache:
         """
         return {
             "pubkeys_by_index": toolz.valmap(
-                _serialize_bls_pubkeys,
-                self.all_pubkeys_by_index,
-            ),
+                _serialize_bls_pubkeys, self.all_pubkeys_by_index
+            )
         }
 
     def _privkey_view(self):
@@ -113,7 +103,9 @@ class BLSKeyCache:
 
     def _get_privkey_for(self, index):
         # Want privkey an intger slightly less than the curve order
-        privkey = int.from_bytes(hash_eth2(index.to_bytes(32, 'little')), 'little') % 2**254
+        privkey = (
+            int.from_bytes(hash_eth2(index.to_bytes(32, "little")), "little") % 2 ** 254
+        )
         self.all_privkeys_by_index[index] = privkey
         return privkey
 
@@ -173,14 +165,8 @@ def _key_cache(request, _should_persist_bls_keys):
     cache_key = f"eth2/bls/key-cache/{bls.backend.__name__}"
 
     if _should_persist_bls_keys:
-        backing_cache_reader = functools.partial(
-            request.config.cache.get,
-            cache_key,
-        )
-        backing_cache_writer = functools.partial(
-            request.config.cache.set,
-            cache_key,
-        )
+        backing_cache_reader = functools.partial(request.config.cache.get, cache_key)
+        backing_cache_writer = functools.partial(request.config.cache.set, cache_key)
     else:
         backing_cache_reader = None
         backing_cache_writer = None

--- a/tests/eth2/conftest.py
+++ b/tests/eth2/conftest.py
@@ -1,7 +1,6 @@
 import functools
 
 import eth_utils.toolz as toolz
-
 import pytest
 
 from eth2._utils.bls import bls

--- a/tests/eth2/core/beacon/chains/conftest.py
+++ b/tests/eth2/core/beacon/chains/conftest.py
@@ -1,17 +1,16 @@
 import pytest
 
-from eth2.beacon.chains.base import (
-    BeaconChain,
-)
+from eth2.beacon.chains.base import BeaconChain
 
 
 def _beacon_chain_with_block_validation(
-        base_db,
-        genesis_block,
-        genesis_state,
-        fixture_sm_class,
-        config,
-        chain_cls=BeaconChain):
+    base_db,
+    genesis_block,
+    genesis_state,
+    fixture_sm_class,
+    config,
+    chain_cls=BeaconChain,
+):
     """
     Return a Chain object containing just the genesis block.
 
@@ -25,34 +24,21 @@ def _beacon_chain_with_block_validation(
     """
 
     klass = chain_cls.configure(
-        __name__='TestChain',
-        sm_configuration=(
-            (genesis_state.slot, fixture_sm_class),
-        ),
+        __name__="TestChain",
+        sm_configuration=((genesis_state.slot, fixture_sm_class),),
         chain_id=5566,
     )
 
-    chain = klass.from_genesis(
-        base_db,
-        genesis_state,
-        genesis_block,
-        config,
-    )
+    chain = klass.from_genesis(base_db, genesis_state, genesis_block, config)
     return chain
 
 
 @pytest.fixture
-def beacon_chain_with_block_validation(base_db,
-                                       genesis_block,
-                                       genesis_state,
-                                       fixture_sm_class,
-                                       config):
+def beacon_chain_with_block_validation(
+    base_db, genesis_block, genesis_state, fixture_sm_class, config
+):
     return _beacon_chain_with_block_validation(
-        base_db,
-        genesis_block,
-        genesis_state,
-        fixture_sm_class,
-        config,
+        base_db, genesis_block, genesis_state, fixture_sm_class, config
     )
 
 
@@ -62,11 +48,8 @@ def import_block_without_validation(chain, block):
 
 @pytest.fixture(params=[BeaconChain])
 def beacon_chain_without_block_validation(
-        request,
-        base_db,
-        genesis_state,
-        genesis_block,
-        fixture_sm_class):
+    request, base_db, genesis_state, genesis_block, fixture_sm_class
+):
     """
     Return a Chain object containing just the genesis block.
 
@@ -77,22 +60,14 @@ def beacon_chain_without_block_validation(
     chain itself.
     """
     # Disable block validation so that we don't need to construct finalized blocks.
-    overrides = {
-        'import_block': import_block_without_validation,
-    }
+    overrides = {"import_block": import_block_without_validation}
     chain_class = request.param
     klass = chain_class.configure(
-        __name__='TestChainWithoutBlockValidation',
-        sm_configuration=(
-            (0, fixture_sm_class),
-        ),
+        __name__="TestChainWithoutBlockValidation",
+        sm_configuration=((0, fixture_sm_class),),
         chain_id=5566,
         **overrides,
     )
 
-    chain = klass.from_genesis(
-        base_db,
-        genesis_state,
-        genesis_block,
-    )
+    chain = klass.from_genesis(base_db, genesis_state, genesis_block)
     return chain

--- a/tests/eth2/core/beacon/chains/test_beacon_chain.py
+++ b/tests/eth2/core/beacon/chains/test_beacon_chain.py
@@ -3,29 +3,13 @@ import copy
 import pytest
 
 
-from eth2.beacon.exceptions import (
-    BlockClassError,
-)
-from eth2.beacon.chains.base import (
-    BeaconChain,
-)
-from eth2.beacon.db.exceptions import (
-    AttestationRootNotFound,
-    StateSlotNotFound,
-)
-from eth2.beacon.types.blocks import (
-    BeaconBlock,
-)
-from eth2.beacon.tools.builder.proposer import (
-    create_mock_block,
-
-)
-from eth2.beacon.tools.builder.validator import (
-    create_mock_signed_attestations_at_slot,
-)
-from eth2.beacon.state_machines.forks.serenity.blocks import (
-    SerenityBeaconBlock,
-)
+from eth2.beacon.exceptions import BlockClassError
+from eth2.beacon.chains.base import BeaconChain
+from eth2.beacon.db.exceptions import AttestationRootNotFound, StateSlotNotFound
+from eth2.beacon.types.blocks import BeaconBlock
+from eth2.beacon.tools.builder.proposer import create_mock_block
+from eth2.beacon.tools.builder.validator import create_mock_signed_attestations_at_slot
+from eth2.beacon.state_machines.forks.serenity.blocks import SerenityBeaconBlock
 
 
 @pytest.fixture
@@ -39,12 +23,8 @@ def valid_chain(beacon_chain_with_block_validation):
 
 
 @pytest.mark.parametrize(
-    (
-        'validator_count,slots_per_epoch,target_committee_size,shard_count'
-    ),
-    [
-        (100, 20, 10, 20),
-    ]
+    ("validator_count,slots_per_epoch,target_committee_size,shard_count"),
+    [(100, 20, 10, 20)],
 )
 def test_canonical_chain(valid_chain, genesis_slot, fork_choice_scoring):
     genesis_block = valid_chain.get_canonical_block_by_slot(genesis_slot)
@@ -56,8 +36,7 @@ def test_canonical_chain(valid_chain, genesis_slot, fork_choice_scoring):
     assert valid_chain.get_score(genesis_block.signing_root) == 0
 
     block = genesis_block.copy(
-        slot=genesis_block.slot + 1,
-        parent_root=genesis_block.signing_root,
+        slot=genesis_block.slot + 1, parent_root=genesis_block.signing_root
     )
     valid_chain.chaindb.persist_block(block, block.__class__, fork_choice_scoring)
 
@@ -68,9 +47,7 @@ def test_canonical_chain(valid_chain, genesis_slot, fork_choice_scoring):
     assert valid_chain.get_score(block.signing_root) == scoring_fn(block)
     assert scoring_fn(block) != 0
 
-    canonical_block_1 = valid_chain.get_canonical_block_by_slot(
-        genesis_block.slot + 1,
-    )
+    canonical_block_1 = valid_chain.get_canonical_block_by_slot(genesis_block.slot + 1)
     assert canonical_block_1 == block
 
     result_block = valid_chain.get_block_by_root(block.signing_root)
@@ -78,35 +55,24 @@ def test_canonical_chain(valid_chain, genesis_slot, fork_choice_scoring):
 
 
 @pytest.mark.parametrize(
-    (
-        'validator_count,'
-        'slots_per_epoch,'
-        'target_committee_size,'
-        'shard_count,'
-    ),
-    [
-        (100, 16, 10, 16),
-    ]
+    ("validator_count," "slots_per_epoch," "target_committee_size," "shard_count,"),
+    [(100, 16, 10, 16)],
 )
-def test_get_state_by_slot(valid_chain,
-                           genesis_block,
-                           genesis_state,
-                           config,
-                           keymap):
+def test_get_state_by_slot(valid_chain, genesis_block, genesis_state, config, keymap):
     # Fisrt, skip block and check if `get_state_by_slot` returns the expected state
     state_machine = valid_chain.get_state_machine(genesis_block.slot)
     state = state_machine.state
     block_skipped_slot = genesis_block.slot + 1
     block_skipped_state = state_machine.state_transition.apply_state_transition(
-        state,
-        future_slot=block_skipped_slot,
+        state, future_slot=block_skipped_slot
     )
     with pytest.raises(StateSlotNotFound):
         valid_chain.get_state_by_slot(block_skipped_slot)
     valid_chain.chaindb.persist_state(block_skipped_state)
-    assert valid_chain.get_state_by_slot(
-        block_skipped_slot
-    ).hash_tree_root == block_skipped_state.hash_tree_root
+    assert (
+        valid_chain.get_state_by_slot(block_skipped_slot).hash_tree_root
+        == block_skipped_state.hash_tree_root
+    )
 
     # Next, import proposed block and check if `get_state_by_slot` returns the expected state
     proposed_slot = block_skipped_slot + 1
@@ -122,23 +88,18 @@ def test_get_state_by_slot(valid_chain,
     )
     valid_chain.import_block(block)
     state = valid_chain.get_state_machine().state
-    assert valid_chain.get_state_by_slot(proposed_slot).hash_tree_root == state.hash_tree_root
+    assert (
+        valid_chain.get_state_by_slot(proposed_slot).hash_tree_root
+        == state.hash_tree_root
+    )
 
 
 @pytest.mark.long
 @pytest.mark.parametrize(
-    (
-        'validator_count,slots_per_epoch,target_committee_size,shard_count'
-    ),
-    [
-        (100, 16, 10, 16),
-    ]
+    ("validator_count,slots_per_epoch,target_committee_size,shard_count"),
+    [(100, 16, 10, 16)],
 )
-def test_import_blocks(valid_chain,
-                       genesis_block,
-                       genesis_state,
-                       config,
-                       keymap):
+def test_import_blocks(valid_chain, genesis_block, genesis_state, config, keymap):
     state = genesis_state
     blocks = (genesis_block,)
     valid_chain_2 = copy.deepcopy(valid_chain)
@@ -158,12 +119,8 @@ def test_import_blocks(valid_chain,
 
         state = valid_chain.get_state_by_slot(block.slot)
 
-        assert block == valid_chain.get_canonical_block_by_slot(
-            block.slot
-        )
-        assert block.signing_root == valid_chain.get_canonical_block_root(
-            block.slot
-        )
+        assert block == valid_chain.get_canonical_block_by_slot(block.slot)
+        assert block.signing_root == valid_chain.get_canonical_block_root(block.slot)
         blocks += (block,)
 
     assert valid_chain.get_canonical_head() != valid_chain_2.get_canonical_head()
@@ -173,23 +130,14 @@ def test_import_blocks(valid_chain,
 
     assert valid_chain.get_canonical_head() == valid_chain_2.get_canonical_head()
     assert valid_chain.get_state_by_slot(blocks[-1].slot).slot != 0
-    assert (
-        valid_chain.get_state_by_slot(blocks[-1].slot) ==
-        valid_chain_2.get_state_by_slot(blocks[-1].slot)
-    )
+    assert valid_chain.get_state_by_slot(
+        blocks[-1].slot
+    ) == valid_chain_2.get_state_by_slot(blocks[-1].slot)
 
 
-def test_from_genesis(base_db,
-                      genesis_block,
-                      genesis_state,
-                      fixture_sm_class,
-                      config):
+def test_from_genesis(base_db, genesis_block, genesis_state, fixture_sm_class, config):
     klass = BeaconChain.configure(
-        __name__='TestChain',
-        sm_configuration=(
-            (0, fixture_sm_class),
-        ),
-        chain_id=5566,
+        __name__="TestChain", sm_configuration=((0, fixture_sm_class),), chain_id=5566
     )
 
     assert type(genesis_block) == SerenityBeaconBlock
@@ -197,33 +145,28 @@ def test_from_genesis(base_db,
     assert type(block) == BeaconBlock
 
     with pytest.raises(BlockClassError):
-        klass.from_genesis(
-            base_db,
-            genesis_state,
-            block,
-            config,
-        )
+        klass.from_genesis(base_db, genesis_state, block, config)
 
 
 @pytest.mark.long
 @pytest.mark.parametrize(
     (
-        'validator_count,'
-        'slots_per_epoch,'
-        'target_committee_size,'
-        'shard_count,'
-        'min_attestation_inclusion_delay,'
+        "validator_count,"
+        "slots_per_epoch,"
+        "target_committee_size,"
+        "shard_count,"
+        "min_attestation_inclusion_delay,"
     ),
-    [
-        (100, 16, 10, 16, 0),
-    ]
+    [(100, 16, 10, 16, 0)],
 )
-def test_get_attestation_root(valid_chain,
-                              genesis_block,
-                              genesis_state,
-                              config,
-                              keymap,
-                              min_attestation_inclusion_delay):
+def test_get_attestation_root(
+    valid_chain,
+    genesis_block,
+    genesis_state,
+    config,
+    keymap,
+    min_attestation_inclusion_delay,
+):
     state_machine = valid_chain.get_state_machine()
     attestations = create_mock_signed_attestations_at_slot(
         state=genesis_state,
@@ -248,9 +191,7 @@ def test_get_attestation_root(valid_chain,
     a0 = attestations[0]
     assert valid_chain.get_attestation_by_root(a0.hash_tree_root) == a0
     assert valid_chain.attestation_exists(a0.hash_tree_root)
-    fake_attestation = a0.copy(
-        signature=b'\x78' * 96,
-    )
+    fake_attestation = a0.copy(signature=b"\x78" * 96)
     with pytest.raises(AttestationRootNotFound):
         valid_chain.get_attestation_by_root(fake_attestation.hash_tree_root)
     assert not valid_chain.attestation_exists(fake_attestation.hash_tree_root)

--- a/tests/eth2/core/beacon/chains/test_beacon_chain.py
+++ b/tests/eth2/core/beacon/chains/test_beacon_chain.py
@@ -2,14 +2,13 @@ import copy
 
 import pytest
 
-
-from eth2.beacon.exceptions import BlockClassError
 from eth2.beacon.chains.base import BeaconChain
 from eth2.beacon.db.exceptions import AttestationRootNotFound, StateSlotNotFound
-from eth2.beacon.types.blocks import BeaconBlock
+from eth2.beacon.exceptions import BlockClassError
+from eth2.beacon.state_machines.forks.serenity.blocks import SerenityBeaconBlock
 from eth2.beacon.tools.builder.proposer import create_mock_block
 from eth2.beacon.tools.builder.validator import create_mock_signed_attestations_at_slot
-from eth2.beacon.state_machines.forks.serenity.blocks import SerenityBeaconBlock
+from eth2.beacon.types.blocks import BeaconBlock
 
 
 @pytest.fixture

--- a/tests/eth2/core/beacon/chains/test_chains.py
+++ b/tests/eth2/core/beacon/chains/test_chains.py
@@ -2,15 +2,7 @@ import pytest
 from eth2.beacon.chains.testnet import TestnetChain as _TestnetChain
 
 
-@pytest.mark.parametrize(
-    "chain_klass",
-    (
-        _TestnetChain,
-    )
-)
-def test_chain_class_well_defined(base_db,
-                                  chain_klass,
-                                  empty_attestation_pool,
-                                  config):
+@pytest.mark.parametrize("chain_klass", (_TestnetChain,))
+def test_chain_class_well_defined(base_db, chain_klass, empty_attestation_pool, config):
     chain = chain_klass(base_db, empty_attestation_pool, config)
     assert chain.sm_configuration is not () and chain.sm_configuration is not None

--- a/tests/eth2/core/beacon/chains/test_chains.py
+++ b/tests/eth2/core/beacon/chains/test_chains.py
@@ -1,4 +1,5 @@
 import pytest
+
 from eth2.beacon.chains.testnet import TestnetChain as _TestnetChain
 
 

--- a/tests/eth2/core/beacon/conftest.py
+++ b/tests/eth2/core/beacon/conftest.py
@@ -1,26 +1,16 @@
 import pytest
 
-from eth.constants import (
-    ZERO_HASH32,
-)
-from eth_typing import (
-    BLSPubkey,
-)
+from eth.constants import ZERO_HASH32
+from eth_typing import BLSPubkey
 
-from eth2.configs import (
-    Eth2Config,
-    CommitteeConfig,
-    Eth2GenesisConfig,
-)
+from eth2.configs import Eth2Config, CommitteeConfig, Eth2GenesisConfig
 from eth2.beacon.constants import (
     DEPOSIT_CONTRACT_TREE_DEPTH,
     FAR_FUTURE_EPOCH,
     GWEI_PER_ETH,
     JUSTIFICATION_BITS_LENGTH,
 )
-from eth2.beacon.fork_choice.higher_slot import (
-    higher_slot_scoring,
-)
+from eth2.beacon.fork_choice.higher_slot import higher_slot_scoring
 from eth2.beacon.operations.attestation_pool import AttestationPool
 from eth2.beacon.types.attestations import IndexedAttestation
 from eth2.beacon.types.attestation_data import AttestationData
@@ -31,43 +21,19 @@ from eth2.beacon.types.deposit_data import DepositData
 from eth2.beacon.types.eth1_data import Eth1Data
 from eth2.beacon.types.states import BeaconState
 
-from eth2.beacon.genesis import (
-    get_genesis_block,
-)
-from eth2.beacon.tools.misc.ssz_vector import (
-    override_lengths,
-)
-from eth2.beacon.tools.builder.state import (
-    create_mock_genesis_state_from_validators,
-)
-from eth2.beacon.types.blocks import (
-    BeaconBlockBody,
-    BeaconBlockHeader,
-)
-from eth2.beacon.types.forks import (
-    Fork,
-)
-from eth2.beacon.typing import (
-    Gwei,
-    ValidatorIndex,
-    Timestamp,
-    Version,
-)
-from eth2.beacon.state_machines.forks.serenity import (
-    SerenityStateMachine,
-)
-from eth2.beacon.state_machines.forks.serenity.blocks import (
-    SerenityBeaconBlock,
-)
+from eth2.beacon.genesis import get_genesis_block
+from eth2.beacon.tools.misc.ssz_vector import override_lengths
+from eth2.beacon.tools.builder.state import create_mock_genesis_state_from_validators
+from eth2.beacon.types.blocks import BeaconBlockBody, BeaconBlockHeader
+from eth2.beacon.types.forks import Fork
+from eth2.beacon.typing import Gwei, ValidatorIndex, Timestamp, Version
+from eth2.beacon.state_machines.forks.serenity import SerenityStateMachine
+from eth2.beacon.state_machines.forks.serenity.blocks import SerenityBeaconBlock
 from eth2.beacon.state_machines.forks.serenity.configs import SERENITY_CONFIG
 
-from eth2.beacon.tools.builder.initializer import (
-    create_mock_validator,
-)
+from eth2.beacon.tools.builder.initializer import create_mock_validator
 
-from eth2.beacon.db.chain import (
-    BeaconChainDB,
-)
+from eth2.beacon.db.chain import BeaconChainDB
 
 
 # SSZ
@@ -295,48 +261,50 @@ def deposit_contract_address():
 
 
 @pytest.fixture
-def config(shard_count,
-           target_committee_size,
-           max_validators_per_committee,
-           min_per_epoch_churn_limit,
-           churn_limit_quotient,
-           shuffle_round_count,
-           min_genesis_active_validator_count,
-           min_genesis_time,
-           min_deposit_amount,
-           max_effective_balance,
-           ejection_balance,
-           effective_balance_increment,
-           genesis_slot,
-           genesis_epoch,
-           bls_withdrawal_prefix,
-           seconds_per_slot,
-           min_attestation_inclusion_delay,
-           slots_per_epoch,
-           min_seed_lookahead,
-           activation_exit_delay,
-           slots_per_eth1_voting_period,
-           slots_per_historical_root,
-           min_validator_withdrawability_delay,
-           persistent_committee_period,
-           max_epochs_per_crosslink,
-           min_epochs_to_inactivity_penalty,
-           epochs_per_historical_vector,
-           epochs_per_slashings_vector,
-           historical_roots_limit,
-           validator_registry_limit,
-           base_reward_factor,
-           whistleblower_reward_quotient,
-           proposer_reward_quotient,
-           inactivity_penalty_quotient,
-           min_slashing_penalty_quotient,
-           max_proposer_slashings,
-           max_attester_slashings,
-           max_attestations,
-           max_deposits,
-           max_voluntary_exits,
-           max_transfers,
-           deposit_contract_address):
+def config(
+    shard_count,
+    target_committee_size,
+    max_validators_per_committee,
+    min_per_epoch_churn_limit,
+    churn_limit_quotient,
+    shuffle_round_count,
+    min_genesis_active_validator_count,
+    min_genesis_time,
+    min_deposit_amount,
+    max_effective_balance,
+    ejection_balance,
+    effective_balance_increment,
+    genesis_slot,
+    genesis_epoch,
+    bls_withdrawal_prefix,
+    seconds_per_slot,
+    min_attestation_inclusion_delay,
+    slots_per_epoch,
+    min_seed_lookahead,
+    activation_exit_delay,
+    slots_per_eth1_voting_period,
+    slots_per_historical_root,
+    min_validator_withdrawability_delay,
+    persistent_committee_period,
+    max_epochs_per_crosslink,
+    min_epochs_to_inactivity_penalty,
+    epochs_per_historical_vector,
+    epochs_per_slashings_vector,
+    historical_roots_limit,
+    validator_registry_limit,
+    base_reward_factor,
+    whistleblower_reward_quotient,
+    proposer_reward_quotient,
+    inactivity_penalty_quotient,
+    min_slashing_penalty_quotient,
+    max_proposer_slashings,
+    max_attester_slashings,
+    max_attestations,
+    max_deposits,
+    max_voluntary_exits,
+    max_transfers,
+    deposit_contract_address,
+):
     # adding some config validity conditions here
     # abstract out into the config object?
     assert shard_count >= slots_per_epoch
@@ -402,126 +370,120 @@ def genesis_config(config):
 #
 @pytest.fixture
 def sample_signature():
-    return b'\56' * 96
+    return b"\56" * 96
 
 
 @pytest.fixture
 def sample_fork_params():
     return {
-        'previous_version': Version((0).to_bytes(4, 'little')),
-        'current_version': Version((0).to_bytes(4, 'little')),
-        'epoch': 2**32,
+        "previous_version": Version((0).to_bytes(4, "little")),
+        "current_version": Version((0).to_bytes(4, "little")),
+        "epoch": 2 ** 32,
     }
 
 
 @pytest.fixture
 def sample_validator_record_params():
     return {
-        'pubkey': b'\x67' * 48,
-        'withdrawal_credentials': b'\x01' * 32,
-        'effective_balance': Gwei(32 * GWEI_PER_ETH),
-        'slashed': False,
-        'activation_eligibility_epoch': FAR_FUTURE_EPOCH,
-        'activation_epoch': FAR_FUTURE_EPOCH,
-        'exit_epoch': FAR_FUTURE_EPOCH,
-        'withdrawable_epoch': FAR_FUTURE_EPOCH,
+        "pubkey": b"\x67" * 48,
+        "withdrawal_credentials": b"\x01" * 32,
+        "effective_balance": Gwei(32 * GWEI_PER_ETH),
+        "slashed": False,
+        "activation_eligibility_epoch": FAR_FUTURE_EPOCH,
+        "activation_epoch": FAR_FUTURE_EPOCH,
+        "exit_epoch": FAR_FUTURE_EPOCH,
+        "withdrawable_epoch": FAR_FUTURE_EPOCH,
     }
 
 
 @pytest.fixture
 def sample_crosslink_record_params():
     return {
-        'shard': 0,
-        'parent_root': b'\x34' * 32,
-        'start_epoch': 0,
-        'end_epoch': 1,
-        'data_root': b'\x43' * 32,
+        "shard": 0,
+        "parent_root": b"\x34" * 32,
+        "start_epoch": 0,
+        "end_epoch": 1,
+        "data_root": b"\x43" * 32,
     }
 
 
 @pytest.fixture
 def sample_attestation_data_params(sample_crosslink_record_params):
     return {
-        'beacon_block_root': b'\x11' * 32,
-        'source': Checkpoint(
-            epoch=11,
-            root=b'\x22' * 32,
-        ),
-        'target': Checkpoint(
-            epoch=12,
-            root=b'\x33' * 32,
-        ),
-        'crosslink': Crosslink(**sample_crosslink_record_params),
+        "beacon_block_root": b"\x11" * 32,
+        "source": Checkpoint(epoch=11, root=b"\x22" * 32),
+        "target": Checkpoint(epoch=12, root=b"\x33" * 32),
+        "crosslink": Crosslink(**sample_crosslink_record_params),
     }
 
 
 @pytest.fixture
 def sample_attestation_data_and_custody_bit_params(sample_attestation_data_params):
     return {
-        'data': AttestationData(**sample_attestation_data_params),
-        'custody_bit': False,
+        "data": AttestationData(**sample_attestation_data_params),
+        "custody_bit": False,
     }
 
 
 @pytest.fixture
 def sample_indexed_attestation_params(sample_signature, sample_attestation_data_params):
     return {
-        'custody_bit_0_indices': (10, 11, 12, 15, 28),
-        'custody_bit_1_indices': tuple(),
-        'data': AttestationData(**sample_attestation_data_params),
-        'signature': sample_signature,
+        "custody_bit_0_indices": (10, 11, 12, 15, 28),
+        "custody_bit_1_indices": tuple(),
+        "data": AttestationData(**sample_attestation_data_params),
+        "signature": sample_signature,
     }
 
 
 @pytest.fixture
 def sample_pending_attestation_record_params(sample_attestation_data_params):
     return {
-        'aggregation_bits': (True, False) * 4 * 16,
-        'data': AttestationData(**sample_attestation_data_params),
-        'inclusion_delay': 1,
-        'proposer_index': ValidatorIndex(12),
+        "aggregation_bits": (True, False) * 4 * 16,
+        "data": AttestationData(**sample_attestation_data_params),
+        "inclusion_delay": 1,
+        "proposer_index": ValidatorIndex(12),
     }
 
 
 @pytest.fixture
 def sample_eth1_data_params():
     return {
-        'deposit_root': b'\x43' * 32,
-        'deposit_count': 22,
-        'block_hash': b'\x46' * 32,
+        "deposit_root": b"\x43" * 32,
+        "deposit_count": 22,
+        "block_hash": b"\x46" * 32,
     }
 
 
 @pytest.fixture
 def sample_historical_batch_params(config):
     return {
-        'block_roots': tuple(
+        "block_roots": tuple(
             (bytes([i] * 32) for i in range(config.SLOTS_PER_HISTORICAL_ROOT))
         ),
-        'state_roots': tuple(
+        "state_roots": tuple(
             (bytes([i] * 32) for i in range(config.SLOTS_PER_HISTORICAL_ROOT))
-        )
+        ),
     }
 
 
 @pytest.fixture
 def sample_deposit_data_params(sample_signature):
     return {
-        'pubkey': BLSPubkey(b'\x67' * 48),
-        'withdrawal_credentials': b'\11' * 32,
-        'amount': Gwei(56),
-        'signature': sample_signature,
+        "pubkey": BLSPubkey(b"\x67" * 48),
+        "withdrawal_credentials": b"\11" * 32,
+        "amount": Gwei(56),
+        "signature": sample_signature,
     }
 
 
 @pytest.fixture
 def sample_block_header_params():
     return {
-        'slot': 10,
-        'parent_root': b'\x22' * 32,
-        'state_root': b'\x33' * 32,
-        'body_root': b'\x43' * 32,
-        'signature': b'\x56' * 96,
+        "slot": 10,
+        "parent_root": b"\x22" * 32,
+        "state_root": b"\x33" * 32,
+        "body_root": b"\x43" * 32,
+        "signature": b"\x56" * 96,
     }
 
 
@@ -529,146 +491,133 @@ def sample_block_header_params():
 def sample_proposer_slashing_params(sample_block_header_params):
     block_header_data = BeaconBlockHeader(**sample_block_header_params)
     return {
-        'proposer_index': 1,
-        'header_1': block_header_data,
-        'header_2': block_header_data,
+        "proposer_index": 1,
+        "header_1": block_header_data,
+        "header_2": block_header_data,
     }
 
 
 @pytest.fixture
 def sample_attester_slashing_params(sample_indexed_attestation_params):
-    indexed_attestation = IndexedAttestation(
-        **sample_indexed_attestation_params
-    )
-    return {
-        'attestation_1': indexed_attestation,
-        'attestation_2': indexed_attestation,
-    }
+    indexed_attestation = IndexedAttestation(**sample_indexed_attestation_params)
+    return {"attestation_1": indexed_attestation, "attestation_2": indexed_attestation}
 
 
 @pytest.fixture
 def sample_attestation_params(sample_signature, sample_attestation_data_params):
     return {
-        'aggregation_bits': (True,) * 16,
-        'data': AttestationData(**sample_attestation_data_params),
-        'custody_bits': (False,) * 16,
-        'signature': sample_signature,
+        "aggregation_bits": (True,) * 16,
+        "data": AttestationData(**sample_attestation_data_params),
+        "custody_bits": (False,) * 16,
+        "signature": sample_signature,
     }
 
 
 @pytest.fixture
 def sample_deposit_params(sample_deposit_data_params, deposit_contract_tree_depth):
     return {
-        'proof': (b'\x22' * 32,) * (deposit_contract_tree_depth + 1),
-        'data': DepositData(**sample_deposit_data_params)
+        "proof": (b"\x22" * 32,) * (deposit_contract_tree_depth + 1),
+        "data": DepositData(**sample_deposit_data_params),
     }
 
 
 @pytest.fixture
 def sample_voluntary_exit_params(sample_signature):
-    return {
-        'epoch': 123,
-        'validator_index': 15,
-        'signature': sample_signature,
-    }
+    return {"epoch": 123, "validator_index": 15, "signature": sample_signature}
 
 
 @pytest.fixture
 def sample_transfer_params():
     return {
-        'sender': 10,
-        'recipient': 12,
-        'amount': 10 * 10**9,
-        'fee': 5 * 10**9,
-        'slot': 5,
-        'pubkey': b'\x67' * 48,
-        'signature': b'\x43' * 96,
+        "sender": 10,
+        "recipient": 12,
+        "amount": 10 * 10 ** 9,
+        "fee": 5 * 10 ** 9,
+        "slot": 5,
+        "pubkey": b"\x67" * 48,
+        "signature": b"\x43" * 96,
     }
 
 
 @pytest.fixture
 def sample_beacon_block_body_params(sample_signature, sample_eth1_data_params):
     return {
-        'randao_reveal': sample_signature,
-        'eth1_data': Eth1Data(**sample_eth1_data_params),
-        'graffiti': ZERO_HASH32,
-        'proposer_slashings': (),
-        'attester_slashings': (),
-        'attestations': (),
-        'deposits': (),
-        'voluntary_exits': (),
-        'transfers': (),
+        "randao_reveal": sample_signature,
+        "eth1_data": Eth1Data(**sample_eth1_data_params),
+        "graffiti": ZERO_HASH32,
+        "proposer_slashings": (),
+        "attester_slashings": (),
+        "attestations": (),
+        "deposits": (),
+        "voluntary_exits": (),
+        "transfers": (),
     }
 
 
 @pytest.fixture
-def sample_beacon_block_params(sample_signature, sample_beacon_block_body_params, genesis_slot):
+def sample_beacon_block_params(
+    sample_signature, sample_beacon_block_body_params, genesis_slot
+):
     return {
-        'slot': genesis_slot + 10,
-        'parent_root': ZERO_HASH32,
-        'state_root': b'\x55' * 32,
-        'body': BeaconBlockBody(**sample_beacon_block_body_params),
-        'signature': sample_signature,
+        "slot": genesis_slot + 10,
+        "parent_root": ZERO_HASH32,
+        "state_root": b"\x55" * 32,
+        "body": BeaconBlockBody(**sample_beacon_block_body_params),
+        "signature": sample_signature,
     }
 
 
 @pytest.fixture
-def sample_beacon_state_params(config,
-                               genesis_slot,
-                               genesis_epoch,
-                               sample_fork_params,
-                               sample_eth1_data_params,
-                               sample_block_header_params,
-                               sample_crosslink_record_params):
+def sample_beacon_state_params(
+    config,
+    genesis_slot,
+    genesis_epoch,
+    sample_fork_params,
+    sample_eth1_data_params,
+    sample_block_header_params,
+    sample_crosslink_record_params,
+):
     return {
         # Versioning
-        'genesis_time': 0,
-        'slot': genesis_slot + 100,
-        'fork': Fork(**sample_fork_params),
+        "genesis_time": 0,
+        "slot": genesis_slot + 100,
+        "fork": Fork(**sample_fork_params),
         # History
-        'latest_block_header': BeaconBlockHeader(**sample_block_header_params),
-        'block_roots': (ZERO_HASH32,) * config.SLOTS_PER_HISTORICAL_ROOT,
-        'state_roots': (ZERO_HASH32,) * config.SLOTS_PER_HISTORICAL_ROOT,
-        'historical_roots': (),
+        "latest_block_header": BeaconBlockHeader(**sample_block_header_params),
+        "block_roots": (ZERO_HASH32,) * config.SLOTS_PER_HISTORICAL_ROOT,
+        "state_roots": (ZERO_HASH32,) * config.SLOTS_PER_HISTORICAL_ROOT,
+        "historical_roots": (),
         # Eth1
-        'eth1_data': Eth1Data(**sample_eth1_data_params),
-        'eth1_data_votes': (),
-        'eth1_deposit_index': 0,
+        "eth1_data": Eth1Data(**sample_eth1_data_params),
+        "eth1_data_votes": (),
+        "eth1_deposit_index": 0,
         # Registry
-        'validators': (),
-        'balances': (),
+        "validators": (),
+        "balances": (),
         # Shuffling
-        'start_shard': 1,
-        'randao_mixes': (ZERO_HASH32,) * config.EPOCHS_PER_HISTORICAL_VECTOR,
-        'active_index_roots': (ZERO_HASH32,) * config.EPOCHS_PER_HISTORICAL_VECTOR,
-        'compact_committees_roots': (ZERO_HASH32,) * config.EPOCHS_PER_HISTORICAL_VECTOR,
+        "start_shard": 1,
+        "randao_mixes": (ZERO_HASH32,) * config.EPOCHS_PER_HISTORICAL_VECTOR,
+        "active_index_roots": (ZERO_HASH32,) * config.EPOCHS_PER_HISTORICAL_VECTOR,
+        "compact_committees_roots": (ZERO_HASH32,)
+        * config.EPOCHS_PER_HISTORICAL_VECTOR,
         # Slashings
-        'slashings': (0,) * config.EPOCHS_PER_SLASHINGS_VECTOR,
+        "slashings": (0,) * config.EPOCHS_PER_SLASHINGS_VECTOR,
         # Attestations
-        'previous_epoch_attestations': (),
-        'current_epoch_attestations': (),
+        "previous_epoch_attestations": (),
+        "current_epoch_attestations": (),
         # Crosslinks
-        'previous_crosslinks': (
+        "previous_crosslinks": (
             (Crosslink(**sample_crosslink_record_params),) * config.SHARD_COUNT
         ),
-        'current_crosslinks': (
+        "current_crosslinks": (
             (Crosslink(**sample_crosslink_record_params),) * config.SHARD_COUNT
         ),
         # Justification
-        'justification_bits': (False,) * JUSTIFICATION_BITS_LENGTH,
-        'previous_justified_checkpoint': Checkpoint(
-            epoch=0,
-            root=b'\x99' * 32,
-        ),
-        'current_justified_checkpoint': Checkpoint(
-            epoch=0,
-            root=b'\x55' * 32,
-        ),
+        "justification_bits": (False,) * JUSTIFICATION_BITS_LENGTH,
+        "previous_justified_checkpoint": Checkpoint(epoch=0, root=b"\x99" * 32),
+        "current_justified_checkpoint": Checkpoint(epoch=0, root=b"\x55" * 32),
         # Finality
-        'finalized_checkpoint': Checkpoint(
-            epoch=0,
-            root=b'\x33' * 32,
-        )
+        "finalized_checkpoint": Checkpoint(epoch=0, root=b"\x33" * 32),
     }
 
 
@@ -696,10 +645,8 @@ def genesis_validators(validator_count, pubkeys, config):
     Returns ``validator_count`` number of activated validators.
     """
     return tuple(
-        create_mock_validator(
-            pubkey=pubkey,
-            config=config,
-        ) for pubkey in pubkeys[:validator_count]
+        create_mock_validator(pubkey=pubkey, config=config)
+        for pubkey in pubkeys[:validator_count]
     )
 
 
@@ -709,30 +656,21 @@ def genesis_balances(validator_count, max_effective_balance):
 
 
 @pytest.fixture
-def genesis_state(genesis_validators,
-                  genesis_balances,
-                  genesis_time,
-                  sample_eth1_data_params,
-                  config):
+def genesis_state(
+    genesis_validators, genesis_balances, genesis_time, sample_eth1_data_params, config
+):
     genesis_eth1_data = Eth1Data(**sample_eth1_data_params).copy(
-        deposit_count=len(genesis_validators),
+        deposit_count=len(genesis_validators)
     )
 
     return create_mock_genesis_state_from_validators(
-        genesis_time,
-        genesis_eth1_data,
-        genesis_validators,
-        genesis_balances,
-        config,
+        genesis_time, genesis_eth1_data, genesis_validators, genesis_balances, config
     )
 
 
 @pytest.fixture
 def genesis_block(genesis_state):
-    return get_genesis_block(
-        genesis_state.hash_tree_root,
-        SerenityBeaconBlock,
-    )
+    return get_genesis_block(genesis_state.hash_tree_root, SerenityBeaconBlock)
 
 
 #
@@ -741,9 +679,9 @@ def genesis_block(genesis_state):
 @pytest.fixture
 def fixture_sm_class(config, fork_choice_scoring):
     return SerenityStateMachine.configure(
-        __name__='SerenityStateMachineForTesting',
+        __name__="SerenityStateMachineForTesting",
         config=config,
-        get_fork_choice_scoring=lambda self: fork_choice_scoring
+        get_fork_choice_scoring=lambda self: fork_choice_scoring,
     )
 
 

--- a/tests/eth2/core/beacon/conftest.py
+++ b/tests/eth2/core/beacon/conftest.py
@@ -1,39 +1,34 @@
-import pytest
-
 from eth.constants import ZERO_HASH32
 from eth_typing import BLSPubkey
+import pytest
 
-from eth2.configs import Eth2Config, CommitteeConfig, Eth2GenesisConfig
 from eth2.beacon.constants import (
     DEPOSIT_CONTRACT_TREE_DEPTH,
     FAR_FUTURE_EPOCH,
     GWEI_PER_ETH,
     JUSTIFICATION_BITS_LENGTH,
 )
+from eth2.beacon.db.chain import BeaconChainDB
 from eth2.beacon.fork_choice.higher_slot import higher_slot_scoring
+from eth2.beacon.genesis import get_genesis_block
 from eth2.beacon.operations.attestation_pool import AttestationPool
-from eth2.beacon.types.attestations import IndexedAttestation
+from eth2.beacon.state_machines.forks.serenity import SerenityStateMachine
+from eth2.beacon.state_machines.forks.serenity.blocks import SerenityBeaconBlock
+from eth2.beacon.state_machines.forks.serenity.configs import SERENITY_CONFIG
+from eth2.beacon.tools.builder.initializer import create_mock_validator
+from eth2.beacon.tools.builder.state import create_mock_genesis_state_from_validators
+from eth2.beacon.tools.misc.ssz_vector import override_lengths
 from eth2.beacon.types.attestation_data import AttestationData
-from eth2.beacon.types.blocks import BeaconBlock
+from eth2.beacon.types.attestations import IndexedAttestation
+from eth2.beacon.types.blocks import BeaconBlock, BeaconBlockBody, BeaconBlockHeader
 from eth2.beacon.types.checkpoints import Checkpoint
 from eth2.beacon.types.crosslinks import Crosslink
 from eth2.beacon.types.deposit_data import DepositData
 from eth2.beacon.types.eth1_data import Eth1Data
-from eth2.beacon.types.states import BeaconState
-
-from eth2.beacon.genesis import get_genesis_block
-from eth2.beacon.tools.misc.ssz_vector import override_lengths
-from eth2.beacon.tools.builder.state import create_mock_genesis_state_from_validators
-from eth2.beacon.types.blocks import BeaconBlockBody, BeaconBlockHeader
 from eth2.beacon.types.forks import Fork
-from eth2.beacon.typing import Gwei, ValidatorIndex, Timestamp, Version
-from eth2.beacon.state_machines.forks.serenity import SerenityStateMachine
-from eth2.beacon.state_machines.forks.serenity.blocks import SerenityBeaconBlock
-from eth2.beacon.state_machines.forks.serenity.configs import SERENITY_CONFIG
-
-from eth2.beacon.tools.builder.initializer import create_mock_validator
-
-from eth2.beacon.db.chain import BeaconChainDB
+from eth2.beacon.types.states import BeaconState
+from eth2.beacon.typing import Gwei, Timestamp, ValidatorIndex, Version
+from eth2.configs import CommitteeConfig, Eth2Config, Eth2GenesisConfig
 
 
 # SSZ

--- a/tests/eth2/core/beacon/db/test_beacon_chaindb.py
+++ b/tests/eth2/core/beacon/db/test_beacon_chaindb.py
@@ -1,16 +1,14 @@
 import random
 
-import pytest
-
-from hypothesis import given, strategies as st
-
-import ssz
-
 from eth.constants import GENESIS_PARENT_HASH
 from eth.exceptions import BlockNotFound, ParentNotFound
+from hypothesis import given
+from hypothesis import strategies as st
+import pytest
+import ssz
+
 from eth2._utils.hash import hash_eth2
 from eth2._utils.ssz import validate_ssz_equal
-
 from eth2.beacon.db.exceptions import (
     AttestationRootNotFound,
     FinalizedHeadNotFound,
@@ -20,8 +18,8 @@ from eth2.beacon.db.exceptions import (
 from eth2.beacon.db.schema import SchemaV1
 from eth2.beacon.state_machines.forks.serenity.blocks import BeaconBlock
 from eth2.beacon.types.attestations import Attestation
-from eth2.beacon.types.states import BeaconState
 from eth2.beacon.types.checkpoints import Checkpoint
+from eth2.beacon.types.states import BeaconState
 
 
 @pytest.fixture(params=[1, 10, 999])

--- a/tests/eth2/core/beacon/fork_choice/test_higher_slot.py
+++ b/tests/eth2/core/beacon/fork_choice/test_higher_slot.py
@@ -4,14 +4,9 @@ from eth2.beacon.fork_choice.higher_slot import higher_slot_scoring
 from eth2.beacon.types.blocks import BeaconBlock
 
 
-@pytest.mark.parametrize(
-    "slot",
-    (i for i in range(10)),
-)
+@pytest.mark.parametrize("slot", (i for i in range(10)))
 def test_higher_slot_fork_choice_scoring(sample_beacon_block_params, slot):
-    block = BeaconBlock(**sample_beacon_block_params).copy(
-        slot=slot,
-    )
+    block = BeaconBlock(**sample_beacon_block_params).copy(slot=slot)
 
     expected_score = slot
 

--- a/tests/eth2/core/beacon/fork_choice/test_lmd_ghost.py
+++ b/tests/eth2/core/beacon/fork_choice/test_lmd_ghost.py
@@ -1,6 +1,5 @@
 import random
 
-import pytest
 from eth_utils import to_dict
 from eth_utils.toolz import (
     first,
@@ -11,6 +10,7 @@ from eth_utils.toolz import (
     second,
     sliding_window,
 )
+import pytest
 
 from eth2._utils import bitfield
 from eth2.beacon.attestation_helpers import get_attestation_data_slot
@@ -27,8 +27,8 @@ from eth2.beacon.fork_choice.lmd_ghost import (
     score_block_by_root,
 )
 from eth2.beacon.helpers import (
-    compute_start_slot_of_epoch,
     compute_epoch_of_slot,
+    compute_start_slot_of_epoch,
     get_active_validator_indices,
 )
 from eth2.beacon.tools.builder.validator import get_crosslink_committees_at_slot

--- a/tests/eth2/core/beacon/operations/test_pool.py
+++ b/tests/eth2/core/beacon/operations/test_pool.py
@@ -8,9 +8,7 @@ from eth2.beacon.types.attestations import Attestation
 
 
 def mk_attestation(index, sample_attestation_params):
-    return Attestation(**sample_attestation_params).copy(
-        custody_bits=(True,) * 128,
-    )
+    return Attestation(**sample_attestation_params).copy(custody_bits=(True,) * 128)
 
 
 def test_iterating_operation_pool(sample_attestation_params):

--- a/tests/eth2/core/beacon/state_machines/forks/test_serenity_block_attestation_validation.py
+++ b/tests/eth2/core/beacon/state_machines/forks/test_serenity_block_attestation_validation.py
@@ -1,19 +1,17 @@
+from eth.constants import ZERO_HASH32
+from eth_utils import ValidationError
 import pytest
 
-from eth_utils import ValidationError
-
-from eth.constants import ZERO_HASH32
 from eth2.beacon.committee_helpers import get_start_shard
 from eth2.beacon.helpers import compute_start_slot_of_epoch
 from eth2.beacon.state_machines.forks.serenity.block_validation import (
-    validate_attestation_slot,
     _validate_attestation_data,
     _validate_crosslink,
+    validate_attestation_slot,
 )
 from eth2.beacon.types.attestation_data import AttestationData
 from eth2.beacon.types.checkpoints import Checkpoint
 from eth2.beacon.types.crosslinks import Crosslink
-
 from eth2.configs import CommitteeConfig
 
 

--- a/tests/eth2/core/beacon/state_machines/forks/test_serenity_block_processing.py
+++ b/tests/eth2/core/beacon/state_machines/forks/test_serenity_block_processing.py
@@ -1,28 +1,22 @@
-import pytest
-
 from eth.constants import ZERO_HASH32
 from eth_utils import ValidationError
-from eth_utils.toolz import first, mapcat, concat
+from eth_utils.toolz import concat, first, mapcat
+import pytest
 
 from eth2._utils.bls import bls
-
-from eth2.beacon.types.blocks import BeaconBlock, BeaconBlockBody
-from eth2.beacon.types.eth1_data import Eth1Data
-from eth2.beacon.types.states import BeaconState
+from eth2.beacon.helpers import compute_start_slot_of_epoch, get_domain
 from eth2.beacon.signature_domain import SignatureDomain
-
-from eth2.beacon.helpers import get_domain, compute_start_slot_of_epoch
-
-from eth2.beacon.state_machines.forks.serenity.blocks import SerenityBeaconBlock
-from eth2.beacon.state_machines.forks.serenity.states import SerenityBeaconState
-
 from eth2.beacon.state_machines.forks.serenity.block_processing import (
     process_eth1_data,
     process_randao,
 )
-from eth2.beacon.tools.builder.proposer import _generate_randao_reveal
-
+from eth2.beacon.state_machines.forks.serenity.blocks import SerenityBeaconBlock
+from eth2.beacon.state_machines.forks.serenity.states import SerenityBeaconState
 from eth2.beacon.tools.builder.initializer import create_mock_validator
+from eth2.beacon.tools.builder.proposer import _generate_randao_reveal
+from eth2.beacon.types.blocks import BeaconBlock, BeaconBlockBody
+from eth2.beacon.types.eth1_data import Eth1Data
+from eth2.beacon.types.states import BeaconState
 
 
 def test_randao_processing(

--- a/tests/eth2/core/beacon/state_machines/forks/test_serenity_block_proposer_slashing_validation.py
+++ b/tests/eth2/core/beacon/state_machines/forks/test_serenity_block_proposer_slashing_validation.py
@@ -1,8 +1,6 @@
 import pytest
 
-from eth_utils import (
-    ValidationError,
-)
+from eth_utils import ValidationError
 
 from eth2.beacon.state_machines.forks.serenity.block_validation import (
     validate_proposer_slashing,
@@ -10,77 +8,55 @@ from eth2.beacon.state_machines.forks.serenity.block_validation import (
     validate_proposer_slashing_headers,
     validate_block_header_signature,
 )
-from eth2.beacon.tools.builder.validator import (
-    create_mock_proposer_slashing_at_block,
-)
+from eth2.beacon.tools.builder.validator import create_mock_proposer_slashing_at_block
 
 
-def get_valid_proposer_slashing(state,
-                                keymap,
-                                config,
-                                proposer_index=0):
+def get_valid_proposer_slashing(state, keymap, config, proposer_index=0):
     return create_mock_proposer_slashing_at_block(
         state,
         config,
         keymap,
-        block_root_1=b'\x11' * 32,
-        block_root_2=b'\x22' * 32,
+        block_root_1=b"\x11" * 32,
+        block_root_2=b"\x22" * 32,
         proposer_index=proposer_index,
     )
 
 
-def test_validate_proposer_slashing_valid(genesis_state,
-                                          keymap,
-                                          slots_per_epoch,
-                                          config):
+def test_validate_proposer_slashing_valid(
+    genesis_state, keymap, slots_per_epoch, config
+):
     state = genesis_state
-    valid_proposer_slashing = get_valid_proposer_slashing(
-        state,
-        keymap,
-        config,
-    )
+    valid_proposer_slashing = get_valid_proposer_slashing(state, keymap, config)
     validate_proposer_slashing(state, valid_proposer_slashing, slots_per_epoch)
 
 
-def test_validate_proposer_slashing_epoch(genesis_state,
-                                          keymap,
-                                          config):
+def test_validate_proposer_slashing_epoch(genesis_state, keymap, config):
     state = genesis_state
-    valid_proposer_slashing = get_valid_proposer_slashing(
-        state,
-        keymap,
-        config,
-    )
+    valid_proposer_slashing = get_valid_proposer_slashing(state, keymap, config)
     # Valid
     validate_proposer_slashing_epoch(valid_proposer_slashing, config.SLOTS_PER_EPOCH)
 
     header_1 = valid_proposer_slashing.header_1.copy(
         slot=valid_proposer_slashing.header_2.slot + 2 * config.SLOTS_PER_EPOCH
     )
-    invalid_proposer_slashing = valid_proposer_slashing.copy(
-        header_1=header_1,
-    )
+    invalid_proposer_slashing = valid_proposer_slashing.copy(header_1=header_1)
 
     # Invalid
     with pytest.raises(ValidationError):
-        validate_proposer_slashing_epoch(invalid_proposer_slashing, config.SLOTS_PER_EPOCH)
+        validate_proposer_slashing_epoch(
+            invalid_proposer_slashing, config.SLOTS_PER_EPOCH
+        )
 
 
-def test_validate_proposer_slashing_headers(genesis_state,
-                                            keymap,
-                                            config):
+def test_validate_proposer_slashing_headers(genesis_state, keymap, config):
     state = genesis_state
-    valid_proposer_slashing = get_valid_proposer_slashing(
-        state,
-        keymap,
-        config,
-    )
+    valid_proposer_slashing = get_valid_proposer_slashing(state, keymap, config)
 
     # Valid
     validate_proposer_slashing_headers(valid_proposer_slashing)
 
     invalid_proposer_slashing = valid_proposer_slashing.copy(
-        header_1=valid_proposer_slashing.header_2,
+        header_1=valid_proposer_slashing.header_2
     )
 
     # Invalid
@@ -88,17 +64,12 @@ def test_validate_proposer_slashing_headers(genesis_state,
         validate_proposer_slashing_headers(invalid_proposer_slashing)
 
 
-def test_validate_block_header_signature(slots_per_epoch,
-                                         genesis_state,
-                                         keymap,
-                                         config):
+def test_validate_block_header_signature(
+    slots_per_epoch, genesis_state, keymap, config
+):
     state = genesis_state
     proposer_index = 0
-    valid_proposer_slashing = get_valid_proposer_slashing(
-        state,
-        keymap,
-        config,
-    )
+    valid_proposer_slashing = get_valid_proposer_slashing(state, keymap, config)
     proposer = state.validators[proposer_index]
 
     # Valid

--- a/tests/eth2/core/beacon/state_machines/forks/test_serenity_block_proposer_slashing_validation.py
+++ b/tests/eth2/core/beacon/state_machines/forks/test_serenity_block_proposer_slashing_validation.py
@@ -1,12 +1,11 @@
+from eth_utils import ValidationError
 import pytest
 
-from eth_utils import ValidationError
-
 from eth2.beacon.state_machines.forks.serenity.block_validation import (
+    validate_block_header_signature,
     validate_proposer_slashing,
     validate_proposer_slashing_epoch,
     validate_proposer_slashing_headers,
-    validate_block_header_signature,
 )
 from eth2.beacon.tools.builder.validator import create_mock_proposer_slashing_at_block
 

--- a/tests/eth2/core/beacon/state_machines/forks/test_serenity_block_validation.py
+++ b/tests/eth2/core/beacon/state_machines/forks/test_serenity_block_validation.py
@@ -1,18 +1,9 @@
 import pytest
-from eth_utils import (
-    ValidationError,
-)
+from eth_utils import ValidationError
 from eth2._utils.bls import bls
-from eth2.configs import (
-    CommitteeConfig,
-)
-from eth2.beacon.signature_domain import (
-    SignatureDomain,
-)
-from eth2.beacon.helpers import (
-    get_domain,
-    compute_start_slot_of_epoch,
-)
+from eth2.configs import CommitteeConfig
+from eth2.beacon.signature_domain import SignatureDomain
+from eth2.beacon.helpers import get_domain, compute_start_slot_of_epoch
 from eth2.beacon.state_machines.forks.serenity.block_validation import (
     validate_block_slot,
     validate_proposer_signature,
@@ -25,26 +16,18 @@ from eth2.beacon.tools.builder.initializer import create_mock_validator
 
 
 @pytest.mark.parametrize(
-    'state_slot,'
-    'block_slot,'
-    'expected',
-    (
-        (10, 10, None),
-        (1, 10, ValidationError()),
-        (10, 1, ValidationError()),
-    ),
+    "state_slot," "block_slot," "expected",
+    ((10, 10, None), (1, 10, ValidationError()), (10, 1, ValidationError())),
 )
-def test_validate_block_slot(sample_beacon_state_params,
-                             sample_beacon_block_params,
-                             state_slot,
-                             block_slot,
-                             expected):
-    state = BeaconState(**sample_beacon_state_params).copy(
-        slot=state_slot,
-    )
-    block = BeaconBlock(**sample_beacon_block_params).copy(
-        slot=block_slot,
-    )
+def test_validate_block_slot(
+    sample_beacon_state_params,
+    sample_beacon_block_params,
+    state_slot,
+    block_slot,
+    expected,
+):
+    state = BeaconState(**sample_beacon_state_params).copy(slot=state_slot)
+    block = BeaconBlock(**sample_beacon_block_params).copy(slot=block_slot)
     if isinstance(expected, Exception):
         with pytest.raises(ValidationError):
             validate_block_slot(state, block)
@@ -53,31 +36,31 @@ def test_validate_block_slot(sample_beacon_state_params,
 
 
 @pytest.mark.parametrize(
-    'slots_per_epoch, shard_count,'
-    'proposer_privkey, proposer_pubkey, is_valid_signature',
+    "slots_per_epoch, shard_count,"
+    "proposer_privkey, proposer_pubkey, is_valid_signature",
     (
-        (5, 5, 56, bls.privtopub(56), True, ),
-        (5, 5, 56, bls.privtopub(56)[1:] + b'\x01', False),
+        (5, 5, 56, bls.privtopub(56), True),
+        (5, 5, 56, bls.privtopub(56)[1:] + b"\x01", False),
         (5, 5, 123, bls.privtopub(123), True),
-        (5, 5, 123, bls.privtopub(123)[1:] + b'\x01', False),
-    )
+        (5, 5, 123, bls.privtopub(123)[1:] + b"\x01", False),
+    ),
 )
 def test_validate_proposer_signature(
-        slots_per_epoch,
-        shard_count,
-        proposer_privkey,
-        proposer_pubkey,
-        is_valid_signature,
-        sample_beacon_block_params,
-        sample_beacon_state_params,
-        target_committee_size,
-        max_effective_balance,
-        config):
+    slots_per_epoch,
+    shard_count,
+    proposer_privkey,
+    proposer_pubkey,
+    is_valid_signature,
+    sample_beacon_block_params,
+    sample_beacon_state_params,
+    target_committee_size,
+    max_effective_balance,
+    config,
+):
 
     state = BeaconState(**sample_beacon_state_params).copy(
         validators=tuple(
-            create_mock_validator(proposer_pubkey, config)
-            for _ in range(10)
+            create_mock_validator(proposer_pubkey, config) for _ in range(10)
         ),
         balances=(max_effective_balance,) * 10,
     )
@@ -90,63 +73,50 @@ def test_validate_proposer_signature(
             message_hash=header.signing_root,
             privkey=proposer_privkey,
             domain=get_domain(
-                state,
-                SignatureDomain.DOMAIN_BEACON_PROPOSER,
-                slots_per_epoch,
+                state, SignatureDomain.DOMAIN_BEACON_PROPOSER, slots_per_epoch
             ),
-        ),
+        )
     )
 
     if is_valid_signature:
-        validate_proposer_signature(
-            state,
-            proposed_block,
-            CommitteeConfig(config),
-        )
+        validate_proposer_signature(state, proposed_block, CommitteeConfig(config))
     else:
         with pytest.raises(ValidationError):
-            validate_proposer_signature(
-                state,
-                proposed_block,
-                CommitteeConfig(config),
-            )
+            validate_proposer_signature(state, proposed_block, CommitteeConfig(config))
 
 
 @pytest.mark.parametrize(
-    ["is_valid", "epoch", "expected_epoch", "proposer_key_index", "expected_proposer_key_index"],
-    (
-        (True, 0, 0, 0, 0),
-        (True, 1, 1, 1, 1),
-        (False, 0, 1, 0, 0),
-        (False, 0, 0, 0, 1),
-    )
+    [
+        "is_valid",
+        "epoch",
+        "expected_epoch",
+        "proposer_key_index",
+        "expected_proposer_key_index",
+    ],
+    ((True, 0, 0, 0, 0), (True, 1, 1, 1, 1), (False, 0, 1, 0, 0), (False, 0, 0, 0, 1)),
 )
-def test_randao_reveal_validation(is_valid,
-                                  epoch,
-                                  expected_epoch,
-                                  proposer_key_index,
-                                  expected_proposer_key_index,
-                                  privkeys,
-                                  pubkeys,
-                                  sample_fork_params,
-                                  genesis_state,
-                                  config):
+def test_randao_reveal_validation(
+    is_valid,
+    epoch,
+    expected_epoch,
+    proposer_key_index,
+    expected_proposer_key_index,
+    privkeys,
+    pubkeys,
+    sample_fork_params,
+    genesis_state,
+    config,
+):
     state = genesis_state.copy(
-        slot=compute_start_slot_of_epoch(epoch, config.SLOTS_PER_EPOCH),
+        slot=compute_start_slot_of_epoch(epoch, config.SLOTS_PER_EPOCH)
     )
     message_hash = epoch.to_bytes(32, byteorder="little")
     slots_per_epoch = config.SLOTS_PER_EPOCH
-    domain = get_domain(
-        state,
-        SignatureDomain.DOMAIN_RANDAO,
-        slots_per_epoch,
-    )
+    domain = get_domain(state, SignatureDomain.DOMAIN_RANDAO, slots_per_epoch)
 
     proposer_privkey = privkeys[proposer_key_index]
     randao_reveal = bls.sign(
-        message_hash=message_hash,
-        privkey=proposer_privkey,
-        domain=domain,
+        message_hash=message_hash, privkey=proposer_privkey, domain=domain
     )
 
     try:

--- a/tests/eth2/core/beacon/state_machines/forks/test_serenity_block_validation.py
+++ b/tests/eth2/core/beacon/state_machines/forks/test_serenity_block_validation.py
@@ -1,18 +1,18 @@
-import pytest
 from eth_utils import ValidationError
+import pytest
+
 from eth2._utils.bls import bls
-from eth2.configs import CommitteeConfig
+from eth2.beacon.helpers import compute_start_slot_of_epoch, get_domain
 from eth2.beacon.signature_domain import SignatureDomain
-from eth2.beacon.helpers import get_domain, compute_start_slot_of_epoch
 from eth2.beacon.state_machines.forks.serenity.block_validation import (
     validate_block_slot,
     validate_proposer_signature,
     validate_randao_reveal,
 )
+from eth2.beacon.tools.builder.initializer import create_mock_validator
 from eth2.beacon.types.blocks import BeaconBlock
 from eth2.beacon.types.states import BeaconState
-
-from eth2.beacon.tools.builder.initializer import create_mock_validator
+from eth2.configs import CommitteeConfig
 
 
 @pytest.mark.parametrize(

--- a/tests/eth2/core/beacon/state_machines/forks/test_serenity_block_voluntary_exit_validation.py
+++ b/tests/eth2/core/beacon/state_machines/forks/test_serenity_block_voluntary_exit_validation.py
@@ -1,15 +1,9 @@
 import pytest
 
-from eth_utils import (
-    ValidationError,
-)
+from eth_utils import ValidationError
 
-from eth2.beacon.constants import (
-    FAR_FUTURE_EPOCH,
-)
-from eth2.beacon.helpers import (
-    compute_start_slot_of_epoch,
-)
+from eth2.beacon.constants import FAR_FUTURE_EPOCH
+from eth2.beacon.helpers import compute_start_slot_of_epoch
 from eth2.beacon.state_machines.forks.serenity.block_validation import (
     _validate_validator_has_not_exited,
     _validate_eligible_exit_epoch,
@@ -17,78 +11,50 @@ from eth2.beacon.state_machines.forks.serenity.block_validation import (
     _validate_voluntary_exit_signature,
     validate_voluntary_exit,
 )
-from eth2.beacon.tools.builder.validator import (
-    create_mock_voluntary_exit,
-)
+from eth2.beacon.tools.builder.validator import create_mock_voluntary_exit
 
 
 @pytest.mark.parametrize(
     (
-        'validator_count',
-        'slots_per_epoch',
-        'target_committee_size',
-        'persistent_committee_period',
+        "validator_count",
+        "slots_per_epoch",
+        "target_committee_size",
+        "persistent_committee_period",
     ),
-    [
-        (40, 2, 2, 16),
-    ]
+    [(40, 2, 2, 16)],
 )
-def test_validate_voluntary_exit(genesis_state,
-                                 keymap,
-                                 slots_per_epoch,
-                                 persistent_committee_period,
-                                 config):
+def test_validate_voluntary_exit(
+    genesis_state, keymap, slots_per_epoch, persistent_committee_period, config
+):
     state = genesis_state.copy(
         slot=compute_start_slot_of_epoch(
-            config.GENESIS_EPOCH + persistent_committee_period,
-            slots_per_epoch,
-        ),
+            config.GENESIS_EPOCH + persistent_committee_period, slots_per_epoch
+        )
     )
     validator_index = 0
     valid_voluntary_exit = create_mock_voluntary_exit(
-        state,
-        config,
-        keymap,
-        validator_index,
+        state, config, keymap, validator_index
     )
     validate_voluntary_exit(
-        state,
-        valid_voluntary_exit,
-        slots_per_epoch,
-        persistent_committee_period,
+        state, valid_voluntary_exit, slots_per_epoch, persistent_committee_period
     )
 
 
 @pytest.mark.parametrize(
-    (
-        'validator_count',
-        'slots_per_epoch',
-        'target_committee_size',
-    ),
-    [
-        (40, 2, 2),
-    ]
+    ("validator_count", "slots_per_epoch", "target_committee_size"), [(40, 2, 2)]
 )
 @pytest.mark.parametrize(
-    (
-        'validator_exit_epoch',
-        'success',
-    ),
-    [
-        (FAR_FUTURE_EPOCH, True),
-        (FAR_FUTURE_EPOCH - 1, False),
-    ]
+    ("validator_exit_epoch", "success"),
+    [(FAR_FUTURE_EPOCH, True), (FAR_FUTURE_EPOCH - 1, False)],
 )
-def test_validate_validator_has_not_exited(genesis_state,
-                                           validator_exit_epoch,
-                                           success):
+def test_validate_validator_has_not_exited(
+    genesis_state, validator_exit_epoch, success
+):
     state = genesis_state
 
     validator_index = 0
 
-    validator = state.validators[validator_index].copy(
-        exit_epoch=validator_exit_epoch,
-    )
+    validator = state.validators[validator_index].copy(exit_epoch=validator_exit_epoch)
 
     if success:
         _validate_validator_has_not_exited(validator)
@@ -98,95 +64,65 @@ def test_validate_validator_has_not_exited(genesis_state,
 
 
 @pytest.mark.parametrize(
-    (
-        'validator_count',
-        'slots_per_epoch',
-        'target_committee_size',
-    ),
-    [
-        (40, 2, 2),
-    ]
+    ("validator_count", "slots_per_epoch", "target_committee_size"), [(40, 2, 2)]
 )
 @pytest.mark.parametrize(
-    (
-        'activation_exit_delay',
-        'current_epoch',
-        'voluntary_exit_epoch',
-        'success',
-    ),
-    [
-        (4, 8, 8, True),
-        (4, 8, 8 + 1, False),
-    ]
+    ("activation_exit_delay", "current_epoch", "voluntary_exit_epoch", "success"),
+    [(4, 8, 8, True), (4, 8, 8 + 1, False)],
 )
-def test_validate_eligible_exit_epoch(genesis_state,
-                                      keymap,
-                                      current_epoch,
-                                      voluntary_exit_epoch,
-                                      slots_per_epoch,
-                                      config,
-                                      success):
+def test_validate_eligible_exit_epoch(
+    genesis_state,
+    keymap,
+    current_epoch,
+    voluntary_exit_epoch,
+    slots_per_epoch,
+    config,
+    success,
+):
     state = genesis_state.copy(
-        slot=compute_start_slot_of_epoch(current_epoch, slots_per_epoch),
+        slot=compute_start_slot_of_epoch(current_epoch, slots_per_epoch)
     )
 
     validator_index = 0
     voluntary_exit = create_mock_voluntary_exit(
-        state,
-        config,
-        keymap,
-        validator_index,
-        exit_epoch=voluntary_exit_epoch,
+        state, config, keymap, validator_index, exit_epoch=voluntary_exit_epoch
     )
     if success:
         _validate_eligible_exit_epoch(
-            voluntary_exit.epoch,
-            state.current_epoch(slots_per_epoch),
+            voluntary_exit.epoch, state.current_epoch(slots_per_epoch)
         )
     else:
         with pytest.raises(ValidationError):
             _validate_eligible_exit_epoch(
-                voluntary_exit.epoch,
-                state.current_epoch(slots_per_epoch),
+                voluntary_exit.epoch, state.current_epoch(slots_per_epoch)
             )
 
 
 @pytest.mark.parametrize(
-    (
-        'current_epoch',
-        'persistent_committee_period',
-        'activation_epoch',
-        'success',
-    ),
-    [
-        (16, 4, 16 - 4, True),
-        (16, 4, 16 - 4 + 1, False),
-    ]
+    ("current_epoch", "persistent_committee_period", "activation_epoch", "success"),
+    [(16, 4, 16 - 4, True), (16, 4, 16 - 4 + 1, False)],
 )
-def test_validate_validator_minimum_lifespan(genesis_state,
-                                             keymap,
-                                             current_epoch,
-                                             activation_epoch,
-                                             slots_per_epoch,
-                                             persistent_committee_period,
-                                             success):
+def test_validate_validator_minimum_lifespan(
+    genesis_state,
+    keymap,
+    current_epoch,
+    activation_epoch,
+    slots_per_epoch,
+    persistent_committee_period,
+    success,
+):
     state = genesis_state.copy(
-        slot=compute_start_slot_of_epoch(
-            current_epoch,
-            slots_per_epoch
-        ),
+        slot=compute_start_slot_of_epoch(current_epoch, slots_per_epoch)
     )
     validator_index = 0
     validator = state.validators[validator_index].copy(
-        activation_epoch=activation_epoch,
+        activation_epoch=activation_epoch
     )
     state = state.update_validator(validator_index, validator)
 
     if success:
         _validate_validator_minimum_lifespan(
-            validator,
-            state.current_epoch(slots_per_epoch),
-            persistent_committee_period,
+            validator, state.current_epoch(slots_per_epoch), persistent_committee_period
         )
     else:
         with pytest.raises(ValidationError):
@@ -199,44 +135,28 @@ def test_validate_validator_minimum_lifespan(genesis_state,
 
 @pytest.mark.parametrize(
     (
-        'validator_count',
-        'slots_per_epoch',
-        'target_committee_size',
-        'activation_exit_delay',
+        "validator_count",
+        "slots_per_epoch",
+        "target_committee_size",
+        "activation_exit_delay",
     ),
-    [
-        (40, 2, 2, 2),
-    ]
+    [(40, 2, 2, 2)],
 )
-@pytest.mark.parametrize(
-    (
-        'success',
-    ),
-    [
-        (True,),
-        (False,),
-    ]
-)
-def test_validate_voluntary_exit_signature(genesis_state,
-                                           keymap,
-                                           config,
-                                           success):
+@pytest.mark.parametrize(("success",), [(True,), (False,)])
+def test_validate_voluntary_exit_signature(genesis_state, keymap, config, success):
     slots_per_epoch = config.SLOTS_PER_EPOCH
     state = genesis_state
     validator_index = 0
-    voluntary_exit = create_mock_voluntary_exit(
-        state,
-        config,
-        keymap,
-        validator_index,
-    )
+    voluntary_exit = create_mock_voluntary_exit(state, config, keymap, validator_index)
     validator = state.validators[validator_index]
     if success:
-        _validate_voluntary_exit_signature(state, voluntary_exit, validator, slots_per_epoch)
+        _validate_voluntary_exit_signature(
+            state, voluntary_exit, validator, slots_per_epoch
+        )
     else:
         # Use wrong signature
-        voluntary_exit = voluntary_exit.copy(
-            signature=b'\x12' * 96,  # wrong signature
-        )
+        voluntary_exit = voluntary_exit.copy(signature=b"\x12" * 96)  # wrong signature
         with pytest.raises(ValidationError):
-            _validate_voluntary_exit_signature(state, voluntary_exit, validator, slots_per_epoch)
+            _validate_voluntary_exit_signature(
+                state, voluntary_exit, validator, slots_per_epoch
+            )

--- a/tests/eth2/core/beacon/state_machines/forks/test_serenity_block_voluntary_exit_validation.py
+++ b/tests/eth2/core/beacon/state_machines/forks/test_serenity_block_voluntary_exit_validation.py
@@ -1,12 +1,11 @@
-import pytest
-
 from eth_utils import ValidationError
+import pytest
 
 from eth2.beacon.constants import FAR_FUTURE_EPOCH
 from eth2.beacon.helpers import compute_start_slot_of_epoch
 from eth2.beacon.state_machines.forks.serenity.block_validation import (
-    _validate_validator_has_not_exited,
     _validate_eligible_exit_epoch,
+    _validate_validator_has_not_exited,
     _validate_validator_minimum_lifespan,
     _validate_voluntary_exit_signature,
     validate_voluntary_exit,

--- a/tests/eth2/core/beacon/state_machines/forks/test_serenity_epoch_processing.py
+++ b/tests/eth2/core/beacon/state_machines/forks/test_serenity_epoch_processing.py
@@ -3,13 +3,8 @@ import pytest
 
 import ssz
 
-from eth2._utils.bitfield import (
-    set_voted,
-    get_empty_bitfield,
-)
-from eth2.configs import (
-    CommitteeConfig,
-)
+from eth2._utils.bitfield import set_voted, get_empty_bitfield
+from eth2.configs import CommitteeConfig
 from eth2.beacon.committee_helpers import (
     get_beacon_proposer_index,
     get_start_shard,
@@ -27,9 +22,7 @@ from eth2.beacon.helpers import (
     compute_start_slot_of_epoch,
     compute_epoch_of_slot,
 )
-from eth2.beacon.epoch_processing_helpers import (
-    get_base_reward,
-)
+from eth2.beacon.epoch_processing_helpers import get_base_reward
 from eth2.beacon.types.attestation_data import AttestationData
 from eth2.beacon.types.checkpoints import Checkpoint
 from eth2.beacon.types.crosslinks import Crosslink
@@ -58,21 +51,13 @@ from eth2.beacon.tools.builder.validator import (
 
 
 @pytest.mark.parametrize(
-    "total_balance,"
-    "attesting_balance,"
-    "expected,",
+    "total_balance," "attesting_balance," "expected,",
     (
-        (
-            1500 * GWEI_PER_ETH, 1000 * GWEI_PER_ETH, True,
-        ),
-        (
-            1500 * GWEI_PER_ETH, 999 * GWEI_PER_ETH, False,
-        ),
-    )
+        (1500 * GWEI_PER_ETH, 1000 * GWEI_PER_ETH, True),
+        (1500 * GWEI_PER_ETH, 999 * GWEI_PER_ETH, False),
+    ),
 )
-def test_bft_threshold_met(attesting_balance,
-                           total_balance,
-                           expected):
+def test_bft_threshold_met(attesting_balance, total_balance, expected):
     assert _bft_threshold_met(attesting_balance, total_balance) == expected
 
 
@@ -93,26 +78,26 @@ def test_bft_threshold_met(attesting_balance,
         # No finalize
         ((False, False, False, False), 2, 2, 1),
         ((True, True, True, True), 2, 2, 1),
-    )
+    ),
 )
-def test_get_finalized_epoch(justification_bits,
-                             previous_justified_epoch,
-                             current_justified_epoch,
-                             expected):
+def test_get_finalized_epoch(
+    justification_bits, previous_justified_epoch, current_justified_epoch, expected
+):
     current_epoch = 6
     finalized_epoch = 1
-    assert _determine_new_finalized_epoch(
-        finalized_epoch,
-        previous_justified_epoch,
-        current_justified_epoch,
-        current_epoch,
-        justification_bits,
-    ) == expected
+    assert (
+        _determine_new_finalized_epoch(
+            finalized_epoch,
+            previous_justified_epoch,
+            current_justified_epoch,
+            current_epoch,
+            justification_bits,
+        )
+        == expected
+    )
 
 
-def test_justification_without_mock(genesis_state,
-                                    slots_per_historical_root,
-                                    config):
+def test_justification_without_mock(genesis_state, slots_per_historical_root, config):
 
     state = genesis_state
     state = process_justification_and_finalization(state, config)
@@ -161,18 +146,20 @@ def _convert_to_bitfield(bits):
         (5, False, True, 2, 3, 0b11110, 1, 4, 0b111110, 2),  # R1 finalize 2
     ),
 )
-def test_process_justification_and_finalization(genesis_state,
-                                                current_epoch,
-                                                current_epoch_justifiable,
-                                                previous_epoch_justifiable,
-                                                previous_justified_epoch,
-                                                current_justified_epoch,
-                                                justification_bits,
-                                                finalized_epoch,
-                                                justified_epoch_after,
-                                                justification_bits_after,
-                                                finalized_epoch_after,
-                                                config):
+def test_process_justification_and_finalization(
+    genesis_state,
+    current_epoch,
+    current_epoch_justifiable,
+    previous_epoch_justifiable,
+    previous_justified_epoch,
+    current_justified_epoch,
+    justification_bits,
+    finalized_epoch,
+    justified_epoch_after,
+    justification_bits_after,
+    finalized_epoch_after,
+    config,
+):
     justification_bits = _convert_to_bitfield(justification_bits)
     justification_bits_after = _convert_to_bitfield(justification_bits_after)
     previous_epoch = max(current_epoch - 1, 0)
@@ -180,99 +167,53 @@ def test_process_justification_and_finalization(genesis_state,
 
     state = genesis_state.copy(
         slot=slot,
-        previous_justified_checkpoint=Checkpoint(
-            epoch=previous_justified_epoch,
-        ),
-        current_justified_checkpoint=Checkpoint(
-            epoch=current_justified_epoch,
-        ),
+        previous_justified_checkpoint=Checkpoint(epoch=previous_justified_epoch),
+        current_justified_checkpoint=Checkpoint(epoch=current_justified_epoch),
         justification_bits=justification_bits,
-        finalized_checkpoint=Checkpoint(
-            epoch=finalized_epoch,
-        ),
+        finalized_checkpoint=Checkpoint(epoch=finalized_epoch),
         block_roots=tuple(
-            i.to_bytes(32, "little")
-            for i in range(config.SLOTS_PER_HISTORICAL_ROOT)
+            i.to_bytes(32, "little") for i in range(config.SLOTS_PER_HISTORICAL_ROOT)
         ),
     )
 
     if previous_epoch_justifiable:
         attestations = mk_all_pending_attestations_with_full_participation_in_epoch(
-            state,
-            previous_epoch,
-            config,
+            state, previous_epoch, config
         )
-        state = state.copy(
-            previous_epoch_attestations=attestations,
-        )
+        state = state.copy(previous_epoch_attestations=attestations)
 
     if current_epoch_justifiable:
         attestations = mk_all_pending_attestations_with_full_participation_in_epoch(
-            state,
-            current_epoch,
-            config,
+            state, current_epoch, config
         )
-        state = state.copy(
-            current_epoch_attestations=attestations,
-        )
+        state = state.copy(current_epoch_attestations=attestations)
 
     post_state = process_justification_and_finalization(state, config)
 
     assert (
-        post_state.previous_justified_checkpoint.epoch == state.current_justified_checkpoint.epoch
+        post_state.previous_justified_checkpoint.epoch
+        == state.current_justified_checkpoint.epoch
     )
     assert post_state.current_justified_checkpoint.epoch == justified_epoch_after
     assert post_state.justification_bits == justification_bits_after
     assert post_state.finalized_checkpoint.epoch == finalized_epoch_after
 
 
+@pytest.mark.parametrize(("slots_per_epoch," "shard_count,"), [(10, 10)])
 @pytest.mark.parametrize(
-    (
-        'slots_per_epoch,'
-        'shard_count,'
-    ),
-    [
-        (
-            10,
-            10,
-        ),
-    ]
+    ("success_in_previous_epoch," "success_in_current_epoch,"),
+    [(False, False), (True, False), (False, True)],
 )
-@pytest.mark.parametrize(
-    (
-        'success_in_previous_epoch,'
-        'success_in_current_epoch,'
-    ),
-    [
-        (
-            False,
-            False,
-        ),
-        (
-            True,
-            False,
-        ),
-        (
-            False,
-            True,
-        ),
-    ]
-)
-def test_process_crosslinks(genesis_state,
-                            config,
-                            success_in_previous_epoch,
-                            success_in_current_epoch):
+def test_process_crosslinks(
+    genesis_state, config, success_in_previous_epoch, success_in_current_epoch
+):
     shard_count = config.SHARD_COUNT
     current_slot = config.SLOTS_PER_EPOCH * 5 - 1
     current_epoch = compute_epoch_of_slot(current_slot, config.SLOTS_PER_EPOCH)
     assert current_epoch - 4 >= 0
 
     previous_crosslinks = tuple(
-        Crosslink(
-            shard=i,
-            start_epoch=current_epoch - 4,
-            end_epoch=current_epoch - 3,
-        )
+        Crosslink(shard=i, start_epoch=current_epoch - 4, end_epoch=current_epoch - 3)
         for i in range(shard_count)
     )
     parent_crosslinks = tuple(
@@ -306,10 +247,7 @@ def test_process_crosslinks(genesis_state,
     expected_success_shards = set()
     previous_epoch_attestations = tuple(
         mk_all_pending_attestations_with_some_participation_in_epoch(
-            state,
-            previous_epoch,
-            config,
-            0.7 if success_in_previous_epoch else 0,
+            state, previous_epoch, config, 0.7 if success_in_previous_epoch else 0
         )
     )
     if success_in_previous_epoch:
@@ -318,10 +256,7 @@ def test_process_crosslinks(genesis_state,
 
     current_epoch_attestations = tuple(
         mk_all_pending_attestations_with_some_participation_in_epoch(
-            state,
-            current_epoch,
-            config,
-            0.7 if success_in_current_epoch else 0,
+            state, current_epoch, config, 0.7 if success_in_current_epoch else 0
         )
     )
     if success_in_current_epoch:
@@ -351,60 +286,30 @@ def test_process_crosslinks(genesis_state,
 
 
 # TODO better testing on attestation deltas
+@pytest.mark.parametrize(("validator_count,"), [(10)])
 @pytest.mark.parametrize(
-    (
-        'validator_count,'
-    ),
-    [
-        (
-            10
-        )
-    ]
+    ("finalized_epoch", "current_slot"),
+    [(4, 384), (3, 512)],  # epochs_since_finality <= 4  # epochs_since_finality > 4
 )
-@pytest.mark.parametrize(
-    (
-        "finalized_epoch",
-        "current_slot",
-    ),
-    [
-        (
-            4,
-            384,  # epochs_since_finality <= 4
-        ),
-        (
-            3,
-            512,  # epochs_since_finality > 4
-        ),
-    ]
-)
-def test_get_attestation_deltas(genesis_state,
-                                config,
-                                slots_per_epoch,
-                                target_committee_size,
-                                shard_count,
-                                min_attestation_inclusion_delay,
-                                inactivity_penalty_quotient,
-                                finalized_epoch,
-                                current_slot,
-                                sample_pending_attestation_record_params,
-                                sample_attestation_data_params):
+def test_get_attestation_deltas(
+    genesis_state,
+    config,
+    slots_per_epoch,
+    target_committee_size,
+    shard_count,
+    min_attestation_inclusion_delay,
+    inactivity_penalty_quotient,
+    finalized_epoch,
+    current_slot,
+    sample_pending_attestation_record_params,
+    sample_attestation_data_params,
+):
     state = genesis_state.copy(
-        slot=current_slot,
-        finalized_checkpoint=Checkpoint(
-            epoch=finalized_epoch,
-        )
+        slot=current_slot, finalized_checkpoint=Checkpoint(epoch=finalized_epoch)
     )
     previous_epoch = state.previous_epoch(config.SLOTS_PER_EPOCH, config.GENESIS_EPOCH)
-    epoch_start_shard = get_start_shard(
-        state,
-        previous_epoch,
-        CommitteeConfig(config),
-    )
-    shard_delta = get_shard_delta(
-        state,
-        previous_epoch,
-        CommitteeConfig(config),
-    )
+    epoch_start_shard = get_start_shard(state, previous_epoch, CommitteeConfig(config))
+    shard_delta = get_shard_delta(state, previous_epoch, CommitteeConfig(config))
 
     a = epoch_start_shard
     b = epoch_start_shard + shard_delta
@@ -419,9 +324,7 @@ def test_get_attestation_deltas(genesis_state,
     prev_epoch_attestations = tuple()
     for slot in range(prev_epoch_start_slot, prev_epoch_start_slot + slots_per_epoch):
         committee, shard = get_crosslink_committees_at_slot(
-            state,
-            slot,
-            CommitteeConfig(config),
+            state, slot, CommitteeConfig(config)
         )[0]
         if not committee:
             continue
@@ -436,15 +339,10 @@ def test_get_attestation_deltas(genesis_state,
                 aggregation_bits=participants_bitfield,
                 inclusion_delay=min_attestation_inclusion_delay,
                 proposer_index=get_beacon_proposer_index(
-                    state.copy(
-                        slot=slot,
-                    ),
-                    CommitteeConfig(config),
+                    state.copy(slot=slot), CommitteeConfig(config)
                 ),
                 data=AttestationData(**sample_attestation_data_params).copy(
-                    crosslink=Crosslink(
-                        shard=shard,
-                    ),
+                    crosslink=Crosslink(shard=shard),
                     target=Checkpoint(
                         epoch=previous_epoch,
                         root=get_block_root(
@@ -455,98 +353,63 @@ def test_get_attestation_deltas(genesis_state,
                         ),
                     ),
                     beacon_block_root=get_block_root_at_slot(
-                        state,
-                        slot,
-                        config.SLOTS_PER_HISTORICAL_ROOT,
+                        state, slot, config.SLOTS_PER_HISTORICAL_ROOT
                     ),
                 ),
             ),
         )
-    state = state.copy(
-        previous_epoch_attestations=prev_epoch_attestations,
-    )
+    state = state.copy(previous_epoch_attestations=prev_epoch_attestations)
 
-    rewards_received, penalties_received = get_attestation_deltas(
-        state,
-        config,
-    )
+    rewards_received, penalties_received = get_attestation_deltas(state, config)
 
     # everyone attested, no penalties
-    assert(sum(penalties_received) == 0)
+    assert sum(penalties_received) == 0
     the_reward = rewards_received[0]
     # everyone performed the same, equal rewards
-    assert(sum(rewards_received) // len(rewards_received) == the_reward)
+    assert sum(rewards_received) // len(rewards_received) == the_reward
 
 
 @pytest.mark.parametrize(
     (
-        'validator_count,'
-        'slots_per_epoch,'
-        'target_committee_size,'
-        'shard_count,'
-        'current_slot,'
-        'num_attesting_validators,'
-        'genesis_slot,'
+        "validator_count,"
+        "slots_per_epoch,"
+        "target_committee_size,"
+        "shard_count,"
+        "current_slot,"
+        "num_attesting_validators,"
+        "genesis_slot,"
     ),
-    [
-        (
-            50,
-            10,
-            5,
-            10,
-            100,
-            3,
-            0,
-        ),
-        (
-            50,
-            10,
-            5,
-            10,
-            100,
-            4,
-            0,
-        ),
-    ]
+    [(50, 10, 5, 10, 100, 3, 0), (50, 10, 5, 10, 100, 4, 0)],
 )
-def test_process_rewards_and_penalties_for_crosslinks(genesis_state,
-                                                      config,
-                                                      slots_per_epoch,
-                                                      target_committee_size,
-                                                      shard_count,
-                                                      current_slot,
-                                                      num_attesting_validators,
-                                                      max_effective_balance,
-                                                      min_attestation_inclusion_delay,
-                                                      sample_attestation_data_params,
-                                                      sample_pending_attestation_record_params):
-    state = genesis_state.copy(
-        slot=current_slot,
-    )
+def test_process_rewards_and_penalties_for_crosslinks(
+    genesis_state,
+    config,
+    slots_per_epoch,
+    target_committee_size,
+    shard_count,
+    current_slot,
+    num_attesting_validators,
+    max_effective_balance,
+    min_attestation_inclusion_delay,
+    sample_attestation_data_params,
+    sample_pending_attestation_record_params,
+):
+    state = genesis_state.copy(slot=current_slot)
     previous_epoch = state.previous_epoch(config.SLOTS_PER_EPOCH, config.GENESIS_EPOCH)
 
     prev_epoch_start_slot = compute_start_slot_of_epoch(previous_epoch, slots_per_epoch)
     prev_epoch_crosslink_committees = [
-        get_crosslink_committees_at_slot(
-            state,
-            slot,
-            CommitteeConfig(config),
-        )[0] for slot in range(prev_epoch_start_slot, prev_epoch_start_slot + slots_per_epoch)
+        get_crosslink_committees_at_slot(state, slot, CommitteeConfig(config))[0]
+        for slot in range(
+            prev_epoch_start_slot, prev_epoch_start_slot + slots_per_epoch
+        )
     ]
 
     # Record which validators attest during each slot for reward collation.
     each_slot_attestion_validators_list = []
 
-    epoch_start_shard = get_start_shard(
-        state,
-        previous_epoch,
-        CommitteeConfig(config),
-    )
-    shard_delta = get_shard_delta(
-        state,
-        previous_epoch,
-        CommitteeConfig(config),
-    )
+    epoch_start_shard = get_start_shard(state, previous_epoch, CommitteeConfig(config))
+    shard_delta = get_shard_delta(state, previous_epoch, CommitteeConfig(config))
 
     a = epoch_start_shard
     b = epoch_start_shard + shard_delta
@@ -566,40 +429,30 @@ def test_process_rewards_and_penalties_for_crosslinks(genesis_state,
         # Randomly sample `num_attesting_validators` validators
         # from the committee to attest in this slot.
         crosslink_attesting_validators = random.sample(
-            committee,
-            num_attesting_validators,
+            committee, num_attesting_validators
         )
         each_slot_attestion_validators_list.append(crosslink_attesting_validators)
         participants_bitfield = get_empty_bitfield(len(committee))
         for index in crosslink_attesting_validators:
-            participants_bitfield = set_voted(participants_bitfield, committee.index(index))
+            participants_bitfield = set_voted(
+                participants_bitfield, committee.index(index)
+            )
         previous_epoch_attestations.append(
             PendingAttestation(**sample_pending_attestation_record_params).copy(
                 aggregation_bits=participants_bitfield,
                 data=AttestationData(**sample_attestation_data_params).copy(
-                    target=Checkpoint(
-                        epoch=previous_epoch,
-                    ),
+                    target=Checkpoint(epoch=previous_epoch),
                     crosslink=Crosslink(
-                        shard=shard,
-                        parent_root=Crosslink().hash_tree_root,
+                        shard=shard, parent_root=Crosslink().hash_tree_root
                     ),
                 ),
             )
         )
-    state = state.copy(
-        previous_epoch_attestations=tuple(previous_epoch_attestations),
-    )
+    state = state.copy(previous_epoch_attestations=tuple(previous_epoch_attestations))
 
-    rewards_received, penalties_received = get_crosslink_deltas(
-        state,
-        config,
-    )
+    rewards_received, penalties_received = get_crosslink_deltas(state, config)
 
-    expected_rewards_received = {
-        index: 0
-        for index in range(len(state.validators))
-    }
+    expected_rewards_received = {index: 0 for index in range(len(state.validators))}
     validator_balance = max_effective_balance
     for i in range(slots_per_epoch):
         crosslink_committee, shard = prev_epoch_crosslink_committees[i]
@@ -610,18 +463,14 @@ def test_process_rewards_and_penalties_for_crosslinks(genesis_state,
         total_committee_balance = len(crosslink_committee) * validator_balance
         for index in crosslink_committee:
             if index in attesting_validators:
-                reward = get_base_reward(
-                    state=state,
-                    index=index,
-                    config=config,
-                ) * total_attesting_balance // total_committee_balance
+                reward = (
+                    get_base_reward(state=state, index=index, config=config)
+                    * total_attesting_balance
+                    // total_committee_balance
+                )
                 expected_rewards_received[index] += reward
             else:
-                penalty = get_base_reward(
-                    state=state,
-                    index=index,
-                    config=config,
-                )
+                penalty = get_base_reward(state=state, index=index, config=config)
                 expected_rewards_received[index] -= penalty
 
     # Check the rewards/penalties match
@@ -629,46 +478,36 @@ def test_process_rewards_and_penalties_for_crosslinks(genesis_state,
         if index not in indices_to_check:
             continue
         assert (
-            rewards_received[index] - penalties_received[index] == expected_rewards_received[index]
+            rewards_received[index] - penalties_received[index]
+            == expected_rewards_received[index]
         )
 
 
 @pytest.mark.parametrize(
-    (
-        'validator_count',
-        'slots_per_epoch',
-        'target_committee_size',
-        'shard_count',
-    ),
-    [
-        (
-            10,
-            10,
-            9,
-            10,
-        ),
-    ]
+    ("validator_count", "slots_per_epoch", "target_committee_size", "shard_count"),
+    [(10, 10, 9, 10)],
 )
-def test_process_registry_updates(validator_count,
-                                  genesis_state,
-                                  config,
-                                  slots_per_epoch):
+def test_process_registry_updates(
+    validator_count, genesis_state, config, slots_per_epoch
+):
     activation_index = len(genesis_state.validators)
     exiting_index = len(genesis_state.validators) - 1
 
     activating_validator = Validator.create_pending_validator(
-        pubkey=b'\x10' * 48,
-        withdrawal_credentials=b'\x11' * 32,
+        pubkey=b"\x10" * 48,
+        withdrawal_credentials=b"\x11" * 32,
         amount=Gwei(32 * GWEI_PER_ETH),
         config=config,
     )
 
     state = genesis_state.copy(
-        validators=genesis_state.validators[:exiting_index] + (
+        validators=genesis_state.validators[:exiting_index]
+        + (
             genesis_state.validators[exiting_index].copy(
-                effective_balance=config.EJECTION_BALANCE - 1,
+                effective_balance=config.EJECTION_BALANCE - 1
             ),
-        ) + (activating_validator,),
+        )
+        + (activating_validator,),
         balances=genesis_state.balances + (config.MAX_EFFECTIVE_BALANCE,),
     )
 
@@ -682,8 +521,7 @@ def test_process_registry_updates(validator_count,
     assert pre_activation_validator.activation_epoch == FAR_FUTURE_EPOCH
     assert post_activation_validator.activation_eligibility_epoch != FAR_FUTURE_EPOCH
     activation_epoch = compute_activation_exit_epoch(
-        state.current_epoch(config.SLOTS_PER_EPOCH),
-        config.ACTIVATION_EXIT_DELAY,
+        state.current_epoch(config.SLOTS_PER_EPOCH), config.ACTIVATION_EXIT_DELAY
     )
     assert post_activation_validator.is_active(activation_epoch)
     # Check if the activating_validator is exited
@@ -699,51 +537,52 @@ def test_process_registry_updates(validator_count,
 
 @pytest.mark.parametrize(
     (
-        'validator_count',
-        'slots_per_epoch',
-        'genesis_slot',
-        'current_epoch',
-        'epochs_per_slashings_vector',
+        "validator_count",
+        "slots_per_epoch",
+        "genesis_slot",
+        "current_epoch",
+        "epochs_per_slashings_vector",
     ),
-    [
-        (
-            10, 4, 8, 8, 8,
-        )
-    ]
+    [(10, 4, 8, 8, 8)],
 )
 @pytest.mark.parametrize(
-    (
-        'total_penalties',
-        'total_balance',
-        'expected_penalty',
-    ),
+    ("total_penalties", "total_balance", "expected_penalty"),
     [
         # total_penalties * 3 is less than total_balance
         (
-            32 * 10**9,  # 1 ETH
-            (32 * 10**9 * 10),
+            32 * 10 ** 9,  # 1 ETH
+            (32 * 10 ** 9 * 10),
             # effective_balance * total_penalties * 3 // total_balance
-            ((32 * 10**9) // 10**9) * (3 * 32 * 10**9) // (32 * 10**9 * 10) * 10**9,
+            ((32 * 10 ** 9) // 10 ** 9)
+            * (3 * 32 * 10 ** 9)
+            // (32 * 10 ** 9 * 10)
+            * 10 ** 9,
         ),
         # total_balance is less than total_penalties * 3
         (
-            32 * 4 * 10**9,
-            (32 * 10**9 * 10),
+            32 * 4 * 10 ** 9,
+            (32 * 10 ** 9 * 10),
             # effective_balance * total_balance // total_balance,
-            (32 * 10**9) // 10**9 * (32 * 10**9 * 10) // (32 * 10**9 * 10) * 10**9,
+            (32 * 10 ** 9)
+            // 10 ** 9
+            * (32 * 10 ** 9 * 10)
+            // (32 * 10 ** 9 * 10)
+            * 10 ** 9,
         ),
-    ]
+    ],
 )
-def test_determine_slashing_penalty(genesis_state,
-                                    config,
-                                    slots_per_epoch,
-                                    current_epoch,
-                                    epochs_per_slashings_vector,
-                                    total_penalties,
-                                    total_balance,
-                                    expected_penalty):
+def test_determine_slashing_penalty(
+    genesis_state,
+    config,
+    slots_per_epoch,
+    current_epoch,
+    epochs_per_slashings_vector,
+    total_penalties,
+    total_balance,
+    expected_penalty,
+):
     state = genesis_state.copy(
-        slot=compute_start_slot_of_epoch(current_epoch, slots_per_epoch),
+        slot=compute_start_slot_of_epoch(current_epoch, slots_per_epoch)
     )
     # if the size of the v-set changes then update the parameters above
     assert len(state.validators) == 10
@@ -759,12 +598,12 @@ def test_determine_slashing_penalty(genesis_state,
 
 @pytest.mark.parametrize(
     (
-        'validator_count',
-        'slots_per_epoch',
-        'current_epoch',
-        'epochs_per_slashings_vector',
-        'slashings',
-        'expected_penalty',
+        "validator_count",
+        "slots_per_epoch",
+        "current_epoch",
+        "epochs_per_slashings_vector",
+        "slashings",
+        "expected_penalty",
     ),
     [
         (
@@ -772,18 +611,20 @@ def test_determine_slashing_penalty(genesis_state,
             4,
             8,
             8,
-            (19 * 10**9, 10**9) + (0,) * 6,
-            (32 * 10**9 // 10**9 * 60 * 10**9) // (320 * 10**9) * 10**9,
-        ),
-    ]
+            (19 * 10 ** 9, 10 ** 9) + (0,) * 6,
+            (32 * 10 ** 9 // 10 ** 9 * 60 * 10 ** 9) // (320 * 10 ** 9) * 10 ** 9,
+        )
+    ],
 )
-def test_process_slashings(genesis_state,
-                           config,
-                           current_epoch,
-                           slashings,
-                           slots_per_epoch,
-                           epochs_per_slashings_vector,
-                           expected_penalty):
+def test_process_slashings(
+    genesis_state,
+    config,
+    current_epoch,
+    slashings,
+    slots_per_epoch,
+    epochs_per_slashings_vector,
+    expected_penalty,
+):
     state = genesis_state.copy(
         slot=compute_start_slot_of_epoch(current_epoch, slots_per_epoch),
         slashings=slashings,
@@ -791,50 +632,40 @@ def test_process_slashings(genesis_state,
     slashing_validator_index = 0
     validator = state.validators[slashing_validator_index].copy(
         slashed=True,
-        withdrawable_epoch=current_epoch + epochs_per_slashings_vector // 2
+        withdrawable_epoch=current_epoch + epochs_per_slashings_vector // 2,
     )
     state = state.update_validator(slashing_validator_index, validator)
 
     result_state = process_slashings(state, config)
     penalty = (
-        state.balances[slashing_validator_index] -
-        result_state.balances[slashing_validator_index]
+        state.balances[slashing_validator_index]
+        - result_state.balances[slashing_validator_index]
     )
     assert penalty == expected_penalty
 
 
 @pytest.mark.parametrize(
-    (
-        'slots_per_epoch,'
-        'epochs_per_historical_vector,'
-        'state_slot,'
-    ),
-    [
-        (4, 16, 4),
-        (4, 16, 64),
-    ]
+    ("slots_per_epoch," "epochs_per_historical_vector," "state_slot,"),
+    [(4, 16, 4), (4, 16, 64)],
 )
-def test_update_active_index_roots(genesis_state,
-                                   config,
-                                   state_slot,
-                                   slots_per_epoch,
-                                   epochs_per_historical_vector,
-                                   activation_exit_delay):
-    state = genesis_state.copy(
-        slot=state_slot,
-    )
+def test_update_active_index_roots(
+    genesis_state,
+    config,
+    state_slot,
+    slots_per_epoch,
+    epochs_per_historical_vector,
+    activation_exit_delay,
+):
+    state = genesis_state.copy(slot=state_slot)
 
     result = _compute_next_active_index_roots(state, config)
 
     index_root = ssz.get_hash_tree_root(
         get_active_validator_indices(
-            state.validators,
-            compute_epoch_of_slot(state.slot, slots_per_epoch),
+            state.validators, compute_epoch_of_slot(state.slot, slots_per_epoch)
         ),
         ssz.sedes.List(ssz.uint64, config.VALIDATOR_REGISTRY_LIMIT),
     )
 
     target_epoch = state.next_epoch(slots_per_epoch) + activation_exit_delay
-    assert result[
-        target_epoch % epochs_per_historical_vector
-    ] == index_root
+    assert result[target_epoch % epochs_per_historical_vector] == index_root

--- a/tests/eth2/core/beacon/state_machines/forks/test_serenity_epoch_processing.py
+++ b/tests/eth2/core/beacon/state_machines/forks/test_serenity_epoch_processing.py
@@ -1,53 +1,52 @@
 import random
-import pytest
 
+import pytest
 import ssz
 
-from eth2._utils.bitfield import set_voted, get_empty_bitfield
-from eth2.configs import CommitteeConfig
+from eth2._utils.bitfield import get_empty_bitfield, set_voted
 from eth2.beacon.committee_helpers import (
     get_beacon_proposer_index,
-    get_start_shard,
     get_shard_delta,
+    get_start_shard,
 )
 from eth2.beacon.constants import (
     FAR_FUTURE_EPOCH,
     GWEI_PER_ETH,
     JUSTIFICATION_BITS_LENGTH,
 )
+from eth2.beacon.epoch_processing_helpers import get_base_reward
 from eth2.beacon.helpers import (
+    compute_epoch_of_slot,
+    compute_start_slot_of_epoch,
     get_active_validator_indices,
     get_block_root,
     get_block_root_at_slot,
-    compute_start_slot_of_epoch,
-    compute_epoch_of_slot,
 )
-from eth2.beacon.epoch_processing_helpers import get_base_reward
+from eth2.beacon.state_machines.forks.serenity.epoch_processing import (
+    _bft_threshold_met,
+    _compute_next_active_index_roots,
+    _determine_new_finalized_epoch,
+    _determine_slashing_penalty,
+    compute_activation_exit_epoch,
+    get_attestation_deltas,
+    get_crosslink_deltas,
+    process_crosslinks,
+    process_justification_and_finalization,
+    process_registry_updates,
+    process_slashings,
+)
+from eth2.beacon.tools.builder.validator import (
+    get_crosslink_committees_at_slot,
+    mk_all_pending_attestations_with_full_participation_in_epoch,
+    mk_all_pending_attestations_with_some_participation_in_epoch,
+)
 from eth2.beacon.types.attestation_data import AttestationData
 from eth2.beacon.types.checkpoints import Checkpoint
 from eth2.beacon.types.crosslinks import Crosslink
 from eth2.beacon.types.pending_attestations import PendingAttestation
-from eth2.beacon.typing import Gwei
-from eth2.beacon.state_machines.forks.serenity.epoch_processing import (
-    _bft_threshold_met,
-    _determine_new_finalized_epoch,
-    _determine_slashing_penalty,
-    compute_activation_exit_epoch,
-    process_crosslinks,
-    process_justification_and_finalization,
-    process_slashings,
-    _compute_next_active_index_roots,
-    process_registry_updates,
-    get_crosslink_deltas,
-    get_attestation_deltas,
-)
-
 from eth2.beacon.types.validators import Validator
-from eth2.beacon.tools.builder.validator import (
-    mk_all_pending_attestations_with_full_participation_in_epoch,
-    mk_all_pending_attestations_with_some_participation_in_epoch,
-    get_crosslink_committees_at_slot,
-)
+from eth2.beacon.typing import Gwei
+from eth2.configs import CommitteeConfig
 
 
 @pytest.mark.parametrize(

--- a/tests/eth2/core/beacon/state_machines/forks/test_serenity_operation_processing.py
+++ b/tests/eth2/core/beacon/state_machines/forks/test_serenity_operation_processing.py
@@ -1,28 +1,14 @@
 import pytest
 
-from eth_utils import (
-    ValidationError,
-)
+from eth_utils import ValidationError
 
-from eth2.configs import (
-    CommitteeConfig,
-)
-from eth2.beacon.committee_helpers import (
-    get_beacon_proposer_index,
-)
-from eth2.beacon.constants import (
-    FAR_FUTURE_EPOCH,
-)
-from eth2.beacon.helpers import (
-    compute_start_slot_of_epoch,
-)
-from eth2.beacon.types.blocks import (
-    BeaconBlockBody,
-)
+from eth2.configs import CommitteeConfig
+from eth2.beacon.committee_helpers import get_beacon_proposer_index
+from eth2.beacon.constants import FAR_FUTURE_EPOCH
+from eth2.beacon.helpers import compute_start_slot_of_epoch
+from eth2.beacon.types.blocks import BeaconBlockBody
 from eth2.beacon.types.crosslinks import Crosslink
-from eth2.beacon.state_machines.forks.serenity.blocks import (
-    SerenityBeaconBlock,
-)
+from eth2.beacon.state_machines.forks.serenity.blocks import SerenityBeaconBlock
 from eth2.beacon.state_machines.forks.serenity.operation_processing import (
     process_attestations,
     process_proposer_slashings,
@@ -37,37 +23,26 @@ from eth2.beacon.tools.builder.validator import (
 )
 
 
-@pytest.mark.parametrize(
-    (
-        'validator_count,'
-    ),
-    [
-        (100),
-    ],
-)
-def test_process_max_attestations(genesis_state,
-                                  genesis_block,
-                                  sample_beacon_block_params,
-                                  sample_beacon_block_body_params,
-                                  config,
-                                  keymap,
-                                  fixture_sm_class,
-                                  chaindb,
-                                  empty_attestation_pool):
+@pytest.mark.parametrize(("validator_count,"), [(100)])
+def test_process_max_attestations(
+    genesis_state,
+    genesis_block,
+    sample_beacon_block_params,
+    sample_beacon_block_body_params,
+    config,
+    keymap,
+    fixture_sm_class,
+    chaindb,
+    empty_attestation_pool,
+):
     attestation_slot = config.GENESIS_SLOT
     current_slot = attestation_slot + config.MIN_ATTESTATION_INCLUSION_DELAY
-    state = genesis_state.copy(
-        slot=current_slot,
-    )
+    state = genesis_state.copy(slot=current_slot)
 
     attestations = create_mock_signed_attestations_at_slot(
         state=state,
         config=config,
-        state_machine=fixture_sm_class(
-            chaindb,
-            empty_attestation_pool,
-            current_slot,
-        ),
+        state_machine=fixture_sm_class(chaindb, empty_attestation_pool, current_slot),
         attestation_slot=attestation_slot,
         beacon_block_root=genesis_block.signing_root,
         keymap=keymap,
@@ -78,52 +53,44 @@ def test_process_max_attestations(genesis_state,
     assert attestations_count > 0
 
     block_body = BeaconBlockBody(**sample_beacon_block_body_params).copy(
-        attestations=attestations * (config.MAX_ATTESTATIONS // attestations_count + 1),
+        attestations=attestations * (config.MAX_ATTESTATIONS // attestations_count + 1)
     )
     block = SerenityBeaconBlock(**sample_beacon_block_params).copy(
-        slot=current_slot,
-        body=block_body,
+        slot=current_slot, body=block_body
     )
 
     with pytest.raises(ValidationError):
-        process_attestations(
-            state,
-            block,
-            config,
-        )
+        process_attestations(state, block, config)
 
 
 @pytest.mark.parametrize(
     (
-        'validator_count',
-        'slots_per_epoch',
-        'target_committee_size',
-        'shard_count',
-        'block_root_1',
-        'block_root_2',
-        'success'
+        "validator_count",
+        "slots_per_epoch",
+        "target_committee_size",
+        "shard_count",
+        "block_root_1",
+        "block_root_2",
+        "success",
     ),
     [
-        (10, 2, 2, 2, b'\x11' * 32, b'\x22' * 32, True),
-        (10, 2, 2, 2, b'\x11' * 32, b'\x11' * 32, False),
-    ]
+        (10, 2, 2, 2, b"\x11" * 32, b"\x22" * 32, True),
+        (10, 2, 2, 2, b"\x11" * 32, b"\x11" * 32, False),
+    ],
 )
-def test_process_proposer_slashings(genesis_state,
-                                    sample_beacon_block_params,
-                                    sample_beacon_block_body_params,
-                                    config,
-                                    keymap,
-                                    block_root_1,
-                                    block_root_2,
-                                    success):
+def test_process_proposer_slashings(
+    genesis_state,
+    sample_beacon_block_params,
+    sample_beacon_block_body_params,
+    config,
+    keymap,
+    block_root_1,
+    block_root_2,
+    success,
+):
     current_slot = config.GENESIS_SLOT + 1
-    state = genesis_state.copy(
-        slot=current_slot,
-    )
-    whistleblower_index = get_beacon_proposer_index(
-        state,
-        CommitteeConfig(config),
-    )
+    state = genesis_state.copy(slot=current_slot)
+    whistleblower_index = get_beacon_proposer_index(state, CommitteeConfig(config))
     slashing_proposer_index = (whistleblower_index + 1) % len(state.validators)
     proposer_slashing = create_mock_proposer_slashing_at_block(
         state,
@@ -136,156 +103,121 @@ def test_process_proposer_slashings(genesis_state,
     proposer_slashings = (proposer_slashing,)
 
     block_body = BeaconBlockBody(**sample_beacon_block_body_params).copy(
-        proposer_slashings=proposer_slashings,
+        proposer_slashings=proposer_slashings
     )
     block = SerenityBeaconBlock(**sample_beacon_block_params).copy(
-        slot=current_slot,
-        body=block_body,
+        slot=current_slot, body=block_body
     )
 
     if success:
-        new_state = process_proposer_slashings(
-            state,
-            block,
-            config,
-        )
+        new_state = process_proposer_slashings(state, block, config)
         # Check if slashed
         assert (
-            new_state.balances[slashing_proposer_index] <
-            state.balances[slashing_proposer_index]
+            new_state.balances[slashing_proposer_index]
+            < state.balances[slashing_proposer_index]
         )
     else:
         with pytest.raises(ValidationError):
-            process_proposer_slashings(
-                state,
-                block,
-                config,
-            )
+            process_proposer_slashings(state, block, config)
 
 
 @pytest.mark.parametrize(
     (
-        'validator_count',
-        'slots_per_epoch',
-        'target_committee_size',
-        'shard_count',
-        'min_attestation_inclusion_delay',
+        "validator_count",
+        "slots_per_epoch",
+        "target_committee_size",
+        "shard_count",
+        "min_attestation_inclusion_delay",
     ),
-    [
-        (100, 2, 2, 2, 1),
-    ]
+    [(100, 2, 2, 2, 1)],
 )
-@pytest.mark.parametrize(
-    ('success'),
-    [
-        (True),
-        (False),
-    ]
-)
-def test_process_attester_slashings(genesis_state,
-                                    sample_beacon_block_params,
-                                    sample_beacon_block_body_params,
-                                    config,
-                                    keymap,
-                                    min_attestation_inclusion_delay,
-                                    success):
+@pytest.mark.parametrize(("success"), [(True), (False)])
+def test_process_attester_slashings(
+    genesis_state,
+    sample_beacon_block_params,
+    sample_beacon_block_body_params,
+    config,
+    keymap,
+    min_attestation_inclusion_delay,
+    success,
+):
     attesting_state = genesis_state.copy(
         slot=genesis_state.slot + config.SLOTS_PER_EPOCH,
         block_roots=tuple(
-            i.to_bytes(32, "little")
-            for i in range(config.SLOTS_PER_HISTORICAL_ROOT)
-        )
+            i.to_bytes(32, "little") for i in range(config.SLOTS_PER_HISTORICAL_ROOT)
+        ),
     )
     valid_attester_slashing = create_mock_attester_slashing_is_double_vote(
-        attesting_state,
-        config,
-        keymap,
-        attestation_epoch=0,
+        attesting_state, config, keymap, attestation_epoch=0
     )
     state = attesting_state.copy(
-        slot=attesting_state.slot + min_attestation_inclusion_delay,
+        slot=attesting_state.slot + min_attestation_inclusion_delay
     )
 
     if success:
         block_body = BeaconBlockBody(**sample_beacon_block_body_params).copy(
-            attester_slashings=(valid_attester_slashing,),
+            attester_slashings=(valid_attester_slashing,)
         )
         block = SerenityBeaconBlock(**sample_beacon_block_params).copy(
-            slot=state.slot,
-            body=block_body,
+            slot=state.slot, body=block_body
         )
 
         attester_index = valid_attester_slashing.attestation_1.custody_bit_0_indices[0]
 
-        new_state = process_attester_slashings(
-            state,
-            block,
-            config,
-        )
+        new_state = process_attester_slashings(state, block, config)
         # Check if slashed
         assert not state.validators[attester_index].slashed
         assert new_state.validators[attester_index].slashed
     else:
         invalid_attester_slashing = valid_attester_slashing.copy(
             attestation_2=valid_attester_slashing.attestation_2.copy(
-                data=valid_attester_slashing.attestation_1.data,
+                data=valid_attester_slashing.attestation_1.data
             )
         )
         block_body = BeaconBlockBody(**sample_beacon_block_body_params).copy(
-            attester_slashings=(invalid_attester_slashing,),
+            attester_slashings=(invalid_attester_slashing,)
         )
         block = SerenityBeaconBlock(**sample_beacon_block_params).copy(
-            slot=state.slot,
-            body=block_body,
+            slot=state.slot, body=block_body
         )
 
         with pytest.raises(ValidationError):
-            process_attester_slashings(
-                state,
-                block,
-                config,
-            )
+            process_attester_slashings(state, block, config)
 
 
 @pytest.mark.parametrize(
     (
-        'validator_count,'
-        'slots_per_epoch,'
-        'min_attestation_inclusion_delay,'
-        'target_committee_size,'
-        'shard_count,'
-        'success,'
+        "validator_count,"
+        "slots_per_epoch,"
+        "min_attestation_inclusion_delay,"
+        "target_committee_size,"
+        "shard_count,"
+        "success,"
     ),
-    [
-        (10, 2, 1, 2, 2, True),
-        (10, 2, 1, 2, 2, False),
-        (40, 4, 2, 3, 5, True),
-    ]
+    [(10, 2, 1, 2, 2, True), (10, 2, 1, 2, 2, False), (40, 4, 2, 3, 5, True)],
 )
-def test_process_attestations(genesis_state,
-                              genesis_block,
-                              sample_beacon_block_params,
-                              sample_beacon_block_body_params,
-                              config,
-                              keymap,
-                              fixture_sm_class,
-                              chaindb,
-                              empty_attestation_pool,
-                              success):
+def test_process_attestations(
+    genesis_state,
+    genesis_block,
+    sample_beacon_block_params,
+    sample_beacon_block_body_params,
+    config,
+    keymap,
+    fixture_sm_class,
+    chaindb,
+    empty_attestation_pool,
+    success,
+):
 
     attestation_slot = 0
     current_slot = attestation_slot + config.MIN_ATTESTATION_INCLUSION_DELAY
-    state = genesis_state.copy(
-        slot=current_slot,
-    )
+    state = genesis_state.copy(slot=current_slot)
 
     attestations = create_mock_signed_attestations_at_slot(
         state=state,
         config=config,
         state_machine=fixture_sm_class(
-            chaindb,
-            empty_attestation_pool,
-            genesis_block.slot,
+            chaindb, empty_attestation_pool, genesis_block.slot
         ),
         attestation_slot=attestation_slot,
         beacon_block_root=genesis_block.signing_root,
@@ -300,120 +232,88 @@ def test_process_attestations(genesis_state,
         # i.e. wrong parent
         invalid_attestation_data = attestations[-1].data.copy(
             crosslink=attestations[-1].data.crosslink.copy(
-                parent_root=Crosslink(
-                    shard=333,
-                ).hash_tree_root,
+                parent_root=Crosslink(shard=333).hash_tree_root
             )
         )
-        invalid_attestation = attestations[-1].copy(
-            data=invalid_attestation_data,
-        )
+        invalid_attestation = attestations[-1].copy(data=invalid_attestation_data)
         attestations = attestations[:-1] + (invalid_attestation,)
 
     block_body = BeaconBlockBody(**sample_beacon_block_body_params).copy(
-        attestations=attestations,
+        attestations=attestations
     )
     block = SerenityBeaconBlock(**sample_beacon_block_params).copy(
-        slot=current_slot,
-        body=block_body,
+        slot=current_slot, body=block_body
     )
 
     if success:
-        new_state = process_attestations(
-            state,
-            block,
-            config,
-        )
+        new_state = process_attestations(state, block, config)
 
         assert len(new_state.current_epoch_attestations) == len(attestations)
     else:
         with pytest.raises(ValidationError):
-            process_attestations(
-                state,
-                block,
-                config,
-            )
+            process_attestations(state, block, config)
 
 
 @pytest.mark.parametrize(
     (
-        'validator_count',
-        'slots_per_epoch',
-        'target_committee_size',
-        'activation_exit_delay',
+        "validator_count",
+        "slots_per_epoch",
+        "target_committee_size",
+        "activation_exit_delay",
     ),
-    [
-        (40, 2, 2, 2),
-    ]
+    [(40, 2, 2, 2)],
 )
-@pytest.mark.parametrize(
-    (
-        'success',
-    ),
-    [
-        (True,),
-        (False,),
-    ]
-)
-def test_process_voluntary_exits(genesis_state,
-                                 sample_beacon_block_params,
-                                 sample_beacon_block_body_params,
-                                 config,
-                                 keymap,
-                                 success):
+@pytest.mark.parametrize(("success",), [(True,), (False,)])
+def test_process_voluntary_exits(
+    genesis_state,
+    sample_beacon_block_params,
+    sample_beacon_block_body_params,
+    config,
+    keymap,
+    success,
+):
     state = genesis_state.copy(
         slot=compute_start_slot_of_epoch(
             config.GENESIS_EPOCH + config.PERSISTENT_COMMITTEE_PERIOD,
             config.SLOTS_PER_EPOCH,
-        ),
+        )
     )
     validator_index = 0
     validator = state.validators[validator_index].copy(
-        activation_epoch=config.GENESIS_EPOCH,
+        activation_epoch=config.GENESIS_EPOCH
     )
     state = state.update_validator(validator_index, validator)
     valid_voluntary_exit = create_mock_voluntary_exit(
-        state,
-        config,
-        keymap,
-        validator_index,
+        state, config, keymap, validator_index
     )
 
     if success:
         block_body = BeaconBlockBody(**sample_beacon_block_body_params).copy(
-            voluntary_exits=(valid_voluntary_exit,),
+            voluntary_exits=(valid_voluntary_exit,)
         )
         block = SerenityBeaconBlock(**sample_beacon_block_params).copy(
-            slot=state.slot,
-            body=block_body,
+            slot=state.slot, body=block_body
         )
 
-        new_state = process_voluntary_exits(
-            state,
-            block,
-            config,
-        )
+        new_state = process_voluntary_exits(state, block, config)
         updated_validator = new_state.validators[validator_index]
         assert updated_validator.exit_epoch != FAR_FUTURE_EPOCH
-        assert updated_validator.exit_epoch > state.current_epoch(config.SLOTS_PER_EPOCH)
+        assert updated_validator.exit_epoch > state.current_epoch(
+            config.SLOTS_PER_EPOCH
+        )
         assert updated_validator.withdrawable_epoch == (
             updated_validator.exit_epoch + config.MIN_VALIDATOR_WITHDRAWABILITY_DELAY
         )
     else:
         invalid_voluntary_exit = valid_voluntary_exit.copy(
-            signature=b'\x12' * 96,  # Put wrong signature
+            signature=b"\x12" * 96  # Put wrong signature
         )
         block_body = BeaconBlockBody(**sample_beacon_block_body_params).copy(
-            voluntary_exits=(invalid_voluntary_exit,),
+            voluntary_exits=(invalid_voluntary_exit,)
         )
         block = SerenityBeaconBlock(**sample_beacon_block_params).copy(
-            slot=state.slot,
-            body=block_body,
+            slot=state.slot, body=block_body
         )
 
         with pytest.raises(ValidationError):
-            process_voluntary_exits(
-                state,
-                block,
-                config,
-            )
+            process_voluntary_exits(state, block, config)

--- a/tests/eth2/core/beacon/state_machines/forks/test_serenity_operation_processing.py
+++ b/tests/eth2/core/beacon/state_machines/forks/test_serenity_operation_processing.py
@@ -1,26 +1,25 @@
+from eth_utils import ValidationError
 import pytest
 
-from eth_utils import ValidationError
-
-from eth2.configs import CommitteeConfig
 from eth2.beacon.committee_helpers import get_beacon_proposer_index
 from eth2.beacon.constants import FAR_FUTURE_EPOCH
 from eth2.beacon.helpers import compute_start_slot_of_epoch
-from eth2.beacon.types.blocks import BeaconBlockBody
-from eth2.beacon.types.crosslinks import Crosslink
 from eth2.beacon.state_machines.forks.serenity.blocks import SerenityBeaconBlock
 from eth2.beacon.state_machines.forks.serenity.operation_processing import (
     process_attestations,
-    process_proposer_slashings,
     process_attester_slashings,
+    process_proposer_slashings,
     process_voluntary_exits,
 )
 from eth2.beacon.tools.builder.validator import (
     create_mock_attester_slashing_is_double_vote,
-    create_mock_signed_attestations_at_slot,
     create_mock_proposer_slashing_at_block,
+    create_mock_signed_attestations_at_slot,
     create_mock_voluntary_exit,
 )
+from eth2.beacon.types.blocks import BeaconBlockBody
+from eth2.beacon.types.crosslinks import Crosslink
+from eth2.configs import CommitteeConfig
 
 
 @pytest.mark.parametrize(("validator_count,"), [(100)])

--- a/tests/eth2/core/beacon/state_machines/forks/test_state_machine.py
+++ b/tests/eth2/core/beacon/state_machines/forks/test_state_machine.py
@@ -1,20 +1,10 @@
 import pytest
 
-from eth2.beacon.state_machines.forks.serenity import (
-    SerenityStateMachine,
-)
-from eth2.beacon.state_machines.forks.xiao_long_bao import (
-    XiaoLongBaoStateMachine,
-)
+from eth2.beacon.state_machines.forks.serenity import SerenityStateMachine
+from eth2.beacon.state_machines.forks.xiao_long_bao import XiaoLongBaoStateMachine
 
 
-@pytest.mark.parametrize(
-    "sm_klass",
-    (
-        SerenityStateMachine,
-        XiaoLongBaoStateMachine,
-    )
-)
+@pytest.mark.parametrize("sm_klass", (SerenityStateMachine, XiaoLongBaoStateMachine))
 def test_sm_class_well_defined(sm_klass):
     state_machine = sm_klass(chaindb=None, attestation_pool=None, slot=None)
     assert state_machine.get_block_class()

--- a/tests/eth2/core/beacon/state_machines/test_state_transition.py
+++ b/tests/eth2/core/beacon/state_machines/test_state_transition.py
@@ -1,23 +1,19 @@
 import pytest
 
-from eth2.beacon.state_machines.forks.serenity.blocks import (
-    SerenityBeaconBlock,
-)
-from eth2.beacon.tools.builder.proposer import (
-    create_mock_block,
-)
+from eth2.beacon.state_machines.forks.serenity.blocks import SerenityBeaconBlock
+from eth2.beacon.tools.builder.proposer import create_mock_block
 from eth2.beacon.types.historical_batch import HistoricalBatch
 
 
 @pytest.mark.parametrize(
     (
-        'validator_count,'
-        'slots_per_epoch,'
-        'min_attestation_inclusion_delay,'
-        'target_committee_size,'
-        'shard_count,'
-        'state_slot,'
-        'slots_per_historical_root'
+        "validator_count,"
+        "slots_per_epoch,"
+        "min_attestation_inclusion_delay,"
+        "target_committee_size,"
+        "shard_count,"
+        "state_slot,"
+        "slots_per_historical_root"
     ),
     [
         (10, 10, 1, 2, 10, 2, 8192),
@@ -35,17 +31,19 @@ from eth2.beacon.types.historical_batch import HistoricalBatch
         # updated_state.slot % SLOTS_PER_HISTORICAL_ROOT = 0
         # (11, 4, 1, 2, 4, 15, 8),
         # (16, 4, 1, 2, 4, 31, 8),
-    ]
+    ],
 )
-def test_per_slot_transition(chaindb,
-                             genesis_block,
-                             genesis_state,
-                             fixture_sm_class,
-                             config,
-                             state_slot,
-                             fork_choice_scoring,
-                             empty_attestation_pool,
-                             keymap):
+def test_per_slot_transition(
+    chaindb,
+    genesis_block,
+    genesis_state,
+    fixture_sm_class,
+    config,
+    state_slot,
+    fork_choice_scoring,
+    empty_attestation_pool,
+    keymap,
+):
     chaindb.persist_block(genesis_block, SerenityBeaconBlock, fork_choice_scoring)
     chaindb.persist_state(genesis_state)
 
@@ -56,9 +54,7 @@ def test_per_slot_transition(chaindb,
         state=state,
         config=config,
         state_machine=fixture_sm_class(
-            chaindb,
-            empty_attestation_pool,
-            genesis_block.slot,
+            chaindb, empty_attestation_pool, genesis_block.slot
         ),
         block_class=SerenityBeaconBlock,
         parent_block=genesis_block,
@@ -70,11 +66,7 @@ def test_per_slot_transition(chaindb,
     chaindb.persist_block(block, SerenityBeaconBlock, fork_choice_scoring)
 
     # Get state machine instance
-    sm = fixture_sm_class(
-        chaindb,
-        empty_attestation_pool,
-        block.slot,
-    )
+    sm = fixture_sm_class(chaindb, empty_attestation_pool, block.slot)
 
     # Get state transition instance
     st = sm.state_transition_class(sm.config)
@@ -94,8 +86,7 @@ def test_per_slot_transition(chaindb,
     # historical_roots
     if updated_state.slot % st.config.SLOTS_PER_HISTORICAL_ROOT == 0:
         historical_batch = HistoricalBatch(
-            block_roots=state.block_roots,
-            state_roots=state.state_roots,
+            block_roots=state.block_roots, state_roots=state.state_roots
         )
         assert updated_state.historical_roots[-1] == historical_batch.hash_tree_root
     else:

--- a/tests/eth2/core/beacon/test_attestation_helpers.py
+++ b/tests/eth2/core/beacon/test_attestation_helpers.py
@@ -5,16 +5,10 @@ import pytest
 
 from eth2._utils.bls import bls
 
-from eth_utils import (
-    ValidationError,
-)
-from eth_utils.toolz import (
-    assoc,
-)
+from eth_utils import ValidationError
+from eth_utils.toolz import assoc
 
-from eth2.beacon.helpers import (
-    get_domain,
-)
+from eth2.beacon.helpers import get_domain
 from eth2.beacon.signature_domain import SignatureDomain
 from eth2.beacon.attestation_helpers import (
     is_slashable_attestation_data,
@@ -22,37 +16,33 @@ from eth2.beacon.attestation_helpers import (
     validate_indexed_attestation,
 )
 from eth2.beacon.types.attestation_data import AttestationData
-from eth2.beacon.types.attestation_data_and_custody_bits import AttestationDataAndCustodyBit
+from eth2.beacon.types.attestation_data_and_custody_bits import (
+    AttestationDataAndCustodyBit,
+)
 from eth2.beacon.types.attestations import IndexedAttestation
 from eth2.beacon.types.forks import Fork
 
 
-@pytest.mark.parametrize(
-    (
-        'validator_count',
-    ),
-    [
-        (40,),
-    ]
-)
+@pytest.mark.parametrize(("validator_count",), [(40,)])
 def test_verify_indexed_attestation_signature(
-        slots_per_epoch,
-        validator_count,
-        genesis_state,
-        config,
-        privkeys,
-        sample_beacon_state_params,
-        genesis_validators,
-        genesis_balances,
-        sample_indexed_attestation_params,
-        sample_fork_params):
-    state = genesis_state.copy(
-        fork=Fork(**sample_fork_params),
-    )
+    slots_per_epoch,
+    validator_count,
+    genesis_state,
+    config,
+    privkeys,
+    sample_beacon_state_params,
+    genesis_validators,
+    genesis_balances,
+    sample_indexed_attestation_params,
+    sample_fork_params,
+):
+    state = genesis_state.copy(fork=Fork(**sample_fork_params))
 
     # NOTE: we can do this before "correcting" the params as they
     # touch disjoint subsets of the provided params
-    message_hashes = _create_indexed_attestation_messages(sample_indexed_attestation_params)
+    message_hashes = _create_indexed_attestation_messages(
+        sample_indexed_attestation_params
+    )
 
     valid_params = _correct_indexed_attestation_params(
         validator_count,
@@ -64,12 +54,16 @@ def test_verify_indexed_attestation_signature(
     )
     valid_votes = IndexedAttestation(**valid_params)
 
-    validate_indexed_attestation_aggregate_signature(state, valid_votes, slots_per_epoch)
+    validate_indexed_attestation_aggregate_signature(
+        state, valid_votes, slots_per_epoch
+    )
 
     invalid_params = _corrupt_signature(slots_per_epoch, valid_params, state.fork)
     invalid_votes = IndexedAttestation(**invalid_params)
     with pytest.raises(ValidationError):
-        validate_indexed_attestation_aggregate_signature(state, invalid_votes, slots_per_epoch)
+        validate_indexed_attestation_aggregate_signature(
+            state, invalid_votes, slots_per_epoch
+        )
 
 
 def _get_indices_and_signatures(validator_count, state, config, message_hash, privkeys):
@@ -85,41 +79,28 @@ def _get_indices_and_signatures(validator_count, state, config, message_hash, pr
         signature_domain=signature_domain,
         slots_per_epoch=config.SLOTS_PER_EPOCH,
     )
-    signatures = tuple(
-        map(lambda key: bls.sign(message_hash, key, domain), privkeys)
-    )
+    signatures = tuple(map(lambda key: bls.sign(message_hash, key, domain), privkeys))
     return (indices, signatures)
 
 
-def _run_verify_indexed_vote(slots_per_epoch,
-                             params,
-                             state,
-                             max_validators_per_committee,
-                             should_succeed):
+def _run_verify_indexed_vote(
+    slots_per_epoch, params, state, max_validators_per_committee, should_succeed
+):
     votes = IndexedAttestation(**params)
     if should_succeed:
         validate_indexed_attestation(
-            state,
-            votes,
-            max_validators_per_committee,
-            slots_per_epoch,
+            state, votes, max_validators_per_committee, slots_per_epoch
         )
     else:
         with pytest.raises(ValidationError):
             validate_indexed_attestation(
-                state,
-                votes,
-                max_validators_per_committee,
-                slots_per_epoch,
+                state, votes, max_validators_per_committee, slots_per_epoch
             )
 
 
-def _correct_indexed_attestation_params(validator_count,
-                                        message_hashes,
-                                        params,
-                                        privkeys,
-                                        state,
-                                        config):
+def _correct_indexed_attestation_params(
+    validator_count, message_hashes, params, privkeys, state, config
+):
     valid_params = copy.deepcopy(params)
 
     (custody_bit_0_indices, signatures) = _get_indices_and_signatures(
@@ -154,47 +135,26 @@ def _corrupt_custody_bit_0_indices(params):
 
 
 def _corrupt_custody_bit_0_indices_max(max_validators_per_committee, params):
-    corrupt_custody_bit_0_indices = [
-        i
-        for i in range(max_validators_per_committee + 1)
-    ]
+    corrupt_custody_bit_0_indices = [i for i in range(max_validators_per_committee + 1)]
     return assoc(params, "custody_bit_0_indices", corrupt_custody_bit_0_indices)
 
 
 def _corrupt_signature(slots_per_epoch, params, fork):
-    return assoc(params, "signature", b'\x12' * 96)
+    return assoc(params, "signature", b"\x12" * 96)
 
 
 def _create_indexed_attestation_messages(params):
     attestation = IndexedAttestation(**params)
     data = attestation.data
     return (
-        AttestationDataAndCustodyBit(
-            data=data,
-            custody_bit=False,
-        ).hash_tree_root,
-        AttestationDataAndCustodyBit(
-            data=data,
-            custody_bit=True,
-        ).hash_tree_root,
+        AttestationDataAndCustodyBit(data=data, custody_bit=False).hash_tree_root,
+        AttestationDataAndCustodyBit(data=data, custody_bit=True).hash_tree_root,
     )
 
 
+@pytest.mark.parametrize(("validator_count",), [(40,)])
 @pytest.mark.parametrize(
-    (
-        'validator_count',
-    ),
-    [
-        (40,),
-    ]
-)
-@pytest.mark.parametrize(
-    (
-        'param_mapper',
-        'should_succeed',
-        'needs_fork',
-        'is_testing_max_length',
-    ),
+    ("param_mapper", "should_succeed", "needs_fork", "is_testing_max_length"),
     [
         (lambda params: params, True, False, False),
         (_corrupt_custody_bit_1_indices_not_empty, False, False, False),
@@ -203,28 +163,30 @@ def _create_indexed_attestation_messages(params):
         (_corrupt_signature, False, True, False),
     ],
 )
-def test_validate_indexed_attestation(slots_per_epoch,
-                                      validator_count,
-                                      genesis_state,
-                                      param_mapper,
-                                      should_succeed,
-                                      needs_fork,
-                                      is_testing_max_length,
-                                      privkeys,
-                                      sample_beacon_state_params,
-                                      genesis_validators,
-                                      genesis_balances,
-                                      sample_indexed_attestation_params,
-                                      sample_fork_params,
-                                      max_validators_per_committee,
-                                      config):
-    state = genesis_state.copy(
-        fork=Fork(**sample_fork_params),
-    )
+def test_validate_indexed_attestation(
+    slots_per_epoch,
+    validator_count,
+    genesis_state,
+    param_mapper,
+    should_succeed,
+    needs_fork,
+    is_testing_max_length,
+    privkeys,
+    sample_beacon_state_params,
+    genesis_validators,
+    genesis_balances,
+    sample_indexed_attestation_params,
+    sample_fork_params,
+    max_validators_per_committee,
+    config,
+):
+    state = genesis_state.copy(fork=Fork(**sample_fork_params))
 
     # NOTE: we can do this before "correcting" the params as they
     # touch disjoint subsets of the provided params
-    message_hashes = _create_indexed_attestation_messages(sample_indexed_attestation_params)
+    message_hashes = _create_indexed_attestation_messages(
+        sample_indexed_attestation_params
+    )
 
     params = _correct_indexed_attestation_params(
         validator_count,
@@ -242,47 +204,37 @@ def test_validate_indexed_attestation(slots_per_epoch,
     else:
         params = param_mapper(params)
     _run_verify_indexed_vote(
-        slots_per_epoch,
-        params,
-        state,
-        max_validators_per_committee,
-        should_succeed,
+        slots_per_epoch, params, state, max_validators_per_committee, should_succeed
     )
 
 
-@pytest.mark.parametrize(
-    (
-        'validator_count',
-    ),
-    [
-        (40,),
-    ]
-)
-def test_verify_indexed_attestation_after_fork(genesis_state,
-                                               slots_per_epoch,
-                                               validator_count,
-                                               privkeys,
-                                               sample_beacon_state_params,
-                                               genesis_validators,
-                                               genesis_balances,
-                                               sample_indexed_attestation_params,
-                                               sample_fork_params,
-                                               config,
-                                               max_validators_per_committee):
+@pytest.mark.parametrize(("validator_count",), [(40,)])
+def test_verify_indexed_attestation_after_fork(
+    genesis_state,
+    slots_per_epoch,
+    validator_count,
+    privkeys,
+    sample_beacon_state_params,
+    genesis_validators,
+    genesis_balances,
+    sample_indexed_attestation_params,
+    sample_fork_params,
+    config,
+    max_validators_per_committee,
+):
     # Test that indexed data is still valid after fork
     # Indexed data slot = 10, fork slot = 15, current slot = 20
     past_fork_params = {
-        'previous_version': (0).to_bytes(4, 'little'),
-        'current_version': (1).to_bytes(4, 'little'),
-        'epoch': 15,
+        "previous_version": (0).to_bytes(4, "little"),
+        "current_version": (1).to_bytes(4, "little"),
+        "epoch": 15,
     }
 
-    state = genesis_state.copy(
-        slot=20,
-        fork=Fork(**past_fork_params),
-    )
+    state = genesis_state.copy(slot=20, fork=Fork(**past_fork_params))
 
-    message_hashes = _create_indexed_attestation_messages(sample_indexed_attestation_params)
+    message_hashes = _create_indexed_attestation_messages(
+        sample_indexed_attestation_params
+    )
 
     valid_params = _correct_indexed_attestation_params(
         validator_count,
@@ -293,53 +245,33 @@ def test_verify_indexed_attestation_after_fork(genesis_state,
         config,
     )
     _run_verify_indexed_vote(
-        slots_per_epoch,
-        valid_params,
-        state,
-        max_validators_per_committee,
-        True,
+        slots_per_epoch, valid_params, state, max_validators_per_committee, True
     )
 
 
 @pytest.mark.parametrize(
-    (
-        'is_double_vote,'
-        'is_surround_vote,'
-    ),
-    [
-        (False, False),
-        (False, True),
-        (True, False),
-        (True, True),
-    ],
+    ("is_double_vote," "is_surround_vote,"),
+    [(False, False), (False, True), (True, False), (True, True)],
 )
-def test_is_slashable_attestation_data(sample_attestation_data_params,
-                                       is_double_vote,
-                                       is_surround_vote):
+def test_is_slashable_attestation_data(
+    sample_attestation_data_params, is_double_vote, is_surround_vote
+):
     data_1 = AttestationData(**sample_attestation_data_params)
     data_2 = AttestationData(**sample_attestation_data_params)
 
     if is_double_vote:
         data_2 = data_2.copy(
             beacon_block_root=(
-                int.from_bytes(
-                    data_1.beacon_block_root,
-                    "little",
-                ) + 1
+                int.from_bytes(data_1.beacon_block_root, "little") + 1
             ).to_bytes(32, "little")
         )
 
     if is_surround_vote:
         data_1 = data_1.copy(
-            source=data_1.source.copy(
-                epoch=data_2.source.epoch - 1,
-            ),
-            target=data_1.target.copy(
-                epoch=data_2.target.epoch + 1,
-            ),
+            source=data_1.source.copy(epoch=data_2.source.epoch - 1),
+            target=data_1.target.copy(epoch=data_2.target.epoch + 1),
         )
 
-    assert is_slashable_attestation_data(
-        data_1,
-        data_2
-    ) == (is_double_vote or is_surround_vote)
+    assert is_slashable_attestation_data(data_1, data_2) == (
+        is_double_vote or is_surround_vote
+    )

--- a/tests/eth2/core/beacon/test_attestation_helpers.py
+++ b/tests/eth2/core/beacon/test_attestation_helpers.py
@@ -1,20 +1,18 @@
 import copy
 import random
 
+from eth_utils import ValidationError
+from eth_utils.toolz import assoc
 import pytest
 
 from eth2._utils.bls import bls
-
-from eth_utils import ValidationError
-from eth_utils.toolz import assoc
-
-from eth2.beacon.helpers import get_domain
-from eth2.beacon.signature_domain import SignatureDomain
 from eth2.beacon.attestation_helpers import (
     is_slashable_attestation_data,
-    validate_indexed_attestation_aggregate_signature,
     validate_indexed_attestation,
+    validate_indexed_attestation_aggregate_signature,
 )
+from eth2.beacon.helpers import get_domain
+from eth2.beacon.signature_domain import SignatureDomain
 from eth2.beacon.types.attestation_data import AttestationData
 from eth2.beacon.types.attestation_data_and_custody_bits import (
     AttestationDataAndCustodyBit,

--- a/tests/eth2/core/beacon/test_committee_helpers.py
+++ b/tests/eth2/core/beacon/test_committee_helpers.py
@@ -2,9 +2,7 @@ import random
 
 import pytest
 
-from eth_utils import (
-    ValidationError,
-)
+from eth_utils import ValidationError
 
 from eth2.beacon.committee_helpers import (
     get_committees_per_slot,
@@ -20,18 +18,16 @@ from eth2.beacon.helpers import (
     get_active_validator_indices,
     compute_start_slot_of_epoch,
 )
-from eth2.configs import (
-    CommitteeConfig,
-)
+from eth2.configs import CommitteeConfig
 
 
 @pytest.mark.parametrize(
     (
-        'active_validator_count,'
-        'slots_per_epoch,'
-        'target_committee_size,'
-        'shard_count,'
-        'expected_committee_count'
+        "active_validator_count,"
+        "slots_per_epoch,"
+        "target_committee_size,"
+        "shard_count,"
+        "expected_committee_count"
     ),
     [
         # SHARD_COUNT // SLOTS_PER_EPOCH
@@ -44,11 +40,13 @@ from eth2.configs import (
         (40, 5, 10, 5, 5),
     ],
 )
-def test_get_committees_per_slot(active_validator_count,
-                                 slots_per_epoch,
-                                 target_committee_size,
-                                 shard_count,
-                                 expected_committee_count):
+def test_get_committees_per_slot(
+    active_validator_count,
+    slots_per_epoch,
+    target_committee_size,
+    shard_count,
+    expected_committee_count,
+):
     assert expected_committee_count // slots_per_epoch == get_committees_per_slot(
         active_validator_count=active_validator_count,
         shard_count=shard_count,
@@ -59,11 +57,11 @@ def test_get_committees_per_slot(active_validator_count,
 
 @pytest.mark.parametrize(
     (
-        'active_validator_count,'
-        'slots_per_epoch,'
-        'target_committee_size,'
-        'shard_count,'
-        'expected_committee_count'
+        "active_validator_count,"
+        "slots_per_epoch,"
+        "target_committee_size,"
+        "shard_count,"
+        "expected_committee_count"
     ),
     [
         # SHARD_COUNT // SLOTS_PER_EPOCH
@@ -76,11 +74,13 @@ def test_get_committees_per_slot(active_validator_count,
         (40, 5, 10, 5, 5),
     ],
 )
-def test_get_committee_count(active_validator_count,
-                             slots_per_epoch,
-                             target_committee_size,
-                             shard_count,
-                             expected_committee_count):
+def test_get_committee_count(
+    active_validator_count,
+    slots_per_epoch,
+    target_committee_size,
+    shard_count,
+    expected_committee_count,
+):
     assert expected_committee_count == get_committee_count(
         active_validator_count=active_validator_count,
         shard_count=shard_count,
@@ -91,11 +91,11 @@ def test_get_committee_count(active_validator_count,
 
 @pytest.mark.parametrize(
     (
-        'validator_count,'
-        'slots_per_epoch,'
-        'target_committee_size,'
-        'shard_count,'
-        'expected_shard_delta,'
+        "validator_count,"
+        "slots_per_epoch,"
+        "target_committee_size,"
+        "shard_count,"
+        "expected_shard_delta,"
     ),
     [
         # SHARD_COUNT - SHARD_COUNT // SLOTS_PER_EPOCH
@@ -104,9 +104,7 @@ def test_get_committee_count(active_validator_count,
         (500, 20, 10, 100, 40),
     ],
 )
-def test_get_shard_delta(genesis_state,
-                         expected_shard_delta,
-                         config):
+def test_get_shard_delta(genesis_state, expected_shard_delta, config):
     state = genesis_state
     epoch = state.current_epoch(config.SLOTS_PER_EPOCH)
 
@@ -115,13 +113,13 @@ def test_get_shard_delta(genesis_state,
 
 @pytest.mark.parametrize(
     (
-        'validator_count,'
-        'slots_per_epoch,'
-        'target_committee_size,'
-        'shard_count,'
-        'current_epoch,'
-        'target_epoch,'
-        'expected_epoch_start_shard,'
+        "validator_count,"
+        "slots_per_epoch,"
+        "target_committee_size,"
+        "shard_count,"
+        "current_epoch,"
+        "target_epoch,"
+        "expected_epoch_start_shard,"
     ),
     [
         (1000, 25, 5, 50, 3, 2, 2),
@@ -130,29 +128,28 @@ def test_get_shard_delta(genesis_state,
         (1000, 25, 5, 50, 3, 5, None),
     ],
 )
-def test_get_start_shard(genesis_state,
-                         current_epoch,
-                         target_epoch,
-                         expected_epoch_start_shard,
-                         config):
+def test_get_start_shard(
+    genesis_state, current_epoch, target_epoch, expected_epoch_start_shard, config
+):
     state = genesis_state.copy(
-        slot=compute_start_slot_of_epoch(current_epoch, config.SLOTS_PER_EPOCH),
+        slot=compute_start_slot_of_epoch(current_epoch, config.SLOTS_PER_EPOCH)
     )
 
     if expected_epoch_start_shard is None:
         with pytest.raises(ValidationError):
             get_start_shard(state, target_epoch, CommitteeConfig(config))
     else:
-        epoch_start_shard = get_start_shard(state, target_epoch, CommitteeConfig(config))
+        epoch_start_shard = get_start_shard(
+            state, target_epoch, CommitteeConfig(config)
+        )
         assert epoch_start_shard == expected_epoch_start_shard
 
 
-SOME_SEED = b'\x33' * 32
+SOME_SEED = b"\x33" * 32
 
 
-def test_find_proposer_in_committee(genesis_validators,
-                                    config):
-    epoch = random.randrange(config.GENESIS_EPOCH, 2**64)
+def test_find_proposer_in_committee(genesis_validators, config):
+    epoch = random.randrange(config.GENESIS_EPOCH, 2 ** 64)
     proposer_index = random.randrange(0, len(genesis_validators))
 
     validators = tuple()
@@ -160,26 +157,26 @@ def test_find_proposer_in_committee(genesis_validators,
     # should at a minimum have 17 ETH as ``effective_balance``.
     # Using 1 ETH should maintain the same spirit of the test and
     # ensure we can know the likely candidate ahead of time.
-    one_eth_in_gwei = 1 * 10**9
+    one_eth_in_gwei = 1 * 10 ** 9
     for index, validator in enumerate(genesis_validators):
         if index == proposer_index:
             validators += (validator,)
         else:
-            validators += (validator.copy(
-                effective_balance=one_eth_in_gwei,
-            ),)
+            validators += (validator.copy(effective_balance=one_eth_in_gwei),)
 
-    assert _find_proposer_in_committee(
-        validators,
-        range(len(validators)),
-        epoch,
-        SOME_SEED,
-        config.MAX_EFFECTIVE_BALANCE
-    ) == proposer_index
+    assert (
+        _find_proposer_in_committee(
+            validators,
+            range(len(validators)),
+            epoch,
+            SOME_SEED,
+            config.MAX_EFFECTIVE_BALANCE,
+        )
+        == proposer_index
+    )
 
 
-def test_calculate_first_committee_at_slot(genesis_state,
-                                           config):
+def test_calculate_first_committee_at_slot(genesis_state, config):
     state = genesis_state
     slots_per_epoch = config.SLOTS_PER_EPOCH
     shard_count = config.SHARD_COUNT
@@ -187,7 +184,9 @@ def test_calculate_first_committee_at_slot(genesis_state,
 
     current_epoch = state.current_epoch(slots_per_epoch)
 
-    active_validator_indices = get_active_validator_indices(state.validators, current_epoch)
+    active_validator_indices = get_active_validator_indices(
+        state.validators, current_epoch
+    )
 
     committees_per_slot = get_committees_per_slot(
         len(active_validator_indices),
@@ -199,73 +198,48 @@ def test_calculate_first_committee_at_slot(genesis_state,
     assert state.slot % config.SLOTS_PER_EPOCH == 0
     for slot in range(state.slot, state.slot + config.SLOTS_PER_EPOCH):
         offset = committees_per_slot * (slot % slots_per_epoch)
-        shard = (
-            get_start_shard(state, current_epoch, config) + offset
-        ) % shard_count
-        committee = get_crosslink_committee(
-            state,
-            current_epoch,
-            shard,
-            config,
-        )
+        shard = (get_start_shard(state, current_epoch, config) + offset) % shard_count
+        committee = get_crosslink_committee(state, current_epoch, shard, config)
 
-        assert committee == _calculate_first_committee_at_slot(state, slot, CommitteeConfig(config))
+        assert committee == _calculate_first_committee_at_slot(
+            state, slot, CommitteeConfig(config)
+        )
 
 
 def _invalidate_all_but_proposer(proposer_index, index, validator):
     if proposer_index == index:
         return validator
     else:
-        return validator.copy(
-            effective_balance=-1,
-        )
+        return validator.copy(effective_balance=-1)
 
 
-@pytest.mark.parametrize(
-    (
-        'validator_count,'
-    ),
-    [
-        (1000),
-    ],
-)
-def test_get_beacon_proposer_index(genesis_state,
-                                   config):
+@pytest.mark.parametrize(("validator_count,"), [(1000)])
+def test_get_beacon_proposer_index(genesis_state, config):
     state = genesis_state
     first_committee = _calculate_first_committee_at_slot(
-        state,
-        state.slot,
-        CommitteeConfig(config),
+        state, state.slot, CommitteeConfig(config)
     )
     some_validator_index = random.sample(first_committee, 1)[0]
 
     state = state.copy(
         validators=tuple(
-            _invalidate_all_but_proposer(
-                some_validator_index,
-                index,
-                validator,
-            ) for index, validator in enumerate(state.validators)
-        ),
+            _invalidate_all_but_proposer(some_validator_index, index, validator)
+            for index, validator in enumerate(state.validators)
+        )
     )
 
-    assert get_beacon_proposer_index(state, CommitteeConfig(config)) == some_validator_index
+    assert (
+        get_beacon_proposer_index(state, CommitteeConfig(config))
+        == some_validator_index
+    )
 
 
-@pytest.mark.parametrize(
-    (
-        'validator_count,'
-    ),
-    [
-        (1000),
-    ],
-)
-def test_get_crosslink_committee(genesis_state,
-                                 config):
+@pytest.mark.parametrize(("validator_count,"), [(1000)])
+def test_get_crosslink_committee(genesis_state, config):
     indices = tuple()
-    for shard in range(get_shard_delta(genesis_state,
-                                       config.GENESIS_EPOCH,
-                                       CommitteeConfig(config))):
+    for shard in range(
+        get_shard_delta(genesis_state, config.GENESIS_EPOCH, CommitteeConfig(config))
+    ):
         some_committee = get_crosslink_committee(
             genesis_state,
             genesis_state.current_epoch(config.SLOTS_PER_EPOCH),

--- a/tests/eth2/core/beacon/test_committee_helpers.py
+++ b/tests/eth2/core/beacon/test_committee_helpers.py
@@ -1,22 +1,21 @@
 import random
 
+from eth_utils import ValidationError
 import pytest
 
-from eth_utils import ValidationError
-
 from eth2.beacon.committee_helpers import (
-    get_committees_per_slot,
+    _calculate_first_committee_at_slot,
+    _find_proposer_in_committee,
+    get_beacon_proposer_index,
     get_committee_count,
+    get_committees_per_slot,
+    get_crosslink_committee,
     get_shard_delta,
     get_start_shard,
-    _find_proposer_in_committee,
-    _calculate_first_committee_at_slot,
-    get_beacon_proposer_index,
-    get_crosslink_committee,
 )
 from eth2.beacon.helpers import (
-    get_active_validator_indices,
     compute_start_slot_of_epoch,
+    get_active_validator_indices,
 )
 from eth2.configs import CommitteeConfig
 

--- a/tests/eth2/core/beacon/test_deposit_helpers.py
+++ b/tests/eth2/core/beacon/test_deposit_helpers.py
@@ -1,74 +1,44 @@
 import pytest
 
-from eth_utils import (
-    ValidationError,
-)
+from eth_utils import ValidationError
 
-from eth2.beacon.deposit_helpers import (
-    process_deposit,
-    validate_deposit_proof,
-)
+from eth2.beacon.deposit_helpers import process_deposit, validate_deposit_proof
 
-from eth2.beacon.tools.builder.initializer import (
-    create_mock_deposit,
-)
+from eth2.beacon.tools.builder.initializer import create_mock_deposit
 
 
-@pytest.mark.parametrize(
-    (
-        'success',
-    ),
-    [
-        (True,),
-        (False,),
-    ]
-)
-def test_validate_deposit_proof(config,
-                                keymap,
-                                pubkeys,
-                                deposit_contract_tree_depth,
-                                genesis_state,
-                                success):
+@pytest.mark.parametrize(("success",), [(True,), (False,)])
+def test_validate_deposit_proof(
+    config, keymap, pubkeys, deposit_contract_tree_depth, genesis_state, success
+):
     state = genesis_state
-    withdrawal_credentials = b'\x34' * 32
+    withdrawal_credentials = b"\x34" * 32
     state, deposit = create_mock_deposit(
-        state,
-        pubkeys[0],
-        keymap,
-        withdrawal_credentials,
-        config,
+        state, pubkeys[0], keymap, withdrawal_credentials, config
     )
 
     if success:
         validate_deposit_proof(state, deposit, deposit_contract_tree_depth)
     else:
         deposit = deposit.copy(
-            data=deposit.data.copy(
-                withdrawal_credentials=b'\x23' * 32,
-            )
+            data=deposit.data.copy(withdrawal_credentials=b"\x23" * 32)
         )
         with pytest.raises(ValidationError):
             validate_deposit_proof(state, deposit, deposit_contract_tree_depth)
 
 
-@pytest.mark.parametrize(
-    (
-        'is_new_validator',
-    ),
-    [
-        (True,),
-        (False,),
-    ]
-)
-def test_process_deposit(config,
-                         sample_beacon_state_params,
-                         keymap,
-                         genesis_state,
-                         validator_count,
-                         is_new_validator,
-                         pubkeys):
+@pytest.mark.parametrize(("is_new_validator",), [(True,), (False,)])
+def test_process_deposit(
+    config,
+    sample_beacon_state_params,
+    keymap,
+    genesis_state,
+    validator_count,
+    is_new_validator,
+    pubkeys,
+):
     state = genesis_state
-    withdrawal_credentials = b'\x34' * 32
+    withdrawal_credentials = b"\x34" * 32
     if is_new_validator:
         validator_index = validator_count
     else:
@@ -77,20 +47,12 @@ def test_process_deposit(config,
     pubkey = pubkeys[validator_index]
 
     state, deposit = create_mock_deposit(
-        state,
-        pubkey,
-        keymap,
-        withdrawal_credentials,
-        config,
+        state, pubkey, keymap, withdrawal_credentials, config
     )
 
     validator_count_before_deposit = state.validator_count
 
-    result_state = process_deposit(
-        state=state,
-        deposit=deposit,
-        config=config,
-    )
+    result_state = process_deposit(state=state, deposit=deposit, config=config)
 
     # test immutability
     assert len(state.validators) == validator_count_before_deposit
@@ -104,4 +66,6 @@ def test_process_deposit(config,
     else:
         assert len(result_state.validators) == len(state.validators)
         assert validator.pubkey == pubkeys[validator_index]
-        assert result_state.balances[validator_index] == 2 * config.MAX_EFFECTIVE_BALANCE
+        assert (
+            result_state.balances[validator_index] == 2 * config.MAX_EFFECTIVE_BALANCE
+        )

--- a/tests/eth2/core/beacon/test_deposit_helpers.py
+++ b/tests/eth2/core/beacon/test_deposit_helpers.py
@@ -1,9 +1,7 @@
+from eth_utils import ValidationError
 import pytest
 
-from eth_utils import ValidationError
-
 from eth2.beacon.deposit_helpers import process_deposit, validate_deposit_proof
-
 from eth2.beacon.tools.builder.initializer import create_mock_deposit
 
 

--- a/tests/eth2/core/beacon/test_epoch_processing_helpers.py
+++ b/tests/eth2/core/beacon/test_epoch_processing_helpers.py
@@ -1,26 +1,14 @@
 import random
 import pytest
 
-from eth_utils.toolz import (
-    random_sample,
-)
+from eth_utils.toolz import random_sample
 
-from eth2._utils.bitfield import (
-    set_voted,
-    get_empty_bitfield,
-)
-from eth2._utils.tuple import (
-    update_tuple_item,
-)
+from eth2._utils.bitfield import set_voted, get_empty_bitfield
+from eth2._utils.tuple import update_tuple_item
 from eth2.configs import CommitteeConfig
-from eth2.beacon.constants import (
-    FAR_FUTURE_EPOCH,
-    GWEI_PER_ETH,
-)
+from eth2.beacon.constants import FAR_FUTURE_EPOCH, GWEI_PER_ETH
 from eth2.beacon.exceptions import InvalidEpochError
-from eth2.beacon.committee_helpers import (
-    get_crosslink_committee,
-)
+from eth2.beacon.committee_helpers import get_crosslink_committee
 from eth2.beacon.epoch_processing_helpers import (
     increase_balance,
     decrease_balance,
@@ -36,37 +24,20 @@ from eth2.beacon.epoch_processing_helpers import (
     _find_winning_crosslink_and_attesting_indices_from_candidates,
     get_base_reward,
 )
-from eth2.beacon.helpers import (
-    compute_start_slot_of_epoch,
-)
-from eth2.beacon.types.attestation_data import (
-    AttestationData,
-)
+from eth2.beacon.helpers import compute_start_slot_of_epoch
+from eth2.beacon.types.attestation_data import AttestationData
 from eth2.beacon.types.checkpoints import Checkpoint
 from eth2.beacon.types.crosslinks import Crosslink
 from eth2.beacon.types.pending_attestations import PendingAttestation
-from eth2.beacon.typing import (
-    Gwei,
-)
-from eth2.beacon.tools.builder.validator import (
-    mk_pending_attestation_from_committee,
-)
+from eth2.beacon.typing import Gwei
+from eth2.beacon.tools.builder.validator import mk_pending_attestation_from_committee
 
 
 @pytest.mark.parametrize(
-    (
-        "delta,"
-    ),
-    [
-        (1),
-        (GWEI_PER_ETH),
-        (2 * GWEI_PER_ETH),
-        (32 * GWEI_PER_ETH),
-        (33 * GWEI_PER_ETH),
-    ],
+    ("delta,"),
+    [(1), (GWEI_PER_ETH), (2 * GWEI_PER_ETH), (32 * GWEI_PER_ETH), (33 * GWEI_PER_ETH)],
 )
-def test_increase_balance(genesis_state,
-                          delta):
+def test_increase_balance(genesis_state, delta):
     index = random.sample(range(len(genesis_state.validators)), 1)[0]
     prior_balance = genesis_state.balances[index]
     state = increase_balance(genesis_state, index, delta)
@@ -74,9 +45,7 @@ def test_increase_balance(genesis_state,
 
 
 @pytest.mark.parametrize(
-    (
-        "delta,"
-    ),
+    ("delta,"),
     [
         (1),
         (GWEI_PER_ETH),
@@ -86,43 +55,26 @@ def test_increase_balance(genesis_state,
         (100 * GWEI_PER_ETH),
     ],
 )
-def test_decrease_balance(genesis_state,
-                          delta):
+def test_decrease_balance(genesis_state, delta):
     index = random.sample(range(len(genesis_state.validators)), 1)[0]
     prior_balance = genesis_state.balances[index]
     state = decrease_balance(genesis_state, index, delta)
     assert state.balances[index] == Gwei(max(prior_balance - delta, 0))
 
 
-@pytest.mark.parametrize(
-    (
-        'validator_count,'
-    ),
-    [
-        (1000),
-    ],
-)
-def test_get_attesting_indices(genesis_state,
-                               config):
+@pytest.mark.parametrize(("validator_count,"), [(1000)])
+def test_get_attesting_indices(genesis_state, config):
     state = genesis_state.copy(
         slot=compute_start_slot_of_epoch(3, config.SLOTS_PER_EPOCH)
     )
     target_epoch = state.current_epoch(config.SLOTS_PER_EPOCH)
     target_shard = (state.start_shard + 3) % config.SHARD_COUNT
     some_committee = get_crosslink_committee(
-        state,
-        target_epoch,
-        target_shard,
-        CommitteeConfig(config),
+        state, target_epoch, target_shard, CommitteeConfig(config)
     )
 
     data = AttestationData(
-        target=Checkpoint(
-            epoch=target_epoch,
-        ),
-        crosslink=Crosslink(
-            shard=target_shard,
-        ),
+        target=Checkpoint(epoch=target_epoch), crosslink=Crosslink(shard=target_shard)
     )
     some_subset_count = random.randrange(1, len(some_committee) // 2)
     some_subset = random.sample(some_committee, some_subset_count)
@@ -132,12 +84,7 @@ def test_get_attesting_indices(genesis_state,
         if index in some_subset:
             bitfield = set_voted(bitfield, i)
 
-    indices = get_attesting_indices(
-        state,
-        data,
-        bitfield,
-        CommitteeConfig(config),
-    )
+    indices = get_attesting_indices(state, data, bitfield, CommitteeConfig(config))
 
     assert set(indices) == set(some_subset)
     assert len(indices) == len(some_subset)
@@ -146,8 +93,7 @@ def test_get_attesting_indices(genesis_state,
 def test_compute_activation_exit_epoch(activation_exit_delay):
     epoch = random.randrange(0, FAR_FUTURE_EPOCH)
     entry_exit_effect_epoch = compute_activation_exit_epoch(
-        epoch,
-        activation_exit_delay,
+        epoch, activation_exit_delay
     )
     assert entry_exit_effect_epoch == (epoch + 1 + activation_exit_delay)
 
@@ -166,61 +112,40 @@ def test_compute_activation_exit_epoch(activation_exit_delay):
         (100, 1, 5, 100),
     ],
 )
-def test_get_validator_churn_limit(genesis_state,
-                                   expected_churn_limit,
-                                   config):
+def test_get_validator_churn_limit(genesis_state, expected_churn_limit, config):
     assert get_validator_churn_limit(genesis_state, config) == expected_churn_limit
 
 
 @pytest.mark.parametrize(
-    (
-        "current_epoch,"
-        "target_epoch,"
-        "success,"
-    ),
-    [
-        (40, 40, True),
-        (40, 39, True),
-        (40, 38, False),
-        (40, 41, False),
-    ],
+    ("current_epoch," "target_epoch," "success,"),
+    [(40, 40, True), (40, 39, True), (40, 38, False), (40, 41, False)],
 )
-def test_get_matching_source_attestations(genesis_state,
-                                          current_epoch,
-                                          target_epoch,
-                                          success,
-                                          config):
+def test_get_matching_source_attestations(
+    genesis_state, current_epoch, target_epoch, success, config
+):
     state = genesis_state.copy(
         slot=compute_start_slot_of_epoch(current_epoch, config.SLOTS_PER_EPOCH),
         current_epoch_attestations=tuple(
             PendingAttestation(
                 data=AttestationData(
-                    beacon_block_root=current_epoch.to_bytes(32, "little"),
+                    beacon_block_root=current_epoch.to_bytes(32, "little")
                 )
             )
         ),
         previous_epoch_attestations=tuple(
             PendingAttestation(
                 data=AttestationData(
-                    beacon_block_root=(current_epoch - 1).to_bytes(32, "little"),
+                    beacon_block_root=(current_epoch - 1).to_bytes(32, "little")
                 )
             )
-        )
+        ),
     )
 
     if success:
-        attestations = get_matching_source_attestations(
-            state,
-            target_epoch,
-            config,
-        )
+        attestations = get_matching_source_attestations(state, target_epoch, config)
     else:
         with pytest.raises(InvalidEpochError):
-            get_matching_source_attestations(
-                state,
-                target_epoch,
-                config,
-            )
+            get_matching_source_attestations(state, target_epoch, config)
         return
 
     if current_epoch == target_epoch:
@@ -229,31 +154,24 @@ def test_get_matching_source_attestations(genesis_state,
         assert attestations == state.previous_epoch_attestations
 
 
-def test_get_matching_target_attestations(genesis_state,
-                                          config):
+def test_get_matching_target_attestations(genesis_state, config):
     some_epoch = config.GENESIS_EPOCH + 20
     some_slot = compute_start_slot_of_epoch(some_epoch, config.SLOTS_PER_EPOCH)
-    some_target_root = b'\x33' * 32
+    some_target_root = b"\x33" * 32
     target_attestations = tuple(
         (
             PendingAttestation(
-                data=AttestationData(
-                    target=Checkpoint(
-                        root=some_target_root,
-                    ),
-                ),
-            ) for _ in range(3)
+                data=AttestationData(target=Checkpoint(root=some_target_root))
+            )
+            for _ in range(3)
         )
     )
     current_epoch_attestations = target_attestations + tuple(
         (
             PendingAttestation(
-                data=AttestationData(
-                    target=Checkpoint(
-                        root=b'\x44' * 32,
-                    ),
-                ),
-            ) for _ in range(3)
+                data=AttestationData(target=Checkpoint(root=b"\x44" * 32))
+            )
+            for _ in range(3)
         )
     )
     state = genesis_state.copy(
@@ -266,48 +184,39 @@ def test_get_matching_target_attestations(genesis_state,
         current_epoch_attestations=current_epoch_attestations,
     )
 
-    attestations = get_matching_target_attestations(
-        state,
-        some_epoch,
-        config,
-    )
+    attestations = get_matching_target_attestations(state, some_epoch, config)
 
     assert attestations == target_attestations
 
 
-def test_get_matching_head_attestations(genesis_state,
-                                        config):
+def test_get_matching_head_attestations(genesis_state, config):
     some_epoch = config.GENESIS_EPOCH + 20
-    some_slot = compute_start_slot_of_epoch(
-        some_epoch,
-        config.SLOTS_PER_EPOCH
-    ) + config.SLOTS_PER_EPOCH // 4
-    some_target_root = b'\x33' * 32
+    some_slot = (
+        compute_start_slot_of_epoch(some_epoch, config.SLOTS_PER_EPOCH)
+        + config.SLOTS_PER_EPOCH // 4
+    )
+    some_target_root = b"\x33" * 32
     target_attestations = tuple(
         (
             PendingAttestation(
                 data=AttestationData(
                     beacon_block_root=some_target_root,
-                    target=Checkpoint(
-                        epoch=some_epoch - 1,
-                    ),
-                    crosslink=Crosslink(
-                        shard=i,
-                    )
-                ),
-            ) for i in range(3)
+                    target=Checkpoint(epoch=some_epoch - 1),
+                    crosslink=Crosslink(shard=i),
+                )
+            )
+            for i in range(3)
         )
     )
     current_epoch_attestations = target_attestations + tuple(
         (
             PendingAttestation(
                 data=AttestationData(
-                    beacon_block_root=b'\x44' * 32,
-                    target=Checkpoint(
-                        epoch=some_epoch - 1,
-                    ),
-                ),
-            ) for _ in range(3)
+                    beacon_block_root=b"\x44" * 32,
+                    target=Checkpoint(epoch=some_epoch - 1),
+                )
+            )
+            for _ in range(3)
         )
     )
     state = genesis_state.copy(
@@ -318,44 +227,24 @@ def test_get_matching_head_attestations(genesis_state,
         current_epoch_attestations=current_epoch_attestations,
     )
 
-    attestations = get_matching_head_attestations(
-        state,
-        some_epoch,
-        config,
-    )
+    attestations = get_matching_head_attestations(state, some_epoch, config)
 
     assert attestations == target_attestations
 
 
-@pytest.mark.parametrize(
-    (
-        'validator_count,'
-    ),
-    [
-        (1000),
-    ],
-)
-def test_get_unslashed_attesting_indices(genesis_state,
-                                         config):
+@pytest.mark.parametrize(("validator_count,"), [(1000)])
+def test_get_unslashed_attesting_indices(genesis_state, config):
     state = genesis_state.copy(
         slot=compute_start_slot_of_epoch(3, config.SLOTS_PER_EPOCH)
     )
     target_epoch = state.current_epoch(config.SLOTS_PER_EPOCH)
     target_shard = (state.start_shard + 3) % config.SHARD_COUNT
     some_committee = get_crosslink_committee(
-        state,
-        target_epoch,
-        target_shard,
-        CommitteeConfig(config),
+        state, target_epoch, target_shard, CommitteeConfig(config)
     )
 
     data = AttestationData(
-        target=Checkpoint(
-            epoch=target_epoch,
-        ),
-        crosslink=Crosslink(
-            shard=target_shard,
-        ),
+        target=Checkpoint(epoch=target_epoch), crosslink=Crosslink(shard=target_shard)
     )
     some_subset_count = random.randrange(1, len(some_committee) // 2)
     some_subset = random.sample(some_committee, some_subset_count)
@@ -365,26 +254,17 @@ def test_get_unslashed_attesting_indices(genesis_state,
         if index in some_subset:
             if random.choice([True, False]):
                 state = state.update_validator_with_fn(
-                    index,
-                    lambda v, *_: v.copy(
-                        slashed=True,
-                    )
+                    index, lambda v, *_: v.copy(slashed=True)
                 )
             bitfield = set_voted(bitfield, i)
 
-    some_subset = tuple(filter(
-        lambda index: not state.validators[index].slashed,
-        some_subset,
-    ))
+    some_subset = tuple(
+        filter(lambda index: not state.validators[index].slashed, some_subset)
+    )
 
     indices = get_unslashed_attesting_indices(
         state,
-        (
-            PendingAttestation(
-                data=data,
-                aggregation_bits=bitfield,
-            ),
-        ),
+        (PendingAttestation(data=data, aggregation_bits=bitfield),),
         CommitteeConfig(config),
     )
 
@@ -392,16 +272,8 @@ def test_get_unslashed_attesting_indices(genesis_state,
     assert len(indices) == len(some_subset)
 
 
-@pytest.mark.parametrize(
-    (
-        'validator_count,'
-    ),
-    [
-        (1000),
-    ],
-)
-def test_find_candidate_attestations_for_shard(genesis_state,
-                                               config):
+@pytest.mark.parametrize(("validator_count,"), [(1000)])
+def test_find_candidate_attestations_for_shard(genesis_state, config):
     some_epoch = config.GENESIS_EPOCH + 20
     # start on some shard and walk a subset of them
     some_shard = 3
@@ -411,48 +283,41 @@ def test_find_candidate_attestations_for_shard(genesis_state,
         slot=compute_start_slot_of_epoch(some_epoch, config.SLOTS_PER_EPOCH),
         start_shard=some_shard,
         current_crosslinks=tuple(
-            Crosslink(
-                shard=i,
-                data_root=(i).to_bytes(32, "little"),
-            )
+            Crosslink(shard=i, data_root=(i).to_bytes(32, "little"))
             for i in range(config.SHARD_COUNT)
         ),
     )
 
     # sample a subset of the shards to make attestations for
     some_shards_with_attestations = random.sample(
-        range(some_shard, some_shard + shard_offset),
-        shard_offset // 2,
+        range(some_shard, some_shard + shard_offset), shard_offset // 2
     )
 
     committee_and_shard_pairs = tuple(
         (
             get_crosslink_committee(
-                state,
-                some_epoch,
-                some_shard + i,
-                CommitteeConfig(config),
-            ), some_shard + i
-        ) for i in range(shard_offset)
+                state, some_epoch, some_shard + i, CommitteeConfig(config)
+            ),
+            some_shard + i,
+        )
+        for i in range(shard_offset)
         if some_shard + i in some_shards_with_attestations
     )
 
     pending_attestations = {
         shard: mk_pending_attestation_from_committee(
-            state.current_crosslinks[shard],
-            len(committee),
-            shard,
-        ) for committee, shard in committee_and_shard_pairs
+            state.current_crosslinks[shard], len(committee), shard
+        )
+        for committee, shard in committee_and_shard_pairs
     }
 
     # invalidate some crosslinks to test the crosslink filter
     some_crosslinks_to_mangle = random.sample(
-        some_shards_with_attestations,
-        len(some_shards_with_attestations) // 2,
+        some_shards_with_attestations, len(some_shards_with_attestations) // 2
     )
 
-    shards_with_valid_crosslinks = (
-        set(some_shards_with_attestations) - set(some_crosslinks_to_mangle)
+    shards_with_valid_crosslinks = set(some_shards_with_attestations) - set(
+        some_crosslinks_to_mangle
     )
 
     crosslinks = tuple()
@@ -462,68 +327,37 @@ def test_find_candidate_attestations_for_shard(genesis_state,
         else:
             crosslinks += (Crosslink(),)
 
-    state = state.copy(
-        current_crosslinks=crosslinks,
-    )
+    state = state.copy(current_crosslinks=crosslinks)
 
     # check around the range of shards we built up
     for shard in range(0, some_shard + shard_offset + 3):
         if shard in some_shards_with_attestations:
             attestations = _get_attestations_for_shard(
-                pending_attestations.values(),
-                shard,
+                pending_attestations.values(), shard
             )
             assert attestations == (pending_attestations[shard],)
 
             if shard in some_crosslinks_to_mangle:
                 assert not _get_attestations_for_valid_crosslink(
-                    pending_attestations.values(),
-                    state,
-                    shard,
-                    config,
+                    pending_attestations.values(), state, shard, config
                 )
             else:
                 attestations = _get_attestations_for_valid_crosslink(
-                    pending_attestations.values(),
-                    state,
-                    shard,
-                    config,
+                    pending_attestations.values(), state, shard, config
                 )
                 assert attestations == (pending_attestations[shard],)
         else:
-            assert not _get_attestations_for_shard(
-                pending_attestations.values(),
-                shard,
-            )
+            assert not _get_attestations_for_shard(pending_attestations.values(), shard)
             assert not _get_attestations_for_valid_crosslink(
-                pending_attestations.values(),
-                state,
-                shard,
-                config,
+                pending_attestations.values(), state, shard, config
             )
 
 
-@pytest.mark.parametrize(
-    (
-        'validator_count,'
-    ),
-    [
-        (1000),
-    ],
-)
-@pytest.mark.parametrize(
-    (
-        'number_of_candidates,'
-    ),
-    [
-        (0),
-        (1),
-        (3),
-    ],
-)
-def test_find_winning_crosslink_and_attesting_indices_from_candidates(genesis_state,
-                                                                      number_of_candidates,
-                                                                      config):
+@pytest.mark.parametrize(("validator_count,"), [(1000)])
+@pytest.mark.parametrize(("number_of_candidates,"), [(0), (1), (3)])
+def test_find_winning_crosslink_and_attesting_indices_from_candidates(
+    genesis_state, number_of_candidates, config
+):
     some_epoch = config.GENESIS_EPOCH + 20
     some_shard = 3
 
@@ -531,19 +365,13 @@ def test_find_winning_crosslink_and_attesting_indices_from_candidates(genesis_st
         slot=compute_start_slot_of_epoch(some_epoch, config.SLOTS_PER_EPOCH),
         start_shard=some_shard,
         current_crosslinks=tuple(
-            Crosslink(
-                shard=i,
-                data_root=(i).to_bytes(32, "little"),
-            )
+            Crosslink(shard=i, data_root=(i).to_bytes(32, "little"))
             for i in range(config.SHARD_COUNT)
         ),
     )
 
     full_committee = get_crosslink_committee(
-        state,
-        some_epoch,
-        some_shard,
-        CommitteeConfig(config),
+        state, some_epoch, some_shard, CommitteeConfig(config)
     )
 
     # break the committees up into different subsets to simulate different
@@ -570,25 +398,20 @@ def test_find_winning_crosslink_and_attesting_indices_from_candidates(genesis_st
             len(full_committee),
             some_shard,
             target_epoch=some_epoch,
-        ) for committee in filtered_committees
+        )
+        for committee in filtered_committees
     )
 
     if number_of_candidates == 0:
         expected_result = (Crosslink(), set())
     else:
-        expected_result = (
-            candidates[0].data.crosslink,
-            set(sorted(full_committee)),
-        )
+        expected_result = (candidates[0].data.crosslink, set(sorted(full_committee)))
 
     result = _find_winning_crosslink_and_attesting_indices_from_candidates(
-        state,
-        candidates,
-        config,
+        state, candidates, config
     )
     assert result == expected_result
 
 
-def test_get_base_reward(genesis_state,
-                         config):
+def test_get_base_reward(genesis_state, config):
     assert get_base_reward(genesis_state, 0, config) == 724077

--- a/tests/eth2/core/beacon/test_epoch_processing_helpers.py
+++ b/tests/eth2/core/beacon/test_epoch_processing_helpers.py
@@ -1,36 +1,36 @@
 import random
-import pytest
 
 from eth_utils.toolz import random_sample
+import pytest
 
-from eth2._utils.bitfield import set_voted, get_empty_bitfield
+from eth2._utils.bitfield import get_empty_bitfield, set_voted
 from eth2._utils.tuple import update_tuple_item
-from eth2.configs import CommitteeConfig
-from eth2.beacon.constants import FAR_FUTURE_EPOCH, GWEI_PER_ETH
-from eth2.beacon.exceptions import InvalidEpochError
 from eth2.beacon.committee_helpers import get_crosslink_committee
+from eth2.beacon.constants import FAR_FUTURE_EPOCH, GWEI_PER_ETH
 from eth2.beacon.epoch_processing_helpers import (
-    increase_balance,
-    decrease_balance,
-    get_attesting_indices,
-    compute_activation_exit_epoch,
-    get_validator_churn_limit,
-    get_matching_source_attestations,
-    get_matching_target_attestations,
-    get_matching_head_attestations,
-    get_unslashed_attesting_indices,
+    _find_winning_crosslink_and_attesting_indices_from_candidates,
     _get_attestations_for_shard,
     _get_attestations_for_valid_crosslink,
-    _find_winning_crosslink_and_attesting_indices_from_candidates,
+    compute_activation_exit_epoch,
+    decrease_balance,
+    get_attesting_indices,
     get_base_reward,
+    get_matching_head_attestations,
+    get_matching_source_attestations,
+    get_matching_target_attestations,
+    get_unslashed_attesting_indices,
+    get_validator_churn_limit,
+    increase_balance,
 )
+from eth2.beacon.exceptions import InvalidEpochError
 from eth2.beacon.helpers import compute_start_slot_of_epoch
+from eth2.beacon.tools.builder.validator import mk_pending_attestation_from_committee
 from eth2.beacon.types.attestation_data import AttestationData
 from eth2.beacon.types.checkpoints import Checkpoint
 from eth2.beacon.types.crosslinks import Crosslink
 from eth2.beacon.types.pending_attestations import PendingAttestation
 from eth2.beacon.typing import Gwei
-from eth2.beacon.tools.builder.validator import mk_pending_attestation_from_committee
+from eth2.configs import CommitteeConfig
 
 
 @pytest.mark.parametrize(

--- a/tests/eth2/core/beacon/test_genesis.py
+++ b/tests/eth2/core/beacon/test_genesis.py
@@ -1,13 +1,8 @@
 import pytest
 
-from eth.constants import (
-    ZERO_HASH32,
-)
+from eth.constants import ZERO_HASH32
 
-from eth2.beacon.constants import (
-    EMPTY_SIGNATURE,
-    JUSTIFICATION_BITS_LENGTH,
-)
+from eth2.beacon.constants import EMPTY_SIGNATURE, JUSTIFICATION_BITS_LENGTH
 from eth2.beacon.types.blocks import BeaconBlock, BeaconBlockBody
 from eth2.beacon.types.block_headers import BeaconBlockHeader
 from eth2.beacon.types.crosslinks import Crosslink
@@ -18,16 +13,12 @@ from eth2.beacon.genesis import (
     initialize_beacon_state_from_eth1,
     _genesis_time_from_eth1_timestamp,
 )
-from eth2.beacon.tools.builder.initializer import (
-    create_mock_deposits_and_root,
-)
-from eth2.beacon.typing import (
-    Gwei,
-)
+from eth2.beacon.tools.builder.initializer import create_mock_deposits_and_root
+from eth2.beacon.typing import Gwei
 
 
 def test_get_genesis_block():
-    genesis_state_root = b'\x10' * 32
+    genesis_state_root = b"\x10" * 32
     genesis_slot = 0
     genesis_block = get_genesis_block(genesis_state_root, BeaconBlock)
     assert genesis_block.slot == genesis_slot
@@ -37,29 +28,21 @@ def test_get_genesis_block():
     assert genesis_block.body.is_empty
 
 
-@pytest.mark.parametrize(
-    (
-        'validator_count,'
-    ),
-    [
-        (10)
-    ]
-)
+@pytest.mark.parametrize(("validator_count,"), [(10)])
 def test_get_genesis_beacon_state(
-        validator_count,
-        pubkeys,
-        genesis_epoch,
-        genesis_slot,
-        shard_count,
-        slots_per_historical_root,
-        epochs_per_slashings_vector,
-        epochs_per_historical_vector,
-        config,
-        keymap):
+    validator_count,
+    pubkeys,
+    genesis_epoch,
+    genesis_slot,
+    shard_count,
+    slots_per_historical_root,
+    epochs_per_slashings_vector,
+    epochs_per_historical_vector,
+    config,
+    keymap,
+):
     genesis_deposits, deposit_root = create_mock_deposits_and_root(
-        pubkeys=pubkeys[:validator_count],
-        keymap=keymap,
-        config=config,
+        pubkeys=pubkeys[:validator_count], keymap=keymap, config=config
     )
 
     genesis_eth1_data = Eth1Data(
@@ -83,7 +66,7 @@ def test_get_genesis_beacon_state(
 
     # History
     assert state.latest_block_header == BeaconBlockHeader(
-        body_root=BeaconBlockBody().hash_tree_root,
+        body_root=BeaconBlockBody().hash_tree_root
     )
     assert len(state.block_roots) == slots_per_historical_root
     assert state.block_roots == (ZERO_HASH32,) * slots_per_historical_root

--- a/tests/eth2/core/beacon/test_genesis.py
+++ b/tests/eth2/core/beacon/test_genesis.py
@@ -1,19 +1,18 @@
+from eth.constants import ZERO_HASH32
 import pytest
 
-from eth.constants import ZERO_HASH32
-
 from eth2.beacon.constants import EMPTY_SIGNATURE, JUSTIFICATION_BITS_LENGTH
-from eth2.beacon.types.blocks import BeaconBlock, BeaconBlockBody
+from eth2.beacon.genesis import (
+    _genesis_time_from_eth1_timestamp,
+    get_genesis_block,
+    initialize_beacon_state_from_eth1,
+)
+from eth2.beacon.tools.builder.initializer import create_mock_deposits_and_root
 from eth2.beacon.types.block_headers import BeaconBlockHeader
+from eth2.beacon.types.blocks import BeaconBlock, BeaconBlockBody
 from eth2.beacon.types.crosslinks import Crosslink
 from eth2.beacon.types.eth1_data import Eth1Data
 from eth2.beacon.types.forks import Fork
-from eth2.beacon.genesis import (
-    get_genesis_block,
-    initialize_beacon_state_from_eth1,
-    _genesis_time_from_eth1_timestamp,
-)
-from eth2.beacon.tools.builder.initializer import create_mock_deposits_and_root
 from eth2.beacon.typing import Gwei
 
 

--- a/tests/eth2/core/beacon/test_helpers.py
+++ b/tests/eth2/core/beacon/test_helpers.py
@@ -1,21 +1,11 @@
 import pytest
 
-from eth_utils import (
-    ValidationError,
-    to_tuple,
-)
+from eth_utils import ValidationError, to_tuple
 
-from eth.constants import (
-    ZERO_HASH32,
-)
+from eth.constants import ZERO_HASH32
 
-from eth2._utils.hash import (
-    hash_eth2,
-)
-from eth2.beacon.constants import (
-    GWEI_PER_ETH,
-    FAR_FUTURE_EPOCH,
-)
+from eth2._utils.hash import hash_eth2
+from eth2.beacon.constants import GWEI_PER_ETH, FAR_FUTURE_EPOCH
 
 from eth2.beacon.types.states import BeaconState
 from eth2.beacon.types.forks import Fork
@@ -40,28 +30,19 @@ def get_pseudo_chain(length, genesis_block):
     block = genesis_block.copy()
     yield block
     for slot in range(1, length * 3):
-        block = genesis_block.copy(
-            slot=slot,
-            parent_root=block.signing_root
-        )
+        block = genesis_block.copy(slot=slot, parent_root=block.signing_root)
         yield block
 
 
 def generate_mock_latest_historical_roots(
-        genesis_block,
-        current_slot,
-        slots_per_epoch,
-        slots_per_historical_root):
+    genesis_block, current_slot, slots_per_epoch, slots_per_historical_root
+):
     assert current_slot < slots_per_historical_root
 
     chain_length = (current_slot // slots_per_epoch + 1) * slots_per_epoch
     blocks = get_pseudo_chain(chain_length, genesis_block)
-    block_roots = [
-        block.signing_root
-        for block in blocks[:current_slot]
-    ] + [
-        ZERO_HASH32
-        for _ in range(slots_per_historical_root - current_slot)
+    block_roots = [block.signing_root for block in blocks[:current_slot]] + [
+        ZERO_HASH32 for _ in range(slots_per_historical_root - current_slot)
     ]
     return blocks, block_roots
 
@@ -70,9 +51,7 @@ def generate_mock_latest_historical_roots(
 # Get historical roots
 #
 @pytest.mark.parametrize(
-    (
-        'current_slot,target_slot,success'
-    ),
+    ("current_slot,target_slot,success"),
     [
         (10, 0, True),
         (10, 9, True),
@@ -82,49 +61,38 @@ def generate_mock_latest_historical_roots(
         (128, 128, False),
     ],
 )
-def test_get_block_root_at_slot(sample_beacon_state_params,
-                                current_slot,
-                                target_slot,
-                                success,
-                                slots_per_epoch,
-                                slots_per_historical_root,
-                                sample_block):
+def test_get_block_root_at_slot(
+    sample_beacon_state_params,
+    current_slot,
+    target_slot,
+    success,
+    slots_per_epoch,
+    slots_per_historical_root,
+    sample_block,
+):
     blocks, block_roots = generate_mock_latest_historical_roots(
-        sample_block,
-        current_slot,
-        slots_per_epoch,
-        slots_per_historical_root,
+        sample_block, current_slot, slots_per_epoch, slots_per_historical_root
     )
     state = BeaconState(**sample_beacon_state_params).copy(
-        slot=current_slot,
-        block_roots=block_roots,
+        slot=current_slot, block_roots=block_roots
     )
 
     if success:
         block_root = get_block_root_at_slot(
-            state,
-            target_slot,
-            slots_per_historical_root,
+            state, target_slot, slots_per_historical_root
         )
         assert block_root == blocks[target_slot].signing_root
     else:
         with pytest.raises(ValidationError):
-            get_block_root_at_slot(
-                state,
-                target_slot,
-                slots_per_historical_root,
-            )
+            get_block_root_at_slot(state, target_slot, slots_per_historical_root)
 
 
 def test_get_active_validator_indices(sample_validator_record_params):
     current_epoch = 1
     # 3 validators are ACTIVE
     validators = [
-        Validator(
-            **sample_validator_record_params,
-        ).copy(
-            activation_epoch=0,
-            exit_epoch=FAR_FUTURE_EPOCH,
+        Validator(**sample_validator_record_params).copy(
+            activation_epoch=0, exit_epoch=FAR_FUTURE_EPOCH
         )
         for i in range(3)
     ]
@@ -132,172 +100,119 @@ def test_get_active_validator_indices(sample_validator_record_params):
     assert len(active_validator_indices) == 3
 
     validators[0] = validators[0].copy(
-        activation_epoch=current_epoch + 1,  # activation_epoch > current_epoch
+        activation_epoch=current_epoch + 1  # activation_epoch > current_epoch
     )
     active_validator_indices = get_active_validator_indices(validators, current_epoch)
     assert len(active_validator_indices) == 2
 
     validators[1] = validators[1].copy(
-        exit_epoch=current_epoch,  # current_epoch == exit_epoch
+        exit_epoch=current_epoch  # current_epoch == exit_epoch
     )
     active_validator_indices = get_active_validator_indices(validators, current_epoch)
     assert len(active_validator_indices) == 1
 
 
 @pytest.mark.parametrize(
-    (
-        'balances,'
-        'validator_indices,'
-        'expected'
-    ),
+    ("balances," "validator_indices," "expected"),
     [
-        (
-            tuple(),
-            tuple(),
-            1,
-        ),
-        (
-            (32 * GWEI_PER_ETH, 32 * GWEI_PER_ETH),
-            (0, 1),
-            64 * GWEI_PER_ETH,
-        ),
-        (
-            (32 * GWEI_PER_ETH, 32 * GWEI_PER_ETH),
-            (1,),
-            32 * GWEI_PER_ETH,
-        ),
-    ]
+        (tuple(), tuple(), 1),
+        ((32 * GWEI_PER_ETH, 32 * GWEI_PER_ETH), (0, 1), 64 * GWEI_PER_ETH),
+        ((32 * GWEI_PER_ETH, 32 * GWEI_PER_ETH), (1,), 32 * GWEI_PER_ETH),
+    ],
 )
-def test_get_total_balance(genesis_state,
-                           balances,
-                           validator_indices,
-                           expected):
+def test_get_total_balance(genesis_state, balances, validator_indices, expected):
     state = genesis_state
     for i, index in enumerate(validator_indices):
-        state = state._update_validator_balance(
-            index,
-            balances[i],
-        )
+        state = state._update_validator_balance(index, balances[i])
     total_balance = get_total_balance(state, validator_indices)
     assert total_balance == expected
 
 
 @pytest.mark.parametrize(
-    (
-        'previous_version,'
-        'current_version,'
-        'epoch,'
-        'current_epoch,'
-        'expected'
-    ),
+    ("previous_version," "current_version," "epoch," "current_epoch," "expected"),
     [
-        (b'\x00' * 4, b'\x00' * 4, 0, 0, b'\x00' * 4),
-        (b'\x00' * 4, b'\x00' * 4, 0, 1, b'\x00' * 4),
-        (b'\x00' * 4, b'\x11' * 4, 20, 10, b'\x00' * 4),
-        (b'\x00' * 4, b'\x11' * 4, 20, 20, b'\x11' * 4),
-        (b'\x00' * 4, b'\x11' * 4, 10, 20, b'\x11' * 4),
-    ]
+        (b"\x00" * 4, b"\x00" * 4, 0, 0, b"\x00" * 4),
+        (b"\x00" * 4, b"\x00" * 4, 0, 1, b"\x00" * 4),
+        (b"\x00" * 4, b"\x11" * 4, 20, 10, b"\x00" * 4),
+        (b"\x00" * 4, b"\x11" * 4, 20, 20, b"\x11" * 4),
+        (b"\x00" * 4, b"\x11" * 4, 10, 20, b"\x11" * 4),
+    ],
 )
-def test_get_fork_version(previous_version,
-                          current_version,
-                          epoch,
-                          current_epoch,
-                          expected):
+def test_get_fork_version(
+    previous_version, current_version, epoch, current_epoch, expected
+):
     fork = Fork(
-        previous_version=previous_version,
-        current_version=current_version,
-        epoch=epoch,
+        previous_version=previous_version, current_version=current_version, epoch=epoch
     )
-    assert expected == _get_fork_version(
-        fork,
-        current_epoch,
-    )
+    assert expected == _get_fork_version(fork, current_epoch)
 
 
 @pytest.mark.parametrize(
     (
-        'previous_version,'
-        'current_version,'
-        'epoch,'
-        'current_epoch,'
-        'signature_domain,'
-        'expected'
+        "previous_version,"
+        "current_version,"
+        "epoch,"
+        "current_epoch,"
+        "signature_domain,"
+        "expected"
     ),
     [
-        (
-            b'\x11' * 4,
-            b'\x22' * 4,
-            4,
-            4,
-            1,
-            b'\x01\x00\x00\x00' + b'\x22' * 4,
-        ),
-        (
-            b'\x11' * 4,
-            b'\x22' * 4,
-            4,
-            4 - 1,
-            1,
-            b'\x01\x00\x00\x00' + b'\x11' * 4,
-        ),
-    ]
+        (b"\x11" * 4, b"\x22" * 4, 4, 4, 1, b"\x01\x00\x00\x00" + b"\x22" * 4),
+        (b"\x11" * 4, b"\x22" * 4, 4, 4 - 1, 1, b"\x01\x00\x00\x00" + b"\x11" * 4),
+    ],
 )
-def test_get_domain(previous_version,
-                    current_version,
-                    epoch,
-                    current_epoch,
-                    signature_domain,
-                    genesis_state,
-                    slots_per_epoch,
-                    expected):
+def test_get_domain(
+    previous_version,
+    current_version,
+    epoch,
+    current_epoch,
+    signature_domain,
+    genesis_state,
+    slots_per_epoch,
+    expected,
+):
     state = genesis_state
     fork = Fork(
-        previous_version=previous_version,
-        current_version=current_version,
-        epoch=epoch,
+        previous_version=previous_version, current_version=current_version, epoch=epoch
     )
     assert expected == get_domain(
-        state=state.copy(
-            fork=fork,
-        ),
+        state=state.copy(fork=fork),
         signature_domain=signature_domain,
         slots_per_epoch=slots_per_epoch,
         message_epoch=current_epoch,
     )
 
 
-def test_get_seed(genesis_state,
-                  committee_config,
-                  slots_per_epoch,
-                  min_seed_lookahead,
-                  activation_exit_delay,
-                  epochs_per_historical_vector):
-    def mock_get_randao_mix(state,
-                            epoch,
-                            epochs_per_historical_vector):
+def test_get_seed(
+    genesis_state,
+    committee_config,
+    slots_per_epoch,
+    min_seed_lookahead,
+    activation_exit_delay,
+    epochs_per_historical_vector,
+):
+    def mock_get_randao_mix(state, epoch, epochs_per_historical_vector):
         return hash_eth2(
-            state.hash_tree_root +
-            epoch.to_bytes(32, byteorder='little') +
-            epochs_per_historical_vector.to_bytes(32, byteorder='little')
+            state.hash_tree_root
+            + epoch.to_bytes(32, byteorder="little")
+            + epochs_per_historical_vector.to_bytes(32, byteorder="little")
         )
 
-    def mock_get_active_index_root(state,
-                                   epoch,
-                                   epochs_per_historical_vector):
+    def mock_get_active_index_root(state, epoch, epochs_per_historical_vector):
         return hash_eth2(
-            state.hash_tree_root +
-            epoch.to_bytes(32, byteorder='little') +
-            slots_per_epoch.to_bytes(32, byteorder='little') +
-            epochs_per_historical_vector.to_bytes(32, byteorder='little')
+            state.hash_tree_root
+            + epoch.to_bytes(32, byteorder="little")
+            + slots_per_epoch.to_bytes(32, byteorder="little")
+            + epochs_per_historical_vector.to_bytes(32, byteorder="little")
         )
 
     state = genesis_state
     epoch = 1
     state = state.copy(
-        slot=compute_start_slot_of_epoch(epoch, committee_config.SLOTS_PER_EPOCH),
+        slot=compute_start_slot_of_epoch(epoch, committee_config.SLOTS_PER_EPOCH)
     )
 
-    epoch_as_bytes = epoch.to_bytes(32, 'little')
+    epoch_as_bytes = epoch.to_bytes(32, "little")
 
     seed = _get_seed(
         state=state,
@@ -312,9 +227,11 @@ def test_get_seed(genesis_state,
             state=state,
             epoch=(epoch + epochs_per_historical_vector - min_seed_lookahead - 1),
             epochs_per_historical_vector=epochs_per_historical_vector,
-        ) + mock_get_active_index_root(
+        )
+        + mock_get_active_index_root(
             state=state,
             epoch=epoch,
             epochs_per_historical_vector=epochs_per_historical_vector,
-        ) + epoch_as_bytes
+        )
+        + epoch_as_bytes
     )

--- a/tests/eth2/core/beacon/test_helpers.py
+++ b/tests/eth2/core/beacon/test_helpers.py
@@ -1,25 +1,21 @@
+from eth.constants import ZERO_HASH32
+from eth_utils import ValidationError, to_tuple
 import pytest
 
-from eth_utils import ValidationError, to_tuple
-
-from eth.constants import ZERO_HASH32
-
 from eth2._utils.hash import hash_eth2
-from eth2.beacon.constants import GWEI_PER_ETH, FAR_FUTURE_EPOCH
-
-from eth2.beacon.types.states import BeaconState
-from eth2.beacon.types.forks import Fork
-from eth2.beacon.types.validators import Validator
-
+from eth2.beacon.constants import FAR_FUTURE_EPOCH, GWEI_PER_ETH
 from eth2.beacon.helpers import (
+    _get_fork_version,
     _get_seed,
+    compute_start_slot_of_epoch,
     get_active_validator_indices,
     get_block_root_at_slot,
-    compute_start_slot_of_epoch,
     get_domain,
-    _get_fork_version,
     get_total_balance,
 )
+from eth2.beacon.types.forks import Fork
+from eth2.beacon.types.states import BeaconState
+from eth2.beacon.types.validators import Validator
 
 
 @to_tuple

--- a/tests/eth2/core/beacon/test_validator_status_helpers.py
+++ b/tests/eth2/core/beacon/test_validator_status_helpers.py
@@ -1,16 +1,16 @@
 import random
 
+from eth_utils.toolz import first, groupby, update_in
 import pytest
 
-from eth_utils.toolz import first, update_in, groupby
-
-from eth2.beacon.constants import FAR_FUTURE_EPOCH
 from eth2.beacon.committee_helpers import get_beacon_proposer_index
-from eth2.beacon.helpers import compute_start_slot_of_epoch
+from eth2.beacon.constants import FAR_FUTURE_EPOCH
 from eth2.beacon.epoch_processing_helpers import (
     compute_activation_exit_epoch,
     get_validator_churn_limit,
 )
+from eth2.beacon.helpers import compute_start_slot_of_epoch
+from eth2.beacon.tools.builder.initializer import create_mock_validator
 from eth2.beacon.validator_status_helpers import (
     _compute_exit_queue_epoch,
     _set_validator_slashed,
@@ -18,7 +18,6 @@ from eth2.beacon.validator_status_helpers import (
     initiate_exit_for_validator,
     slash_validator,
 )
-from eth2.beacon.tools.builder.initializer import create_mock_validator
 from eth2.configs import CommitteeConfig
 
 

--- a/tests/eth2/core/beacon/test_validator_status_helpers.py
+++ b/tests/eth2/core/beacon/test_validator_status_helpers.py
@@ -2,21 +2,11 @@ import random
 
 import pytest
 
-from eth_utils.toolz import (
-    first,
-    update_in,
-    groupby,
-)
+from eth_utils.toolz import first, update_in, groupby
 
-from eth2.beacon.constants import (
-    FAR_FUTURE_EPOCH,
-)
-from eth2.beacon.committee_helpers import (
-    get_beacon_proposer_index,
-)
-from eth2.beacon.helpers import (
-    compute_start_slot_of_epoch,
-)
+from eth2.beacon.constants import FAR_FUTURE_EPOCH
+from eth2.beacon.committee_helpers import get_beacon_proposer_index
+from eth2.beacon.helpers import compute_start_slot_of_epoch
 from eth2.beacon.epoch_processing_helpers import (
     compute_activation_exit_epoch,
     get_validator_churn_limit,
@@ -28,29 +18,15 @@ from eth2.beacon.validator_status_helpers import (
     initiate_exit_for_validator,
     slash_validator,
 )
-from eth2.beacon.tools.builder.initializer import (
-    create_mock_validator,
-)
-from eth2.configs import (
-    CommitteeConfig,
-)
+from eth2.beacon.tools.builder.initializer import create_mock_validator
+from eth2.configs import CommitteeConfig
 
 
-@pytest.mark.parametrize(
-    (
-        'is_already_activated,'
-    ),
-    [
-        (True),
-        (False),
-    ]
-)
-def test_activate_validator(genesis_state,
-                            is_already_activated,
-                            validator_count,
-                            pubkeys,
-                            config):
-    some_future_epoch = config.GENESIS_EPOCH + random.randrange(1, 2**32)
+@pytest.mark.parametrize(("is_already_activated,"), [(True), (False)])
+def test_activate_validator(
+    genesis_state, is_already_activated, validator_count, pubkeys, config
+):
+    some_future_epoch = config.GENESIS_EPOCH + random.randrange(1, 2 ** 32)
 
     if is_already_activated:
         assert validator_count > 0
@@ -59,9 +35,7 @@ def test_activate_validator(genesis_state,
         assert some_validator.activation_epoch == config.GENESIS_EPOCH
     else:
         some_validator = create_mock_validator(
-            pubkeys[:validator_count + 1],
-            config,
-            is_active=is_already_activated,
+            pubkeys[: validator_count + 1], config, is_active=is_already_activated
         )
         assert some_validator.activation_eligibility_epoch == FAR_FUTURE_EPOCH
         assert some_validator.activation_epoch == FAR_FUTURE_EPOCH
@@ -74,54 +48,36 @@ def test_activate_validator(genesis_state,
 
 
 @pytest.mark.parametrize(
-    (
-        "is_delayed_exit_epoch_the_maximum_exit_queue_epoch"
-    ),
-    [
-        (True,),
-        (False,),
-    ]
+    ("is_delayed_exit_epoch_the_maximum_exit_queue_epoch"), [(True,), (False,)]
 )
-@pytest.mark.parametrize(
-    (
-        "is_churn_limit_met"
-    ),
-    [
-        (True,),
-        (False,),
-    ]
-)
-def test_compute_exit_queue_epoch(genesis_state,
-                                  is_delayed_exit_epoch_the_maximum_exit_queue_epoch,
-                                  is_churn_limit_met,
-                                  config):
+@pytest.mark.parametrize(("is_churn_limit_met"), [(True,), (False,)])
+def test_compute_exit_queue_epoch(
+    genesis_state,
+    is_delayed_exit_epoch_the_maximum_exit_queue_epoch,
+    is_churn_limit_met,
+    config,
+):
     state = genesis_state
-    for index in random.sample(range(len(state.validators)), len(state.validators) // 4):
-        some_future_epoch = config.GENESIS_EPOCH + random.randrange(1, 2**32)
+    for index in random.sample(
+        range(len(state.validators)), len(state.validators) // 4
+    ):
+        some_future_epoch = config.GENESIS_EPOCH + random.randrange(1, 2 ** 32)
         state = state.update_validator_with_fn(
-            index,
-            lambda validator, *_: validator.copy(
-                exit_epoch=some_future_epoch,
-            ),
+            index, lambda validator, *_: validator.copy(exit_epoch=some_future_epoch)
         )
 
     if is_delayed_exit_epoch_the_maximum_exit_queue_epoch:
         expected_candidate_exit_queue_epoch = compute_activation_exit_epoch(
-            state.current_epoch(config.SLOTS_PER_EPOCH),
-            config.ACTIVATION_EXIT_DELAY,
+            state.current_epoch(config.SLOTS_PER_EPOCH), config.ACTIVATION_EXIT_DELAY
         )
         for index, validator in enumerate(state.validators):
             if validator.exit_epoch == FAR_FUTURE_EPOCH:
                 continue
             some_prior_epoch = random.randrange(
-                config.GENESIS_EPOCH,
-                expected_candidate_exit_queue_epoch,
+                config.GENESIS_EPOCH, expected_candidate_exit_queue_epoch
             )
             state = state.update_validator_with_fn(
-                index,
-                lambda validator, *_: validator.copy(
-                    exit_epoch=some_prior_epoch,
-                ),
+                index, lambda validator, *_: validator.copy(exit_epoch=some_prior_epoch)
             )
             validator = state.validators[index]
             assert expected_candidate_exit_queue_epoch >= validator.exit_epoch
@@ -146,44 +102,37 @@ def test_compute_exit_queue_epoch(genesis_state,
             if validator.exit_epoch == expected_candidate_exit_queue_epoch
         }
         additional_queued_validator_count = random.randrange(
-            len(queued_validators),
-            len(state.validators),
+            len(queued_validators), len(state.validators)
         )
         unqueued_validators = tuple(
-            v for v in state.validators
-            if v.exit_epoch == FAR_FUTURE_EPOCH
+            v for v in state.validators if v.exit_epoch == FAR_FUTURE_EPOCH
         )
         for index in random.sample(
-                range(len(unqueued_validators)),
-                additional_queued_validator_count,
+            range(len(unqueued_validators)), additional_queued_validator_count
         ):
             state = state.update_validator_with_fn(
                 index,
                 lambda validator, *_: validator.copy(
-                    exit_epoch=expected_candidate_exit_queue_epoch,
+                    exit_epoch=expected_candidate_exit_queue_epoch
                 ),
             )
 
         all_queued_validators = tuple(
-            v for v in state.validators
+            v
+            for v in state.validators
             if v.exit_epoch == expected_candidate_exit_queue_epoch
         )
         churn_limit = len(all_queued_validators) + 1
 
         expected_exit_queue_epoch = expected_candidate_exit_queue_epoch
 
-    assert _compute_exit_queue_epoch(state, churn_limit, config) == expected_exit_queue_epoch
+    assert (
+        _compute_exit_queue_epoch(state, churn_limit, config)
+        == expected_exit_queue_epoch
+    )
 
 
-@pytest.mark.parametrize(
-    (
-        'is_already_exited,'
-    ),
-    [
-        (True),
-        (False),
-    ]
-)
+@pytest.mark.parametrize(("is_already_exited,"), [(True), (False)])
 def test_initiate_validator_exit(genesis_state, is_already_exited, config):
     state = genesis_state
     index = random.choice(range(len(state.validators)))
@@ -199,14 +148,11 @@ def test_initiate_validator_exit(genesis_state, is_already_exited, config):
         exit_queue_epoch = _compute_exit_queue_epoch(state, churn_limit, config)
         validator = validator.copy(
             exit_epoch=exit_queue_epoch,
-            withdrawable_epoch=exit_queue_epoch + config.MIN_VALIDATOR_WITHDRAWABILITY_DELAY,
+            withdrawable_epoch=exit_queue_epoch
+            + config.MIN_VALIDATOR_WITHDRAWABILITY_DELAY,
         )
 
-    exited_validator = initiate_exit_for_validator(
-        validator,
-        state,
-        config,
-    )
+    exited_validator = initiate_exit_for_validator(validator, state, config)
 
     if is_already_exited:
         assert exited_validator == validator
@@ -219,29 +165,18 @@ def test_initiate_validator_exit(genesis_state, is_already_exited, config):
         )
 
 
-@pytest.mark.parametrize(
-    (
-        'is_already_slashed,'
-    ),
-    [
-        (True),
-        (False),
-    ]
-)
-def test_set_validator_slashed(genesis_state,
-                               is_already_slashed,
-                               validator_count,
-                               pubkeys,
-                               config):
-    some_future_epoch = config.GENESIS_EPOCH + random.randrange(1, 2**32)
+@pytest.mark.parametrize(("is_already_slashed,"), [(True), (False)])
+def test_set_validator_slashed(
+    genesis_state, is_already_slashed, validator_count, pubkeys, config
+):
+    some_future_epoch = config.GENESIS_EPOCH + random.randrange(1, 2 ** 32)
 
     assert len(genesis_state.validators) > 0
     some_validator = genesis_state.validators[0]
 
     if is_already_slashed:
         some_validator = some_validator.copy(
-            slashed=True,
-            withdrawable_epoch=some_future_epoch,
+            slashed=True, withdrawable_epoch=some_future_epoch
         )
         assert some_validator.slashed
         assert some_validator.withdrawable_epoch == some_future_epoch
@@ -249,50 +184,42 @@ def test_set_validator_slashed(genesis_state,
         assert not some_validator.slashed
 
     slashed_validator = _set_validator_slashed(
-        some_validator,
-        some_future_epoch,
-        config.EPOCHS_PER_SLASHINGS_VECTOR,
+        some_validator, some_future_epoch, config.EPOCHS_PER_SLASHINGS_VECTOR
     )
     assert slashed_validator.slashed
     assert slashed_validator.withdrawable_epoch == max(
         slashed_validator.withdrawable_epoch,
-        some_future_epoch + config.EPOCHS_PER_SLASHINGS_VECTOR
+        some_future_epoch + config.EPOCHS_PER_SLASHINGS_VECTOR,
     )
 
 
-@pytest.mark.parametrize(
-    (
-        'validator_count'
-    ),
-    [
-        (100),
-    ]
-)
-def test_slash_validator(genesis_state,
-                         config):
+@pytest.mark.parametrize(("validator_count"), [(100)])
+def test_slash_validator(genesis_state, config):
     some_epoch = (
-        config.GENESIS_EPOCH + random.randrange(1, 2**32) + config.EPOCHS_PER_SLASHINGS_VECTOR
+        config.GENESIS_EPOCH
+        + random.randrange(1, 2 ** 32)
+        + config.EPOCHS_PER_SLASHINGS_VECTOR
     )
     earliest_slashable_epoch = some_epoch - config.EPOCHS_PER_SLASHINGS_VECTOR
     slashable_range = range(earliest_slashable_epoch, some_epoch)
     sampling_quotient = 4
 
     state = genesis_state.copy(
-        slot=compute_start_slot_of_epoch(earliest_slashable_epoch, config.SLOTS_PER_EPOCH),
+        slot=compute_start_slot_of_epoch(
+            earliest_slashable_epoch, config.SLOTS_PER_EPOCH
+        )
     )
     validator_count_to_slash = len(state.validators) // sampling_quotient
     assert validator_count_to_slash > 1
     validator_indices_to_slash = random.sample(
-        range(len(state.validators)),
-        validator_count_to_slash,
+        range(len(state.validators)), validator_count_to_slash
     )
     # ensure case w/ one slashing in an epoch
     # by ignoring the first
     set_of_colluding_validators = validator_indices_to_slash[1:]
     # simulate multiple slashings in an epoch
     validators_grouped_by_coalition = groupby(
-        lambda index: index % sampling_quotient,
-        set_of_colluding_validators,
+        lambda index: index % sampling_quotient, set_of_colluding_validators
     )
     coalition_count = len(validators_grouped_by_coalition)
     slashings = {
@@ -326,9 +253,10 @@ def test_slash_validator(genesis_state,
                 expected_individual_penalties,
                 [index],
                 lambda penalty: (
-                    penalty + (
-                        state.validators[index].effective_balance //
-                        config.MIN_SLASHING_PENALTY_QUOTIENT
+                    penalty
+                    + (
+                        state.validators[index].effective_balance
+                        // config.MIN_SLASHING_PENALTY_QUOTIENT
                     )
                 ),
                 default=0,
@@ -347,9 +275,8 @@ def test_slash_validator(genesis_state,
         expected_proposer_rewards = update_in(
             expected_proposer_rewards,
             [proposer_index],
-            lambda reward: reward + (
-                expected_total_slashed_balance // config.WHISTLEBLOWER_REWARD_QUOTIENT
-            ),
+            lambda reward: reward
+            + (expected_total_slashed_balance // config.WHISTLEBLOWER_REWARD_QUOTIENT),
             default=0,
         )
         for index in coalition:
@@ -373,14 +300,14 @@ def test_slash_validator(genesis_state,
             slashed_balance = state.slashings[slashed_epoch_index]
             assert slashed_balance == expected_slashings[epoch]
             assert state.balances[index] == (
-                config.MAX_EFFECTIVE_BALANCE -
-                expected_individual_penalties[index] +
-                expected_proposer_rewards.get(index, 0)
+                config.MAX_EFFECTIVE_BALANCE
+                - expected_individual_penalties[index]
+                + expected_proposer_rewards.get(index, 0)
             )
 
     for proposer_index, total_reward in expected_proposer_rewards.items():
         assert state.balances[proposer_index] == (
-            total_reward +
-            config.MAX_EFFECTIVE_BALANCE -
-            expected_individual_penalties.get(proposer_index, 0)
+            total_reward
+            + config.MAX_EFFECTIVE_BALANCE
+            - expected_individual_penalties.get(proposer_index, 0)
         )

--- a/tests/eth2/core/beacon/tools/builder/test_committee_assignment.py
+++ b/tests/eth2/core/beacon/tools/builder/test_committee_assignment.py
@@ -1,61 +1,47 @@
 import pytest
 
-from eth2.beacon.exceptions import (
-    NoCommitteeAssignment,
-)
-from eth2.beacon.helpers import (
-    compute_start_slot_of_epoch,
-)
+from eth2.beacon.exceptions import NoCommitteeAssignment
+from eth2.beacon.helpers import compute_start_slot_of_epoch
 
-from eth2.beacon.tools.builder.committee_assignment import (
-    get_committee_assignment,
-)
+from eth2.beacon.tools.builder.committee_assignment import get_committee_assignment
 
 
 @pytest.mark.parametrize(
     (
-        'validator_count,'
-        'slots_per_epoch,'
-        'target_committee_size,'
-        'shard_count,'
-        'state_epoch,'
-        'epoch,'
+        "validator_count,"
+        "slots_per_epoch,"
+        "target_committee_size,"
+        "shard_count,"
+        "state_epoch,"
+        "epoch,"
     ),
     [
         (40, 16, 1, 16, 0, 0),  # genesis
         (40, 16, 1, 16, 1, 1),  # current epoch
         (40, 16, 1, 16, 1, 0),  # previous epoch
         (40, 16, 1, 16, 1, 2),  # next epoch
-    ]
+    ],
 )
-def test_get_committee_assignment(genesis_state,
-                                  slots_per_epoch,
-                                  shard_count,
-                                  config,
-                                  validator_count,
-                                  state_epoch,
-                                  epoch,
-                                  fixture_sm_class):
+def test_get_committee_assignment(
+    genesis_state,
+    slots_per_epoch,
+    shard_count,
+    config,
+    validator_count,
+    state_epoch,
+    epoch,
+    fixture_sm_class,
+):
     state_slot = compute_start_slot_of_epoch(state_epoch, slots_per_epoch)
-    state = genesis_state.copy(
-        slot=state_slot,
-    )
+    state = genesis_state.copy(slot=state_slot)
     proposer_count = 0
-    shard_validator_count = [
-        0
-        for _ in range(shard_count)
-    ]
+    shard_validator_count = [0 for _ in range(shard_count)]
     slots = []
 
     epoch_start_slot = compute_start_slot_of_epoch(epoch, slots_per_epoch)
 
     for validator_index in range(validator_count):
-        assignment = get_committee_assignment(
-            state,
-            config,
-            epoch,
-            validator_index,
-        )
+        assignment = get_committee_assignment(state, config, epoch, validator_index)
         assert assignment.slot >= epoch_start_slot
         assert assignment.slot < epoch_start_slot + slots_per_epoch
         if assignment.is_proposer:
@@ -69,30 +55,17 @@ def test_get_committee_assignment(genesis_state,
 
 
 @pytest.mark.parametrize(
-    (
-        'validator_count,'
-        'slots_per_epoch,'
-        'target_committee_size,'
-        'shard_count,'
-    ),
-    [
-        (40, 16, 1, 16),
-    ]
+    ("validator_count," "slots_per_epoch," "target_committee_size," "shard_count,"),
+    [(40, 16, 1, 16)],
 )
-def test_get_committee_assignment_no_assignment(genesis_state,
-                                                genesis_epoch,
-                                                slots_per_epoch,
-                                                config):
+def test_get_committee_assignment_no_assignment(
+    genesis_state, genesis_epoch, slots_per_epoch, config
+):
     state = genesis_state
     validator_index = 1
     current_epoch = state.current_epoch(slots_per_epoch)
-    validator = state.validators[validator_index].copy(
-        exit_epoch=genesis_epoch,
-    )
-    state = state.update_validator(
-        validator_index,
-        validator,
-    )
+    validator = state.validators[validator_index].copy(exit_epoch=genesis_epoch)
+    state = state.update_validator(validator_index, validator)
     assert not validator.is_active(current_epoch)
 
     with pytest.raises(NoCommitteeAssignment):

--- a/tests/eth2/core/beacon/tools/builder/test_committee_assignment.py
+++ b/tests/eth2/core/beacon/tools/builder/test_committee_assignment.py
@@ -2,7 +2,6 @@ import pytest
 
 from eth2.beacon.exceptions import NoCommitteeAssignment
 from eth2.beacon.helpers import compute_start_slot_of_epoch
-
 from eth2.beacon.tools.builder.committee_assignment import get_committee_assignment
 
 

--- a/tests/eth2/core/beacon/tools/builder/test_validator.py
+++ b/tests/eth2/core/beacon/tools/builder/test_validator.py
@@ -1,12 +1,12 @@
-import pytest
-from hypothesis import given, settings, strategies as st
-
 from eth_utils import ValidationError
+from hypothesis import given, settings
+from hypothesis import strategies as st
+import pytest
 
+from eth2._utils.bitfield import get_empty_bitfield, has_voted
 from eth2._utils.bls import bls
 from eth2._utils.bls.backends.chia import ChiaBackend
 from eth2._utils.bls.backends.milagro import MilagroBackend
-from eth2._utils.bitfield import get_empty_bitfield, has_voted
 from eth2.beacon.helpers import compute_domain
 from eth2.beacon.signature_domain import SignatureDomain
 from eth2.beacon.tools.builder.validator import aggregate_votes, verify_votes

--- a/tests/eth2/core/beacon/tools/builder/test_validator.py
+++ b/tests/eth2/core/beacon/tools/builder/test_validator.py
@@ -1,60 +1,29 @@
 import pytest
-from hypothesis import (
-    given,
-    settings,
-    strategies as st,
-)
+from hypothesis import given, settings, strategies as st
 
-from eth_utils import (
-    ValidationError,
-)
+from eth_utils import ValidationError
 
 from eth2._utils.bls import bls
-from eth2._utils.bls.backends.chia import (
-    ChiaBackend,
-)
-from eth2._utils.bls.backends.milagro import (
-    MilagroBackend,
-)
-from eth2._utils.bitfield import (
-    get_empty_bitfield,
-    has_voted,
-)
-from eth2.beacon.helpers import (
-    compute_domain,
-)
+from eth2._utils.bls.backends.chia import ChiaBackend
+from eth2._utils.bls.backends.milagro import MilagroBackend
+from eth2._utils.bitfield import get_empty_bitfield, has_voted
+from eth2.beacon.helpers import compute_domain
 from eth2.beacon.signature_domain import SignatureDomain
-from eth2.beacon.tools.builder.validator import (
-    aggregate_votes,
-    verify_votes,
-)
+from eth2.beacon.tools.builder.validator import aggregate_votes, verify_votes
 
 
 @pytest.mark.slow
-@settings(
-    max_examples=1,
-    deadline=None,
-)
+@settings(max_examples=1, deadline=None)
 @given(random=st.randoms())
-@pytest.mark.parametrize(
-    (
-        'votes_count'
-    ),
-    [
-        (0),
-        (9),
-    ],
-)
+@pytest.mark.parametrize(("votes_count"), [(0), (9)])
 def test_aggregate_votes(votes_count, random, privkeys, pubkeys):
     bit_count = 10
     pre_bitfield = get_empty_bitfield(bit_count)
     pre_sigs = ()
-    domain = compute_domain(
-        SignatureDomain.DOMAIN_ATTESTATION,
-    )
+    domain = compute_domain(SignatureDomain.DOMAIN_ATTESTATION)
 
     random_votes = random.sample(range(bit_count), votes_count)
-    message_hash = b'\x12' * 32
+    message_hash = b"\x12" * 32
 
     # Get votes: (committee_index, sig, public_key)
     votes = [
@@ -74,7 +43,7 @@ def test_aggregate_votes(votes_count, random, privkeys, pubkeys):
         bitfield=pre_bitfield,
         sigs=pre_sigs,
         voting_sigs=sigs,
-        attesting_indices=committee_indices
+        attesting_indices=committee_indices,
     )
 
     try:

--- a/tests/eth2/core/beacon/types/test_attestation.py
+++ b/tests/eth2/core/beacon/types/test_attestation.py
@@ -2,17 +2,10 @@ import pytest
 
 import ssz
 
-from eth2.beacon.types.attestations import (
-    Attestation,
-)
+from eth2.beacon.types.attestations import Attestation
 
 
-@pytest.mark.parametrize(
-    'param,default_value',
-    [
-        ('signature', b'\x00' * 96),
-    ]
-)
+@pytest.mark.parametrize("param,default_value", [("signature", b"\x00" * 96)])
 def test_defaults(param, default_value, sample_attestation_params):
     del sample_attestation_params[param]
     attestation = Attestation(**sample_attestation_params)

--- a/tests/eth2/core/beacon/types/test_attestation.py
+++ b/tests/eth2/core/beacon/types/test_attestation.py
@@ -1,5 +1,4 @@
 import pytest
-
 import ssz
 
 from eth2.beacon.types.attestations import Attestation

--- a/tests/eth2/core/beacon/types/test_attestation_data.py
+++ b/tests/eth2/core/beacon/types/test_attestation_data.py
@@ -1,9 +1,9 @@
-from eth2.beacon.types.attestation_data import (
-    AttestationData,
-)
+from eth2.beacon.types.attestation_data import AttestationData
 
 
 def test_defaults(sample_attestation_data_params):
     attestation_data = AttestationData(**sample_attestation_data_params)
 
-    assert attestation_data.source.epoch == sample_attestation_data_params['source'].epoch
+    assert (
+        attestation_data.source.epoch == sample_attestation_data_params["source"].epoch
+    )

--- a/tests/eth2/core/beacon/types/test_attestation_data_and_custody_bit.py
+++ b/tests/eth2/core/beacon/types/test_attestation_data_and_custody_bit.py
@@ -7,5 +7,5 @@ def test_defaults(sample_attestation_data_and_custody_bit_params):
     params = sample_attestation_data_and_custody_bit_params
     attestation_data_and_custody_bit = AttestationDataAndCustodyBit(**params)
 
-    assert attestation_data_and_custody_bit.data == params['data']
-    assert attestation_data_and_custody_bit.custody_bit == params['custody_bit']
+    assert attestation_data_and_custody_bit.data == params["data"]
+    assert attestation_data_and_custody_bit.custody_bit == params["custody_bit"]

--- a/tests/eth2/core/beacon/types/test_attester_slashings.py
+++ b/tests/eth2/core/beacon/types/test_attester_slashings.py
@@ -7,12 +7,12 @@ def test_defaults(sample_attester_slashing_params):
     attester_slashing = AttesterSlashing(**sample_attester_slashing_params)
 
     assert (
-        attester_slashing.attestation_1.custody_bit_0_indices ==
-        sample_attester_slashing_params['attestation_1'].custody_bit_0_indices
+        attester_slashing.attestation_1.custody_bit_0_indices
+        == sample_attester_slashing_params["attestation_1"].custody_bit_0_indices
     )
     assert (
-        attester_slashing.attestation_2.data ==
-        sample_attester_slashing_params['attestation_2'].data
+        attester_slashing.attestation_2.data
+        == sample_attester_slashing_params["attestation_2"].data
     )
 
     assert ssz.encode(attester_slashing)

--- a/tests/eth2/core/beacon/types/test_block.py
+++ b/tests/eth2/core/beacon/types/test_block.py
@@ -1,19 +1,12 @@
-from eth2.beacon.types.attestations import (
-    Attestation,
-)
-from eth2.beacon.types.blocks import (
-    BeaconBlock,
-    BeaconBlockBody,
-)
+from eth2.beacon.types.attestations import Attestation
+from eth2.beacon.types.blocks import BeaconBlock, BeaconBlockBody
 
-from eth2.beacon.typing import (
-    FromBlockParams,
-)
+from eth2.beacon.typing import FromBlockParams
 
 
 def test_defaults(sample_beacon_block_params):
     block = BeaconBlock(**sample_beacon_block_params)
-    assert block.slot == sample_beacon_block_params['slot']
+    assert block.slot == sample_beacon_block_params["slot"]
     assert block.is_genesis
 
 
@@ -29,12 +22,8 @@ def test_update_attestations(sample_attestation_params, sample_beacon_block_para
     attestations = block.body.attestations
     attestations = list(attestations)
     attestations.append(Attestation(**sample_attestation_params))
-    body2 = block.body.copy(
-        attestations=attestations
-    )
-    block2 = block.copy(
-        body=body2
-    )
+    body2 = block.body.copy(attestations=attestations)
+    block2 = block.copy(body=body2)
     assert len(block2.body.attestations) == 1
 
 
@@ -50,7 +39,7 @@ def test_block_body_empty(sample_attestation_params):
     assert block_body.is_empty
 
     block_body = block_body.copy(
-        attestations=(Attestation(**sample_attestation_params),),
+        attestations=(Attestation(**sample_attestation_params),)
     )
     assert not block_body.is_empty
 

--- a/tests/eth2/core/beacon/types/test_block.py
+++ b/tests/eth2/core/beacon/types/test_block.py
@@ -1,6 +1,5 @@
 from eth2.beacon.types.attestations import Attestation
 from eth2.beacon.types.blocks import BeaconBlock, BeaconBlockBody
-
 from eth2.beacon.typing import FromBlockParams
 
 

--- a/tests/eth2/core/beacon/types/test_crosslink_record.py
+++ b/tests/eth2/core/beacon/types/test_crosslink_record.py
@@ -1,9 +1,7 @@
-from eth2.beacon.types.crosslinks import (
-    Crosslink,
-)
+from eth2.beacon.types.crosslinks import Crosslink
 
 
 def test_defaults(sample_crosslink_record_params):
     crosslink = Crosslink(**sample_crosslink_record_params)
-    assert crosslink.start_epoch == sample_crosslink_record_params['start_epoch']
-    assert crosslink.data_root == sample_crosslink_record_params['data_root']
+    assert crosslink.start_epoch == sample_crosslink_record_params["start_epoch"]
+    assert crosslink.data_root == sample_crosslink_record_params["data_root"]

--- a/tests/eth2/core/beacon/types/test_deposit_data.py
+++ b/tests/eth2/core/beacon/types/test_deposit_data.py
@@ -4,5 +4,5 @@ from eth2.beacon.types.deposit_data import DepositData
 def test_defaults(sample_deposit_data_params):
     deposit_data = DepositData(**sample_deposit_data_params)
 
-    assert deposit_data.pubkey == sample_deposit_data_params['pubkey']
-    assert deposit_data.amount == sample_deposit_data_params['amount']
+    assert deposit_data.pubkey == sample_deposit_data_params["pubkey"]
+    assert deposit_data.amount == sample_deposit_data_params["amount"]

--- a/tests/eth2/core/beacon/types/test_deposits.py
+++ b/tests/eth2/core/beacon/types/test_deposits.py
@@ -4,4 +4,4 @@ from eth2.beacon.types.deposits import Deposit
 def test_defaults(sample_deposit_params):
     deposit = Deposit(**sample_deposit_params)
 
-    assert deposit.data == sample_deposit_params['data']
+    assert deposit.data == sample_deposit_params["data"]

--- a/tests/eth2/core/beacon/types/test_eth1_data.py
+++ b/tests/eth2/core/beacon/types/test_eth1_data.py
@@ -1,11 +1,7 @@
-from eth2.beacon.types.eth1_data import (
-    Eth1Data,
-)
+from eth2.beacon.types.eth1_data import Eth1Data
 
 
 def test_defaults(sample_eth1_data_params):
-    eth1_data = Eth1Data(
-        **sample_eth1_data_params,
-    )
-    assert eth1_data.deposit_root == sample_eth1_data_params['deposit_root']
-    assert eth1_data.block_hash == sample_eth1_data_params['block_hash']
+    eth1_data = Eth1Data(**sample_eth1_data_params)
+    assert eth1_data.deposit_root == sample_eth1_data_params["deposit_root"]
+    assert eth1_data.block_hash == sample_eth1_data_params["block_hash"]

--- a/tests/eth2/core/beacon/types/test_fork.py
+++ b/tests/eth2/core/beacon/types/test_fork.py
@@ -1,13 +1,11 @@
 import ssz
 
-from eth2.beacon.types.forks import (
-    Fork,
-)
+from eth2.beacon.types.forks import Fork
 
 
 def test_defaults(sample_fork_params):
     fork = Fork(**sample_fork_params)
-    assert fork.previous_version == sample_fork_params['previous_version']
-    assert fork.current_version == sample_fork_params['current_version']
-    assert fork.epoch == sample_fork_params['epoch']
+    assert fork.previous_version == sample_fork_params["previous_version"]
+    assert fork.current_version == sample_fork_params["current_version"]
+    assert fork.epoch == sample_fork_params["epoch"]
     assert ssz.encode(fork)

--- a/tests/eth2/core/beacon/types/test_pending_attestation_record.py
+++ b/tests/eth2/core/beacon/types/test_pending_attestation_record.py
@@ -1,15 +1,22 @@
 import ssz
 
-from eth2.beacon.types.pending_attestations import (
-    PendingAttestation,
-)
+from eth2.beacon.types.pending_attestations import PendingAttestation
 
 
 def test_defaults(sample_pending_attestation_record_params):
     pending_attestation = PendingAttestation(**sample_pending_attestation_record_params)
 
-    assert pending_attestation.data == sample_pending_attestation_record_params['data']
-    assert pending_attestation.aggregation_bits == sample_pending_attestation_record_params['aggregation_bits']  # noqa: E501
-    assert pending_attestation.inclusion_delay == sample_pending_attestation_record_params['inclusion_delay']  # noqa: E501
-    assert pending_attestation.proposer_index == sample_pending_attestation_record_params['proposer_index']  # noqa: E501
+    assert pending_attestation.data == sample_pending_attestation_record_params["data"]
+    assert (
+        pending_attestation.aggregation_bits
+        == sample_pending_attestation_record_params["aggregation_bits"]
+    )  # noqa: E501
+    assert (
+        pending_attestation.inclusion_delay
+        == sample_pending_attestation_record_params["inclusion_delay"]
+    )  # noqa: E501
+    assert (
+        pending_attestation.proposer_index
+        == sample_pending_attestation_record_params["proposer_index"]
+    )  # noqa: E501
     assert ssz.encode(pending_attestation)

--- a/tests/eth2/core/beacon/types/test_proposer_slashings.py
+++ b/tests/eth2/core/beacon/types/test_proposer_slashings.py
@@ -1,13 +1,11 @@
 import ssz
 
-from eth2.beacon.types.proposer_slashings import (
-    ProposerSlashing,
-)
+from eth2.beacon.types.proposer_slashings import ProposerSlashing
 
 
 def test_defaults(sample_proposer_slashing_params):
     slashing = ProposerSlashing(**sample_proposer_slashing_params)
-    assert slashing.proposer_index == sample_proposer_slashing_params['proposer_index']
-    assert slashing.header_1 == sample_proposer_slashing_params['header_1']
-    assert slashing.header_2 == sample_proposer_slashing_params['header_2']
+    assert slashing.proposer_index == sample_proposer_slashing_params["proposer_index"]
+    assert slashing.header_1 == sample_proposer_slashing_params["header_1"]
+    assert slashing.header_2 == sample_proposer_slashing_params["header_2"]
     assert ssz.encode(slashing)

--- a/tests/eth2/core/beacon/types/test_states.py
+++ b/tests/eth2/core/beacon/types/test_states.py
@@ -2,18 +2,14 @@ import pytest
 
 import ssz
 
-from eth2.beacon.types.states import (
-    BeaconState,
-)
+from eth2.beacon.types.states import BeaconState
 
-from eth2.beacon.tools.builder.initializer import (
-    create_mock_validator,
-)
+from eth2.beacon.tools.builder.initializer import create_mock_validator
 
 
 def test_defaults(sample_beacon_state_params):
     state = BeaconState(**sample_beacon_state_params)
-    assert state.validators == sample_beacon_state_params['validators']
+    assert state.validators == sample_beacon_state_params["validators"]
     assert ssz.encode(state)
 
 
@@ -22,34 +18,30 @@ def test_validators_and_balances_length(sample_beacon_state_params, config):
     with pytest.raises(ValueError):
         BeaconState(**sample_beacon_state_params).copy(
             validators=tuple(
-                create_mock_validator(pubkey, config)
-                for pubkey in range(10)
-            ),
+                create_mock_validator(pubkey, config) for pubkey in range(10)
+            )
         )
 
 
 @pytest.mark.parametrize(
-    'validator_index_offset, new_pubkey, new_balance',
-    [
-        (0, 5566, 100),
-        (100, 5566, 100),
-    ]
+    "validator_index_offset, new_pubkey, new_balance",
+    [(0, 5566, 100), (100, 5566, 100)],
 )
-def test_update_validator(genesis_state,
-                          validator_index_offset,
-                          validator_count,
-                          new_pubkey,
-                          new_balance,
-                          config):
+def test_update_validator(
+    genesis_state,
+    validator_index_offset,
+    validator_count,
+    new_pubkey,
+    new_balance,
+    config,
+):
     state = genesis_state
     validator = create_mock_validator(new_pubkey, config)
     validator_index = validator_count + validator_index_offset
 
     if validator_index < state.validator_count:
         result_state = state.update_validator(
-            validator_index=validator_index,
-            validator=validator,
-            balance=new_balance,
+            validator_index=validator_index, validator=validator, balance=new_balance
         )
         assert result_state.balances[validator_index] == new_balance
         assert result_state.validators[validator_index].pubkey == new_pubkey

--- a/tests/eth2/core/beacon/types/test_states.py
+++ b/tests/eth2/core/beacon/types/test_states.py
@@ -1,10 +1,8 @@
 import pytest
-
 import ssz
 
-from eth2.beacon.types.states import BeaconState
-
 from eth2.beacon.tools.builder.initializer import create_mock_validator
+from eth2.beacon.types.states import BeaconState
 
 
 def test_defaults(sample_beacon_state_params):

--- a/tests/eth2/core/beacon/types/test_transfer.py
+++ b/tests/eth2/core/beacon/types/test_transfer.py
@@ -1,12 +1,10 @@
 import ssz
 
-from eth2.beacon.types.transfers import (
-    Transfer,
-)
+from eth2.beacon.types.transfers import Transfer
 
 
 def test_defaults(sample_transfer_params):
     transfer = Transfer(**sample_transfer_params)
 
-    assert transfer.recipient == sample_transfer_params['recipient']
+    assert transfer.recipient == sample_transfer_params["recipient"]
     assert ssz.encode(transfer)

--- a/tests/eth2/core/beacon/types/test_validator_record.py
+++ b/tests/eth2/core/beacon/types/test_validator_record.py
@@ -1,39 +1,30 @@
 import pytest
 
-from eth2.beacon.constants import (
-    FAR_FUTURE_EPOCH,
-    GWEI_PER_ETH,
-)
-from eth2.beacon.types.validators import (
-    Validator,
-)
+from eth2.beacon.constants import FAR_FUTURE_EPOCH, GWEI_PER_ETH
+from eth2.beacon.types.validators import Validator
 from eth2.beacon.typing import Gwei
 
 
 def test_defaults(sample_validator_record_params):
     validator = Validator(**sample_validator_record_params)
-    assert validator.pubkey == sample_validator_record_params['pubkey']
-    assert validator.withdrawal_credentials == sample_validator_record_params['withdrawal_credentials']  # noqa: E501
+    assert validator.pubkey == sample_validator_record_params["pubkey"]
+    assert (
+        validator.withdrawal_credentials
+        == sample_validator_record_params["withdrawal_credentials"]
+    )  # noqa: E501
 
 
 @pytest.mark.parametrize(
-    'activation_epoch,exit_epoch,epoch,expected',
-    [
-        (0, 1, 0, True),
-        (1, 1, 1, False),
-        (0, 1, 1, False),
-        (0, 1, 2, False),
-    ],
+    "activation_epoch,exit_epoch,epoch,expected",
+    [(0, 1, 0, True), (1, 1, 1, False), (0, 1, 1, False), (0, 1, 2, False)],
 )
-def test_is_active(sample_validator_record_params,
-                   activation_epoch,
-                   exit_epoch,
-                   epoch,
-                   expected):
+def test_is_active(
+    sample_validator_record_params, activation_epoch, exit_epoch, epoch, expected
+):
     validator_record_params = {
         **sample_validator_record_params,
-        'activation_epoch': activation_epoch,
-        'exit_epoch': exit_epoch,
+        "activation_epoch": activation_epoch,
+        "exit_epoch": exit_epoch,
     }
     validator = Validator(**validator_record_params)
     assert validator.is_active(epoch) == expected
@@ -41,7 +32,7 @@ def test_is_active(sample_validator_record_params,
 
 def test_create_pending_validator(config):
     pubkey = 123
-    withdrawal_credentials = b'\x11' * 32
+    withdrawal_credentials = b"\x11" * 32
 
     effective_balance = 22 * GWEI_PER_ETH
     amount = Gwei(effective_balance + config.EFFECTIVE_BALANCE_INCREMENT // 2)

--- a/tests/eth2/core/beacon/types/test_voluntary_exits.py
+++ b/tests/eth2/core/beacon/types/test_voluntary_exits.py
@@ -1,12 +1,10 @@
 import ssz
 
-from eth2.beacon.types.voluntary_exits import (
-    VoluntaryExit,
-)
+from eth2.beacon.types.voluntary_exits import VoluntaryExit
 
 
 def test_defaults(sample_voluntary_exit_params):
     exit = VoluntaryExit(**sample_voluntary_exit_params)
 
-    assert exit.signature[0] == sample_voluntary_exit_params['signature'][0]
+    assert exit.signature[0] == sample_voluntary_exit_params["signature"][0]
     assert ssz.encode(exit)

--- a/tests/eth2/fixtures/bls-fixtures/test_bls.py
+++ b/tests/eth2/fixtures/bls-fixtures/test_bls.py
@@ -1,17 +1,11 @@
-from typing import (
-    Tuple,
-)
-from dataclasses import (
-    dataclass,
-)
+from typing import Tuple
+from dataclasses import dataclass
 import pytest
 
 from py_ecc.bls.typing import Domain
 
 from eth2._utils.bls import bls
-from eth2._utils.bls.backends import (
-    MilagroBackend,
-)
+from eth2._utils.bls.backends import MilagroBackend
 from eth2.beacon.tools.fixtures.loading import (
     get_input_bls_privkey,
     get_input_bls_pubkeys,
@@ -20,34 +14,23 @@ from eth2.beacon.tools.fixtures.loading import (
     get_output_bls_pubkey,
     get_output_bls_signature,
 )
-from eth2.beacon.tools.fixtures.test_case import (
-    BaseTestCase,
-)
-from eth_typing import (
-    BLSPubkey,
-    BLSSignature,
-    Hash32,
-)
+from eth2.beacon.tools.fixtures.test_case import BaseTestCase
+from eth_typing import BLSPubkey, BLSSignature, Hash32
 
 
-from tests.eth2.fixtures.helpers import (
-    get_test_cases,
-)
-from tests.eth2.fixtures.path import (
-    BASE_FIXTURE_PATH,
-    ROOT_PROJECT_DIR,
-)
+from tests.eth2.fixtures.helpers import get_test_cases
+from tests.eth2.fixtures.path import BASE_FIXTURE_PATH, ROOT_PROJECT_DIR
 
 
 # Test files
-RUNNER_FIXTURE_PATH = BASE_FIXTURE_PATH / 'bls'
+RUNNER_FIXTURE_PATH = BASE_FIXTURE_PATH / "bls"
 HANDLER_FIXTURE_PATHES = (
-    RUNNER_FIXTURE_PATH / 'aggregate_pubkeys',
-    RUNNER_FIXTURE_PATH / 'aggregate_sigs',
+    RUNNER_FIXTURE_PATH / "aggregate_pubkeys",
+    RUNNER_FIXTURE_PATH / "aggregate_sigs",
     # RUNNER_FIXTURE_PATH / 'msg_hash_g2_compressed',  # NOTE: No public API in PyEECBackend
     # RUNNER_FIXTURE_PATH / 'msg_hash_g2_uncompressed',  # NOTE: No public API in PyEECBackend
-    RUNNER_FIXTURE_PATH / 'priv_to_pub',
-    RUNNER_FIXTURE_PATH / 'sign_msg',
+    RUNNER_FIXTURE_PATH / "priv_to_pub",
+    RUNNER_FIXTURE_PATH / "sign_msg",
 )
 FILTERED_CONFIG_NAMES = ()
 
@@ -80,25 +63,25 @@ class BLSSignMessageTestCase(BaseTestCase):
 
 
 handler_to_processing_call_map = {
-    'aggregate_pubkeys': (
+    "aggregate_pubkeys": (
         bls.aggregate_pubkeys,
         BLSPubkeyAggregationTestCase,
         get_input_bls_pubkeys,
         get_output_bls_pubkey,
     ),
-    'aggregate_sigs': (
+    "aggregate_sigs": (
         bls.aggregate_signatures,
         BLSSignaturesAggregationTestCase,
         get_input_bls_signatures,
         get_output_bls_signature,
     ),
-    'priv_to_pub': (
+    "priv_to_pub": (
         bls.privtopub,
         BLSPrivToPubTestCase,
         get_input_bls_privkey,
         get_output_bls_pubkey,
     ),
-    'sign_msg': (
+    "sign_msg": (
         bls.sign,
         BLSSignMessageTestCase,
         get_input_sign_message,
@@ -128,10 +111,7 @@ all_test_cases = get_test_cases(
 )
 
 
-@pytest.mark.parametrize(
-    "test_case, config",
-    all_test_cases
-)
+@pytest.mark.parametrize("test_case, config", all_test_cases)
 def test_aggregate_pubkeys_fixture(config, test_case):
     bls.use(MilagroBackend)
     processing_call, _, _, _ = handler_to_processing_call_map[test_case.handler]

--- a/tests/eth2/fixtures/bls-fixtures/test_bls.py
+++ b/tests/eth2/fixtures/bls-fixtures/test_bls.py
@@ -1,8 +1,9 @@
-from typing import Tuple
 from dataclasses import dataclass
-import pytest
+from typing import Tuple
 
+from eth_typing import BLSPubkey, BLSSignature, Hash32
 from py_ecc.bls.typing import Domain
+import pytest
 
 from eth2._utils.bls import bls
 from eth2._utils.bls.backends import MilagroBackend
@@ -15,12 +16,8 @@ from eth2.beacon.tools.fixtures.loading import (
     get_output_bls_signature,
 )
 from eth2.beacon.tools.fixtures.test_case import BaseTestCase
-from eth_typing import BLSPubkey, BLSSignature, Hash32
-
-
 from tests.eth2.fixtures.helpers import get_test_cases
 from tests.eth2.fixtures.path import BASE_FIXTURE_PATH, ROOT_PROJECT_DIR
-
 
 # Test files
 RUNNER_FIXTURE_PATH = BASE_FIXTURE_PATH / "bls"

--- a/tests/eth2/fixtures/helpers.py
+++ b/tests/eth2/fixtures/helpers.py
@@ -1,19 +1,11 @@
 import pytest
 
-from eth_utils import (
-    to_tuple,
-)
+from eth_utils import to_tuple
 
-from eth2.configs import (
-    Eth2GenesisConfig,
-)
+from eth2.configs import Eth2GenesisConfig
 from eth2.beacon.db.chain import BeaconChainDB
-from eth2.beacon.state_machines.forks.serenity import (
-    SerenityStateMachine,
-)
-from eth2.beacon.tools.fixtures.loading import (
-    get_all_test_files,
-)
+from eth2.beacon.state_machines.forks.serenity import SerenityStateMachine
+from eth2.beacon.tools.fixtures.loading import get_all_test_files
 
 
 #
@@ -29,19 +21,18 @@ def bls_setting_mark_fn(bls_setting):
 def get_test_cases(root_project_dir, fixture_pathes, config_names, parse_test_case_fn):
     # TODO: batch reading files
     test_files = get_all_test_files(
-        root_project_dir,
-        fixture_pathes,
-        config_names,
-        parse_test_case_fn,
+        root_project_dir, fixture_pathes, config_names, parse_test_case_fn
     )
     for test_file in test_files:
         for test_case in test_file.test_cases:
-            bls_setting = test_case.bls_setting if hasattr(test_case, 'bls_setting') else False
+            bls_setting = (
+                test_case.bls_setting if hasattr(test_case, "bls_setting") else False
+            )
             yield mark_test_case(test_file, test_case, bls_setting=bls_setting)
 
 
 def get_test_id(test_file, test_case):
-    description = test_case.description if hasattr(test_case, 'description') else ''
+    description = test_case.description if hasattr(test_case, "description") else ""
     return f"{test_file.file_name}:{test_case.index}:{description}"
 
 
@@ -60,8 +51,7 @@ def mark_test_case(test_file, test_case, bls_setting=False):
 #
 def get_sm_class_of_config(config):
     return SerenityStateMachine.configure(
-        __name__='SerenityStateMachineForTesting',
-        config=config,
+        __name__="SerenityStateMachineForTesting", config=config
     )
 
 

--- a/tests/eth2/fixtures/helpers.py
+++ b/tests/eth2/fixtures/helpers.py
@@ -1,11 +1,10 @@
+from eth_utils import to_tuple
 import pytest
 
-from eth_utils import to_tuple
-
-from eth2.configs import Eth2GenesisConfig
 from eth2.beacon.db.chain import BeaconChainDB
 from eth2.beacon.state_machines.forks.serenity import SerenityStateMachine
 from eth2.beacon.tools.fixtures.loading import get_all_test_files
+from eth2.configs import Eth2GenesisConfig
 
 
 #

--- a/tests/eth2/fixtures/path.py
+++ b/tests/eth2/fixtures/path.py
@@ -6,4 +6,4 @@ from pathlib import Path
 ROOT_PROJECT_DIR = Path(
     os.path.dirname(os.path.dirname(os.path.dirname(os.path.dirname(__file__))))
 )
-BASE_FIXTURE_PATH = ROOT_PROJECT_DIR / 'eth2-fixtures' / 'tests'
+BASE_FIXTURE_PATH = ROOT_PROJECT_DIR / "eth2-fixtures" / "tests"

--- a/tests/eth2/fixtures/path.py
+++ b/tests/eth2/fixtures/path.py
@@ -1,7 +1,6 @@
 import os
 from pathlib import Path
 
-
 # ROOT_PROJECT_DIR = Path(__file__).cwd()
 ROOT_PROJECT_DIR = Path(
     os.path.dirname(os.path.dirname(os.path.dirname(os.path.dirname(__file__))))

--- a/tests/eth2/fixtures/shuffling-fixtures/test_shuffling_core.py
+++ b/tests/eth2/fixtures/shuffling-fixtures/test_shuffling_core.py
@@ -1,18 +1,15 @@
-import pytest
+from dataclasses import dataclass
 from typing import Tuple
 
-from dataclasses import dataclass
-
 from eth_utils import decode_hex
+import pytest
 
-from eth2.beacon.tools.misc.ssz_vector import override_lengths
 from eth2.beacon.committee_helpers import compute_shuffled_index
 from eth2.beacon.tools.fixtures.config_name import ONLY_MINIMAL
 from eth2.beacon.tools.fixtures.test_case import BaseTestCase
-
+from eth2.beacon.tools.misc.ssz_vector import override_lengths
 from tests.eth2.fixtures.helpers import get_test_cases
 from tests.eth2.fixtures.path import BASE_FIXTURE_PATH, ROOT_PROJECT_DIR
-
 
 # Test files
 SHUFFLING_FIXTURE_PATH = BASE_FIXTURE_PATH / "shuffling"

--- a/tests/eth2/fixtures/shuffling-fixtures/test_shuffling_core.py
+++ b/tests/eth2/fixtures/shuffling-fixtures/test_shuffling_core.py
@@ -1,43 +1,22 @@
 import pytest
-from typing import (
-    Tuple,
-)
+from typing import Tuple
 
-from dataclasses import (
-    dataclass,
-)
+from dataclasses import dataclass
 
-from eth_utils import (
-    decode_hex,
-)
+from eth_utils import decode_hex
 
-from eth2.beacon.tools.misc.ssz_vector import (
-    override_lengths,
-)
-from eth2.beacon.committee_helpers import (
-    compute_shuffled_index,
-)
-from eth2.beacon.tools.fixtures.config_name import (
-    ONLY_MINIMAL,
-)
-from eth2.beacon.tools.fixtures.test_case import (
-    BaseTestCase,
-)
+from eth2.beacon.tools.misc.ssz_vector import override_lengths
+from eth2.beacon.committee_helpers import compute_shuffled_index
+from eth2.beacon.tools.fixtures.config_name import ONLY_MINIMAL
+from eth2.beacon.tools.fixtures.test_case import BaseTestCase
 
-from tests.eth2.fixtures.helpers import (
-    get_test_cases,
-)
-from tests.eth2.fixtures.path import (
-    BASE_FIXTURE_PATH,
-    ROOT_PROJECT_DIR,
-)
+from tests.eth2.fixtures.helpers import get_test_cases
+from tests.eth2.fixtures.path import BASE_FIXTURE_PATH, ROOT_PROJECT_DIR
 
 
 # Test files
-SHUFFLING_FIXTURE_PATH = BASE_FIXTURE_PATH / 'shuffling'
-FIXTURE_PATHES = (
-    SHUFFLING_FIXTURE_PATH,
-)
+SHUFFLING_FIXTURE_PATH = BASE_FIXTURE_PATH / "shuffling"
+FIXTURE_PATHES = (SHUFFLING_FIXTURE_PATH,)
 FILTERED_CONFIG_NAMES = ONLY_MINIMAL
 
 
@@ -57,9 +36,9 @@ def parse_shuffling_test_case(test_case, handler, index, config):
     return ShufflingTestCase(
         handler=handler,
         index=index,
-        seed=decode_hex(test_case['seed']),
-        count=test_case['count'],
-        shuffled=tuple(test_case['shuffled']),
+        seed=decode_hex(test_case["seed"]),
+        count=test_case["count"],
+        shuffled=tuple(test_case["shuffled"]),
     )
 
 
@@ -71,14 +50,13 @@ all_test_cases = get_test_cases(
 )
 
 
-@pytest.mark.parametrize(
-    "test_case, config",
-    all_test_cases
-)
+@pytest.mark.parametrize("test_case, config", all_test_cases)
 def test_shuffling_fixture(test_case, config):
 
     result = tuple(
-        compute_shuffled_index(index, test_case.count, test_case.seed, config.SHUFFLE_ROUND_COUNT)
+        compute_shuffled_index(
+            index, test_case.count, test_case.seed, config.SHUFFLE_ROUND_COUNT
+        )
         for index in range(test_case.count)
     )
     assert result == test_case.shuffled

--- a/tests/eth2/fixtures/state-fixtures/conftest.py
+++ b/tests/eth2/fixtures/state-fixtures/conftest.py
@@ -9,7 +9,7 @@ from eth2.beacon.operations.attestation_pool import AttestationPool
 #
 @pytest.fixture(autouse=True)
 def mock_bls(mocker, request):
-    if 'noautofixture' in request.keywords:
+    if "noautofixture" in request.keywords:
         bls.use(PyECCBackend)
     else:
         bls.use_noop_backend()

--- a/tests/eth2/fixtures/state-fixtures/conftest.py
+++ b/tests/eth2/fixtures/state-fixtures/conftest.py
@@ -1,4 +1,5 @@
 import pytest
+
 from eth2._utils.bls import bls
 from eth2._utils.bls.backends import PyECCBackend
 from eth2.beacon.operations.attestation_pool import AttestationPool

--- a/tests/eth2/fixtures/state-fixtures/test_genesis_initialization.py
+++ b/tests/eth2/fixtures/state-fixtures/test_genesis_initialization.py
@@ -1,24 +1,22 @@
-from typing import Tuple
 from dataclasses import dataclass, field
-import pytest
+from typing import Tuple
 
-from eth_utils import decode_hex
 from eth_typing import Hash32
+from eth_utils import decode_hex
+import pytest
 from ssz.tools import from_formatted_dict
 
 from eth2.beacon.genesis import initialize_beacon_state_from_eth1
-from eth2.beacon.tools.misc.ssz_vector import override_lengths
-from eth2.beacon.types.deposits import Deposit
-from eth2.beacon.types.states import BeaconState
 from eth2.beacon.tools.fixtures.config_name import ONLY_MINIMAL
 from eth2.beacon.tools.fixtures.helpers import validate_state
 from eth2.beacon.tools.fixtures.loading import get_bls_setting, get_deposits
 from eth2.beacon.tools.fixtures.test_case import BaseTestCase
+from eth2.beacon.tools.misc.ssz_vector import override_lengths
+from eth2.beacon.types.deposits import Deposit
+from eth2.beacon.types.states import BeaconState
 from eth2.beacon.typing import Timestamp
-
 from tests.eth2.fixtures.helpers import get_test_cases
 from tests.eth2.fixtures.path import BASE_FIXTURE_PATH, ROOT_PROJECT_DIR
-
 
 # Test files
 RUNNER_FIXTURE_PATH = BASE_FIXTURE_PATH / "genesis"

--- a/tests/eth2/fixtures/state-fixtures/test_genesis_initialization.py
+++ b/tests/eth2/fixtures/state-fixtures/test_genesis_initialization.py
@@ -1,61 +1,28 @@
-from typing import (
-    Tuple,
-)
-from dataclasses import (
-    dataclass,
-    field,
-)
+from typing import Tuple
+from dataclasses import dataclass, field
 import pytest
 
-from eth_utils import (
-    decode_hex,
-)
-from eth_typing import (
-    Hash32,
-)
-from ssz.tools import (
-    from_formatted_dict,
-)
+from eth_utils import decode_hex
+from eth_typing import Hash32
+from ssz.tools import from_formatted_dict
 
-from eth2.beacon.genesis import (
-    initialize_beacon_state_from_eth1,
-)
-from eth2.beacon.tools.misc.ssz_vector import (
-    override_lengths,
-)
+from eth2.beacon.genesis import initialize_beacon_state_from_eth1
+from eth2.beacon.tools.misc.ssz_vector import override_lengths
 from eth2.beacon.types.deposits import Deposit
 from eth2.beacon.types.states import BeaconState
-from eth2.beacon.tools.fixtures.config_name import (
-    ONLY_MINIMAL,
-)
-from eth2.beacon.tools.fixtures.helpers import (
-    validate_state,
-)
-from eth2.beacon.tools.fixtures.loading import (
-    get_bls_setting,
-    get_deposits,
-)
-from eth2.beacon.tools.fixtures.test_case import (
-    BaseTestCase,
-)
-from eth2.beacon.typing import (
-    Timestamp,
-)
+from eth2.beacon.tools.fixtures.config_name import ONLY_MINIMAL
+from eth2.beacon.tools.fixtures.helpers import validate_state
+from eth2.beacon.tools.fixtures.loading import get_bls_setting, get_deposits
+from eth2.beacon.tools.fixtures.test_case import BaseTestCase
+from eth2.beacon.typing import Timestamp
 
-from tests.eth2.fixtures.helpers import (
-    get_test_cases,
-)
-from tests.eth2.fixtures.path import (
-    BASE_FIXTURE_PATH,
-    ROOT_PROJECT_DIR,
-)
+from tests.eth2.fixtures.helpers import get_test_cases
+from tests.eth2.fixtures.path import BASE_FIXTURE_PATH, ROOT_PROJECT_DIR
 
 
 # Test files
-RUNNER_FIXTURE_PATH = BASE_FIXTURE_PATH / 'genesis'
-HANDLER_FIXTURE_PATHES = (
-    RUNNER_FIXTURE_PATH / 'initialization',
-)
+RUNNER_FIXTURE_PATH = BASE_FIXTURE_PATH / "genesis"
+HANDLER_FIXTURE_PATHES = (RUNNER_FIXTURE_PATH / "initialization",)
 FILTERED_CONFIG_NAMES = ONLY_MINIMAL
 
 
@@ -79,16 +46,16 @@ def parse_genesis_initialization_test_case(test_case, handler, index, config):
     override_lengths(config)
 
     bls_setting = get_bls_setting(test_case)
-    eth1_block_hash = decode_hex(test_case['eth1_block_hash'])
-    eth1_timestamp = test_case['eth1_timestamp']
-    state = from_formatted_dict(test_case['state'], BeaconState)
+    eth1_block_hash = decode_hex(test_case["eth1_block_hash"])
+    eth1_timestamp = test_case["eth1_timestamp"]
+    state = from_formatted_dict(test_case["state"], BeaconState)
     deposits = get_deposits(test_case, Deposit)
 
     return GenesisInitializationTestCase(
         handler=handler,
         index=index,
         bls_setting=bls_setting,
-        description=test_case['description'],
+        description=test_case["description"],
         eth1_block_hash=eth1_block_hash,
         eth1_timestamp=eth1_timestamp,
         state=state,
@@ -104,10 +71,7 @@ all_test_cases = get_test_cases(
 )
 
 
-@pytest.mark.parametrize(
-    "test_case, config",
-    all_test_cases
-)
+@pytest.mark.parametrize("test_case, config", all_test_cases)
 def test_genesis_initialization_fixture(config, test_case):
     result_state = initialize_beacon_state_from_eth1(
         eth1_block_hash=test_case.eth1_block_hash,

--- a/tests/eth2/fixtures/state-fixtures/test_genesis_validity.py
+++ b/tests/eth2/fixtures/state-fixtures/test_genesis_validity.py
@@ -1,44 +1,23 @@
-from dataclasses import (
-    dataclass,
-)
+from dataclasses import dataclass
 import pytest
 
-from ssz.tools import (
-    from_formatted_dict,
-)
+from ssz.tools import from_formatted_dict
 
-from eth2.beacon.genesis import (
-    is_valid_genesis_state,
-)
-from eth2.beacon.tools.misc.ssz_vector import (
-    override_lengths,
-)
+from eth2.beacon.genesis import is_valid_genesis_state
+from eth2.beacon.tools.misc.ssz_vector import override_lengths
 from eth2.beacon.types.states import BeaconState
-from eth2.beacon.tools.fixtures.config_name import (
-    ONLY_MINIMAL,
-)
+from eth2.beacon.tools.fixtures.config_name import ONLY_MINIMAL
 
-from eth2.beacon.tools.fixtures.loading import (
-    get_bls_setting,
-)
-from eth2.beacon.tools.fixtures.test_case import (
-    BaseTestCase,
-)
+from eth2.beacon.tools.fixtures.loading import get_bls_setting
+from eth2.beacon.tools.fixtures.test_case import BaseTestCase
 
-from tests.eth2.fixtures.helpers import (
-    get_test_cases,
-)
-from tests.eth2.fixtures.path import (
-    BASE_FIXTURE_PATH,
-    ROOT_PROJECT_DIR,
-)
+from tests.eth2.fixtures.helpers import get_test_cases
+from tests.eth2.fixtures.path import BASE_FIXTURE_PATH, ROOT_PROJECT_DIR
 
 
 # Test files
-RUNNER_FIXTURE_PATH = BASE_FIXTURE_PATH / 'genesis'
-HANDLER_FIXTURE_PATHES = (
-    RUNNER_FIXTURE_PATH / 'validity',
-)
+RUNNER_FIXTURE_PATH = BASE_FIXTURE_PATH / "genesis"
+HANDLER_FIXTURE_PATHES = (RUNNER_FIXTURE_PATH / "validity",)
 FILTERED_CONFIG_NAMES = ONLY_MINIMAL
 
 
@@ -57,14 +36,14 @@ def parse_genesis_validity_test_case(test_case, handler, index, config):
     override_lengths(config)
 
     bls_setting = get_bls_setting(test_case)
-    genesis = from_formatted_dict(test_case['genesis'], BeaconState)
-    is_valid = test_case['is_valid']
+    genesis = from_formatted_dict(test_case["genesis"], BeaconState)
+    is_valid = test_case["is_valid"]
 
     return GenesisValidityTestCase(
         handler=handler,
         index=index,
         bls_setting=bls_setting,
-        description=test_case['description'],
+        description=test_case["description"],
         genesis=genesis,
         is_valid=is_valid,
     )
@@ -78,9 +57,6 @@ all_test_cases = get_test_cases(
 )
 
 
-@pytest.mark.parametrize(
-    "test_case, config",
-    all_test_cases
-)
+@pytest.mark.parametrize("test_case, config", all_test_cases)
 def test_genesis_validity_fixture(config, test_case):
     assert test_case.is_valid == is_valid_genesis_state(test_case.genesis, config)

--- a/tests/eth2/fixtures/state-fixtures/test_genesis_validity.py
+++ b/tests/eth2/fixtures/state-fixtures/test_genesis_validity.py
@@ -1,19 +1,16 @@
 from dataclasses import dataclass
-import pytest
 
+import pytest
 from ssz.tools import from_formatted_dict
 
 from eth2.beacon.genesis import is_valid_genesis_state
-from eth2.beacon.tools.misc.ssz_vector import override_lengths
-from eth2.beacon.types.states import BeaconState
 from eth2.beacon.tools.fixtures.config_name import ONLY_MINIMAL
-
 from eth2.beacon.tools.fixtures.loading import get_bls_setting
 from eth2.beacon.tools.fixtures.test_case import BaseTestCase
-
+from eth2.beacon.tools.misc.ssz_vector import override_lengths
+from eth2.beacon.types.states import BeaconState
 from tests.eth2.fixtures.helpers import get_test_cases
 from tests.eth2.fixtures.path import BASE_FIXTURE_PATH, ROOT_PROJECT_DIR
-
 
 # Test files
 RUNNER_FIXTURE_PATH = BASE_FIXTURE_PATH / "genesis"

--- a/tests/eth2/fixtures/state-fixtures/test_operations.py
+++ b/tests/eth2/fixtures/state-fixtures/test_operations.py
@@ -1,21 +1,12 @@
 import pytest
 
-from eth_utils import (
-    ValidationError,
-)
+from eth_utils import ValidationError
 
-from eth2.beacon.exceptions import (
-    SignatureError,
-)
-from eth2.beacon.tools.misc.ssz_vector import (
-    override_lengths,
-)
+from eth2.beacon.exceptions import SignatureError
+from eth2.beacon.tools.misc.ssz_vector import override_lengths
 from eth2.beacon.types.attestations import Attestation
 from eth2.beacon.types.attester_slashings import AttesterSlashing
-from eth2.beacon.types.blocks import (
-    BeaconBlock,
-    BeaconBlockBody,
-)
+from eth2.beacon.types.blocks import BeaconBlock, BeaconBlockBody
 from eth2.beacon.types.deposits import Deposit
 from eth2.beacon.types.proposer_slashings import ProposerSlashing
 from eth2.beacon.types.states import BeaconState
@@ -23,12 +14,8 @@ from eth2.beacon.types.transfers import Transfer
 from eth2.beacon.types.voluntary_exits import VoluntaryExit
 
 
-from eth2.beacon.tools.fixtures.config_name import (
-    ONLY_MINIMAL,
-)
-from eth2.beacon.tools.fixtures.helpers import (
-    validate_state,
-)
+from eth2.beacon.tools.fixtures.config_name import ONLY_MINIMAL
+from eth2.beacon.tools.fixtures.helpers import validate_state
 from eth2.beacon.state_machines.forks.serenity.operation_processing import (
     process_attestations,
     process_attester_slashings,
@@ -42,38 +29,31 @@ from eth2.beacon.tools.fixtures.loading import (
     get_operation_or_header,
     get_states,
 )
-from eth2.beacon.tools.fixtures.test_case import (
-    OperationCase,
-)
+from eth2.beacon.tools.fixtures.test_case import OperationCase
 
-from tests.eth2.fixtures.helpers import (
-    get_test_cases,
-)
-from tests.eth2.fixtures.path import (
-    BASE_FIXTURE_PATH,
-    ROOT_PROJECT_DIR,
-)
+from tests.eth2.fixtures.helpers import get_test_cases
+from tests.eth2.fixtures.path import BASE_FIXTURE_PATH, ROOT_PROJECT_DIR
 
 
 # Test files
-RUNNER_FIXTURE_PATH = BASE_FIXTURE_PATH / 'operations'
+RUNNER_FIXTURE_PATH = BASE_FIXTURE_PATH / "operations"
 HANDLER_FIXTURE_PATHES = (
-    RUNNER_FIXTURE_PATH / 'proposer_slashing',
-    RUNNER_FIXTURE_PATH / 'attester_slashing',
-    RUNNER_FIXTURE_PATH / 'attestation',
-    RUNNER_FIXTURE_PATH / 'deposit',
-    RUNNER_FIXTURE_PATH / 'voluntary_exit',
-    RUNNER_FIXTURE_PATH / 'transfer',
+    RUNNER_FIXTURE_PATH / "proposer_slashing",
+    RUNNER_FIXTURE_PATH / "attester_slashing",
+    RUNNER_FIXTURE_PATH / "attestation",
+    RUNNER_FIXTURE_PATH / "deposit",
+    RUNNER_FIXTURE_PATH / "voluntary_exit",
+    RUNNER_FIXTURE_PATH / "transfer",
 )
 FILTERED_CONFIG_NAMES = ONLY_MINIMAL
 
 handler_to_processing_call_map = {
-    'proposer_slashing': (ProposerSlashing, process_proposer_slashings),
-    'attester_slashing': (AttesterSlashing, process_attester_slashings),
-    'attestation': (Attestation, process_attestations),
-    'deposit': (Deposit, process_deposits),
-    'voluntary_exit': (VoluntaryExit, process_voluntary_exits),
-    'transfer': (Transfer, process_transfers),
+    "proposer_slashing": (ProposerSlashing, process_proposer_slashings),
+    "attester_slashing": (AttesterSlashing, process_attester_slashings),
+    "attestation": (Attestation, process_attestations),
+    "deposit": (Deposit, process_deposits),
+    "voluntary_exit": (VoluntaryExit, process_voluntary_exits),
+    "transfer": (Transfer, process_transfers),
 }
 
 
@@ -81,9 +61,7 @@ handler_to_processing_call_map = {
 # Helpers for generating test suite
 #
 def parse_operation_test_case(test_case, handler, index, config):
-    config = config._replace(
-        MAX_TRANSFERS=1,
-    )
+    config = config._replace(MAX_TRANSFERS=1)
     override_lengths(config)
 
     bls_setting = get_bls_setting(test_case)
@@ -95,7 +73,7 @@ def parse_operation_test_case(test_case, handler, index, config):
         handler=handler,
         index=index,
         bls_setting=bls_setting,
-        description=test_case['description'],
+        description=test_case["description"],
         pre=pre,
         operation=operation,
         post=post,
@@ -111,18 +89,13 @@ all_test_cases = get_test_cases(
 )
 
 
-@pytest.mark.parametrize(
-    "test_case, config",
-    all_test_cases
-)
+@pytest.mark.parametrize("test_case, config", all_test_cases)
 def test_operation_fixture(config, test_case):
-    config = config._replace(
-        MAX_TRANSFERS=1,
-    )
+    config = config._replace(MAX_TRANSFERS=1)
     post_state = test_case.pre
     block = BeaconBlock().copy(
         body=BeaconBlockBody(
-            **{test_case.handler + 's': (test_case.operation,)}  # TODO: it looks awful
+            **{test_case.handler + "s": (test_case.operation,)}  # TODO: it looks awful
         )
     )
     _, operation_processing = handler_to_processing_call_map[test_case.handler]

--- a/tests/eth2/fixtures/state-fixtures/test_operations.py
+++ b/tests/eth2/fixtures/state-fixtures/test_operations.py
@@ -1,8 +1,23 @@
+from eth_utils import ValidationError
 import pytest
 
-from eth_utils import ValidationError
-
 from eth2.beacon.exceptions import SignatureError
+from eth2.beacon.state_machines.forks.serenity.operation_processing import (
+    process_attestations,
+    process_attester_slashings,
+    process_deposits,
+    process_proposer_slashings,
+    process_transfers,
+    process_voluntary_exits,
+)
+from eth2.beacon.tools.fixtures.config_name import ONLY_MINIMAL
+from eth2.beacon.tools.fixtures.helpers import validate_state
+from eth2.beacon.tools.fixtures.loading import (
+    get_bls_setting,
+    get_operation_or_header,
+    get_states,
+)
+from eth2.beacon.tools.fixtures.test_case import OperationCase
 from eth2.beacon.tools.misc.ssz_vector import override_lengths
 from eth2.beacon.types.attestations import Attestation
 from eth2.beacon.types.attester_slashings import AttesterSlashing
@@ -12,28 +27,8 @@ from eth2.beacon.types.proposer_slashings import ProposerSlashing
 from eth2.beacon.types.states import BeaconState
 from eth2.beacon.types.transfers import Transfer
 from eth2.beacon.types.voluntary_exits import VoluntaryExit
-
-
-from eth2.beacon.tools.fixtures.config_name import ONLY_MINIMAL
-from eth2.beacon.tools.fixtures.helpers import validate_state
-from eth2.beacon.state_machines.forks.serenity.operation_processing import (
-    process_attestations,
-    process_attester_slashings,
-    process_deposits,
-    process_proposer_slashings,
-    process_transfers,
-    process_voluntary_exits,
-)
-from eth2.beacon.tools.fixtures.loading import (
-    get_bls_setting,
-    get_operation_or_header,
-    get_states,
-)
-from eth2.beacon.tools.fixtures.test_case import OperationCase
-
 from tests.eth2.fixtures.helpers import get_test_cases
 from tests.eth2.fixtures.path import BASE_FIXTURE_PATH, ROOT_PROJECT_DIR
-
 
 # Test files
 RUNNER_FIXTURE_PATH = BASE_FIXTURE_PATH / "operations"

--- a/tests/eth2/fixtures/state-fixtures/test_sanity.py
+++ b/tests/eth2/fixtures/state-fixtures/test_sanity.py
@@ -1,50 +1,32 @@
-from dataclasses import (
-    dataclass,
-)
+from dataclasses import dataclass
 import pytest
 
-from eth_utils import (
-    ValidationError,
-)
+from eth_utils import ValidationError
 
-from eth2.beacon.tools.misc.ssz_vector import (
-    override_lengths,
-)
+from eth2.beacon.tools.misc.ssz_vector import override_lengths
 from eth2.beacon.types.blocks import BeaconBlock
 from eth2.beacon.types.states import BeaconState
-from eth2.beacon.tools.fixtures.config_name import (
-    ONLY_MINIMAL,
-)
-from eth2.beacon.tools.fixtures.helpers import (
-    run_state_execution,
-    validate_state,
-)
+from eth2.beacon.tools.fixtures.config_name import ONLY_MINIMAL
+from eth2.beacon.tools.fixtures.helpers import run_state_execution, validate_state
 from eth2.beacon.tools.fixtures.loading import (
     get_bls_setting,
     get_blocks,
     get_slots,
     get_states,
 )
-from eth2.beacon.tools.fixtures.test_case import (
-    StateTestCase,
-)
+from eth2.beacon.tools.fixtures.test_case import StateTestCase
 
 from tests.eth2.fixtures.helpers import (
     get_test_cases,
     get_chaindb_of_config,
     get_sm_class_of_config,
 )
-from tests.eth2.fixtures.path import (
-    BASE_FIXTURE_PATH,
-    ROOT_PROJECT_DIR,
-)
+from tests.eth2.fixtures.path import BASE_FIXTURE_PATH, ROOT_PROJECT_DIR
 
 
 # Test files
-RUNNER_FIXTURE_PATH = BASE_FIXTURE_PATH / 'sanity'
-HANDLER_FIXTURE_PATHES = (
-    RUNNER_FIXTURE_PATH,
-)
+RUNNER_FIXTURE_PATH = BASE_FIXTURE_PATH / "sanity"
+HANDLER_FIXTURE_PATHES = (RUNNER_FIXTURE_PATH,)
 FILTERED_CONFIG_NAMES = ONLY_MINIMAL
 
 
@@ -71,7 +53,7 @@ def parse_sanity_test_case(test_case, handler, index, config):
         handler=handler,
         index=index,
         bls_setting=bls_setting,
-        description=test_case['description'],
+        description=test_case["description"],
         pre=pre,
         post=post,
         is_valid=is_valid,
@@ -88,10 +70,7 @@ all_test_cases = get_test_cases(
 )
 
 
-@pytest.mark.parametrize(
-    "test_case, config",
-    all_test_cases
-)
+@pytest.mark.parametrize("test_case, config", all_test_cases)
 def test_sanity_fixture(base_db, config, test_case, empty_attestation_pool):
     sm_class = get_sm_class_of_config(config)
     chaindb = get_chaindb_of_config(base_db, config)
@@ -99,20 +78,12 @@ def test_sanity_fixture(base_db, config, test_case, empty_attestation_pool):
     post_state = test_case.pre
     if test_case.is_valid:
         post_state = run_state_execution(
-            test_case,
-            sm_class,
-            chaindb,
-            empty_attestation_pool,
-            post_state,
+            test_case, sm_class, chaindb, empty_attestation_pool, post_state
         )
 
         validate_state(test_case.post, post_state)
     else:
         with pytest.raises(ValidationError):
             run_state_execution(
-                test_case,
-                sm_class,
-                chaindb,
-                empty_attestation_pool,
-                post_state,
+                test_case, sm_class, chaindb, empty_attestation_pool, post_state
             )

--- a/tests/eth2/fixtures/state-fixtures/test_sanity.py
+++ b/tests/eth2/fixtures/state-fixtures/test_sanity.py
@@ -1,28 +1,26 @@
 from dataclasses import dataclass
-import pytest
 
 from eth_utils import ValidationError
+import pytest
 
-from eth2.beacon.tools.misc.ssz_vector import override_lengths
-from eth2.beacon.types.blocks import BeaconBlock
-from eth2.beacon.types.states import BeaconState
 from eth2.beacon.tools.fixtures.config_name import ONLY_MINIMAL
 from eth2.beacon.tools.fixtures.helpers import run_state_execution, validate_state
 from eth2.beacon.tools.fixtures.loading import (
-    get_bls_setting,
     get_blocks,
+    get_bls_setting,
     get_slots,
     get_states,
 )
 from eth2.beacon.tools.fixtures.test_case import StateTestCase
-
+from eth2.beacon.tools.misc.ssz_vector import override_lengths
+from eth2.beacon.types.blocks import BeaconBlock
+from eth2.beacon.types.states import BeaconState
 from tests.eth2.fixtures.helpers import (
-    get_test_cases,
     get_chaindb_of_config,
     get_sm_class_of_config,
+    get_test_cases,
 )
 from tests.eth2.fixtures.path import BASE_FIXTURE_PATH, ROOT_PROJECT_DIR
-
 
 # Test files
 RUNNER_FIXTURE_PATH = BASE_FIXTURE_PATH / "sanity"

--- a/tests/eth2/integration/test_demo.py
+++ b/tests/eth2/integration/test_demo.py
@@ -1,17 +1,17 @@
 import pytest
 
+from eth2._utils.bls import bls
 from eth2.beacon.db.chain import BeaconChainDB
 from eth2.beacon.fork_choice.higher_slot import higher_slot_scoring
 from eth2.beacon.helpers import compute_epoch_of_slot
 from eth2.beacon.operations.attestation_pool import AttestationPool
+from eth2.beacon.state_machines.forks.serenity import SerenityStateMachine
 from eth2.beacon.state_machines.forks.serenity.blocks import SerenityBeaconBlock
 from eth2.beacon.state_machines.forks.serenity.configs import SERENITY_CONFIG
-from eth2.beacon.state_machines.forks.serenity import SerenityStateMachine
 from eth2.beacon.tools.builder.initializer import create_mock_genesis
 from eth2.beacon.tools.builder.proposer import create_mock_block
 from eth2.beacon.tools.builder.validator import create_mock_signed_attestations_at_slot
 from eth2.beacon.tools.misc.ssz_vector import override_lengths
-from eth2._utils.bls import bls
 
 
 @pytest.fixture

--- a/tests/eth2/utils-tests/bitfield-utils/test_bitfields.py
+++ b/tests/eth2/utils-tests/bitfield-utils/test_bitfields.py
@@ -1,9 +1,6 @@
 import random
 
-from hypothesis import (
-    given,
-    strategies as st,
-)
+from hypothesis import given, strategies as st
 import pytest
 
 from eth2._utils.bitfield import (
@@ -16,15 +13,8 @@ from eth2._utils.bitfield import (
 
 
 @pytest.mark.parametrize(
-    'attester_count, bitfield_length',
-    [
-        (0, 0),
-        (1, 1),
-        (8, 1),
-        (9, 2),
-        (16, 2),
-        (17, 3),
-    ]
+    "attester_count, bitfield_length",
+    [(0, 0), (1, 1), (8, 1), (9, 2), (16, 2), (17, 3)],
 )
 def test_bitfield_length(attester_count, bitfield_length):
     assert get_bitfield_length(attester_count) == bitfield_length
@@ -42,24 +32,114 @@ def test_bitfield_single_votes():
     attesters = list(range(10))
     bitfield = get_empty_bitfield(len(attesters))
 
-    assert set_voted(bitfield, 0) == (True, False, False, False, False,
-                                      False, False, False, False, False)
-    assert set_voted(bitfield, 1) == (False, True, False, False, False,
-                                      False, False, False, False, False)
-    assert set_voted(bitfield, 2) == (False, False, True, False, False,
-                                      False, False, False, False, False)
-    assert set_voted(bitfield, 4) == (False, False, False, False, True,
-                                      False, False, False, False, False)
-    assert set_voted(bitfield, 5) == (False, False, False, False, False,
-                                      True, False, False, False, False)
-    assert set_voted(bitfield, 6) == (False, False, False, False, False,
-                                      False, True, False, False, False)
-    assert set_voted(bitfield, 7) == (False, False, False, False, False,
-                                      False, False, True, False, False)
-    assert set_voted(bitfield, 8) == (False, False, False, False, False,
-                                      False, False, False, True, False)
-    assert set_voted(bitfield, 9) == (False, False, False, False, False,
-                                      False, False, False, False, True)
+    assert set_voted(bitfield, 0) == (
+        True,
+        False,
+        False,
+        False,
+        False,
+        False,
+        False,
+        False,
+        False,
+        False,
+    )
+    assert set_voted(bitfield, 1) == (
+        False,
+        True,
+        False,
+        False,
+        False,
+        False,
+        False,
+        False,
+        False,
+        False,
+    )
+    assert set_voted(bitfield, 2) == (
+        False,
+        False,
+        True,
+        False,
+        False,
+        False,
+        False,
+        False,
+        False,
+        False,
+    )
+    assert set_voted(bitfield, 4) == (
+        False,
+        False,
+        False,
+        False,
+        True,
+        False,
+        False,
+        False,
+        False,
+        False,
+    )
+    assert set_voted(bitfield, 5) == (
+        False,
+        False,
+        False,
+        False,
+        False,
+        True,
+        False,
+        False,
+        False,
+        False,
+    )
+    assert set_voted(bitfield, 6) == (
+        False,
+        False,
+        False,
+        False,
+        False,
+        False,
+        True,
+        False,
+        False,
+        False,
+    )
+    assert set_voted(bitfield, 7) == (
+        False,
+        False,
+        False,
+        False,
+        False,
+        False,
+        False,
+        True,
+        False,
+        False,
+    )
+    assert set_voted(bitfield, 8) == (
+        False,
+        False,
+        False,
+        False,
+        False,
+        False,
+        False,
+        False,
+        True,
+        False,
+    )
+    assert set_voted(bitfield, 9) == (
+        False,
+        False,
+        False,
+        False,
+        False,
+        False,
+        False,
+        False,
+        False,
+        True,
+    )
 
     for voter in attesters:
         bitfield = set_voted((False,) * 16, voter)
@@ -84,12 +164,7 @@ def test_bitfield_all_votes():
 
 def test_bitfield_some_votes():
     attesters = list(range(10))
-    voters = [
-        0,  # b'\x01\x00'
-        4,  # b'\x10\x00'
-        5,  # b'\x20\x00'
-        9,  # b'\x00\x02'
-    ]
+    voters = [0, 4, 5, 9]  # b'\x01\x00'  # b'\x10\x00'  # b'\x20\x00'  # b'\x00\x02'
 
     bitfield = get_empty_bitfield(len(attesters))
     for voter in voters:

--- a/tests/eth2/utils-tests/bitfield-utils/test_bitfields.py
+++ b/tests/eth2/utils-tests/bitfield-utils/test_bitfields.py
@@ -1,14 +1,15 @@
 import random
 
-from hypothesis import given, strategies as st
+from hypothesis import given
+from hypothesis import strategies as st
 import pytest
 
 from eth2._utils.bitfield import (
-    has_voted,
-    set_voted,
     get_bitfield_length,
     get_empty_bitfield,
     get_vote_count,
+    has_voted,
+    set_voted,
 )
 
 

--- a/tests/eth2/utils-tests/bls-utils/test_backends.py
+++ b/tests/eth2/utils-tests/bls-utils/test_backends.py
@@ -1,12 +1,10 @@
+from eth_utils import ValidationError
+from py_ecc.optimized_bls12_381 import curve_order
 import pytest
 
-from py_ecc.optimized_bls12_381 import curve_order
-
-from eth2._utils.bls.backends import AVAILABLE_BACKENDS, NoOpBackend
 from eth2._utils.bls import bls
-
+from eth2._utils.bls.backends import AVAILABLE_BACKENDS, NoOpBackend
 from eth2.beacon.constants import EMPTY_PUBKEY, EMPTY_SIGNATURE
-from eth_utils import ValidationError
 
 
 def assert_pubkey(obj):

--- a/tests/eth2/utils-tests/bls-utils/test_backends.py
+++ b/tests/eth2/utils-tests/bls-utils/test_backends.py
@@ -1,24 +1,12 @@
 import pytest
 
-from py_ecc.optimized_bls12_381 import (
-    curve_order,
-)
+from py_ecc.optimized_bls12_381 import curve_order
 
-from eth2._utils.bls.backends import (
-    AVAILABLE_BACKENDS,
-    NoOpBackend,
-)
-from eth2._utils.bls import (
-    bls,
-)
+from eth2._utils.bls.backends import AVAILABLE_BACKENDS, NoOpBackend
+from eth2._utils.bls import bls
 
-from eth2.beacon.constants import (
-    EMPTY_PUBKEY,
-    EMPTY_SIGNATURE,
-)
-from eth_utils import (
-    ValidationError,
-)
+from eth2.beacon.constants import EMPTY_PUBKEY, EMPTY_SIGNATURE
+from eth_utils import ValidationError
 
 
 def assert_pubkey(obj):
@@ -31,12 +19,10 @@ def assert_signature(obj):
 
 @pytest.fixture
 def domain():
-    return (123).to_bytes(8, 'big')
+    return (123).to_bytes(8, "big")
 
 
-@pytest.mark.parametrize(
-    "backend", AVAILABLE_BACKENDS
-)
+@pytest.mark.parametrize("backend", AVAILABLE_BACKENDS)
 def test_sanity(backend, domain):
     bls.use(backend)
     msg_0 = b"\x32" * 32
@@ -81,11 +67,9 @@ def test_sanity(backend, domain):
     )
 
 
+@pytest.mark.parametrize("backend", AVAILABLE_BACKENDS)
 @pytest.mark.parametrize(
-    "backend", AVAILABLE_BACKENDS
-)
-@pytest.mark.parametrize(
-    'privkey',
+    "privkey",
     [
         (1),
         (5),
@@ -94,67 +78,51 @@ def test_sanity(backend, domain):
         (127409812145),
         (90768492698215092512159),
         (curve_order - 1),
-    ]
+    ],
 )
 def test_bls_core_succeed(backend, privkey, domain):
     bls.use(backend)
-    msg = str(privkey).encode('utf-8')
+    msg = str(privkey).encode("utf-8")
     sig = bls.sign(msg, privkey, domain=domain)
     pub = bls.privtopub(privkey)
     assert bls.verify(msg, pub, sig, domain=domain)
 
 
-@pytest.mark.parametrize(
-    "backend", AVAILABLE_BACKENDS
-)
-@pytest.mark.parametrize(
-    'privkey',
-    [
-        (0),
-        (curve_order),
-        (curve_order + 1),
-    ]
-)
+@pytest.mark.parametrize("backend", AVAILABLE_BACKENDS)
+@pytest.mark.parametrize("privkey", [(0), (curve_order), (curve_order + 1)])
 def test_invalid_private_key(backend, privkey, domain):
     bls.use(backend)
-    msg = str(privkey).encode('utf-8')
+    msg = str(privkey).encode("utf-8")
     with pytest.raises(ValueError):
         bls.privtopub(privkey)
     with pytest.raises(ValueError):
         bls.sign(msg, privkey, domain=domain)
 
 
-@pytest.mark.parametrize(
-    "backend", AVAILABLE_BACKENDS
-)
+@pytest.mark.parametrize("backend", AVAILABLE_BACKENDS)
 def test_empty_aggregation(backend):
     bls.use(backend)
     assert bls.aggregate_pubkeys([]) == EMPTY_PUBKEY
     assert bls.aggregate_signatures([]) == EMPTY_SIGNATURE
 
 
-@pytest.mark.parametrize(
-    "backend", AVAILABLE_BACKENDS
-)
+@pytest.mark.parametrize("backend", AVAILABLE_BACKENDS)
 def test_verify_empty_signatures(backend, domain):
     # Want EMPTY_SIGNATURE to fail in Trinity
     bls.use(backend)
 
     def validate():
-        bls.validate(b'\x11' * 32, EMPTY_PUBKEY, EMPTY_SIGNATURE, domain)
+        bls.validate(b"\x11" * 32, EMPTY_PUBKEY, EMPTY_SIGNATURE, domain)
 
     def validate_multiple_1():
         bls.validate_multiple(
-            pubkeys=(),
-            message_hashes=(),
-            signature=EMPTY_SIGNATURE,
-            domain=domain,
+            pubkeys=(), message_hashes=(), signature=EMPTY_SIGNATURE, domain=domain
         )
 
     def validate_multiple_2():
         bls.validate_multiple(
             pubkeys=(EMPTY_PUBKEY, EMPTY_PUBKEY),
-            message_hashes=(b'\x11' * 32, b'\x12' * 32),
+            message_hashes=(b"\x11" * 32, b"\x12" * 32),
             signature=EMPTY_SIGNATURE,
             domain=domain,
         )
@@ -172,15 +140,16 @@ def test_verify_empty_signatures(backend, domain):
             validate_multiple_2()
 
 
+@pytest.mark.parametrize("backend", AVAILABLE_BACKENDS)
 @pytest.mark.parametrize(
-    "backend", AVAILABLE_BACKENDS
-)
-@pytest.mark.parametrize(
-    'msg, privkeys',
+    "msg, privkeys",
     [
-        (b'\x12' * 32, [1, 5, 124, 735, 127409812145, 90768492698215092512159, curve_order - 1]),
-        (b'\x34' * 32, [42, 666, 1274099945, 4389392949595]),
-    ]
+        (
+            b"\x12" * 32,
+            [1, 5, 124, 735, 127409812145, 90768492698215092512159, curve_order - 1],
+        ),
+        (b"\x34" * 32, [42, 666, 1274099945, 4389392949595]),
+    ],
 )
 def test_signature_aggregation(backend, msg, privkeys, domain):
     bls.use(backend)
@@ -191,33 +160,30 @@ def test_signature_aggregation(backend, msg, privkeys, domain):
     assert bls.verify(msg, aggpub, aggsig, domain=domain)
 
 
+@pytest.mark.parametrize("backend", AVAILABLE_BACKENDS)
+@pytest.mark.parametrize("msg_1, msg_2", [(b"\x12" * 32, b"\x34" * 32)])
 @pytest.mark.parametrize(
-    "backend", AVAILABLE_BACKENDS
-)
-@pytest.mark.parametrize(
-    'msg_1, msg_2',
-    [
-        (b'\x12' * 32, b'\x34' * 32)
-    ]
-)
-@pytest.mark.parametrize(
-    'privkeys_1, privkeys_2',
+    "privkeys_1, privkeys_2",
     [
         (tuple(range(1, 11)), tuple(range(1, 11))),
         ((1, 2, 3), (4, 5, 6, 7)),
         ((1, 2, 3), (2, 3, 4, 5)),
         ((1, 2, 3), ()),
         ((), (2, 3, 4, 5)),
-    ]
+    ],
 )
 def test_multi_aggregation(backend, msg_1, msg_2, privkeys_1, privkeys_2, domain):
     bls.use(backend)
 
-    sigs_1 = [bls.sign(msg_1, k, domain=domain) for k in privkeys_1]  # signatures to msg_1
+    sigs_1 = [
+        bls.sign(msg_1, k, domain=domain) for k in privkeys_1
+    ]  # signatures to msg_1
     pubs_1 = [bls.privtopub(k) for k in privkeys_1]
     aggpub_1 = bls.aggregate_pubkeys(pubs_1)  # sig_1 to msg_1
 
-    sigs_2 = [bls.sign(msg_2, k, domain=domain) for k in privkeys_2]  # signatures to msg_2
+    sigs_2 = [
+        bls.sign(msg_2, k, domain=domain) for k in privkeys_2
+    ]  # signatures to msg_2
     pubs_2 = [bls.privtopub(k) for k in privkeys_2]
     aggpub_2 = bls.aggregate_pubkeys(pubs_2)  # sig_2 to msg_2
 
@@ -226,8 +192,5 @@ def test_multi_aggregation(backend, msg_1, msg_2, privkeys_1, privkeys_2, domain
     aggsig = bls.aggregate_signatures(sigs_1 + sigs_2)
 
     assert bls.verify_multiple(
-        pubkeys=pubs,
-        message_hashes=message_hashes,
-        signature=aggsig,
-        domain=domain,
+        pubkeys=pubs, message_hashes=message_hashes, signature=aggsig, domain=domain
     )

--- a/tests/eth2/utils-tests/hash-utils/test_hash.py
+++ b/tests/eth2/utils-tests/hash-utils/test_hash.py
@@ -4,9 +4,9 @@ from eth2._utils.hash import hash_eth2
 
 
 def test_hash():
-    output = hash_eth2(b'helloworld')
+    output = hash_eth2(b"helloworld")
     assert len(output) == 32
 
 
 def test_hash_is_keccak256():
-    assert hash_eth2(b'foo') == sha256(b'foo').digest()
+    assert hash_eth2(b"foo") == sha256(b"foo").digest()

--- a/tests/eth2/utils-tests/merkle-utils/test_merkle_trees.py
+++ b/tests/eth2/utils-tests/merkle-utils/test_merkle_trees.py
@@ -1,14 +1,13 @@
-import pytest
-
 from eth_utils import ValidationError
+import pytest
 
 from eth2._utils.hash import hash_eth2
 from eth2._utils.merkle.normal import (
-    get_merkle_root_from_items,
     calc_merkle_tree,
-    get_root,
     get_merkle_proof,
     get_merkle_root,
+    get_merkle_root_from_items,
+    get_root,
     verify_merkle_proof,
 )
 

--- a/tests/eth2/utils-tests/merkle-utils/test_sparse_merkle_trees.py
+++ b/tests/eth2/utils-tests/merkle-utils/test_sparse_merkle_trees.py
@@ -1,8 +1,6 @@
 import pytest
 
-from eth2._utils.hash import (
-    hash_eth2,
-)
+from eth2._utils.hash import hash_eth2
 from eth2._utils.merkle.sparse import (
     calc_merkle_tree,
     get_merkle_proof,
@@ -11,24 +9,27 @@ from eth2._utils.merkle.sparse import (
 )
 
 
-@pytest.mark.parametrize("items,expected_root", [
-    (
-        (b"1",),
-        b'p\xb1\xcf\x0ej\x9b{\xf3\x16\xb2\x0f~,l\x15\xdc\xd3\xcdJ?K\x05GD`~9\xfe\x1e\xae\xf82',
-    ),
-    (
-        (b"1", b"2",),
-        b'\x83H%\xac_\xbd\x03\xd7!\x95Z\x08\xa1\x0c\xe8/\x83\xfe\x8a\x9b\xe5fe\x94J\xd4\xf5\x1c&FE\xdd',  # noqa: E501
-    ),
-    (
-        (b"1", b"2", b"3",),
-        b'\xc2\x95\xf3\xf8:\xc1" \xf1\xe4\x87b_\xa4\xdb\xa9\x14e\xd3\xa9D\x85j\x17\xf5R\xc4\xdd\x88"\x8aJ',  # noqa: E501
-    ),
-    (
-        (b"1", b"2", b"3", b"4"),
-        b'\x81!\xeaI4\xfc4_\x15\x13b\xa7tT#i\x9fT5\x1fs\x83B\xbc\x9f\xeb\xa1\x9ekv\xc5g',
-    ),
-])
+@pytest.mark.parametrize(
+    "items,expected_root",
+    [
+        (
+            (b"1",),
+            b"p\xb1\xcf\x0ej\x9b{\xf3\x16\xb2\x0f~,l\x15\xdc\xd3\xcdJ?K\x05GD`~9\xfe\x1e\xae\xf82",
+        ),
+        (
+            (b"1", b"2"),
+            b"\x83H%\xac_\xbd\x03\xd7!\x95Z\x08\xa1\x0c\xe8/\x83\xfe\x8a\x9b\xe5fe\x94J\xd4\xf5\x1c&FE\xdd",  # noqa: E501
+        ),
+        (
+            (b"1", b"2", b"3"),
+            b'\xc2\x95\xf3\xf8:\xc1" \xf1\xe4\x87b_\xa4\xdb\xa9\x14e\xd3\xa9D\x85j\x17\xf5R\xc4\xdd\x88"\x8aJ',  # noqa: E501
+        ),
+        (
+            (b"1", b"2", b"3", b"4"),
+            b"\x81!\xeaI4\xfc4_\x15\x13b\xa7tT#i\x9fT5\x1fs\x83B\xbc\x9f\xeb\xa1\x9ekv\xc5g",
+        ),
+    ],
+)
 def test_merkle_root_and_proofs(items, expected_root):
     tree = calc_merkle_tree(items)
     assert get_root(tree) == expected_root
@@ -38,14 +39,17 @@ def test_merkle_root_and_proofs(items, expected_root):
         assert verify_merkle_proof(expected_root, hash_eth2(item), index, proof)
 
         assert not verify_merkle_proof(b"\x32" * 32, hash_eth2(item), index, proof)
-        assert not verify_merkle_proof(expected_root, hash_eth2(b"\x32" * 32), index, proof)
+        assert not verify_merkle_proof(
+            expected_root, hash_eth2(b"\x32" * 32), index, proof
+        )
         if len(items) > 1:
             assert not verify_merkle_proof(
-                expected_root,
-                hash_eth2(item),
-                (index + 1) % len(items),
-                proof
+                expected_root, hash_eth2(item), (index + 1) % len(items), proof
             )
         for replaced_index in range(len(proof)):
-            altered_proof = proof[:replaced_index] + (b"\x32" * 32,) + proof[replaced_index + 1:]
-            assert not verify_merkle_proof(expected_root, hash_eth2(item), index, altered_proof)
+            altered_proof = (
+                proof[:replaced_index] + (b"\x32" * 32,) + proof[replaced_index + 1 :]
+            )
+            assert not verify_merkle_proof(
+                expected_root, hash_eth2(item), index, altered_proof
+            )

--- a/tests/eth2/utils-tests/numeric-utils/test_bitwise_xor.py
+++ b/tests/eth2/utils-tests/numeric-utils/test_bitwise_xor.py
@@ -3,11 +3,6 @@ import pytest
 from eth2._utils.numeric import bitwise_xor
 
 
-@pytest.mark.parametrize(
-    'a,b,result',
-    [
-        (b'\x00' * 32, b'\x0a' * 32, b'\x0a' * 32),
-    ]
-)
+@pytest.mark.parametrize("a,b,result", [(b"\x00" * 32, b"\x0a" * 32, b"\x0a" * 32)])
 def test_bitwise_xor_success(a, b, result):
     assert bitwise_xor(a, b) == result

--- a/tests/eth2/utils-tests/numeric-utils/test_integer_squareroot.py
+++ b/tests/eth2/utils-tests/numeric-utils/test_integer_squareroot.py
@@ -1,12 +1,7 @@
 import pytest
-from hypothesis import (
-    given,
-    strategies as st,
-)
+from hypothesis import given, strategies as st
 
-from eth2._utils.numeric import (
-    integer_squareroot,
-)
+from eth2._utils.numeric import integer_squareroot
 
 
 @given(st.integers(min_value=0, max_value=100))
@@ -17,7 +12,7 @@ def test_integer_squareroot_correct(value):
 
 
 @pytest.mark.parametrize(
-    'value,expected',
+    "value,expected",
     (
         (0, 0),
         (1, 1),
@@ -28,20 +23,14 @@ def test_integer_squareroot_correct(value):
         (65535, 255),
         (65536, 256),
         (18446744073709551615, 4294967295),
-    )
+    ),
 )
 def test_integer_squareroot_success(value, expected):
     actual = integer_squareroot(value)
     assert actual == expected
 
 
-@pytest.mark.parametrize(
-    'value',
-    (
-        (1.5),
-        (-1),
-    )
-)
+@pytest.mark.parametrize("value", ((1.5), (-1)))
 def test_integer_squareroot_edge_cases(value):
     with pytest.raises(ValueError):
         integer_squareroot(value)

--- a/tests/eth2/utils-tests/numeric-utils/test_integer_squareroot.py
+++ b/tests/eth2/utils-tests/numeric-utils/test_integer_squareroot.py
@@ -1,5 +1,6 @@
+from hypothesis import given
+from hypothesis import strategies as st
 import pytest
-from hypothesis import given, strategies as st
 
 from eth2._utils.numeric import integer_squareroot
 

--- a/tests/eth2/utils-tests/tuple-utils/test_tuple.py
+++ b/tests/eth2/utils-tests/tuple-utils/test_tuple.py
@@ -1,57 +1,25 @@
 import pytest
 
-from eth_utils import (
-    ValidationError,
-)
+from eth_utils import ValidationError
 
-from eth2._utils.tuple import (
-    update_tuple_item,
-)
+from eth2._utils.tuple import update_tuple_item
 
 
 @pytest.mark.parametrize(
-    (
-        'tuple_data, index, new_value, expected'
-    ),
+    ("tuple_data, index, new_value, expected"),
     [
-        (
-            (1, ) * 10,
-            0,
-            -99,
-            (-99,) + (1, ) * 9,
-        ),
-        (
-            (1, ) * 10,
-            5,
-            -99,
-            (1, ) * 5 + (-99,) + (1, ) * 4,
-        ),
-        (
-            (1, ) * 10,
-            9,
-            -99,
-            (1, ) * 9 + (-99,),
-        ),
-        (
-            (1, ) * 10,
-            10,
-            -99,
-            ValidationError(),
-        )
-    ]
+        ((1,) * 10, 0, -99, (-99,) + (1,) * 9),
+        ((1,) * 10, 5, -99, (1,) * 5 + (-99,) + (1,) * 4),
+        ((1,) * 10, 9, -99, (1,) * 9 + (-99,)),
+        ((1,) * 10, 10, -99, ValidationError()),
+    ],
 )
 def test_update_tuple_item(tuple_data, index, new_value, expected):
     if isinstance(expected, Exception):
         with pytest.raises(ValidationError):
-            update_tuple_item(
-                tuple_data=tuple_data,
-                index=index,
-                new_value=new_value,
-            )
+            update_tuple_item(tuple_data=tuple_data, index=index, new_value=new_value)
     else:
         result = update_tuple_item(
-            tuple_data=tuple_data,
-            index=index,
-            new_value=new_value,
+            tuple_data=tuple_data, index=index, new_value=new_value
         )
         assert result == expected

--- a/tests/eth2/utils-tests/tuple-utils/test_tuple.py
+++ b/tests/eth2/utils-tests/tuple-utils/test_tuple.py
@@ -1,6 +1,5 @@
-import pytest
-
 from eth_utils import ValidationError
+import pytest
 
 from eth2._utils.tuple import update_tuple_item
 

--- a/tests/libp2p/bcc/conftest.py
+++ b/tests/libp2p/bcc/conftest.py
@@ -3,11 +3,8 @@ import asyncio
 import pytest
 
 from eth2.beacon.tools.factories import BeaconChainFactory
-
 from trinity.protocol.bcc_libp2p import utils
-
 from trinity.tools.bcc_factories import NodeFactory
-
 
 MOCK_TIME = 0.01
 

--- a/tests/libp2p/bcc/conftest.py
+++ b/tests/libp2p/bcc/conftest.py
@@ -2,15 +2,11 @@ import asyncio
 
 import pytest
 
-from eth2.beacon.tools.factories import (
-    BeaconChainFactory,
-)
+from eth2.beacon.tools.factories import BeaconChainFactory
 
 from trinity.protocol.bcc_libp2p import utils
 
-from trinity.tools.bcc_factories import (
-    NodeFactory,
-)
+from trinity.tools.bcc_factories import NodeFactory
 
 
 MOCK_TIME = 0.01
@@ -35,10 +31,7 @@ async def nodes(num_nodes):
 
 @pytest.fixture
 async def nodes_with_chain(num_nodes):
-    chains = tuple([
-        BeaconChainFactory()
-        for _ in range(num_nodes)
-    ])
+    chains = tuple([BeaconChainFactory() for _ in range(num_nodes)])
     async for _nodes in make_nodes(num_nodes, chains):
         yield _nodes
 
@@ -48,10 +41,7 @@ async def make_nodes(num_nodes, chains=None):
         _nodes = NodeFactory.create_batch(num_nodes)
     else:
         assert num_nodes == len(chains)
-        _nodes = tuple(
-            NodeFactory(chain=chain)
-            for chain in chains
-        )
+        _nodes = tuple(NodeFactory(chain=chain) for chain in chains)
     for n in _nodes:
         asyncio.ensure_future(n.run())
         await n.events.started.wait()

--- a/tests/libp2p/bcc/test_node.py
+++ b/tests/libp2p/bcc/test_node.py
@@ -6,17 +6,10 @@ from libp2p.peer.id import ID
 
 from p2p.tools.factories import get_open_port
 
-from trinity.tools.bcc_factories import (
-    NodeFactory,
-)
+from trinity.tools.bcc_factories import NodeFactory
 
 
-@pytest.mark.parametrize(
-    "num_nodes",
-    (
-        1,
-    )
-)
+@pytest.mark.parametrize("num_nodes", (1,))
 @pytest.mark.asyncio
 async def test_node(nodes):
     node = nodes[0]
@@ -24,54 +17,28 @@ async def test_node(nodes):
     assert node.host.get_addrs() == expected_addrs
 
 
-@pytest.mark.parametrize(
-    "num_nodes",
-    (
-        3,
-    )
-)
+@pytest.mark.parametrize("num_nodes", (3,))
 @pytest.mark.asyncio
 async def test_node_dial_peer(nodes):
     # Test: Exception raised when dialing a wrong addr
     with pytest.raises(ConnectionRefusedError):
-        await nodes[0].dial_peer(
-            nodes[1].listen_ip,
-            get_open_port(),
-            ID("123"),
-        )
+        await nodes[0].dial_peer(nodes[1].listen_ip, get_open_port(), ID("123"))
     # Test: 0 <-> 1
-    await nodes[0].dial_peer(
-        nodes[1].listen_ip,
-        nodes[1].listen_port,
-        nodes[1].peer_id,
-    )
+    await nodes[0].dial_peer(nodes[1].listen_ip, nodes[1].listen_port, nodes[1].peer_id)
     assert nodes[0].peer_id in nodes[1].host.get_network().connections
     assert nodes[1].peer_id in nodes[0].host.get_network().connections
     # Test: Second dial to a connected peer does not open a new connection
     original_conn = nodes[1].host.get_network().connections[nodes[0].peer_id]
-    await nodes[0].dial_peer(
-        nodes[1].listen_ip,
-        nodes[1].listen_port,
-        nodes[1].peer_id,
-    )
+    await nodes[0].dial_peer(nodes[1].listen_ip, nodes[1].listen_port, nodes[1].peer_id)
     assert nodes[1].host.get_network().connections[nodes[0].peer_id] is original_conn
     # Test: 0 <-> 1 <-> 2
-    await nodes[2].dial_peer(
-        nodes[1].listen_ip,
-        nodes[1].listen_port,
-        nodes[1].peer_id,
-    )
+    await nodes[2].dial_peer(nodes[1].listen_ip, nodes[1].listen_port, nodes[1].peer_id)
     assert nodes[1].peer_id in nodes[2].host.get_network().connections
     assert nodes[2].peer_id in nodes[1].host.get_network().connections
     assert len(nodes[1].host.get_network().connections) == 2
 
 
-@pytest.mark.parametrize(
-    "num_nodes",
-    (
-        3,
-    )
-)
+@pytest.mark.parametrize("num_nodes", (3,))
 @pytest.mark.asyncio
 async def test_node_dial_peer_maddr(nodes):
     # Test: 0 <-> 1 <-> 2
@@ -83,12 +50,7 @@ async def test_node_dial_peer_maddr(nodes):
     assert nodes[0].peer_id in nodes[1].host.get_network().connections
 
 
-@pytest.mark.parametrize(
-    "num_nodes",
-    (
-        2,
-    )
-)
+@pytest.mark.parametrize("num_nodes", (2,))
 @pytest.mark.asyncio
 async def test_node_connect_preferred_nodes(nodes):
     new_node = NodeFactory(

--- a/tests/libp2p/bcc/test_node.py
+++ b/tests/libp2p/bcc/test_node.py
@@ -1,11 +1,9 @@
 import asyncio
 
+from libp2p.peer.id import ID
 import pytest
 
-from libp2p.peer.id import ID
-
 from p2p.tools.factories import get_open_port
-
 from trinity.tools.bcc_factories import NodeFactory
 
 

--- a/tests/libp2p/bcc/test_req_resp.py
+++ b/tests/libp2p/bcc/test_req_resp.py
@@ -2,28 +2,14 @@ import asyncio
 
 import pytest
 
-from trinity.protocol.bcc_libp2p.node import (
-    REQ_RESP_HELLO_SSZ,
-)
-from trinity.protocol.bcc_libp2p.configs import (
-    ResponseCode,
-)
-from trinity.protocol.bcc_libp2p.exceptions import (
-    HandshakeFailure,
-)
-from trinity.protocol.bcc_libp2p.messages import (
-    HelloRequest,
-)
-from trinity.protocol.bcc_libp2p.utils import (
-    read_req,
-    write_resp,
-)
+from trinity.protocol.bcc_libp2p.node import REQ_RESP_HELLO_SSZ
+from trinity.protocol.bcc_libp2p.configs import ResponseCode
+from trinity.protocol.bcc_libp2p.exceptions import HandshakeFailure
+from trinity.protocol.bcc_libp2p.messages import HelloRequest
+from trinity.protocol.bcc_libp2p.utils import read_req, write_resp
 
 
-@pytest.mark.parametrize(
-    "num_nodes",
-    (2,),
-)
+@pytest.mark.parametrize("num_nodes", (2,))
 @pytest.mark.asyncio
 async def test_hello_success(nodes_with_chain):
     nodes = nodes_with_chain
@@ -34,19 +20,19 @@ async def test_hello_success(nodes_with_chain):
     assert nodes[0].peer_id in nodes[1].handshaked_peers
 
 
-@pytest.mark.parametrize(
-    "num_nodes",
-    (2,),
-)
+@pytest.mark.parametrize("num_nodes", (2,))
 @pytest.mark.asyncio
-async def test_hello_failure_invalid_hello_packet(nodes_with_chain, monkeypatch, mock_timeout):
+async def test_hello_failure_invalid_hello_packet(
+    nodes_with_chain, monkeypatch, mock_timeout
+):
     nodes = nodes_with_chain
     await nodes[0].dial_peer_maddr(nodes[1].listen_maddr_with_peer_id)
 
     def _make_inconsistent_hello_packet():
         return HelloRequest(
-            fork_version=b"\x12\x34\x56\x78",  # version different from another node.
+            fork_version=b"\x12\x34\x56\x78"  # version different from another node.
         )
+
     monkeypatch.setattr(nodes[0], "_make_hello_packet", _make_inconsistent_hello_packet)
     monkeypatch.setattr(nodes[1], "_make_hello_packet", _make_inconsistent_hello_packet)
     # Test: Handshake fails when either side sends invalid hello packets.
@@ -56,10 +42,7 @@ async def test_hello_failure_invalid_hello_packet(nodes_with_chain, monkeypatch,
     assert nodes[0].peer_id not in nodes[1].handshaked_peers
 
 
-@pytest.mark.parametrize(
-    "num_nodes",
-    (2,),
-)
+@pytest.mark.parametrize("num_nodes", (2,))
 @pytest.mark.asyncio
 async def test_hello_failure_failure_response(nodes_with_chain):
     nodes = nodes_with_chain
@@ -69,6 +52,7 @@ async def test_hello_failure_failure_response(nodes_with_chain):
         await read_req(stream, HelloRequest)
         # The overridden `resp_code` can be anything other than `ResponseCode.SUCCESS`
         await write_resp(stream, "error msg", ResponseCode.INVALID_REQUEST)
+
     # Mock the handler.
     nodes[1].host.set_stream_handler(REQ_RESP_HELLO_SSZ, fake_handle_hello)
     # Test: Handshake fails when the response is not success.

--- a/tests/libp2p/bcc/test_req_resp.py
+++ b/tests/libp2p/bcc/test_req_resp.py
@@ -2,10 +2,10 @@ import asyncio
 
 import pytest
 
-from trinity.protocol.bcc_libp2p.node import REQ_RESP_HELLO_SSZ
 from trinity.protocol.bcc_libp2p.configs import ResponseCode
 from trinity.protocol.bcc_libp2p.exceptions import HandshakeFailure
 from trinity.protocol.bcc_libp2p.messages import HelloRequest
+from trinity.protocol.bcc_libp2p.node import REQ_RESP_HELLO_SSZ
 from trinity.protocol.bcc_libp2p.utils import read_req, write_resp
 
 

--- a/tests/libp2p/bcc/test_utils.py
+++ b/tests/libp2p/bcc/test_utils.py
@@ -1,22 +1,16 @@
 import asyncio
-from typing import (
-    NamedTuple,
-)
+from typing import NamedTuple
 
 import pytest
 
 from eth_keys import datatypes
 
-from trinity.protocol.bcc_libp2p.configs import (
-    ResponseCode,
-)
+from trinity.protocol.bcc_libp2p.configs import ResponseCode
 from trinity.protocol.bcc_libp2p.exceptions import (
     ReadMessageFailure,
     WriteMessageFailure,
 )
-from trinity.protocol.bcc_libp2p.messages import (
-    HelloRequest,
-)
+from trinity.protocol.bcc_libp2p.messages import HelloRequest
 from trinity.protocol.bcc_libp2p.utils import (
     peer_id_from_pubkey,
     read_req,
@@ -25,9 +19,7 @@ from trinity.protocol.bcc_libp2p.utils import (
     write_resp,
 )
 
-from libp2p.peer.id import (
-    ID,
-)
+from libp2p.peer.id import ID
 
 
 # Wrong type of `fork_version`, which should be `bytes4`.
@@ -36,7 +28,7 @@ invalid_ssz_msg = HelloRequest(fork_version="1")
 
 def test_peer_id_from_pubkey():
     pubkey = datatypes.PublicKey(
-        b'n\x85UD\xe9^\xbfo\x05\xd1z\xbd\xe5k\x87Y\xe9\xfa\xb3z:\xf8z\xc5\xd7K\xa6\x00\xbbc\xda4M\x10\x1cO\x88\tl\x82\x7f\xd7\xec6\xd8\xdc\xe2\x9c\xdcG\xa5\xea|\x9e\xc57\xf8G\xbe}\xfa\x10\xe9\x12'  # noqa: E501
+        b"n\x85UD\xe9^\xbfo\x05\xd1z\xbd\xe5k\x87Y\xe9\xfa\xb3z:\xf8z\xc5\xd7K\xa6\x00\xbbc\xda4M\x10\x1cO\x88\tl\x82\x7f\xd7\xec6\xd8\xdc\xe2\x9c\xdcG\xa5\xea|\x9e\xc57\xf8G\xbe}\xfa\x10\xe9\x12"  # noqa: E501
     )
     peer_id_expected = ID.from_base58("QmQiv6sR3qHqhUVgC5qUBVWi8YzM6HknYbu4oQKVAqPCGF")
     assert peer_id_from_pubkey(pubkey) == peer_id_expected
@@ -57,7 +49,7 @@ class FakeNetStream:
         buf = bytearray()
         # Exit with empty bytes directly if `n == 0`.
         if n == 0:
-            return b''
+            return b""
         # Force to blocking wait for first byte.
         buf.extend(await self._queue.get())
         while not self._queue.empty():
@@ -72,12 +64,7 @@ class FakeNetStream:
         return len(data)
 
 
-@pytest.mark.parametrize(
-    "msg",
-    (
-        HelloRequest(),
-    )
-)
+@pytest.mark.parametrize("msg", (HelloRequest(),))
 @pytest.mark.asyncio
 async def test_read_write_req_msg(msg):
     s = FakeNetStream()
@@ -86,12 +73,7 @@ async def test_read_write_req_msg(msg):
     assert msg_read == msg
 
 
-@pytest.mark.parametrize(
-    "msg",
-    (
-        HelloRequest(),
-    )
-)
+@pytest.mark.parametrize("msg", (HelloRequest(),))
 @pytest.mark.asyncio
 async def test_read_write_resp_msg(msg):
     s = FakeNetStream()
@@ -150,7 +132,8 @@ async def test_read_resp_failure(monkeypatch, mock_timeout):
 
     async def _fake_read(n):
         return b""
-    monkeypatch.setattr(s, 'read', _fake_read)
+
+    monkeypatch.setattr(s, "read", _fake_read)
     with pytest.raises(ReadMessageFailure):
         await read_resp(s, HelloRequest)
 

--- a/tests/libp2p/bcc/test_utils.py
+++ b/tests/libp2p/bcc/test_utils.py
@@ -1,9 +1,9 @@
 import asyncio
 from typing import NamedTuple
 
-import pytest
-
 from eth_keys import datatypes
+from libp2p.peer.id import ID
+import pytest
 
 from trinity.protocol.bcc_libp2p.configs import ResponseCode
 from trinity.protocol.bcc_libp2p.exceptions import (
@@ -18,9 +18,6 @@ from trinity.protocol.bcc_libp2p.utils import (
     write_req,
     write_resp,
 )
-
-from libp2p.peer.id import ID
-
 
 # Wrong type of `fork_version`, which should be `bytes4`.
 invalid_ssz_msg = HelloRequest(fork_version="1")

--- a/tox.ini
+++ b/tox.ini
@@ -7,6 +7,7 @@ envlist=
     py37-rpc-state-{quadratic,sstore,zero_knowledge}
     py37-libp2p
     py{36,37}-lint
+    py{36,37}-lint-eth2
     py{36,37}-wheel-cli
     py36-docs
 
@@ -14,6 +15,15 @@ envlist=
 max-line-length= 100
 exclude=
 ignore=
+
+[isort]
+force_sort_within_sections=True
+known_third_party=hypothesis,pytest,async_generator,cytoolz,trio_typing,pytest_trio,factory
+multi_line_output=3
+include_trailing_comma=True
+force_grid_wrap=0
+use_parentheses=True
+line_length=88
 
 [testenv]
 usedevelop=True
@@ -132,16 +142,23 @@ commands =
     pytest -n 1 {posargs:tests/libp2p}
 
 [common-lint]
-deps = .[p2p,trinity,lint,eth2]
+deps = .[p2p,trinity,lint]
 commands=
-    flake8 {toxinidir}/p2p
-    flake8 {toxinidir}/tests
-    flake8 {toxinidir}/tests-trio
-    flake8 {toxinidir}/trinity
-    flake8 {toxinidir}/scripts
-    flake8 {toxinidir}/eth2
-    flake8 {toxinidir}/setup.py
-    mypy -p p2p -p trinity -p eth2 --config-file {toxinidir}/mypy.ini
+    flake8 --config {toxinidir}/tox.ini {toxinidir}/p2p
+    flake8 --config {toxinidir}/tox.ini {toxinidir}/tests/__init__.py
+    flake8 --config {toxinidir}/tox.ini {toxinidir}/tests/conftest.py
+    flake8 --config {toxinidir}/tox.ini {toxinidir}/tests/core
+    flake8 --config {toxinidir}/tox.ini {toxinidir}/tests/integration
+    flake8 --config {toxinidir}/tox.ini {toxinidir}/tests/json-fixtures-over-rpc
+    flake8 --config {toxinidir}/tox.ini {toxinidir}/tests/p2p
+    flake8 --config {toxinidir}/tox.ini {toxinidir}/tests/p2p-trio
+    flake8 --config {toxinidir}/tox.ini {toxinidir}/tests/plugins
+    flake8 --config {toxinidir}/tox.ini {toxinidir}/tests/trinity_long_run
+    flake8 --config {toxinidir}/tox.ini {toxinidir}/tests-trio
+    flake8 --config {toxinidir}/tox.ini {toxinidir}/trinity
+    flake8 --config {toxinidir}/tox.ini {toxinidir}/scripts
+    flake8 --config {toxinidir}/tox.ini {toxinidir}/setup.py
+    mypy -p p2p -p trinity --config-file {toxinidir}/mypy.ini
 
 
 [testenv:py36-lint]
@@ -152,3 +169,25 @@ commands= {[common-lint]commands}
 [testenv:py37-lint]
 deps = {[common-lint]deps}
 commands= {[common-lint]commands}
+
+
+[testenv:py36-lint-eth2]
+deps = .[lint,eth2-lint,eth2]
+commands=
+    flake8 --config {toxinidir}/.flake8-eth2 {toxinidir}/eth2
+    flake8 --config {toxinidir}/.flake8-eth2 {toxinidir}/tests/eth2
+    flake8 --config {toxinidir}/.flake8-eth2 {toxinidir}/tests/libp2p
+    mypy -p eth2 --config-file {toxinidir}/mypy.ini
+    black --check eth2 tests/eth2 tests/libp2p
+    isort --recursive --check-only eth2 tests/eth2 tests/libp2p
+
+
+[testenv:py37-lint-eth2]
+deps = .[lint,eth2-lint,eth2]
+commands=
+    flake8 --config {toxinidir}/.flake8-eth2 {toxinidir}/eth2
+    flake8 --config {toxinidir}/.flake8-eth2 {toxinidir}/tests/eth2
+    flake8 --config {toxinidir}/.flake8-eth2 {toxinidir}/tests/libp2p
+    mypy -p eth2 --config-file {toxinidir}/mypy.ini
+    black --check eth2 tests/eth2 tests/libp2p
+    isort --recursive --check-only eth2 tests/eth2 tests/libp2p


### PR DESCRIPTION
### What was wrong?

Replaces #866.

### How was it fixed?

Adds code formatting and imports wrangler to our linting stack for eth2-specific code.

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://proxy.duckduckgo.com/iu/?u=http%3A%2F%2Facimg.auctivacommerce.com%2Fimgdata%2F0%2F3%2F3%2F5%2F1%2F0%2Fwebimg%2F6391757.jpg&f=1)
