### PR TITLE
All eth JSON-RPCs fetch data from the beam syncer, if missing

### DIFF
--- a/newsfragments/975.feature.rst
+++ b/newsfragments/975.feature.rst
@@ -1,0 +1,2 @@
+Fetch missing data from remote peers, if requested over json-rpc during beam sync.
+Requests for data at an old block will fail; remote peers probably don't have it.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -316,7 +316,9 @@ async def ipc_server(
     the course of all tests. It yields the IPC server only for monkeypatching purposes
     """
     rpc = RPCServer(
-        initialize_eth1_modules(chain_with_block_validation, event_bus), event_bus,
+        initialize_eth1_modules(chain_with_block_validation, event_bus),
+        chain_with_block_validation,
+        event_bus,
     )
     ipc_server = IPCServer(rpc, jsonrpc_ipc_pipe_path, loop=event_loop)
 

--- a/tests/core/json-rpc/test_rpc_during_beam_sync.py
+++ b/tests/core/json-rpc/test_rpc_during_beam_sync.py
@@ -1,4 +1,5 @@
 import asyncio
+import contextlib
 import json
 import os
 import pytest
@@ -10,6 +11,8 @@ from eth_utils.toolz import (
 )
 from eth_utils import (
     decode_hex,
+    function_signature_to_4byte_selector,
+    to_hex,
 )
 
 from eth.db.account import AccountDB
@@ -151,61 +154,76 @@ def ipc_request(jsonrpc_ipc_pipe_path, event_loop, event_bus, ipc_server):
     return make_request
 
 
+@pytest.fixture
+def fake_beam_syncer(chain, event_bus):
+    @contextlib.asynccontextmanager
+    async def fake_beam_sync(removed_hash, removed_node):
+        # beam sync starts, it fetches requested nodes from remote peers
+
+        async def collect_accounts(event: CollectMissingAccount):
+            chain.chaindb.db[removed_hash] = removed_node
+            await event_bus.broadcast(
+                MissingAccountCollected(1), event.broadcast_config()
+            )
+        accounts_sub = event_bus.subscribe(CollectMissingAccount, collect_accounts)
+
+        async def collect_bytecodes(event: CollectMissingBytecode):
+            chain.chaindb.db[removed_hash] = removed_node
+            await event_bus.broadcast(
+                MissingBytecodeCollected(), event.broadcast_config()
+            )
+        bytecode_sub = event_bus.subscribe(CollectMissingBytecode, collect_bytecodes)
+
+        async def collect_storage(event: CollectMissingStorage):
+            chain.chaindb.db[removed_hash] = removed_node
+            await event_bus.broadcast(
+                MissingStorageCollected(1), event.broadcast_config()
+            )
+        storage_sub = event_bus.subscribe(CollectMissingStorage, collect_storage)
+
+        await event_bus.wait_until_any_endpoint_subscribed_to(CollectMissingAccount)
+        await event_bus.wait_until_any_endpoint_subscribed_to(CollectMissingBytecode)
+        await event_bus.wait_until_any_endpoint_subscribed_to(CollectMissingStorage)
+
+        try:
+            yield
+        finally:
+            accounts_sub.unsubscribe()
+            bytecode_sub.unsubscribe()
+            storage_sub.unsubscribe()
+
+    return fake_beam_sync
+
+
 # Test that eth_getBalance works during beam sync
 
 
 @pytest.mark.asyncio
-async def test_get_balance_works(
-        ipc_request, funded_address, funded_address_initial_balance):
+async def test_getBalance_during_beam_sync(
+        chain, ipc_request, funded_address, funded_address_initial_balance,
+        fake_beam_syncer):
     """
     Sanity check, if we call eth_getBalance we get back the expected response.
     """
+
+    # sanity check, by default it works
     response = await ipc_request('eth_getBalance', [funded_address.hex(), 'latest'])
     assert 'error' not in response
     assert response['result'] == hex(funded_address_initial_balance)
 
+    state_root_hash = chain.get_canonical_head().state_root
+    state_root = chain.chaindb.db.pop(state_root_hash)
 
-@pytest.fixture
-def missing_node(chain):
-    state_root = chain.get_canonical_head().state_root
-    return chain.chaindb.db.pop(state_root)
-
-
-@pytest.mark.asyncio
-async def test_fails_when_state_is_missing(ipc_request, funded_address, missing_node):
-    """
-    If the state root is missing then eth_getBalance throws an error.
-    """
+    # now that the hash is missing we should receive an error
     response = await ipc_request('eth_getBalance', [funded_address.hex(), 'latest'])
     assert 'error' in response
     assert response['error'].startswith('State trie database is missing node for hash')
 
-
-@pytest.mark.asyncio
-async def test_missing_state_is_fetched_if_fetcher_exists(
-        ipc_request, funded_address, funded_address_initial_balance,
-        missing_node, chain, event_bus):
-
-    # beam sync is not running, so we receive an error
-    response = await ipc_request('eth_getBalance', [funded_address.hex(), 'latest'])
-    assert 'error' in response
-    assert response['error'].startswith('State trie database is missing node for hash')
-
-    # beam sync starts, it fetches requested nodes from remote peers
-    async def find_and_insert_node(event: CollectMissingAccount):
-        state_root = chain.get_canonical_head().state_root
-        chain.chaindb.db[state_root] = missing_node
-        await event_bus.broadcast(MissingAccountCollected(1), event.broadcast_config())
-    event_bus.subscribe(CollectMissingAccount, find_and_insert_node)
-    await event_bus.wait_until_any_endpoint_subscribed_to(CollectMissingAccount)
-
-    # beam sync fetches the missing node so no error is returned
-    response = await ipc_request('eth_getBalance', [funded_address.hex(), 'latest'])
-    assert 'error' not in response
-    assert response['result'] == hex(funded_address_initial_balance)
-
-
-# Test that eth_getCode works during beam sync
+    # with a beam syncer running it should work again! It sends requests to the syncer
+    async with fake_beam_syncer(state_root_hash, state_root):
+        response = await ipc_request('eth_getBalance', [funded_address.hex(), 'latest'])
+        assert 'error' not in response
+        assert response['result'] == hex(funded_address_initial_balance)
 
 
 @pytest.fixture
@@ -214,65 +232,30 @@ async def contract_code_hash(genesis_state, simple_contract_address):
 
 
 @pytest.mark.asyncio
-async def test_getCode(ipc_request, simple_contract_address, contract_code_hash):
-    """
-    Sanity check, if we call eth_getBalance we get back the expected response.
-    """
+async def test_getCode_during_beam_sync(
+        chain, ipc_request, simple_contract_address, contract_code_hash,
+        fake_beam_syncer):
+
+    # sanity check, by default it works
     response = await ipc_request('eth_getCode', [simple_contract_address.hex(), 'latest'])
     assert 'error' not in response
     assert keccak(decode_hex(response['result'])) == contract_code_hash
 
+    missing_bytecode = chain.chaindb.db.pop(contract_code_hash)
 
-@pytest.fixture
-def missing_bytecode(chain, contract_code_hash):
-    return chain.chaindb.db.pop(contract_code_hash)
-
-
-@pytest.mark.asyncio
-async def test_getCode_fails_when_state_is_missing(
-        ipc_request, simple_contract_address, missing_bytecode):
-    """
-    If the state root is missing then eth_getBalance throws an error.
-    """
+    # now that the hash is missing we should receive an error
     response = await ipc_request('eth_getCode', [simple_contract_address.hex(), 'latest'])
     assert 'error' in response
     assert response['error'].startswith('Database is missing bytecode for code hash')
 
-
-@pytest.mark.asyncio
-async def test_missing_code_is_fetched_if_fetcher_exists(
-        ipc_request, simple_contract_address, contract_code_hash, missing_bytecode, chain,
-        event_bus):
-
-    # beam sync is not running, so we receive an error
-    response = await ipc_request('eth_getCode', [simple_contract_address.hex(), 'latest'])
-    assert 'error' in response
-    assert response['error'].startswith('Database is missing bytecode for code hash')
-
-    # beam sync starts, it fetches requested nodes from remote peers
-    async def find_and_insert_node(event: CollectMissingBytecode):
-        chain.chaindb.db[contract_code_hash] = missing_bytecode
-        await event_bus.broadcast(MissingBytecodeCollected(), event.broadcast_config())
-    event_bus.subscribe(CollectMissingBytecode, find_and_insert_node)
-    await event_bus.wait_until_any_endpoint_subscribed_to(CollectMissingBytecode)
-
-    # beam sync fetches the missing node so no error is returned
-    response = await ipc_request('eth_getCode', [simple_contract_address.hex(), 'latest'])
-    assert 'error' not in response
-    assert keccak(decode_hex(response['result'])) == contract_code_hash
+    # with a beam syncer running it should work again! It sends requests to the syncer
+    async with fake_beam_syncer(contract_code_hash, missing_bytecode):
+        response = await ipc_request('eth_getCode', [simple_contract_address.hex(), 'latest'])
+        assert 'error' not in response
+        assert keccak(decode_hex(response['result'])) == contract_code_hash
 
 
 # Test that eth_getStorageAt works during Beam Sync
-
-
-@pytest.mark.asyncio
-async def test_getStorageAt(ipc_request, simple_contract_address):
-    """
-    Sanity check, if we call eth_getBalance we get back the expected response.
-    """
-    response = await ipc_request('eth_getStorageAt', [simple_contract_address.hex(), 1, 'latest'])
-    assert 'error' not in response
-    assert response['result'] == '0x01'  # this was set in the genesis_state fixture
 
 
 @pytest.fixture
@@ -282,39 +265,81 @@ def storage_root(chain, simple_contract_address):
     return account_db._get_storage_root(simple_contract_address)
 
 
-@pytest.fixture
-def missing_storage_root(chain, storage_root):
-    return chain.chaindb.db.pop(storage_root)
-
-
 @pytest.mark.asyncio
-async def test_missing_root_get_storage(ipc_request, simple_contract_address, missing_storage_root):
-    """
-    Sanity check, if we call eth_getBalance we get back the expected response.
-    """
-    response = await ipc_request('eth_getStorageAt', [simple_contract_address.hex(), 1, 'latest'])
-    assert 'error' in response
-    assert response['error'].startswith('Storage trie database is missing hash')
+async def test_getStorageAt_during_beam_sync(
+        ipc_request, simple_contract_address, storage_root, chain, fake_beam_syncer):
 
-
-@pytest.mark.asyncio
-async def test_missing_storage_is_fetched_if_fetcher_exists(
-        ipc_request, simple_contract_address, storage_root, missing_storage_root, chain,
-        event_bus):
-
-    # beam sync is not running, so we receive an error
-    response = await ipc_request('eth_getStorageAt', [simple_contract_address.hex(), 1, 'latest'])
-    assert 'error' in response
-    assert response['error'].startswith('Storage trie database is missing hash')
-
-    # beam sync starts, it fetches requested nodes from remote peers
-    async def find_and_insert_node(event: CollectMissingStorage):
-        chain.chaindb.db[storage_root] = missing_storage_root
-        await event_bus.broadcast(MissingStorageCollected(1), event.broadcast_config())
-    event_bus.subscribe(CollectMissingStorage, find_and_insert_node)
-    await event_bus.wait_until_any_endpoint_subscribed_to(CollectMissingStorage)
-
-    # beam sync fetches the missing node so no error is returned
+    # sanity check, by default it works
     response = await ipc_request('eth_getStorageAt', [simple_contract_address.hex(), 1, 'latest'])
     assert 'error' not in response
     assert response['result'] == '0x01'  # this was set in the genesis_state fixture
+
+    missing_node = chain.chaindb.db.pop(storage_root)
+
+    # now that the hash is missing we should receive an error
+    response = await ipc_request('eth_getStorageAt', [simple_contract_address.hex(), 1, 'latest'])
+    assert 'error' in response
+    assert response['error'].startswith('Storage trie database is missing hash')
+
+    # with a beam syncer running it should work again! It sends requests to the syncer
+    async with fake_beam_syncer(storage_root, missing_node):
+        response = await ipc_request('eth_getStorageAt', [simple_contract_address.hex(), 1, 'latest'])
+        assert 'error' not in response
+        assert response['result'] == '0x01'  # this was set in the genesis_state fixture
+
+
+@pytest.fixture
+def transaction(simple_contract_address):
+    function_selector = function_signature_to_4byte_selector('getMeaningOfLife()')
+    return {
+        'from': '0x' + 'ff' * 20,  # unfunded address
+        'to': to_hex(simple_contract_address),
+        'gasPrice': to_hex(0),
+        'data': to_hex(function_selector),
+    }
+
+
+@pytest.mark.asyncio
+async def test_eth_call(
+        ipc_request, contract_code_hash, chain, transaction, fake_beam_syncer):
+
+    # sanity check, by default it works
+    response = await ipc_request('eth_call', [transaction, 'latest'])
+    assert 'error' not in response
+    assert response['result'].endswith('002a')
+
+    bytecode = chain.chaindb.db.pop(contract_code_hash)
+
+    # now that the hash is missing we should receive an error
+    response = await ipc_request('eth_call', [transaction, 'latest'])
+    assert 'error' in response
+    assert response['error'].startswith('Database is missing bytecode for code hash')
+
+    # with a beam syncer running it should work again! It sends requests to the syncer
+    async with fake_beam_syncer(contract_code_hash, bytecode):
+        response = await ipc_request('eth_call', [transaction, 'latest'])
+        assert 'error' not in response
+        assert response['result'].endswith('002a')
+
+
+@pytest.mark.asyncio
+async def test_eth_estimateGas(
+        ipc_request, contract_code_hash, chain, transaction, fake_beam_syncer):
+
+    # sanity check, by default it works
+    response = await ipc_request('eth_estimateGas', [transaction, 'latest'])
+    assert 'error' not in response
+    assert response['result'] == '0x82a8'
+
+    bytecode = chain.chaindb.db.pop(contract_code_hash)
+
+    # now that the hash is missing we should receive an error
+    response = await ipc_request('eth_estimateGas', [transaction, 'latest'])
+    assert 'error' in response
+    assert response['error'].startswith('Database is missing bytecode for code hash')
+
+    # with a beam syncer running it should work again! It sends requests to the syncer
+    async with fake_beam_syncer(contract_code_hash, bytecode):
+        response = await ipc_request('eth_estimateGas', [transaction, 'latest'])
+        assert 'error' not in response
+        assert response['result'] == '0x82a8'

--- a/tests/json-fixtures-over-rpc/test_rpc_fixtures.py
+++ b/tests/json-fixtures-over-rpc/test_rpc_fixtures.py
@@ -434,9 +434,8 @@ class MainnetFullChain(FullChain):
 
 @pytest.mark.asyncio
 async def test_rpc_against_fixtures(event_bus, chain_fixture, fixture_data):
-    rpc = RPCServer(
-        initialize_eth1_modules(MainnetFullChain(None), event_bus), event_bus,
-    )
+    chain = MainnetFullChain(None)
+    rpc = RPCServer(initialize_eth1_modules(chain, event_bus), chain, event_bus)
 
     setup_result, setup_error = await call_rpc(rpc, 'evm_resetToGenesisFixture', [chain_fixture])
     # We need to advance the event loop for modules to be able to pickup the new chain

--- a/trinity/rpc/main.py
+++ b/trinity/rpc/main.py
@@ -14,6 +14,7 @@ from eth_utils import (
     ValidationError,
 )
 
+from trinity.chains.base import AsyncChainAPI
 from trinity.rpc.modules import (
     BaseRPCModule,
 )
@@ -64,9 +65,11 @@ class RPCServer:
 
     def __init__(self,
                  modules: Sequence[BaseRPCModule],
+                 chain: AsyncChainAPI=None,
                  event_bus: EndpointAPI=None) -> None:
         self.event_bus = event_bus
         self.modules: Dict[str, BaseRPCModule] = {}
+        self.chain = chain
 
         for module in modules:
             name = module.name.lower()
@@ -113,7 +116,7 @@ class RPCServer:
             method = self._lookup_method(request['method'])
             params = request.get('params', [])
             result = await execute_with_retries(
-                self.event_bus, method, params
+                self.event_bus, method, params, self.chain,
             )
 
             if request['method'] == 'evm_resetToGenesisFixture':

--- a/trinity/rpc/modules/_util.py
+++ b/trinity/rpc/modules/_util.py
@@ -1,0 +1,36 @@
+from typing import (
+    Union,
+)
+
+from eth_typing import (
+    BlockNumber,
+)
+from eth_utils import (
+    is_integer,
+)
+
+from eth.rlp.headers import (
+    BlockHeader,
+)
+
+from trinity.chains.base import AsyncChainAPI
+
+
+async def get_header(chain: AsyncChainAPI, at_block: Union[str, int]) -> BlockHeader:
+    if at_block == 'pending':
+        raise NotImplementedError("RPC interface does not support the 'pending' block at this time")
+    elif at_block == 'latest':
+        at_header = chain.get_canonical_head()
+    elif at_block == 'earliest':
+        # TODO find if genesis block can be non-zero. Why does 'earliest' option even exist?
+        block = await chain.coro_get_canonical_block_by_number(BlockNumber(0))
+        at_header = block.header
+    # mypy doesn't have user defined type guards yet
+    # https://github.com/python/mypy/issues/5206
+    elif is_integer(at_block) and at_block >= 0:  # type: ignore
+        block = await chain.coro_get_canonical_block_by_number(BlockNumber(int(at_block)))
+        at_header = block.header
+    else:
+        raise TypeError("Unrecognized block reference: %r" % at_block)
+
+    return at_header

--- a/trinity/rpc/modules/eth.py
+++ b/trinity/rpc/modules/eth.py
@@ -41,10 +41,10 @@ from eth.vm.spoof import (
     SpoofTransaction,
 )
 
+from trinity.chains.base import AsyncChainAPI
 from trinity.constants import (
     TO_NETWORKING_BROADCAST_CONFIG,
 )
-from trinity.chains.base import AsyncChainAPI
 from trinity.rpc.format import (
     block_to_dict,
     header_to_dict,
@@ -65,25 +65,7 @@ from trinity._utils.validation import (
     validate_transaction_gas_estimation_dict,
 )
 
-
-async def get_header(chain: AsyncChainAPI, at_block: Union[str, int]) -> BlockHeader:
-    if at_block == 'pending':
-        raise NotImplementedError("RPC interface does not support the 'pending' block at this time")
-    elif at_block == 'latest':
-        at_header = chain.get_canonical_head()
-    elif at_block == 'earliest':
-        # TODO find if genesis block can be non-zero. Why does 'earliest' option even exist?
-        block = await chain.coro_get_canonical_block_by_number(BlockNumber(0))
-        at_header = block.header
-    # mypy doesn't have user defined type guards yet
-    # https://github.com/python/mypy/issues/5206
-    elif is_integer(at_block) and at_block >= 0:  # type: ignore
-        block = await chain.coro_get_canonical_block_by_number(BlockNumber(int(at_block)))
-        at_header = block.header
-    else:
-        raise TypeError("Unrecognized block reference: %r" % at_block)
-
-    return at_header
+from ._util import get_header
 
 
 async def state_at_block(
@@ -151,7 +133,7 @@ class Eth(Eth1ChainRPCModule):
         num = self.chain.get_canonical_head().block_number
         return hex(num)
 
-    @retryable
+    @retryable(which_block_arg_name='at_block')
     @format_params(identity, to_int_if_hex)
     async def call(self, txn_dict: Dict[str, Any], at_block: Union[str, int]) -> str:
         header = await get_header(self.chain, at_block)
@@ -165,7 +147,7 @@ class Eth(Eth1ChainRPCModule):
         coinbase_address = ZERO_ADDRESS
         return encode_hex(coinbase_address)
 
-    @retryable
+    @retryable(which_block_arg_name='at_block')
     @format_params(identity, to_int_if_hex)
     async def estimateGas(self, txn_dict: Dict[str, Any], at_block: Union[str, int]) -> str:
         header = await get_header(self.chain, at_block)
@@ -177,7 +159,7 @@ class Eth(Eth1ChainRPCModule):
     async def gasPrice(self) -> str:
         return hex(int(os.environ.get('TRINITY_GAS_PRICE', to_wei(1, 'gwei'))))
 
-    @retryable
+    @retryable(which_block_arg_name='at_block')
     @format_params(decode_hex, to_int_if_hex)
     async def getBalance(self, address: Address, at_block: Union[str, int]) -> str:
         state = await state_at_block(self.chain, at_block)
@@ -209,14 +191,14 @@ class Eth(Eth1ChainRPCModule):
         block = await get_block_at_number(self.chain, at_block)
         return hex(len(block.transactions))
 
-    @retryable
+    @retryable(which_block_arg_name='at_block')
     @format_params(decode_hex, to_int_if_hex)
     async def getCode(self, address: Address, at_block: Union[str, int]) -> str:
         state = await state_at_block(self.chain, at_block)
         code = state.get_code(address)
         return encode_hex(code)
 
-    @retryable
+    @retryable(which_block_arg_name='at_block')
     @format_params(decode_hex, to_int_if_hex, to_int_if_hex)
     async def getStorageAt(self, address: Address, position: int, at_block: Union[str, int]) -> str:
         if not is_integer(position) or position < 0:

--- a/trinity/rpc/modules/eth.py
+++ b/trinity/rpc/modules/eth.py
@@ -151,6 +151,7 @@ class Eth(Eth1ChainRPCModule):
         num = self.chain.get_canonical_head().block_number
         return hex(num)
 
+    @retryable
     @format_params(identity, to_int_if_hex)
     async def call(self, txn_dict: Dict[str, Any], at_block: Union[str, int]) -> str:
         header = await get_header(self.chain, at_block)
@@ -164,6 +165,7 @@ class Eth(Eth1ChainRPCModule):
         coinbase_address = ZERO_ADDRESS
         return encode_hex(coinbase_address)
 
+    @retryable
     @format_params(identity, to_int_if_hex)
     async def estimateGas(self, txn_dict: Dict[str, Any], at_block: Union[str, int]) -> str:
         header = await get_header(self.chain, at_block)

--- a/trinity/rpc/retry.py
+++ b/trinity/rpc/retry.py
@@ -2,10 +2,12 @@
 Tools for retrying failed RPC methods. If we're beam syncing we can fault in missing data
 from remote peers.
 """
+import inspect
 import itertools
 from typing import (
     Any,
     Callable,
+    Optional,
     TypeVar,
 )
 
@@ -17,11 +19,14 @@ from eth.vm.interrupt import (
     MissingStorageTrieNode,
 )
 
+from trinity.chains.base import AsyncChainAPI
 from trinity.sync.common.events import (
     CollectMissingAccount,
     CollectMissingBytecode,
     CollectMissingStorage,
 )
+
+from trinity.rpc.modules._util import get_header
 
 
 Func = Callable[..., Any]
@@ -29,19 +34,58 @@ Meth = TypeVar('Meth', bound=Func)
 
 
 RETRYABLE_ATTRIBUTE_NAME = '_is_rpc_retryable'
+AT_BLOCK_ATTRIBUTE_NAME = '_at_block_parameter'
 MAX_RETRIES = 1000
 
 
-def retryable(func: Meth) -> Meth:
-    setattr(func, RETRYABLE_ATTRIBUTE_NAME, True)
-    return func
+def retryable(which_block_arg_name: str) -> Func:
+    """
+    A decorator which marks eth_* RPCs which:
+    - are idempotent
+    - throw errors which the beam syncer can help to recover from
+
+    :param which_block_arg_name: names one of the arguments of the wrapped function.
+    Specifically, the arg used to pass in the block identifier ("at_block", usually)
+    """
+    def make_meth_retryable(meth: Meth) -> Meth:
+        sig = inspect.signature(meth)
+        if which_block_arg_name not in sig.parameters:
+            raise Exception(
+                f'"{which_block_arg_name}" does not name an argument to this function'
+            )
+
+        setattr(meth, RETRYABLE_ATTRIBUTE_NAME, True)
+        setattr(meth, AT_BLOCK_ATTRIBUTE_NAME, which_block_arg_name)
+        return meth
+    return make_meth_retryable
 
 
 def is_retryable(func: Func) -> bool:
     return getattr(func, RETRYABLE_ATTRIBUTE_NAME, False)
 
 
-async def execute_with_retries(event_bus: EndpointAPI, func: Func, params: Any) -> None:
+async def check_requested_block_age(chain: Optional[AsyncChainAPI],
+                                    func: Func, params: Any) -> None:
+    sig = inspect.signature(func)
+    params = sig.bind(*params)
+
+    try:
+        at_block_name = getattr(func, AT_BLOCK_ATTRIBUTE_NAME)
+    except AttributeError as e:
+        raise Exception("Function {func} was not decorated with @retryable") from e
+
+    at_block = params.arguments[at_block_name]
+
+    requested_header = await get_header(chain, at_block)
+    requested_block = requested_header.block_number
+    current_block = chain.get_canonical_head().block_number
+
+    if requested_block < current_block - 64:
+        raise Exception(f'block "{at_block}" is too old to be fetched over the network')
+
+
+async def execute_with_retries(event_bus: EndpointAPI, func: Func, params: Any,
+                               chain: Optional[AsyncChainAPI]) -> None:
     """
     If a beam sync (or anything which responds to CollectMissingAccount) is running then
     attempt to fetch missing data from it before giving up.
@@ -63,6 +107,8 @@ async def execute_with_retries(event_bus: EndpointAPI, func: Func, params: Any) 
             if not event_bus.is_any_endpoint_subscribed_to(CollectMissingAccount):
                 raise
 
+            await check_requested_block_age(chain, func, params)
+
             await event_bus.request(CollectMissingAccount(
                 exc.missing_node_hash,
                 exc.address_hash,
@@ -81,6 +127,8 @@ async def execute_with_retries(event_bus: EndpointAPI, func: Func, params: Any) 
             if not event_bus.is_any_endpoint_subscribed_to(CollectMissingBytecode):
                 raise
 
+            await check_requested_block_age(chain, func, params)
+
             await event_bus.request(CollectMissingBytecode(
                 bytecode_hash=exc.missing_code_hash,
                 urgent=True,
@@ -96,6 +144,8 @@ async def execute_with_retries(event_bus: EndpointAPI, func: Func, params: Any) 
 
             if not event_bus.is_any_endpoint_subscribed_to(CollectMissingStorage):
                 raise
+
+            await check_requested_block_age(chain, func, params)
 
             await event_bus.request(CollectMissingStorage(
                 missing_node_hash=exc.missing_node_hash,


### PR DESCRIPTION
Followup to #957, and solves #893. This is really two changes in one, I'm happy to break them out into two PRs if you'd prefer!

- All the `eth_*` RPC calls which interact with the things that beam sync syncs now have a `@retryable` decorator, and have tests that they work.
- If the user asks for a block which is more than 64 blocks behind the tip we throw an error explaining the problem.

### To-Do

- [ ] Make python 3.6 happy

[//]: # (Stay ahead of things, add list items here!)
- [ ] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

[//]: # (See: https://trinity-client.readthedocs.io/en/latest/contributing.html#pull-requests)
- [ ] Add entry to the [release notes](https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses]()
