### PR TITLE
Bump ssz==0.1.4

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -110,7 +110,7 @@ deps = {
         "py-ecc==1.7.1",
         "rlp>=1.1.0,<2.0.0",
         PYEVM_DEPENDENCY,
-        "ssz==0.1.3",
+        "ssz==0.1.4",
         "milagro-bls-binding==0.1.3",
         "blspy>=0.1.8,<1",  # for `bls_chia`
     ],


### PR DESCRIPTION
### What was wrong?

Some py-ssz optimizations.

### How was it fixed?

Bump `ssz==0.1.4`

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

[//]: # (See: https://trinity-client.readthedocs.io/en/latest/contributing.html#pull-requests)
- [ ] Add entry to the [release notes](https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![tmg-article_tall](https://user-images.githubusercontent.com/9263930/63776005-1c6d5680-c913-11e9-84b2-a91f3d9e70d0.jpg)
