### PR TITLE
Allow block creation via db-shell REPL

### DIFF
--- a/newsfragments/977.feature.rst
+++ b/newsfragments/977.feature.rst
@@ -1,0 +1,1 @@
+Expose the ``MiningChain`` on the `db-shell` REPL to allow creating blocks on a REPL


### PR DESCRIPTION
### What was wrong?

Trinity does not have a mode of operation where it mines blocks. However, every know and then it is useful to manually mine blocks. Mostly for testing but also for learning purposes, fiddling with private test nets etc.

So, far the only way to mine blocks was to put together a custom script. It would be great to be able to manually create blocks on a REPL.

### How was it fixed?

1. Expose a `MiningChain` in the `db-shell` REPL
2. Profit.

```
$ trinity --genesis ./trinity/assets/eip1085/private_net.json --data-dir /home/cburgdorf/.local/share/trinity/deadbeef --network-id 666 db-shell
    INFO  08-27 17:23:29               trinity  
      ______     _       _ __       
     /_  __/____(_)___  (_) /___  __
      / / / ___/ / __ \/ / __/ / / /
     / / / /  / / / / / / /_/ /_/ / 
    /_/ /_/  /_/_/ /_/_/\__/\__, /  
                           /____/   
    INFO  08-27 17:23:29               trinity  Started main process (pid=3023)
    INFO  08-27 17:23:29               trinity  Trinity/0.1.0a27/linux/cpython3.7.3
    INFO  08-27 17:23:29               trinity  Trinity DEBUG log file is created at /home/cburgdorf/.local/share/trinity/deadbeef/logs-eth1/trinity.log
> /home/cburgdorf/Documents/hacking/ef/trinity/trinity/plugins/builtin/attach/console.py(148)get_eth1_shell_context()
-> from eth.chains.base import MiningChain
(Pdb) continue
Trinity DB Shell
---------------
An instance of `ChainDB` connected to the database is available as the `chaindb` variable

    Head: #0
    Hash: 0x065fd78e53dcef113bf9d7732dac7c5132dcf85c9588a454d832722ceb097422
    State Root: 0x96afaf18b5d2a2c2b0f2e670ba7d3d8d60d56d42398185e94adcdc95362811d3
    Inspecting active Trinity? False

    Available Context Variables:
      - `db`: base database object
      - `chaindb`: `ChainDB` instance
      - `trinity_config`: `TrinityConfig` instance
      - `chain_config`: `ChainConfig` instance
      - `chain`: `Chain` instance
      - `mining_chain: `MiningChain` instance. (use a REPL to create blocks)

    
In [1]: block = mining_chain.get_vm().finalize_block(mining_chain.get_block())

In [2]: from eth.consensus.pow import mine_pow_nonce

In [3]: nonce, mix_hash = mine_pow_nonce(block.number, block.header.mining_hash, block.header.difficulty)

In [4]: nonce
Out[4]: b'\x00\x00\x00\x00\x00\x00\x00\x00'

In [5]: mix_hash
Out[5]: b'r\xcd)\xee\xd5\xd1<MQ\xb5\xe9xN\xeeu\xf5\xb4Z\x95~\x94h\x9f\xe5\xa87z`V\xf1\xe6\x7f'

In [6]: block = mining_chain.mine_block(mix_hash=mix_hash, nonce=nonce)

In [7]: block
Out[7]: <PetersburgBlock(#Block #1)>

In [10]: chain.get_canonical_head()
Out[10]: <eth.rlp.headers.BlockHeader at 0x7f51e6bc8a20>

In [12]: chain.get_canonical_head().hash
Out[12]: b"\xc4m\x01\x90/8\xe1\xb6\x08\x07i\xf7\xbe\xb5\xa3\xeb\x81\xa8P\xf4\x85$l\xba9\x14+\x89\x17'\x0fI"

In [13]: chain.get_canonical_head().parent_hash
Out[13]: b'\x06_\xd7\x8eS\xdc\xef\x11;\xf9\xd7s-\xac|Q2\xdc\xf8\\\x95\x88\xa4T\xd82r,\xeb\tt"'

In [14]: from eth_utils import encode_hex

In [15]: encode_hex(chain.get_canonical_head().parent_hash)
Out[15]: '0x065fd78e53dcef113bf9d7732dac7c5132dcf85c9588a454d832722ceb097422'

```

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

[//]: # (See: https://trinity-client.readthedocs.io/en/latest/contributing.html#pull-requests)
- [x] Add entry to the [release notes](https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://sbly-web-prod-shareably.netdna-ssl.com/wp-content/uploads/2017/08/03232532/cute_baby_animals_featured.jpg)
