### PR TITLE
Use `MilagroBackend` for fixtures tests

### DIFF
--- a/eth2/beacon/tools/fixtures/test_case.py
+++ b/eth2/beacon/tools/fixtures/test_case.py
@@ -2,7 +2,7 @@ from enum import Enum
 from typing import Any, Dict
 
 from eth2._utils.bls import bls
-from eth2._utils.bls.backends import PyECCBackend
+from eth2._utils.bls.backends import MilagroBackend
 from eth2.configs import Eth2Config
 
 from .test_handler import Input, Output, TestHandler
@@ -18,7 +18,7 @@ def _select_bls_backend(bls_setting: BLSSetting) -> None:
     if bls_setting == BLSSetting.Disabled:
         bls.use_noop_backend()
     elif bls_setting == BLSSetting.Enabled:
-        bls.use(PyECCBackend)
+        bls.use(MilagroBackend)
     elif bls_setting == BLSSetting.Optional:
         # do not verify BLS to save time
         bls.use_noop_backend()


### PR DESCRIPTION
### What was wrong?

Enable Milagro for fixtures tests.


### How was it fixed?


### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

[//]: # (See: https://trinity-client.readthedocs.io/en/latest/contributing.html#pull-requests)
- [ ] Add entry to the [release notes](https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![guinea-pig-1055537_640](https://user-images.githubusercontent.com/9263930/63835164-728cd900-c9a9-11e9-8dd8-32d1a1c883e0.jpg)
