### PR TITLE
update to latest lahja

### DIFF
--- a/newsfragments/917.misc.rst
+++ b/newsfragments/917.misc.rst
@@ -1,0 +1,1 @@
+Update to ``lahja>=0.14.2`` to fix warnings during endpoint shutdown.

--- a/setup.py
+++ b/setup.py
@@ -33,9 +33,7 @@ deps = {
         "plyvel==1.0.5",
         PYEVM_DEPENDENCY,
         "web3==4.4.1",
-        "lahja==0.14.0",
-        # Exact version pin until connection timeout issue is resolved
-        # "lahja>=0.14.0,<0.15.0",
+        "lahja>=0.14.2,<0.15.0",
         "termcolor>=1.1.0,<2.0.0",
         "uvloop==0.11.2;platform_system=='Linux' or platform_system=='Darwin' or platform_system=='FreeBSD'",  # noqa: E501
         "websockets==5.0.1",


### PR DESCRIPTION
### What was wrong?

This replaces #917 (Update to latest `lahja` to fix some warnings). I can't push into @pipermerriam repo so this is just the same change wrapped in a different PR.

### How was it fixed?

Update to latest `lahja`.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

[//]: # (See: https://trinity-client.readthedocs.io/en/latest/contributing.html#pull-requests)
- [x] Add entry to the [release notes](https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](http://www.awesomelycute.com/gallery/2014/02/cutest-wild-animals-2931.jpg)
