### PR TITLE
Expand CLI web3 test to ropsten and devnet

### DIFF
--- a/newsfragments/983.misc.rst
+++ b/newsfragments/983.misc.rst
@@ -1,0 +1,1 @@
+Expand test coverage to ensure Ropsten and custom nets do actually work.

--- a/trinity/assets/eip1085/devnet.json
+++ b/trinity/assets/eip1085/devnet.json
@@ -1,0 +1,24 @@
+{
+  "accounts":{
+     "0x00000000000000000000000000000000deadbeef":{
+        "balance":"0x0ad78ebc5ac6200000"
+     },
+     "0x00000000000000000000000000000000deadcafe":{
+        "balance":"0x0ad78ebc5ac6200000"
+     }
+  },
+  "genesis":{
+     "author":"0x0000000000000000000000000000000000000000",
+     "difficulty":"0x1",
+     "extraData":"0xdeadbeef",
+     "gasLimit":"0x900000",
+     "nonce":"0x00000000deadbeef",
+     "timestamp":"0x0"
+  },
+  "params":{
+     "petersburgForkBlock":"0x0",
+     "chainId":"0xdeadbeef",
+     "miningMethod":"ethash"
+  },
+  "version":"1"
+}

--- a/trinity/cli_parser.py
+++ b/trinity/cli_parser.py
@@ -281,7 +281,7 @@ class EIP1085GenesisLoader(argparse.Action):
 chain_parser.add_argument(
     '--genesis',
     help=(
-        "File containing a custom genesis block header"
+        "File containing a custom genesis configuration file per EIP1085"
     ),
     action=EIP1085GenesisLoader,
 )


### PR DESCRIPTION
### What was wrong?

We can look at this from two angels:

1. Our `test_web3` integration test did only cover mainnet so far leaving us uncovered for other nets.
2. We do not have coverage yet that ensures Trinity does indeed work with private nets

### How was it fixed?

I considered other options but I went with expanding our existing web3 test mainly because:

1. It feels right that this test would not only cover `mainnet` but also `ropsten` and custom nets
2. Since this is an end to end test it protects us from lots of subtle breakage that may be left untested using other options.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

[//]: # (See: https://trinity-client.readthedocs.io/en/latest/contributing.html#pull-requests)
- [x] Add entry to the [release notes](https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://media3.giphy.com/media/33zX3zllJBGY8/giphy.gif?cid=790b761165d87fb7478f35324791c3bbbae88e6da360e8f8&rid=giphy.gif)
