### PR TITLE
BaseService ABC

### DIFF
--- a/newsfragments/985.misc.rst
+++ b/newsfragments/985.misc.rst
@@ -1,0 +1,1 @@
+Add ``ABC`` base class for ``p2p.service.BaseService``

--- a/p2p/peer_pool.py
+++ b/p2p/peer_pool.py
@@ -34,7 +34,7 @@ from lahja import (
     EndpointAPI,
 )
 
-from p2p.abc import NodeAPI
+from p2p.abc import AsyncioServiceAPI, NodeAPI
 from p2p.constants import (
     DEFAULT_MAX_PEERS,
     DEFAULT_PEER_BOOT_TIMEOUT,
@@ -439,7 +439,7 @@ class BasePeerPool(BaseService, AsyncIterable[BasePeer]):
         else:
             await self.start_peer(peer)
 
-    def _peer_finished(self, peer: BaseService) -> None:
+    def _peer_finished(self, peer: AsyncioServiceAPI) -> None:
         """
         Remove the given peer from our list of connected nodes.
         This is passed as a callback to be called when a peer finishes.


### PR DESCRIPTION
### What was wrong?

The `BaseService` APIs were not part of the `ConnectionAPI` ABC base class and thus, using them causes `mypy` to complain.

### How was it fixed?

Added an `ABC` base class for a subset of the `BaseService` API.


### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

[//]: # (See: https://trinity-client.readthedocs.io/en/latest/contributing.html#pull-requests)
- [x] Add entry to the [release notes](https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![bunny-1](https://user-images.githubusercontent.com/824194/63874986-cb477c00-c97f-11e9-8bd4-3daece76b6d8.jpeg)

