### PR TITLE
Connection.get_p2p_receipt

### DIFF
--- a/newsfragments/986.feature.rst
+++ b/newsfragments/986.feature.rst
@@ -1,0 +1,1 @@
+Add ``ConnectionAPI.get_p2p_receipt`` for fetching the ``HandshakeReceipt`` for the base ``p2p`` protocol.

--- a/p2p/connection.py
+++ b/p2p/connection.py
@@ -19,10 +19,7 @@ from p2p.exceptions import (
     UnknownProtocol,
     UnknownProtocolCommand,
 )
-from p2p.handshake import (
-    DevP2PReceipt,
-    HandshakeReceipt,
-)
+from p2p.handshake import DevP2PReceipt, HandshakeReceipt
 from p2p.service import BaseService
 from p2p.p2p_proto import BaseP2PProtocol
 from p2p.typing import Capabilities


### PR DESCRIPTION
### What was wrong?

There was no API for retrieving the handshake receipt for the base `p2p` protocol.

### How was it fixed?

Added `ConnectionAPI.get_p2p_receipt()`

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

[//]: # (See: https://trinity-client.readthedocs.io/en/latest/contributing.html#pull-requests)
- [x] Add entry to the [release notes](https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![pet-18](https://user-images.githubusercontent.com/824194/63875261-5163c280-c980-11e9-86fb-fefd285137fe.jpg)

