### PR TITLE
Protocol.supports_command now classmethod

### DIFF
--- a/newsfragments/987.feature.rst
+++ b/newsfragments/987.feature.rst
@@ -1,0 +1,1 @@
+``p2p.protocol.Protocol.supports_command`` is now a ``classmethod``

--- a/p2p/abc.py
+++ b/p2p/abc.py
@@ -243,8 +243,9 @@ class ProtocolAPI(ABC):
     def send_request(self, request: RequestAPI[Payload]) -> None:
         ...
 
+    @classmethod
     @abstractmethod
-    def supports_command(self, cmd_type: Type[CommandAPI]) -> bool:
+    def supports_command(cls, cmd_type: Type[CommandAPI]) -> bool:
         ...
 
     @classmethod

--- a/p2p/protocol.py
+++ b/p2p/protocol.py
@@ -172,8 +172,9 @@ class Protocol(ProtocolAPI):
         header, body = command.encode(request.command_payload)
         self.transport.send(header, body)
 
-    def supports_command(self, cmd_type: Type[CommandAPI]) -> bool:
-        return cmd_type in self.cmd_by_type
+    @classmethod
+    def supports_command(cls, cmd_type: Type[CommandAPI]) -> bool:
+        return cmd_type in cls._commands
 
     @classmethod
     def as_capability(cls) -> Capability:


### PR DESCRIPTION
### What was wrong?

I need to use the `Protocol.supports_command` API from the protocol classes.

### How was it fixed?

Converted `Protocol.supports_command` to be a `classmethod`

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

[//]: # (See: https://trinity-client.readthedocs.io/en/latest/contributing.html#pull-requests)
- [x] Add entry to the [release notes](https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![maxresdefault](https://user-images.githubusercontent.com/824194/63876558-fe3f3f00-c982-11e9-858c-e810ca0c3e08.jpg)

