### PR TITLE
Add ``HandshakeReceiptAPI`` ABC base class

### DIFF
--- a/newsfragments/988.misc.rst
+++ b/newsfragments/988.misc.rst
@@ -1,0 +1,1 @@
+Add ``ABC`` base class ``p2p.abc.HandshakeReceiptAPI``

--- a/p2p/connection.py
+++ b/p2p/connection.py
@@ -1,13 +1,21 @@
 import asyncio
 import collections
 import functools
-from typing import Any, Callable, DefaultDict, Sequence, Set, Type
+from typing import (
+    Any,
+    Callable,
+    DefaultDict,
+    Sequence,
+    Set,
+    Type,
+)
 
 from eth_keys import keys
 
 from p2p.abc import (
     CommandAPI,
     HandlerSubscriptionAPI,
+    HandshakeReceiptAPI,
     MultiplexerAPI,
     NodeAPI,
     ProtocolAPI,
@@ -20,7 +28,7 @@ from p2p.exceptions import (
     UnknownProtocol,
     UnknownProtocolCommand,
 )
-from p2p.handshake import DevP2PReceipt, HandshakeReceipt
+from p2p.handshake import DevP2PReceipt
 from p2p.service import BaseService
 from p2p.p2p_proto import BaseP2PProtocol
 from p2p.typing import Capabilities
@@ -47,7 +55,7 @@ class Connection(ConnectionAPI, BaseService):
     def __init__(self,
                  multiplexer: MultiplexerAPI,
                  devp2p_receipt: DevP2PReceipt,
-                 protocol_receipts: Sequence[HandshakeReceipt],
+                 protocol_receipts: Sequence[HandshakeReceiptAPI],
                  is_dial_out: bool) -> None:
         super().__init__(token=multiplexer.cancel_token, loop=multiplexer.cancel_token.loop)
         self._multiplexer = multiplexer
@@ -87,9 +95,6 @@ class Connection(ConnectionAPI, BaseService):
                 await self.cancellation()
         except (PeerConnectionLost, asyncio.CancelledError):
             pass
-
-    async def _cleanup(self) -> None:
-        self._multiplexer.close()
 
     async def _cleanup(self) -> None:
         self._multiplexer.close()


### PR DESCRIPTION
### What was wrong?

Needed an `ABC` API for talking about the `HandshakeReceipt`

### How was it fixed?

Added an `ABC` base class for `HandshakeReceiptAPI`

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

[//]: # (See: https://trinity-client.readthedocs.io/en/latest/contributing.html#pull-requests)
- [x] Add entry to the [release notes](https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![93064796](https://user-images.githubusercontent.com/824194/63877180-4874f000-c984-11e9-8f67-9a113c8bb4d7.jpg)

