### PR TITLE
Add context manager API to HandlerSubscriptionAPI

### DIFF
--- a/newsfragments/989.feature.rst
+++ b/newsfragments/989.feature.rst
@@ -1,0 +1,1 @@
+The ``HandlerSubscriptionAPI`` now supports a context manager interface, removing/cancelling the subscription when the context exits

--- a/p2p/abc.py
+++ b/p2p/abc.py
@@ -7,6 +7,7 @@ from typing import (
     Awaitable,
     Callable,
     ClassVar,
+    ContextManager,
     Dict,
     Generic,
     List,
@@ -393,7 +394,7 @@ class HandshakeReceiptAPI(ABC):
     protocol: ProtocolAPI
 
 
-class HandlerSubscriptionAPI:
+class HandlerSubscriptionAPI(ContextManager['HandlerSubscriptionAPI']):
     @abstractmethod
     def cancel(self) -> None:
         ...

--- a/p2p/connection.py
+++ b/p2p/connection.py
@@ -1,14 +1,7 @@
 import asyncio
 import collections
 import functools
-from typing import (
-    Any,
-    Callable,
-    DefaultDict,
-    Sequence,
-    Set,
-    Type,
-)
+from typing import DefaultDict, Sequence, Set, Type
 
 from eth_keys import keys
 
@@ -29,17 +22,10 @@ from p2p.exceptions import (
     UnknownProtocolCommand,
 )
 from p2p.handshake import DevP2PReceipt
+from p2p.handler_subscription import HandlerSubscription
 from p2p.service import BaseService
 from p2p.p2p_proto import BaseP2PProtocol
 from p2p.typing import Capabilities
-
-
-class HandlerSubscription(HandlerSubscriptionAPI):
-    def __init__(self, remove_fn: Callable[[], Any]) -> None:
-        self._remove_fn = remove_fn
-
-    def cancel(self) -> None:
-        self._remove_fn()
 
 
 class Connection(ConnectionAPI, BaseService):

--- a/p2p/handler_subscription.py
+++ b/p2p/handler_subscription.py
@@ -1,0 +1,25 @@
+from typing import (
+    Any,
+    Callable,
+    Type,
+)
+from types import TracebackType
+
+from p2p.abc import HandlerSubscriptionAPI
+
+
+class HandlerSubscription(HandlerSubscriptionAPI):
+    def __init__(self, remove_fn: Callable[[], Any]) -> None:
+        self._remove_fn = remove_fn
+
+    def cancel(self) -> None:
+        self._remove_fn()
+
+    def __enter__(self) -> HandlerSubscriptionAPI:
+        return self
+
+    def __exit__(self,
+                 exc_type: Type[BaseException],
+                 exc_value: BaseException,
+                 exc_tb: TracebackType) -> None:
+        self._remove_fn()


### PR DESCRIPTION
### What was wrong?

The `HandlerSubscription` API works nicely as a context manager to give reliable control over ensuring temporary subscriptions get removed.

### How was it fixed?

Added a context manager API to the `HandlerSubscriptionAPI` which cancels the subscription on exit.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

[//]: # (See: https://trinity-client.readthedocs.io/en/latest/contributing.html#pull-requests)
- [x] Add entry to the [release notes](https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![3028529D00000578-0-image-m-90_1452773994916](https://user-images.githubusercontent.com/824194/63877700-56774080-c985-11e9-9fc7-80e97a34b558.jpg)

