### PR TITLE
Connection handlers take connection arg

### DIFF
--- a/newsfragments/990.feature.rst
+++ b/newsfragments/990.feature.rst
@@ -1,0 +1,1 @@
+Handler functions for ``Connection.add_protocol_handler`` and ``Connection.add_command_handler`` now expect the ``Connection`` instance as the first argument.

--- a/p2p/abc.py
+++ b/p2p/abc.py
@@ -396,6 +396,10 @@ class HandlerSubscriptionAPI:
         ...
 
 
+ProtocolHandlerFn = Callable[['ConnectionAPI', CommandAPI, Payload], Awaitable[Any]]
+CommandHandlerFn = Callable[['ConnectionAPI', Payload], Awaitable[Any]]
+
+
 class ConnectionAPI(AsyncioServiceAPI):
     protocol_receipts: Tuple[HandshakeReceiptAPI, ...]
 
@@ -422,14 +426,14 @@ class ConnectionAPI(AsyncioServiceAPI):
     @abstractmethod
     def add_protocol_handler(self,
                              protocol_type: Type[ProtocolAPI],
-                             handler_fn: Callable[[CommandAPI, Payload], Awaitable[Any]],
+                             handler_fn: ProtocolHandlerFn,
                              ) -> HandlerSubscriptionAPI:
         ...
 
     @abstractmethod
     def add_command_handler(self,
                             command_type: Type[CommandAPI],
-                            handler_fn: Callable[[Payload], Awaitable[Any]],
+                            handler_fn: CommandHandlerFn,
                             ) -> HandlerSubscriptionAPI:
         ...
 

--- a/p2p/peer.py
+++ b/p2p/peer.py
@@ -339,10 +339,10 @@ class BasePeer(BaseService):
 
         await self.cancellation()
 
-    async def _ping_handler(self, msg: Payload) -> None:
+    async def _ping_handler(self, connection: ConnectionAPI, msg: Payload) -> None:
         self.base_protocol.send_pong()
 
-    async def _disconnect_handler(self, msg: Payload) -> None:
+    async def _disconnect_handler(self, connection: ConnectionAPI, msg: Payload) -> None:
         msg = cast(Dict[str, Any], msg)
         try:
             reason = DisconnectReason(msg['reason'])
@@ -353,7 +353,10 @@ class BasePeer(BaseService):
 
         self.cancel_nowait()
 
-    async def _handle_subscriber_message(self, cmd: CommandAPI, msg: Payload) -> None:
+    async def _handle_subscriber_message(self,
+                                         connection: ConnectionAPI,
+                                         cmd: CommandAPI,
+                                         msg: Payload) -> None:
         subscriber_msg = PeerMessage(self, cmd, msg)
         for subscriber in self._subscribers:
             subscriber.add_msg(subscriber_msg)

--- a/p2p/tools/connection.py
+++ b/p2p/tools/connection.py
@@ -9,11 +9,11 @@ async def do_ping_pong_test(alice_connection: ConnectionAPI, bob_connection: Con
     got_ping = asyncio.Event()
     got_pong = asyncio.Event()
 
-    async def _handle_ping(msg: Any) -> None:
+    async def _handle_ping(connection: ConnectionAPI, msg: Any) -> None:
         got_ping.set()
         bob_connection.get_base_protocol().send_pong()
 
-    async def _handle_pong(msg: Any) -> None:
+    async def _handle_pong(connection: ConnectionAPI, msg: Any) -> None:
         got_pong.set()
 
     alice_connection.add_command_handler(Pong, _handle_pong)

--- a/tests/core/p2p-proto/test_les_protocol_commands.py
+++ b/tests/core/p2p-proto/test_les_protocol_commands.py
@@ -39,7 +39,7 @@ async def test_les_protocol_methods_request_id(
     messages = []
     got_message = asyncio.Event()
 
-    async def collect_messages(cmd, msg):
+    async def collect_messages(conn, cmd, msg):
         messages.append((cmd, msg))
         got_message.set()
 

--- a/tests/p2p/test_connection.py
+++ b/tests/p2p/test_connection.py
@@ -26,7 +26,7 @@ async def test_connection_waits_to_feed_protocol_streams():
     async with ConnectionPairFactory(start_streams=False) as (alice_connection, bob_connection):
         got_ping = asyncio.Event()
 
-        async def _handle_ping(msg):
+        async def _handle_ping(conn, msg):
             got_ping.set()
 
         alice_connection.add_command_handler(Ping, _handle_ping)
@@ -142,16 +142,16 @@ async def test_connection_protocol_and_command_handlers():
 
         done = asyncio.Event()
 
-        async def _handler_second_protocol(cmd, msg):
+        async def _handler_second_protocol(conn, cmd, msg):
             messages_second_protocol.append((cmd, msg))
 
-        async def _handler_cmd_A(msg):
+        async def _handler_cmd_A(conn, msg):
             messages_cmd_A.append(msg)
 
-        async def _handler_cmd_D(msg):
+        async def _handler_cmd_D(conn, msg):
             messages_cmd_D.append(msg)
 
-        async def _handler_cmd_C(msg):
+        async def _handler_cmd_C(conn, msg):
             done.set()
 
         alice_connection.add_protocol_handler(SecondProtocol, _handler_second_protocol)

--- a/tests/p2p/test_peer_pair_factory.py
+++ b/tests/p2p/test_peer_pair_factory.py
@@ -12,11 +12,11 @@ async def test_connection_factory_with_ParagonPeer():
         got_ping = asyncio.Event()
         got_pong = asyncio.Event()
 
-        async def handle_ping(msg):
+        async def handle_ping(conn, msg):
             got_ping.set()
             bob.base_protocol.send_pong()
 
-        async def handle_pong(msg):
+        async def handle_pong(conn, msg):
             got_pong.set()
 
         alice.connection.add_command_handler(Pong, handle_pong)

--- a/trinity/protocol/eth/peer.py
+++ b/trinity/protocol/eth/peer.py
@@ -16,7 +16,7 @@ from lahja import (
     BroadcastConfig,
 )
 
-from p2p.abc import CommandAPI, HandshakeReceiptAPI, NodeAPI
+from p2p.abc import CommandAPI, ConnectionAPI, HandshakeReceiptAPI, NodeAPI
 from p2p.handshake import DevP2PReceipt
 from p2p.protocol import (
     Payload,
@@ -109,7 +109,7 @@ class ETHPeer(BaseChainPeer):
     def setup_protocol_handlers(self) -> None:
         self.connection.add_command_handler(NewBlock, self._handle_new_block)
 
-    async def _handle_new_block(self, msg: Payload) -> None:
+    async def _handle_new_block(self, connection: ConnectionAPI, msg: Payload) -> None:
         msg = cast(Dict[str, Any], msg)
         header, _, _ = msg['block']
         actual_head = header.parent_hash

--- a/trinity/protocol/les/peer.py
+++ b/trinity/protocol/les/peer.py
@@ -25,7 +25,7 @@ from lahja import (
     BroadcastConfig,
 )
 
-from p2p.abc import CommandAPI, HandshakeReceiptAPI, NodeAPI
+from p2p.abc import CommandAPI, ConnectionAPI, HandshakeReceiptAPI, NodeAPI
 from p2p.handshake import DevP2PReceipt, Handshaker
 from p2p.peer_pool import BasePeerPool
 from p2p.typing import Payload
@@ -113,7 +113,7 @@ class LESPeer(BaseChainPeer):
     def setup_protocol_handlers(self) -> None:
         self.connection.add_command_handler(Announce, self._handle_announce)
 
-    async def _handle_announce(self, msg: Payload) -> None:
+    async def _handle_announce(self, connection: ConnectionAPI, msg: Payload) -> None:
         head_info = cast(Dict[str, Union[int, Hash32, BlockNumber]], msg)
         self.head_td = cast(int, head_info['head_td'])
         self.head_hash = cast(Hash32, head_info['head_hash'])


### PR DESCRIPTION
### What was wrong?

For the handler function API on the `Connection` object to be useful, the handlers need to have access to the connection.

### How was it fixed?

Now handler functions expect the connection as the first argument.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

[//]: # (See: https://trinity-client.readthedocs.io/en/latest/contributing.html#pull-requests)
- [x] Add entry to the [release notes](https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![Halloween-Pet-Costumes22__880](https://user-images.githubusercontent.com/824194/63878022-f46b0b00-c985-11e9-90a2-3401d9fd3786.jpg)

