### PR TITLE
Missing APIs on ConnectionAPI

### DIFF
--- a/newsfragments/991.misc.rst
+++ b/newsfragments/991.misc.rst
@@ -1,0 +1,1 @@
+Add ``ConnectionAPI.is_dial_out`` and ``ConnectionAPI.start_protocol_streams`` to ABC definition.

--- a/p2p/abc.py
+++ b/p2p/abc.py
@@ -407,6 +407,8 @@ class ConnectionAPI(AsyncioServiceAPI):
     #
     # Primary properties of the connection
     #
+    is_dial_out: bool
+
     @property
     @abstractmethod
     def is_dial_in(self) -> bool:


### PR DESCRIPTION
### What was wrong?

Missing APIs on the ABC definition of `ConnectionAPI`

### How was it fixed?

Added them.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

[//]: # (See: https://trinity-client.readthedocs.io/en/latest/contributing.html#pull-requests)
- [x] Add entry to the [release notes](https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![006e842b0070bd2356e75e9a9e483ed2-animals-in-costumes-horse-costumes](https://user-images.githubusercontent.com/824194/63878187-50ce2a80-c986-11e9-93e7-c84314c47c12.jpg)

