### PR TITLE
Error handling in Connection and Transport

### DIFF
--- a/newsfragments/992.bugfix.rst
+++ b/newsfragments/992.bugfix.rst
@@ -1,0 +1,1 @@
+Add missing exception handling inside of ``Connection.run`` for ``PeerConnectionLost`` exception that bubbles from multiplexer.  ``Connection`` is now responsible for calling ``Multiplexer.close`` on shutdown.  Detect a closed connection during handshake.

--- a/p2p/connection.py
+++ b/p2p/connection.py
@@ -14,6 +14,7 @@ from p2p.abc import (
     ConnectionAPI,
 )
 from p2p.exceptions import (
+    PeerConnectionLost,
     UnknownProtocol,
     UnknownProtocolCommand,
 )
@@ -81,11 +82,17 @@ class Connection(ConnectionAPI, BaseService):
         return self._multiplexer.remote
 
     async def _run(self) -> None:
-        async with self._multiplexer.multiplex():
-            for protocol in self._multiplexer.get_protocols():
-                self.run_daemon_task(self._feed_protocol_handlers(protocol))
+        try:
+            async with self._multiplexer.multiplex():
+                for protocol in self._multiplexer.get_protocols():
+                    self.run_daemon_task(self._feed_protocol_handlers(protocol))
 
-            await self.cancellation()
+                await self.cancellation()
+        except (PeerConnectionLost, asyncio.CancelledError):
+            pass
+
+    async def _cleanup(self) -> None:
+        self._multiplexer.close()
 
     #
     # Subscriptions/Handler API

--- a/p2p/transport.py
+++ b/p2p/transport.py
@@ -193,6 +193,9 @@ class Transport(TransportAPI):
         auth_ack_msg = responder.create_auth_ack_message(responder_nonce)
         auth_ack_ciphertext = responder.encrypt_auth_ack_message(auth_ack_msg)
 
+        if writer.transport.is_closing() or reader.at_eof():
+            raise HandshakeFailure("Connection is closing")
+
         # Use the `writer` to send the reply to the remote
         writer.write(auth_ack_ciphertext)
         await token.cancellable_wait(writer.drain())

--- a/tests/p2p/test_peer_pair_factory.py
+++ b/tests/p2p/test_peer_pair_factory.py
@@ -23,5 +23,5 @@ async def test_connection_factory_with_ParagonPeer():
 
         alice.base_protocol.send_ping()
 
-        await asyncio.wait_for(got_ping.wait(), timeout=0.1)
-        await asyncio.wait_for(got_pong.wait(), timeout=0.1)
+        await asyncio.wait_for(got_ping.wait(), timeout=1)
+        await asyncio.wait_for(got_pong.wait(), timeout=1)


### PR DESCRIPTION
### What was wrong?

- Needed to catch and handle `PeerConnectionLost` which bubbles out of the multiplexer API.
- Handle a case inside the `Transport` code to catch a lost connection during handshake.
- Make `Connection` responsible for closing the `Multiplexer` on exit.

### How was it fixed?

Fixed the things.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

[//]: # (See: https://trinity-client.readthedocs.io/en/latest/contributing.html#pull-requests)
- [x] Add entry to the [release notes](https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![20-hilarious-pictures-of-pets-in-costumes-1](https://user-images.githubusercontent.com/824194/63878420-ca661880-c986-11e9-9a7e-67e8e27d6c67.jpg)

