### PR TITLE
type cleanup for Tuple/Sequence

### DIFF
--- a/newsfragments/993.misc.rst
+++ b/newsfragments/993.misc.rst
@@ -1,0 +1,1 @@
+Relax some input types from ``Tuple[thing, ...]`` to ``Sequence[thing]``

--- a/p2p/handshake.py
+++ b/p2p/handshake.py
@@ -9,6 +9,7 @@ from typing import (
     Dict,
     Iterable,
     NamedTuple,
+    Sequence,
     Type,
     Tuple,
 )
@@ -200,7 +201,7 @@ async def _do_p2p_handshake(transport: TransportAPI,
 
 async def negotiate_protocol_handshakes(transport: TransportAPI,
                                         p2p_handshake_params: DevP2PHandshakeParams,
-                                        protocol_handshakers: Tuple[Handshaker, ...],
+                                        protocol_handshakers: Sequence[Handshaker],
                                         token: CancelToken,
                                         ) -> Tuple[MultiplexerAPI, DevP2PReceipt, Tuple[HandshakeReceipt, ...]]:  # noqa: E501
     """


### PR DESCRIPTION
### What was wrong?

Our input parameters don't need to be strict about `Tuple` types.

### How was it fixed?

Relax to allow `Sequence`

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

[//]: # (See: https://trinity-client.readthedocs.io/en/latest/contributing.html#pull-requests)
- [x] Add entry to the [release notes](https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![maxresdefault](https://user-images.githubusercontent.com/824194/63878632-38124480-c987-11e9-9078-0f806e4c7524.jpg)

