### PR TITLE
Bugfix for P2PProtocol.send_disconnect

### DIFF
--- a/newsfragments/994.bugfix.rst
+++ b/newsfragments/994.bugfix.rst
@@ -1,0 +1,1 @@
+Fix ``P2PProtocol.send_disconnect`` to accept enum values from ``p2p.disconnect.DisconnectReason``

--- a/p2p/p2p_proto.py
+++ b/p2p/p2p_proto.py
@@ -118,7 +118,7 @@ class BaseP2PProtocol(Protocol):
         self.transport.send(header, body)
 
     def send_disconnect(self, reason: _DisconnectReason) -> None:
-        msg: Dict[str, Any] = {"reason": reason}
+        msg: Dict[str, Any] = {"reason": reason.value}
         header, body = Disconnect(
             self.cmd_id_offset,
             self.snappy_support

--- a/p2p/peer.py
+++ b/p2p/peer.py
@@ -370,7 +370,7 @@ class BasePeer(BaseService):
             )
 
         self.logger.debug("Disconnecting from remote peer %s; reason: %s", self.remote, reason.name)
-        self.base_protocol.send_disconnect(reason.value)
+        self.base_protocol.send_disconnect(reason)
         self.cancel_nowait()
 
     async def disconnect(self, reason: DisconnectReason) -> None:


### PR DESCRIPTION
### What was wrong?

`P2PProtocol.send_disconnect` treated the reason argument as the raw value when really we want to use the enum value

### How was it fixed?

Adjusted it to properly accept an enum value.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

[//]: # (See: https://trinity-client.readthedocs.io/en/latest/contributing.html#pull-requests)
- [x] Add entry to the [release notes](https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![costume 1](https://user-images.githubusercontent.com/824194/63878821-9808eb00-c987-11e9-8918-53091ce2f5c3.jpg)

