### PR TITLE
Adjust request response api to use connection

### DIFF
--- a/newsfragments/997.misc.rst
+++ b/newsfragments/997.misc.rst
@@ -1,0 +1,1 @@
+Convert the request/response APIs to use the ``ConnectionAPI`` instead of ``BasePeer``

--- a/trinity/protocol/bcc/peer.py
+++ b/trinity/protocol/bcc/peer.py
@@ -94,7 +94,7 @@ class BCCPeer(BasePeer):
     @property
     def requests(self) -> BCCExchangeHandler:
         if self._requests is None:
-            self._requests = BCCExchangeHandler(self)
+            self._requests = BCCExchangeHandler(self.connection)
         return self._requests
 
 

--- a/trinity/protocol/common/exchanges.py
+++ b/trinity/protocol/common/exchanges.py
@@ -83,6 +83,10 @@ class BaseExchange(ABC, Generic[TRequestPayload, TResponsePayload, TResult]):
     def response_cmd_type(cls) -> Type[CommandAPI]:
         return cls.request_class.response_type
 
+    @classproperty
+    def request_cmd_type(cls) -> Type[CommandAPI]:
+        return cls.request_class.cmd_type
+
     @abstractmethod
     async def __call__(self, *args: Any, **kwargs: Any) -> None:
         """

--- a/trinity/protocol/common/handlers.py
+++ b/trinity/protocol/common/handlers.py
@@ -12,8 +12,12 @@ from typing import (
 
 from eth_typing import BlockIdentifier
 
+from eth_utils import ValidationError
+
 from eth.rlp.headers import BlockHeader
-from p2p.peer import BasePeer
+
+from p2p.abc import ConnectionAPI
+from p2p.exceptions import UnknownProtocol
 
 from trinity.protocol.common.exchanges import (
     BaseExchange,
@@ -29,17 +33,54 @@ class BaseExchangeHandler(ABC):
     def _exchange_config(self) -> Dict[str, Type[BaseExchange[Any, Any, Any]]]:
         ...
 
-    def __init__(self, peer: BasePeer) -> None:
-        self._peer = peer
+    def __init__(self, connection: ConnectionAPI) -> None:
+        self._connection = connection
 
+        available_protocols = self._connection.get_multiplexer().get_protocols()
         for attr, exchange_cls in self._exchange_config.items():
             if hasattr(self, attr):
                 raise AttributeError(
                     f"Unable to set manager on attribute `{attr}` which is already "
                     f"present on the class: {getattr(self, attr)}"
                 )
+
+            # determine which protocol should be used to issue requests
+            supported_protocols = tuple(
+                protocol
+                for protocol in available_protocols
+                if protocol.supports_command(exchange_cls.request_cmd_type)
+            )
+            if len(supported_protocols) == 1:
+                protocol_type = type(supported_protocols[0])
+            elif not supported_protocols:
+                raise UnknownProtocol(
+                    f"Connection does not have any protocols that support the "
+                    f"request command: {exchange_cls.request_cmd_type}"
+                )
+            elif len(supported_protocols) > 1:
+                raise ValidationError(
+                    f"Could not determine appropriate protocol for command: "
+                    f"{exchange_cls.request_cmd_type}.  Command was found in the "
+                    f"protocols {supported_protocols}"
+                )
+            else:
+                raise Exception("This code path should be unreachable")
+
+            if not protocol_type.supports_command(exchange_cls.response_cmd_type):
+                raise ValidationError(
+                    f"Could not determine appropriate protocol: "
+                    f"The response command type "
+                    f"{exchange_cls.response_cmd_type} is not supported by the "
+                    f"protocol that matched the request command type: "
+                    f"{protocol_type}"
+                )
+
             manager: ExchangeManager[Any, Any, Any]
-            manager = ExchangeManager(self._peer, exchange_cls.response_cmd_type, peer.cancel_token)
+            manager = ExchangeManager(
+                connection=self._connection,
+                requesting_on=protocol_type,
+                listening_for=exchange_cls.response_cmd_type,
+            )
             exchange = exchange_cls(manager)
             setattr(self, attr, exchange)
 

--- a/trinity/protocol/eth/peer.py
+++ b/trinity/protocol/eth/peer.py
@@ -103,7 +103,7 @@ class ETHPeer(BaseChainPeer):
     @property
     def requests(self) -> ETHExchangeHandler:
         if self._requests is None:
-            self._requests = ETHExchangeHandler(self)
+            self._requests = ETHExchangeHandler(self.connection)
         return self._requests
 
     def setup_protocol_handlers(self) -> None:

--- a/trinity/protocol/les/peer.py
+++ b/trinity/protocol/les/peer.py
@@ -107,7 +107,7 @@ class LESPeer(BaseChainPeer):
     @property
     def requests(self) -> LESExchangeHandler:
         if self._requests is None:
-            self._requests = LESExchangeHandler(self)
+            self._requests = LESExchangeHandler(self.connection)
         return self._requests
 
     def setup_protocol_handlers(self) -> None:


### PR DESCRIPTION
Builds on #962 and #989 and #987 and #990 

### What was wrong?

The request/response API was tied in with the `BasePeer` class.  Since we are moving away from individual `Peer` types we need the request/response API to be based on the `ConnectionAPI`

### How was it fixed?

Changed the various places where the request/response API references `BasePeer` to now use `ConnectionAPI`.  This involves the removal of some non-critical functionality that we can add back later.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

[//]: # (See: https://trinity-client.readthedocs.io/en/latest/contributing.html#pull-requests)
- [x] Add entry to the [release notes](https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses]()
