### PR TITLE
Basic Endpoint Tracker

### DIFF
--- a/p2p/discv5/constants.py
+++ b/p2p/discv5/constants.py
@@ -32,3 +32,7 @@ DATAGRAM_BUFFER_SIZE = 2048
 
 MAX_REQUEST_ID = 2**32 - 1  # highest request id used for outgoing requests
 MAX_REQUEST_ID_ATTEMPTS = 100  # number of attempts we take to guess a available request id
+
+# ENR keys for endpoint information
+IP_V4_ADDRESS_ENR_KEY = b"ip"
+UDP_PORT_ENR_KEY = b"udp"

--- a/p2p/discv5/endpoint_tracker.py
+++ b/p2p/discv5/endpoint_tracker.py
@@ -1,0 +1,108 @@
+import logging
+from typing import (
+    NamedTuple,
+)
+
+from trio.abc import (
+    ReceiveChannel,
+)
+
+from eth_utils import (
+    encode_hex,
+)
+from eth_utils.toolz import (
+    merge,
+)
+
+from p2p.trio_service import (
+    Service,
+)
+
+from p2p.discv5.abc import (
+    EnrDbApi,
+)
+from p2p.discv5.channel_services import (
+    Endpoint,
+)
+from p2p.discv5.constants import (
+    IP_V4_ADDRESS_ENR_KEY,
+    UDP_PORT_ENR_KEY,
+)
+from p2p.discv5.enr import (
+    UnsignedENR,
+)
+from p2p.discv5.identity_schemes import (
+    IdentitySchemeRegistry,
+)
+from p2p.discv5.typing import (
+    NodeID,
+)
+
+
+class EndpointVote(NamedTuple):
+    endpoint: Endpoint
+    node_id: NodeID
+    timestamp: float
+
+
+class EndpointTracker(Service):
+
+    logger = logging.getLogger("p2p.discv5.endpoint_tracker.EndpointTracker")
+
+    def __init__(self,
+                 local_private_key: bytes,
+                 local_node_id: NodeID,
+                 enr_db: EnrDbApi,
+                 identity_scheme_registry: IdentitySchemeRegistry,
+                 vote_receive_channel: ReceiveChannel[EndpointVote],
+                 ) -> None:
+        self.local_private_key = local_private_key
+        self.local_node_id = local_node_id
+        self.enr_db = enr_db
+        self.identity_scheme_registry = identity_scheme_registry
+
+        self.vote_receive_channel = vote_receive_channel
+
+    async def run(self) -> None:
+        async with self.vote_receive_channel:
+            async for vote in self.vote_receive_channel:
+                await self.handle_vote(vote)
+
+    async def handle_vote(self, vote: EndpointVote) -> None:
+        self.logger.debug(
+            "Received vote for %s from %s",
+            vote.endpoint,
+            encode_hex(vote.node_id),
+        )
+
+        current_enr = await self.enr_db.get(self.local_node_id)
+
+        # TODO: majority voting, discard old votes
+        are_endpoint_keys_present = (
+            IP_V4_ADDRESS_ENR_KEY in current_enr and
+            UDP_PORT_ENR_KEY in current_enr
+        )
+        enr_needs_update = not are_endpoint_keys_present or (
+            vote.endpoint.ip_address != current_enr[IP_V4_ADDRESS_ENR_KEY] and
+            vote.endpoint.port != current_enr[UDP_PORT_ENR_KEY]
+        )
+        if enr_needs_update:
+            kv_pairs = merge(
+                current_enr,
+                {
+                    IP_V4_ADDRESS_ENR_KEY: vote.endpoint.ip_address,
+                    UDP_PORT_ENR_KEY: vote.endpoint.port,
+                }
+            )
+            new_unsigned_enr = UnsignedENR(
+                kv_pairs=kv_pairs,
+                sequence_number=current_enr.sequence_number + 1,
+                identity_scheme_registry=self.identity_scheme_registry,
+            )
+            signed_enr = new_unsigned_enr.to_signed_enr(self.local_private_key)
+            self.logger.info(
+                f"Updating local endpoint to %s (new ENR sequence number: %d)",
+                vote.endpoint,
+                signed_enr.sequence_number,
+            )
+            await self.enr_db.update(signed_enr)

--- a/p2p/tools/factories/discovery.py
+++ b/p2p/tools/factories/discovery.py
@@ -29,6 +29,9 @@ from p2p.discv5.channel_services import (
     Endpoint,
     IncomingPacket,
 )
+from p2p.discv5.endpoint_tracker import (
+    EndpointVote,
+)
 from p2p.discv5.enr import (
     ENR,
     UnsignedENR,
@@ -113,6 +116,15 @@ class EndpointFactory(factory.Factory):
 
     ip_address = factory.LazyFunction(lambda: socket.inet_aton(factory.Faker("ipv4").generate({})))
     port = factory.Faker("pyint", min_value=0, max_value=65535)
+
+
+class EndpointVoteFactory(factory.Factory):
+    class Meta:
+        model = EndpointVote
+
+    endpoint = factory.SubFactory(EndpointFactory)
+    node_id = factory.LazyFunction(lambda: ENRFactory().node_id)
+    timestamp = factory.Faker("unix_time")
 
 
 class IncomingPacketFactory(factory.Factory):

--- a/tests-trio/p2p-trio/test_endpoint_tracker.py
+++ b/tests-trio/p2p-trio/test_endpoint_tracker.py
@@ -1,0 +1,86 @@
+import pytest
+
+import trio
+
+from trio.testing import (
+    wait_all_tasks_blocked,
+)
+
+import pytest_trio
+
+from p2p.trio_service import (
+    background_service,
+)
+
+from p2p.tools.factories.discovery import (
+    EndpointFactory,
+    EndpointVoteFactory,
+    ENRFactory,
+)
+from p2p.tools.factories.keys import (
+    PrivateKeyFactory,
+)
+
+from p2p.discv5.constants import (
+    IP_V4_ADDRESS_ENR_KEY,
+    UDP_PORT_ENR_KEY,
+)
+from p2p.discv5.endpoint_tracker import (
+    EndpointTracker,
+)
+from p2p.discv5.enr_db import (
+    MemoryEnrDb,
+)
+from p2p.discv5.identity_schemes import (
+    default_identity_scheme_registry,
+)
+
+
+@pytest.fixture
+def private_key():
+    return PrivateKeyFactory().to_bytes()
+
+
+@pytest.fixture
+def initial_enr(private_key):
+    return ENRFactory(
+        private_key=private_key,
+    )
+
+
+@pytest_trio.trio_fixture
+async def enr_db(initial_enr):
+    enr_db = MemoryEnrDb(default_identity_scheme_registry)
+    await enr_db.insert(initial_enr)
+    return enr_db
+
+
+@pytest.fixture
+def vote_channels():
+    return trio.open_memory_channel(0)
+
+
+@pytest.fixture
+async def endpoint_tracker(private_key, initial_enr, enr_db, vote_channels):
+    endpoint_tracker = EndpointTracker(
+        local_private_key=private_key,
+        local_node_id=initial_enr.node_id,
+        enr_db=enr_db,
+        identity_scheme_registry=default_identity_scheme_registry,
+        vote_receive_channel=vote_channels[1],
+    )
+    async with background_service(endpoint_tracker):
+        yield endpoint_tracker
+
+
+@pytest.mark.trio
+async def test_endpoint_tracker_updates_enr(endpoint_tracker, initial_enr, enr_db, vote_channels):
+    endpoint = EndpointFactory()
+    endpoint_vote = EndpointVoteFactory(endpoint=endpoint)
+    await vote_channels[0].send(endpoint_vote)
+    await wait_all_tasks_blocked()  # wait until vote has been processed
+
+    updated_enr = await enr_db.get(initial_enr.node_id)
+    assert updated_enr.sequence_number == initial_enr.sequence_number + 1
+    assert updated_enr[IP_V4_ADDRESS_ENR_KEY] == endpoint.ip_address
+    assert updated_enr[UDP_PORT_ENR_KEY] == endpoint.port


### PR DESCRIPTION
This PR implements a basic endpoint tracker, a service that's in charge of updating our ENRs when our endpoint changes.

Often we don't know our own endpoint, especially if we sit behind a NAT. On the other hand, our peers do know (they see where packets come from). Therefore, discv5 requires nodes to include the ping's sender endpoint in pong messages. That's the data that should be passed to the endpoint tracker.

Of course, we shouldn't trust individual peers to give us the right information. Therefore, we have to use some sort of majority voting. However, for simplicity's sake we just use the most recent message as absolute truth for now.

### To-Do

- [ ] Rebase on top of message dispatcher PR once merged, which includes a few duplicate changes

#### Cute Animal Picture
![put a cute animal picture link inside the parentheses](https://user-images.githubusercontent.com/29854669/63938207-8ba69000-ca64-11e9-921c-6b354282c193.jpg)