### PR TITLE
DiscV5 Flat Routing Table

### DIFF
--- a/p2p/discv5/routing_table.py
+++ b/p2p/discv5/routing_table.py
@@ -1,0 +1,69 @@
+from collections import (
+    deque,
+)
+import logging
+import random
+from typing import (
+    Any,
+    Deque,
+    Iterator,
+    Collection,
+)
+
+from eth_utils import (
+    encode_hex,
+)
+
+from p2p.discv5.typing import (
+    NodeID,
+)
+
+
+class FlatRoutingTable(Collection[NodeID]):
+
+    logger = logging.getLogger("p2p.discv5.routing_table_manager.FlatRoutingTable")
+
+    def __init__(self) -> None:
+        self.entries: Deque[NodeID] = deque()
+
+    def add(self, node_id: NodeID) -> None:
+        if node_id not in self:
+            self.logger.debug("Adding entry %s", encode_hex(node_id))
+            self.entries.appendleft(node_id)
+        else:
+            raise ValueError(f"Entry {encode_hex(node_id)} already present in the routing table")
+
+    def update(self, node_id: NodeID) -> None:
+        self.remove(node_id)
+        self.add(node_id)
+
+    def add_or_update(self, node_id: NodeID) -> None:
+        try:
+            self.remove(node_id)
+        except KeyError:
+            pass
+        finally:
+            self.add(node_id)
+
+    def remove(self, node_id: NodeID) -> None:
+        try:
+            self.entries.remove(node_id)
+        except ValueError:
+            raise KeyError(f"Entry {encode_hex(node_id)} not present in the routing table")
+        else:
+            self.logger.debug("Removing entry %s", encode_hex(node_id))
+
+    def __contains__(self, node_id: Any) -> bool:
+        return node_id in self.entries
+
+    def __len__(self) -> int:
+        return len(self.entries)
+
+    def __iter__(self) -> Iterator[NodeID]:
+        return iter(self.entries)
+
+    def get_random_entry(self) -> NodeID:
+        return random.choice(self.entries)
+
+    def get_oldest_entry(self) -> NodeID:
+        return self.entries[-1]

--- a/p2p/tools/factories/discovery.py
+++ b/p2p/tools/factories/discovery.py
@@ -43,6 +43,9 @@ from p2p.discv5.handshake import (
     HandshakeInitiator,
     HandshakeRecipient,
 )
+from p2p.discv5.typing import (
+    NodeID,
+)
 from p2p.ecies import generate_privkey
 
 from .cancel_token import CancelTokenFactory
@@ -118,6 +121,14 @@ class IncomingPacketFactory(factory.Factory):
 
     packet = factory.SubFactory(AuthTagPacketFactory)
     sender_endpoint = factory.SubFactory(EndpointFactory)
+
+
+class NodeIDFactory(factory.Factory):
+    class Meta:
+        model = NodeID
+        inline_args = ("node_id",)
+
+    node_id = factory.Faker("binary", length=32)
 
 
 class ENRFactory(factory.Factory):

--- a/tests/p2p/discv5/test_routing_table.py
+++ b/tests/p2p/discv5/test_routing_table.py
@@ -1,0 +1,60 @@
+import pytest
+
+from p2p.discv5.routing_table import (
+    FlatRoutingTable,
+)
+
+from p2p.tools.factories.discovery import (
+    NodeIDFactory,
+)
+
+
+@pytest.fixture
+def routing_table():
+    return FlatRoutingTable()
+
+
+def test_add(routing_table):
+    node_id = NodeIDFactory()
+    assert node_id not in routing_table
+    routing_table.add(node_id)
+    assert node_id in routing_table
+    with pytest.raises(ValueError):
+        routing_table.add(node_id)
+
+
+def test_update(routing_table):
+    first_node_id = NodeIDFactory()
+    second_node_id = NodeIDFactory()
+
+    with pytest.raises(KeyError):
+        routing_table.update(first_node_id)
+    routing_table.add(first_node_id)
+    routing_table.add(second_node_id)
+
+    assert routing_table.get_oldest_entry() == first_node_id
+    routing_table.update(first_node_id)
+    assert routing_table.get_oldest_entry() == second_node_id
+
+
+def test_add_or_update(routing_table):
+    first_node_id = NodeIDFactory()
+    second_node_id = NodeIDFactory()
+
+    routing_table.add_or_update(first_node_id)
+    assert first_node_id in routing_table
+
+    routing_table.add(second_node_id)
+    assert routing_table.get_oldest_entry() == first_node_id
+    routing_table.add_or_update(first_node_id)
+    assert routing_table.get_oldest_entry() == second_node_id
+
+
+def test_remove(routing_table):
+    node_id = NodeIDFactory()
+
+    with pytest.raises(KeyError):
+        routing_table.remove(node_id)
+    routing_table.add(node_id)
+    routing_table.remove(node_id)
+    assert node_id not in routing_table


### PR DESCRIPTION
We need a way to store node ids. This should be a Kademlia-style table, pretty much equivalent to the one used in earlier versions. However, the existing implementation isn't usable for us as is because

- It stores `NodeAPI` objects which need a public key and a tcp port, both of which we don't have
- we query it slightly differently (not nodes around a certain address, but nodes at some distance (range) from us

So as a placeholder until there is a native discv5 implementation or the existing one is generalized,  I've added this simple `FlatRoutingTable` which should be good enough for now (i.e. it runs).

#### Cute Animal Picture
![put a cute animal picture link inside the parentheses](https://user-images.githubusercontent.com/29854669/63940361-9b74a300-ca69-11e9-8c4b-4aadb805d8e8.jpg)