### PR TITLE
Remove global ProcessPoolExecutor

### DIFF
--- a/newsfragments/1004.bugfix.rst
+++ b/newsfragments/1004.bugfix.rst
@@ -1,0 +1,7 @@
+Instead of the ``ProcessPoolExecutor`` use a ``ThreadPoolExecutor`` to normalize
+expensive messages. This fixes a bug where Trinity would leave idle processes
+from the ``ProcessPoolExecutor`` behind every time it shuts down after a sync.
+
+Performance wise, both methods should be roughly compareable and since many
+task have already been moved to their own managed processes over time, using
+a ``ThreadPoolExecutor`` strikes as a simple solution to fix that bug.

--- a/p2p/_utils.py
+++ b/p2p/_utils.py
@@ -1,8 +1,4 @@
 import collections
-from concurrent.futures import Executor, ProcessPoolExecutor
-import logging
-import os
-import signal
 from typing import Hashable, Sequence, Tuple, TypeVar
 
 import rlp
@@ -29,67 +25,6 @@ def get_devp2p_cmd_id(msg: bytes) -> int:
     as an integer.
     """
     return rlp.decode(msg[:1], sedes=rlp.sedes.big_endian_int)
-
-
-CPU_EMPTY_VALUES = {None, 0}
-
-
-_executor: Executor = None
-
-
-def ensure_global_asyncio_executor(cpu_count: int=None) -> Executor:
-    """
-    Returns a global `ProcessPoolExecutor` instance.
-
-    NOTE: We use the ProcessPoolExecutor to offload CPU intensive tasks to
-    separate processes to ensure we don't block the main networking process.
-    This pattern will only work correctly if used within a single process.  If
-    multiple processes use this executor API we'll end up with more workers
-    than there are CPU cores at which point the networking process will be
-    competing with all the worker processes for CPU resources.  At the point
-    where we need this in more than one process we will need to come up with a
-    different solution
-    """
-    global _executor
-
-    if _executor is None:
-        # Use CPU_COUNT - 1 processes to make sure we always leave one CPU idle
-        # so that it can run asyncio's event loop.
-        if cpu_count is None:
-            os_cpu_count = os.cpu_count()
-            if os_cpu_count in CPU_EMPTY_VALUES:
-                # Need this because os.cpu_count() returns None when the # of
-                # CPUs is indeterminable.
-                logger = logging.getLogger('p2p')
-                logger.warning(
-                    "Could not determine number of CPUs, defaulting to 1 instead of %s",
-                    os_cpu_count,
-                )
-                cpu_count = 1
-            else:
-                cpu_count = max(1, os_cpu_count - 1)
-        # The following block of code allows us to gracefully handle
-        # `KeyboardInterrupt` in the worker processes.  This is accomplished
-        # via two "hacks".
-        #
-        # First: We set the signal handler for SIGINT to the special case
-        # `SIG_IGN` which instructs the process to ignore SIGINT, while
-        # preserving the original signal handler.  We do this because child
-        # processes inherit the signal handlers of their parent processes.
-        #
-        # Second, we have to force the executor to initialize the worker
-        # processes, as they are not initialized on instantiation, but rather
-        # lazily when the first work is submitted.  We do this by calling the
-        # private method `_start_queue_management_thread`.
-        #
-        # Finally, we restore the original signal handler now that we know the
-        # child processes have been initialized to ensure that
-        # `KeyboardInterrupt` in the main process is still handled normally.
-        original_handler = signal.signal(signal.SIGINT, signal.SIG_IGN)
-        _executor = ProcessPoolExecutor(cpu_count)
-        _executor._start_queue_management_thread()  # type: ignore
-        signal.signal(signal.SIGINT, original_handler)
-    return _executor
 
 
 def trim_middle(arbitrary_string: str, max_length: int) -> str:

--- a/trinity/nodes/base.py
+++ b/trinity/nodes/base.py
@@ -16,7 +16,6 @@ from p2p.peer_pool import BasePeerPool
 from p2p.service import (
     BaseService,
 )
-from p2p._utils import ensure_global_asyncio_executor
 
 from trinity.chains.full import FullChain
 from trinity.db.manager import DBClient
@@ -127,9 +126,6 @@ class Node(BaseService, Generic[TPeer]):
         return self._headerdb
 
     async def _run(self) -> None:
-        # The `networking` process creates a process pool executor to offload cpu intensive
-        # tasks. We should revisit that when we move the sync in its own process
-        ensure_global_asyncio_executor()
         self.run_daemon_task(self.handle_network_id_requests())
         self.run_daemon(self.get_p2p_server())
         self.run_daemon(self.get_event_server())

--- a/trinity/protocol/common/managers.py
+++ b/trinity/protocol/common/managers.py
@@ -17,7 +17,6 @@ from eth_utils import (
     ValidationError,
 )
 
-from p2p._utils import ensure_global_asyncio_executor
 from p2p.abc import CommandAPI, RequestAPI, TRequestPayload
 from p2p.constants import BLACKLIST_SECONDS_TOO_MANY_TIMEOUTS
 from p2p.exceptions import PeerConnectionLost
@@ -306,9 +305,7 @@ class ExchangeManager(Generic[TRequestPayload, TResponsePayload, TResult]):
 
                 if normalizer.is_normalization_slow:
                     result = await stream._run_in_executor(
-                        # We just retrieve the global executor that was created when the
-                        # Node launches. The node manages the lifecycle of the executor.
-                        ensure_global_asyncio_executor(),
+                        None,
                         normalizer.normalize_result,
                         payload
                     )


### PR DESCRIPTION
### What was wrong?

Trinity does currently leave processes behind. Read #897 for a more detailed description.

I used the following steps to reproduce the issue:

1. Check you have no dangling processes `ps aux |grep trinity`
2. If you do, kill them. (`pkill python` if you are brave)
3. Run beam sync (*should* work with other sync, too but I used that) until it is fully involved syncing
4. ☝ This is important, killing Trinity when it isn't yet syncing does not leave these processes behind.
5. Kill trinity with `CTRL + C`

Another important hint: One can check the process ids with these of the plugin processes. It makes it clear that those process ids are not ours. They really are from the `ProcessPoolExecutor`

### How was it fixed?

I've spent almost the entire day on this and it got me so frustrated that the outcome now is this removal of the entire `ProcessPoolExecutor`.

Here's the backstory:

1. The problem of leftover processes was originally discovered by @veox and back then it was even more severe as every isolated plugin would create a ton of idle processes.

2. I fixed this back then in https://github.com/ethereum/trinity/pull/227

3. Back then, @pipermerriam already [raised concerns](https://github.com/ethereum/trinity/pull/227#pullrequestreview-197099468) with the solution, noting that someone may accidentally remove it at some point. He also proposed using a `weakref.finalizer` for a more robust solution.

4. Ironically it is @pipermerriam 's PR under my review that then happens to do exactly that: [accidentally remove the fix](https://github.com/ethereum/trinity/commit/6493c94656b907ca9f73ce2fe677dfd9f03a2974#diff-31de14ce34c9eb0bd0c3a7fed15bda1eL141).

Now, I've spend a fair amount of time trying to come up with something more robust including the proposed `weakref.finalizer` solution. Unfortunately, it has proven to be really hard (or maybe that's just me) to come up with something that works reliably.

This got me questioning if we really need the `ProcessPoolExecutor` here or if a simple `ThreadPoolExecutor` might do it as well.

I haven't done any profiling about the performance impact of this.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

[//]: # (See: https://trinity-client.readthedocs.io/en/latest/contributing.html#pull-requests)
- [ ] Add entry to the [release notes](https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://static.boredpanda.com/blog/wp-content/uploads/2014/03/cute-smiling-animals-9.jpg)
