### PR TITLE
Fix bug where variable might not be set

### DIFF
--- a/newsfragments/1005.bugfix.rst
+++ b/newsfragments/1005.bugfix.rst
@@ -1,0 +1,3 @@
+Fix a bug where trying to start beam sync from a checkpoint would throw an error
+due to an uninitialized var if a request to a peer would raise an error while
+we are trying to resolve a header from it.


### PR DESCRIPTION
### What was wrong?

The `headers` var might end up not being initialized leaving us with an error when we try to start beam sync from a checkpoint.

### How was it fixed?

Set `headers` to `None` to start with.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

[//]: # (See: https://trinity-client.readthedocs.io/en/latest/contributing.html#pull-requests)
- [x] Add entry to the [release notes](https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](http://www.mashbox.org/wp-content/uploads/2017/03/smile6.jpg)
