### PR TITLE
Fix transport corruption

### DIFF
--- a/p2p/abc.py
+++ b/p2p/abc.py
@@ -28,6 +28,7 @@ from eth_utils import ExtendedDebugLogger
 from eth_keys import datatypes
 
 from p2p.typing import Capability, Capabilities, Payload, Structure
+from p2p.transport_state import TransportState
 
 if TYPE_CHECKING:
     from p2p.handshake import DevP2PReceipt  # noqa: F401
@@ -195,6 +196,7 @@ class RequestAPI(ABC, Generic[TRequestPayload]):
 
 class TransportAPI(ABC):
     remote: NodeAPI
+    read_state: TransportState
 
     @property
     @abstractmethod

--- a/p2p/transport.py
+++ b/p2p/transport.py
@@ -47,10 +47,17 @@ from p2p.exceptions import (
     UnreachablePeer,
 )
 from p2p.kademlia import Address, Node
+from p2p.transport_state import TransportState
 
 
 class Transport(TransportAPI):
-    logger = cast(ExtendedDebugLogger, logging.getLogger('p2p.connection.Transport'))
+    logger = cast(ExtendedDebugLogger, logging.getLogger('p2p.transport.Transport'))
+
+    # This status flag allows those managing a `Transport` to determine the
+    # proper cancellation strategy if the transport is mid-read.  Hard
+    # cancellations are allowed for both `IDLE` and `HEADER`.  A hard
+    # cancellation during `BODY` will leave the transport in a corrupt state.
+    read_state: TransportState = TransportState.IDLE
 
     def __init__(self,
                  remote: NodeAPI,
@@ -236,7 +243,30 @@ class Transport(TransportAPI):
         self._writer.write(data)
 
     async def recv(self, token: CancelToken) -> bytes:
-        header_data = await self.read(HEADER_LEN + MAC_LEN, token)
+        # Check that Transport read state is IDLE.
+        if self.read_state is not TransportState.IDLE:
+            # This is logged at INFO level because it indicates we are not
+            # properly managing the Transport and are interrupting it mid-read
+            # somewhere.
+            self.logger.info(
+                'Corrupted transport: %s - state=%s',
+                self,
+                self.read_state.name,
+            )
+            raise Exception(f"Corrupted transport: {self} - state={self.read_state.name}")
+
+        # Set status to indicate we are waiting to read the message header
+        self.read_state = TransportState.HEADER
+
+        try:
+            header_data = await self.read(HEADER_LEN + MAC_LEN, token)
+        except asyncio.CancelledError:
+            self.logger.debug('Transport cancelled during header read. resetting to IDLE state')
+            self.read_state = TransportState.IDLE
+            raise
+
+        # Set status to indicate we are waiting to read the message body
+        self.read_state = TransportState.BODY
         try:
             header = self._decrypt_header(header_data)
         except DecryptionError as err:
@@ -259,6 +289,8 @@ class Transport(TransportAPI):
             )
             raise MalformedMessage from err
 
+        # Reset status back to IDLE
+        self.read_state = TransportState.IDLE
         return msg
 
     def send(self, header: bytes, body: bytes) -> None:

--- a/p2p/transport_state.py
+++ b/p2p/transport_state.py
@@ -1,0 +1,7 @@
+import enum
+
+
+class TransportState(enum.Enum):
+    IDLE = enum.auto()
+    HEADER = enum.auto()
+    BODY = enum.auto()


### PR DESCRIPTION
fixes #1001 

### What was wrong?

When exiting the `multiplexer.multiplex()` context blocks, we were issueing a hard cancellation to the `Transport.recv`.  If this happened to occur in-between reading the header and body, then the transport would become "corrupt".  On the next `Transport.recv` call it would *think* that it was reading the message header, but would actually be reading into the body.

### How was it fixed?

The `Transport` object now exposes a `Transport.read_state` which can be in any of the three `IDLE/HEADER/BODY` states.  When we exit the multiplexing context we issue a soft cancellation first, allowing the message stream loop to exit naturally.

After that we issue a *harder* cancellation via `fut.cancel()`.  If the transport is simply waiting for a header, this cancellation is handled and the state is reset to `IDLE`.  This should work fine since a cancellation at this stage should not result in us having read any bytes from the `StreamReader`.  If I'm wrong about this then we'll start getting `MalformedMessage` exceptions again.

After the `fut.cancel()` we issue a cancellation via the `CancelToken` mechanism (this is not handled and will corrupt the transport if it isn't `IDLE`).

Then, the multiplexer checks whether the transport has been corrupted, logs some info loudly and closes itself.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

[//]: # (See: https://trinity-client.readthedocs.io/en/latest/contributing.html#pull-requests)
- [x] Add entry to the [release notes](https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![Halloween Dog 1](https://user-images.githubusercontent.com/824194/63969562-58adcd80-ca5f-11e9-9966-13cb0a089289.jpg)
