### PR TITLE
Make some INFO lines DEBUG

### DIFF
--- a/p2p/discovery.py
+++ b/p2p/discovery.py
@@ -420,7 +420,7 @@ class DiscoveryProtocol(asyncio.DatagramProtocol):
             pubkey_head = pubkey[:16]
             pubkey_tail = pubkey[-8:]
             self.logger.debug("full-bootnode: %s", uri)
-            self.logger.info("bootnode: %s...%s@%s", pubkey_head, pubkey_tail, uri_tail)
+            self.logger.debug("bootnode: %s...%s@%s", pubkey_head, pubkey_tail, uri_tail)
 
         try:
             bonding_queries = (

--- a/tests/integration/test_trinity_cli.py
+++ b/tests/integration/test_trinity_cli.py
@@ -124,8 +124,8 @@ async def test_light_boot(async_process_runner, command):
 @pytest.mark.parametrize(
     'command, expected_network_id, expected_genesis_hash',
     (
-        (('trinity',), 1, MAINNET_GENESIS_HASH),
-        (('trinity', '--ropsten'), 3, ROPSTEN_GENESIS_HASH),
+        (('trinity', '--log-level=DEBUG'), 1, MAINNET_GENESIS_HASH),
+        (('trinity', '--ropsten', '--log-level=DEBUG'), 3, ROPSTEN_GENESIS_HASH),
         (
             (
                 'trinity',
@@ -133,7 +133,8 @@ async def test_light_boot(async_process_runner, command):
                 # We don't have a way to refer to the tmp xdg_trinity_root here so we
                 # make up this replacement marker
                 '--data-dir={trinity_root_path}/devnet',
-                '--network-id=5'
+                '--network-id=5',
+                '--log-level=DEBUG',
             ), 5, '0x065fd78e53dcef113bf9d7732dac7c5132dcf85c9588a454d832722ceb097422'),
     )
 )

--- a/trinity/event_bus.py
+++ b/trinity/event_bus.py
@@ -151,7 +151,7 @@ class AsyncioEventBusService(BaseService):
                 for connection_config in ev.available_endpoints[index:]
                 if not self._endpoint.is_connected_to(connection_config.name)
             )
-            self._endpoint.logger.info(
+            self._endpoint.logger.debug(
                 "EventBus Endpoint %s connecting to other Endpoints %s",
                 self._endpoint.name,
                 ','.join((config.name for config in endpoints_to_connect_to)),


### PR DESCRIPTION
### What was wrong?

When trinity starts it emits a lot of log output that most users won't find useful:

```
    INFO  08-29 16:15:46              Endpoint  EventBus Endpoint bjson-rpc-api connecting to other Endpoints 
    INFO  08-29 16:15:46              Endpoint  EventBus Endpoint network-db connecting to other Endpoints 
    INFO  08-29 16:15:46              Endpoint  EventBus Endpoint bjson-rpc-api connecting to other Endpoints network-db
    INFO  08-29 16:15:46              Endpoint  EventBus Endpoint discovery connecting to other Endpoints 
    INFO  08-29 16:15:46              Endpoint  EventBus Endpoint network-db connecting to other Endpoints 
    INFO  08-29 16:15:46              Endpoint  EventBus Endpoint brequest-server connecting to other Endpoints 
    INFO  08-29 16:15:46              Endpoint  EventBus Endpoint network-db connecting to other Endpoints discovery
    INFO  08-29 16:15:46              Endpoint  EventBus Endpoint discovery connecting to other Endpoints 
    INFO  08-29 16:15:46              Endpoint  EventBus Endpoint bjson-rpc-api connecting to other Endpoints discovery
    INFO  08-29 16:15:46              Endpoint  EventBus Endpoint bjson-rpc-api connecting to other Endpoints brequest-server
    INFO  08-29 16:15:46              Endpoint  EventBus Endpoint discovery connecting to other Endpoints brequest-server
    INFO  08-29 16:15:46              Endpoint  EventBus Endpoint bupnp connecting to other Endpoints 
    INFO  08-29 16:15:46              Endpoint  EventBus Endpoint brequest-server connecting to other Endpoints 
    INFO  08-29 16:15:46              Endpoint  EventBus Endpoint network-db connecting to other Endpoints brequest-server
    INFO  08-29 16:15:46              Endpoint  EventBus Endpoint bupnp connecting to other Endpoints 
    INFO  08-29 16:15:46              Endpoint  EventBus Endpoint brequest-server connecting to other Endpoints bupnp
    INFO  08-29 16:15:46              Endpoint  EventBus Endpoint discovery connecting to other Endpoints bupnp
    INFO  08-29 16:15:46              Endpoint  EventBus Endpoint bjson-rpc-api connecting to other Endpoints bupnp
    INFO  08-29 16:15:46              Endpoint  EventBus Endpoint network-db connecting to other Endpoints bupnp
```

and 

```
    INFO  08-29 17:03:44     DiscoveryProtocol  bootnode: enode://a979fb57...3331163c@52.16.188.185:30303
    INFO  08-29 17:03:44     DiscoveryProtocol  bootnode: enode://aa36fdf3...9bded46f@13.93.211.84:30303
    INFO  08-29 17:03:44     DiscoveryProtocol  bootnode: enode://78de8a09...2722344d@191.235.84.50:30303
    INFO  08-29 17:03:44     DiscoveryProtocol  bootnode: enode://158f8aab...0385e8e6@13.75.154.138:30303
    INFO  08-29 17:03:44     DiscoveryProtocol  bootnode: enode://1118980b...f0855082@52.74.57.123:30303
    INFO  08-29 17:03:44     DiscoveryProtocol  bootnode: enode://3f1d1204...b3ed0a99@13.93.211.84:30303
    INFO  08-29 17:03:44     DiscoveryProtocol  bootnode: enode://979b7fa2...aa3637f9@5.1.83.226:30303
    INFO  08-29 17:03:44     DiscoveryProtocol  bootnode: enode://81863f47...dd886701@193.70.55.37:30303
    INFO  08-29 17:03:44     DiscoveryProtocol  bootnode: enode://4afb3a91...8f140686@144.217.139.5:30303
    INFO  08-29 17:03:44     DiscoveryProtocol  bootnode: enode://c16d390b...fade404d@139.99.51.203:30303
    INFO  08-29 17:03:44     DiscoveryProtocol  bootnode: enode://4faf867a...c4a4b16b@139.99.160.213:30303
    INFO  08-29 17:03:44     DiscoveryProtocol  bootnode: enode://6a868ced...1db285f5@163.172.131.191:30303
    INFO  08-29 17:03:44     DiscoveryProtocol  bootnode: enode://66a48338...9d6006ba@212.47.247.103:30303
    INFO  08-29 17:03:44     DiscoveryProtocol  bootnode: enode://cd661146...d3022aa3@163.172.157.114:30303
    INFO  08-29 17:03:44     DiscoveryProtocol  bootnode: enode://1d1f7bcb...b5e31d49@138.201.223.35:30303
    INFO  08-29 17:03:44     DiscoveryProtocol  bootnode: enode://0cc5f5ff...e4b6440b@40.118.3.223:30305
    INFO  08-29 17:03:44     DiscoveryProtocol  bootnode: enode://1c7a64d7...15dcd2dc@40.118.3.223:30308
    INFO  08-29 17:03:44     DiscoveryProtocol  bootnode: enode://85c85d71...6e75daaf@40.118.3.223:30309
    INFO  08-29 17:03:44     DiscoveryProtocol  bootnode: enode://de471bcc...b723c786@54.94.239.50:30303
    INFO  08-29 17:03:44     DiscoveryProtocol  bootnode: enode://4cd540b2...6596936f@138.201.144.135:30303
    INFO  08-29 17:03:44     DiscoveryProtocol  bootnode: enode://01f76fa0...e33f4e3c@51.15.42.252:30303
    INFO  08-29 17:03:44     DiscoveryProtocol  bootnode: enode://2c9059f0...569bcf4b@163.172.171.38:30303
    INFO  08-29 17:03:44     DiscoveryProtocol  bootnode: enode://efe4f249...a4ba521c@163.172.187.252:30303
    INFO  08-29 17:03:44     DiscoveryProtocol  bootnode: enode://bcc72405...ecc3330e@136.243.154.244:30303
    INFO  08-29 17:03:44     DiscoveryProtocol  bootnode: enode://ed422768...f9501455@88.212.206.70:30303
    INFO  08-29 17:03:44     DiscoveryProtocol  bootnode: enode://cadc6e57...40dead1e@37.128.191.230:30303
    INFO  08-29 17:03:44     DiscoveryProtocol  bootnode: enode://595a9a06...aace65ec@46.20.235.22:30303
    INFO  08-29 17:03:44     DiscoveryProtocol  bootnode: enode://029178d6...40a0f56c@216.158.85.185:30303
    INFO  08-29 17:03:44     DiscoveryProtocol  bootnode: enode://fdd1b9bb...7b63f181@212.47.247.103:30303
    INFO  08-29 17:03:44     DiscoveryProtocol  bootnode: enode://cc26c967...a89f227b@52.79.241.155:30303
    INFO  08-29 17:03:44     DiscoveryProtocol  bootnode: enode://140872ce...25727e45@52.78.149.82:30303
```

### How was it fixed?

These two into lines were turned into debug lines. A booting trinity node now emits very few and mostly relevant linse:

```
(trinity) brian@beat:~/ef/trinity$ PYTHONWARNINGS=ignore::DeprecationWarning trinity --data-dir /tmp/trin-data-dir/ --preferred-node 'enode://6bec07bbb8e3ea36e195f9501e5b74e0ac4c914c923c5fe92b3d8fb0a12813ad44a0c6b530514f1618ea8d124538d0633ac76c48dbf7e97c8c1a9a55bb84dd1b@10.186.10.146:30303' --port 30304
    INFO  08-29 17:05:13               trinity  
      ______     _       _ __       
     /_  __/____(_)___  (_) /___  __
      / / / ___/ / __ \/ / __/ / / /
     / / / /  / / / / / / /_/ /_/ / 
    /_/ /_/  /_/_/ /_/_/\__/\__, /  
                           /____/   
    INFO  08-29 17:05:13               trinity  Started main process (pid=7700)
    INFO  08-29 17:05:13               trinity  Trinity/0.1.0a27/linux/cpython3.7.4
    INFO  08-29 17:05:13               trinity  Trinity DEBUG log file is created at /tmp/trin-data-dir/logs-eth1/trinity.log
    INFO  08-29 17:05:17                  root  Started DB server process (pid=7712)
    INFO  08-29 17:05:21  plugin(#JsonRpcServerPlugin)  Plugin started: JSON-RPC API (pid=7725)
    INFO  08-29 17:05:22             IPCServer  IPC started at: /tmp/trin-data-dir/ipcs-eth1/jsonrpc.ipc
    INFO  08-29 17:05:25  plugin(#NetworkDBPlugin)  Plugin started: Network Database (pid=7739)
    INFO  08-29 17:05:28  plugin(#PeerDiscoveryPlugin)  Plugin started: Discovery (pid=7766)
    INFO  08-29 17:05:28     DiscoveryProtocol  Preferred peers: (<Node(0x6bec07bbb8e3ea36e195f9501e5b74e0ac4c914c923c5fe92b3d8fb0a12813ad44a0c6b530514f1618ea8d124538d0633ac76c48dbf7e97c8c1a9a55bb84dd1b@10.186.10.146:30303)>,)
    INFO  08-29 17:05:30  plugin(#RequestServerPlugin)  Plugin started: Request Server (pid=7773)
    INFO  08-29 17:05:33   plugin(#UpnpPlugin)  Plugin started: Upnp (pid=7785)
    INFO  08-29 17:05:33           UPnPService  Setting up NAT portmap...
    INFO  08-29 17:05:36  plugin(#SyncerPlugin)  Plugin started: Sync / PeerPool (pid=7794)
    INFO  08-29 17:05:38            FullServer  Running server...
    INFO  08-29 17:05:38            FullServer  enode://060342f7374b408b0b86bfd6086d7414767119181739a3118fd00da66b27fca92879fa43fd7c9359f1e49774880edd8b67b9289dea9cf589c8c9700eabc17e4c@0.0.0.0:30304
    INFO  08-29 17:05:38            FullServer  network: 1
    INFO  08-29 17:05:38            FullServer  peers: max_peers=25
    INFO  08-29 17:05:38           ETHPeerPool  Connected peers: 0 inbound, 0 outbound
    INFO  08-29 17:05:38  FastThenFullChainSyncer  Starting fast-sync; current head: <BlockHeader #0 d4e56740>
    INFO  08-29 17:05:38           UPnPService  No UPNP-enabled devices found
 WARNING  08-29 17:05:39           ETHPeerPool  PeerCandidateRequest timed out to backend <trinity.plugins.builtin.network_db.eth1_peer_db.tracker.EventBusEth1PeerTracker object at 0x7fe8cb01a750>
    INFO  08-29 17:05:43   FastChainBodySyncer  blks=0     txs=0      bps=0    tps=0     elapsed=5.0  head=#0 d4e5..8fa3  age=49y8m1w
    INFO  08-29 17:05:48   FastChainBodySyncer  blks=0     txs=0      bps=0    tps=0     elapsed=5.0  head=#0 d4e5..8fa3  age=49y8m1w
```

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

[//]: # (See: https://trinity-client.readthedocs.io/en/latest/contributing.html#pull-requests)
- [ ] Add entry to the [release notes](https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![beaver-stick](https://user-images.githubusercontent.com/466333/63984327-99b5da00-ca7f-11e9-8648-c8a0731eeb0d.jpg)

