### PR TITLE
Added a missing call to BaseService.wait_for

### DIFF
--- a/trinity/event_bus.py
+++ b/trinity/event_bus.py
@@ -62,7 +62,7 @@ class PluginManagerService(BaseService):
             await self.cancellation()
 
     async def _handle_shutdown_request(self) -> None:
-        req = await self._endpoint.wait_for(ShutdownRequest)
+        req = await self.wait(self._endpoint.wait_for(ShutdownRequest))
         self._kill_trinity_fn(req.reason)
         self.cancel_nowait()
 


### PR DESCRIPTION
Found this while looking into our unclean shutdowns: shutdown is now ever-so-slightly cleaner.

### How was it fixed?


### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

[//]: # (See: https://trinity-client.readthedocs.io/en/latest/contributing.html#pull-requests)
- [ ] Add entry to the [release notes](https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![kitten-grass](https://user-images.githubusercontent.com/466333/63990924-a5fb6080-ca9a-11e9-81c7-3db61ef5718f.jpeg)
