### PR TITLE
Fix deprecation warning

### DIFF
--- a/newsfragments/1021.misc.rst
+++ b/newsfragments/1021.misc.rst
@@ -1,0 +1,1 @@
+Fix ``DeprecationWarning`` being issued from a regex.

--- a/trinity/plugins/builtin/syncer/cli.py
+++ b/trinity/plugins/builtin/syncer/cli.py
@@ -31,7 +31,7 @@ def is_block_hash(value: str) -> bool:
 
 
 def remove_non_digits(value: str) -> str:
-    return re.sub("\D", "", value)
+    return re.sub(r"\D", "", value)
 
 
 def parse_checkpoint_uri(uri: str) -> Checkpoint:


### PR DESCRIPTION
### What was wrong?

A regex was triggering a `DeprecationWarning`

### How was it fixed?

Fixed it.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

[//]: # (See: https://trinity-client.readthedocs.io/en/latest/contributing.html#pull-requests)
- [x] Add entry to the [release notes](https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![imgfave-2](https://user-images.githubusercontent.com/824194/64046935-83188d00-cb2a-11e9-9d6a-223d8715585b.jpeg)

