### PR TITLE
Peer pool no longer logs exception when cancelled

### DIFF
--- a/p2p/peer_pool.py
+++ b/p2p/peer_pool.py
@@ -375,6 +375,9 @@ class BasePeerPool(BaseService, AsyncIterable[BasePeer]):
             except COMMON_PEER_CONNECTION_EXCEPTIONS as e:
                 self.logger.debug("Could not complete handshake with %r: %s", remote, repr(e))
                 raise
+            except asyncio.CancelledError:
+                # no need to log this exception, this is expected
+                raise
             except Exception:
                 self.logger.exception("Unexpected error during auth/p2p handshake with %r", remote)
                 raise


### PR DESCRIPTION
### What was wrong?

More work on the #373 train; shutdowns often included some logs complaining about cancellation during a handshake:

```python
   ERROR  08-30 19:31:14           ETHPeerPool  Unexpected error during auth/p2p handshake with <Node(0xaacaac22fe17a296fb08a0181ee53b1b7634c71de19e3bf718ba1b188e9a87c1690ec686a3b84f37d71ea87f712e96637a1e249e4ef554a0e537b8a84360b20a@159.89.175.124:21000)>
Traceback (most recent call last):
  File "/home/brian/ef/trinity/p2p/peer_pool.py", line 349, in connect
    peer = await self.wait(self.get_peer_factory().handshake(remote))
  File "/home/brian/ef/trinity/p2p/cancellable.py", line 20, in wait
    return await self.wait_first(awaitable, token=token, timeout=timeout)
  File "/home/brian/ef/trinity/p2p/cancellable.py", line 42, in wait_first
    return await token_chain.cancellable_wait(*awaitables, timeout=timeout)
  File "/home/brian/.local/share/virtualenvs/trinity-mNs_Su9C/lib/python3.7/site-packages/cancel_token/token.py", line 133, in cancellable_wait
    loop=self.loop,
  File "/home/brian/.pyenv/versions/3.7.4/lib/python3.7/asyncio/tasks.py", line 389, in wait
    return await _wait(fs, timeout, return_when, loop)
  File "/home/brian/.pyenv/versions/3.7.4/lib/python3.7/asyncio/tasks.py", line 482, in _wait
    await waiter
concurrent.futures._base.CancelledError
```

### How was it fixed?

The relevant exception handler allows `CancelledError` exceptions through without logging them.

#### Cute Animal Picture

![meerkat](https://user-images.githubusercontent.com/466333/64059923-38befc80-cb7a-11e9-8a46-52fd70ddf5c6.jpg)
