### PR TITLE
Discv5 Minor Improvements

### DIFF
--- a/p2p/discv5/abc.py
+++ b/p2p/discv5/abc.py
@@ -6,6 +6,7 @@ from typing import (
     AsyncContextManager,
     AsyncIterable,
     Generic,
+    Optional,
     Type,
     TypeVar,
 )
@@ -14,6 +15,7 @@ from p2p.discv5.enr import (
     ENR,
 )
 from p2p.discv5.channel_services import (
+    Endpoint,
     IncomingMessage,
 )
 from p2p.discv5.identity_schemes import (
@@ -170,7 +172,11 @@ class MessageDispatcherAPI(ABC):
         ...
 
     @abstractmethod
-    async def request(self, receiver_node_id: NodeID, message: BaseMessage) -> IncomingMessage:
+    async def request(self,
+                      receiver_node_id: NodeID,
+                      message: BaseMessage,
+                      endpoint: Optional[Endpoint] = None,
+                      ) -> IncomingMessage:
         """Send a request to the given peer and return the response.
 
         This is the primary interface for requesting data from a peer. Internally, it will look up
@@ -178,6 +184,9 @@ class MessageDispatcherAPI(ABC):
         handler, send the request, wait for the response, and finally remove the handler again.
 
         This method cannot be used if the response consists of multiple messages.
+
+        If no endpoint is given, it will be queried from the ENR DB, raising a ValueError if it is
+        not present.
         """
         ...
 

--- a/p2p/discv5/abc.py
+++ b/p2p/discv5/abc.py
@@ -183,7 +183,7 @@ class MessageDispatcherAPI(ABC):
 
     @abstractmethod
     def add_request_handler(self,
-                            message_type: int,
+                            message_class: Type[BaseMessage],
                             ) -> ChannelHandlerSubscriptionAPI[IncomingMessage]:
         """Add a request handler for messages of a given type.
 

--- a/p2p/discv5/channel_services.py
+++ b/p2p/discv5/channel_services.py
@@ -84,6 +84,13 @@ class IncomingMessage(NamedTuple):
     def __str__(self) -> str:
         return f"{self.__class__.__name__}[{self.message.__class__.__name__}]"
 
+    def to_response(self, response_message: BaseMessage) -> "OutgoingMessage":
+        return OutgoingMessage(
+            message=response_message,
+            receiver_endpoint=self.sender_endpoint,
+            receiver_node_id=self.sender_node_id,
+        )
+
 
 class OutgoingMessage(NamedTuple):
     message: BaseMessage

--- a/p2p/discv5/message_dispatcher.py
+++ b/p2p/discv5/message_dispatcher.py
@@ -315,8 +315,8 @@ class MessageDispatcher(Service, MessageDispatcherAPI):
             self.logger.debug(
                 "Received %s from %s with request id %d as response to %s",
                 response,
-                outgoing_message,
                 encode_hex(receiver_node_id),
                 message.request_id,
+                outgoing_message,
             )
             return response

--- a/p2p/discv5/routing_table.py
+++ b/p2p/discv5/routing_table.py
@@ -2,7 +2,7 @@ from collections import (
     deque,
 )
 import logging
-import random
+import secrets
 from typing import (
     Any,
     Deque,
@@ -63,7 +63,7 @@ class FlatRoutingTable(Collection[NodeID]):
         return iter(self.entries)
 
     def get_random_entry(self) -> NodeID:
-        return random.choice(self.entries)
+        return secrets.choice(self.entries)
 
     def get_oldest_entry(self) -> NodeID:
         return self.entries[-1]

--- a/tests-trio/p2p-trio/test_message_dispatcher.py
+++ b/tests-trio/p2p-trio/test_message_dispatcher.py
@@ -159,16 +159,16 @@ async def test_request(message_dispatcher,
     response = PingMessageFactory(request_id=request_id)
 
     async def handle_request_on_remote():
-        outgoing_message = await outgoing_message_channels[1].receive()
-        assert outgoing_message.message == request
-        assert outgoing_message.receiver_endpoint == remote_endpoint
-        assert outgoing_message.receiver_node_id == remote_enr.node_id
+        async for outgoing_message in outgoing_message_channels[1]:
+            assert outgoing_message.message == request
+            assert outgoing_message.receiver_endpoint == remote_endpoint
+            assert outgoing_message.receiver_node_id == remote_enr.node_id
 
-        await incoming_message_channels[0].send(IncomingMessage(
-            message=response,
-            sender_endpoint=remote_endpoint,
-            sender_node_id=remote_enr.node_id,
-        ))
+            await incoming_message_channels[0].send(IncomingMessage(
+                message=response,
+                sender_endpoint=remote_endpoint,
+                sender_node_id=remote_enr.node_id,
+            ))
 
     nursery.start_soon(handle_request_on_remote)
 
@@ -177,3 +177,10 @@ async def test_request(message_dispatcher,
     assert received_response.message == response
     assert received_response.sender_endpoint == remote_endpoint
     assert received_response.sender_node_id == remote_enr.node_id
+
+    received_response_with_explicit_endpoint = await message_dispatcher.request(
+        remote_enr.node_id,
+        request,
+        endpoint=remote_endpoint,
+    )
+    assert received_response_with_explicit_endpoint == received_response

--- a/tests-trio/p2p-trio/test_message_dispatcher.py
+++ b/tests-trio/p2p-trio/test_message_dispatcher.py
@@ -110,9 +110,7 @@ async def test_request_handling(message_dispatcher,
                                 remote_endpoint):
     ping_send_channel, ping_receive_channel = trio.open_memory_channel(0)
 
-    async with message_dispatcher.add_request_handler(
-        PingMessage.message_type,
-    ) as request_subscription:
+    async with message_dispatcher.add_request_handler(PingMessage) as request_subscription:
 
         incoming_message = IncomingMessage(
             message=PingMessageFactory(),


### PR DESCRIPTION
A couple of very minor improvements, mostly in the message dispatcher, to make the follow up a little bit more digestible:

- add `IncomingMessage.to_response` for convenience which creates a corresponding response (i.e. an `OutgoingMessage` with the same endpoint and node id)
- add `endpoint` as an optional argument to `MessageDispatcher.request` to avoid loading it from the ENR DB (used in case we request something in response to an incoming message)
- Register request handlers by message class, instead of the message type int: Pretty much equivalent, but just a tiny bit easier to write
- Use `secrets.choice` instead of `random.choice` in routing table as suggested [here](https://github.com/ethereum/trinity/pull/1003#discussion_r319182656) (forgot to do it in the PR)

#### Cute Animal Picture

![animal-blur-branch-416179](https://user-images.githubusercontent.com/29854669/64076146-5d71bc00-ccc1-11e9-934e-44be0cd81bd8.jpg)
