### PR TITLE
Discv5 ping handler

### DIFF
--- a/p2p/discv5/abc.py
+++ b/p2p/discv5/abc.py
@@ -6,6 +6,7 @@ from typing import (
     AsyncContextManager,
     AsyncIterable,
     Generic,
+    Optional,
     Type,
     TypeVar,
 )
@@ -14,6 +15,7 @@ from p2p.discv5.enr import (
     ENR,
 )
 from p2p.discv5.channel_services import (
+    Endpoint,
     IncomingMessage,
 )
 from p2p.discv5.identity_schemes import (
@@ -170,7 +172,11 @@ class MessageDispatcherAPI(ABC):
         ...
 
     @abstractmethod
-    async def request(self, receiver_node_id: NodeID, message: BaseMessage) -> IncomingMessage:
+    async def request(self,
+                      receiver_node_id: NodeID,
+                      message: BaseMessage,
+                      endpoint: Optional[Endpoint] = None,
+                      ) -> IncomingMessage:
         """Send a request to the given peer and return the response.
 
         This is the primary interface for requesting data from a peer. Internally, it will look up
@@ -178,6 +184,9 @@ class MessageDispatcherAPI(ABC):
         handler, send the request, wait for the response, and finally remove the handler again.
 
         This method cannot be used if the response consists of multiple messages.
+
+        If no endpoint is given, it will be queried from the ENR DB, raising a ValueError if it is
+        not present.
         """
         ...
 

--- a/p2p/discv5/abc.py
+++ b/p2p/discv5/abc.py
@@ -183,7 +183,7 @@ class MessageDispatcherAPI(ABC):
 
     @abstractmethod
     def add_request_handler(self,
-                            message_type: int,
+                            message_class: Type[BaseMessage],
                             ) -> ChannelHandlerSubscriptionAPI[IncomingMessage]:
         """Add a request handler for messages of a given type.
 

--- a/p2p/discv5/channel_services.py
+++ b/p2p/discv5/channel_services.py
@@ -84,6 +84,13 @@ class IncomingMessage(NamedTuple):
     def __str__(self) -> str:
         return f"{self.__class__.__name__}[{self.message.__class__.__name__}]"
 
+    def to_response(self, response_message: BaseMessage) -> "OutgoingMessage":
+        return OutgoingMessage(
+            message=response_message,
+            receiver_endpoint=self.sender_endpoint,
+            receiver_node_id=self.sender_node_id,
+        )
+
 
 class OutgoingMessage(NamedTuple):
     message: BaseMessage

--- a/p2p/discv5/constants.py
+++ b/p2p/discv5/constants.py
@@ -36,3 +36,5 @@ MAX_REQUEST_ID_ATTEMPTS = 100  # number of attempts we take to guess a available
 # ENR keys for endpoint information
 IP_V4_ADDRESS_ENR_KEY = b"ip"
 UDP_PORT_ENR_KEY = b"udp"
+
+REQUEST_RESPONSE_TIMEOUT = 0.5  # timeout for waiting for response after request was sent

--- a/p2p/discv5/message_dispatcher.py
+++ b/p2p/discv5/message_dispatcher.py
@@ -315,8 +315,8 @@ class MessageDispatcher(Service, MessageDispatcherAPI):
             self.logger.debug(
                 "Received %s from %s with request id %d as response to %s",
                 response,
-                outgoing_message,
                 encode_hex(receiver_node_id),
                 message.request_id,
+                outgoing_message,
             )
             return response

--- a/p2p/discv5/routing_table.py
+++ b/p2p/discv5/routing_table.py
@@ -2,7 +2,7 @@ from collections import (
     deque,
 )
 import logging
-import random
+import secrets
 from typing import (
     Any,
     Deque,
@@ -63,7 +63,7 @@ class FlatRoutingTable(Collection[NodeID]):
         return iter(self.entries)
 
     def get_random_entry(self) -> NodeID:
-        return random.choice(self.entries)
+        return secrets.choice(self.entries)
 
     def get_oldest_entry(self) -> NodeID:
         return self.entries[-1]

--- a/p2p/discv5/routing_table_manager.py
+++ b/p2p/discv5/routing_table_manager.py
@@ -1,5 +1,4 @@
 import logging
-import time
 
 from eth_utils import (
     encode_hex,

--- a/p2p/discv5/routing_table_manager.py
+++ b/p2p/discv5/routing_table_manager.py
@@ -1,0 +1,270 @@
+import logging
+import time
+
+from eth_utils import (
+    encode_hex,
+)
+
+import trio
+from trio.abc import (
+    SendChannel,
+)
+
+from p2p.trio_service import (
+    Service,
+)
+
+from p2p.discv5.abc import (
+    EnrDbApi,
+    MessageDispatcherAPI,
+)
+from p2p.discv5.channel_services import (
+    IncomingMessage,
+    OutgoingMessage,
+)
+from p2p.discv5.constants import (
+    REQUEST_RESPONSE_TIMEOUT,
+)
+from p2p.discv5.endpoint_tracker import (
+    EndpointVote,
+)
+from p2p.discv5.enr import (
+    ENR,
+)
+from p2p.discv5.messages import (
+    FindNodeMessage,
+    NodesMessage,
+    PingMessage,
+    PongMessage,
+)
+from p2p.discv5.routing_table import (
+    FlatRoutingTable,
+)
+from p2p.discv5.typing import (
+    NodeID,
+)
+
+
+class BaseRoutingTableManagerComponent(Service):
+    """Base class for services that participate in managing the routing table."""
+
+    logger = logging.getLogger("p2p.discv5.routing_table_manager.BaseRoutingTableManager")
+
+    def __init__(self,
+                 local_node_id: NodeID,
+                 routing_table: FlatRoutingTable,
+                 message_dispatcher: MessageDispatcherAPI,
+                 enr_db: EnrDbApi,
+                 ) -> None:
+        self.local_node_id = local_node_id
+        self.routing_table = routing_table
+        self.message_dispatcher = message_dispatcher
+        self.enr_db = enr_db
+
+    def update_routing_table(self, node_id: NodeID) -> None:
+        """Update a peer's entry in the routing table.
+
+        This method should be called, whenever we receive a message from them.
+        """
+        self.logger.debug("Updating %s in routing table", encode_hex(node_id))
+        self.routing_table.add_or_update(node_id)
+
+    async def get_local_enr(self) -> ENR:
+        """Get the local enr from the ENR DB."""
+        try:
+            local_enr = await self.enr_db.get(self.local_node_id)
+        except KeyError:
+            raise ValueError(
+                f"Local ENR with node id {encode_hex(self.local_node_id)} not "
+                f"present in db"
+            )
+        else:
+            return local_enr
+
+    async def maybe_request_remote_enr(self, incoming_message: IncomingMessage) -> None:
+        """Request the peers ENR if there is a newer version according to a ping or pong."""
+        if not isinstance(incoming_message.message, (PingMessage, PongMessage)):
+            raise TypeError(
+                f"Only ping and pong messages contain an ENR sequence number, got "
+                f"{incoming_message}"
+            )
+
+        try:
+            remote_enr = await self.enr_db.get(incoming_message.sender_node_id)
+        except KeyError:
+            self.logger.warning(
+                "No ENR of %s present in the database even though it should post handshake. "
+                "Requesting it now.",
+                encode_hex(incoming_message.sender_node_id)
+            )
+            request_update = True
+        else:
+            current_sequence_number = remote_enr.sequence_number
+            advertized_sequence_number = incoming_message.message.enr_seq
+
+            if current_sequence_number < advertized_sequence_number:
+                self.logger.debug(
+                    "ENR advertized by %s is newer than ours (sequence number %d > %d)",
+                    encode_hex(incoming_message.sender_node_id),
+                    advertized_sequence_number,
+                    current_sequence_number,
+                )
+                request_update = True
+            elif current_sequence_number == advertized_sequence_number:
+                self.logger.debug(
+                    "ENR of %s is up to date (sequence number %d)",
+                    encode_hex(incoming_message.sender_node_id),
+                    advertized_sequence_number,
+                )
+                request_update = False
+            elif current_sequence_number > advertized_sequence_number:
+                self.logger.warning(
+                    "Peer %s advertizes apparently outdated ENR (sequence number %d < %d)",
+                    encode_hex(incoming_message.sender_node_id),
+                    advertized_sequence_number,
+                    current_sequence_number,
+                )
+                request_update = False
+            else:
+                raise Exception("Invariant: Unreachable")
+
+        if request_update:
+            await self.request_remote_enr(incoming_message)
+
+    async def request_remote_enr(self, incoming_message: IncomingMessage) -> None:
+        """Request the ENR of the sender of an incoming message and store it in the ENR db."""
+        self.logger.debug("Requesting ENR from %s", encode_hex(incoming_message.sender_node_id))
+
+        find_nodes_message = FindNodeMessage(
+            request_id=self.message_dispatcher.get_free_request_id(incoming_message.sender_node_id),
+            distance=0,  # request enr of the peer directly
+        )
+        try:
+            with trio.fail_after(REQUEST_RESPONSE_TIMEOUT):
+                response = await self.message_dispatcher.request(
+                    incoming_message.sender_node_id,
+                    find_nodes_message,
+                    endpoint=incoming_message.sender_endpoint,
+                )
+        except trio.TooSlowError:
+            self.logger.warning(
+                "FindNode request to %s has timed out",
+                encode_hex(incoming_message.sender_node_id),
+            )
+            return
+
+        sender_node_id = response.sender_node_id
+        self.update_routing_table(sender_node_id)
+
+        if not isinstance(response.message, NodesMessage):
+            self.logger.warning(
+                "Peer %s responded to FindNode with %s instead of Nodes message",
+                encode_hex(sender_node_id),
+                response.message.__class__.__name__,
+            )
+            return
+        self.logger.debug("Received Nodes message from %s", encode_hex(sender_node_id))
+
+        if len(response.message.enrs) == 0:
+            self.logger.warning(
+                "Peer %s responded to FindNode with an empty Nodes message",
+                encode_hex(sender_node_id),
+            )
+        elif len(response.message.enrs) > 1:
+            self.logger.warning(
+                "Peer %s responded to FindNode with more than one ENR",
+                encode_hex(incoming_message.sender_node_id),
+            )
+
+        for enr in response.message.enrs:
+            if enr.node_id != sender_node_id:
+                self.logger.warning(
+                    "Peer %s responded to FindNode with ENR from %s",
+                    encode_hex(sender_node_id),
+                    encode_hex(response.message.enrs[0].node_id),
+                )
+            await self.enr_db.insert_or_update(enr)
+
+
+class PingHandler(BaseRoutingTableManagerComponent):
+    """Responds to Pings with Pongs and requests ENR updates."""
+
+    logger = logging.getLogger("p2p.discv5.routing_table_manager.PingHandler")
+
+    def __init__(self,
+                 local_node_id: NodeID,
+                 routing_table: FlatRoutingTable,
+                 message_dispatcher: MessageDispatcherAPI,
+                 enr_db: EnrDbApi,
+                 outgoing_message_send_channel: SendChannel[OutgoingMessage]
+                 ) -> None:
+        super().__init__(local_node_id, routing_table, message_dispatcher, enr_db)
+        self.outgoing_message_send_channel = outgoing_message_send_channel
+
+    async def run(self) -> None:
+        channel_handler_subscription = self.message_dispatcher.add_request_handler(PingMessage)
+        async with channel_handler_subscription:
+            async for incoming_message in channel_handler_subscription:
+                self.logger.debug(
+                    "Handling %s from %s",
+                    incoming_message,
+                    encode_hex(incoming_message.sender_node_id),
+                )
+                self.update_routing_table(incoming_message.sender_node_id)
+                await self.respond_with_pong(incoming_message)
+                self.manager.run_task(self.maybe_request_remote_enr, incoming_message)
+
+    async def respond_with_pong(self, incoming_message: IncomingMessage) -> None:
+        if not isinstance(incoming_message.message, PingMessage):
+            raise TypeError(
+                f"Can only respond with Pong to Ping, not "
+                f"{incoming_message.message.__class__.__name__}"
+            )
+
+        local_enr = await self.get_local_enr()
+
+        pong = PongMessage(
+            request_id=incoming_message.message.request_id,
+            enr_seq=local_enr.sequence_number,
+            packet_ip=incoming_message.sender_endpoint.ip_address,
+            packet_port=incoming_message.sender_endpoint.port,
+        )
+        outgoing_message = incoming_message.to_response(pong)
+        self.logger.debug(
+            "Responding with Pong to %s",
+            encode_hex(outgoing_message.receiver_node_id),
+        )
+        await self.outgoing_message_send_channel.send(outgoing_message)
+
+
+class RoutingTableManager(Service):
+    """Manages the routing table. The actual work is delegated to a few sub components."""
+
+    def __init__(self,
+                 local_node_id: NodeID,
+                 routing_table: FlatRoutingTable,
+                 message_dispatcher: MessageDispatcherAPI,
+                 enr_db: EnrDbApi,
+                 outgoing_message_send_channel: SendChannel[OutgoingMessage],
+                 endpoint_vote_send_channel: SendChannel[EndpointVote],
+                 ) -> None:
+        shared_component_kwargs = {
+            "local_node_id": NodeID,
+            "routing_table": FlatRoutingTable,
+            "message_dispatcher": MessageDispatcherAPI,
+            "enr_db": EnrDbApi,
+        }
+
+        self.ping_handler = PingHandler(
+            outgoing_message_send_channel=outgoing_message_send_channel,
+            **shared_component_kwargs,
+        )
+
+    async def run(self) -> None:
+        components = (
+            self.ping_handler,
+        )
+        for component in components:
+            self.manager.run_daemon_task(component.run)
+
+        await self.manager.wait_cancelled()

--- a/p2p/tools/factories/discovery.py
+++ b/p2p/tools/factories/discovery.py
@@ -28,6 +28,7 @@ from p2p.discv5.constants import (
 from p2p.discv5.channel_services import (
     Endpoint,
     IncomingPacket,
+    IncomingMessage,
 )
 from p2p.discv5.endpoint_tracker import (
     EndpointVote,
@@ -170,6 +171,15 @@ class PingMessageFactory(factory.Factory):
 
     request_id = factory.Faker("pyint", min_value=0, max_value=100)
     enr_seq = factory.Faker("pyint", min_value=0, max_value=100)
+
+
+class IncomingMessageFactory(factory.Factory):
+    class Meta:
+        model = IncomingMessage
+
+    message = factory.SubFactory(PingMessageFactory)
+    sender_endpoint = factory.SubFactory(EndpointFactory)
+    sender_node_id = factory.SubFactory(NodeIDFactory)
 
 
 class HandshakeInitiatorFactory(factory.Factory):

--- a/tests-trio/p2p-trio/test_message_dispatcher.py
+++ b/tests-trio/p2p-trio/test_message_dispatcher.py
@@ -159,16 +159,16 @@ async def test_request(message_dispatcher,
     response = PingMessageFactory(request_id=request_id)
 
     async def handle_request_on_remote():
-        outgoing_message = await outgoing_message_channels[1].receive()
-        assert outgoing_message.message == request
-        assert outgoing_message.receiver_endpoint == remote_endpoint
-        assert outgoing_message.receiver_node_id == remote_enr.node_id
+        async for outgoing_message in outgoing_message_channels[1]:
+            assert outgoing_message.message == request
+            assert outgoing_message.receiver_endpoint == remote_endpoint
+            assert outgoing_message.receiver_node_id == remote_enr.node_id
 
-        await incoming_message_channels[0].send(IncomingMessage(
-            message=response,
-            sender_endpoint=remote_endpoint,
-            sender_node_id=remote_enr.node_id,
-        ))
+            await incoming_message_channels[0].send(IncomingMessage(
+                message=response,
+                sender_endpoint=remote_endpoint,
+                sender_node_id=remote_enr.node_id,
+            ))
 
     nursery.start_soon(handle_request_on_remote)
 
@@ -177,3 +177,10 @@ async def test_request(message_dispatcher,
     assert received_response.message == response
     assert received_response.sender_endpoint == remote_endpoint
     assert received_response.sender_node_id == remote_enr.node_id
+
+    received_response_with_explicit_endpoint = await message_dispatcher.request(
+        remote_enr.node_id,
+        request,
+        endpoint=remote_endpoint,
+    )
+    assert received_response_with_explicit_endpoint == received_response

--- a/tests-trio/p2p-trio/test_message_dispatcher.py
+++ b/tests-trio/p2p-trio/test_message_dispatcher.py
@@ -110,9 +110,7 @@ async def test_request_handling(message_dispatcher,
                                 remote_endpoint):
     ping_send_channel, ping_receive_channel = trio.open_memory_channel(0)
 
-    async with message_dispatcher.add_request_handler(
-        PingMessage.message_type,
-    ) as request_subscription:
+    async with message_dispatcher.add_request_handler(PingMessage) as request_subscription:
 
         incoming_message = IncomingMessage(
             message=PingMessageFactory(),

--- a/tests-trio/p2p-trio/test_routing_table_manager.py
+++ b/tests-trio/p2p-trio/test_routing_table_manager.py
@@ -1,0 +1,185 @@
+import pytest
+
+import pytest_trio
+
+import trio
+from trio.testing import (
+    wait_all_tasks_blocked,
+)
+
+from p2p.discv5.enr_db import (
+    MemoryEnrDb,
+)
+from p2p.discv5.identity_schemes import (
+    default_identity_scheme_registry,
+)
+from p2p.discv5.messages import (
+    FindNodeMessage,
+    PongMessage,
+)
+from p2p.discv5.message_dispatcher import (
+    MessageDispatcher,
+)
+from p2p.discv5.routing_table import (
+    FlatRoutingTable,
+)
+from p2p.discv5.routing_table_manager import (
+    PingHandler,
+)
+
+from p2p.tools.factories.discovery import (
+    EndpointFactory,
+    ENRFactory,
+    NodeIDFactory,
+    IncomingMessageFactory,
+    PingMessageFactory,
+)
+
+from p2p.trio_service import (
+    background_service,
+)
+
+
+@pytest.fixture
+def incoming_message_channels():
+    return trio.open_memory_channel(0)
+
+
+@pytest.fixture
+def outgoing_message_channels():
+    return trio.open_memory_channel(0)
+
+
+@pytest.fixture
+def local_enr():
+    return ENRFactory()
+
+
+@pytest.fixture
+def remote_enr(remote_endpoint):
+    return ENRFactory(
+        custom_kv_pairs={
+            b"ip": remote_endpoint.ip_address,
+            b"udp": remote_endpoint.port,
+        },
+    )
+
+
+@pytest.fixture
+def remote_endpoint():
+    return EndpointFactory()
+
+
+@pytest.fixture
+def routing_table(remote_enr):
+    routing_table = FlatRoutingTable()
+    routing_table.add(remote_enr.node_id)
+    return routing_table
+
+
+@pytest_trio.trio_fixture
+async def enr_db(local_enr, remote_enr):
+    enr_db = MemoryEnrDb(default_identity_scheme_registry)
+    await enr_db.insert(local_enr)
+    await enr_db.insert(remote_enr)
+    return enr_db
+
+
+@pytest_trio.trio_fixture
+async def message_dispatcher(enr_db, incoming_message_channels, outgoing_message_channels):
+    message_dispatcher = MessageDispatcher(
+        enr_db=enr_db,
+        incoming_message_receive_channel=incoming_message_channels[1],
+        outgoing_message_send_channel=outgoing_message_channels[0],
+    )
+    async with background_service(message_dispatcher):
+        yield message_dispatcher
+
+
+@pytest_trio.trio_fixture
+async def ping_handler(local_enr,
+                       routing_table,
+                       message_dispatcher,
+                       enr_db,
+                       incoming_message_channels,
+                       outgoing_message_channels):
+    ping_handler = PingHandler(
+        local_node_id=local_enr.node_id,
+        routing_table=routing_table,
+        message_dispatcher=message_dispatcher,
+        enr_db=enr_db,
+        outgoing_message_send_channel=outgoing_message_channels[0],
+    )
+    async with background_service(ping_handler):
+        yield ping_handler
+
+
+@pytest.mark.trio
+async def test_ping_handler_sends_pong(ping_handler,
+                                       incoming_message_channels,
+                                       outgoing_message_channels,
+                                       local_enr):
+    ping = PingMessageFactory()
+    incoming_message = IncomingMessageFactory(message=ping)
+    await incoming_message_channels[0].send(incoming_message)
+    await wait_all_tasks_blocked()
+
+    outgoing_message = outgoing_message_channels[1].receive_nowait()
+    assert isinstance(outgoing_message.message, PongMessage)
+    assert outgoing_message.message.request_id == ping.request_id
+    assert outgoing_message.message.enr_seq == local_enr.sequence_number
+    assert outgoing_message.receiver_endpoint == incoming_message.sender_endpoint
+    assert outgoing_message.receiver_node_id == incoming_message.sender_node_id
+
+
+@pytest.mark.trio
+async def test_ping_handler_updates_routing_table(ping_handler,
+                                                  incoming_message_channels,
+                                                  outgoing_message_channels,
+                                                  local_enr,
+                                                  remote_enr,
+                                                  routing_table):
+    other_node_id = NodeIDFactory()
+    routing_table.add(other_node_id)
+    assert routing_table.get_oldest_entry() == remote_enr.node_id
+
+    ping = PingMessageFactory()
+    incoming_message = IncomingMessageFactory(
+        message=ping,
+        sender_node_id=remote_enr.node_id,
+    )
+    await incoming_message_channels[0].send(incoming_message)
+    await wait_all_tasks_blocked()
+
+    assert routing_table.get_oldest_entry() == other_node_id
+
+
+@pytest.mark.trio
+async def test_ping_handler_requests_updated_enr(ping_handler,
+                                                 incoming_message_channels,
+                                                 outgoing_message_channels,
+                                                 local_enr,
+                                                 remote_enr,
+                                                 routing_table):
+    ping = PingMessageFactory(enr_seq=remote_enr.sequence_number + 1)
+    incoming_message = IncomingMessageFactory(message=ping)
+    await incoming_message_channels[0].send(incoming_message)
+
+    await wait_all_tasks_blocked()
+    first_outgoing_message = outgoing_message_channels[1].receive_nowait()
+    await wait_all_tasks_blocked()
+    second_outgoing_message = outgoing_message_channels[1].receive_nowait()
+
+    assert {
+        first_outgoing_message.message.__class__,
+        second_outgoing_message.message.__class__,
+    } == {PongMessage, FindNodeMessage}
+
+    outgoing_find_node = (
+        first_outgoing_message if isinstance(first_outgoing_message.message, FindNodeMessage)
+        else second_outgoing_message
+    )
+
+    assert outgoing_find_node.message.distance == 0
+    assert outgoing_find_node.receiver_endpoint == incoming_message.sender_endpoint
+    assert outgoing_find_node.receiver_node_id == incoming_message.sender_node_id


### PR DESCRIPTION
Builds on top of #1025. Only the last two commits are new.

This PR implements the basic architecture of the routing table manager and the first of its components, the ping handler.

The routing table manager is quite simple: All it does is start a bunch of subservices that do the real work. The components derive from a common base class which contains some shared functionality. Originally, I've implemented all functionality in a single class, but it got quite big for no good reason, so I split it up.

For every incoming ping, the ping handler's job is to

- add the sender to the routing table or update its position in the routing table
- respond with an appropriate pong message
- if the ENR we have of the peer is outdated based on the sequence number in the ping message, ask for an update with a FindNode request

#### Cute Animal Picture

![animal-animal-photography-avian-2679504](https://user-images.githubusercontent.com/29854669/64076716-91041480-ccc8-11e9-9d52-89f98e3df34b.jpg)