### PR TITLE
Discv5 Ping Sender

### DIFF
--- a/p2p/discv5/constants.py
+++ b/p2p/discv5/constants.py
@@ -33,8 +33,5 @@ DATAGRAM_BUFFER_SIZE = 2048
 MAX_REQUEST_ID = 2**32 - 1  # highest request id used for outgoing requests
 MAX_REQUEST_ID_ATTEMPTS = 100  # number of attempts we take to guess a available request id
 
-# ENR keys for endpoint information
-IP_V4_ADDRESS_ENR_KEY = b"ip"
-UDP_PORT_ENR_KEY = b"udp"
-
 REQUEST_RESPONSE_TIMEOUT = 0.5  # timeout for waiting for response after request was sent
+ROUTING_TABLE_PING_INTERVAL = 5  # interval of outgoing pings sent to maintain the routing table

--- a/p2p/discv5/routing_table_manager.py
+++ b/p2p/discv5/routing_table_manager.py
@@ -10,6 +10,10 @@ from trio.abc import (
     SendChannel,
 )
 
+from mypy_extensions import (
+    TypedDict,
+)
+
 from p2p.trio_service import (
     Service,
 )
@@ -376,12 +380,18 @@ class RoutingTableManager(Service):
                  outgoing_message_send_channel: SendChannel[OutgoingMessage],
                  endpoint_vote_send_channel: SendChannel[EndpointVote],
                  ) -> None:
-        shared_component_kwargs = {
+        SharedComponentKwargType = TypedDict("SharedComponentKwargType", {
+            "local_node_id": NodeID,
+            "routing_table": FlatRoutingTable,
+            "message_dispatcher": MessageDispatcherAPI,
+            "enr_db": EnrDbApi,
+        })
+        shared_component_kwargs = SharedComponentKwargType({
             "local_node_id": local_node_id,
             "routing_table": routing_table,
             "message_dispatcher": message_dispatcher,
             "enr_db": enr_db,
-        }
+        })
 
         self.ping_handler = PingHandler(
             outgoing_message_send_channel=outgoing_message_send_channel,


### PR DESCRIPTION
Builds on top of #1027, please only review the last commit.

This implements the last component for the most basic version of the routing table manager. It regularly pings the oldest node in the routing table. If they respond in time, they are pushed to the top.

#### Cute Animal Picture


![put a cute animal picture link inside the parentheses](https://user-images.githubusercontent.com/29854669/64077273-0d015b00-cccf-11e9-8867-b2bb4849ec36.jpg)