### PR TITLE
Fix deprecated regex syntax

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -125,7 +125,7 @@ def to_package_name(dependency):
     """
     Turn a dependency (e.g. "blspy>=0.1.8,<1") into the package name (e.g. "blspy")
     """
-    return re.sub("[!=<>](.|)+", "", dependency)
+    return re.sub(r"[!=<>](.|)+", "", dependency)
 
 
 def filter_dependencies(package_list, *package_name):


### PR DESCRIPTION
### What was wrong?

Using string syntax for the regex in `re.sub` is deprecated.

### How was it fixed?

Put an `r` in front of the string.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

[//]: # (See: https://trinity-client.readthedocs.io/en/latest/contributing.html#pull-requests)
- [ ] ~~Add entry to the release notes~~

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://i.pinimg.com/236x/ee/52/68/ee52689c305f386063d394b5d324dee1--smiling-animals-wild-animals.jpg)
