### PR TITLE
Expose API to check if a request is active

### DIFF
--- a/trinity/protocol/common/exchanges.py
+++ b/trinity/protocol/common/exchanges.py
@@ -89,3 +89,7 @@ class BaseExchange(ABC, Generic[TRequestPayload, TResponsePayload, TResult]):
         Issue the request to the peer for the desired data
         """
         ...
+
+    @property
+    def is_requesting(self) -> bool:
+        return self._manager.is_requesting

--- a/trinity/protocol/common/managers.py
+++ b/trinity/protocol/common/managers.py
@@ -104,7 +104,7 @@ class ResponseCandidateStream(
 
         try:
             self._request(request)
-            while self._is_pending():
+            while self.is_pending:
                 timeout_remaining = max(0, total_timeout - (time.perf_counter() - start_at))
 
                 try:
@@ -200,7 +200,8 @@ class ResponseCandidateStream(
         future: 'asyncio.Future[TResponsePayload]' = asyncio.Future()
         self.pending_request = (time.perf_counter(), future)
 
-    def _is_pending(self) -> bool:
+    @property
+    def is_pending(self) -> bool:
         return self.pending_request is not None
 
     async def _cleanup(self) -> None:
@@ -350,3 +351,7 @@ class ExchangeManager(Generic[TRequestPayload, TResponsePayload, TResult]):
         This service that needs to be running for calls to execute properly
         """
         return self._response_stream
+
+    @property
+    def is_requesting(self) -> bool:
+        return self._response_stream is not None and self._response_stream.is_pending


### PR DESCRIPTION
### What was wrong?

It is useful during Beam Sync to understand whether a request is already active for a peer, but the API is private.

### How was it fixed?

Expose `is_requesting` API

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

[//]: # (See: https://trinity-client.readthedocs.io/en/latest/contributing.html#pull-requests)
- [x] ~~Add entry to the [release notes](https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)~~

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](http://www.unmissablejapan.com/etcetera/wildlife-images/ryukyu-wild-boar.jpg)
