### PR TITLE
A bunch of minor fixups, especially "Attempted to send msg ... to disconnected peer" & "Peer is no longer alive but had not been removed from pool"

### DIFF
--- a/p2p/peer.py
+++ b/p2p/peer.py
@@ -38,6 +38,7 @@ from p2p.abc import (
 from p2p.constants import BLACKLIST_SECONDS_BAD_PROTOCOL
 from p2p.disconnect import DisconnectReason
 from p2p.exceptions import (
+    PeerConnectionLost,
     UnknownProtocol,
 )
 from p2p.connection import Connection
@@ -370,7 +371,10 @@ class BasePeer(BaseService):
             )
 
         self.logger.debug("Disconnecting from remote peer %s; reason: %s", self.remote, reason.name)
-        self.base_protocol.send_disconnect(reason)
+        try:
+            self.base_protocol.send_disconnect(reason)
+        except PeerConnectionLost:
+            self.logger.debug("%s was already disconnected", self.remote)
         self.cancel_nowait()
 
     async def disconnect(self, reason: DisconnectReason) -> None:

--- a/p2p/peer_pool.py
+++ b/p2p/peer_pool.py
@@ -484,10 +484,13 @@ class BasePeerPool(BaseService, AsyncIterable[BasePeer]):
                     subscribers, longest_queue.__class__.__name__, longest_queue.queue_size)
 
             self.logger.debug("== Peer details == ")
-            for peer in self.connected_nodes.values():
+            # make a copy, because we might edit the original during iteration
+            peers = tuple(self.connected_nodes.values())
+            for peer in peers:
                 if not peer.is_running:
                     self.logger.warning(
-                        "%s is no longer alive but has not been removed from pool", peer)
+                        "%s is no longer alive but had not been removed from pool", peer)
+                    self._peer_finished(peer)
                     continue
                 self.logger.debug(
                     "%s: uptime=%s, received_msgs=%d",

--- a/p2p/peer_pool.py
+++ b/p2p/peer_pool.py
@@ -455,7 +455,7 @@ class BasePeerPool(BaseService, AsyncIterable[BasePeer]):
             self.logger.warning(
                 "%s finished but was not found in connected_nodes (%s)",
                 peer,
-                tuple(sorted(self.connected_nodes.values())),
+                tuple(self.connected_nodes.values()),
             )
 
         for subscriber in self._subscribers:

--- a/p2p/transport.py
+++ b/p2p/transport.py
@@ -300,9 +300,8 @@ class Transport(TransportAPI):
         cmd_id = get_devp2p_cmd_id(body)
         self.logger.debug2("Sending msg with cmd id %d to %s", cmd_id, self)
         if self.is_closing:
-            self.logger.error(
+            raise PeerConnectionLost(
                 "Attempted to send msg with cmd id %d to disconnected peer %s", cmd_id, self)
-            return
 
         self.write(self._encrypt(header, body))
 

--- a/trinity/sync/beam/importer.py
+++ b/trinity/sync/beam/importer.py
@@ -451,7 +451,7 @@ def partial_speculative_execute(
         except ValidationError as exc:
             preview_time = t.elapsed
             vm.logger.debug(
-                "Speculative transactions %d failed for %s after %.1fs: %s",
+                "Speculative transactions %s failed for %s after %.1fs: %s",
                 transactions,
                 header,
                 preview_time,


### PR DESCRIPTION
### What was wrong?

Handful of minor issues:
- catch a `PeerConnectionLost` in disconnect
- a warning log was broken, trying to sort peers (which are unsortable)
- peers seem to sometimes be stuck in a disconnecting state, and printing error logs
- a bug in the formatting of a beam importer log
- Perpetually got "Peer is no longer alive but had not been removed from pool"

### How was it fixed?

Fixed things. Notably:
- when trying to send a message to a disconnected peer, raise a `PeerConnectionLost`
- when the peer pool log notices a zombie peer, remove it from the pool

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

[//]: # (See: https://trinity-client.readthedocs.io/en/latest/contributing.html#pull-requests)
- [x] ~~Add entry to the [release notes](https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)~~

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](http://www.unmissablejapan.com/etcetera/wildlife-images/red-squirrel.jpg)
