### PR TITLE
Handle NoMatchingPeerCapabilities when receiving handshake

### DIFF
--- a/trinity/server.py
+++ b/trinity/server.py
@@ -23,6 +23,7 @@ from p2p.constants import DEFAULT_MAX_PEERS, DEVP2P_V5
 from p2p.disconnect import DisconnectReason
 from p2p.exceptions import (
     HandshakeFailure,
+    NoMatchingPeerCapabilities,
     PeerConnectionLost,
 )
 from p2p.handshake import DevP2PHandshakeParams
@@ -144,6 +145,7 @@ class BaseServer(BaseService, Generic[TPeerPool]):
             TimeoutError,
             PeerConnectionLost,
             HandshakeFailure,
+            NoMatchingPeerCapabilities,
             asyncio.IncompleteReadError,
         )
 


### PR DESCRIPTION
### What was wrong?

There's an error escaping when we receive a handshake.

```
 ERROR  09-02 13:55:52            FullServer  Unexpected error handling handshake
Traceback (most recent call last):
  File "/home/ubuntu/trinity/trinity/server.py", line 156, in receive_handshake
    await self._receive_handshake(reader, writer)
  File "/home/ubuntu/trinity/trinity/server.py", line 176, in _receive_handshake
    token=self.cancel_token,
  File "/home/ubuntu/trinity/p2p/peer.py", line 133, in receive_handshake
    token=token,
  File "/home/ubuntu/trinity/p2p/handshake.py", line 268, in negotiate_protocol_handshakes
    "Found no matching capabilities between self and peer:\n"
p2p.exceptions.NoMatchingPeerCapabilities: Found no matching capabilities between self and peer:
 - local : (('eth', 63),)
 - remote: (('pip', 1),)
```
Fixes #1031

### How was it fixed?

As far as I can tell this error should be caught in `receive_handshake` as part of the `expected_exceptions` in `receive_handshake`.

I've also put these into a constant as I think that's *slightly* better.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

[//]: # (See: https://trinity-client.readthedocs.io/en/latest/contributing.html#pull-requests)
- [ ] Add entry to the [release notes](https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://i2-prod.irishmirror.ie/incoming/article7018560.ece/ALTERNATES/s615b/lemurs2.jpg)
