### PR TITLE
Bump `ssz` to `0.1.5`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -110,7 +110,7 @@ deps = {
         "py-ecc==1.7.1",
         "rlp>=1.1.0,<2.0.0",
         PYEVM_DEPENDENCY,
-        "ssz==0.1.4",
+        "ssz==0.1.5",
         "milagro-bls-binding==0.1.3",
         "blspy>=0.1.8,<1",  # for `bls_chia`
     ],


### PR DESCRIPTION
### What was wrong?

- Fix the bug of cache key
- When `b = a.copy()`, set the `b.cache` to `a.cache`.

### How was it fixed?


### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

[//]: # (See: https://trinity-client.readthedocs.io/en/latest/contributing.html#pull-requests)
- [ ] Add entry to the [release notes](https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![corgi-3697186_640](https://user-images.githubusercontent.com/9263930/64191299-c23c3a80-ceaa-11e9-8c33-954168b57e50.jpg)
