### PR TITLE
Fix how trio services manage tasks

### DIFF
--- a/newsfragments/1040.bugfix.rst
+++ b/newsfragments/1040.bugfix.rst
@@ -1,0 +1,1 @@
+Fix for ``TrioService.run_task`` to ensure that when a background task throws an unhandled exception that it causes full service cancellation and that the exception is propagated.

--- a/p2p/trio_service.py
+++ b/p2p/trio_service.py
@@ -400,6 +400,8 @@ class Manager(ManagerAPI):
                 err,
                 exc_info=True,
             )
+            self._run_error = sys.exc_info()
+            self.cancel()
         else:
             self.logger.debug(
                 "task '%s[daemon=%s]' finished.",
@@ -408,7 +410,12 @@ class Manager(ManagerAPI):
             )
         finally:
             if daemon:
-                self.cancel()
+                self.logger.debug(
+                    "daemon task '%s' exited unexpectedly.  Cancelling service: %s",
+                    name,
+                    self,
+                )
+                raise LifecycleError(f"Daemon task {name} exited")
 
     def run_task(self,
                  async_fn: Callable[..., Awaitable[Any]],

--- a/tests-trio/p2p-trio/test_channel_services.py
+++ b/tests-trio/p2p-trio/test_channel_services.py
@@ -82,6 +82,7 @@ async def test_datagram_sender(socket_pair):
         assert sender == sender_endpoint
 
 
+@pytest.mark.trio
 async def test_packet_decoder():
     datagram_send_channel, datagram_receive_channel = trio.open_memory_channel(1)
     packet_send_channel, packet_receive_channel = trio.open_memory_channel(1)
@@ -102,6 +103,7 @@ async def test_packet_decoder():
         assert incoming_packet.sender_endpoint.port == sender_endpoint.port
 
 
+@pytest.mark.trio
 async def test_packet_decoder_error():
     datagram_send_channel, datagram_receive_channel = trio.open_memory_channel(1)
     packet_send_channel, packet_receive_channel = trio.open_memory_channel(1)
@@ -130,6 +132,7 @@ async def test_packet_decoder_error():
         assert incoming_packet.sender_endpoint.port == sender_endpoint.port
 
 
+@pytest.mark.trio
 async def test_packet_encoder():
     packet_send_channel, packet_receive_channel = trio.open_memory_channel(1)
     datagram_send_channel, datagram_receive_channel = trio.open_memory_channel(1)


### PR DESCRIPTION
fixes #1032 

### What was wrong?

This addresses a few things.

- The `TrioService` incorrectly allowed background tasks to error out without causing the whole service to cancel itself.
- A service run using `await Manager.run()` didn't end up having the `stopped` event set when an **exception** occurs. 

### How was it fixed?

Added two new tests.

1. a task that errors to show it causes the whole service to exit with the exception.
2. a daemon task that finishes early to show it causes the whole service to exit.

Functionality to ensure this behavior is followed by the service.

Also added a `try/finally` block to the main `Manager.run()` body to ensure that `stopped` gets properly set.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

[//]: # (See: https://trinity-client.readthedocs.io/en/latest/contributing.html#pull-requests)
- [x] Add entry to the [release notes](https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![a15187aefb02e2fee1e99e68197d1fe9--cats-in-costumes-animals-in-costumes](https://user-images.githubusercontent.com/824194/64203582-01d63880-ce51-11e9-9cf0-e27fd0aaa38c.jpg)

