### PR TITLE
Less aggressive peer dropping during skeleton sync

### DIFF
--- a/newsfragments/1043.misc.rst
+++ b/newsfragments/1043.misc.rst
@@ -1,0 +1,1 @@
+Be less aggressive about dropping peers for minor misbehavior during (skeleton) header sync.

--- a/trinity/protocol/common/managers.py
+++ b/trinity/protocol/common/managers.py
@@ -274,6 +274,8 @@ class ExchangeManager(Generic[TRequestPayload, TResponsePayload, TResult]):
                     self._connection,
                     err,
                 )
+                # If this response was just for the wrong request, we'll catch the right one later.
+                # Otherwise, this request will eventually time out.
                 continue
             else:
                 tracker.record_response(

--- a/trinity/sync/common/headers.py
+++ b/trinity/sync/common/headers.py
@@ -120,9 +120,9 @@ class SkeletonSyncer(BaseService, Generic[TChainPeer]):
     async def _run(self) -> None:
         self.run_daemon_task(self._display_stats())
         await self.wait(self._quietly_fetch_full_skeleton())
-        self.logger.debug("Skeleton %s stopped responding, waiting for sync to complete", self.peer)
+        self.logger.debug2("Skeleton %s stopped responding, pausing for headers to emit", self.peer)
         await self.wait(self._fetched_headers.join())
-        self.logger.debug("Skeleton %s emitted all headers", self.peer)
+        self.logger.debug2("Skeleton %s emitted all headers", self.peer)
 
     async def _display_stats(self) -> None:
         queue = self._fetched_headers
@@ -478,7 +478,7 @@ class SkeletonSyncer(BaseService, Generic[TChainPeer]):
             return tuple()
 
         if not headers:
-            self.logger.debug("Got no new headers from %s, exiting skeleton sync", peer)
+            self.logger.debug2("Got no new headers from %s, exiting skeleton sync", peer)
             return tuple()
         else:
             return headers
@@ -903,7 +903,7 @@ class BaseHeaderChainSyncer(BaseService, HeaderSyncerAPI, Generic[TChainPeer]):
             if self._skeleton.is_operational:
                 self._skeleton.cancel_nowait()
         finally:
-            self.logger.debug("Skeleton sync with %s ended", peer)
+            self.logger.debug2("Skeleton sync with %s ended", peer)
             self._last_target_header_hash = peer.head_hash
             self._skeleton = None
 


### PR DESCRIPTION
### What was wrong?

We were too aggressive about dropping peers who didn't handle skeleton syncing well. It causes us to lose peers that are valuable in other ways.

### How was it fixed?

Removed the disconnects.

Bonus:
- reduce some noisy debug logs
- add a comment explaining the `continue` after validation error

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

[//]: # (See: https://trinity-client.readthedocs.io/en/latest/contributing.html#pull-requests)
- [ ] Add entry to the [release notes](https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://i.ytimg.com/vi/rYGRExT1vg0/hqdefault.jpg)
