### PR TITLE
Make Beam Sync more forgiving

### DIFF
--- a/newsfragments/1045.misc.rst
+++ b/newsfragments/1045.misc.rst
@@ -1,0 +1,4 @@
+Switch Beam Sync from preferring low RTT to preferring high items per second (a patch to avoid peers
+that return very quickly, but without most of the data you asked for).
+Be more forgiving of slightly misbehaving peers during beam sync (for example, when they return no
+nodes from GetNodeData request).

--- a/trinity/sync/beam/constants.py
+++ b/trinity/sync/beam/constants.py
@@ -8,10 +8,6 @@ DELAY_BEFORE_NON_URGENT_REQUEST = 0.001
 # nodes we can request at once from a single peer.
 REQUEST_BUFFER_MULTIPLIER = 16
 
-# How long should we wait after a peer gives us an empty response for node data,
-# before we ask for some new data from them? Measured in seconds.
-EMPTY_PEER_RESPONSE_PENALTY = 5
-
 # How many different processes are running previews? They will split the
 # block imports equally. A higher number means a slower startup, but more
 # previews are possible at a time (given that you have enough CPU cores).
@@ -23,3 +19,8 @@ NUM_PREVIEW_SHARDS = 4
 #   constrain the I/O, which can become the global bottleneck.
 MAX_CONCURRENT_SPECULATIVE_EXECUTIONS = 40
 MAX_SPECULATIVE_EXECUTIONS_PER_PROCESS = MAX_CONCURRENT_SPECULATIVE_EXECUTIONS // NUM_PREVIEW_SHARDS
+
+# If a peer does something not ideal, give it a little time to breath,
+# and maybe to try out another peeer. Then reinsert it relatively soon.
+# Measured in seconds.
+NON_IDEAL_RESPONSE_PENALTY = 0.5

--- a/trinity/sync/beam/state.py
+++ b/trinity/sync/beam/state.py
@@ -72,7 +72,7 @@ class BeamDownloader(BaseService, PeerSubscriber):
     _total_requests = 0
     _timer = Timer(auto_start=False)
     _report_interval = 10  # Number of seconds between progress reports.
-    _reply_timeout = 1  # seconds
+    _reply_timeout = 10  # seconds
 
     # We are only interested in peers entering or leaving the pool
     subscription_msg_types: FrozenSet[Type[CommandAPI]] = frozenset()

--- a/trinity/sync/beam/state.py
+++ b/trinity/sync/beam/state.py
@@ -13,7 +13,6 @@ from lahja import EndpointAPI
 
 from eth_hash.auto import keccak
 from eth_utils import (
-    encode_hex,
     to_checksum_address,
     ValidationError,
 )
@@ -477,10 +476,10 @@ class BeamDownloader(BaseService, PeerSubscriber):
                 delay = NON_IDEAL_RESPONSE_PENALTY
                 self.logger.debug(
                     "Pausing %s for %.1fs, for replying with no node data "
-                    "to request for: %r",
+                    "to request for %d nodes",
                     peer,
                     delay,
-                    [encode_hex(h) for h in node_hashes],
+                    len(node_hashes),
                 )
                 self.call_later(delay, self._node_data_peers.put_nowait, peer)
             return completed_nodes

--- a/trinity/sync/beam/state.py
+++ b/trinity/sync/beam/state.py
@@ -36,9 +36,6 @@ from trie.exceptions import MissingTrieNode
 
 from trinity._utils.datastructures import TaskQueue
 from trinity._utils.timer import Timer
-from trinity.protocol.common.trackers import (
-    BasePerformance,
-)
 from trinity.protocol.common.types import (
     NodeDataBundles,
 )
@@ -59,17 +56,6 @@ from trinity.sync.beam.constants import (
 )
 
 from trinity.sync.common.peers import WaitingPeers
-
-
-def _is_hash(maybe_hash: bytes) -> bool:
-    return isinstance(maybe_hash, bytes) and len(maybe_hash) == 32
-
-
-def _get_rtt(tracker: BasePerformance) -> float:
-    """
-    Extract the round trip time from the peer's tracker.
-    """
-    return tracker.round_trip_ema.value
 
 
 class BeamDownloader(BaseService, PeerSubscriber):
@@ -105,7 +91,7 @@ class BeamDownloader(BaseService, PeerSubscriber):
         super().__init__(token)
         self._db = db
         self._trie_db = HexaryTrie(db)
-        self._node_data_peers = WaitingPeers[ETHPeer](NodeData, sort_key=_get_rtt)
+        self._node_data_peers = WaitingPeers[ETHPeer](NodeData)
         self._event_bus = event_bus
 
         # Track the needed node data that is urgent and important:

--- a/trinity/sync/full/constants.py
+++ b/trinity/sync/full/constants.py
@@ -27,4 +27,6 @@ BLOCK_QUEUE_SIZE_TARGET = 1000
 #   causing a massive slowdown.
 # Every block gets previewed, and a block only enters the queue if another block import
 #   is active. So a queue size of 3 means that up to 4 previews are happening at once.
-BLOCK_IMPORT_QUEUE_SIZE = 15
+BLOCK_IMPORT_QUEUE_SIZE = 31
+# This metric seems hard to pin down, we may have to expose it as a command line flag,
+#   until we have a better mechanism for backpressure related to slowness in I/O.


### PR DESCRIPTION
### What was wrong?

Beam Sync was a bit aggressive about booting or pausing peers.

### How was it fixed?

Relax a little bit, and permit longer timeout.
Plus a couple bonus log fixes, and constant tweaks.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

[//]: # (See: https://trinity-client.readthedocs.io/en/latest/contributing.html#pull-requests)
- [x] Add entry to the [release notes](https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcRlt-CfRxnKxlHUr-cYamSrz6K7wkDHuw5v-IkpVupuTbRxeDql)
