### PR TITLE
Give every failed build a second try

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,6 +36,10 @@ common: &common
     - run:
         name: run tox
         command: ~/.local/bin/tox
+    - run:
+        name: run tox (2nd try)
+        command: ~/.local/bin/tox
+        when: on_fail
     - save_cache:
         paths:
           - .hypothesis


### PR DESCRIPTION
### What was wrong?

Some times CI builds fail for no apparent reason.

### How was it fixed?

This gives every failed build a second try.

We can look at this from various angles:

PRO

- Everyone deserves a second chance :sweat_smile: 
- It basically automates what everyone is doing manually when a build fails for no apparent reason
- It makes minor issues less annoying while still exposing us to the really bad things

CON:

- It kinda sweeps issues under the rug

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

[//]: # (See: https://trinity-client.readthedocs.io/en/latest/contributing.html#pull-requests)
- [ ] Add entry to the [release notes](https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://2.bp.blogspot.com/-hrbA4OjVW3k/W_Qd4M6WpPI/AAAAAAAANK4/31Mc3OnZsKY1PrfFnA8AL0dyLr2jEd5nQCLcBGAs/s1600/Brolgas.jpg)
