### PR TITLE
Remove unneeded cancel_nowait in peer

### DIFF
--- a/newsfragments/99999.bugfix.rst
+++ b/newsfragments/99999.bugfix.rst
@@ -1,0 +1,1 @@
+Fix warning caused by inappropriate call to ``cancel_nowait``.

--- a/p2p/peer.py
+++ b/p2p/peer.py
@@ -375,7 +375,6 @@ class BasePeer(BaseService):
             self.base_protocol.send_disconnect(reason)
         except PeerConnectionLost:
             self.logger.debug("%s was already disconnected", self.remote)
-        self.cancel_nowait()
 
     async def disconnect(self, reason: DisconnectReason) -> None:
         """Send a disconnect msg to the remote node and stop this Peer.


### PR DESCRIPTION
### What was wrong?

This error came up a lot.

```python
 ERROR  09-04 13:48:35            FullServer  Unexpected error handling handshake
Traceback (most recent call last):
  File "/home/ubuntu/trinity/trinity/server.py", line 159, in receive_handshake
    await self._receive_handshake(reader, writer)
  File "/home/ubuntu/trinity/trinity/server.py", line 201, in _receive_handshake
    await peer.disconnect(DisconnectReason.too_many_peers)
  File "/home/ubuntu/trinity/p2p/peer.py", line 387, in disconnect
    self._disconnect(reason)
  File "/home/ubuntu/trinity/p2p/peer.py", line 378, in _disconnect
    self.cancel_nowait()
  File "/home/ubuntu/trinity/p2p/service.py", line 304, in cancel_nowait
    raise ValidationError("Cannot cancel a service that has not been started")
eth_utils.exceptions.ValidationError: Cannot cancel a service that has not been started

```

### How was it fixed?

I removed the `cancel_nowait` in `_disconnect` as `disconnect` or `disconnect_nowait` already take care of this in a more graceful way.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

[//]: # (See: https://trinity-client.readthedocs.io/en/latest/contributing.html#pull-requests)
- [x] Add entry to the [release notes](https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](http://1.bp.blogspot.com/-knezloKCYYM/UNlAsCNZdTI/AAAAAAAAA3I/4lr9hSPpGvI/s1600/5.jpg)
