### PR TITLE
Handle MalformedMessage in Connection

### DIFF
--- a/newsfragments/1051.bugfix.rst
+++ b/newsfragments/1051.bugfix.rst
@@ -1,0 +1,1 @@
+Handle ``MalformedMessage`` rising out of the ``Transport`` in the ``Connection``.

--- a/p2p/connection.py
+++ b/p2p/connection.py
@@ -16,7 +16,9 @@ from p2p.abc import (
     CommandHandlerFn,
     ConnectionAPI,
 )
+from p2p.disconnect import DisconnectReason
 from p2p.exceptions import (
+    MalformedMessage,
     PeerConnectionLost,
     UnknownProtocol,
     UnknownProtocolCommand,
@@ -80,6 +82,10 @@ class Connection(ConnectionAPI, BaseService):
 
                 await self.cancellation()
         except (PeerConnectionLost, asyncio.CancelledError):
+            pass
+        except (MalformedMessage,) as err:
+            self.logger.debug("Disconnecting peer %s for sending MalformedMessage: %s", err)
+            self.get_base_protocol().send_disconnect(DisconnectReason.bad_protocol)
             pass
 
     async def _cleanup(self) -> None:


### PR DESCRIPTION
### What was wrong?

Unhandled `MalformedMessage` rising out of the the `Transport`.

### How was it fixed?

Added it to the current connection handling but with an extra `except` block so we can `DEBUG` log it in case it's not genuine.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

[//]: # (See: https://trinity-client.readthedocs.io/en/latest/contributing.html#pull-requests)
- [x] Add entry to the [release notes](https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![awesomelycute-com-2607](https://user-images.githubusercontent.com/824194/64272545-d01aab80-cefc-11e9-943e-eca3be7d2844.jpg)

