### PR TITLE
ABC base class for HandshakerAPI

### DIFF
--- a/newsfragments/1052.misc.rst
+++ b/newsfragments/1052.misc.rst
@@ -1,0 +1,1 @@
+Add ``p2p.abc.HandshakerAPI`` for formal handshaker interface.

--- a/p2p/abc.py
+++ b/p2p/abc.py
@@ -26,7 +26,7 @@ from cancel_token import CancelToken
 
 from eth_utils import ExtendedDebugLogger
 
-from eth_keys import datatypes
+from eth_keys import keys
 
 from p2p.typing import Capability, Capabilities, Payload, Structure
 from p2p.transport_state import TransportState
@@ -95,12 +95,12 @@ TNode = TypeVar('TNode', bound='NodeAPI')
 
 
 class NodeAPI(ABC):
-    pubkey: datatypes.PublicKey
+    pubkey: keys.PublicKey
     address: AddressAPI
     id: int
 
     @abstractmethod
-    def __init__(self, pubkey: datatypes.PublicKey, address: AddressAPI) -> None:
+    def __init__(self, pubkey: keys.PublicKey, address: AddressAPI) -> None:
         ...
 
     @classmethod
@@ -206,7 +206,7 @@ class TransportAPI(ABC):
 
     @property
     @abstractmethod
-    def public_key(self) -> datatypes.PublicKey:
+    def public_key(self) -> keys.PublicKey:
         ...
 
     @abstractmethod
@@ -392,6 +392,21 @@ class AsyncioServiceAPI(ABC):
 
 class HandshakeReceiptAPI(ABC):
     protocol: ProtocolAPI
+
+
+class HandshakerAPI(ABC):
+    logger: ExtendedDebugLogger
+
+    protocol_class: Type[ProtocolAPI]
+
+    @abstractmethod
+    async def do_handshake(self,
+                           multiplexer: MultiplexerAPI,
+                           protocol: ProtocolAPI) -> HandshakeReceiptAPI:
+        """
+        Perform the actual handshake for the protocol.
+        """
+        ...
 
 
 class HandlerSubscriptionAPI(ContextManager['HandlerSubscriptionAPI']):

--- a/p2p/peer.py
+++ b/p2p/peer.py
@@ -31,6 +31,7 @@ from cancel_token import CancelToken
 from p2p.abc import (
     CommandAPI,
     ConnectionAPI,
+    HandshakerAPI,
     HandshakeReceiptAPI,
     NodeAPI,
     ProtocolAPI,
@@ -44,12 +45,11 @@ from p2p.exceptions import (
 from p2p.handshake import (
     dial_out,
     DevP2PHandshakeParams,
-    Handshaker,
+    DevP2PReceipt,
 )
 from p2p.service import BaseService
 from p2p.p2p_proto import (
     BaseP2PProtocol,
-    DevP2PReceipt,
     Disconnect,
     Ping,
 )
@@ -486,7 +486,7 @@ class BasePeerFactory(ABC):
         self.event_bus = event_bus
 
     @abstractmethod
-    async def get_handshakers(self) -> Tuple[Handshaker, ...]:
+    async def get_handshakers(self) -> Tuple[HandshakerAPI, ...]:
         ...
 
     async def handshake(self, remote: NodeAPI) -> BasePeer:

--- a/p2p/tools/factories/connection.py
+++ b/p2p/tools/factories/connection.py
@@ -7,12 +7,11 @@ from cancel_token import CancelToken
 
 from eth_keys import keys
 
-from p2p.abc import ConnectionAPI, NodeAPI
+from p2p.abc import ConnectionAPI, HandshakerAPI, NodeAPI
 from p2p.connection import Connection
 from p2p.constants import DEVP2P_V5
 from p2p.handshake import (
     DevP2PReceipt,
-    Handshaker,
     negotiate_protocol_handshakes,
 )
 from p2p.service import run_service
@@ -25,8 +24,8 @@ from .transport import MemoryTransportPairFactory
 
 @asynccontextmanager
 async def ConnectionPairFactory(*,
-                                alice_handshakers: Tuple[Handshaker, ...] = (),
-                                bob_handshakers: Tuple[Handshaker, ...] = (),
+                                alice_handshakers: Tuple[HandshakerAPI, ...] = (),
+                                bob_handshakers: Tuple[HandshakerAPI, ...] = (),
                                 alice_remote: NodeAPI = None,
                                 alice_private_key: keys.PrivateKey = None,
                                 alice_client_version: str = 'alice',

--- a/p2p/tools/paragon/peer.py
+++ b/p2p/tools/paragon/peer.py
@@ -3,7 +3,7 @@ from typing import (
     Tuple,
 )
 
-from p2p.abc import MultiplexerAPI
+from p2p.abc import HandshakerAPI, MultiplexerAPI
 from p2p.handshake import Handshaker
 from p2p.receipt import HandshakeReceipt
 
@@ -49,7 +49,7 @@ class ParagonPeerFactory(BasePeerFactory):
     peer_class = ParagonPeer
     context: ParagonContext
 
-    async def get_handshakers(self) -> Tuple[Handshaker, ...]:
+    async def get_handshakers(self) -> Tuple[HandshakerAPI, ...]:
         return (ParagonHandshaker(),)
 
 

--- a/trinity/protocol/eth/peer.py
+++ b/trinity/protocol/eth/peer.py
@@ -16,7 +16,7 @@ from lahja import (
     BroadcastConfig,
 )
 
-from p2p.abc import CommandAPI, ConnectionAPI, HandshakeReceiptAPI, NodeAPI
+from p2p.abc import CommandAPI, ConnectionAPI, HandshakerAPI, HandshakeReceiptAPI, NodeAPI
 from p2p.handshake import DevP2PReceipt
 from p2p.protocol import (
     Payload,
@@ -154,7 +154,7 @@ class ETHProxyPeer(BaseProxyPeer):
 class ETHPeerFactory(BaseChainPeerFactory):
     peer_class = ETHPeer
 
-    async def get_handshakers(self) -> Tuple[ETHHandshaker, ...]:
+    async def get_handshakers(self) -> Tuple[HandshakerAPI, ...]:
         headerdb = self.context.headerdb
         wait = self.cancel_token.cancellable_wait
 

--- a/trinity/protocol/les/peer.py
+++ b/trinity/protocol/les/peer.py
@@ -25,8 +25,8 @@ from lahja import (
     BroadcastConfig,
 )
 
-from p2p.abc import CommandAPI, ConnectionAPI, HandshakeReceiptAPI, NodeAPI
-from p2p.handshake import DevP2PReceipt, Handshaker
+from p2p.abc import CommandAPI, ConnectionAPI, HandshakerAPI, HandshakeReceiptAPI, NodeAPI
+from p2p.handshake import DevP2PReceipt
 from p2p.peer_pool import BasePeerPool
 from p2p.typing import Payload
 
@@ -147,7 +147,7 @@ class LESProxyPeer(BaseProxyPeer):
 class LESPeerFactory(BaseChainPeerFactory):
     peer_class = LESPeer
 
-    async def get_handshakers(self) -> Tuple[Handshaker, ...]:
+    async def get_handshakers(self) -> Tuple[HandshakerAPI, ...]:
         headerdb = self.context.headerdb
         wait = self.cancel_token.cancellable_wait
 

--- a/trinity/tools/factories.py
+++ b/trinity/tools/factories.py
@@ -21,7 +21,7 @@ from eth.constants import GENESIS_DIFFICULTY, GENESIS_BLOCK_NUMBER
 from eth.chains.mainnet import MAINNET_VM_CONFIGURATION
 
 from p2p import kademlia
-from p2p.handshake import Handshaker
+from p2p.abc import HandshakerAPI
 from p2p.tools.factories import PeerPairFactory
 
 from trinity.constants import MAINNET_NETWORK_ID
@@ -209,7 +209,7 @@ class LESV1Peer(LESPeer):
 class LESV1PeerFactory(LESPeerFactory):
     peer_class = LESV1Peer
 
-    async def get_handshakers(self) -> Tuple[Handshaker, ...]:
+    async def get_handshakers(self) -> Tuple[HandshakerAPI, ...]:
         return (
             LESV1Handshaker(LESHandshakeParamsFactory(version=1)),
         )


### PR DESCRIPTION
extracted from #966 

### What was wrong?

Found need to formalize the `Handshaker` with an ABC base class

### How was it fixed?

Created `ABC` base class for it.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

[//]: # (See: https://trinity-client.readthedocs.io/en/latest/contributing.html#pull-requests)
- [x] Add entry to the [release notes](https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![cowboy](https://user-images.githubusercontent.com/824194/64274324-61d7e800-cf00-11e9-9653-89263c7ad3a6.jpg)

