### PR TITLE
Relocate HandshakeReceipt to p2p.receipt

### DIFF
--- a/newsfragments/1055.misc.rst
+++ b/newsfragments/1055.misc.rst
@@ -1,0 +1,1 @@
+Move ``HandshakeReceipt`` to ``p2p.receipt`` to fix circular dependency.

--- a/p2p/connection.py
+++ b/p2p/connection.py
@@ -21,10 +21,9 @@ from p2p.exceptions import (
     UnknownProtocol,
     UnknownProtocolCommand,
 )
-from p2p.handshake import DevP2PReceipt
 from p2p.handler_subscription import HandlerSubscription
 from p2p.service import BaseService
-from p2p.p2p_proto import BaseP2PProtocol
+from p2p.p2p_proto import BaseP2PProtocol, DevP2PReceipt
 from p2p.typing import Capabilities
 
 

--- a/p2p/handshake.py
+++ b/p2p/handshake.py
@@ -40,6 +40,7 @@ from p2p.multiplexer import (
     Multiplexer,
 )
 from p2p.p2p_proto import (
+    DevP2PReceipt,
     Hello,
     BaseP2PProtocol,
     P2PProtocol,
@@ -50,17 +51,6 @@ from p2p.typing import (
     Capabilities,
     Capability,
 )
-
-
-class HandshakeReceipt(HandshakeReceiptAPI):
-    """
-    Data storage object for ephemeral data exchanged during protocol
-    handshakes.
-    """
-    protocol: ProtocolAPI
-
-    def __init__(self, protocol: ProtocolAPI) -> None:
-        self.protocol = protocol
 
 
 class Handshaker(ABC):
@@ -76,30 +66,11 @@ class Handshaker(ABC):
     @abstractmethod
     async def do_handshake(self,
                            multiplexer: MultiplexerAPI,
-                           protocol: ProtocolAPI) -> HandshakeReceipt:
+                           protocol: ProtocolAPI) -> HandshakeReceiptAPI:
         """
         Perform the actual handshake for the protocol.
         """
         ...
-
-
-class DevP2PReceipt(HandshakeReceipt):
-    """
-    Record of the handshake data from the core `p2p` protocol handshake.
-    """
-    def __init__(self,
-                 protocol: BaseP2PProtocol,
-                 version: int,
-                 client_version_string: str,
-                 capabilities: Capabilities,
-                 listen_port: int,
-                 remote_public_key: bytes) -> None:
-        super().__init__(protocol)
-        self.version = version
-        self.client_version_string = client_version_string
-        self.capabilities = capabilities
-        self.listen_port = listen_port
-        self.remote_public_key = remote_public_key
 
 
 class DevP2PHandshakeParams(NamedTuple):
@@ -208,7 +179,7 @@ async def negotiate_protocol_handshakes(transport: TransportAPI,
                                         p2p_handshake_params: DevP2PHandshakeParams,
                                         protocol_handshakers: Sequence[Handshaker],
                                         token: CancelToken,
-                                        ) -> Tuple[MultiplexerAPI, DevP2PReceipt, Tuple[HandshakeReceipt, ...]]:  # noqa: E501
+                                        ) -> Tuple[MultiplexerAPI, DevP2PReceipt, Tuple[HandshakeReceiptAPI, ...]]:  # noqa: E501
     """
     Negotiate the handshakes for both the base `p2p` protocol and the
     appropriate sub protocols.  The basic logic follows the following steps.

--- a/p2p/p2p_proto.py
+++ b/p2p/p2p_proto.py
@@ -14,6 +14,7 @@ from p2p.abc import TransportAPI
 from p2p.constants import P2P_PROTOCOL_COMMAND_LENGTH
 from p2p.disconnect import DisconnectReason as _DisconnectReason
 from p2p.exceptions import MalformedMessage
+from p2p.receipt import HandshakeReceipt
 from p2p.typing import Capabilities, Payload
 
 from p2p.protocol import (
@@ -148,3 +149,22 @@ class P2PProtocolV4(BaseP2PProtocol):
 
 class P2PProtocol(BaseP2PProtocol):
     version = 5
+
+
+class DevP2PReceipt(HandshakeReceipt):
+    """
+    Record of the handshake data from the core `p2p` protocol handshake.
+    """
+    def __init__(self,
+                 protocol: BaseP2PProtocol,
+                 version: int,
+                 client_version_string: str,
+                 capabilities: Capabilities,
+                 listen_port: int,
+                 remote_public_key: bytes) -> None:
+        super().__init__(protocol)
+        self.version = version
+        self.client_version_string = client_version_string
+        self.capabilities = capabilities
+        self.listen_port = listen_port
+        self.remote_public_key = remote_public_key

--- a/p2p/peer.py
+++ b/p2p/peer.py
@@ -45,12 +45,12 @@ from p2p.connection import Connection
 from p2p.handshake import (
     negotiate_protocol_handshakes,
     DevP2PHandshakeParams,
-    DevP2PReceipt,
     Handshaker,
 )
 from p2p.service import BaseService
 from p2p.p2p_proto import (
     BaseP2PProtocol,
+    DevP2PReceipt,
     Disconnect,
     Ping,
 )

--- a/p2p/receipt.py
+++ b/p2p/receipt.py
@@ -1,0 +1,15 @@
+from p2p.abc import (
+    HandshakeReceiptAPI,
+    ProtocolAPI,
+)
+
+
+class HandshakeReceipt(HandshakeReceiptAPI):
+    """
+    Data storage object for ephemeral data exchanged during protocol
+    handshakes.
+    """
+    protocol: ProtocolAPI
+
+    def __init__(self, protocol: ProtocolAPI) -> None:
+        self.protocol = protocol

--- a/p2p/tools/handshake.py
+++ b/p2p/tools/handshake.py
@@ -1,7 +1,8 @@
 from typing import Type
 
 from p2p.abc import MultiplexerAPI, ProtocolAPI
-from p2p.handshake import Handshaker, HandshakeReceipt
+from p2p.handshake import Handshaker
+from p2p.receipt import HandshakeReceipt
 
 
 class NoopHandshaker(Handshaker):

--- a/p2p/tools/paragon/peer.py
+++ b/p2p/tools/paragon/peer.py
@@ -4,10 +4,8 @@ from typing import (
 )
 
 from p2p.abc import MultiplexerAPI
-from p2p.handshake import (
-    Handshaker,
-    HandshakeReceipt,
-)
+from p2p.handshake import Handshaker
+from p2p.receipt import HandshakeReceipt
 
 from p2p.abc import ProtocolAPI
 from p2p.constants import DEVP2P_V5

--- a/trinity/protocol/bcc/handshaker.py
+++ b/trinity/protocol/bcc/handshaker.py
@@ -7,10 +7,8 @@ from p2p.abc import MultiplexerAPI, ProtocolAPI
 from p2p.exceptions import (
     HandshakeFailure,
 )
-from p2p.handshake import (
-    HandshakeReceipt,
-    Handshaker,
-)
+from p2p.handshake import Handshaker
+from p2p.receipt import HandshakeReceipt
 
 from .commands import (
     Status,

--- a/trinity/protocol/eth/handshaker.py
+++ b/trinity/protocol/eth/handshaker.py
@@ -6,10 +6,8 @@ from p2p.abc import MultiplexerAPI, ProtocolAPI
 from p2p.exceptions import (
     HandshakeFailure,
 )
-from p2p.handshake import (
-    HandshakeReceipt,
-    Handshaker,
-)
+from p2p.handshake import Handshaker
+from p2p.receipt import HandshakeReceipt
 
 from trinity.exceptions import WrongGenesisFailure, WrongNetworkFailure
 

--- a/trinity/protocol/les/handshaker.py
+++ b/trinity/protocol/les/handshaker.py
@@ -12,10 +12,8 @@ from p2p.abc import MultiplexerAPI, ProtocolAPI
 from p2p.exceptions import (
     HandshakeFailure,
 )
-from p2p.handshake import (
-    HandshakeReceipt,
-    Handshaker,
-)
+from p2p.handshake import Handshaker
+from p2p.receipt import HandshakeReceipt
 
 from trinity.exceptions import WrongGenesisFailure, WrongNetworkFailure
 


### PR DESCRIPTION
### What was wrong?

There was a circular module dependency forming between `p2p.handshake` and `p2p.connection` while working on #966 due to the `DevP2PReceipt`

### How was it fixed?

Moved the receipt stuff to its own module.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

[//]: # (See: https://trinity-client.readthedocs.io/en/latest/contributing.html#pull-requests)
- [x] Add entry to the [release notes](https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![7ef33baf998696b728f72c0fc5a3b495--animals-in-costumes-cats-in-costumes](https://user-images.githubusercontent.com/824194/64277289-37d5f400-cf07-11e9-84ed-7b6dd156bf18.jpg)

