### PR TITLE
Use `unique` decorator to increase safety of using the enum.

### DIFF
--- a/eth2/beacon/signature_domain.py
+++ b/eth2/beacon/signature_domain.py
@@ -1,6 +1,7 @@
-from enum import IntEnum
+from enum import IntEnum, unique
 
 
+@unique
 class SignatureDomain(IntEnum):
     DOMAIN_BEACON_PROPOSER = 0
     DOMAIN_RANDAO = 1

--- a/p2p/transport_state.py
+++ b/p2p/transport_state.py
@@ -1,6 +1,7 @@
 import enum
 
 
+@enum.unique
 class TransportState(enum.Enum):
     IDLE = enum.auto()
     HEADER = enum.auto()

--- a/trinity/components/builtin/network_db/cli.py
+++ b/trinity/components/builtin/network_db/cli.py
@@ -3,6 +3,7 @@ import enum
 from typing import Any
 
 
+@enum.unique
 class TrackingBackend(enum.Enum):
     sqlite3 = 'sqlite3'
     memory = 'memory'

--- a/trinity/db/manager.py
+++ b/trinity/db/manager.py
@@ -48,6 +48,7 @@ class BufferedSocket:
         return bytes(payload)
 
 
+@enum.unique
 class Operation(enum.Enum):
     GET = b'\x00'
     SET = b'\x01'
@@ -141,6 +142,7 @@ SUCCESS_BYTE = b'\x01'
 FAIL_BYTE = b'\x00'
 
 
+@enum.unique
 class Result(enum.Enum):
     SUCCESS = SUCCESS_BYTE
     FAIL = FAIL_BYTE

--- a/trinity/sync/full/chain.py
+++ b/trinity/sync/full/chain.py
@@ -486,6 +486,7 @@ class FastChainSyncer(BaseService):
         self._header_syncer.cancel_nowait()
 
 
+@enum.unique
 class BlockPersistPrereqs(enum.Enum):
     StoreBlockBodies = enum.auto()
     StoreReceipts = enum.auto()
@@ -966,6 +967,7 @@ class RegularChainSyncer(BaseService):
         await self.events.cancelled.wait()
 
 
+@enum.unique
 class BlockImportPrereqs(enum.Enum):
     StoreBlockBodies = enum.auto()
 


### PR DESCRIPTION
Fixes #919.

### What was wrong?

Not using `@unique`.

### How was it fixed?

Using the decorator.

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://proxy.duckduckgo.com/iu/?u=http%3A%2F%2Fanimalsbirds.com%2Fwp-content%2Fuploads%2F2016%2F07%2FCute-duckling-wallpaper-screenshots-cute-ducks-gt-cute-ducks.jpg&f=1)
