### PR TITLE
Add mainnet tests to ci

### DIFF
--- a/eth2/beacon/tools/fixtures/test_generation.py
+++ b/eth2/beacon/tools/fixtures/test_generation.py
@@ -162,8 +162,11 @@ def _generate_test_suite_descriptors_from(
         config_type = config_types[0]
         _add_config_type_to_tracking_set(config_type)
         _check_only_one_config_type(config_type)
+        configs_to_exclude = eth2_fixture_request.get("exclude_for", ())
+        should_include_handler = config_type not in configs_to_exclude
     else:
         config_types = (General,)
+        should_include_handler = True
 
     test_types = eth2_fixture_request["test_types"]
 
@@ -175,7 +178,7 @@ def _generate_test_suite_descriptors_from(
     selected_handlers: Tuple[Tuple[TestType[Any], TestHandler[Any, Any]], ...] = tuple()
     for test_type, handler_filter in test_types.items():
         for handler in test_type.handlers:
-            if handler_filter(handler):
+            if handler_filter(handler) and should_include_handler:
                 selected_handlers += ((test_type, handler),)
 
     return tuple(itertools.product(selected_handlers, config_types, fork_types))

--- a/tests/eth2/fixtures/test_genesis.py
+++ b/tests/eth2/fixtures/test_genesis.py
@@ -1,4 +1,4 @@
-from eth2.beacon.tools.fixtures.config_types import Minimal
+from eth2.beacon.tools.fixtures.config_types import Mainnet, Minimal
 from eth2.beacon.tools.fixtures.test_generation import (
     generate_pytests_from_eth2_fixture,
     pytest_from_eth2_fixture,
@@ -14,6 +14,7 @@ def pytest_generate_tests(metafunc):
     {
         "config_types": (Minimal,),
         "test_types": {GenesisTestType: lambda handler: handler.name == "validity"},
+        "exclude_for": (Mainnet,),
     }
 )
 def test_validity(test_case):
@@ -26,6 +27,7 @@ def test_validity(test_case):
         "test_types": {
             GenesisTestType: lambda handler: handler.name == "initialization"
         },
+        "exclude_for": (Mainnet,),
     }
 )
 def test_initialization(test_case):

--- a/tests/eth2/fixtures/test_operations.py
+++ b/tests/eth2/fixtures/test_operations.py
@@ -1,7 +1,7 @@
 from eth_utils import ValidationError
 import pytest
 
-from eth2.beacon.tools.fixtures.config_types import Minimal
+from eth2.beacon.tools.fixtures.config_types import Mainnet, Minimal
 from eth2.beacon.tools.fixtures.test_generation import (
     generate_pytests_from_eth2_fixture,
     pytest_from_eth2_fixture,
@@ -95,6 +95,7 @@ def test_proposer_slashing(test_case):
     {
         "config_types": (Minimal,),
         "test_types": {OperationsTestType: lambda handler: handler.name == "transfer"},
+        "exclude_for": (Mainnet,),
     }
 )
 def test_transfer(test_case):

--- a/tox.ini
+++ b/tox.ini
@@ -33,7 +33,6 @@ commands=
     eth1-core: pytest -n 4 {posargs:tests/core/}
     eth2-core: pytest -n 4 {posargs:tests/eth2/core/}
     eth2-utils: pytest -n 4 {posargs:tests/eth2/utils-tests/}
-    eth2-fixtures: pytest -n 4 {posargs:tests/eth2/fixtures/}
     eth2-integration: pytest -n 4 {posargs:tests/eth2/integration/}
     p2p: pytest -n 4 {posargs:tests/p2p}
     p2p-trio: pytest -n 4 {posargs:tests-trio/p2p-trio}
@@ -184,7 +183,15 @@ commands=
 deps = {[common-lint-eth2]deps}
 commands= {[common-lint-eth2]commands}
 
+[testenv:py36-eth2-fixtures]
+deps = .[eth2,test]
+commands=
+    pytest -n 4 --config minimal {posargs:tests/eth2/fixtures/}
+    pytest -n 4 --config mainnet {posargs:tests/eth2/fixtures/}
 
-[testenv:py37-lint-eth2]
-deps = {[common-lint-eth2]deps}
-commands= {[common-lint-eth2]commands}
+
+[testenv:py37-eth2-fixtures]
+deps = .[eth2,test]
+commands=
+    pytest -n 4 --config minimal {posargs:tests/eth2/fixtures/}
+    pytest -n 4 --config mainnet {posargs:tests/eth2/fixtures/}


### PR DESCRIPTION
### What was wrong?

Fixes #1022.

### How was it fixed?

Adding the ability to exclude some tests by config (when they miss data for that configuration, for instance) and then modify the CI settings to run both configs of interest in `tox`.

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://proxy.duckduckgo.com/iu/?u=http%3A%2F%2F2.bp.blogspot.com%2F-Z4pjyNBojA8%2FU8gTtOgRNII%2FAAAAAAABBBo%2FthbD8dCDc-M%2Fs1600%2Fcute-red-panda-17.jpg&f=1&nofb=1)
