### PR TITLE
Fix _GatheringFuture exceptions during shutdown

### DIFF
--- a/p2p/peer_pool.py
+++ b/p2p/peer_pool.py
@@ -203,10 +203,10 @@ class BasePeerPool(BaseService, AsyncIterable[BasePeer]):
             await self.wait(rate_limiter.take())
 
             try:
-                await self.wait(asyncio.gather(*(
+                await asyncio.gather(*(
                     self._add_peers_from_backend(backend)
                     for backend in self.peer_backends
-                )))
+                ))
             except OperationCancelled:
                 break
 
@@ -406,10 +406,10 @@ class BasePeerPool(BaseService, AsyncIterable[BasePeer]):
                 available_peer_slots,
             )
             # Try to connect to the peers concurrently.
-            await self.wait(asyncio.gather(
+            await asyncio.gather(
                 *(self.connect_to_node(node) for node in batch),
                 loop=self.get_event_loop(),
-            ))
+            )
 
     async def connect_to_node(self, node: NodeAPI) -> None:
         """


### PR DESCRIPTION
### What was wrong?

During shutdown triinty would emit two sets of:

```
    ERROR  09-04 19:40:12               asyncio  _GatheringFuture exception was never retrieved
future: <_GatheringFuture finished exception=CancelledError()>
concurrent.futures._base.CancelledError
```

[Long explanation that could probably be skipped]

Before this PR, `BaseService.wait()` wrapped the calls to `asyncio.gather()`. `BaseService.wait()` eventually turns into a call to `CancelToken.cancellable_wait()`. When the token is cancelled (which is what happens during trinity shutdown) `cancellable_wait()`, tries to cancel all the futures. This is usually fine, however, `asyncio.gather()` returns a special kind of future. When a `_GatheringFuture` is cancelled it sets an exception on itself! This is why we're seeing `exception was never retrieved`, the cancel token is cancelling the future and assumes that it can then forge about the future, but instead the future, when cancelled, raises an exception.

There are a couple ways forward, and I don't know which is best:

- I think `asyncio.gather()` was only ever intended to be used as `await asyncio.gather(...)`, we could replace our calls to `gather()` with a call to something else that's better behaved.
- I don't think `asyncio.gather(..., return_exceptions=True)` would have this behavior, we could add that flag and be careful to raise exceptions which look important.
- `CancelToken` could hard-code knowledge of how `_GatheringFuture` works. It could cancel the future and then let the event loop spin a few times and then retrieve the cancelled exception.

[/long explanation]

### How was it fixed?

In this PR I opted to remove the call to `cancellable_wait()`. It's fine in this situation, because each of the coros which are being gathered are awaiting on the same token, they'll be cancelled and the cancellation will trickle up through the call to `gather()`. I think that in general calling `gather()` without `self.wait()` is okay, as long as the coros being gathered call `wait`. (Just like how it's fine to call `await self.xxx()` methods, as long as those methods eventually block on `self.wait()`)

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

[//]: # (See: https://trinity-client.readthedocs.io/en/latest/contributing.html#pull-requests)
- [ ] Add entry to the [release notes](https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![black-tailed-prairie-dog](https://user-images.githubusercontent.com/466333/64307882-4266ac80-cf4c-11e9-9671-914afb10b2dc.jpg)
