### PR TITLE
Ensure discovery can handle invalid command ids

### DIFF
--- a/newsfragments/1063.bugfix.rst
+++ b/newsfragments/1063.bugfix.rst
@@ -1,0 +1,1 @@
+Ensure discovery V4 handles invalid command ids gracefully

--- a/p2p/discovery.py
+++ b/p2p/discovery.py
@@ -107,6 +107,10 @@ class WrongMAC(DefectiveMessage):
     pass
 
 
+class UnknownCommand(DefectiveMessage):
+    pass
+
+
 class DiscoveryCommand:
     def __init__(self, name: str, id: int, elem_count: int) -> None:
         self.name = name
@@ -1258,7 +1262,10 @@ def _unpack_v4(message: bytes) -> Tuple[datatypes.PublicKey, int, Tuple[Any, ...
     signed_data = message[HEAD_SIZE:]
     remote_pubkey = signature.recover_public_key_from_msg(signed_data)
     cmd_id = message[HEAD_SIZE]
-    cmd = CMD_ID_MAP[cmd_id]
+    try:
+        cmd = CMD_ID_MAP[cmd_id]
+    except KeyError as e:
+        raise UnknownCommand(f"Invalid Command ID {cmd_id}") from e
     payload = tuple(rlp.decode(message[HEAD_SIZE + 1:], strict=False))
     # Ignore excessive list elements as required by EIP-8.
     payload = payload[:cmd.elem_count]


### PR DESCRIPTION
### What was wrong?

This error came up during beam sync.

```python
   ERROR  09-05 12:01:05               asyncio  Exception in callback UDPTransport._on_read_ready
handle: <Handle UDPTransport._on_read_ready>
Traceback (most recent call last):
  File "uvloop/cbhandles.pyx", line 69, in uvloop.loop.Handle._run
  File "uvloop/handles/udp.pyx", line 64, in uvloop.loop.UDPTransport._on_read_ready
  File "/home/ubuntu/trinity/p2p/discovery.py", line 448, in datagram_received
    self.receive(address, cast(bytes, data))
  File "/home/ubuntu/trinity/p2p/discovery.py", line 463, in receive
    remote_pubkey, cmd_id, payload, message_hash = _unpack_v4(message)
  File "/home/ubuntu/trinity/p2p/discovery.py", line 1261, in _unpack_v4
    cmd = CMD_ID_MAP[cmd_id]
KeyError: 9
```
It's a bit surprising to me that this didn't came up earlier but I've seen it a lot today.

Relates to #1062

### How was it fixed?

Catch the `KeyError` and raise a `InvalidCommandID` error that is then handled among the other `DefectiveMessage` errors.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

[//]: # (See: https://trinity-client.readthedocs.io/en/latest/contributing.html#pull-requests)
- [x] Add entry to the [release notes](https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://www.naturalworldsafaris.com/media/3317/shannon-wild-africa-madagascar-dancing-verreauxs-sifaka.jpg)
