### PR TITLE
Fix peer connection issue

### DIFF
--- a/newsfragments/1069.bugfix.rst
+++ b/newsfragments/1069.bugfix.rst
@@ -1,0 +1,1 @@
+Fix issue where attempts to establish new peer connections would halt shortly after startup due to missing timeout when attempting to dial a peer.

--- a/p2p/cancellable.py
+++ b/p2p/cancellable.py
@@ -31,7 +31,8 @@ class CancellableMixin:
 
         Returns the result of the first one to complete.
 
-        Raises TimeoutError if we timeout or OperationCancelled if the token chain is triggered.
+        Raises asyncio.TimeoutError if we timeout or OperationCancelled if the
+        token chain is triggered.
 
         All pending futures are cancelled before returning.
         """

--- a/p2p/constants.py
+++ b/p2p/constants.py
@@ -35,6 +35,9 @@ MAC_LEN = 16
 # The amount of seconds a connection can be idle.
 CONN_IDLE_TIMEOUT = 30
 
+# The amount of seconds a connection can be idle.
+HANDSHAKE_TIMEOUT = 10
+
 # Timeout used when waiting for a reply from a remote node.
 REPLY_TIMEOUT = 3
 MAX_REQUEST_ATTEMPTS = 3

--- a/p2p/discovery.py
+++ b/p2p/discovery.py
@@ -245,7 +245,7 @@ class DiscoveryProtocol(asyncio.DatagramProtocol):
                 got_ping = await self.cancel_token.cancellable_wait(
                     event.wait(), timeout=constants.KADEMLIA_REQUEST_TIMEOUT)
                 self.logger.debug2('got expected ping from %s', remote)
-            except TimeoutError:
+            except asyncio.TimeoutError:
                 self.logger.debug2('timed out waiting for ping from %s', remote)
 
         return got_ping
@@ -272,7 +272,7 @@ class DiscoveryProtocol(asyncio.DatagramProtocol):
                 got_pong = await self.cancel_token.cancellable_wait(
                     event.wait(), timeout=constants.KADEMLIA_REQUEST_TIMEOUT)
                 self.logger.debug2('got expected pong with token %s', encode_hex(token))
-            except TimeoutError:
+            except asyncio.TimeoutError:
                 self.logger.debug2(
                     'timed out waiting for pong from %s (token == %s)',
                     remote,
@@ -302,7 +302,7 @@ class DiscoveryProtocol(asyncio.DatagramProtocol):
                 await self.cancel_token.cancellable_wait(
                     event.wait(), timeout=constants.KADEMLIA_REQUEST_TIMEOUT)
                 self.logger.debug2('got expected neighbours response from %s', remote)
-            except TimeoutError:
+            except asyncio.TimeoutError:
                 self.logger.debug2(
                     'timed out waiting for %d neighbours from %s',
                     constants.KADEMLIA_BUCKET_SIZE,
@@ -815,7 +815,7 @@ class DiscoveryProtocol(asyncio.DatagramProtocol):
             try:
                 await self.cancel_token.cancellable_wait(
                     event.wait(), timeout=constants.KADEMLIA_REQUEST_TIMEOUT)
-            except TimeoutError:
+            except asyncio.TimeoutError:
                 # A timeout here just means we didn't get at least MAX_ENTRIES_PER_TOPIC nodes,
                 # but we'll still process the ones we get.
                 self.logger.debug2(

--- a/p2p/peer_pool.py
+++ b/p2p/peer_pool.py
@@ -88,7 +88,7 @@ TO_DISCOVERY_BROADCAST_CONFIG = BroadcastConfig(filter_endpoint=DISCOVERY_EVENTB
 COMMON_PEER_CONNECTION_EXCEPTIONS = cast(Tuple[Type[BaseP2PError], ...], (
     NoMatchingPeerCapabilities,
     PeerConnectionLost,
-    TimeoutError,
+    asyncio.TimeoutError,
     UnreachablePeer,
 ))
 
@@ -177,7 +177,7 @@ class BasePeerPool(BaseService, AsyncIterable[BasePeer]):
                 ),
                 timeout=REQUEST_PEER_CANDIDATE_TIMEOUT,
             )
-        except TimeoutError:
+        except asyncio.TimeoutError:
             self.logger.warning("PeerCandidateRequest timed out to backend %s", backend)
             return
         else:
@@ -267,7 +267,7 @@ class BasePeerPool(BaseService, AsyncIterable[BasePeer]):
                 peer.boot_manager.events.finished.wait(),
                 timeout=self._peer_boot_timeout
             )
-        except TimeoutError as err:
+        except asyncio.TimeoutError as err:
             self.logger.debug('Timout waiting for peer to boot: %s', err)
             await peer.disconnect(DisconnectReason.timeout)
             return
@@ -337,7 +337,7 @@ class BasePeerPool(BaseService, AsyncIterable[BasePeer]):
                     self.connection_tracker.should_connect_to(remote),
                     timeout=1,
                 )
-            except TimeoutError:
+            except asyncio.TimeoutError:
                 self.logger.warning("ConnectionTracker.should_connect_to request timed out.")
                 raise
 
@@ -346,9 +346,10 @@ class BasePeerPool(BaseService, AsyncIterable[BasePeer]):
 
             try:
                 self.logger.debug2("Connecting to %s...", remote)
-                peer = await self.wait(self.get_peer_factory().handshake(remote))
-
-                return peer
+                return await self.wait(
+                    self.get_peer_factory().handshake(remote),
+                    timeout=5,
+                )
             except OperationCancelled:
                 # Pass it on to instruct our main loop to stop.
                 raise

--- a/p2p/peer_pool.py
+++ b/p2p/peer_pool.py
@@ -39,6 +39,7 @@ from p2p.constants import (
     DEFAULT_MAX_PEERS,
     DEFAULT_PEER_BOOT_TIMEOUT,
     DISCOVERY_EVENTBUS_ENDPOINT,
+    HANDSHAKE_TIMEOUT,
     MAX_CONCURRENT_CONNECTION_ATTEMPTS,
     MAX_SEQUENTIAL_PEER_CONNECT,
     PEER_CONNECT_INTERVAL,
@@ -348,7 +349,7 @@ class BasePeerPool(BaseService, AsyncIterable[BasePeer]):
                 self.logger.debug2("Connecting to %s...", remote)
                 return await self.wait(
                     self.get_peer_factory().handshake(remote),
-                    timeout=5,
+                    timeout=HANDSHAKE_TIMEOUT,
                 )
             except OperationCancelled:
                 # Pass it on to instruct our main loop to stop.

--- a/p2p/transport.py
+++ b/p2p/transport.py
@@ -200,7 +200,7 @@ class Transport(TransportAPI):
         auth_ack_ciphertext = responder.encrypt_auth_ack_message(auth_ack_msg)
 
         if writer.transport.is_closing() or reader.at_eof():
-            raise HandshakeFailure("Connection is closing")
+            raise HandshakeFailure(f"Connection to {initiator_remote} is closing")
 
         # Use the `writer` to send the reply to the remote
         writer.write(auth_ack_ciphertext)
@@ -239,7 +239,7 @@ class Transport(TransportAPI):
                 timeout=CONN_IDLE_TIMEOUT,
             )
         except (asyncio.IncompleteReadError, ConnectionResetError, BrokenPipeError) as err:
-            raise PeerConnectionLost from err
+            raise PeerConnectionLost(f"Lost connection to {self.remote}") from err
 
     def write(self, data: bytes) -> None:
         self._writer.write(data)

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ PYEVM_DEPENDENCY = "py-evm==0.3.0a6"
 deps = {
     'p2p': [
         "async-generator==1.10",
-        "asyncio-cancel-token==0.1.0a2",
+        "asyncio-cancel-token>=0.2,<0.3",
         "async_lru>=0.1.0,<1.0.0",
         "cached-property>=1.5.1,<2",
         # cryptography does not use semver and allows breaking changes within `0.3` version bumps.
@@ -69,7 +69,6 @@ deps = {
     # See: https://github.com/ethereum/trinity/pull/790
     'test-asyncio': [
         "pytest-asyncio>=0.10.0,<0.11",
-        "pytest-asyncio-network-simulator==0.1.0a2;python_version>='3.6'",
     ],
     'test-trio': [
         'pytest-trio==0.5.2',

--- a/tests/core/p2p-proto/test_requests.py
+++ b/tests/core/p2p-proto/test_requests.py
@@ -1,3 +1,5 @@
+import asyncio
+
 import pytest
 
 from p2p.exceptions import PeerConnectionLost
@@ -107,16 +109,16 @@ async def test_proxy_peer_requests_with_timeouts(request,
 
         proxy_peer = await client_proxy_peer_pool.ensure_proxy_peer(client_peer.remote)
 
-        with pytest.raises(TimeoutError):
+        with pytest.raises(asyncio.TimeoutError):
             await proxy_peer.requests.get_block_headers(0, 1, 0, False, timeout=0.01)
 
-        with pytest.raises(TimeoutError):
+        with pytest.raises(asyncio.TimeoutError):
             await proxy_peer.requests.get_receipts((), timeout=0.01)
 
-        with pytest.raises(TimeoutError):
+        with pytest.raises(asyncio.TimeoutError):
             await proxy_peer.requests.get_block_bodies((), timeout=0.01)
 
-        with pytest.raises(TimeoutError):
+        with pytest.raises(asyncio.TimeoutError):
             await proxy_peer.requests.get_node_data((), timeout=0.01)
 
 

--- a/tests/p2p/conftest.py
+++ b/tests/p2p/conftest.py
@@ -1,8 +1,0 @@
-import pytest
-
-
-@pytest.fixture(autouse=True)
-def _network_sim(router):
-    network = router.get_network(name='simulated')
-    with network.patch_asyncio():
-        yield network

--- a/tests/p2p/test_service.py
+++ b/tests/p2p/test_service.py
@@ -55,16 +55,19 @@ async def test_cancel_exits_async_generator():
 
     async def async_iterator():
         yield 1
-        await asyncio.sleep(0.05)
+        await asyncio.sleep(10)
         assert False, "iterator should have been cancelled by now"
 
-    try:
-        async for val in service.wait_iter(async_iterator()):
-            assert val == 1
-    except OperationCancelled:
-        pass
-    else:
-        assert False, "iterator should have been cancelled during iteration"
+    async def do_iter_and_assert():
+        try:
+            async for val in service.wait_iter(async_iterator()):
+                assert val == 1
+        except OperationCancelled:
+            pass
+        else:
+            assert False, "iterator should have been cancelled during iteration"
+
+    await asyncio.wait_for(do_iter_and_assert(), timeout=1)
 
     await service.cancel()
 

--- a/trinity/_utils/ipc.py
+++ b/trinity/_utils/ipc.py
@@ -19,8 +19,10 @@ def wait_for_ipc(ipc_path: pathlib.Path, timeout: int=30) -> None:
             return
         else:
             time.sleep(0.05)
-    # haven't `return`ed by now - raise unconditionally
-    raise TimeoutError("IPC socket file has not appeared in %d seconds!" % timeout)
+    else:
+        # this is intentionally the built-in version of `TimeoutError` as opposed
+        # to the `asyncio` version.
+        raise TimeoutError("IPC socket file has not appeared in %d seconds!" % timeout)
 
 
 def remove_dangling_ipc_files(logger: Logger,

--- a/trinity/plugins/builtin/ethstats/ethstats_service.py
+++ b/trinity/plugins/builtin/ethstats/ethstats_service.py
@@ -1,3 +1,4 @@
+import asyncio
 import platform
 
 import websockets
@@ -151,7 +152,7 @@ class EthstatsService(BaseService):
                 ),
                 timeout=1
             )).peer_count
-        except TimeoutError:
+        except asyncio.TimeoutError:
             self.logger.warning("Timeout: PeerPool did not answer PeerCountRequest")
             peer_count = 0
 

--- a/trinity/plugins/builtin/upnp/nat.py
+++ b/trinity/plugins/builtin/upnp/nat.py
@@ -160,7 +160,7 @@ class UPnPService(BaseService):
                 loop.run_in_executor(ThreadPoolExecutor(max_workers=1), upnpclient.discover),
                 timeout=UPNP_DISCOVER_TIMEOUT_SECONDS,
             )
-        except TimeoutError:
+        except asyncio.TimeoutError:
             self.logger.info("Timeout waiting for UPNP-enabled devices")
             return
         else:

--- a/trinity/protocol/common/boot.py
+++ b/trinity/protocol/common/boot.py
@@ -1,3 +1,4 @@
+import asyncio
 from typing import TYPE_CHECKING
 
 from eth_utils import ValidationError
@@ -54,7 +55,7 @@ class DAOCheckBootManager(BasePeerBootManager):
                     timeout=CHAIN_SPLIT_CHECK_TIMEOUT,
                 )
 
-            except (TimeoutError, PeerConnectionLost) as err:
+            except (asyncio.TimeoutError, PeerConnectionLost) as err:
                 raise DAOForkCheckFailure(
                     f"Timed out waiting for DAO fork header from {self.peer}: {err}"
                 ) from err
@@ -92,7 +93,7 @@ class DAOCheckBootManager(BasePeerBootManager):
                 timeout=CHAIN_SPLIT_CHECK_TIMEOUT,
             )
 
-        except (TimeoutError, PeerConnectionLost) as err:
+        except (asyncio.TimeoutError, PeerConnectionLost) as err:
             raise DAOForkCheckFailure(
                 f"Timed out waiting for tip header from {self.peer}: {err}"
             ) from err

--- a/trinity/protocol/common/constants.py
+++ b/trinity/protocol/common/constants.py
@@ -18,6 +18,6 @@ NUM_QUEUED_REQUESTS = 3
 
 
 # Parameters for the token bucket which manages whether a peer should be
-# disconnected from in the event of a TimeoutError during a request/response.
+# disconnected from in the event of a asyncio.TimeoutError during a request/response.
 TIMEOUT_BUCKET_RATE = 1 / 60  # refill 1 token every minute
 TIMEOUT_BUCKET_CAPACITY = 3  # max capacity of 3 tokens

--- a/trinity/protocol/common/managers.py
+++ b/trinity/protocol/common/managers.py
@@ -91,7 +91,7 @@ class ResponseCandidateStream(
         # single peer for a single command pair in flight.
         try:
             await self.wait(self._lock.acquire(), timeout=total_timeout * NUM_QUEUED_REQUESTS)
-        except TimeoutError:
+        except asyncio.TimeoutError:
             raise AlreadyWaiting(
                 f"Timed out waiting for {self.response_msg_name} request lock "
                 f"or connection: {self._connection}"
@@ -106,7 +106,7 @@ class ResponseCandidateStream(
 
                 try:
                     yield await self._get_payload(timeout_remaining)
-                except TimeoutError as err:
+                except asyncio.TimeoutError as err:
                     tracker.record_timeout(total_timeout)
                     raise
         finally:

--- a/trinity/sync/beam/chain.py
+++ b/trinity/sync/beam/chain.py
@@ -169,7 +169,7 @@ class BeamSyncer(BaseService):
 
         try:
             await self.wait(self._launch_strategy.fulfill_prerequisites())
-        except TimeoutError:
+        except asyncio.TimeoutError:
             self.logger.error(
                 "Timed out while trying to fulfill prerequisites of"
                 f"sync launch strategy: {self._launch_strategy}"

--- a/trinity/sync/beam/state.py
+++ b/trinity/sync/beam/state.py
@@ -329,7 +329,7 @@ class BeamDownloader(BaseService, PeerSubscriber):
                 self._node_tasks.get(eth_constants.MAX_STATE_FETCH),
                 timeout=timeout,
             )
-        except TimeoutError:
+        except asyncio.TimeoutError:
             return None, ()
 
     def _maybe_add_predictive_nodes(
@@ -493,7 +493,7 @@ class BeamDownloader(BaseService, PeerSubscriber):
         self.logger.debug2("Requesting %d nodes from %s", num_nodes, peer)
         try:
             return await peer.requests.get_node_data(node_hashes, timeout=self._reply_timeout)
-        except TimeoutError as err:
+        except asyncio.TimeoutError as err:
             # This kind of exception shouldn't necessarily *drop* the peer,
             # so capture error, log and swallow
             self.logger.debug("Timed out requesting %d nodes from %s", num_nodes, peer)

--- a/trinity/sync/common/chain.py
+++ b/trinity/sync/common/chain.py
@@ -1,4 +1,5 @@
 from abc import ABC, abstractmethod
+import asyncio
 from typing import (
     AsyncIterator,
     Tuple,
@@ -153,7 +154,7 @@ class PeerHeaderSyncer(BaseService):
             except OperationCancelled:
                 self.logger.info("Sync with %s completed", peer)
                 break
-            except TimeoutError:
+            except asyncio.TimeoutError:
                 self.logger.warning("Timeout waiting for header batch from %s, aborting sync", peer)
                 await peer.disconnect(DisconnectReason.timeout)
                 break

--- a/trinity/sync/common/headers.py
+++ b/trinity/sync/common/headers.py
@@ -137,7 +137,7 @@ class SkeletonSyncer(BaseService, Generic[TChainPeer]):
                 self.peer,
                 exc,
             )
-        except TimeoutError:
+        except asyncio.TimeoutError:
             self.logger.warning("Timeout waiting for header batch from %s, halting sync", self.peer)
 
     async def _fetch_full_skeleton(self) -> None:
@@ -461,7 +461,7 @@ class SkeletonSyncer(BaseService, Generic[TChainPeer]):
         except OperationCancelled:
             self.logger.info("Skeleteon sync with %s cancelled", peer)
             return tuple()
-        except TimeoutError:
+        except asyncio.TimeoutError:
             self.logger.warning("Timeout waiting for header batch from %s, aborting sync", peer)
             return tuple()
         except ValidationError as err:
@@ -740,7 +740,7 @@ class HeaderMeatSyncer(BaseService, PeerSubscriber, Generic[TChainPeer]):
         self.logger.debug("Requesting %d headers from %s", length, peer)
         try:
             return await peer.requests.get_block_headers(start_at, length, skip=0, reverse=False)
-        except TimeoutError as err:
+        except asyncio.TimeoutError as err:
             self.logger.debug("Timed out requesting %d headers from %s", length, peer)
             return tuple()
         except CancelledError:

--- a/trinity/sync/common/strategies.py
+++ b/trinity/sync/common/strategies.py
@@ -113,7 +113,7 @@ class FromCheckpointLaunchStrategy(SyncLaunchStrategyAPI):
                     skip=0,
                     reverse=False,
                 )
-            except (TimeoutError, PeerConnectionLost, ValidationError):
+            except (asyncio.TimeoutError, PeerConnectionLost, ValidationError):
                 # Nothing to do here. The ExchangeManager will disconnect if appropriate
                 # and eventually lead us to a better peer.
                 continue
@@ -131,7 +131,9 @@ class FromCheckpointLaunchStrategy(SyncLaunchStrategyAPI):
 
             await asyncio.sleep(0.05)
 
-        raise TimeoutError(f"Failed to get checkpoint header within {max_attempts} attempts")
+        raise asyncio.TimeoutError(
+            f"Failed to get checkpoint header within {max_attempts} attempts"
+        )
 
     def get_genesis_parent_hash(self) -> Hash32:
         return self._checkpoint.block_hash

--- a/trinity/sync/full/chain.py
+++ b/trinity/sync/full/chain.py
@@ -396,7 +396,7 @@ class BaseBodyChainSyncer(BaseService, PeerSubscriber):
         self.logger.debug("Requesting block bodies for %d headers from %s", len(batch), peer)
         try:
             block_body_bundles = await peer.requests.get_block_bodies(tuple(batch))
-        except TimeoutError as err:
+        except asyncio.TimeoutError as err:
             self.logger.debug(
                 "Timed out requesting block bodies for %d headers from %s", len(batch), peer,
             )
@@ -918,7 +918,7 @@ class FastChainBodySyncer(BaseBodyChainSyncer):
         self.logger.debug("Requesting receipts for %d headers from %s", len(batch), peer)
         try:
             receipt_bundles = await peer.requests.get_receipts(tuple(batch))
-        except TimeoutError as err:
+        except asyncio.TimeoutError as err:
             self.logger.debug(
                 "Timed out requesting receipts for %d headers from %s", len(batch), peer,
             )

--- a/trinity/sync/full/state.py
+++ b/trinity/sync/full/state.py
@@ -1,3 +1,4 @@
+import asyncio
 import collections
 import itertools
 from pathlib import Path
@@ -178,7 +179,7 @@ class StateDownloader(BaseService, PeerSubscriber):
         self.logger.debug("Requesting %d trie nodes from %s", len(batch), peer)
         try:
             node_data = await peer.requests.get_node_data(batch)
-        except TimeoutError as err:
+        except asyncio.TimeoutError as err:
             self.logger.debug(
                 "Timed out waiting for %s trie nodes from %s: %s",
                 len(batch),

--- a/trinity/sync/light/service.py
+++ b/trinity/sync/light/service.py
@@ -154,7 +154,7 @@ class LightPeerChain(PeerSubscriber, BaseService, BaseLightPeerChain):
         :return: header returned by peer
 
         :raise NoEligiblePeers: if no peers are available to fulfill the request
-        :raise TimeoutError: if an individual request or the overall process times out
+        :raise asyncio.TimeoutError: if an individual request or the overall process times out
         """
         return await self._retry_on_bad_response(
             partial(self._get_block_header_by_hash, block_hash)
@@ -221,7 +221,7 @@ class LightPeerChain(PeerSubscriber, BaseService, BaseLightPeerChain):
         :return: bytecode of the contract, ``b''`` if no code is set
 
         :raise NoEligiblePeers: if no peers are available to fulfill the request
-        :raise TimeoutError: if an individual request or the overall process times out
+        :raise asyncio.TimeoutError: if an individual request or the overall process times out
         """
         # get account for later verification, and
         # to confirm that our highest total difficulty peer has the info
@@ -369,7 +369,7 @@ class LightPeerChain(PeerSubscriber, BaseService, BaseLightPeerChain):
         :param make_request_to_peer: an abstract call to a peer that may raise a BadLESResponse
 
         :raise NoEligiblePeers: if no peers are available to fulfill the request
-        :raise TimeoutError: if an individual request or the overall process times out
+        :raise asyncio.TimeoutError: if an individual request or the overall process times out
         """
         for _ in range(MAX_REQUEST_ATTEMPTS):
             try:
@@ -384,4 +384,6 @@ class LightPeerChain(PeerSubscriber, BaseService, BaseLightPeerChain):
                 await peer.disconnect(DisconnectReason.subprotocol_error)
                 # reattempt after removing this peer from our pool
 
-        raise TimeoutError(f"Could not complete peer request in {MAX_REQUEST_ATTEMPTS} attempts")
+        raise asyncio.TimeoutError(
+            f"Could not complete peer request in {MAX_REQUEST_ATTEMPTS} attempts"
+        )

--- a/trinity/tools/async_process_runner.py
+++ b/trinity/tools/async_process_runner.py
@@ -63,7 +63,7 @@ class AsyncProcessRunner():
     async def kill_after_timeout(self, timeout_sec: int) -> None:
         await asyncio.sleep(timeout_sec)
         self.kill()
-        raise TimeoutError(f'Killed process after {timeout_sec} seconds')
+        raise asyncio.TimeoutError(f'Killed process after {timeout_sec} seconds')
 
     def kill(self, sig: int = signal.SIGKILL) -> None:
         try:


### PR DESCRIPTION
fixes #1067 

### What was wrong?

I have no idea what was wrong.....

### How was it fixed?

Added a timeout to the call to `PeerPool.connect` and updated to fixed version of `asyncio-cancel-token` library that properly handles cancelling the background tasks.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

[//]: # (See: https://trinity-client.readthedocs.io/en/latest/contributing.html#pull-requests)
- [x] Add entry to the [release notes](https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![48118983fed2a705708c168f0b73c8f3](https://user-images.githubusercontent.com/824194/64446862-29b6dd80-d097-11e9-89d7-bf4f5ad8e012.jpg)

