### PR TITLE
Dont log exception for CancelledError in BaseService

### DIFF
--- a/p2p/service.py
+++ b/p2p/service.py
@@ -118,6 +118,9 @@ class BaseService(CancellableMixin, AsyncioServiceAPI):
                 await self._run()
         except OperationCancelled as e:
             self.logger.debug("%s finished: %s", self, e)
+        except asyncio.CancelledError:
+            # If a cancellation occurs we just want to re-raise it.  No need to log anything.
+            raise
         except Exception:
             self.logger.exception("Unexpected error in %r, exiting", self)
         else:


### PR DESCRIPTION
### What was wrong?

`BaseService` would occasionally log an exception because the `run()` method was issued a `CancelledError`.  These should just be re-raised.

### How was it fixed?

Added handling to re-raise so it doesn't hit the other exception handling logic that logs the stacktrace.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

[//]: # (See: https://trinity-client.readthedocs.io/en/latest/contributing.html#pull-requests)
- [x] Add entry to the [release notes](https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![efbbf8641116d89e4cc0dfba36ed7e93--animals-in-costumes-dogs-in-costumes](https://user-images.githubusercontent.com/824194/64446822-0724c480-d097-11e9-8782-cf3b6ae7fa88.jpg)

