### PR TITLE
Piper/fix broken logging statement in connection

### DIFF
--- a/p2p/connection.py
+++ b/p2p/connection.py
@@ -83,7 +83,11 @@ class Connection(ConnectionAPI, BaseService):
         except (PeerConnectionLost, asyncio.CancelledError):
             pass
         except (MalformedMessage,) as err:
-            self.logger.debug("Disconnecting peer %s for sending MalformedMessage: %s", err)
+            self.logger.debug(
+                "Disconnecting peer %s for sending MalformedMessage: %s",
+                self.remote,
+                err,
+            )
             self.get_base_protocol().send_disconnect(DisconnectReason.bad_protocol)
             pass
 


### PR DESCRIPTION
### What was wrong?

A logging statement in the `Connection` object's error handling was incorrectly not supplying enough arguments for the logging string.

### How was it fixed?

Added the missing argument.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history


#### Cute Animal Picture

![awesomelycute-com-2625](https://user-images.githubusercontent.com/824194/64447001-8adeb100-d097-11e9-9a1d-884d85e818dd.jpg)

