### PR TITLE
Catch all PeerConnectionLost in try_with_node

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -387,10 +387,16 @@ workflows:
   version: 2
   test:
     jobs:
+      # These tests are long, so should be started first to optimize for total suite run time
+      - py36-integration
+      - py36-wheel-cli
+      - py37-wheel-cli
+      - py36-long_run_integration
+      - py37-rpc-state-sstore
+
       - py36-docs
 
       - py37-eth1-core
-      - py37-wheel-cli
       - py37-p2p
       - py36-p2p-trio
       - py37-eth2-core
@@ -402,7 +408,6 @@ workflows:
       - py37-eth1-plugins
 
       - py37-rpc-state-quadratic
-      - py37-rpc-state-sstore
       - py37-rpc-state-zero_knowledge
 
       - py36-rpc-state-byzantium
@@ -415,7 +420,6 @@ workflows:
       - py36-rpc-blockchain
 
       - py36-eth1-core
-      - py36-wheel-cli
       - py36-p2p
       - py36-p2p-trio
       - py36-eth2-core
@@ -425,9 +429,7 @@ workflows:
       - py36-eth2-plugins
       - py36-eth1-plugins
 
-      - py36-integration
       - py36-lightchain_integration
-      - py36-long_run_integration
 
       - py36-lint
       - py36-lint-eth2

--- a/newsfragments/1074.bugfix.rst
+++ b/newsfragments/1074.bugfix.rst
@@ -1,0 +1,2 @@
+An exception while serving peer requests would crash out the peer pool event server.
+Now it doesn't crash, but logs a big red error (and catches innocuous exceptions, early on).

--- a/trinity/_utils/decorators.py
+++ b/trinity/_utils/decorators.py
@@ -1,8 +1,41 @@
+import functools
 from typing import (
     Any,
+    Awaitable,
+    Callable,
+    Type,
 )
 
 
 class classproperty(property):
     def __get__(self, obj: Any, objtype: Any = None) -> Any:
         return super().__get__(objtype)
+
+
+def suppress_exceptions(*exception_types: Type[BaseException]) -> Callable[..., Any]:
+    def _suppress_decorator(func: Callable[..., Any]) -> Callable[..., Any]:
+        @functools.wraps(func)
+        def _suppressed_func(*args: Any, **kwargs: Any) -> Any:
+            try:
+                return func(*args, **kwargs)
+            except exception_types:
+                # these exceptions are expected, and require no handling
+                pass
+
+        return _suppressed_func
+
+    return _suppress_decorator
+
+
+def async_suppress_exceptions(*exception_types: Type[BaseException]) -> Callable[..., Any]:
+    def _suppress_decorator(func: Callable[..., Awaitable[Any]]) -> Callable[..., Awaitable[Any]]:
+        async def _suppressed_func(*args: Any, **kwargs: Any) -> Any:
+            try:
+                return await func(*args, **kwargs)
+            except exception_types:
+                # these exceptions are expected, and require no handling
+                pass
+
+        return _suppressed_func
+
+    return _suppress_decorator

--- a/trinity/_utils/decorators.py
+++ b/trinity/_utils/decorators.py
@@ -1,10 +1,13 @@
-import functools
 from typing import (
     Any,
     Awaitable,
     Callable,
     Type,
+    TypeVar,
 )
+
+
+TAsyncFn = TypeVar("TAsyncFn", bound=Callable[..., Awaitable[None]])
 
 
 class classproperty(property):
@@ -12,30 +15,15 @@ class classproperty(property):
         return super().__get__(objtype)
 
 
-def suppress_exceptions(*exception_types: Type[BaseException]) -> Callable[..., Any]:
-    def _suppress_decorator(func: Callable[..., Any]) -> Callable[..., Any]:
-        @functools.wraps(func)
-        def _suppressed_func(*args: Any, **kwargs: Any) -> Any:
+def async_suppress_exceptions(*exception_types: Type[BaseException]) -> TAsyncFn:
+    def _suppress_decorator(func: TAsyncFn) -> TAsyncFn:
+        async def _suppressed_func(*args: Any, **kwargs: Any) -> None:
             try:
-                return func(*args, **kwargs)
+                await func(*args, **kwargs)
             except exception_types:
                 # these exceptions are expected, and require no handling
                 pass
 
-        return _suppressed_func
+        return _suppressed_func  # type: ignore
 
-    return _suppress_decorator
-
-
-def async_suppress_exceptions(*exception_types: Type[BaseException]) -> Callable[..., Any]:
-    def _suppress_decorator(func: Callable[..., Awaitable[Any]]) -> Callable[..., Awaitable[Any]]:
-        async def _suppressed_func(*args: Any, **kwargs: Any) -> Any:
-            try:
-                return await func(*args, **kwargs)
-            except exception_types:
-                # these exceptions are expected, and require no handling
-                pass
-
-        return _suppressed_func
-
-    return _suppress_decorator
+    return _suppress_decorator  # type: ignore

--- a/trinity/protocol/common/peer_pool_event_bus.py
+++ b/trinity/protocol/common/peer_pool_event_bus.py
@@ -159,6 +159,10 @@ class PeerPoolEventServer(BaseService, PeerSubscriber, Generic[TPeer]):
     async def handle_stream(self,
                             event_type: Type[TEvent],
                             event_handler_fn: Callable[[TEvent], Any]) -> None:
+        """
+        Event handlers must not raise exceptions, they should all be handled internally,
+        because there is no obvious place to forward the exception.
+        """
 
         async for event in self.wait_iter(self.event_bus.stream(event_type)):
             try:
@@ -173,6 +177,9 @@ class PeerPoolEventServer(BaseService, PeerSubscriber, Generic[TPeer]):
             self,
             event_type: Type[TRequest],
             event_handler_fn: Callable[[TRequest], Any]) -> None:
+        """
+        Handlers may raise exceptions, which will be wrapped and sent in response.
+        """
 
         async for event in self.wait_iter(self.event_bus.stream(event_type)):
             try:

--- a/trinity/protocol/common/peer_pool_event_bus.py
+++ b/trinity/protocol/common/peer_pool_event_bus.py
@@ -161,7 +161,13 @@ class PeerPoolEventServer(BaseService, PeerSubscriber, Generic[TPeer]):
                             event_handler_fn: Callable[[TEvent], Any]) -> None:
 
         async for event in self.wait_iter(self.event_bus.stream(event_type)):
-            await event_handler_fn(event)
+            try:
+                await event_handler_fn(event)
+            except Exception as exc:
+                self.logger.exception(
+                    "Suppressed uncaught exception to continue handling events: %s",
+                    exc,
+                )
 
     async def handle_request_stream(
             self,

--- a/trinity/protocol/eth/peer.py
+++ b/trinity/protocol/eth/peer.py
@@ -181,7 +181,7 @@ class ETHPeerFactory(BaseChainPeerFactory):
         )
 
 
-async_fire_and_forget = async_suppress_exceptions(PeerConnectionLost, asyncio.TimeoutError)
+async_fire_and_forget = async_suppress_exceptions(PeerConnectionLost, asyncio.TimeoutError)  # type: ignore  # noqa: E501
 
 
 class ETHPeerPoolEventServer(PeerPoolEventServer[ETHPeer]):


### PR DESCRIPTION
Failures here would stop the peer pool events from working at all, if
a send action were to get a PeerConnectionLost, for example.

### How was it fixed?
When handling requests via the server, catch and drop `PeerConnectionLost` exceptions.

Hm, as I'm writing this, I realize it may be too aggressive, and drop PCLs related to other peers during handling.

Anyway, we need to do something here, because unhandled exceptions cause the PeerPoolEventServer loop to break, and stops handling events.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

[//]: # (See: https://trinity-client.readthedocs.io/en/latest/contributing.html#pull-requests)
- [ ] Add entry to the [release notes](https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcSxYWRw9ZXwxT5X2Gqt1mFCvNc299IwnGPtZCDx5Ck0488MtD-OfA)
