### PR TITLE
Differentiate Signing root and Hash tree root

### DIFF
--- a/eth2/beacon/chains/base.py
+++ b/eth2/beacon/chains/base.py
@@ -6,7 +6,6 @@ from eth._utils.datatypes import Configurable
 from eth.abc import AtomicDatabaseAPI
 from eth.exceptions import BlockNotFound
 from eth.validation import validate_word
-from eth_typing import Hash32
 from eth_utils import ValidationError, encode_hex
 
 from eth2._utils.funcs import constantly
@@ -17,7 +16,7 @@ from eth2.beacon.operations.attestation_pool import AttestationPool
 from eth2.beacon.types.attestations import Attestation
 from eth2.beacon.types.blocks import BaseBeaconBlock
 from eth2.beacon.types.states import BeaconState
-from eth2.beacon.typing import FromBlockParams, Slot
+from eth2.beacon.typing import FromBlockParams, SigningRoot, Slot
 from eth2.configs import Eth2Config, Eth2GenesisConfig
 
 if TYPE_CHECKING:
@@ -104,7 +103,7 @@ class BaseBeaconChain(Configurable, ABC):
     # Block API
     #
     @abstractmethod
-    def get_block_class(self, block_root: Hash32) -> Type[BaseBeaconBlock]:
+    def get_block_class(self, block_root: SigningRoot) -> Type[BaseBeaconBlock]:
         ...
 
     @abstractmethod
@@ -114,7 +113,7 @@ class BaseBeaconChain(Configurable, ABC):
         ...
 
     @abstractmethod
-    def get_block_by_root(self, block_root: Hash32) -> BaseBeaconBlock:
+    def get_block_by_root(self, block_root: SigningRoot) -> BaseBeaconBlock:
         ...
 
     @abstractmethod
@@ -122,7 +121,7 @@ class BaseBeaconChain(Configurable, ABC):
         ...
 
     @abstractmethod
-    def get_score(self, block_root: Hash32) -> int:
+    def get_score(self, block_root: SigningRoot) -> int:
         ...
 
     @abstractmethod
@@ -130,7 +129,7 @@ class BaseBeaconChain(Configurable, ABC):
         ...
 
     @abstractmethod
-    def get_canonical_block_root(self, slot: Slot) -> Hash32:
+    def get_canonical_block_root(self, slot: Slot) -> SigningRoot:
         ...
 
     @abstractmethod
@@ -149,11 +148,11 @@ class BaseBeaconChain(Configurable, ABC):
     # Attestation API
     #
     @abstractmethod
-    def get_attestation_by_root(self, attestation_root: Hash32) -> Attestation:
+    def get_attestation_by_root(self, attestation_root: SigningRoot) -> Attestation:
         ...
 
     @abstractmethod
-    def attestation_exists(self, attestation_root: Hash32) -> bool:
+    def attestation_exists(self, attestation_root: SigningRoot) -> bool:
         ...
 
 
@@ -308,7 +307,7 @@ class BeaconChain(BaseBeaconChain):
     #
     # Block API
     #
-    def get_block_class(self, block_root: Hash32) -> Type[BaseBeaconBlock]:
+    def get_block_class(self, block_root: SigningRoot) -> Type[BaseBeaconBlock]:
         slot = self.chaindb.get_slot_by_root(block_root)
         sm_class = self.get_state_machine_class_for_block_slot(slot)
         block_class = sm_class.block_class
@@ -326,7 +325,7 @@ class BeaconChain(BaseBeaconChain):
             slot=slot
         ).create_block_from_parent(parent_block, block_params)
 
-    def get_block_by_root(self, block_root: Hash32) -> BaseBeaconBlock:
+    def get_block_by_root(self, block_root: SigningRoot) -> BaseBeaconBlock:
         """
         Return the requested block as specified by block hash.
 
@@ -348,7 +347,7 @@ class BeaconChain(BaseBeaconChain):
         block_class = self.get_block_class(block_root)
         return self.chaindb.get_block_by_root(block_root, block_class)
 
-    def get_score(self, block_root: Hash32) -> int:
+    def get_score(self, block_root: SigningRoot) -> int:
         """
         Return the score of the block with the given hash.
 
@@ -365,7 +364,7 @@ class BeaconChain(BaseBeaconChain):
         """
         return self.get_block_by_root(self.chaindb.get_canonical_block_root(slot))
 
-    def get_canonical_block_root(self, slot: Slot) -> Hash32:
+    def get_canonical_block_root(self, slot: Slot) -> SigningRoot:
         """
         Return the block hash with the given number in the canonical chain.
 
@@ -450,10 +449,10 @@ class BeaconChain(BaseBeaconChain):
     #
     # Attestation API
     #
-    def get_attestation_by_root(self, attestation_root: Hash32) -> Attestation:
+    def get_attestation_by_root(self, attestation_root: SigningRoot) -> Attestation:
         block_root, index = self.chaindb.get_attestation_key_by_root(attestation_root)
         block = self.get_block_by_root(block_root)
         return block.body.attestations[index]
 
-    def attestation_exists(self, attestation_root: Hash32) -> bool:
+    def attestation_exists(self, attestation_root: SigningRoot) -> bool:
         return self.chaindb.attestation_exists(attestation_root)

--- a/eth2/beacon/chains/base.py
+++ b/eth2/beacon/chains/base.py
@@ -16,7 +16,7 @@ from eth2.beacon.operations.attestation_pool import AttestationPool
 from eth2.beacon.types.attestations import Attestation
 from eth2.beacon.types.blocks import BaseBeaconBlock
 from eth2.beacon.types.states import BeaconState
-from eth2.beacon.typing import FromBlockParams, SigningRoot, Slot
+from eth2.beacon.typing import FromBlockParams, HashTreeRoot, SigningRoot, Slot
 from eth2.configs import Eth2Config, Eth2GenesisConfig
 
 if TYPE_CHECKING:
@@ -148,11 +148,11 @@ class BaseBeaconChain(Configurable, ABC):
     # Attestation API
     #
     @abstractmethod
-    def get_attestation_by_root(self, attestation_root: SigningRoot) -> Attestation:
+    def get_attestation_by_root(self, attestation_root: HashTreeRoot) -> Attestation:
         ...
 
     @abstractmethod
-    def attestation_exists(self, attestation_root: SigningRoot) -> bool:
+    def attestation_exists(self, attestation_root: HashTreeRoot) -> bool:
         ...
 
 
@@ -449,10 +449,10 @@ class BeaconChain(BaseBeaconChain):
     #
     # Attestation API
     #
-    def get_attestation_by_root(self, attestation_root: SigningRoot) -> Attestation:
+    def get_attestation_by_root(self, attestation_root: HashTreeRoot) -> Attestation:
         block_root, index = self.chaindb.get_attestation_key_by_root(attestation_root)
         block = self.get_block_by_root(block_root)
         return block.body.attestations[index]
 
-    def attestation_exists(self, attestation_root: SigningRoot) -> bool:
+    def attestation_exists(self, attestation_root: HashTreeRoot) -> bool:
         return self.chaindb.attestation_exists(attestation_root)

--- a/eth2/beacon/constants.py
+++ b/eth2/beacon/constants.py
@@ -1,7 +1,7 @@
 from eth.constants import ZERO_HASH32
-from eth_typing import BLSPubkey, BLSSignature, SigningRoot
+from eth_typing import BLSPubkey, BLSSignature
 
-from eth2.beacon.typing import Epoch, Timestamp
+from eth2.beacon.typing import Epoch, HashTreeRoot, SigningRoot, Timestamp
 
 EMPTY_SIGNATURE = BLSSignature(b"\x00" * 96)
 EMPTY_PUBKEY = BLSPubkey(b"\x00" * 48)
@@ -9,6 +9,7 @@ GWEI_PER_ETH = 10 ** 9
 FAR_FUTURE_EPOCH = Epoch(2 ** 64 - 1)
 
 ZERO_SIGNING_ROOT = SigningRoot(ZERO_HASH32)
+ZERO_HASH_TREE_ROOT = HashTreeRoot(ZERO_HASH32)
 GENESIS_PARENT_ROOT = ZERO_SIGNING_ROOT
 
 ZERO_TIMESTAMP = Timestamp(0)

--- a/eth2/beacon/constants.py
+++ b/eth2/beacon/constants.py
@@ -1,5 +1,5 @@
 from eth.constants import ZERO_HASH32
-from eth_typing import BLSPubkey, BLSSignature
+from eth_typing import BLSPubkey, BLSSignature, SigningRoot
 
 from eth2.beacon.typing import Epoch, Timestamp
 
@@ -8,7 +8,8 @@ EMPTY_PUBKEY = BLSPubkey(b"\x00" * 48)
 GWEI_PER_ETH = 10 ** 9
 FAR_FUTURE_EPOCH = Epoch(2 ** 64 - 1)
 
-GENESIS_PARENT_ROOT = ZERO_HASH32
+ZERO_SIGNING_ROOT = SigningRoot(ZERO_HASH32)
+GENESIS_PARENT_ROOT = ZERO_SIGNING_ROOT
 
 ZERO_TIMESTAMP = Timestamp(0)
 

--- a/eth2/beacon/db/chain.py
+++ b/eth2/beacon/db/chain.py
@@ -7,10 +7,11 @@ from eth.abc import AtomicDatabaseAPI, DatabaseAPI
 from eth.constants import ZERO_HASH32
 from eth.exceptions import BlockNotFound, CanonicalHeadNotFound, ParentNotFound
 from eth.validation import validate_word
-from eth_typing import Hash32, HashTreeRoot, SigningRoot
+from eth_typing import Hash32
 from eth_utils import ValidationError, encode_hex, to_tuple
 import ssz
 
+from eth2.beacon.constants import ZERO_SIGNING_ROOT
 from eth2.beacon.db.exceptions import (
     AttestationRootNotFound,
     FinalizedHeadNotFound,
@@ -24,7 +25,7 @@ from eth2.beacon.fork_choice.scoring import ScoringFn as ForkChoiceScoringFn
 from eth2.beacon.helpers import compute_epoch_of_slot
 from eth2.beacon.types.blocks import BaseBeaconBlock, BeaconBlock  # noqa: F401
 from eth2.beacon.types.states import BeaconState  # noqa: F401
-from eth2.beacon.typing import Epoch, Slot
+from eth2.beacon.typing import Epoch, SigningRoot, Slot
 from eth2.configs import Eth2GenesisConfig
 
 

--- a/eth2/beacon/db/chain.py
+++ b/eth2/beacon/db/chain.py
@@ -25,7 +25,7 @@ from eth2.beacon.fork_choice.scoring import ScoringFn as ForkChoiceScoringFn
 from eth2.beacon.helpers import compute_epoch_of_slot
 from eth2.beacon.types.blocks import BaseBeaconBlock, BeaconBlock  # noqa: F401
 from eth2.beacon.types.states import BeaconState  # noqa: F401
-from eth2.beacon.typing import Epoch, SigningRoot, Slot
+from eth2.beacon.typing import Epoch, HashTreeRoot, SigningRoot, Slot
 from eth2.configs import Eth2GenesisConfig
 
 
@@ -141,12 +141,12 @@ class BaseBeaconChainDB(ABC):
     #
     @abstractmethod
     def get_attestation_key_by_root(
-        self, attestation_root: SigningRoot
+        self, attestation_root: HashTreeRoot
     ) -> Tuple[SigningRoot, int]:
         pass
 
     @abstractmethod
-    def attestation_exists(self, attestation_root: SigningRoot) -> bool:
+    def attestation_exists(self, attestation_root: HashTreeRoot) -> bool:
         pass
 
     #
@@ -807,13 +807,13 @@ class BeaconChainDB(BaseBeaconChainDB):
             )
 
     def get_attestation_key_by_root(
-        self, attestation_root: SigningRoot
+        self, attestation_root: HashTreeRoot
     ) -> Tuple[SigningRoot, int]:
         return self._get_attestation_key_by_root(self.db, attestation_root)
 
     @staticmethod
     def _get_attestation_key_by_root(
-        db: DatabaseAPI, attestation_root: SigningRoot
+        db: DatabaseAPI, attestation_root: HashTreeRoot
     ) -> Tuple[SigningRoot, int]:
         try:
             encoded_key = db[
@@ -826,7 +826,7 @@ class BeaconChainDB(BaseBeaconChainDB):
         attestation_key = ssz.decode(encoded_key, sedes=AttestationKey)
         return attestation_key.block_root, attestation_key.index
 
-    def attestation_exists(self, attestation_root: SigningRoot) -> bool:
+    def attestation_exists(self, attestation_root: HashTreeRoot) -> bool:
         lookup_key = SchemaV1.make_attestation_root_to_block_lookup_key(
             attestation_root
         )

--- a/eth2/beacon/db/chain.py
+++ b/eth2/beacon/db/chain.py
@@ -1,6 +1,6 @@
 from abc import ABC, abstractmethod
 import functools
-from typing import Iterable, Optional, Tuple, Type
+from typing import Iterable, Optional, Tuple, Type, cast
 
 from cytoolz import concat, first, sliding_window
 from eth.abc import AtomicDatabaseAPI, DatabaseAPI
@@ -290,7 +290,7 @@ class BeaconChainDB(BaseBeaconChainDB):
             canonical_head_root = db[SchemaV1.make_canonical_head_root_lookup_key()]
         except KeyError:
             raise CanonicalHeadNotFound("No canonical head set for this chain")
-        return SigningRoot(canonical_head_root)
+        return cast(SigningRoot, canonical_head_root)
 
     def get_finalized_head(self, block_class: Type[BaseBeaconBlock]) -> BaseBeaconBlock:
         """
@@ -311,7 +311,7 @@ class BeaconChainDB(BaseBeaconChainDB):
             finalized_head_root = db[SchemaV1.make_finalized_head_root_lookup_key()]
         except KeyError:
             raise FinalizedHeadNotFound("No finalized head set for this chain")
-        return SigningRoot(finalized_head_root)
+        return cast(SigningRoot, finalized_head_root)
 
     def get_justified_head(self, block_class: Type[BaseBeaconBlock]) -> BaseBeaconBlock:
         """
@@ -332,7 +332,7 @@ class BeaconChainDB(BaseBeaconChainDB):
             justified_head_root = db[SchemaV1.make_justified_head_root_lookup_key()]
         except KeyError:
             raise JustifiedHeadNotFound("No justified head set for this chain")
-        return SigningRoot(justified_head_root)
+        return cast(SigningRoot, justified_head_root)
 
     def get_block_by_root(
         self, block_root: SigningRoot, block_class: Type[BaseBeaconBlock]

--- a/eth2/beacon/db/chain.py
+++ b/eth2/beacon/db/chain.py
@@ -4,7 +4,6 @@ from typing import Iterable, Optional, Tuple, Type, cast
 
 from cytoolz import concat, first, sliding_window
 from eth.abc import AtomicDatabaseAPI, DatabaseAPI
-from eth.constants import ZERO_HASH32
 from eth.exceptions import BlockNotFound, CanonicalHeadNotFound, ParentNotFound
 from eth.validation import validate_word
 from eth_typing import Hash32
@@ -171,11 +170,11 @@ class BeaconChainDB(BaseBeaconChainDB):
         self._finalized_root = self._get_finalized_root_if_present(db)
         self._highest_justified_epoch = self._get_highest_justified_epoch(db)
 
-    def _get_finalized_root_if_present(self, db: DatabaseAPI) -> Hash32:
+    def _get_finalized_root_if_present(self, db: DatabaseAPI) -> SigningRoot:
         try:
             return self._get_finalized_head_root(db)
         except FinalizedHeadNotFound:
-            return ZERO_HASH32
+            return ZERO_SIGNING_ROOT
 
     def _get_highest_justified_epoch(self, db: DatabaseAPI) -> Epoch:
         try:

--- a/eth2/beacon/db/chain.py
+++ b/eth2/beacon/db/chain.py
@@ -7,7 +7,7 @@ from eth.abc import AtomicDatabaseAPI, DatabaseAPI
 from eth.constants import ZERO_HASH32
 from eth.exceptions import BlockNotFound, CanonicalHeadNotFound, ParentNotFound
 from eth.validation import validate_word
-from eth_typing import Hash32
+from eth_typing import Hash32, HashTreeRoot, SigningRoot
 from eth_utils import ValidationError, encode_hex, to_tuple
 import ssz
 
@@ -54,11 +54,11 @@ class BaseBeaconChainDB(ABC):
         pass
 
     @abstractmethod
-    def get_canonical_block_root(self, slot: Slot) -> Hash32:
+    def get_canonical_block_root(self, slot: Slot) -> SigningRoot:
         pass
 
     @abstractmethod
-    def get_genesis_block_root(self) -> Hash32:
+    def get_genesis_block_root(self) -> SigningRoot:
         pass
 
     @abstractmethod
@@ -72,7 +72,7 @@ class BaseBeaconChainDB(ABC):
         pass
 
     @abstractmethod
-    def get_canonical_head_root(self) -> Hash32:
+    def get_canonical_head_root(self) -> SigningRoot:
         pass
 
     @abstractmethod
@@ -85,20 +85,20 @@ class BaseBeaconChainDB(ABC):
 
     @abstractmethod
     def get_block_by_root(
-        self, block_root: Hash32, block_class: Type[BaseBeaconBlock]
+        self, block_root: SigningRoot, block_class: Type[BaseBeaconBlock]
     ) -> BaseBeaconBlock:
         pass
 
     @abstractmethod
-    def get_slot_by_root(self, block_root: Hash32) -> Slot:
+    def get_slot_by_root(self, block_root: SigningRoot) -> Slot:
         pass
 
     @abstractmethod
-    def get_score(self, block_root: Hash32) -> int:
+    def get_score(self, block_root: SigningRoot) -> int:
         pass
 
     @abstractmethod
-    def block_exists(self, block_root: Hash32) -> bool:
+    def block_exists(self, block_root: SigningRoot) -> bool:
         pass
 
     @abstractmethod
@@ -140,12 +140,12 @@ class BaseBeaconChainDB(ABC):
     #
     @abstractmethod
     def get_attestation_key_by_root(
-        self, attestation_root: Hash32
-    ) -> Tuple[Hash32, int]:
+        self, attestation_root: SigningRoot
+    ) -> Tuple[SigningRoot, int]:
         pass
 
     @abstractmethod
-    def attestation_exists(self, attestation_root: Hash32) -> bool:
+    def attestation_exists(self, attestation_root: SigningRoot) -> bool:
         pass
 
     #
@@ -224,7 +224,7 @@ class BeaconChainDB(BaseBeaconChainDB):
     #
     # Canonical Chain API
     #
-    def get_canonical_block_root(self, slot: Slot) -> Hash32:
+    def get_canonical_block_root(self, slot: Slot) -> SigningRoot:
         """
         Return the block root for the canonical block at the given number.
 
@@ -233,11 +233,11 @@ class BeaconChainDB(BaseBeaconChainDB):
         """
         return self._get_canonical_block_root(self.db, slot)
 
-    def get_genesis_block_root(self) -> Hash32:
+    def get_genesis_block_root(self) -> SigningRoot:
         return self._get_canonical_block_root(self.db, self.genesis_config.GENESIS_SLOT)
 
     @staticmethod
-    def _get_canonical_block_root(db: DatabaseAPI, slot: Slot) -> Hash32:
+    def _get_canonical_block_root(db: DatabaseAPI, slot: Slot) -> SigningRoot:
         slot_to_root_key = SchemaV1.make_block_slot_to_root_lookup_key(slot)
         try:
             encoded_key = db[slot_to_root_key]
@@ -275,21 +275,21 @@ class BeaconChainDB(BaseBeaconChainDB):
         cls, db: DatabaseAPI, block_class: Type[BaseBeaconBlock]
     ) -> BaseBeaconBlock:
         canonical_head_root = cls._get_canonical_head_root(db)
-        return cls._get_block_by_root(db, Hash32(canonical_head_root), block_class)
+        return cls._get_block_by_root(db, SigningRoot(canonical_head_root), block_class)
 
-    def get_canonical_head_root(self) -> Hash32:
+    def get_canonical_head_root(self) -> SigningRoot:
         """
         Return the current block root at the head of the chain.
         """
         return self._get_canonical_head_root(self.db)
 
     @staticmethod
-    def _get_canonical_head_root(db: DatabaseAPI) -> Hash32:
+    def _get_canonical_head_root(db: DatabaseAPI) -> SigningRoot:
         try:
             canonical_head_root = db[SchemaV1.make_canonical_head_root_lookup_key()]
         except KeyError:
             raise CanonicalHeadNotFound("No canonical head set for this chain")
-        return Hash32(canonical_head_root)
+        return SigningRoot(canonical_head_root)
 
     def get_finalized_head(self, block_class: Type[BaseBeaconBlock]) -> BaseBeaconBlock:
         """
@@ -302,15 +302,15 @@ class BeaconChainDB(BaseBeaconChainDB):
         cls, db: DatabaseAPI, block_class: Type[BaseBeaconBlock]
     ) -> BaseBeaconBlock:
         finalized_head_root = cls._get_finalized_head_root(db)
-        return cls._get_block_by_root(db, Hash32(finalized_head_root), block_class)
+        return cls._get_block_by_root(db, finalized_head_root, block_class)
 
     @staticmethod
-    def _get_finalized_head_root(db: DatabaseAPI) -> Hash32:
+    def _get_finalized_head_root(db: DatabaseAPI) -> SigningRoot:
         try:
             finalized_head_root = db[SchemaV1.make_finalized_head_root_lookup_key()]
         except KeyError:
             raise FinalizedHeadNotFound("No finalized head set for this chain")
-        return Hash32(finalized_head_root)
+        return SigningRoot(finalized_head_root)
 
     def get_justified_head(self, block_class: Type[BaseBeaconBlock]) -> BaseBeaconBlock:
         """
@@ -323,24 +323,24 @@ class BeaconChainDB(BaseBeaconChainDB):
         cls, db: DatabaseAPI, block_class: Type[BaseBeaconBlock]
     ) -> BaseBeaconBlock:
         justified_head_root = cls._get_justified_head_root(db)
-        return cls._get_block_by_root(db, Hash32(justified_head_root), block_class)
+        return cls._get_block_by_root(db, SigningRoot(justified_head_root), block_class)
 
     @staticmethod
-    def _get_justified_head_root(db: DatabaseAPI) -> Hash32:
+    def _get_justified_head_root(db: DatabaseAPI) -> SigningRoot:
         try:
             justified_head_root = db[SchemaV1.make_justified_head_root_lookup_key()]
         except KeyError:
             raise JustifiedHeadNotFound("No justified head set for this chain")
-        return Hash32(justified_head_root)
+        return SigningRoot(justified_head_root)
 
     def get_block_by_root(
-        self, block_root: Hash32, block_class: Type[BaseBeaconBlock]
+        self, block_root: SigningRoot, block_class: Type[BaseBeaconBlock]
     ) -> BaseBeaconBlock:
         return self._get_block_by_root(self.db, block_root, block_class)
 
     @staticmethod
     def _get_block_by_root(
-        db: DatabaseAPI, block_root: Hash32, block_class: Type[BaseBeaconBlock]
+        db: DatabaseAPI, block_root: SigningRoot, block_class: Type[BaseBeaconBlock]
     ) -> BaseBeaconBlock:
         """
         Return the requested block header as specified by block root.
@@ -356,7 +356,7 @@ class BeaconChainDB(BaseBeaconChainDB):
             )
         return _decode_block(block_ssz, block_class)
 
-    def get_slot_by_root(self, block_root: Hash32) -> Slot:
+    def get_slot_by_root(self, block_root: SigningRoot) -> Slot:
         """
         Return the requested block header as specified by block root.
 
@@ -365,7 +365,7 @@ class BeaconChainDB(BaseBeaconChainDB):
         return self._get_slot_by_root(self.db, block_root)
 
     @staticmethod
-    def _get_slot_by_root(db: DatabaseAPI, block_root: Hash32) -> Slot:
+    def _get_slot_by_root(db: DatabaseAPI, block_root: SigningRoot) -> Slot:
         validate_word(block_root, title="block root")
         try:
             encoded_slot = db[SchemaV1.make_block_root_to_slot_lookup_key(block_root)]
@@ -375,11 +375,11 @@ class BeaconChainDB(BaseBeaconChainDB):
             )
         return Slot(ssz.decode(encoded_slot, sedes=ssz.sedes.uint64))
 
-    def get_score(self, block_root: Hash32) -> int:
+    def get_score(self, block_root: SigningRoot) -> int:
         return self._get_score(self.db, block_root)
 
     @staticmethod
-    def _get_score(db: DatabaseAPI, block_root: Hash32) -> int:
+    def _get_score(db: DatabaseAPI, block_root: SigningRoot) -> int:
         try:
             encoded_score = db[SchemaV1.make_block_root_to_score_lookup_key(block_root)]
         except KeyError:
@@ -388,11 +388,11 @@ class BeaconChainDB(BaseBeaconChainDB):
             )
         return ssz.decode(encoded_score, sedes=ssz.sedes.uint64)
 
-    def block_exists(self, block_root: Hash32) -> bool:
+    def block_exists(self, block_root: SigningRoot) -> bool:
         return self._block_exists(self.db, block_root)
 
     @staticmethod
-    def _block_exists(db: DatabaseAPI, block_root: Hash32) -> bool:
+    def _block_exists(db: DatabaseAPI, block_root: SigningRoot) -> bool:
         validate_word(block_root, title="block root")
         return block_root in db
 
@@ -511,7 +511,10 @@ class BeaconChainDB(BaseBeaconChainDB):
 
     @classmethod
     def _set_as_canonical_chain_head(
-        cls, db: DatabaseAPI, block_root: Hash32, block_class: Type[BaseBeaconBlock]
+        cls,
+        db: DatabaseAPI,
+        block_root: SigningRoot,
+        block_class: Type[BaseBeaconBlock],
     ) -> Tuple[Tuple[BaseBeaconBlock, ...], Tuple[BaseBeaconBlock, ...]]:
         """
         Set the canonical chain HEAD to the block as specified by the
@@ -710,7 +713,7 @@ class BeaconChainDB(BaseBeaconChainDB):
             if state.slot > head_state_slot:
                 self._add_head_state_slot_lookup(state.slot)
 
-    def _update_finalized_head(self, finalized_root: Hash32) -> None:
+    def _update_finalized_head(self, finalized_root: SigningRoot) -> None:
         """
         Unconditionally write the ``finalized_root`` as the root of the currently
         finalized block.
@@ -724,14 +727,14 @@ class BeaconChainDB(BaseBeaconChainDB):
         This policy is safe because a large number of validators on the network
         will have violated a slashing condition if the invariant does not hold.
         """
-        if state.finalized_checkpoint.root == ZERO_HASH32:
+        if state.finalized_checkpoint.root == ZERO_SIGNING_ROOT:
             # ignore finality in the genesis state
             return
 
         if state.finalized_checkpoint.root != self._finalized_root:
             self._update_finalized_head(state.finalized_checkpoint.root)
 
-    def _update_justified_head(self, justified_root: Hash32, epoch: Epoch) -> None:
+    def _update_justified_head(self, justified_root: SigningRoot, epoch: Epoch) -> None:
         """
         Unconditionally write the ``justified_root`` as the root of the highest
         justified block.
@@ -741,7 +744,7 @@ class BeaconChainDB(BaseBeaconChainDB):
 
     def _find_updated_justified_root(
         self, state: BeaconState
-    ) -> Optional[Tuple[Hash32, Epoch]]:
+    ) -> Optional[Tuple[SigningRoot, Epoch]]:
         """
         Find the highest epoch that has been justified so far.
 
@@ -803,14 +806,14 @@ class BeaconChainDB(BaseBeaconChainDB):
             )
 
     def get_attestation_key_by_root(
-        self, attestation_root: Hash32
-    ) -> Tuple[Hash32, int]:
+        self, attestation_root: SigningRoot
+    ) -> Tuple[SigningRoot, int]:
         return self._get_attestation_key_by_root(self.db, attestation_root)
 
     @staticmethod
     def _get_attestation_key_by_root(
-        db: DatabaseAPI, attestation_root: Hash32
-    ) -> Tuple[Hash32, int]:
+        db: DatabaseAPI, attestation_root: SigningRoot
+    ) -> Tuple[SigningRoot, int]:
         try:
             encoded_key = db[
                 SchemaV1.make_attestation_root_to_block_lookup_key(attestation_root)
@@ -822,7 +825,7 @@ class BeaconChainDB(BaseBeaconChainDB):
         attestation_key = ssz.decode(encoded_key, sedes=AttestationKey)
         return attestation_key.block_root, attestation_key.index
 
-    def attestation_exists(self, attestation_root: Hash32) -> bool:
+    def attestation_exists(self, attestation_root: SigningRoot) -> bool:
         lookup_key = SchemaV1.make_attestation_root_to_block_lookup_key(
             attestation_root
         )

--- a/eth2/beacon/db/schema.py
+++ b/eth2/beacon/db/schema.py
@@ -1,6 +1,6 @@
 from abc import ABC, abstractmethod
 
-from eth2.beacon.constants import SigningRoot
+from eth2.beacon.constants import HashTreeRoot, SigningRoot
 
 
 class BaseSchema(ABC):
@@ -56,7 +56,7 @@ class BaseSchema(ABC):
     @staticmethod
     @abstractmethod
     def make_attestation_root_to_block_lookup_key(
-        attestaton_root: SigningRoot
+        attestaton_root: HashTreeRoot
     ) -> bytes:
         ...
 
@@ -106,6 +106,6 @@ class SchemaV1(BaseSchema):
     #
     @staticmethod
     def make_attestation_root_to_block_lookup_key(
-        attestaton_root: SigningRoot
+        attestaton_root: HashTreeRoot
     ) -> bytes:
         return b"v1:beacon:attestation-root-to-block:%s" % attestaton_root

--- a/eth2/beacon/db/schema.py
+++ b/eth2/beacon/db/schema.py
@@ -1,6 +1,6 @@
 from abc import ABC, abstractmethod
 
-from eth_typing import Hash32
+from eth2.beacon.constants import SigningRoot
 
 
 class BaseSchema(ABC):
@@ -27,7 +27,7 @@ class BaseSchema(ABC):
 
     @staticmethod
     @abstractmethod
-    def make_block_root_to_slot_lookup_key(block_root: Hash32) -> bytes:
+    def make_block_root_to_slot_lookup_key(block_root: SigningRoot) -> bytes:
         ...
 
     @staticmethod
@@ -37,7 +37,7 @@ class BaseSchema(ABC):
 
     @staticmethod
     @abstractmethod
-    def make_block_root_to_score_lookup_key(block_root: Hash32) -> bytes:
+    def make_block_root_to_score_lookup_key(block_root: SigningRoot) -> bytes:
         ...
 
     @staticmethod
@@ -55,7 +55,9 @@ class BaseSchema(ABC):
     #
     @staticmethod
     @abstractmethod
-    def make_attestation_root_to_block_lookup_key(attestaton_root: Hash32) -> bytes:
+    def make_attestation_root_to_block_lookup_key(
+        attestaton_root: SigningRoot
+    ) -> bytes:
         ...
 
 
@@ -92,16 +94,18 @@ class SchemaV1(BaseSchema):
         return slot_to_root_key
 
     @staticmethod
-    def make_block_root_to_score_lookup_key(block_root: Hash32) -> bytes:
+    def make_block_root_to_score_lookup_key(block_root: SigningRoot) -> bytes:
         return b"v1:beacon:block-root-to-score:%s" % block_root
 
     @staticmethod
-    def make_block_root_to_slot_lookup_key(block_root: Hash32) -> bytes:
+    def make_block_root_to_slot_lookup_key(block_root: SigningRoot) -> bytes:
         return b"v1:beacon:block-root-to-slot:%s" % block_root
 
     #
     # Attestaion
     #
     @staticmethod
-    def make_attestation_root_to_block_lookup_key(attestaton_root: Hash32) -> bytes:
+    def make_attestation_root_to_block_lookup_key(
+        attestaton_root: SigningRoot
+    ) -> bytes:
         return b"v1:beacon:attestation-root-to-block:%s" % attestaton_root

--- a/eth2/beacon/fork_choice/lmd_ghost.py
+++ b/eth2/beacon/fork_choice/lmd_ghost.py
@@ -1,6 +1,5 @@
 from typing import Dict, Iterable, Optional, Sequence, Tuple, Type, Union
 
-from eth_typing import Hash32
 from eth_utils import to_tuple
 from eth_utils.toolz import curry, first, mapcat, merge, merge_with, second, valmap
 
@@ -14,7 +13,7 @@ from eth2.beacon.types.attestations import Attestation
 from eth2.beacon.types.blocks import BaseBeaconBlock
 from eth2.beacon.types.pending_attestations import PendingAttestation
 from eth2.beacon.types.states import BeaconState
-from eth2.beacon.typing import Gwei, Slot, ValidatorIndex
+from eth2.beacon.typing import Gwei, SigningRoot, Slot, ValidatorIndex
 from eth2.configs import CommitteeConfig, Eth2Config
 
 # TODO(ralexstokes) integrate `AttestationPool` once it has been merged
@@ -115,7 +114,7 @@ class Store:
         """
         return self._attestation_index.get(index, None)
 
-    def _get_block_by_root(self, root: Hash32) -> BaseBeaconBlock:
+    def _get_block_by_root(self, root: SigningRoot) -> BaseBeaconBlock:
         return self._db.get_block_by_root(root, self._block_class)
 
     def get_latest_attestation_target(

--- a/eth2/beacon/helpers.py
+++ b/eth2/beacon/helpers.py
@@ -84,7 +84,7 @@ def get_block_root(
     epoch: Epoch,
     slots_per_epoch: int,
     slots_per_historical_root: int,
-) -> Hash32:
+) -> SigningRoot:
     return get_block_root_at_slot(
         state,
         compute_start_slot_of_epoch(epoch, slots_per_epoch),

--- a/eth2/beacon/helpers.py
+++ b/eth2/beacon/helpers.py
@@ -46,11 +46,11 @@ def get_active_validator_indices(
 
 
 def _get_historical_root(
-    historical_roots: Sequence[Hash32],
+    historical_roots: Sequence[SigningRoot],
     state_slot: Slot,
     slot: Slot,
     slots_per_historical_root: int,
-) -> Hash32:
+) -> SigningRoot:
     """
     Return the historical root at a recent ``slot``.
     """

--- a/eth2/beacon/helpers.py
+++ b/eth2/beacon/helpers.py
@@ -12,6 +12,7 @@ from eth2.beacon.typing import (
     DomainType,
     Epoch,
     Gwei,
+    SigningRoot,
     Slot,
     ValidatorIndex,
     Version,
@@ -70,7 +71,7 @@ def _get_historical_root(
 
 def get_block_root_at_slot(
     state: "BeaconState", slot: Slot, slots_per_historical_root: int
-) -> Hash32:
+) -> SigningRoot:
     """
     Return the block root at a recent ``slot``.
     """

--- a/eth2/beacon/operations/pool.py
+++ b/eth2/beacon/operations/pool.py
@@ -1,9 +1,8 @@
 from typing import Dict, Generic, Iterator, Tuple, TypeVar
 
-from eth_typing import Hash32
 from typing_extensions import Protocol
 
-HashTreeRoot = Hash32
+from eth2.beacon.typing import HashTreeRoot
 
 
 class Operation(Protocol):

--- a/eth2/beacon/state_machines/forks/serenity/block_validation.py
+++ b/eth2/beacon/state_machines/forks/serenity/block_validation.py
@@ -32,7 +32,7 @@ from eth2.beacon.types.states import BeaconState
 from eth2.beacon.types.transfers import Transfer
 from eth2.beacon.types.validators import Validator
 from eth2.beacon.types.voluntary_exits import VoluntaryExit
-from eth2.beacon.typing import Epoch, Shard, Slot
+from eth2.beacon.typing import Epoch, Shard, SigningRoot, Slot
 from eth2.configs import CommitteeConfig, Eth2Config
 
 
@@ -88,7 +88,7 @@ def validate_block_parent_root(state: BeaconState, block: BaseBeaconBlock) -> No
 
 
 def validate_proposer_is_not_slashed(
-    state: BeaconState, block_root: Hash32, config: CommitteeConfig
+    state: BeaconState, block_root: SigningRoot, config: CommitteeConfig
 ) -> None:
     proposer_index = get_beacon_proposer_index(state, config)
     proposer = state.validators[proposer_index]

--- a/eth2/beacon/tools/builder/validator.py
+++ b/eth2/beacon/tools/builder/validator.py
@@ -16,6 +16,7 @@ from eth2.beacon.committee_helpers import (
     get_shard_delta,
     get_start_shard,
 )
+from eth2.beacon.constants import ZERO_SIGNING_ROOT
 from eth2.beacon.helpers import (
     compute_domain,
     compute_epoch_of_slot,
@@ -47,6 +48,7 @@ from eth2.beacon.typing import (
     Epoch,
     Gwei,
     Shard,
+    SigningRoot,
     Slot,
     ValidatorIndex,
     default_bitfield,
@@ -59,7 +61,7 @@ from eth2.configs import CommitteeConfig, Eth2Config
 # TODO(ralexstokes) merge w/ below
 def _mk_pending_attestation(
     bitfield: Bitfield = default_bitfield,
-    target_root: Hash32 = ZERO_HASH32,
+    target_root: SigningRoot = ZERO_SIGNING_ROOT,
     target_epoch: Epoch = default_epoch,
     shard: Shard = default_shard,
     start_epoch: Epoch = default_epoch,
@@ -86,7 +88,7 @@ def mk_pending_attestation_from_committee(
     committee_size: int,
     shard: Shard,
     target_epoch: Epoch = default_epoch,
-    target_root: Hash32 = ZERO_HASH32,
+    target_root: SigningRoot = ZERO_SIGNING_ROOT,
     data_root: Hash32 = ZERO_HASH32,
 ) -> PendingAttestation:
     bitfield = get_empty_bitfield(committee_size)
@@ -240,7 +242,7 @@ def sign_transaction(
     return bls.sign(message_hash=message_hash, privkey=privkey, domain=domain)
 
 
-SAMPLE_HASH_1 = Hash32(b"\x11" * 32)
+SAMPLE_HASH_1 = SigningRoot(Hash32(b"\x11" * 32))
 SAMPLE_HASH_2 = Hash32(b"\x22" * 32)
 
 
@@ -249,7 +251,7 @@ def create_block_header_with_signature(
     body_root: Hash32,
     privkey: int,
     slots_per_epoch: int,
-    parent_root: Hash32 = SAMPLE_HASH_1,
+    parent_root: SigningRoot = SAMPLE_HASH_1,
     state_root: Hash32 = SAMPLE_HASH_2,
 ) -> BeaconBlockHeader:
     block_header = BeaconBlockHeader(
@@ -443,8 +445,8 @@ def create_mock_attester_slashing_is_surround_vote(
 # Attestation
 #
 def _get_target_root(
-    state: BeaconState, config: Eth2Config, beacon_block_root: Hash32
-) -> Hash32:
+    state: BeaconState, config: Eth2Config, beacon_block_root: SigningRoot
+) -> SigningRoot:
 
     epoch = compute_epoch_of_slot(state.slot, config.SLOTS_PER_EPOCH)
     epoch_start_slot = compute_start_slot_of_epoch(epoch, config.SLOTS_PER_EPOCH)
@@ -579,7 +581,7 @@ def create_signed_attestation_at_slot(
     config: Eth2Config,
     state_machine: BaseBeaconStateMachine,
     attestation_slot: Slot,
-    beacon_block_root: Hash32,
+    beacon_block_root: SigningRoot,
     validator_privkeys: Dict[ValidatorIndex, int],
     committee: Tuple[ValidatorIndex, ...],
     shard: Shard,
@@ -631,7 +633,7 @@ def create_mock_signed_attestations_at_slot(
     config: Eth2Config,
     state_machine: BaseBeaconStateMachine,
     attestation_slot: Slot,
-    beacon_block_root: Hash32,
+    beacon_block_root: SigningRoot,
     keymap: Dict[BLSPubkey, int],
     voted_attesters_ratio: float = 1.0,
 ) -> Iterable[Attestation]:

--- a/eth2/beacon/types/attestation_data.py
+++ b/eth2/beacon/types/attestation_data.py
@@ -1,11 +1,11 @@
-from eth.constants import ZERO_HASH32
-from eth_typing import Hash32
 from eth_utils import humanize_hash
 import ssz
 from ssz.sedes import bytes32
 
+from eth2.beacon.constants import ZERO_SIGNING_ROOT
 from eth2.beacon.types.checkpoints import Checkpoint, default_checkpoint
 from eth2.beacon.types.crosslinks import Crosslink, default_crosslink
+from eth2.beacon.typing import SigningRoot
 
 
 class AttestationData(ssz.Serializable):
@@ -22,7 +22,7 @@ class AttestationData(ssz.Serializable):
 
     def __init__(
         self,
-        beacon_block_root: Hash32 = ZERO_HASH32,
+        beacon_block_root: SigningRoot = ZERO_SIGNING_ROOT,
         source: Checkpoint = default_checkpoint,
         target: Checkpoint = default_checkpoint,
         crosslink: Crosslink = default_crosslink,

--- a/eth2/beacon/types/block_headers.py
+++ b/eth2/beacon/types/block_headers.py
@@ -4,8 +4,8 @@ from eth_utils import encode_hex
 import ssz
 from ssz.sedes import bytes32, bytes96, uint64
 
-from eth2.beacon.constants import EMPTY_SIGNATURE
-from eth2.beacon.typing import Slot
+from eth2.beacon.constants import EMPTY_SIGNATURE, ZERO_SIGNING_ROOT
+from eth2.beacon.typing import SigningRoot, Slot
 
 from .defaults import default_slot
 
@@ -24,7 +24,7 @@ class BeaconBlockHeader(ssz.SignedSerializable):
         self,
         *,
         slot: Slot = default_slot,
-        parent_root: Hash32 = ZERO_HASH32,
+        parent_root: SigningRoot = ZERO_SIGNING_ROOT,
         state_root: Hash32 = ZERO_HASH32,
         body_root: Hash32 = ZERO_HASH32,
         signature: BLSSignature = EMPTY_SIGNATURE,

--- a/eth2/beacon/types/blocks.py
+++ b/eth2/beacon/types/blocks.py
@@ -8,8 +8,12 @@ from eth_utils import encode_hex
 import ssz
 from ssz.sedes import List, bytes32, bytes96, uint64
 
-from eth2.beacon.constants import EMPTY_SIGNATURE, GENESIS_PARENT_ROOT
-from eth2.beacon.typing import FromBlockParams, Slot
+from eth2.beacon.constants import (
+    EMPTY_SIGNATURE,
+    GENESIS_PARENT_ROOT,
+    ZERO_SIGNING_ROOT,
+)
+from eth2.beacon.typing import FromBlockParams, SigningRoot, Slot
 
 from .attestations import Attestation
 from .attester_slashings import AttesterSlashing
@@ -85,7 +89,7 @@ class BaseBeaconBlock(ssz.SignedSerializable, Configurable, ABC):
         self,
         *,
         slot: Slot = default_slot,
-        parent_root: Hash32 = ZERO_HASH32,
+        parent_root: SigningRoot = ZERO_SIGNING_ROOT,
         state_root: Hash32 = ZERO_HASH32,
         body: BeaconBlockBody = default_beacon_block_body,
         signature: BLSSignature = EMPTY_SIGNATURE,
@@ -124,7 +128,9 @@ class BaseBeaconBlock(ssz.SignedSerializable, Configurable, ABC):
 
     @classmethod
     @abstractmethod
-    def from_root(cls, root: Hash32, chaindb: "BaseBeaconChainDB") -> "BaseBeaconBlock":
+    def from_root(
+        cls, root: SigningRoot, chaindb: "BaseBeaconChainDB"
+    ) -> "BaseBeaconBlock":
         """
         Return the block denoted by the given block root.
         """
@@ -135,7 +141,9 @@ class BeaconBlock(BaseBeaconBlock):
     block_body_class = BeaconBlockBody
 
     @classmethod
-    def from_root(cls, root: Hash32, chaindb: "BaseBeaconChainDB") -> "BeaconBlock":
+    def from_root(
+        cls, root: SigningRoot, chaindb: "BaseBeaconChainDB"
+    ) -> "BeaconBlock":
         """
         Return the block denoted by the given block ``root``.
         """

--- a/eth2/beacon/types/checkpoints.py
+++ b/eth2/beacon/types/checkpoints.py
@@ -1,10 +1,10 @@
-from eth.constants import ZERO_HASH32
 from eth_typing import Hash32
 from eth_utils import encode_hex
 import ssz
 from ssz.sedes import bytes32, uint64
 
-from eth2.beacon.typing import Epoch
+from eth2.beacon.constants import ZERO_SIGNING_ROOT
+from eth2.beacon.typing import Epoch, SigningRoot
 
 from .defaults import default_epoch
 
@@ -14,7 +14,7 @@ class Checkpoint(ssz.Serializable):
     fields = [("epoch", uint64), ("root", bytes32)]
 
     def __init__(
-        self, epoch: Epoch = default_epoch, root: Hash32 = ZERO_HASH32
+        self, epoch: Epoch = default_epoch, root: SigningRoot = ZERO_SIGNING_ROOT
     ) -> None:
         super().__init__(epoch=epoch, root=root)
 

--- a/eth2/beacon/types/checkpoints.py
+++ b/eth2/beacon/types/checkpoints.py
@@ -1,4 +1,3 @@
-from eth_typing import Hash32
 from eth_utils import encode_hex
 import ssz
 from ssz.sedes import bytes32, uint64

--- a/eth2/beacon/types/historical_batch.py
+++ b/eth2/beacon/types/historical_batch.py
@@ -5,6 +5,8 @@ from eth_typing import Hash32
 import ssz
 from ssz.sedes import Vector, bytes32
 
+from eth2.beacon.constants import ZERO_SIGNING_ROOT
+from eth2.beacon.typing import SigningRoot
 from eth2.configs import Eth2Config
 
 from .defaults import default_tuple, default_tuple_of_size
@@ -17,7 +19,7 @@ class HistoricalBatch(ssz.Serializable):
     def __init__(
         self,
         *,
-        block_roots: Sequence[Hash32] = default_tuple,
+        block_roots: Sequence[SigningRoot] = default_tuple,
         state_roots: Sequence[Hash32] = default_tuple,
         config: Eth2Config = None
     ) -> None:
@@ -25,7 +27,7 @@ class HistoricalBatch(ssz.Serializable):
             # try to provide sane defaults
             if block_roots == default_tuple:
                 block_roots = default_tuple_of_size(
-                    config.SLOTS_PER_HISTORICAL_ROOT, ZERO_HASH32
+                    config.SLOTS_PER_HISTORICAL_ROOT, ZERO_SIGNING_ROOT
                 )
             if state_roots == default_tuple:
                 state_roots = default_tuple_of_size(

--- a/eth2/beacon/types/states.py
+++ b/eth2/beacon/types/states.py
@@ -7,13 +7,15 @@ import ssz
 from ssz.sedes import Bitvector, List, Vector, bytes32, uint64
 
 from eth2._utils.tuple import update_tuple_item, update_tuple_item_with_fn
-from eth2.beacon.constants import JUSTIFICATION_BITS_LENGTH
+from eth2.beacon.constants import JUSTIFICATION_BITS_LENGTH, ZERO_SIGNING_ROOT
 from eth2.beacon.helpers import compute_epoch_of_slot
 from eth2.beacon.typing import (
     Bitfield,
     Epoch,
     Gwei,
+    HashTreeRoot,
     Shard,
+    SigningRoot,
     Slot,
     Timestamp,
     ValidatorIndex,
@@ -94,7 +96,7 @@ class BeaconState(ssz.Serializable):
         slot: Slot = default_slot,
         fork: Fork = default_fork,
         latest_block_header: BeaconBlockHeader = default_beacon_block_header,
-        block_roots: Sequence[Hash32] = default_tuple,
+        block_roots: Sequence[SigningRoot] = default_tuple,
         state_roots: Sequence[Hash32] = default_tuple,
         historical_roots: Sequence[Hash32] = default_tuple,
         eth1_data: Eth1Data = default_eth1_data,
@@ -131,7 +133,7 @@ class BeaconState(ssz.Serializable):
             # try to provide sane defaults
             if block_roots == default_tuple:
                 block_roots = default_tuple_of_size(
-                    config.SLOTS_PER_HISTORICAL_ROOT, ZERO_HASH32
+                    config.SLOTS_PER_HISTORICAL_ROOT, ZERO_SIGNING_ROOT
                 )
             if state_roots == default_tuple:
                 state_roots = default_tuple_of_size(

--- a/eth2/beacon/types/states.py
+++ b/eth2/beacon/types/states.py
@@ -13,7 +13,6 @@ from eth2.beacon.typing import (
     Bitfield,
     Epoch,
     Gwei,
-    HashTreeRoot,
     Shard,
     SigningRoot,
     Slot,

--- a/eth2/beacon/typing.py
+++ b/eth2/beacon/typing.py
@@ -1,6 +1,6 @@
 from typing import NamedTuple, NewType, Tuple
 
-from eth.typing import Hash32
+from eth_typing import Hash32
 
 Slot = NewType("Slot", int)  # uint64
 Epoch = NewType("Epoch", int)  # uint64

--- a/eth2/beacon/typing.py
+++ b/eth2/beacon/typing.py
@@ -1,5 +1,7 @@
 from typing import NamedTuple, NewType, Tuple
 
+from eth.typing import Hash32
+
 Slot = NewType("Slot", int)  # uint64
 Epoch = NewType("Epoch", int)  # uint64
 Shard = NewType("Shard", int)  # uint64
@@ -20,6 +22,12 @@ Second = NewType("Second", int)
 Version = NewType("Version", bytes)
 
 DomainType = NewType("DomainType", bytes)  # bytes of length 4
+
+# Use HashTreeRoot and SigningRoot for Merkle tree root of SignedSerializable
+# Merkle tree root with signature field included
+HashTreeRoot = NewType("HashTreeRoot", Hash32)
+# Merkle tree root with signature field excluded
+SigningRoot = NewType("SigningRoot", Hash32)
 
 
 class FromBlockParams(NamedTuple):

--- a/trinity/db/beacon/chain.py
+++ b/trinity/db/beacon/chain.py
@@ -17,7 +17,7 @@ from eth2.beacon.types.blocks import (
 )
 
 from trinity._utils.async_dispatch import async_method
-from eth2.beacon.typing import SigningRoot
+from eth2.beacon.typing import SigningRoot, HashTreeRoot
 
 
 class BaseAsyncBeaconChainDB(BeaconChainDB):
@@ -104,11 +104,11 @@ class BaseAsyncBeaconChainDB(BeaconChainDB):
     # Attestation API
     #
     @abstractmethod
-    async def coro_get_attestation_key_by_root(self, attestation_root: SigningRoot)-> Tuple[SigningRoot, int]:
+    async def coro_get_attestation_key_by_root(self, attestation_root: HashTreeRoot)-> Tuple[SigningRoot, int]:
         ...
 
     @abstractmethod
-    async def coro_attestation_exists(self, attestation_root: SigningRoot) -> bool:
+    async def coro_attestation_exists(self, attestation_root: HashTreeRoot) -> bool:
         ...
 
     #

--- a/trinity/db/beacon/chain.py
+++ b/trinity/db/beacon/chain.py
@@ -17,6 +17,7 @@ from eth2.beacon.types.blocks import (
 )
 
 from trinity._utils.async_dispatch import async_method
+from eth2.beacon.typing import SigningRoot
 
 
 class BaseAsyncBeaconChainDB(BeaconChainDB):
@@ -38,11 +39,11 @@ class BaseAsyncBeaconChainDB(BeaconChainDB):
     #
 
     @abstractmethod
-    async def coro_get_canonical_block_root(self, slot: int) -> Hash32:
+    async def coro_get_canonical_block_root(self, slot: int) -> SigningRoot:
         ...
 
     @abstractmethod
-    async def coro_get_genesis_block_root(self) -> Hash32:
+    async def coro_get_genesis_block_root(self) -> SigningRoot:
         ...
 
     @abstractmethod
@@ -57,7 +58,7 @@ class BaseAsyncBeaconChainDB(BeaconChainDB):
         ...
 
     @abstractmethod
-    async def coro_get_canonical_head_root(self)-> Hash32:
+    async def coro_get_canonical_head_root(self)-> SigningRoot:
         ...
 
     @abstractmethod
@@ -66,16 +67,16 @@ class BaseAsyncBeaconChainDB(BeaconChainDB):
 
     @abstractmethod
     async def coro_get_block_by_root(self,
-                                     block_root: Hash32,
+                                     block_root: SigningRoot,
                                      block_class: Type[BaseBeaconBlock]) -> BaseBeaconBlock:
         ...
 
     @abstractmethod
-    async def coro_get_score(self, block_root: Hash32) -> int:
+    async def coro_get_score(self, block_root: SigningRoot) -> int:
         ...
 
     @abstractmethod
-    async def coro_block_exists(self, block_root: Hash32) -> bool:
+    async def coro_block_exists(self, block_root: SigningRoot) -> bool:
         ...
 
     @abstractmethod
@@ -103,11 +104,11 @@ class BaseAsyncBeaconChainDB(BeaconChainDB):
     # Attestation API
     #
     @abstractmethod
-    async def coro_get_attestation_key_by_root(self, attestation_root: Hash32)-> Tuple[Hash32, int]:
+    async def coro_get_attestation_key_by_root(self, attestation_root: SigningRoot)-> Tuple[SigningRoot, int]:
         ...
 
     @abstractmethod
-    async def coro_attestation_exists(self, attestation_root: Hash32) -> bool:
+    async def coro_attestation_exists(self, attestation_root: SigningRoot) -> bool:
         ...
 
     #

--- a/trinity/db/beacon/chain.py
+++ b/trinity/db/beacon/chain.py
@@ -104,7 +104,9 @@ class BaseAsyncBeaconChainDB(BeaconChainDB):
     # Attestation API
     #
     @abstractmethod
-    async def coro_get_attestation_key_by_root(self, attestation_root: HashTreeRoot)-> Tuple[SigningRoot, int]:
+    async def coro_get_attestation_key_by_root(
+        self, attestation_root: HashTreeRoot
+    )-> Tuple[SigningRoot, int]:
         ...
 
     @abstractmethod

--- a/trinity/protocol/bcc_libp2p/messages.py
+++ b/trinity/protocol/bcc_libp2p/messages.py
@@ -23,6 +23,7 @@ from eth2.beacon.constants import (
     ZERO_SIGNING_ROOT,
 )
 
+
 class HelloRequest(ssz.Serializable):
     fields = [
         ('fork_version', bytes4),

--- a/trinity/protocol/bcc_libp2p/messages.py
+++ b/trinity/protocol/bcc_libp2p/messages.py
@@ -10,14 +10,6 @@ from ssz.sedes import (
     uint64,
 )
 
-from eth_typing import (
-    Hash32,
-)
-
-from eth.constants import (
-    ZERO_HASH32,
-)
-
 from eth2.beacon.typing import (
     Version,
     default_epoch,
@@ -25,7 +17,11 @@ from eth2.beacon.typing import (
     default_version,
 )
 from eth2.beacon.types.blocks import BeaconBlock
-
+from eth2.beacon.typing import SigningRoot, HashTreeRoot, Slot, Epoch
+from eth2.beacon.constants import (
+    ZERO_HASH_TREE_ROOT,
+    ZERO_SIGNING_ROOT,
+)
 
 class HelloRequest(ssz.Serializable):
     fields = [
@@ -39,10 +35,10 @@ class HelloRequest(ssz.Serializable):
     def __init__(
         self,
         fork_version: Version = default_version,
-        finalized_root: Hash32 = ZERO_HASH32,
-        finalized_epoch: int = default_epoch,
-        head_root: Hash32 = ZERO_HASH32,
-        head_slot: int = default_slot,
+        finalized_root: SigningRoot = ZERO_SIGNING_ROOT,
+        finalized_epoch: Epoch = default_epoch,
+        head_root: HashTreeRoot = ZERO_HASH_TREE_ROOT,
+        head_slot: Slot = default_slot,
     ) -> None:
         super().__init__(
             fork_version,
@@ -72,8 +68,8 @@ class BeaconBlocksRequest(ssz.Serializable):
 
     def __init__(
         self,
-        head_block_root: bytes,
-        start_slot: int,
+        head_block_root: HashTreeRoot,
+        start_slot: Slot,
         count: int,
         step: int,
     ) -> None:
@@ -99,7 +95,7 @@ class RecentBeaconBlocksRequest(ssz.Serializable):
         ('block_roots', List(bytes32, 1)),
     ]
 
-    def __init__(self, block_roots: Sequence[Hash32]) -> None:
+    def __init__(self, block_roots: Sequence[HashTreeRoot]) -> None:
         super().__init__(block_roots)
 
 

--- a/trinity/protocol/bcc_libp2p/node.py
+++ b/trinity/protocol/bcc_libp2p/node.py
@@ -13,13 +13,8 @@ from cancel_token import (
     CancelToken,
 )
 
-from eth_typing import (
-    Hash32,
-)
-
 from eth_utils import ValidationError, to_tuple
 
-from eth.constants import ZERO_HASH32
 from eth.exceptions import (
     BlockNotFound,
 )
@@ -39,6 +34,10 @@ from eth2.beacon.types.blocks import (
 from eth2.beacon.typing import (
     Epoch,
     Slot,
+    HashTreeRoot,
+)
+from eth2.beacon.constants import (
+    ZERO_SIGNING_ROOT,
 )
 
 from libp2p import (
@@ -345,7 +344,7 @@ class Node(BaseService):
         # Edge case where nothing is finalized yet
         if (
             hello_other_side.finalized_epoch == 0 and
-            hello_other_side.finalized_root == ZERO_HASH32
+            hello_other_side.finalized_root == ZERO_SIGNING_ROOT
         ):
             return
 
@@ -726,7 +725,7 @@ class Node(BaseService):
 
     async def request_beacon_blocks(self,
                                     peer_id: ID,
-                                    head_block_root: Hash32,
+                                    head_block_root: HashTreeRoot,
                                     start_slot: Slot,
                                     count: int,
                                     step: int) -> Tuple[BaseBeaconBlock, ...]:
@@ -842,7 +841,7 @@ class Node(BaseService):
     async def request_recent_beacon_blocks(
             self,
             peer_id: ID,
-            block_roots: Sequence[Hash32]) -> Tuple[BaseBeaconBlock, ...]:
+            block_roots: Sequence[HashTreeRoot]) -> Tuple[BaseBeaconBlock, ...]:
         # TODO: Handle `stream.close` and `stream.reset`
         if peer_id not in self.handshaked_peers:
             error_msg = f"not handshaked with peer={peer_id} yet"

--- a/trinity/tools/bcc_factories.py
+++ b/trinity/tools/bcc_factories.py
@@ -36,7 +36,7 @@ from p2p.tools.factories import (
     PrivateKeyFactory,
 )
 
-from eth2.beacon.constants import EMPTY_SIGNATURE
+from eth2.beacon.constants import EMPTY_SIGNATURE, ZERO_SIGNING_ROOT
 from eth2.beacon.fork_choice.higher_slot import higher_slot_scoring
 from eth2.beacon.types.blocks import (
     BeaconBlock,
@@ -130,7 +130,7 @@ class BeaconBlockFactory(factory.Factory):
         model = BeaconBlock
 
     slot = SERENITY_GENESIS_CONFIG.GENESIS_SLOT
-    parent_root = ZERO_HASH32
+    parent_root = ZERO_SIGNING_ROOT
     state_root = ZERO_HASH32
     signature = EMPTY_SIGNATURE
     body = factory.SubFactory(BeaconBlockBodyFactory)


### PR DESCRIPTION
### What was wrong?

Current progress was blocked by reasoning whether a hash is  Signing root or Hash tree root.

### How was it fixed?

Create new types to label them clearly 

```
HashTreeRoot = NewType("HashTreeRoot", Hash32)
SigningRoot = NewType("SigningRoot", Hash32)
```

Summary of the changes

- SignedSerializable:
    - Block
        - parent_root: use Signing root. Reason: Specified in spec
        - DB: use Signing root. Reason: easier to find a block by parent root
        - p2p: use HashTreeRoot. Reason: Specified in the network spec
    - Operation
        - Attestation Roots: all use HashTreeRoot. Reason: consider two attestations with the same attestation data but signed by two different validators are different, so that proposer can aggregate them during block proposal.
        - else: use HashTreeRoot. Reason: Operations with different signatures should be considered different. 
    - Deposits
        - untouched. Reason: No Hash32 needs to be specified in the codebase at the moment.
- Not SignedSerializable: use Hash32.
    - Crosslinks
    - State root
    - RANDAO seeds, reveal ...
- bcc/ : Minimal maintainance. Reason: deprecating soon.

### To-Do


#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://preview.redd.it/oa2vj1mnyil31.jpg?width=640&crop=smart&auto=webp&s=5e06b59fcbb6aecd6becda1b4d53dc6f83384115)
