### PR TITLE
Add HTTPServer

### DIFF
--- a/eth2/beacon/scripts/run_beacon_nodes.py
+++ b/eth2/beacon/scripts/run_beacon_nodes.py
@@ -42,6 +42,7 @@ class Node:
     node_privkey: str
     port: int
     preferred_nodes: Tuple["Node", ...]
+    rpcport: Optional[int]
 
     start_time: float
     proc: asyncio.subprocess.Process
@@ -61,6 +62,7 @@ class Node:
         name: str,
         node_privkey: str,
         port: int,
+        rpcport: Optional[int] = None,
         preferred_nodes: Optional[Tuple["Node", ...]] = None,
     ) -> None:
         self.name = name
@@ -69,6 +71,7 @@ class Node:
         if preferred_nodes is None:
             preferred_nodes = []
         self.preferred_nodes = preferred_nodes
+        self.rpcport = rpcport
 
         self.tasks = []
         self.start_time = time.monotonic()
@@ -108,7 +111,9 @@ class Node:
             f"--port={self.port}",
             f"--trinity-root-dir={self.root_dir}",
             f"--beacon-nodekey={remove_0x_prefix(encode_hex(self.node_privkey.to_bytes()))}",
+            f"--rpcport={self.rpcport}",
             "--disable-discovery",
+            "--enable-http",
             "--network-tracking-backend=do-not-track",
             "--disable-upnp",
             "-l debug2",
@@ -218,12 +223,14 @@ async def main():
         node_privkey="6b94ffa2d9b8ee85afb9d7153c463ea22789d3bbc5d961cc4f63a41676883c19",
         port=30304,
         preferred_nodes=[],
+        rpcport=8555,
     )
     node_bob = Node(
         name="bob",
         node_privkey="f5ad1c57b5a489fc8f21ad0e5a19c1f1a60b8ab357a2100ff7e75f3fa8a4fd2e",
         port=30305,
         preferred_nodes=[node_alice],
+        rpcport=8666,
     )
 
     asyncio.ensure_future(node_alice.run())

--- a/eth2/beacon/tools/builder/initializer.py
+++ b/eth2/beacon/tools/builder/initializer.py
@@ -47,7 +47,6 @@ def create_mock_deposits_and_root(
 
     deposit_datas = tuple()  # type: Tuple[DepositData, ...]
     deposit_data_leaves = cast(Tuple[Hash32, ...], leaves)  # type: Tuple[Hash32, ...]
-
     for key, credentials in zip(pubkeys, withdrawal_credentials):
         privkey = keymap[key]
         deposit_data = create_mock_deposit_data(
@@ -71,8 +70,11 @@ def create_mock_deposits_and_root(
         )
         deposits += (deposit,)
 
-    tree_root = get_root(tree)
-    return deposits, hash_eth2(tree_root + length_mix_in)
+    if len(deposit_data_leaves) > 0:
+        tree_root = get_root(tree)
+        return deposits, hash_eth2(tree_root + length_mix_in)
+    else:
+        return tuple(), ZERO_HASH32
 
 
 def create_mock_deposit(

--- a/newsfragments/1078.feature.rst
+++ b/newsfragments/1078.feature.rst
@@ -1,0 +1,1 @@
+Add ``HTTPServer`` for JSON-RPC over HTTP APIs.

--- a/setup.py
+++ b/setup.py
@@ -70,6 +70,7 @@ deps = {
     # See: https://github.com/ethereum/trinity/pull/790
     'test-asyncio': [
         "pytest-asyncio>=0.10.0,<0.11",
+        "pytest-aiohttp==0.3.0",
     ],
     'test-trio': [
         'pytest-trio==0.5.2',

--- a/setup.py
+++ b/setup.py
@@ -26,6 +26,7 @@ deps = {
         "upnpclient>=0.0.8,<1",
     ],
     'trinity': [
+        "aiohttp==3.6.0",
         "bloom-filter==1.3",
         "cachetools>=3.1.0,<4.0.0",
         "coincurve>=10.0.0,<11.0.0",

--- a/tests/plugins/eth2/apis/test_http.py
+++ b/tests/plugins/eth2/apis/test_http.py
@@ -1,0 +1,73 @@
+import pathlib
+import pytest
+import tempfile
+
+from eth_utils import decode_hex
+
+from eth2.configs import Eth2GenesisConfig
+from eth2.beacon.fork_choice.higher_slot import higher_slot_scoring
+from eth2.beacon.state_machines.forks.serenity.configs import SERENITY_CONFIG
+from eth2.beacon.tools.misc.ssz_vector import (
+    override_lengths,
+)
+from eth2.beacon.types.blocks import BeaconBlock
+from eth2.beacon.tools.builder.initializer import create_mock_genesis
+
+from trinity.db.beacon.chain import AsyncBeaconChainDB
+from trinity.db.manager import DBClient, DBManager
+from trinity.rpc.http import handler
+from trinity.rpc.main import RPCServer
+from trinity.rpc.modules import (
+    initialize_beacon_modules,
+)
+
+
+@pytest.fixture
+def ipc_path():
+    with tempfile.TemporaryDirectory() as dir:
+        yield pathlib.Path(dir) / "db_manager.ipc"
+
+
+@pytest.mark.asyncio
+async def test_http_server(aiohttp_raw_server, aiohttp_client, event_bus, base_db, ipc_path):
+    manager = DBManager(base_db)
+    with manager.run(ipc_path):
+        override_lengths(SERENITY_CONFIG)
+        db = DBClient.connect(ipc_path)
+        genesis_config = Eth2GenesisConfig(SERENITY_CONFIG)
+        chaindb = AsyncBeaconChainDB(db, genesis_config)
+
+        fork_choice_scoring = higher_slot_scoring
+        genesis_state, genesis_block = create_mock_genesis(
+            pubkeys=(),
+            config=SERENITY_CONFIG,
+            keymap=dict(),
+            genesis_block_class=BeaconBlock,
+            genesis_time=0,
+        )
+
+        chaindb.persist_state(genesis_state)
+        chaindb.persist_block(genesis_block, genesis_block.__class__, fork_choice_scoring)
+        try:
+            rpc = RPCServer(initialize_beacon_modules(chaindb, event_bus), chaindb, event_bus)
+            raw_server = await aiohttp_raw_server(handler(rpc.execute))
+            client = await aiohttp_client(raw_server)
+            request_id = 1
+            request_data = {
+                "jsonrpc": "2.0",
+                "method": "beacon_head",
+                "params": [],
+                "id": request_id,
+            }
+            response = await client.post('/', json=request_data)
+            response_data = await response.json()
+            assert response_data['id'] == request_id
+            result = response_data['result']
+            assert result['slot'] == 0
+            assert decode_hex(result['block_root']) == genesis_block.signing_root
+            assert decode_hex(result['state_root']) == genesis_state.hash_tree_root
+        except KeyboardInterrupt:
+            pass
+        finally:
+            await raw_server.close()
+            db.close()

--- a/trinity/db/manager.py
+++ b/trinity/db/manager.py
@@ -200,7 +200,15 @@ class DBManager:
         # shutdown.  This allows the server threads to be cleanly closed on
         # demand.
         self.wait_stopped()
-        sock.shutdown(socket.SHUT_RD)
+
+        try:
+            sock.shutdown(socket.SHUT_RD)
+        except OSError as e:
+            # on mac OS this can result in the following error:
+            # OSError: [Errno 57] Socket is not connected
+            if e.errno != errno.ENOTCONN:
+                raise
+
         sock.close()
 
     @contextlib.contextmanager

--- a/trinity/rpc/http.py
+++ b/trinity/rpc/http.py
@@ -71,9 +71,9 @@ class HTTPServer(BaseService):
         self.rpc = rpc
         self.host = host
         self.port = port
+        self.server = web.Server(handler(self.rpc.execute))
 
     async def _run(self) -> None:
-        self.server = web.Server(handler(self.rpc.execute))
         runner = web.ServerRunner(self.server)
         await runner.setup()
         site = web.TCPSite(runner, self.host, self.port)

--- a/trinity/rpc/http.py
+++ b/trinity/rpc/http.py
@@ -1,0 +1,85 @@
+import asyncio
+import logging
+from typing import (
+    Any,
+    Callable,
+)
+
+from aiohttp import web
+from eth_utils.toolz import curry
+
+from cancel_token import (
+    CancelToken,
+)
+
+from p2p.service import (
+    BaseService,
+)
+
+from trinity.rpc.main import (
+    RPCServer,
+)
+
+
+@curry
+async def handler(execute_rpc: Callable[[Any], Any], request: web.Request) -> web.Response:
+    logger = logging.getLogger('trinity.rpc.http')
+
+    if request.method == 'POST':
+        logger.debug(f'Receiving request: {request}')
+        try:
+            body_json = await request.json()
+            logger.debug(f'data: {body_json}')
+        except Exception as e:
+            # invalid json request, keep reading data until a valid json is formed
+            msg = f"Invalid request: {request}"
+            logger.debug(msg)
+            return response_error(msg)
+
+        try:
+            result = await execute_rpc(body_json)
+        except Exception as e:
+            msg = "Unrecognized exception while executing RPC"
+            logger.exception(msg)
+            return response_error(msg)
+        else:
+            logger.debug(f'writing: {result.encode()}')
+            return web.Response(content_type='application/json', text=result)
+    else:
+        return response_error("Request method should be POST")
+
+
+def response_error(message: Any) -> web.Response:
+    data = {'error': message}
+    return web.json_response(data)
+
+
+class HTTPServer(BaseService):
+    rpc = None
+    server = None
+    host = None
+    port = None
+
+    def __init__(
+            self,
+            rpc: RPCServer,
+            host: str = '127.0.0.1',
+            port: int = 8545,
+            token: CancelToken = None,
+            loop: asyncio.AbstractEventLoop = None) -> None:
+        super().__init__(token=token, loop=loop)
+        self.rpc = rpc
+        self.host = host
+        self.port = port
+
+    async def _run(self) -> None:
+        self.server = web.Server(handler(self.rpc.execute))
+        runner = web.ServerRunner(self.server)
+        await runner.setup()
+        site = web.TCPSite(runner, self.host, self.port)
+        await site.start()
+
+        await self.cancel_token.wait()
+
+    async def _cleanup(self) -> None:
+        await self.server.shutdown()

--- a/trinity/rpc/main.py
+++ b/trinity/rpc/main.py
@@ -110,7 +110,6 @@ class RPCServer:
         """
         try:
             validate_request(request)
-            logging.debug(f'request: {request}')
 
             if request.get('jsonrpc', None) != '2.0':
                 raise NotImplementedError("Only the 2.0 jsonrpc protocol is supported")
@@ -118,11 +117,9 @@ class RPCServer:
             method = self._lookup_method(request['method'])
             params = request.get('params', [])
 
-            # TODO: Beacon chain doesn't support retry now
-            if not isinstance(self.chain, BaseAsyncBeaconChainDB):
-                result = await execute_with_retries(
-                    self.event_bus, method, params, self.chain,
-                )
+            result = await execute_with_retries(
+                self.event_bus, method, params, self.chain,
+            )
 
             if request['method'] == 'evm_resetToGenesisFixture':
                 result = True

--- a/trinity/rpc/main.py
+++ b/trinity/rpc/main.py
@@ -15,6 +15,7 @@ from eth_utils import (
 )
 
 from trinity.chains.base import AsyncChainAPI
+from trinity.db.beacon.chain import BaseAsyncBeaconChainDB
 from trinity.rpc.modules import (
     BaseRPCModule,
 )
@@ -65,7 +66,7 @@ class RPCServer:
 
     def __init__(self,
                  modules: Sequence[BaseRPCModule],
-                 chain: AsyncChainAPI=None,
+                 chain: Union[AsyncChainAPI, BaseAsyncBeaconChainDB],
                  event_bus: EndpointAPI=None) -> None:
         self.event_bus = event_bus
         self.modules: Dict[str, BaseRPCModule] = {}
@@ -116,9 +117,12 @@ class RPCServer:
 
             method = self._lookup_method(request['method'])
             params = request.get('params', [])
-            result = await execute_with_retries(
-                self.event_bus, method, params, self.chain,
-            )
+
+            # TODO: Beacon chain doesn't support retry now
+            if not isinstance(self.chain, BaseAsyncBeaconChainDB):
+                result = await execute_with_retries(
+                    self.event_bus, method, params, self.chain,
+                )
 
             if request['method'] == 'evm_resetToGenesisFixture':
                 result = True

--- a/trinity/rpc/main.py
+++ b/trinity/rpc/main.py
@@ -109,6 +109,7 @@ class RPCServer:
         """
         try:
             validate_request(request)
+            logging.debug(f'request: {request}')
 
             if request.get('jsonrpc', None) != '2.0':
                 raise NotImplementedError("Only the 2.0 jsonrpc protocol is supported")

--- a/trinity/rpc/modules/beacon.py
+++ b/trinity/rpc/modules/beacon.py
@@ -10,6 +10,9 @@ from trinity.rpc.modules import BeaconChainRPCModule
 
 class Beacon(BeaconChainRPCModule):
 
+    async def currentSlot(self) -> str:
+        return hex(666)
+
     async def head(self) -> Dict[Any, Any]:
         block = await self.chain.coro_get_canonical_head(BeaconBlock)
         return dict(

--- a/trinity/rpc/modules/beacon.py
+++ b/trinity/rpc/modules/beacon.py
@@ -1,7 +1,19 @@
+from typing import Any, Dict
+
+from eth_utils import (
+    encode_hex,
+)
+
+from eth2.beacon.types.blocks import BeaconBlock
 from trinity.rpc.modules import BeaconChainRPCModule
 
 
 class Beacon(BeaconChainRPCModule):
 
-    async def currentSlot(self) -> str:
-        return hex(666)
+    async def head(self) -> Dict[Any, Any]:
+        block = await self.chain.coro_get_canonical_head(BeaconBlock)
+        return dict(
+            slot=block.slot,
+            block_root=encode_hex(block.signing_root),
+            state_root=encode_hex(block.state_root),
+        )

--- a/trinity/rpc/retry.py
+++ b/trinity/rpc/retry.py
@@ -7,7 +7,6 @@ import itertools
 from typing import (
     Any,
     Callable,
-    Optional,
     TypeVar,
 )
 
@@ -64,7 +63,7 @@ def is_retryable(func: Func) -> bool:
     return getattr(func, RETRYABLE_ATTRIBUTE_NAME, False)
 
 
-async def check_requested_block_age(chain: Optional[AsyncChainAPI],
+async def check_requested_block_age(chain: AsyncChainAPI,
                                     func: Func, params: Any) -> None:
     sig = inspect.signature(func)
     params = sig.bind(*params)
@@ -85,7 +84,7 @@ async def check_requested_block_age(chain: Optional[AsyncChainAPI],
 
 
 async def execute_with_retries(event_bus: EndpointAPI, func: Func, params: Any,
-                               chain: Optional[AsyncChainAPI]) -> None:
+                               chain: AsyncChainAPI) -> None:
     """
     If a beam sync (or anything which responds to CollectMissingAccount) is running then
     attempt to fetch missing data from it before giving up.

--- a/trinity/rpc/retry.py
+++ b/trinity/rpc/retry.py
@@ -8,6 +8,7 @@ from typing import (
     Any,
     Callable,
     TypeVar,
+    Union,
 )
 
 from lahja import EndpointAPI
@@ -19,6 +20,7 @@ from eth.vm.interrupt import (
 )
 
 from trinity.chains.base import AsyncChainAPI
+from trinity.db.beacon.chain import BaseAsyncBeaconChainDB
 from trinity.sync.common.events import (
     CollectMissingAccount,
     CollectMissingBytecode,
@@ -63,7 +65,7 @@ def is_retryable(func: Func) -> bool:
     return getattr(func, RETRYABLE_ATTRIBUTE_NAME, False)
 
 
-async def check_requested_block_age(chain: AsyncChainAPI,
+async def check_requested_block_age(chain: Union[AsyncChainAPI, BaseAsyncBeaconChainDB],
                                     func: Func, params: Any) -> None:
     sig = inspect.signature(func)
     params = sig.bind(*params)
@@ -73,18 +75,18 @@ async def check_requested_block_age(chain: AsyncChainAPI,
     except AttributeError as e:
         raise Exception("Function {func} was not decorated with @retryable") from e
 
-    at_block = params.arguments[at_block_name]
-
-    requested_header = await get_header(chain, at_block)
-    requested_block = requested_header.block_number
-    current_block = chain.get_canonical_head().block_number
-
-    if requested_block < current_block - 64:
-        raise Exception(f'block "{at_block}" is too old to be fetched over the network')
+    # Beacon chain doesn't support it
+    if not isinstance(chain, BaseAsyncBeaconChainDB):
+        at_block = params.arguments[at_block_name]
+        requested_header = await get_header(chain, at_block)
+        requested_block = requested_header.block_number
+        current_block = chain.get_canonical_head().block_number
+        if requested_block < current_block - 64:
+            raise Exception(f'block "{at_block}" is too old to be fetched over the network')
 
 
 async def execute_with_retries(event_bus: EndpointAPI, func: Func, params: Any,
-                               chain: AsyncChainAPI) -> None:
+                               chain: Union[AsyncChainAPI, BaseAsyncBeaconChainDB]) -> None:
     """
     If a beam sync (or anything which responds to CollectMissingAccount) is running then
     attempt to fetch missing data from it before giving up.


### PR DESCRIPTION
### What was wrong?

* For eth2 validator APIs (https://github.com/ethereum/eth2.0-APIs), we need a base HTTP Server.
* The interface could be either JSON-RPC or HTTP RESTful. Now it's set to JSON-RPC. 
    * For JSON-RPC, @cburgdorf has made some example for us: https://github.com/ethereum/trinity/blob/master/trinity/rpc/modules/beacon.py

@pipermerriam @ralexstokes 
While I think this PR should be shared with eth1, the interop is more time-sensitive... which means I'm included to *not* test it with eth1 APIs in this PR. What do you think about it?

### How was it fixed?
* Add `HTTPServer`. `--enable-http` is `False` by default.
* Default port: `8545`

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

[//]: # (See: https://trinity-client.readthedocs.io/en/latest/contributing.html#pull-requests)
- [x] Add entry to the [release notes](https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

- [x] Add some basic tests
- [ ] `aiohttp.StreamReader`?

#### Cute Animal Picture

![dolphin-203875_640](https://user-images.githubusercontent.com/9263930/64486727-50297400-d263-11e9-8a60-e9a7340a3318.jpg)