### PR TITLE
Use hash tree root for Node

### DIFF
--- a/.flake8-eth2
+++ b/.flake8-eth2
@@ -1,4 +1,4 @@
 [flake8]
-max-line-length= 100
+max-line-length= 120
 exclude=
 ignore=W503,E203

--- a/.flake8-eth2
+++ b/.flake8-eth2
@@ -1,4 +1,4 @@
 [flake8]
-max-line-length= 120
+max-line-length= 100
 exclude=
 ignore=W503,E203

--- a/eth2/beacon/chains/base.py
+++ b/eth2/beacon/chains/base.py
@@ -117,6 +117,10 @@ class BaseBeaconChain(Configurable, ABC):
         ...
 
     @abstractmethod
+    def get_block_by_hash_tree_root(self, block_root: HashTreeRoot) -> BaseBeaconBlock:
+        ...
+
+    @abstractmethod
     def get_canonical_head(self) -> BaseBeaconBlock:
         ...
 
@@ -331,10 +335,15 @@ class BeaconChain(BaseBeaconChain):
 
         Raise ``BlockNotFound`` if there's no block with the given hash in the db.
         """
-        validate_word(block_root, title="Block Hash")
+        validate_word(block_root, title="Block Signing Root")
 
         block_class = self.get_block_class(block_root)
         return self.chaindb.get_block_by_root(block_root, block_class)
+
+    def get_block_by_hash_tree_root(self, block_root: HashTreeRoot) -> BaseBeaconBlock:
+        validate_word(block_root, title="Block Hash Tree Root")
+        signing_root = self.chaindb.get_block_signing_root_by_hash_tree_root(block_root)
+        return self.get_block_by_root(signing_root)
 
     def get_canonical_head(self) -> BaseBeaconBlock:
         """

--- a/eth2/beacon/db/chain.py
+++ b/eth2/beacon/db/chain.py
@@ -93,6 +93,7 @@ class BaseBeaconChainDB(ABC):
     def get_slot_by_root(self, block_root: SigningRoot) -> Slot:
         pass
 
+    @abstractmethod
     def get_block_signing_root_by_hash_tree_root(
         self, block_root: HashTreeRoot
     ) -> SigningRoot:
@@ -390,11 +391,9 @@ class BeaconChainDB(BaseBeaconChainDB):
         db: DatabaseAPI, block_root: HashTreeRoot
     ) -> SigningRoot:
         validate_word(block_root, title="block hash tree root")
-        hash_tree_root_to_signing_root_key = SchemaV1.make_block_hash_tree_root_to_signing_root_lookup_key(
-            block_root
-        )
+        key = SchemaV1.make_block_hash_tree_root_to_signing_root_lookup_key(block_root)
         try:
-            signing_root = db[hash_tree_root_to_signing_root_key]
+            signing_root = db[key]
         except KeyError:
             raise BlockNotFound(
                 "No block with hash tree root {0} found".format(encode_hex(block_root))
@@ -641,10 +640,10 @@ class BeaconChainDB(BaseBeaconChainDB):
     def _add_block_hash_tree_root_to_signing_root_lookup(
         db: DatabaseAPI, block: BaseBeaconBlock
     ) -> None:
-        hash_tree_root_to_signing_root_key = SchemaV1.make_block_hash_tree_root_to_signing_root_lookup_key(
+        key = SchemaV1.make_block_hash_tree_root_to_signing_root_lookup_key(
             block.hash_tree_root
         )
-        db.set(hash_tree_root_to_signing_root_key, block.signing_root)
+        db.set(key, block.signing_root)
 
     #
     # Beacon State API

--- a/eth2/beacon/db/schema.py
+++ b/eth2/beacon/db/schema.py
@@ -42,6 +42,13 @@ class BaseSchema(ABC):
 
     @staticmethod
     @abstractmethod
+    def make_block_hash_tree_root_to_signing_root_lookup_key(
+        block_root: HashTreeRoot
+    ) -> bytes:
+        ...
+
+    @staticmethod
+    @abstractmethod
     def make_finalized_head_root_lookup_key() -> bytes:
         ...
 
@@ -100,6 +107,12 @@ class SchemaV1(BaseSchema):
     @staticmethod
     def make_block_root_to_slot_lookup_key(block_root: SigningRoot) -> bytes:
         return b"v1:beacon:block-root-to-slot:%s" % block_root
+
+    @staticmethod
+    def make_block_hash_tree_root_to_signing_root_lookup_key(
+        block_root: HashTreeRoot
+    ) -> bytes:
+        return b"v1:beacon:hash_tree_root_to_signing_root:%s" % block_root
 
     #
     # Attestaion

--- a/tests/eth2/core/beacon/chains/test_beacon_chain.py
+++ b/tests/eth2/core/beacon/chains/test_beacon_chain.py
@@ -52,6 +52,9 @@ def test_canonical_chain(valid_chain, genesis_slot, fork_choice_scoring):
     result_block = valid_chain.get_block_by_root(block.signing_root)
     assert result_block == block
 
+    result_block_2 = valid_chain.get_block_by_hash_tree_root(block.hash_tree_root)
+    assert result_block_2 == block
+
 
 @pytest.mark.parametrize(
     ("validator_count," "slots_per_epoch," "target_committee_size," "shard_count,"),

--- a/tests/eth2/core/beacon/db/test_beacon_chaindb.py
+++ b/tests/eth2/core/beacon/db/test_beacon_chaindb.py
@@ -74,6 +74,25 @@ def test_chaindb_persist_block_and_slot_to_root(chaindb, block, fork_choice_scor
     assert chaindb.exists(slot_to_root_key)
 
 
+def test_chaindb_persist_block_and_hash_tree_root_to_signing_root(
+    chaindb, block, fork_choice_scoring
+):
+    with pytest.raises(BlockNotFound):
+        chaindb.get_block_signing_root_by_hash_tree_root(block.hash_tree_root)
+    hash_tree_root_to_signing_root_key = SchemaV1.make_block_hash_tree_root_to_signing_root_lookup_key(
+        block.hash_tree_root
+    )
+    assert not chaindb.exists(hash_tree_root_to_signing_root_key)
+
+    chaindb.persist_block(block, block.__class__, fork_choice_scoring)
+
+    assert (
+        chaindb.get_block_signing_root_by_hash_tree_root(block.hash_tree_root)
+        == block.signing_root
+    )
+    assert chaindb.exists(hash_tree_root_to_signing_root_key)
+
+
 @given(seed=st.binary(min_size=32, max_size=32))
 def test_chaindb_persist_block_and_unknown_parent(
     chaindb, block, fork_choice_scoring, seed

--- a/tests/eth2/core/beacon/db/test_beacon_chaindb.py
+++ b/tests/eth2/core/beacon/db/test_beacon_chaindb.py
@@ -79,10 +79,10 @@ def test_chaindb_persist_block_and_hash_tree_root_to_signing_root(
 ):
     with pytest.raises(BlockNotFound):
         chaindb.get_block_signing_root_by_hash_tree_root(block.hash_tree_root)
-    hash_tree_root_to_signing_root_key = SchemaV1.make_block_hash_tree_root_to_signing_root_lookup_key(
+    key = SchemaV1.make_block_hash_tree_root_to_signing_root_lookup_key(
         block.hash_tree_root
     )
-    assert not chaindb.exists(hash_tree_root_to_signing_root_key)
+    assert not chaindb.exists(key)
 
     chaindb.persist_block(block, block.__class__, fork_choice_scoring)
 
@@ -90,7 +90,7 @@ def test_chaindb_persist_block_and_hash_tree_root_to_signing_root(
         chaindb.get_block_signing_root_by_hash_tree_root(block.hash_tree_root)
         == block.signing_root
     )
-    assert chaindb.exists(hash_tree_root_to_signing_root_key)
+    assert chaindb.exists(key)
 
 
 @given(seed=st.binary(min_size=32, max_size=32))

--- a/tests/libp2p/bcc/test_req_resp.py
+++ b/tests/libp2p/bcc/test_req_resp.py
@@ -160,10 +160,12 @@ async def test_request_beacon_blocks_invalid_request(monkeypatch):
         # TEST: Can not request blocks with `start_slot` greater than head block slot
         start_slot = 2
 
-        def get_block_by_root(root):
+        def get_block_by_hash_tree_root(root):
             return head_block
 
-        monkeypatch.setattr(bob.chain, "get_block_by_root", get_block_by_root)
+        monkeypatch.setattr(
+            bob.chain, "get_block_by_hash_tree_root", get_block_by_hash_tree_root
+        )
 
         count = 1
         step = 1
@@ -278,10 +280,12 @@ async def test_request_beacon_blocks_on_nonexist_chain(monkeypatch):
 
         request_head_block_root = b"\x56" * 32
 
-        def get_block_by_root(root):
+        def get_block_by_hash_tree_root(root):
             raise BlockNotFound
 
-        monkeypatch.setattr(bob.chain, "get_block_by_root", get_block_by_root)
+        monkeypatch.setattr(
+            bob.chain, "get_block_by_hash_tree_root", get_block_by_hash_tree_root
+        )
 
         start_slot = 0
         count = 5
@@ -310,23 +314,25 @@ async def test_request_recent_beacon_blocks(monkeypatch):
             body=BeaconBlockBody(),
         )
         blocks = [head_block.copy(slot=slot) for slot in range(5)]
-        mock_root_to_block_db = {block.signing_root: block for block in blocks}
+        mock_root_to_block_db = {block.hash_tree_root: block for block in blocks}
 
-        def get_block_by_root(root):
+        def get_block_by_hash_tree_root(root):
             validate_word(root)
             if root in mock_root_to_block_db:
                 return mock_root_to_block_db[root]
             else:
                 raise BlockNotFound
 
-        monkeypatch.setattr(bob.chain, "get_block_by_root", get_block_by_root)
+        monkeypatch.setattr(
+            bob.chain, "get_block_by_hash_tree_root", get_block_by_hash_tree_root
+        )
 
         requesting_block_roots = [
-            blocks[0].signing_root,
+            blocks[0].hash_tree_root,
             b"\x12" * 32,  # Unknown block root
-            blocks[1].signing_root,
+            blocks[1].hash_tree_root,
             b"\x23" * 32,  # Unknown block root
-            blocks[3].signing_root,
+            blocks[3].hash_tree_root,
         ]
         requested_blocks = await alice.request_recent_beacon_blocks(
             peer_id=bob.peer_id, block_roots=requesting_block_roots

--- a/trinity/protocol/bcc_libp2p/node.py
+++ b/trinity/protocol/bcc_libp2p/node.py
@@ -667,7 +667,8 @@ class Node(BaseService):
         self.logger.debug("Received the beacon blocks request message %s", beacon_blocks_request)
 
         try:
-            peer_head_block = self.chain.get_block_by_hash_tree_root(beacon_blocks_request.head_block_root)
+            peer_head_block = self.chain.get_block_by_hash_tree_root(
+                beacon_blocks_request.head_block_root)
         except (BlockNotFound, ValidationError):
             # We don't have the chain data peer is requesting
             requested_beacon_blocks: Tuple[BaseBeaconBlock, ...] = tuple()

--- a/trinity/protocol/bcc_libp2p/node.py
+++ b/trinity/protocol/bcc_libp2p/node.py
@@ -667,7 +667,7 @@ class Node(BaseService):
         self.logger.debug("Received the beacon blocks request message %s", beacon_blocks_request)
 
         try:
-            peer_head_block = self.chain.get_block_by_root(beacon_blocks_request.head_block_root)
+            peer_head_block = self.chain.get_block_by_hash_tree_root(beacon_blocks_request.head_block_root)
         except (BlockNotFound, ValidationError):
             # We don't have the chain data peer is requesting
             requested_beacon_blocks: Tuple[BaseBeaconBlock, ...] = tuple()
@@ -816,7 +816,7 @@ class Node(BaseService):
         recent_beacon_blocks = []
         for block_root in recent_beacon_blocks_request.block_roots:
             try:
-                block = self.chain.get_block_by_root(block_root)
+                block = self.chain.get_block_by_hash_tree_root(block_root)
             except (BlockNotFound, ValidationError):
                 pass
             else:

--- a/trinity/protocol/bcc_libp2p/node.py
+++ b/trinity/protocol/bcc_libp2p/node.py
@@ -373,13 +373,14 @@ class Node(BaseService):
 
     def _make_hello_packet(self) -> HelloRequest:
         state = self.chain.get_head_state()
+        head = self.chain.get_canonical_head()
         finalized_checkpoint = state.finalized_checkpoint
         return HelloRequest(
             fork_version=state.fork.current_version,
             finalized_root=finalized_checkpoint.root,
             finalized_epoch=finalized_checkpoint.epoch,
-            head_root=state.hash_tree_root,
-            head_slot=state.slot,
+            head_root=head.hash_tree_root,
+            head_slot=head.slot,
         )
 
     def _compare_chain_tip_and_finalized_epoch(self,


### PR DESCRIPTION
This builds on top of #1077

### What was wrong?

Node should request and handle blocks with hash_tree_roots 

### How was it fixed?

- add chain.get_block_by_hash_tree_root
- fix node

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://i.imgur.com/70gTepOl.jpg)
