### PR TITLE
Suppress exception during header sync

### DIFF
--- a/newsfragments/1083.bugfix.rst
+++ b/newsfragments/1083.bugfix.rst
@@ -1,0 +1,2 @@
+An occasional warning "ValidationError: Duplicate tasks detected" was crashing the node. It's
+recoverable, so log it, but don't crash.

--- a/trinity/sync/common/headers.py
+++ b/trinity/sync/common/headers.py
@@ -592,9 +592,20 @@ class HeaderMeatSyncer(BaseService, PeerSubscriber, Generic[TChainPeer]):
         :param gap_length: how long is the header gap
         :param skeleton_peer: the peer that provided the parent_header - will not use to fill gaps
         """
-        await self.wait(self._filler_header_tasks.add((
-            (parent_header, gap_length, skeleton_peer),
-        )))
+        try:
+            await self.wait(self._filler_header_tasks.add((
+                (parent_header, gap_length, skeleton_peer),
+            )))
+        except ValidationError as exc:
+            self.logger.debug(
+                "Tried to re-add a duplicate list of headers to the download queue: %s",
+                exc,
+            )
+            # Since the task is already queued up, there is no value in
+            # re-adding it, so it is safe to drop the exception after logging
+            # it. One example of a time it happens is when the skeleton sync
+            # restarts, and happens to choose the same skeleton structure. It
+            # tries to reinsert the same duplicate meat filler tasks.
 
     async def _run(self) -> None:
         self.run_daemon_task(self._display_stats())


### PR DESCRIPTION
Catch, log, and suppress duplicate ValidationError that happens from
trying to add a duplicate task. It shouldn't be happening, but it's
recoverable, so we don't need to crash the node for it.

### What was wrong?

(kind of) fixes #1083 

### How was it fixed?

Well, the error is recoverable, so we basically just log it and continue, so the node doesn't crash. It would still be good to figure out the root cause.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history
- [x] add task to find/resolve the root cause

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

[//]: # (See: https://trinity-client.readthedocs.io/en/latest/contributing.html#pull-requests)
- [x] Add entry to the [release notes](https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](http://earthporm.com/wp-content/uploads/2015/04/cute-animals-hokkaido-ezo-japan-41.jpg)
