### PR TITLE
Refactor p2p request/response API to have ABC bases.

### DIFF
--- a/p2p/abc.py
+++ b/p2p/abc.py
@@ -28,7 +28,7 @@ from eth_utils import ExtendedDebugLogger
 
 from eth_keys import keys
 
-from p2p.typing import Capability, Capabilities, Payload, Structure
+from p2p.typing import Capability, Capabilities, Payload, Structure, TRequestPayload
 from p2p.transport_state import TransportState
 
 if TYPE_CHECKING:
@@ -174,10 +174,6 @@ class CommandAPI(ABC):
     @abstractmethod
     def compress_payload(self, raw_payload: bytes) -> bytes:
         ...
-
-
-# A payload to be delivered with a request
-TRequestPayload = TypeVar('TRequestPayload', bound=Payload, covariant=True)
 
 
 class RequestAPI(ABC, Generic[TRequestPayload]):
@@ -366,6 +362,11 @@ class AsyncioServiceAPI(ABC):
     @property
     @abstractmethod
     def is_running(self) -> bool:
+        ...
+
+    @property
+    @abstractmethod
+    def is_operational(self) -> bool:
         ...
 
     @abstractmethod

--- a/p2p/exceptions.py
+++ b/p2p/exceptions.py
@@ -24,6 +24,14 @@ class PeerConnectionLost(BaseP2PError):
     pass
 
 
+class ConnectionBusy(BaseP2PError):
+    """
+    Raised when an attempt is made to wait for a certain message type from a
+    peer when there is already an active wait for that message type.
+    """
+    pass
+
+
 class IneligiblePeer(BaseP2PError):
     """
     Raised when a peer is not a valid connection candidate.

--- a/p2p/typing.py
+++ b/p2p/typing.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, Sequence, Tuple, Union
+from typing import Any, Dict, Sequence, Tuple, TypeVar, Union
 
 from mypy_extensions import TypedDict
 
@@ -14,6 +14,12 @@ Payload = Union[
     Sequence[rlp.Serializable],
     TypedDictPayload,
 ]
+
+
+# A payload to be delivered with a request
+TRequestPayload = TypeVar('TRequestPayload', bound=Payload, covariant=True)
+# A payload to be delivered as a response
+TResponsePayload = TypeVar('TResponsePayload', bound=Payload)
 
 
 Structure = Union[

--- a/trinity/exceptions.py
+++ b/trinity/exceptions.py
@@ -29,14 +29,6 @@ class MissingPath(BaseTrinityError):
         self.path = path
 
 
-class AlreadyWaiting(BaseTrinityError):
-    """
-    Raised when an attempt is made to wait for a certain message type from a
-    peer when there is already an active wait for that message type.
-    """
-    pass
-
-
 class SyncRequestAlreadyProcessed(BaseTrinityError):
     """
     Raised when a trie SyncRequest has already been processed.

--- a/trinity/protocol/bcc/validators.py
+++ b/trinity/protocol/bcc/validators.py
@@ -21,7 +21,7 @@ from eth2.beacon.typing import (
     Slot,
 )
 
-from trinity.protocol.common.validators import BaseValidator
+from trinity.protocol.common.abc import ValidatorAPI
 
 from trinity.protocol.bcc.commands import (
     RequestMessage,
@@ -29,7 +29,7 @@ from trinity.protocol.bcc.commands import (
 )
 
 
-class BeaconBlocksValidator(BaseValidator[Tuple[BaseBeaconBlock, ...]]):
+class BeaconBlocksValidator(ValidatorAPI[Tuple[BaseBeaconBlock, ...]]):
 
     def __init__(self, block_slot_or_hash: Union[Slot, Hash32], max_blocks: int) -> None:
         self.block_slot_or_hash = block_slot_or_hash

--- a/trinity/protocol/common/abc.py
+++ b/trinity/protocol/common/abc.py
@@ -38,7 +38,7 @@ if TYPE_CHECKING:
 class NormalizerAPI(ABC, Generic[TResponsePayload, TResult]):
     # This variable indicates how slow normalization is. If normalization requires
     # any non-trivial computation, consider it slow. Then, the Manager will run it in
-    # a different process.
+    # a thread to ensure it doesn't block the main loop.
     is_normalization_slow: bool
 
     @staticmethod
@@ -56,10 +56,7 @@ class ValidatorAPI(ABC, Generic[TResponse]):
         ...
 
 
-class PerformanceTrackerAPI(ABC, Generic[TRequest, TResult]):
-    """
-    The statistics of how a command is performing.
-    """
+class PerformanceAPI(ABC):
     total_msgs: int
     total_items: int
     total_timeouts: int
@@ -77,6 +74,12 @@ class PerformanceTrackerAPI(ABC, Generic[TRequest, TResult]):
         Return a human readable string representing the stats for this tracker.
         """
         ...
+
+
+class PerformanceTrackerAPI(PerformanceAPI, Generic[TRequest, TResult]):
+    """
+    The statistics of how a command is performing.
+    """
 
     @abstractmethod
     def record_timeout(self, timeout: float) -> None:

--- a/trinity/protocol/common/abc.py
+++ b/trinity/protocol/common/abc.py
@@ -1,0 +1,255 @@
+from abc import ABC, abstractmethod
+from typing import (
+    Any,
+    AsyncIterator,
+    Callable,
+    Dict,
+    Generic,
+    Iterable,
+    Optional,
+    Tuple,
+    Type,
+    TYPE_CHECKING,
+)
+
+
+from p2p.abc import (
+    AsyncioServiceAPI,
+    CommandAPI,
+    ConnectionAPI,
+    RequestAPI,
+    ProtocolAPI,
+)
+from p2p.typing import (
+    TRequestPayload,
+    TResponsePayload,
+)
+
+from p2p.stats.ema import EMA
+from p2p.stats.percentile import Percentile
+from p2p.stats.stddev import StandardDeviation
+
+from .typing import TResult, TRequest, TResponse
+
+if TYPE_CHECKING:
+    import asyncio  # noqa: F401
+
+
+class NormalizerAPI(ABC, Generic[TResponsePayload, TResult]):
+    # This variable indicates how slow normalization is. If normalization requires
+    # any non-trivial computation, consider it slow. Then, the Manager will run it in
+    # a different process.
+    is_normalization_slow: bool
+
+    @staticmethod
+    @abstractmethod
+    def normalize_result(message: TResponsePayload) -> TResult:
+        """
+        Convert underlying peer message to final result
+        """
+        ...
+
+
+class ValidatorAPI(ABC, Generic[TResponse]):
+    @abstractmethod
+    def validate_result(self, result: TResponse) -> None:
+        ...
+
+
+class PerformanceTrackerAPI(ABC, Generic[TRequest, TResult]):
+    """
+    The statistics of how a command is performing.
+    """
+    total_msgs: int
+    total_items: int
+    total_timeouts: int
+    total_response_time: float
+
+    response_quality_ema: EMA
+    round_trip_ema: EMA
+    round_trip_99th: Percentile
+    round_trip_stddev: StandardDeviation
+    items_per_second_ema: EMA
+
+    @abstractmethod
+    def get_stats(self) -> str:
+        """
+        Return a human readable string representing the stats for this tracker.
+        """
+        ...
+
+    @abstractmethod
+    def record_timeout(self, timeout: float) -> None:
+        ...
+
+    @abstractmethod
+    def record_response(self,
+                        elapsed: float,
+                        request: TRequest,
+                        result: TResult) -> None:
+        ...
+
+
+class ResponseCandidateStreamAPI(AsyncioServiceAPI, Generic[TRequestPayload, TResponsePayload]):
+    response_timeout: float
+
+    pending_request: Optional[Tuple[float, 'asyncio.Future[TResponsePayload]']]
+
+    request_protocol_type: Type[ProtocolAPI]
+    response_cmd_type: Type[CommandAPI]
+
+    last_response_time: float
+
+    @abstractmethod
+    def __init__(
+            self,
+            connection: ConnectionAPI,
+            request_protocol_type: Type[ProtocolAPI],
+            response_cmd_type: Type[CommandAPI]) -> None:
+        ...
+
+    @abstractmethod
+    def payload_candidates(
+            self,
+            request: RequestAPI[TRequestPayload],
+            tracker: PerformanceTrackerAPI[RequestAPI[TRequestPayload], Any],
+            *,
+            timeout: float = None) -> AsyncIterator[TResponsePayload]:
+        """
+        Make a request and iterate through candidates for a valid response.
+
+        To mark a response as valid, use `complete_request`. After that call, payload
+        candidates will stop arriving.
+        """
+        ...
+
+    @property
+    @abstractmethod
+    def response_cmd_name(self) -> str:
+        ...
+
+    @abstractmethod
+    def complete_request(self) -> None:
+        ...
+
+    @property
+    @abstractmethod
+    def is_pending(self) -> bool:
+        ...
+
+    @abstractmethod
+    def __del__(self) -> None:
+        ...
+
+
+class ExchangeManagerAPI(ABC, Generic[TRequestPayload, TResponsePayload, TResult]):
+    _response_stream: Optional[ResponseCandidateStreamAPI[TRequestPayload, TResponsePayload]]
+
+    tracker: PerformanceTrackerAPI[Any, TResult]
+
+    @abstractmethod
+    def __init__(
+            self,
+            connection: ConnectionAPI,
+            requesting_on: Type[ProtocolAPI],
+            listening_for: Type[CommandAPI]) -> None:
+        ...
+
+    @abstractmethod
+    async def launch_service(self) -> None:
+        ...
+
+    @property
+    @abstractmethod
+    def is_operational(self) -> bool:
+        ...
+
+    @abstractmethod
+    async def get_result(
+            self,
+            request: RequestAPI[TRequestPayload],
+            normalizer: NormalizerAPI[TResponsePayload, TResult],
+            validate_result: Callable[[TResult], None],
+            payload_validator: Callable[[TResponsePayload], None],
+            tracker: PerformanceTrackerAPI[RequestAPI[TRequestPayload], TResult],
+            timeout: float = None) -> TResult:
+        ...
+
+    @property
+    @abstractmethod
+    def service(self) -> ResponseCandidateStreamAPI[TRequestPayload, TResponsePayload]:
+        """
+        This service that needs to be running for calls to execute properly
+        """
+        ...
+
+    @property
+    @abstractmethod
+    def is_requesting(self) -> bool:
+        ...
+
+
+class ExchangeAPI(ABC, Generic[TRequestPayload, TResponsePayload, TResult]):
+    """
+    The exchange object handles a few things, in rough order:
+
+     - convert from friendly input arguments to the protocol arguments
+     - generate the appropriate BaseRequest object
+     - identify the BaseNormalizer that can convert the response payload to the desired result
+     - prepare the ValidatorAPI that can validate the final result against the requested data
+     - (if necessary) prepare a response payload validator, which validates data that is *not*
+        present in the final result
+     - issue the request to the ExchangeManager, with the request, normalizer, and validators
+     - await the normalized & validated response, and return it
+
+    TRequestPayload is the data as passed directly to the p2p command
+    TResponsePayload is the data as received directly from the p2p command response
+    TResult is the response data after normalization
+    """
+    request_class: Type[RequestAPI[TRequestPayload]]
+    tracker_class: Type[PerformanceTrackerAPI[Any, TResult]]
+    tracker: PerformanceTrackerAPI[RequestAPI[TRequestPayload], TResult]
+
+    def __init__(self, mgr: ExchangeManagerAPI[TRequestPayload, TResponsePayload, TResult]) -> None:
+        ...
+
+    @abstractmethod
+    async def get_result(
+            self,
+            request: RequestAPI[TRequestPayload],
+            normalizer: NormalizerAPI[TResponsePayload, TResult],
+            result_validator: ValidatorAPI[TResult],
+            payload_validator: Callable[[TRequestPayload, TResponsePayload], None],
+            timeout: float = None) -> TResult:
+        ...
+
+    @classmethod
+    @abstractmethod
+    def get_response_cmd_type(cls) -> Type[CommandAPI]:
+        ...
+
+    @classmethod
+    @abstractmethod
+    def get_request_cmd_type(cls) -> Type[CommandAPI]:
+        ...
+
+    @abstractmethod
+    async def __call__(self, *args: Any, **kwargs: Any) -> None:
+        ...
+
+    @property
+    @abstractmethod
+    def is_requesting(self) -> bool:
+        ...
+
+
+class HandlerAPI(Iterable[ExchangeAPI[Any, Any, Any]]):
+    _exchange_config: Dict[str, Type[ExchangeAPI[Any, Any, Any]]]
+
+    @abstractmethod
+    def __init__(self, connection: ConnectionAPI) -> None:
+        ...
+
+    @abstractmethod
+    def get_stats(self) -> Dict[str, str]:
+        ...

--- a/trinity/protocol/common/constants.py
+++ b/trinity/protocol/common/constants.py
@@ -5,10 +5,6 @@
 # the network will timeout before this timeout is ever hit.
 ROUND_TRIP_TIMEOUT = 20.0
 
-# Timeout used when performing the check to ensure peers are on the same side of chain splits as
-# us.
-CHAIN_SPLIT_CHECK_TIMEOUT = 15
-
 
 # We send requests to peers one at a time, but might initiate a few locally before
 # they are sent. This is an estimate of how many get queued locally. The reason we
@@ -21,3 +17,8 @@ NUM_QUEUED_REQUESTS = 3
 # disconnected from in the event of a asyncio.TimeoutError during a request/response.
 TIMEOUT_BUCKET_RATE = 1 / 60  # refill 1 token every minute
 TIMEOUT_BUCKET_CAPACITY = 3  # max capacity of 3 tokens
+
+
+# Timeout used when performing the check to ensure peers are on the same side of chain splits as
+# us.
+CHAIN_SPLIT_CHECK_TIMEOUT = 15

--- a/trinity/protocol/common/normalizers.py
+++ b/trinity/protocol/common/normalizers.py
@@ -1,36 +1,13 @@
-from abc import abstractmethod, ABC
-from typing import (
-    Generic,
-    TypeVar,
-    cast,
-)
+from typing import cast
 
-from p2p.protocol import Payload
+from p2p.typing import TResponsePayload
 
-from .types import (
-    TResponsePayload,
-    TResult,
-)
+from .abc import NormalizerAPI
+from .typing import TResult
 
 
-class BaseNormalizer(ABC, Generic[TResponsePayload, TResult]):
+class BaseNormalizer(NormalizerAPI[TResponsePayload, TResult]):
     is_normalization_slow = False
-    """
-    This variable indicates how slow normalization is. If normalization requires
-    any non-trivial computation, consider it slow. Then, the Manager will run it in
-    a different process.
-    """
-
-    @staticmethod
-    @abstractmethod
-    def normalize_result(message: TResponsePayload) -> TResult:
-        """
-        Convert underlying peer message to final result
-        """
-        ...
-
-
-TPassthrough = TypeVar('TPassthrough', bound=Payload)
 
 
 class NoopNormalizer(BaseNormalizer[TResponsePayload, TResult]):

--- a/trinity/protocol/common/trackers.py
+++ b/trinity/protocol/common/trackers.py
@@ -1,31 +1,20 @@
-from abc import ABC, abstractmethod
-from typing import (
-    Any,
-    Generic,
-    Optional,
-    TypeVar,
-)
+from abc import abstractmethod
+from typing import Optional
 
 from eth_utils import get_extended_debug_logger
-
-from p2p.abc import RequestAPI
 
 from p2p.stats.ema import EMA
 from p2p.stats.percentile import Percentile
 from p2p.stats.stddev import StandardDeviation
 
+from .abc import PerformanceTrackerAPI
 from .constants import ROUND_TRIP_TIMEOUT
-from .types import (
-    TResult,
-)
-
-TRequest = TypeVar('TRequest', bound=RequestAPI[Any])
+from .typing import TRequest, TResult
 
 
-class BasePerformance(ABC):
-    """
-    The statistics of how a command is performing.
-    """
+class BasePerformanceTracker(PerformanceTrackerAPI[TRequest, TResult]):
+    logger = get_extended_debug_logger('trinity.protocol.common.trackers.PerformanceTracker')
+
     def __init__(self) -> None:
         self.total_msgs = 0
         self.total_items = 0
@@ -76,13 +65,6 @@ class BasePerformance(ABC):
             f"ips={self.items_per_second_ema.value:.5f}  "
             f"timeouts={self.total_timeouts}  quality={int(self.response_quality_ema.value)}"
         )
-
-
-class BasePerformanceTracker(BasePerformance, Generic[TRequest, TResult]):
-    logger = get_extended_debug_logger('trinity.protocol.common.trackers.PerformanceTracker')
-
-    def __init__(self) -> None:
-        super().__init__()
 
     @abstractmethod
     def _get_request_size(self, request: TRequest) -> Optional[int]:

--- a/trinity/protocol/common/typing.py
+++ b/trinity/protocol/common/typing.py
@@ -1,4 +1,5 @@
 from typing import (
+    Any,
     Dict,
     Tuple,
     TypeVar,
@@ -8,17 +9,17 @@ from eth.abc import BlockAPI, ReceiptAPI
 from eth_typing import (
     Hash32,
 )
+
+from p2p.abc import RequestAPI
 from p2p.peer import BasePeer
-from p2p.protocol import Payload
+
+
+TRequest = TypeVar('TRequest', bound=RequestAPI[Any])
+TResponse = TypeVar('TResponse')
+TResult = TypeVar('TResult')
 
 
 TPeer = TypeVar('TPeer', bound=BasePeer)
-
-# A payload delivered by a responding command
-TResponsePayload = TypeVar('TResponsePayload', bound=Payload)
-
-# The returned value at the end of an exchange
-TResult = TypeVar('TResult')
 
 # (
 #   (node_hash, node),

--- a/trinity/protocol/common/validators.py
+++ b/trinity/protocol/common/validators.py
@@ -1,11 +1,9 @@
-from abc import ABC, abstractmethod
+from abc import abstractmethod
 import collections
 from typing import (
     Any,
-    Generic,
     Sequence,
     Tuple,
-    TypeVar,
     cast,
 )
 
@@ -24,23 +22,14 @@ from eth_utils import (
 from trinity._utils.headers import sequence_builder
 from trinity._utils.humanize import humanize_integer_sequence
 
-TResponse = TypeVar('TResponse')
+from .abc import ValidatorAPI
 
 
 def noop_payload_validator(request: Any, response: Any) -> None:
     pass
 
 
-class BaseValidator(ABC, Generic[TResponse]):
-    """
-    A validator which compares the initial request to its normalized result.
-    """
-    @abstractmethod
-    def validate_result(self, result: TResponse) -> None:
-        ...
-
-
-class BaseBlockHeadersValidator(BaseValidator[Tuple[BlockHeaderAPI, ...]]):
+class BaseBlockHeadersValidator(ValidatorAPI[Tuple[BlockHeaderAPI, ...]]):
     block_number_or_hash: BlockIdentifier
     max_headers: int
     skip: int

--- a/trinity/protocol/eth/events.py
+++ b/trinity/protocol/eth/events.py
@@ -28,7 +28,7 @@ from eth_typing import (
 from trinity.protocol.common.events import (
     PeerPoolMessageEvent,
 )
-from trinity.protocol.common.types import (
+from trinity.protocol.common.typing import (
     BlockBodyBundles,
     NodeDataBundles,
     ReceiptsBundles,

--- a/trinity/protocol/eth/exchanges.py
+++ b/trinity/protocol/eth/exchanges.py
@@ -20,7 +20,7 @@ from trinity.protocol.common.normalizers import (
 from trinity.protocol.common.validators import (
     noop_payload_validator,
 )
-from trinity.protocol.common.types import (
+from trinity.protocol.common.typing import (
     BlockBodyBundles,
     NodeDataBundles,
     ReceiptsByBlock,

--- a/trinity/protocol/eth/handlers.py
+++ b/trinity/protocol/eth/handlers.py
@@ -18,7 +18,7 @@ from p2p.abc import NodeAPI
 from trinity.protocol.common.handlers import (
     BaseChainExchangeHandler,
 )
-from trinity.protocol.common.types import (
+from trinity.protocol.common.typing import (
     BlockBodyBundles,
     NodeDataBundles,
     ReceiptsBundles,

--- a/trinity/protocol/eth/normalizers.py
+++ b/trinity/protocol/eth/normalizers.py
@@ -14,7 +14,7 @@ import rlp
 from trinity.protocol.common.normalizers import (
     BaseNormalizer,
 )
-from trinity.protocol.common.types import (
+from trinity.protocol.common.typing import (
     BlockBodyBundle,
     BlockBodyBundles,
     NodeDataBundles,

--- a/trinity/protocol/eth/peer.py
+++ b/trinity/protocol/eth/peer.py
@@ -37,7 +37,7 @@ from trinity.protocol.common.peer_pool_event_bus import (
     BaseProxyPeerPool,
     PeerPoolEventServer,
 )
-from trinity.protocol.common.types import (
+from trinity.protocol.common.typing import (
     BlockBodyBundles,
     NodeDataBundles,
     ReceiptsBundles,

--- a/trinity/protocol/eth/trackers.py
+++ b/trinity/protocol/eth/trackers.py
@@ -6,7 +6,7 @@ from typing import (
 from eth.abc import BlockHeaderAPI
 
 from trinity.protocol.common.trackers import BasePerformanceTracker
-from trinity.protocol.common.types import (
+from trinity.protocol.common.typing import (
     BlockBodyBundles,
     NodeDataBundles,
     ReceiptsBundles,

--- a/trinity/protocol/eth/validators.py
+++ b/trinity/protocol/eth/validators.py
@@ -10,11 +10,11 @@ from eth_utils import (
 )
 from eth.abc import BlockHeaderAPI
 
+from trinity.protocol.common.abc import ValidatorAPI
 from trinity.protocol.common.validators import (
-    BaseValidator,
     BaseBlockHeadersValidator,
 )
-from trinity.protocol.common.types import (
+from trinity.protocol.common.typing import (
     BlockBodyBundles,
     NodeDataBundles,
     ReceiptsBundles,
@@ -27,7 +27,7 @@ class GetBlockHeadersValidator(BaseBlockHeadersValidator):
     protocol_max_request_size = constants.MAX_HEADERS_FETCH
 
 
-class GetNodeDataValidator(BaseValidator[NodeDataBundles]):
+class GetNodeDataValidator(ValidatorAPI[NodeDataBundles]):
     def __init__(self, node_hashes: Sequence[Hash32]) -> None:
         self.node_hashes = node_hashes
 
@@ -48,7 +48,7 @@ class GetNodeDataValidator(BaseValidator[NodeDataBundles]):
             raise ValidationError(f"Response contains {len(unexpected_keys)} unexpected nodes")
 
 
-class ReceiptsValidator(BaseValidator[ReceiptsBundles]):
+class ReceiptsValidator(ValidatorAPI[ReceiptsBundles]):
     def __init__(self, headers: Sequence[BlockHeaderAPI]) -> None:
         self.headers = headers
 
@@ -70,7 +70,7 @@ class ReceiptsValidator(BaseValidator[ReceiptsBundles]):
             raise ValidationError(f"Got {len(unexpected_roots)} unexpected receipt roots")
 
 
-class GetBlockBodiesValidator(BaseValidator[BlockBodyBundles]):
+class GetBlockBodiesValidator(ValidatorAPI[BlockBodyBundles]):
     def __init__(self, headers: Sequence[BlockHeaderAPI]) -> None:
         self.headers = headers
 

--- a/trinity/sync/beam/state.py
+++ b/trinity/sync/beam/state.py
@@ -37,7 +37,7 @@ from trie.exceptions import MissingTrieNode
 
 from trinity._utils.datastructures import TaskQueue
 from trinity._utils.timer import Timer
-from trinity.protocol.common.types import (
+from trinity.protocol.common.typing import (
     NodeDataBundles,
 )
 from trinity.protocol.eth.commands import (

--- a/trinity/sync/common/peers.py
+++ b/trinity/sync/common/peers.py
@@ -1,7 +1,6 @@
 from asyncio import PriorityQueue
 import collections
 from typing import (
-    Any,
     Callable,
     Generic,
     Sequence,
@@ -17,7 +16,7 @@ from eth_utils import (
 
 from p2p.abc import CommandAPI
 
-from trinity.protocol.common.abc import PerformanceTrackerAPI
+from trinity.protocol.common.abc import PerformanceAPI
 from trinity.protocol.common.peer import BaseChainPeer
 from trinity._utils.datastructures import (
     SortableTask,
@@ -26,7 +25,7 @@ from trinity._utils.datastructures import (
 TChainPeer = TypeVar('TChainPeer', bound=BaseChainPeer)
 
 
-def _items_per_second(tracker: PerformanceTrackerAPI[Any, Any]) -> float:
+def _items_per_second(tracker: PerformanceAPI) -> float:
     """
     Sort so that highest items per second have the lowest value.
     They should be sorted first, so they are popped off the queue first.
@@ -45,7 +44,7 @@ class WaitingPeers(Generic[TChainPeer]):
     def __init__(
             self,
             response_command_type: Union[Type[CommandAPI], Sequence[Type[CommandAPI]]],
-            sort_key: Callable[[PerformanceTrackerAPI[Any, Any]], float]=_items_per_second) -> None:
+            sort_key: Callable[[PerformanceAPI], float]=_items_per_second) -> None:
         """
         :param sort_key: how should we sort the peers to get the fastest? low score means top-ranked
         """

--- a/trinity/sync/full/state.py
+++ b/trinity/sync/full/state.py
@@ -42,6 +42,7 @@ from p2p.abc import CommandAPI
 from p2p.service import BaseService
 
 from p2p.exceptions import (
+    ConnectionBusy,
     NoEligiblePeers,
     NoIdlePeers,
 )
@@ -49,7 +50,6 @@ from p2p.peer import BasePeer, PeerSubscriber
 
 from trinity.db.eth1.chain import BaseAsyncChainDB
 from trinity.exceptions import (
-    AlreadyWaiting,
     SyncRequestAlreadyProcessed,
 )
 from trinity.protocol.eth.peer import ETHPeer, ETHPeerPool
@@ -187,7 +187,7 @@ class StateDownloader(BaseService, PeerSubscriber):
                 err,
             )
             node_data = tuple()
-        except AlreadyWaiting as err:
+        except ConnectionBusy as err:
             self.logger.warning(
                 "Already waiting for a NodeData response from %s", peer,
             )


### PR DESCRIPTION
extracted from #966 

### What was wrong?

The Request/Response API needs to be part of the p2p module. 

### How was it fixed?

This is a minor refactor that should contain only superficial functionality changes such as the removal of `classproperty` and which implements ABC base classes for the full API.  This will be followed up by moving the non-trinity parts of this API to live under `p2p.exchange`

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history

#### Cute Animal Picture

![c405ee4ee935a7cd61e0e3b64dd49617](https://user-images.githubusercontent.com/824194/64628277-5415dd00-d3ae-11e9-84cb-855318fd609a.jpg)

