### PR TITLE
[interop] Make `run_beacon_nodes.py` work again

### DIFF
--- a/eth2/beacon/scripts/run_beacon_nodes.py
+++ b/eth2/beacon/scripts/run_beacon_nodes.py
@@ -110,7 +110,7 @@ class Node:
     @property
     def cmd(self) -> str:
         keys_path = (
-            Path().absolute() / 'eth2/beacon/scripts' /
+            Path().absolute() / 'eth2' / 'beacon' / 'scripts' /
             'quickstart_state' / 'keygen_16_validators.yaml'
         )
         _cmds = [

--- a/eth2/beacon/scripts/run_beacon_nodes.py
+++ b/eth2/beacon/scripts/run_beacon_nodes.py
@@ -7,7 +7,7 @@ from pathlib import Path
 import signal
 import sys
 import time
-from typing import ClassVar, Dict, List, MutableSet, NamedTuple, Optional, Tuple
+from typing import ClassVar, Dict, List, MutableSet, NamedTuple, Optional, Sequence, Tuple
 
 from eth_utils import encode_hex, remove_0x_prefix
 from libp2p.crypto.secp256k1 import Secp256k1PrivateKey
@@ -42,6 +42,7 @@ class Node:
     node_privkey: str
     port: int
     preferred_nodes: Tuple["Node", ...]
+    validators: Tuple[int]
     rpcport: Optional[int]
 
     start_time: float
@@ -62,6 +63,7 @@ class Node:
         name: str,
         node_privkey: str,
         port: int,
+        validators: Sequence[int],
         rpcport: Optional[int] = None,
         preferred_nodes: Optional[Tuple["Node", ...]] = None,
     ) -> None:
@@ -71,6 +73,7 @@ class Node:
         if preferred_nodes is None:
             preferred_nodes = []
         self.preferred_nodes = preferred_nodes
+        self.validators = validators
         self.rpcport = rpcport
 
         self.tasks = []
@@ -106,6 +109,10 @@ class Node:
 
     @property
     def cmd(self) -> str:
+        keys_path = (
+            Path().absolute() / 'eth2/beacon/scripts' /
+            'quickstart_state' / 'keygen_16_validators.yaml'
+        )
         _cmds = [
             "trinity-beacon",
             f"--port={self.port}",
@@ -117,6 +124,11 @@ class Node:
             "--network-tracking-backend=do-not-track",
             "--disable-upnp",
             "-l debug2",
+            "interop",
+            f"--validators {','.join([str(index) for index in self.validators])}",
+            f"--keys={keys_path}",
+            "--wipedb",
+            "--start-delay 10",
         ]
         if len(self.preferred_nodes) != 0:
             preferred_nodes_str = ",".join(
@@ -190,26 +202,16 @@ class Node:
 
 
 async def main():
-    num_validators = 9
-    genesis_delay = 20
+    num_validators = 16
+    node_alice_name = 'alice'
+    node_bob_name = 'bob'
 
     proc = await run(f"rm -rf {Node.dir_root}")
     await proc.wait()
-    proc = await run(f"mkdir -p {Node.dir_root}")
-    await proc.wait()
+    for node_name in (node_alice_name, node_bob_name):
+        path = Node.dir_root / node_name / 'mainnet' / 'chain-beacon' / 'full'
+        proc = await run(f"mkdir -p {path}")
 
-    print("Generating genesis file")
-    proc = await run(
-        " ".join(
-            (
-                "trinity-beacon",
-                "testnet",
-                f"--num={num_validators}",
-                f"--network-dir={Node.dir_root}",
-                f"--genesis-delay={genesis_delay}",
-            )
-        )
-    )
     await proc.wait()
 
     def sigint_handler(sig, frame):
@@ -219,17 +221,19 @@ async def main():
     signal.signal(signal.SIGINT, sigint_handler)
 
     node_alice = Node(
-        name="alice",
+        name=node_alice_name,
         node_privkey="6b94ffa2d9b8ee85afb9d7153c463ea22789d3bbc5d961cc4f63a41676883c19",
         port=30304,
         preferred_nodes=[],
+        validators=tuple(index for index in range(num_validators) if index % 2 == 0),
         rpcport=8555,
     )
     node_bob = Node(
-        name="bob",
+        name=node_bob_name,
         node_privkey="f5ad1c57b5a489fc8f21ad0e5a19c1f1a60b8ab357a2100ff7e75f3fa8a4fd2e",
         port=30305,
         preferred_nodes=[node_alice],
+        validators=tuple(index for index in range(num_validators) if index % 2 == 1),
         rpcport=8666,
     )
 

--- a/eth2/beacon/scripts/run_beacon_nodes.py
+++ b/eth2/beacon/scripts/run_beacon_nodes.py
@@ -113,7 +113,10 @@ class Node:
             Path().absolute() / 'eth2' / 'beacon' / 'scripts' /
             'quickstart_state' / 'keygen_16_validators.yaml'
         )
+        preferred_nodes_str = '()'
+
         _cmds = [
+            "PYTHONWARNINGS=ignore::DeprecationWarning",
             "trinity-beacon",
             f"--port={self.port}",
             f"--trinity-root-dir={self.root_dir}",
@@ -124,17 +127,21 @@ class Node:
             "--network-tracking-backend=do-not-track",
             "--disable-upnp",
             "-l debug2",
-            "interop",
-            f"--validators {','.join([str(index) for index in self.validators])}",
-            f"--keys={keys_path}",
-            "--wipedb",
-            "--start-delay 10",
         ]
         if len(self.preferred_nodes) != 0:
             preferred_nodes_str = ",".join(
                 [str(node.maddr) for node in self.preferred_nodes]
             )
             _cmds.append(f"--preferred_nodes={preferred_nodes_str}")
+
+        _cmd_interop = [
+            "interop",
+            f"--validators {','.join([str(index) for index in self.validators])}",
+            f"--keys={keys_path}",
+            "--wipedb",
+            "--start-delay=10",
+        ]
+        _cmds += _cmd_interop
         _cmd = " ".join(_cmds)
         return _cmd
 
@@ -156,6 +163,7 @@ class Node:
 
     async def run(self) -> None:
         print(f"Spinning up {self.name}")
+        print(f"{self.cmd}")
         self.proc = await run(self.cmd)
         self.running_nodes.append(self)
         self.tasks.append(

--- a/trinity/plugins/eth2/interop/plugin.py
+++ b/trinity/plugins/eth2/interop/plugin.py
@@ -61,6 +61,7 @@ from trinity.extensibility import (
 )
 import ssz
 
+from eth2.beacon.tools.fixtures.loading import load_config_at_path
 from eth2.beacon.types.states import BeaconState
 
 from trinity.plugins.eth2.network_generator.constants import (


### PR DESCRIPTION
### What was wrong?
For easy debugging.

### How was it fixed?
1. Fix `run_beacon_nodes.py`
2. Fix one missing `from eth2.beacon.tools.fixtures.loading import load_config_at_path` 

#### Cute Animal Picture
![dolphin-3416519_640](https://user-images.githubusercontent.com/9263930/64590531-59891c80-d3da-11e9-8d61-83fdc1b0fa6d.jpg)
