### PR TITLE
Prepend version with v in version string

### DIFF
--- a/trinity/_utils/version.py
+++ b/trinity/_utils/version.py
@@ -13,7 +13,7 @@ def construct_trinity_client_identifier() -> str:
     """
     return (
         "Trinity/"
-        f"{__version__}/"
+        f"v{__version__}/"
         f"{sys.platform}/"
         f"{sys.implementation.name}"
         f"{sys.version_info.major}.{sys.version_info.minor}.{sys.version_info.micro}"


### PR DESCRIPTION
### What was wrong?

I was looking into why ethstats doesn't report our version string correctly.

![image](https://user-images.githubusercontent.com/521109/64614429-cc919380-d3d8-11e9-8022-3d953e67c332.png)

Turns out they do some parsing on their end and expect the version part of the identifier to be prepended with `v`.

### How was it fixed?

I considered fixing this on another level but while I do think it's debatable if the version needs to be prepended with a `v` or not, even our docstring gives an example with `Trinity/v1.2.3/darwin-amd64/python3.6.5` so that has won me over :)

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

[//]: # (See: https://trinity-client.readthedocs.io/en/latest/contributing.html#pull-requests)
- [ ] Add entry to the [release notes](https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://geekologie.com/2010/06/12/poor-bastard-1.jpg)
