### PR TITLE
Report correct ethstats client API version

### DIFF
--- a/newsfragments/1094.bugfix.rst
+++ b/newsfragments/1094.bugfix.rst
@@ -1,0 +1,1 @@
+Fix warning on ethstats.net due to incorrectly reported API version number.

--- a/trinity/plugins/builtin/ethstats/ethstats_service.py
+++ b/trinity/plugins/builtin/ethstats/ethstats_service.py
@@ -11,9 +11,6 @@ from p2p.service import (
     BaseService,
 )
 
-from trinity import (
-    __version__,
-)
 from trinity.config import (
     Eth1AppConfig,
 )
@@ -125,7 +122,7 @@ class EthstatsService(BaseService):
             'port': self.boot_info.trinity_config.port,
             'os': platform.system(),
             'os_v': platform.release(),
-            'client': __version__,
+            'client': '0.1.1',
             'canUpdateHistory': False,
         }
 


### PR DESCRIPTION
### What was wrong?

The Trinity client is shown with a red mark on ethstats, explaining that the client needs to be updated.

![image](https://user-images.githubusercontent.com/521109/64616893-b33f1600-d3dd-11e9-84bd-5bdde28f56f5.png)


### How was it fixed?

We were incorrectly reporting Trinitys version number where the ethstats API version number was expected.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

[//]: # (See: https://trinity-client.readthedocs.io/en/latest/contributing.html#pull-requests)
- [x] Add entry to the [release notes](https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](http://justsomething.co/wp-content/uploads/2016/02/16-animals-who-got-stuck-but-keep-pretending-everything-s-ok-5-cracked-me-up-05.jpg)
