### PR TITLE
[WIP] - Add ConnectionPool and PoolManager API

### DIFF
--- a/p2p/capacity_limiter.py
+++ b/p2p/capacity_limiter.py
@@ -1,0 +1,42 @@
+import asyncio
+
+from eth_utils import ValidationError
+
+from p2p.abc import CapacityLimiterAPI
+
+
+class CapacityLimiter(CapacityLimiterAPI):
+    def __init__(self, num_tokens: int) -> None:
+        self.total_tokens = num_tokens
+        self.borrowed_tokens = 0
+        self._condition = asyncio.Condition()
+
+    @property
+    def available_tokens(self) -> int:
+        return self.total_tokens - self.borrowed_tokens
+
+    async def wait_for_capacity(self) -> int:
+        async with self._condition:
+            while True:
+                if self.available_tokens > 0:
+                    return
+                else:
+                    await self._condition.wait()
+
+    async def acquire(self) -> None:
+        async with self._condition:
+            while True:
+                if self.available_tokens > 0:
+                    self.borrowed_tokens += 1
+                    return
+                else:
+                    await self._condition.wait()
+
+    async def release(self) -> None:
+        async with self._condition:
+            if self.borrowed_tokens <= 0:
+                raise ValidationError(
+                    "Attempt to release a token when there are no borrowed tokens"
+                )
+            self.borrowed_tokens -= 1
+            self._condition.notify()

--- a/p2p/manager.py
+++ b/p2p/manager.py
@@ -1,0 +1,358 @@
+import asyncio
+import functools
+import operator
+from types import TracebackType
+from typing import (
+    Any,
+    AsyncIterator,
+    Awaitable,
+    Callable,
+    Generator,
+    Sequence,
+    Set,
+    Tuple,
+    Type,
+)
+
+from async_generator import asynccontextmanager
+
+from cancel_token import CancelToken, OperationCancelled
+
+from eth_keys import keys
+
+from eth_utils.toolz import groupby
+
+from p2p.abc import (
+    CapacityLimiterAPI,
+    ConnectionAPI,
+    ConnectionPoolAPI,
+    HandlerSubscriptionAPI,
+    NodeAPI,
+    PoolChangedAPI,
+    PoolManagerAPI,
+)
+from p2p.disconnect import DisconnectReason
+from p2p.exceptions import (
+    HandshakeFailure,
+    IneligiblePeer,
+    NoMatchingPeerCapabilities,
+    PeerConnectionLost,
+    UnreachablePeer
+)
+from p2p.handler_subscription import HandlerSubscription
+from p2p.handshake import (
+    dial_out,
+    receive_dial_in,
+    DevP2PHandshakeParams,
+    Handshaker,
+)
+from p2p.kademlia import Node, Address
+from p2p.pool import ConnectionPool
+from p2p.resource_lock import ResourceLock
+from p2p.service import BaseService, run_service
+
+
+# A function that is given the pool and a remote which returns `True` if we should connect.
+CandidateFilterFn = Callable[[ConnectionPool, NodeAPI], bool]
+ConnectionFilterFn = Callable[[ConnectionPool, ConnectionAPI], bool]
+
+
+EXPECTED_RECEIVE_ERRORS = (
+    HandshakeFailure,
+    NoMatchingPeerCapabilities,
+    OperationCancelled,
+    asyncio.TimeoutError,
+    PeerConnectionLost,
+)
+EXPECTED_DIAL_ERRORS = (
+    HandshakeFailure,
+    NoMatchingPeerCapabilities,
+    OperationCancelled,
+    PeerConnectionLost,
+    asyncio.TimeoutError,
+    UnreachablePeer,
+)
+
+HandshakerProviderFn = Callable[[], Awaitable[Handshaker]]
+PeerProviderFn = Callable[[ConnectionPoolAPI], Awaitable[Tuple[NodeAPI, ...]]]
+OnConnectFn = Callable[[ConnectionPoolAPI, ConnectionAPI], Awaitable[Any]]
+OnDisconnectFn = OnConnectFn
+
+
+class PoolChanged(PoolChangedAPI):
+    """
+    Helper for monitoring changes in the connection pool.
+
+    Usable either as an async context manager or an awaitable.
+    """
+    def __init__(self, condition: asyncio.Condition) -> None:
+        self._condition = condition
+
+    def __await__(self) -> Generator[Any, Any, None]:
+        return self._do_await().__await__()
+
+    async def _do_await(self) -> None:
+        async with self._condition:
+            await self._condition.wait()
+
+    async def __aenter__(self) -> None:
+        await self._condition.acquire()
+
+    async def __aexit__(self,
+                        exc_type: Type[BaseException],
+                        exc_value: BaseException,
+                        exc_tb: TracebackType) -> None:
+        try:
+            await self._condition.wait()
+        finally:
+            self._condition.release()
+
+
+class PoolManager(BaseService, PoolManagerAPI):
+    _on_connect_handlers: Set[OnConnectFn]
+    _on_disconnect_handlers: Set[OnDisconnectFn]
+
+    def __init__(self,
+                 pool: ConnectionPool,
+                 private_key: keys.PrivateKey,
+                 p2p_handshake_params: DevP2PHandshakeParams,
+                 handshaker_providers: Sequence[HandshakerProviderFn],
+                 capacity_limiter: CapacityLimiterAPI,
+                 token: CancelToken) -> None:
+        super().__init__(token=token)
+        self.pool = pool
+        self._private_key = private_key
+        self.p2p_handshake_params = p2p_handshake_params
+        self.handshaker_providers = handshaker_providers
+        self._pool_changed = asyncio.Condition()
+
+        self._on_connect_handlers = set()
+        self._on_disconnect_handlers = set()
+
+        self._handshake_locks = ResourceLock()
+
+        self._capacity_limiter = capacity_limiter
+
+    @property
+    def public_key(self) -> keys.PublicKey:
+        return self._private_key.public_key
+
+    async def _run(self) -> None:
+        try:
+            await self.cancellation()
+        except asyncio.CancelledError:
+            pass
+
+    def wait_pool_changed(self) -> PoolChangedAPI:
+        """
+        Wait for the connection pool to change.
+
+        This can be directly awaited
+        """
+        return PoolChanged(self._pool_changed)
+
+    def on_connect(self, handler_fn: OnConnectFn) -> HandlerSubscriptionAPI:
+        self._on_connect_handlers.add(handler_fn)
+        cancel_fn = functools.partial(self._on_connect_handlers.remove, handler_fn)
+        return HandlerSubscription(cancel_fn)
+
+    def on_disconnect(self, handler_fn: OnDisconnectFn) -> HandlerSubscriptionAPI:
+        self._on_disconnect_handlers.add(handler_fn)
+        cancel_fn = functools.partial(self._on_disconnect_handlers.remove, handler_fn)
+        return HandlerSubscription(cancel_fn)
+
+    async def add_connection(self, connection: ConnectionAPI) -> None:
+        """
+        Adds the provided connection to the pool and runs the connection service.
+        """
+        self.run_task(self._run_connection(connection))
+        await connection.events.started.wait()
+
+    @asynccontextmanager
+    async def listen(self, host: str, port: int) -> AsyncIterator[NodeAPI]:
+        server = await asyncio.start_server(
+            self._receive_handshake,
+            host=host,
+            port=port,
+        )
+        node = Node(pubkey=self.public_key, address=Address(ip=host, udp_port=port))
+        try:
+            yield node
+        finally:
+            server.close()
+            # This check for whether `server.connections` is populated is to
+            # fix a bug where calling `server.wait_closed()` throws an error
+            # due to it trying to do an `asyncio.gather(...)` on an empty set
+            # of coroutines.
+            # mypy doesn't recognize this having the `connections` property.
+            if hasattr(server, 'connections') and server.connections:  # type: ignore
+                await server.wait_closed()
+
+    async def seek_connections(self,
+                               providers: Sequence[PeerProviderFn],
+                               candidate_filters: Sequence[CandidateFilterFn] = ()) -> None:
+        while self.is_operational:
+            for provider in providers:
+                candidates = await provider(self.pool)
+                # TODO: enforce NodeAPI based filters
+                # TODO: concurrent connection attempts
+                for remote in candidates:
+                    if not all(filter_fn(self.pool, remote) for filter_fn in candidate_filters):
+                        continue
+
+                    # This ensures that we stop dialing once at capacity.
+                    await self._capacity_limiter.wait_for_capacity()
+
+                    try:
+                        await self.dial(remote)
+                    except EXPECTED_DIAL_ERRORS:
+                        continue
+
+    async def dial(self, remote: NodeAPI) -> ConnectionAPI:
+        if self._handshake_locks.is_locked(remote):
+            self.logger.debug2("Skipping %s; already shaking hands", remote)
+            raise IneligiblePeer(f"Already shaking hands with {remote}")
+
+        # Try to acquire a token, potentially timing out if the pool is at capacity.
+        await self.wait(self._capacity_limiter.acquire(), timeout=1)
+
+        async with self._handshake_locks.lock(remote):
+            handshakers = await asyncio.gather(*(
+                provider() for provider in self.handshaker_providers
+            ))
+
+            connection = await dial_out(
+                remote,
+                self._private_key,
+                self.p2p_handshake_params,
+                handshakers,
+                token=self.cancel_token,
+            )
+            self.logger.info('Established dial-out connection with: %s', connection.session)
+
+            await self.add_connection(connection)
+            return connection
+
+    async def _run_connection(self, connection: ConnectionAPI) -> None:
+        async with run_service(connection):
+
+            # Run the `on_connect` handlers
+            for on_connect_handler_fn in self._on_connect_handlers:
+                await on_connect_handler_fn(self.pool, connection)
+
+            # Early exit if the connection ends up cancelled as a result of one
+            # of the `on_connect` handlers.
+            if connection.is_cancelled:
+                return
+
+            # Start the protocol streams
+            connection.start_protocol_streams()
+
+            # signal that the pool has changed.
+            async with self._pool_changed:
+                self.pool.add(connection)
+                self._pool_changed.notify_all()
+
+            try:
+                await connection.events.finished.wait()
+            except asyncio.CancelledError:
+                pass
+            finally:
+                # Run the `on_disconnect` handlers
+                for on_disconnect_handler_fn in self._on_disconnect_handlers:
+                    await on_disconnect_handler_fn(self.pool, connection)
+
+                # signal that the pool has changed
+                async with self._pool_changed:
+                    self.pool.remove(connection)
+                    self._pool_changed.notify_all()
+
+                # release the capacity token
+                await self._capacity_limiter.release()
+
+    async def _receive_handshake(self,
+                                 reader: asyncio.StreamReader,
+                                 writer: asyncio.StreamWriter) -> None:
+        # TODO: locking to ensure concurrent dial/receive are not a problem
+        handshakers = await asyncio.gather(*(
+            provider() for provider in self.handshaker_providers
+        ))
+
+        try:
+            try:
+                connection = await receive_dial_in(
+                    reader=reader,
+                    writer=writer,
+                    private_key=self._private_key,
+                    p2p_handshake_params=self.p2p_handshake_params,
+                    protocol_handshakers=handshakers,
+                    token=self.cancel_token,
+                )
+            except BaseException:
+                if not reader.at_eof():
+                    reader.feed_eof()
+                writer.close()
+                raise
+
+            self.logger.info('Established dial-in connection with: %s', connection.session)
+        except EXPECTED_RECEIVE_ERRORS as e:
+            self.logger.debug("Could not complete handshake: %s", e)
+        except Exception as e:
+            self.logger.exception("Unexpected error handling handshake")
+        else:
+            # acquire a capacity token
+            if self._handshake_locks.is_locked(connection.remote):
+                self.logger.debug2("Skipping %s; already shaking hands", connection.remote)
+                connection.get_base_protocol().send_disconnect(DisconnectReason.already_connected)
+                return
+
+            async with self._handshake_locks.lock(connection.remote):
+                # acquire a capacity token
+                try:
+                    await self.wait(self._capacity_limiter.acquire(), timeout=1)
+                except asyncio.TimeoutError:
+                    connection.get_base_protocol().send_disconnect(DisconnectReason.too_many_peers)
+                else:
+                    await self.add_connection(connection)
+
+
+async def enforce_dial_in_to_out_ratio(pool: ConnectionPool,
+                                       connection: ConnectionAPI,
+                                       *,
+                                       ratio: float) -> None:
+    # we count the incoming connection too since it shouldn't be in the pool
+    # yet.
+    if connection.is_dial_out:
+        return
+    total_connections = len(pool) + 1
+    dial_in_count = len(tuple(
+        connection
+        for connection
+        in pool
+        if connection.is_dial_in
+    )) + 1
+    if total_connections > 1 and dial_in_count / total_connections > ratio:
+        connection.get_base_protocol().send_disconnect(DisconnectReason.too_many_peers)
+        connection.cancel_nowait()
+        connection.logger.debug(
+            'Pool dial-in to dial-out ratio too too high. Disconnecting %s.',
+            connection.session,
+        )
+
+
+async def enforce_ip_address_diversity(pool: ConnectionPool,
+                                       connection: ConnectionAPI,
+                                       *,
+                                       max_connections_per_ip: int) -> None:
+    # connect to no more then 2 nodes with the same IP
+    nodes_by_ip = groupby(
+        operator.attrgetter('remote.address.ip'),
+        pool,
+    )
+    matching_ip_nodes = nodes_by_ip.get(connection.remote.address.ip, [])
+    if len(matching_ip_nodes) > 2:
+        connection.logger.debug(
+            'Too many connections from same IP.  Disconnecting %s',
+            connection.session,
+        )
+        connection.get_base_protocol().send_disconnect(DisconnectReason.too_many_peers)

--- a/p2p/pool.py
+++ b/p2p/pool.py
@@ -1,0 +1,33 @@
+from typing import (
+    Any,
+    Dict,
+    Iterator,
+)
+
+from p2p.abc import ConnectionAPI, ConnectionPoolAPI, SessionAPI
+
+
+class ConnectionPool(ConnectionPoolAPI):
+    """
+    A container for managing devp2p peer connections
+    """
+    _connections: Dict[SessionAPI, ConnectionAPI]
+
+    def __init__(self) -> None:
+        self._connections = {}
+
+    def __len__(self) -> int:
+        return len(self._connections)
+
+    def __iter__(self) -> Iterator[ConnectionAPI]:
+        for connection in self._connections.values():
+            yield connection
+
+    def __contains__(self, connection: Any) -> bool:
+        return connection.session in self._connections
+
+    def add(self, connection: ConnectionAPI) -> None:
+        self._connections[connection.session] = connection
+
+    def remove(self, connection: ConnectionAPI) -> None:
+        del self._connections[connection.session]

--- a/p2p/tools/factories/__init__.py
+++ b/p2p/tools/factories/__init__.py
@@ -3,7 +3,8 @@ try:
 except ImportError:
     raise ImportError("The `p2p.tools.factories` module requires the `factory-boy` library")
 from .cancel_token import CancelTokenFactory  # noqa: F401
-from .connection import ConnectionPairFactory  # noqa: F401
+from .capacity_limiter import CapacityLimiterFactory  # noqa: F401
+from .connection import ConnectionPairFactory, make_connection  # noqa: F401
 from .discovery import (  # noqa: F401
     AuthHeaderFactory,
     AuthHeaderPacketFactory,
@@ -17,9 +18,11 @@ from .keys import (  # noqa: F401
     PrivateKeyFactory,
     PublicKeyFactory,
 )
+from .manager import PoolManagerFactory  # noqa: F401
 from .multiplexer import MultiplexerPairFactory  # noqa: F401
 from .p2p_proto import DevP2PHandshakeParamsFactory  # noqa: F401
 from .peer import PeerPairFactory, ParagonPeerPairFactory  # noqa: F401
+from .pool import ConnectionPoolFactory  # noqa: F401
 from .protocol import CommandFactory, ProtocolFactory  # noqa: F401
 from .session import SessionFactory  # noqa: F401
 from .socket import get_open_port  # noqa: F401

--- a/p2p/tools/factories/capacity_limiter.py
+++ b/p2p/tools/factories/capacity_limiter.py
@@ -1,0 +1,10 @@
+import factory
+
+from p2p.capacity_limiter import CapacityLimiter
+
+
+class CapacityLimiterFactory(factory.Factory):
+    class Meta:
+        model = CapacityLimiter
+
+    num_tokens = 25

--- a/p2p/tools/factories/manager.py
+++ b/p2p/tools/factories/manager.py
@@ -1,0 +1,21 @@
+import factory
+
+from p2p.manager import PoolManager
+
+from .cancel_token import CancelTokenFactory
+from .capacity_limiter import CapacityLimiterFactory
+from .keys import PrivateKeyFactory
+from .p2p_proto import DevP2PHandshakeParamsFactory
+from .pool import ConnectionPoolFactory
+
+
+class PoolManagerFactory(factory.Factory):
+    class Meta:
+        model = PoolManager
+
+    pool = factory.SubFactory(ConnectionPoolFactory)
+    private_key = factory.SubFactory(PrivateKeyFactory)
+    p2p_handshake_params = factory.SubFactory(DevP2PHandshakeParamsFactory)
+    handshaker_providers = ()
+    capacity_limiter = factory.SubFactory(CapacityLimiterFactory)
+    token = factory.SubFactory(CancelTokenFactory)

--- a/p2p/tools/factories/pool.py
+++ b/p2p/tools/factories/pool.py
@@ -1,0 +1,8 @@
+import factory
+
+from p2p.pool import ConnectionPool
+
+
+class ConnectionPoolFactory(factory.Factory):
+    class Meta:
+        model = ConnectionPool

--- a/tests/p2p/test_capacity_limiter.py
+++ b/tests/p2p/test_capacity_limiter.py
@@ -1,0 +1,109 @@
+import asyncio
+
+import pytest
+
+from eth_utils import ValidationError
+
+from p2p.capacity_limiter import CapacityLimiter
+
+
+@pytest.mark.asyncio
+async def test_capacity_limiter_tracks_token_counts():
+    limiter = CapacityLimiter(4)
+
+    assert limiter.total_tokens == 4
+    assert limiter.available_tokens == 4
+    assert limiter.borrowed_tokens == 0
+
+    await limiter.acquire()
+
+    assert limiter.total_tokens == 4
+    assert limiter.available_tokens == 3
+    assert limiter.borrowed_tokens == 1
+
+    await limiter.acquire()
+    await limiter.acquire()
+    await limiter.acquire()
+
+    assert limiter.total_tokens == 4
+    assert limiter.available_tokens == 0
+    assert limiter.borrowed_tokens == 4
+
+    await limiter.release()
+
+    assert limiter.total_tokens == 4
+    assert limiter.available_tokens == 1
+    assert limiter.borrowed_tokens == 3
+
+    await limiter.release()
+    await limiter.release()
+    await limiter.release()
+
+    assert limiter.total_tokens == 4
+    assert limiter.available_tokens == 4
+    assert limiter.borrowed_tokens == 0
+
+
+@pytest.mark.asyncio
+async def test_capacity_limiter_error_to_release_extra():
+    limiter = CapacityLimiter(4)
+
+    assert limiter.borrowed_tokens == 0
+
+    with pytest.raises(ValidationError):
+        await limiter.release()
+
+
+@pytest.mark.asyncio
+async def test_capacity_limiter_release_allows_borrow():
+    limiter = CapacityLimiter(1)
+
+    await limiter.acquire()
+
+    assert limiter.available_tokens == 0
+
+    borrow_a = asyncio.Event()
+    borrow_b = asyncio.Event()
+
+    async def _borrow(ev):
+        await limiter.acquire()
+        ev.set()
+
+    asyncio.ensure_future(_borrow(borrow_a))
+    asyncio.ensure_future(_borrow(borrow_b))
+
+    assert limiter.available_tokens == 0
+
+    await limiter.release()
+    await asyncio.wait_for(borrow_a.wait(), timeout=1)
+
+    assert limiter.available_tokens == 0
+
+    await limiter.release()
+    await asyncio.wait_for(borrow_b.wait(), timeout=1)
+
+    assert limiter.available_tokens == 0
+
+
+@pytest.mark.asyncio
+async def test_capacity_limiter_wait_for_capacity():
+    limiter = CapacityLimiter(1)
+
+    await limiter.acquire()
+
+    ready = asyncio.Event()
+    done = asyncio.Event()
+
+    async def _wait_capacity():
+        ready.set()
+        await limiter.wait_for_capacity()
+        done.set()
+
+    asyncio.ensure_future(_wait_capacity())
+
+    await ready.wait()
+    assert not done.is_set()
+
+    asyncio.ensure_future(limiter.release())
+
+    await asyncio.wait_for(done.wait(), timeout=1)

--- a/tests/p2p/test_connection_pool.py
+++ b/tests/p2p/test_connection_pool.py
@@ -1,0 +1,62 @@
+import pytest
+from p2p.pool import ConnectionPool
+
+from p2p.tools.factories import ConnectionPairFactory
+
+
+@pytest.fixture
+async def connections():
+    async with ConnectionPairFactory() as (alice, _):
+        async with ConnectionPairFactory() as (_, bob):
+            async with ConnectionPairFactory(alice_client_version='carol') as (carol, _):
+                yield alice, bob, carol
+
+
+@pytest.mark.asyncio
+async def test_connection_pool(connections):
+    alice, bob, carol = connections
+
+    pool = ConnectionPool()
+
+    assert len(pool) == 0
+    assert set(pool) == set()
+    assert set(conn for conn in pool) == set()
+
+    assert alice not in pool
+    assert bob not in pool
+    assert carol not in pool
+
+    pool.add(alice)
+    assert len(pool) == 1
+    assert set(pool) == {alice}
+    assert set(conn for conn in pool) == {alice}
+
+    assert alice in pool
+    assert bob not in pool
+    assert carol not in pool
+
+    pool.add(bob)
+    assert len(pool) == 2
+    assert set(pool) == {alice, bob}
+    assert set(conn for conn in pool) == {alice, bob}
+
+    assert alice in pool
+    assert bob in pool
+    assert carol not in pool
+
+    pool.add(carol)
+    assert len(pool) == 3
+    assert set(pool) == {alice, bob, carol}
+    assert set(conn for conn in pool) == {alice, bob, carol}
+
+    assert alice in pool
+    assert bob in pool
+    assert carol in pool
+
+    pool.remove(bob)
+
+    assert len(pool) == 2
+    assert bob not in pool
+
+    with pytest.raises(KeyError):
+        pool.remove(bob)

--- a/tests/p2p/test_pool_manager.py
+++ b/tests/p2p/test_pool_manager.py
@@ -1,0 +1,216 @@
+import asyncio
+import functools
+
+import pytest
+
+from p2p.disconnect import DisconnectReason
+from p2p.manager import enforce_dial_in_to_out_ratio
+from p2p.p2p_proto import Disconnect
+from p2p.pool import ConnectionPool
+from p2p.service import run_service
+
+from p2p.tools.paragon import ParagonHandshaker
+from p2p.tools.factories import (
+    get_open_port,
+    PoolManagerFactory,
+    PrivateKeyFactory,
+    make_connection,
+)
+
+
+@pytest.fixture
+def alice_pool():
+    return ConnectionPool()
+
+
+@pytest.fixture
+def alice_private_key():
+    return PrivateKeyFactory()
+
+
+@pytest.fixture
+async def alice_manager(alice_pool, alice_private_key):
+    async def paragon_handshaker_provider():
+        return ParagonHandshaker()
+
+    conn_manager = PoolManagerFactory(
+        pool=alice_pool,
+        private_key=alice_private_key,
+        p2p_handshake_params__client_version_string='alice',
+        handshaker_providers=(paragon_handshaker_provider,),
+    )
+    async with run_service(conn_manager):
+        yield conn_manager
+
+
+async def paragon_handshaker_provider():
+    return ParagonHandshaker()
+
+
+@pytest.fixture
+async def bob_manager():
+    conn_manager = PoolManagerFactory(
+        p2p_handshake_params__client_version_string='bob',
+        handshaker_providers=(paragon_handshaker_provider,),
+    )
+    async with run_service(conn_manager):
+        yield conn_manager
+
+
+@pytest.mark.asyncio
+async def test_connection_manager_pool_changed_direct_await(alice_manager):
+    ready = asyncio.Event()
+    pool_changed = asyncio.Event()
+
+    async def _do_wait():
+        ready.set()
+        await alice_manager.wait_pool_changed()
+        pool_changed.set()
+
+    asyncio.ensure_future(_do_wait())
+    await ready.wait()
+
+    async with alice_manager.listen('0.0.0.0', get_open_port()) as alice_remote:
+        assert not pool_changed.is_set()
+        await asyncio.wait_for(make_connection(alice_remote), timeout=1)
+        # ensure the pool changed event was set
+        await asyncio.wait_for(pool_changed.wait(), timeout=1)
+
+
+@pytest.mark.asyncio
+async def test_connection_manager_pool_changed_as_context_manager(alice_manager):
+    ready = asyncio.Event()
+    pool_changed = asyncio.Event()
+
+    async def _do_wait():
+        async with alice_manager.wait_pool_changed():
+            ready.set()
+        pool_changed.set()
+
+    asyncio.ensure_future(_do_wait())
+    await ready.wait()
+
+    async with alice_manager.listen('0.0.0.0', get_open_port()) as alice_remote:
+        assert not pool_changed.is_set()
+        await asyncio.wait_for(make_connection(alice_remote), timeout=1)
+        # ensure the pool changed event was set
+        await asyncio.wait_for(pool_changed.wait(), timeout=1)
+
+
+@pytest.mark.asyncio
+async def test_connection_manager_listen(alice_manager,
+                                         alice_pool):
+    async with alice_manager.listen('0.0.0.0', get_open_port()) as alice_remote:
+        assert len(alice_pool) == 0
+
+        async with alice_manager.wait_pool_changed():
+            alice = await asyncio.wait_for(make_connection(alice_remote), timeout=1)
+
+        assert alice.client_version_string == 'alice'
+        assert alice.remote == alice_remote
+
+        assert len(alice_pool) == 1
+
+
+@pytest.mark.asyncio
+async def test_connection_manager_seek_connections(alice_manager,
+                                                   alice_pool,
+                                                   bob_manager):
+    async with alice_manager.listen('0.0.0.0', get_open_port()) as alice_remote:
+        async def alice_provider(pool):
+            return (alice_remote,)
+
+        async with alice_manager.wait_pool_changed(), bob_manager.wait_pool_changed():
+            bob_manager.run_task(bob_manager.seek_connections((alice_provider,)))
+
+        bob_pool = bob_manager.pool
+
+        assert len(bob_pool) == 1
+        assert len(alice_pool) == 1
+
+        alice = tuple(bob_pool)[0]
+        bob = tuple(alice_pool)[0]
+
+        assert alice.client_version_string == 'alice'
+        assert alice.remote == alice_remote
+        assert bob.client_version_string == 'bob'
+        assert bob.remote.pubkey == bob_manager.public_key
+
+
+@pytest.mark.asyncio
+async def test_connection_manager_enforces_max_connections():
+    manager = PoolManagerFactory(capacity_limiter__num_tokens=2)
+    async with run_service(manager):
+        async with manager.listen('0.0.0.0', get_open_port()) as listen_remote:
+            # fill pool up with connections
+            for _ in range(2):
+                async with manager.wait_pool_changed():
+                    await make_connection(listen_remote)
+
+            assert len(manager.pool) == 2
+
+            connection = await make_connection(listen_remote)
+            async with run_service(connection):
+                disconnect_reason = asyncio.Future()
+
+                async def _record_disconnect_reason(connection, msg) -> None:
+                    disconnect_reason.set_result(DisconnectReason(msg['reason']))
+
+                connection.add_command_handler(Disconnect, _record_disconnect_reason)
+                connection.start_protocol_streams()
+
+                assert disconnect_reason.done() is False
+                reason = await asyncio.wait_for(disconnect_reason, timeout=1)
+                assert reason is DisconnectReason.too_many_peers
+
+
+@pytest.mark.asyncio
+async def test_connection_manager_enforces_dial_in_to_out_ratio(alice_manager, bob_manager):
+    # register the `on_connect` handler to enforce `max_connections`
+    alice_manager.on_connect(functools.partial(enforce_dial_in_to_out_ratio, ratio=0.75))
+
+    async with alice_manager.listen('0.0.0.0', get_open_port()) as alice_remote:
+        async with bob_manager.listen('0.0.0.0', get_open_port()) as bob_remote:
+            assert len(alice_manager.pool) == 0
+
+            async with alice_manager.wait_pool_changed():
+                await make_connection(alice_remote)
+
+            assert len(alice_manager.pool) == 1
+
+            # now we dial again which should be rejected since the connection
+            # pool is 100% dial-in connections.
+            got_disconnect = asyncio.Event()
+            carol = await make_connection(alice_remote)
+
+            async def _exit_on_disconnect(connection, msg) -> None:
+                got_disconnect.set()
+                connection.cancel_nowait()
+
+            async with run_service(carol):
+                carol.add_command_handler(Disconnect, _exit_on_disconnect)
+                carol.start_protocol_streams()
+                await asyncio.wait_for(got_disconnect.wait(), timeout=1)
+
+            # now we have alice dial-out to bob which brings the connection
+            # ratio to 50/50
+            async with alice_manager.wait_pool_changed():
+                await alice_manager.dial(bob_remote)
+
+            assert len(alice_manager.pool) == 2
+
+            # ratio of 1:1 (0.5) should be allowed in.
+            async with alice_manager.wait_pool_changed():
+                await make_connection(alice_remote)
+            assert len(alice_manager.pool) == 3
+
+            # ratio of 2:1 (0.666) should be allowed in.
+            async with alice_manager.wait_pool_changed():
+                await make_connection(alice_remote)
+            assert len(alice_manager.pool) == 4
+
+            # should no longer be allowed in as would exceed dial in/out ratio
+            wait_changed = asyncio.ensure_future(alice_manager.wait_pool_changed())
+            await make_connection(alice_remote)
+            with pytest.raises(asyncio.TimeoutError):
+                await asyncio.wait_for(wait_changed, timeout=0.1)


### PR DESCRIPTION
extracted from #966 

### What was wrong?

The `Peer` class has now had most of its internals replaced by APIs that support multiple protocols.  Now we need to get the `PeerPool` up to speed.

Similar to how the `Connection` object likely replaces the `Peer`, this introduces the `ConnectionPool` and `PoolManager`.

A `ConnectionPool` is a simple container that houses `Connection` objects.

The `PoolManager` is a service which has funcitonality for:

1. listening on an open TCP port for incoming connections.
2. actively seeking new dial-out connections
3. managing the lifecycle of a `Connection`
4. exposing apis for triggering code when a new connections is added or a connection is removed.
5. attaching functionality to connections.
6. monitoring the pool for changes.


### How was it fixed?


### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

[//]: # (See: https://trinity-client.readthedocs.io/en/latest/contributing.html#pull-requests)
- [ ] Add entry to the [release notes](https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![holy-hound-pet-costume](https://user-images.githubusercontent.com/824194/64629858-35fdac00-d3b1-11e9-81b6-4f20dde8d6d3.jpg)

