### PR TITLE
Make PrivateKeyFactory and PublicKeyFactory proper factories

### DIFF
--- a/p2p/tools/factories/keys.py
+++ b/p2p/tools/factories/keys.py
@@ -1,20 +1,31 @@
 import secrets
 
+import factory
+
 from eth_utils import (
-    keccak,
     int_to_big_endian,
 )
 
 from eth_keys import keys
 
 
-def PrivateKeyFactory(seed: bytes=None) -> keys.PrivateKey:
-    if seed is None:
-        key_bytes = int_to_big_endian(secrets.randbits(256)).rjust(32, b'\x00')
-    else:
-        key_bytes = keccak(seed)
-    return keys.PrivateKey(key_bytes)
+def _mk_private_key_bytes() -> bytes:
+    return int_to_big_endian(secrets.randbits(256)).rjust(32, b'\x00')
 
 
-def PublicKeyFactory() -> keys.PublicKey:
-    return PrivateKeyFactory().public_key
+class PrivateKeyFactory(factory.Factory):
+    class Meta:
+        model = keys.PrivateKey
+
+    private_key_bytes = factory.LazyFunction(_mk_private_key_bytes)
+
+
+def _mk_public_key_bytes() -> bytes:
+    return PrivateKeyFactory().public_key.to_bytes()
+
+
+class PublicKeyFactory(factory.Factory):
+    class Meta:
+        model = keys.PublicKey
+
+    public_key_bytes = factory.LazyFunction(_mk_public_key_bytes)


### PR DESCRIPTION
### What was wrong?

The `p2p.tools.factories.PrivateKeyFactory` and `p2p.tools.factories.PublicKeyFactory` were not implemented as actual factories but rather functions when they are perfectly suitable to be actual factories.

### How was it fixed?

Changed them to be proper factories.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

[//]: # (See: https://trinity-client.readthedocs.io/en/latest/contributing.html#pull-requests)
- [ ] Add entry to the [release notes](https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![96ff75e4144101e9b08553e6a6e59c01](https://user-images.githubusercontent.com/824194/64629841-2f6f3480-d3b1-11e9-9284-73aba77846e4.jpg)

