### PR TITLE
Upgrade lahja to 0.14.5 for cleaner shutdowns

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ deps = {
         "plyvel==1.0.5",
         PYEVM_DEPENDENCY,
         "web3==4.4.1",
-        "lahja>=0.14.2,<0.15.0",
+        "lahja>=0.14.5,<0.15.0",
         "termcolor>=1.1.0,<2.0.0",
         "uvloop==0.11.2;platform_system=='Linux' or platform_system=='Darwin' or platform_system=='FreeBSD'",  # noqa: E501
         "websockets==5.0.1",


### PR DESCRIPTION
### What was wrong?

Lahja `0.14.5` contains a bugfix that cleans up a lot of warnings about an unclosed UnixTransport.

### How was it fixed?

Updated min version to be `>=0.14.5`

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history

#### Cute Animal Picture

![ae4bd022-a4d0-41f5-9923-5ba9c3334899_1 a6e8ba35215ef661633f19023a212acf](https://user-images.githubusercontent.com/824194/64633909-4dd92e00-d3b9-11e9-9935-c5232dbbf8c8.jpeg)

