### PR TITLE
Use new ABC types in TxPool type hints

### DIFF
--- a/trinity/plugins/builtin/tx_pool/validators.py
+++ b/trinity/plugins/builtin/tx_pool/validators.py
@@ -14,9 +14,6 @@ from eth.abc import (
     ChainAPI,
     SignedTransactionAPI,
 )
-from eth.rlp.transactions import (
-    BaseTransactionFields
-)
 
 
 class DefaultTransactionValidator():
@@ -54,7 +51,7 @@ class DefaultTransactionValidator():
 
         self._initial_tx_class_index = self._ordered_tx_classes.index(self._initial_tx_class)
 
-    def __call__(self, transaction: BaseTransactionFields) -> bool:
+    def __call__(self, transaction: SignedTransactionAPI) -> bool:
 
         transaction_class = self.get_appropriate_tx_class()
         tx = transaction_class(**transaction.as_dict())


### PR DESCRIPTION
### What was wrong?

The transaction pool was still using `BaseTransactionFields` for type hints.

### How was it fixed?

Updated to use `eth.abc.SignedTransactionAPI`

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history

#### Cute Animal Picture


![c6e57c8a2e48104d8a0943c0592bee72--clever-halloween-costumes-funny-costumes](https://user-images.githubusercontent.com/824194/64637079-479a8000-d3c0-11e9-8be2-dfefa4f9693a.jpg)
