### PR TITLE
remove the un-used classproperty decorator

### DIFF
--- a/trinity/_utils/decorators.py
+++ b/trinity/_utils/decorators.py
@@ -10,11 +10,6 @@ from typing import (
 TAsyncFn = TypeVar("TAsyncFn", bound=Callable[..., Awaitable[None]])
 
 
-class classproperty(property):
-    def __get__(self, obj: Any, objtype: Any = None) -> Any:
-        return super().__get__(objtype)
-
-
 def async_suppress_exceptions(*exception_types: Type[BaseException]) -> TAsyncFn:
     def _suppress_decorator(func: TAsyncFn) -> TAsyncFn:
         async def _suppressed_func(*args: Any, **kwargs: Any) -> None:


### PR DESCRIPTION
### What was wrong?

The `trinity._utils.decorators.classproperty` decorator is no longer used anywhere in the codebase.

### How was it fixed?

Removed it.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history

#### Cute Animal Picture

![duck-fashion-show-3](https://user-images.githubusercontent.com/824194/64651764-7e33c300-d3df-11e9-80ea-a754f6b5d1db.jpg)

