### PR TITLE
Beam cleanup

### DIFF
--- a/newsfragments/939.bugfix.rst
+++ b/newsfragments/939.bugfix.rst
@@ -1,0 +1,1 @@
+Beam Sync: catch the TimeoutError that was escaping, and retry

--- a/newsfragments/951.feature.rst
+++ b/newsfragments/951.feature.rst
@@ -1,0 +1,2 @@
+Beam Sync: start backfilling data, especially as a way to gather performance data about peers, and
+improve the performance of beam sync importing.

--- a/newsfragments/958.feature.rst
+++ b/newsfragments/958.feature.rst
@@ -1,0 +1,2 @@
+Beam Sync: Sometimes we would get stuck using a bad peer for node retrieval, fixed. Sometimes we
+would stop asking for predicted trie nodes when we don't have any immediate nodes to ask for, fixed.

--- a/p2p/peer_pool.py
+++ b/p2p/peer_pool.py
@@ -501,9 +501,8 @@ class BasePeerPool(BaseService, AsyncIterable[BasePeer]):
             peers = tuple(self.connected_nodes.values())
             for peer in peers:
                 if not peer.is_running:
-                    self.logger.warning(
+                    self.logger.debug(
                         "%s is no longer alive but had not been removed from pool", peer)
-                    self._peer_finished(peer)
                     continue
                 self.logger.debug(
                     "%s: uptime=%s, received_msgs=%d",

--- a/p2p/peer_pool.py
+++ b/p2p/peer_pool.py
@@ -210,6 +210,14 @@ class BasePeerPool(BaseService, AsyncIterable[BasePeer]):
                 ))
             except OperationCancelled:
                 break
+            except asyncio.CancelledError:
+                # no need to log this exception, this is expected
+                raise
+            except Exception:
+                self.logger.exception("unexpected error during peer connection")
+                # Continue trying to connect to peers, even if there was a
+                # surprising failure during one of the attempts.
+                continue
 
     def __len__(self) -> int:
         return len(self.connected_nodes)


### PR DESCRIPTION
### What was wrong?

Fixes #939 
A broader fix for #1067 -- catching and logging, but not exiting the loop for peer discovery

### How was it fixed?

Catch and repeat after `TimeoutError`. My beam sync tests against mainnet have been fairly stable with this PR.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

[//]: # (See: https://trinity-client.readthedocs.io/en/latest/contributing.html#pull-requests)
- [x] Add entry to the [release notes](https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://besthqwallpapers.com/img/original/13003/panda-japan-cute-animals-bears-forest.jpg)
