### PR TITLE
[interop] Metrics APIs

### DIFF
--- a/trinity/constants.py
+++ b/trinity/constants.py
@@ -37,7 +37,10 @@ SYNC_BEAM = 'beam'
 MAIN_EVENTBUS_ENDPOINT = 'main'
 NETWORKDB_EVENTBUS_ENDPOINT = 'network-db'
 NETWORKING_EVENTBUS_ENDPOINT = 'networking'
+BEACON_NETWORKING_EVENTBUS_ENDPOINT = 'beacon-networking'
+
 TO_NETWORKING_BROADCAST_CONFIG = BroadcastConfig(filter_endpoint=NETWORKING_EVENTBUS_ENDPOINT)
+TO_BEACON_NETWORKING_BROADCAST_CONFIG = BroadcastConfig(filter_endpoint=BEACON_NETWORKING_EVENTBUS_ENDPOINT, internal=False)
 
 # Network IDs: https://ethereum.stackexchange.com/questions/17051/how-to-select-a-network-id-or-is-there-a-list-of-network-ids/17101#17101  # noqa: E501
 MAINNET_NETWORK_ID = 1

--- a/trinity/plugins/eth2/beacon/plugin.py
+++ b/trinity/plugins/eth2/beacon/plugin.py
@@ -25,6 +25,10 @@ from trinity._utils.shutdown import (
     exit_with_services,
 )
 from trinity.config import BeaconAppConfig
+from trinity.constants import (
+    BEACON_NETWORKING_EVENTBUS_ENDPOINT,
+    TO_BEACON_NETWORKING_BROADCAST_CONFIG,
+)
 from trinity.db.manager import DBClient
 from trinity.extensibility import AsyncioIsolatedPlugin
 from trinity.protocol.bcc_libp2p.node import Node
@@ -43,6 +47,10 @@ class BeaconNodePlugin(AsyncioIsolatedPlugin):
     @property
     def name(self) -> str:
         return "Beacon Node"
+
+    @property
+    def normalized_name(self) -> str:
+        return BEACON_NETWORKING_EVENTBUS_ENDPOINT
 
     @classmethod
     def configure_parser(cls, arg_parser: ArgumentParser, subparser: _SubParsersAction) -> None:
@@ -117,6 +125,8 @@ class BeaconNodePlugin(AsyncioIsolatedPlugin):
 
         receive_server = BCCReceiveServer(
             chain=chain,
+            event_bus=self.event_bus,
+            broadcast_config=TO_BEACON_NETWORKING_BROADCAST_CONFIG,
             p2p_node=libp2p_node,
             topic_msg_queues=libp2p_node.pubsub.my_topics,
             cancel_token=libp2p_node.cancel_token,

--- a/trinity/plugins/eth2/metrics/events.py
+++ b/trinity/plugins/eth2/metrics/events.py
@@ -1,0 +1,26 @@
+from dataclasses import (
+    dataclass,
+)
+from typing import (
+    Type,
+)
+
+from lahja import (
+    BaseEvent,
+    BaseRequestResponseEvent,
+)
+
+from eth2.beacon.typing import Slot
+from trinity.plugins.eth2.metrics.types import (
+    HeadInfo,
+)
+
+@dataclass
+class HeadSlotResponse(BaseEvent):
+    slot: Slot
+
+
+class HeadSlotRequest(BaseRequestResponseEvent[HeadSlotResponse]):
+    @staticmethod
+    def expected_response_type() -> Type[HeadSlotResponse]:
+        return HeadSlotResponse

--- a/trinity/plugins/eth2/metrics/types.py
+++ b/trinity/plugins/eth2/metrics/types.py
@@ -1,0 +1,17 @@
+from typing import (
+    NamedTuple,
+)
+
+from eth_typing import (
+    BlockNumber,
+)
+from eth2.beacon.typing import (
+    Slot,
+)
+
+
+class HeadInfo(NamedTuple):
+    slot: Slot
+
+    def update_head(self, new_head_slot) -> 'HeadInfo':
+        return HeadInfo(new_head_slot)

--- a/trinity/rpc/modules/beacon.py
+++ b/trinity/rpc/modules/beacon.py
@@ -1,18 +1,36 @@
+import logging
 from typing import Any, Dict
 
 from eth_utils import (
     encode_hex,
 )
+from lahja import EndpointAPI
 
 from eth2.beacon.types.blocks import BeaconBlock
-from trinity.rpc.modules import BeaconChainRPCModule
+from eth2.beacon.typing import (
+    Slot,
+)
+
+from trinity.constants import TO_BEACON_NETWORKING_BROADCAST_CONFIG
+from trinity.db.beacon.chain import BaseAsyncBeaconChainDB
+from trinity.rpc.modules import BaseRPCModule
+from trinity.plugins.eth2.metrics.events import HeadSlotRequest
 
 
-class Beacon(BeaconChainRPCModule):
+class Beacon(BaseRPCModule):
+    logger = logging.getLogger("rpc.module.beacon")
+
+    def __init__(self, chain: BaseAsyncBeaconChainDB, event_bus: EndpointAPI) -> None:
+        self.chain = chain
+        self.event_bus = event_bus
+
 
     async def currentSlot(self) -> str:
         return hex(666)
 
+    #
+    # Validator APIs
+    #
     async def head(self) -> Dict[Any, Any]:
         block = await self.chain.coro_get_canonical_head(BeaconBlock)
         return dict(
@@ -20,3 +38,11 @@ class Beacon(BeaconChainRPCModule):
             block_root=encode_hex(block.signing_root),
             state_root=encode_hex(block.state_root),
         )
+
+    #
+    # Metrics
+    #
+    async def headSlot(self) -> str:
+        self.logger.debug('Building HeadSlotRequest')
+        res = await self.event_bus.request(HeadSlotRequest(), TO_BEACON_NETWORKING_BROADCAST_CONFIG)
+        return str(res.slot)


### PR DESCRIPTION
### What was wrong?

WIP!!!


### How was it fixed?

### How to test it
1. Run scripts
```sh
python eth2/beacon/scripts/run_beacon_nodes.py
```
2. Wait for seconds
3. Call `beacon_headSlot` HTTP API
```sh
curl -X POST \
  http://127.0.0.1:8666/ \
  -H 'Content-Type: application/json' \
  -d '{
    "jsonrpc": "2.0",
    "method": "beacon_headSlot",
    "params": [],
    "id": 1
}'
```

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

[//]: # (See: https://trinity-client.readthedocs.io/en/latest/contributing.html#pull-requests)
- [ ] Add entry to the [release notes](https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![animal-stereotype-5](https://user-images.githubusercontent.com/9263930/64677143-a1c34000-d4a9-11e9-8e96-041e762fff16.jpg)
