### PR TITLE
Make shutdown error scan more sensitive

### DIFF
--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -14,8 +14,10 @@ async def scan_for_errors(async_iterable):
     """
 
     error_trigger = (
+        "Exception ignored",
         "exception was never retrieved",
-        "ResourceWarning: unclosed resource",
+        "finished unexpectedly",
+        "ResourceWarning",
         "Task was destroyed but it is pending",
         "Traceback (most recent call last)",
     )


### PR DESCRIPTION
### What was wrong?

Every now and then we get clean shutdowns which makes our scan-for-shutdown xfail error test flaky.

### How was it fixed?

Make it more sensitive.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

[//]: # (See: https://trinity-client.readthedocs.io/en/latest/contributing.html#pull-requests)
- [ ] Add entry to the [release notes](https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://static.boredpanda.com/blog/wp-content/uuuploads/cute-baby-animals/cute-baby-animals-22.jpg)
