### PR TITLE
Rewrote AsyncProcessRunner to fix some flaky tests

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -51,6 +51,7 @@ deps = {
         "libp2p @ git+https://git@github.com/libp2p/py-libp2p@f38899e",
     ],
     'test': [
+        "async-timeout>=3.0.1,<4",
         "hypothesis>=4.24.3,<5",
         "pexpect>=4.6, <5",
         "factory-boy==2.11.1",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -55,9 +55,6 @@ from trinity.rpc.modules import (
 from trinity.rpc.ipc import (
     IPCServer,
 )
-from trinity.tools.async_process_runner import (
-    AsyncProcessRunner,
-)
 from trinity._utils.xdg import (
     get_xdg_trinity_root,
 )
@@ -95,21 +92,6 @@ def event_loop():
         yield loop
     finally:
         loop.close()
-
-
-# This fixture provides a tear down to run after each test that uses it.
-# This ensures the AsyncProcessRunner will never leave a process behind
-@pytest.fixture(scope="function")
-def async_process_runner():
-    runner = AsyncProcessRunner(
-        # This allows running pytest with -s and observing the output
-        debug_fn=lambda line: print(line)
-    )
-    yield runner
-    try:
-        runner.kill()
-    except ProcessLookupError:
-        pass
 
 
 @asynccontextmanager

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -1,10 +1,13 @@
-async def run_command_and_detect_errors(async_process_runner, command, time):
+from trinity.tools.async_process_runner import AsyncProcessRunner
+
+
+async def run_command_and_detect_errors(command, time):
     """
     Run the given ``command`` on the given ``async_process_runner`` for ``time`` seconds and
     throw an Exception in case any unresolved Exceptions are detected in the output of the command.
     """
-    await async_process_runner.run(command, timeout_sec=time)
-    await scan_for_errors(async_process_runner.stderr)
+    async with AsyncProcessRunner.run(command, timeout_sec=time) as runner:
+        await scan_for_errors(runner.stderr)
 
 
 async def scan_for_errors(async_iterable):

--- a/tests/plugins/eth2/beacon/test_beacon_plugin.py
+++ b/tests/plugins/eth2/beacon/test_beacon_plugin.py
@@ -1,4 +1,5 @@
 import pytest
+from trinity.tools.async_process_runner import AsyncProcessRunner
 from trinity._utils.async_iter import (
     contains_all
 )
@@ -13,8 +14,8 @@ from trinity._utils.async_iter import (
     )
 )
 @pytest.mark.asyncio
-async def test_plugin_boot(async_process_runner, command):
-    await async_process_runner.run(command, timeout_sec=30)
-    assert await contains_all(async_process_runner.stderr, {
-        "Running server",
-    })
+async def test_plugin_boot(command):
+    async with AsyncProcessRunner.run(command, timeout_sec=30) as runner:
+        assert await contains_all(runner.stderr, {
+            "Running server",
+        })

--- a/tests/plugins/eth2/network_generator/test_network_generator.py
+++ b/tests/plugins/eth2/network_generator/test_network_generator.py
@@ -1,4 +1,5 @@
 import pytest
+from trinity.tools.async_process_runner import AsyncProcessRunner
 from trinity._utils.async_iter import (
     contains_all,
 )
@@ -12,14 +13,14 @@ from trinity._utils.async_iter import (
     )
 )
 @pytest.mark.asyncio
-async def test_directory_generation(async_process_runner, command, tmpdir):
+async def test_directory_generation(command, tmpdir):
     testnet_path = tmpdir / "testnet"
     testnet_path.mkdir()
     command = command + (f"--network-dir={testnet_path}", )
-    await async_process_runner.run(command, timeout_sec=30)
-    assert await contains_all(async_process_runner.stderr, {
-        "Network generation completed",
-    })
+    async with AsyncProcessRunner.run(command, timeout_sec=30) as runner:
+        assert await contains_all(runner.stderr, {
+            "Network generation completed",
+        })
 
 
 @pytest.mark.parametrize(
@@ -29,8 +30,8 @@ async def test_directory_generation(async_process_runner, command, tmpdir):
     )
 )
 @pytest.mark.asyncio
-async def test_missing_genesis_time_arg(async_process_runner, command):
-    await async_process_runner.run(command, timeout_sec=30)
-    assert await contains_all(async_process_runner.stderr, {
-        "one of the arguments --genesis-delay --genesis-time is required",
-    })
+async def test_missing_genesis_time_arg(command):
+    async with AsyncProcessRunner.run(command, timeout_sec=30) as runner:
+        assert await contains_all(runner.stderr, {
+            "one of the arguments --genesis-delay --genesis-time is required",
+        })

--- a/tests/trinity_long_run/test_trinity_long_run.py
+++ b/tests/trinity_long_run/test_trinity_long_run.py
@@ -13,6 +13,6 @@ from tests.integration.helpers import (
     )
 )
 @pytest.mark.asyncio
-async def test_does_not_throw_errors_on_long_run(async_process_runner, command):
+async def test_does_not_throw_errors_on_long_run(command):
     # Ensure that no errors are thrown when trinity is run for 90 seconds
-    await run_command_and_detect_errors(async_process_runner, command, 90)
+    await run_command_and_detect_errors(command, 90)


### PR DESCRIPTION
### What was wrong?

AsyncProcessRunner was causing some flakiness. Every now and then we would see failures like this:

```python
self = <trinity.tools.async_process_runner.AsyncProcessRunner object at 0x7f16ef25d2d0>
sig = <Signals.SIGKILL: 9>

    def kill(self, sig: int = signal.SIGKILL) -> None:
        try:
>           os.killpg(os.getpgid(self.proc.pid), sig)
E           AttributeError: 'AsyncProcessRunner' object has no attribute 'proc'
```

Here's a linked CI failure: https://circleci.com/gh/ethereum/trinity/113338

### How was it fixed?

I rewrote it using an `asynccontextmanager`:

- it is now an `asynccontextmanager`
- it doesn't depend on a fixture anymore because usage
- it works well with logging (previously used a hack with an injected `print` function)

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

[//]: # (See: https://trinity-client.readthedocs.io/en/latest/contributing.html#pull-requests)
- [ ] ~~Add entry to the [release notes](https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)~~

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://www.thenational.ae/image/policy:1.885395:1562917940/173084-01-05.jpg?$p=0f2831b&w=1136&$w=ec52ab9)
