### PR TITLE
Ensure JSON RPC requests end with newline

### DIFF
--- a/trinity/rpc/ipc.py
+++ b/trinity/rpc/ipc.py
@@ -103,6 +103,9 @@ async def connection_loop(execute_rpc: Callable[[Any], Any],
                 write_error(writer, "unknown failure: " + str(e)),
             )
         else:
+            if not result.endswith("\n"):
+                result += "\n"
+
             writer.write(result.encode())
 
         await cancel_token.cancellable_wait(writer.drain())


### PR DESCRIPTION
### What was wrong?

I was looking into [dopple](https://github.com/ethereum/dopple) today and noticed it doesn't work against the Trinity JSON-RPC IPC file.

It turns out that it assumes every response ends with a newline character. 

```python
        response = b''
        while True:
            r = self.conn.recv(BUFSIZE)
            if not r:
                break
            if r[-1] == DELIMITER:
                response += r[:-1]
                break
            response += r

        return response
```

Then this got me wondering why this issue doesn't come up when making RPC requests via `trinity attach`. Turns out that uses the `web3.IPCProvider` which continuously tries to parse the so far read raw response whenever it encounters either `]` or `}` until it finally parses at some point.

It even strips away any newlines as it says valid JSON-RPC responses should only end with either `]` or `}`.

```python
with Timeout(self.timeout) as timeout:
                while True:
                    try:
                        raw_response += sock.recv(4096)
                    except socket.timeout:
                        timeout.sleep(0)
                        continue
                    if raw_response == b"":
                        timeout.sleep(0)
                    elif has_valid_json_rpc_ending(raw_response):
                        try:
                            response = self.decode_rpc_response(raw_response)
                        except JSONDecodeError:
                            timeout.sleep(0)
                            continue
                        else:
                            return response
                    else:
                        timeout.sleep(0)
                        continue
```

But others say it **is** actually good practice to append a newline after the JSON payload.

### How was it fixed?

Not really, I'm turning to my smart peers to help me to decide:

Options as I see them:

1. Add a newline to each JSON-RPC response (see code change of this PR)
2. Teach dopple to not rely on newlines as delimiters and do what web3 does instead.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

[//]: # (See: https://trinity-client.readthedocs.io/en/latest/contributing.html#pull-requests)
- [ ] Add entry to the [release notes](https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses]()
