### PR TITLE
Fix is_valid_connection_candidate

### DIFF
--- a/p2p/peer_pool.py
+++ b/p2p/peer_pool.py
@@ -242,7 +242,7 @@ class BasePeerPool(BaseService, AsyncIterable[BasePeer]):
     def is_valid_connection_candidate(self, candidate: NodeAPI) -> bool:
         # connect to no more then 2 nodes with the same IP
         nodes_by_ip = groupby(
-            operator.attrgetter('address.ip'),
+            operator.attrgetter('remote.address.ip'),
             self.connected_nodes.keys(),
         )
         matching_ip_nodes = nodes_by_ip.get(candidate.address.ip, [])


### PR DESCRIPTION
### What was wrong?

The #1054 broke the `PeerPool.is_valid_connection_candidate` function since the `connected_peers` keys are no longer `NodeAPI` objects.

### How was it fixed?

Added the right path to get to the address.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history


#### Cute Animal Picture

![0d6a2236f3d8fec39bc041095e1985be--animals-in-costumes-cats-in-costumes](https://user-images.githubusercontent.com/824194/64875983-6771b400-d60b-11e9-8b13-630666692516.jpg)

