### PR TITLE
Use a rolling bloom filter for transaction pool.

### DIFF
--- a/tests/core/utils/test_rolling_bloom_filter.py
+++ b/tests/core/utils/test_rolling_bloom_filter.py
@@ -1,0 +1,31 @@
+from trinity._utils.bloom import RollingBloom
+
+
+def test_rolling_bloom_maintains_history():
+    # only one historical filter
+    bloom = RollingBloom(generation_size=10, max_generations=2)
+
+    # fill up the main filter and the history
+    for i in range(20):
+        value = bytes((i,))
+        bloom.add(value)
+        assert value in bloom
+
+    for i in range(20):
+        value = bytes((i,))
+        assert value in bloom
+
+    # this should eject all of the 0-9 values
+    bloom.add(b'\xff')
+
+    # this must be done probabalistically since bloom filters have false
+    # positives.  At least one of the 0-9 values should be gone.
+    assert any(
+        bytes((value,)) not in bloom
+        for value in range(10)
+    )
+
+    for i in range(10, 20):
+        value = bytes((i,))
+        assert value in bloom
+    assert b'\xff' in bloom

--- a/tests/core/utils/test_rolling_bloom_filter.py
+++ b/tests/core/utils/test_rolling_bloom_filter.py
@@ -5,27 +5,28 @@ def test_rolling_bloom_maintains_history():
     # only one historical filter
     bloom = RollingBloom(generation_size=10, max_generations=2)
 
+    bloom_values = tuple(bytes((i,)) for i in range(20))
+
     # fill up the main filter and the history
-    for i in range(20):
-        value = bytes((i,))
+    for value in bloom_values:
         bloom.add(value)
         assert value in bloom
 
-    for i in range(20):
-        value = bytes((i,))
+    # since the filter discards old history, we loop back over the values
+    for value in bloom_values:
         assert value in bloom
 
     # this should eject all of the 0-9 values
+    assert b'\xff' not in bloom_values
     bloom.add(b'\xff')
 
     # this must be done probabalistically since bloom filters have false
     # positives.  At least one of the 0-9 values should be gone.
     assert any(
-        bytes((value,)) not in bloom
-        for value in range(10)
+        value not in bloom
+        for value in bloom_values[:10]
     )
 
-    for i in range(10, 20):
-        value = bytes((i,))
+    for value in bloom_values[10:]:
         assert value in bloom
     assert b'\xff' in bloom

--- a/trinity/_utils/bloom.py
+++ b/trinity/_utils/bloom.py
@@ -1,0 +1,40 @@
+import collections
+from typing import Deque
+
+from bloom_filter import (
+    BloomFilter
+)
+
+
+class RollingBloom:
+    def __init__(self, generation_size: int, max_generations: int) -> None:
+        if generation_size < 1:
+            raise ValueError(f"generation_size must be a positive integer: got {generation_size}")
+        if max_generations < 2:
+            raise ValueError(f"max_generations must be 2 or more: got {max_generations}")
+        self._max_bloom_elements = generation_size
+        self._max_generations = max_generations
+        self._history: Deque[BloomFilter] = collections.deque()
+        self._active = BloomFilter(max_elements=self._max_bloom_elements)
+        self._items_in_active = 0
+
+    def add(self, key: bytes) -> None:
+        # before adding check to see if we need to cycle the push the active
+        # bloom filter into history.
+        if self._items_in_active >= self._max_bloom_elements:
+            self._history.appendleft(self._active)
+            self._active = BloomFilter(max_elements=self._max_bloom_elements)
+            self._items_in_active = 0
+
+            # discard any old history that is older than the number of
+            # generations we should be retaining.
+            while len(self._history) > self._max_generations - 1:
+                self._history.pop()
+
+        self._active.add(key)
+        self._items_in_active += 1
+
+    def __contains__(self, key: bytes) -> bool:
+        if key in self._active:
+            return True
+        return any(key in bloom for bloom in self._history)

--- a/trinity/_utils/bloom.py
+++ b/trinity/_utils/bloom.py
@@ -13,14 +13,14 @@ class RollingBloom:
         if max_generations < 2:
             raise ValueError(f"max_generations must be 2 or more: got {max_generations}")
         self._max_bloom_elements = generation_size
-        self._max_generations = max_generations
+        self._max_history = max_generations - 1
         self._history: Deque[BloomFilter] = collections.deque()
         self._active = BloomFilter(max_elements=self._max_bloom_elements)
         self._items_in_active = 0
 
     def add(self, key: bytes) -> None:
-        # before adding check to see if we need to cycle the push the active
-        # bloom filter into history.
+        # before adding the value check if the active bloom filter is full.  If
+        # so, push it into the history and make a new one.
         if self._items_in_active >= self._max_bloom_elements:
             self._history.appendleft(self._active)
             self._active = BloomFilter(max_elements=self._max_bloom_elements)
@@ -28,7 +28,7 @@ class RollingBloom:
 
             # discard any old history that is older than the number of
             # generations we should be retaining.
-            while len(self._history) > self._max_generations - 1:
+            while len(self._history) > self._max_history:
                 self._history.pop()
 
         self._active.add(key)


### PR DESCRIPTION
### What was wrong?

The transaction pool uses a single large bloom filter to determine whether we've already broadcast a given transaction to a given peer.  Eventually this bloom filter will fill up, returning more and more false positives.

### How was it fixed?

Use a *rolling* bloom filter.  We use many smaller bloom filters.  Each time one "fills up" we rotate a new one into place, holding onto the recent history of the old ones.  This should allow the transaction pool to operate indefinitely while retaining reasonably accurate information about what transactions have been sent to which peers.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history


#### Cute Animal Picture

![181838-harry-potter-costume](https://user-images.githubusercontent.com/824194/65072050-4ed80580-d94d-11e9-92df-b5403e204e89.jpg)

