### PR TITLE
Fix broken log message in ProxyPeer

### DIFF
--- a/trinity/protocol/common/peer.py
+++ b/trinity/protocol/common/peer.py
@@ -108,7 +108,7 @@ class BaseProxyPeer(BaseService):
         await self.cancellation()
 
     async def disconnect(self, reason: DisconnectReason) -> None:
-        self.logger.debug("Forwarding `disconnect()` call from proxy to actual peer", self)
+        self.logger.debug("Forwarding `disconnect()` call from proxy to actual peer: %s", self)
         await self.event_bus.broadcast(
             DisconnectPeerEvent(self.session, reason),
             TO_NETWORKING_BROADCAST_CONFIG,


### PR DESCRIPTION
### What was wrong?

Broken logging message in the `ProxyPeer.disconnect`

### How was it fixed?

Added the `%s` to the logging string.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history


#### Cute Animal Picture


![6042b256c3d1e9396bbc0aae30ee3945--guinea-pig-costumes-animals-in-costumes](https://user-images.githubusercontent.com/824194/64880366-4615c580-d615-11e9-9ff9-2118a551c6b6.jpg)
