### PR TITLE
Enable the transaction pool by default

### DIFF
--- a/docs/api/api.cli.rst
+++ b/docs/api/api.cli.rst
@@ -7,129 +7,145 @@ We can also generate an always up-to-date version of them by running ``trinity -
 .. code-block:: shell
 
     usage: trinity [-h] [--version] [--trinity-root-dir TRINITY_ROOT_DIR]
-                [--port PORT] [-l LEVEL] [--stderr-log-level STDERR_LOG_LEVEL]
-                [--file-log-level FILE_LOG_LEVEL]
-                [--network-id NETWORK_ID | --ropsten]
-                [--preferred-node PREFERRED_NODES] [--discv5]
-                [--max-peers MAX_PEERS] [--genesis GENESIS]
-                [--data-dir DATA_DIR] [--nodekey NODEKEY] [--profile]
-                [--disable-rpc]
-                [--network-tracking-backend {sqlite3,memory,do-not-track}]
-                [--disable-networkdb-component] [--disable-blacklistdb]
-                [--disable-eth1-peer-db]
-                [--enable-experimental-eth1-peer-tracking]
-                [--disable-discovery] [--disable-request-server]
-                [--disable-upnp] [--ethstats]
-                [--ethstats-server-url ETHSTATS_SERVER_URL]
-                [--ethstats-server-secret ETHSTATS_SERVER_SECRET]
-                [--ethstats-node-id ETHSTATS_NODE_ID]
-                [--ethstats-node-contact ETHSTATS_NODE_CONTACT]
-                [--ethstats-interval ETHSTATS_INTERVAL]
-                [--sync-mode {fast,full,beam,light,none}] [--tx-pool]
-                {attach,fix-unclean-shutdown,remove-network-db,db-shell} ...
+                   [--port PORT] [-l LEVEL] [--stderr-log-level STDERR_LOG_LEVEL]
+                   [--file-log-level FILE_LOG_LEVEL]
+                   [--network-id NETWORK_ID | --ropsten]
+                   [--preferred-node PREFERRED_NODES] [--discv5]
+                   [--max-peers MAX_PEERS] [--genesis GENESIS]
+                   [--data-dir DATA_DIR] [--nodekey NODEKEY] [--profile]
+                   [--disable-rpc] [--enable-http] [--rpcport RPCPORT]
+                   [--network-tracking-backend {sqlite3,memory,do-not-track}]
+                   [--disable-networkdb-plugin] [--disable-blacklistdb]
+                   [--disable-eth1-peer-db]
+                   [--enable-experimental-eth1-peer-tracking]
+                   [--disable-discovery] [--disable-upnp] [--ethstats]
+                   [--ethstats-server-url ETHSTATS_SERVER_URL]
+                   [--ethstats-server-secret ETHSTATS_SERVER_SECRET]
+                   [--ethstats-node-id ETHSTATS_NODE_ID]
+                   [--ethstats-node-contact ETHSTATS_NODE_CONTACT]
+                   [--ethstats-interval ETHSTATS_INTERVAL]
+                   [--disable-request-server]
+                   [--force-beam-block-number FORCE_BEAM_BLOCK_NUMBER]
+                   [--beam-from-checkpoint BEAM_FROM_CHECKPOINT]
+                   [--sync-mode {full,beam,light,none}] [--disable-tx-pool]
+                   {attach,db-shell,fix-unclean-shutdown,remove-network-db} ...
+
+    Trinity
 
     positional arguments:
-    {attach,fix-unclean-shutdown,remove-network-db,db-shell}
+      {attach,db-shell,fix-unclean-shutdown,remove-network-db}
         attach              open an REPL attached to a currently running chain
+        db-shell            open a REPL to inspect the db
         fix-unclean-shutdown
                             close any dangling processes from a previous unclean
                             shutdown
         remove-network-db   Remove the on-disk sqlite database that tracks data
                             about the p2p network
-        db-shell            open a REPL to inspect the db
 
     optional arguments:
-    -h, --help            show this help message and exit
-    --disable-rpc         Disables the JSON-RPC Server
-    --disable-discovery   Disable peer discovery
-    --disable-request-server
+      -h, --help            show this help message and exit
+      --disable-rpc         Disables the JSON-RPC Server
+      --enable-http         Enables the HTTP Server
+      --rpcport RPCPORT     JSON-RPC server port
+      --disable-discovery   Disable peer discovery
+      --disable-upnp        Disable upnp mapping
+      --disable-request-server
                             Disables the Request Server
-    --disable-upnp        Disable upnp mapping
-    --tx-pool             Enables the Transaction Pool (experimental)
+      --force-beam-block-number FORCE_BEAM_BLOCK_NUMBER
+                            Force beam sync to activate on a specific block number
+                            (for testing)
+      --beam-from-checkpoint BEAM_FROM_CHECKPOINT
+                            Start beam sync from a trusted checkpoint specified
+                            using URI syntax:By specific block,
+                            eth://block/byhash/<hash>?score=<score>Let etherscan
+                            pick a block near the tip,
+                            eth://block/byetherscan/latest
+      --disable-tx-pool     Disables the Transaction Pool
 
     core:
-    --version             show program's version number and exit
-    --trinity-root-dir TRINITY_ROOT_DIR
+      --version             show program's version number and exit
+      --trinity-root-dir TRINITY_ROOT_DIR
                             The filesystem path to the base directory that trinity
                             will store it's information. Default:
                             $XDG_DATA_HOME/.local/share/trinity
-    --port PORT           Port on which trinity should listen for incoming
+      --port PORT           Port on which trinity should listen for incoming
                             p2p/discovery connections. Default: 30303
 
     logging:
-    -l LEVEL, --log-level LEVEL
+      -l LEVEL, --log-level LEVEL
                             Configure the logging level. LEVEL must be one of:
                             8/10/20/30/40/50 (numeric);
                             debug2/debug/info/warn/warning/error/critical
                             (lowercase);
                             DEBUG2/DEBUG/INFO/WARN/WARNING/ERROR/CRITICAL
                             (uppercase).
-    --stderr-log-level STDERR_LOG_LEVEL
+      --stderr-log-level STDERR_LOG_LEVEL
                             Configure the logging level for the stderr logging.
-    --file-log-level FILE_LOG_LEVEL
+      --file-log-level FILE_LOG_LEVEL
                             Configure the logging level for file-based logging.
 
     network:
-    --network-id NETWORK_ID
+      --network-id NETWORK_ID
                             Network identifier (1=Mainnet, 3=Ropsten)
-    --ropsten             Ropsten network: pre configured proof-of-work test
+      --ropsten             Ropsten network: pre configured proof-of-work test
                             network. Shortcut for `--networkid=3`
-    --preferred-node PREFERRED_NODES
+      --preferred-node PREFERRED_NODES
                             An enode address which will be 'preferred' above nodes
                             found using the discovery protocol
-    --discv5              Enable experimental v5 (topic) discovery mechanism
-    --max-peers MAX_PEERS
+      --discv5              Enable experimental v5 (topic) discovery mechanism
+      --max-peers MAX_PEERS
                             Maximum number of network peers
 
     chain:
-    --genesis GENESIS     File containing a custom genesis block header
-    --data-dir DATA_DIR   The directory where chain data is stored
-    --nodekey NODEKEY     Hexadecimal encoded private key to use for the nodekey
+      --genesis GENESIS     File containing a custom genesis configuration file
+                            per EIP1085
+      --data-dir DATA_DIR   The directory where chain data is stored
+      --nodekey NODEKEY     Hexadecimal encoded private key to use for the nodekey
                             or the filesystem path to the file which contains the
                             nodekey
 
     debug:
-    --profile             Enables profiling via cProfile.
+      --profile             Enables profiling via cProfile.
 
     network db:
-    --network-tracking-backend {sqlite3,memory,do-not-track}
+      --network-tracking-backend {sqlite3,memory,do-not-track}
                             Configure whether nodes are tracked and how. (sqlite3:
                             persistent tracking across runs from an on-disk
                             sqlite3 database, memory: tracking only in memory, do-
                             not-track: no tracking)
-    --disable-networkdb-component
-                            Disables the builtin 'Networkt Database' component.
+      --disable-networkdb-plugin
+                            Disables the builtin 'Networkt Database' plugin.
                             **WARNING**: disabling this API without a proper
                             replacement will cause your trinity node to crash.
-    --disable-blacklistdb
+      --disable-blacklistdb
                             Disables the blacklist database server component of
                             the Network Database component.**WARNING**: disabling
                             this API without a proper replacement will cause your
                             trinity node to crash.
-    --disable-eth1-peer-db
+      --disable-eth1-peer-db
                             Disables the ETH1.0 peer database server component of
                             the Network Database component.**WARNING**: disabling
                             this API without a proper replacement will cause your
                             trinity node to crash.
-    --enable-experimental-eth1-peer-tracking
+      --enable-experimental-eth1-peer-tracking
                             Enables the experimental tracking of metadata about
                             successful connections to Eth1 peers.
 
     ethstats (experimental):
-    --ethstats            Enable node stats reporting service
-    --ethstats-server-url ETHSTATS_SERVER_URL
+      --ethstats            Enable node stats reporting service
+      --ethstats-server-url ETHSTATS_SERVER_URL
                             Node stats server URL (e. g. wss://example.com/api)
-    --ethstats-server-secret ETHSTATS_SERVER_SECRET
+      --ethstats-server-secret ETHSTATS_SERVER_SECRET
                             Node stats server secret
-    --ethstats-node-id ETHSTATS_NODE_ID
+      --ethstats-node-id ETHSTATS_NODE_ID
                             Node ID for stats server
-    --ethstats-node-contact ETHSTATS_NODE_CONTACT
+      --ethstats-node-contact ETHSTATS_NODE_CONTACT
                             Node contact information for stats server
-    --ethstats-interval ETHSTATS_INTERVAL
+      --ethstats-interval ETHSTATS_INTERVAL
                             The interval at which data is reported back
 
     sync mode:
-    --sync-mode {full,beam,light,none}
+      --sync-mode {full,beam,light,none}
 
 
 Attach a REPL to a running Trinity instance

--- a/newsfragments/1135.feature.rst
+++ b/newsfragments/1135.feature.rst
@@ -1,0 +1,1 @@
+Transaction pool is now enabled by default.  Use ``--disable-tx-pool`` to disable the transaction pool.  Currently the transaction pool does not support light mode and will be automatically disabled if running in light mode.

--- a/tests/integration/test_trinity_cli.py
+++ b/tests/integration/test_trinity_cli.py
@@ -52,26 +52,6 @@ async def test_expected_logs_for_full_mode(command):
         assert await contains_all(runner.stderr, {
             "Started DB server process",
             "Component started: Sync / PeerPool",
-            "Running server",
-            "IPC started at",
-        })
-
-
-@pytest.mark.parametrize(
-    'command',
-    (
-        ('trinity', '--tx-pool',),
-        ('trinity', '--tx-pool', '--ropsten',),
-    )
-)
-@pytest.mark.asyncio
-async def test_expected_logs_for_full_mode_with_txpool(command):
-    # Since this short-circuits on sucess, we can set the timeout high.
-    # We only hit the timeout if the test fails.
-    async with AsyncProcessRunner.run(command, timeout_sec=120) as runner:
-        assert await contains_all(runner.stderr, {
-            "Started DB server process",
-            "Component started: Sync / PeerPool",
             "Running Tx Pool",
             "Running server",
             "IPC started at",
@@ -81,8 +61,29 @@ async def test_expected_logs_for_full_mode_with_txpool(command):
 @pytest.mark.parametrize(
     'command',
     (
-        ('trinity', '--sync-mode=light', '--tx-pool',),
-        ('trinity', '--sync-mode=light', '--ropsten', '--tx-pool',),
+        ('trinity', '--disable-tx-pool',),
+        ('trinity', '--disable-tx-pool', '--ropsten',),
+    )
+)
+@pytest.mark.asyncio
+async def test_expected_logs_for_full_mode_with_txpool_disabled(command):
+    # Since this short-circuits on sucess, we can set the timeout high.
+    # We only hit the timeout if the test fails.
+    async with AsyncProcessRunner.run(command, timeout_sec=120) as runner:
+        assert await contains_all(runner.stderr, {
+            "Started DB server process",
+            "Component started: Sync / PeerPool",
+            "Transaction pool disabled",
+            "Running server",
+            "IPC started at",
+        })
+
+
+@pytest.mark.parametrize(
+    'command',
+    (
+        ('trinity', '--sync-mode=light'),
+        ('trinity', '--sync-mode=light', '--ropsten'),
     )
 )
 @pytest.mark.asyncio
@@ -93,7 +94,7 @@ async def test_expected_logs_with_disabled_txpool(command):
         assert await contains_all(runner.stderr, {
             "Started DB server process",
             "Component started: Sync / PeerPool",
-            "Transaction pool not available in light mode",
+            "Transaction pool does not support light mode",
         })
 
 
@@ -179,11 +180,11 @@ async def test_web3_commands_via_attached_console(command,
     (
         # mainnet
         ('trinity',),
-        ('trinity', '--tx-pool',),
+        ('trinity', '--disable-tx-pool',),
         ('trinity', '--sync-mode=light',),
         # ropsten
         ('trinity', '--ropsten',),
-        ('trinity', '--ropsten', '--tx-pool',),
+        ('trinity', '--ropsten', '--disable-tx-pool',),
         ('trinity', '--sync-mode=light', '--ropsten',),
     )
 )

--- a/trinity/components/builtin/tx_pool/component.py
+++ b/trinity/components/builtin/tx_pool/component.py
@@ -61,7 +61,7 @@ class TxComponent(AsyncioIsolatedComponent):
         if is_disable:
             self.logger.debug("Transaction pool disabled")
         elif not is_supported:
-            self.logger.debug("Transaction pool does not support light mode")
+            self.logger.warning("Transaction pool disabled.  Not supported in light mode.")
         elif is_enabled:
             self.start()
         else:

--- a/trinity/components/builtin/tx_pool/component.py
+++ b/trinity/components/builtin/tx_pool/component.py
@@ -24,7 +24,6 @@ from trinity.constants import (
     ROPSTEN_NETWORK_ID,
 )
 from trinity.db.manager import DBClient
-from trinity.events import ShutdownRequest
 from trinity.extensibility import (
     AsyncioIsolatedComponent,
 )
@@ -47,26 +46,26 @@ class TxComponent(AsyncioIsolatedComponent):
     @classmethod
     def configure_parser(cls, arg_parser: ArgumentParser, subparser: _SubParsersAction) -> None:
         arg_parser.add_argument(
-            "--tx-pool",
+            "--disable-tx-pool",
             action="store_true",
-            help="Enables the Transaction Pool (experimental)",
+            help="Disables the Transaction Pool",
         )
 
     def on_ready(self, manager_eventbus: EndpointAPI) -> None:
 
         light_mode = self.boot_info.args.sync_mode == SYNC_LIGHT
-        is_enabled = self.boot_info.args.tx_pool and not light_mode
+        is_disable = self.boot_info.args.disable_tx_pool
+        is_supported = not light_mode
+        is_enabled = not is_disable and is_supported
 
-        unsupported = self.boot_info.args.tx_pool and light_mode
-
-        if is_enabled and not unsupported:
+        if is_disable:
+            self.logger.debug("Transaction pool disabled")
+        elif not is_supported:
+            self.logger.debug("Transaction pool does not support light mode")
+        elif is_enabled:
             self.start()
-        elif unsupported:
-            unsupported_msg = "Transaction pool not available in light mode"
-            self.logger.error(unsupported_msg)
-            manager_eventbus.broadcast_nowait(ShutdownRequest(
-                unsupported_msg,
-            ))
+        else:
+            raise Exception("This code path should be unreachable")
 
     def do_start(self) -> None:
 
@@ -83,8 +82,6 @@ class TxComponent(AsyncioIsolatedComponent):
         elif self.boot_info.trinity_config.network_id == ROPSTEN_NETWORK_ID:
             validator = DefaultTransactionValidator(chain, BYZANTIUM_ROPSTEN_BLOCK)
         else:
-            # TODO: We could hint the user about e.g. a --tx-pool-no-validation flag to run the
-            # tx pool without tx validation in this case
             raise ValueError("The TxPool component only supports MainnetChain or RopstenChain")
 
         proxy_peer_pool = ETHProxyPeerPool(self.event_bus, TO_NETWORKING_BROADCAST_CONFIG)

--- a/trinity/components/builtin/tx_pool/pool.py
+++ b/trinity/components/builtin/tx_pool/pool.py
@@ -72,8 +72,7 @@ class TxPool(BaseService):
             await self._handle_tx(event.session, txs)
 
     async def _handle_tx(self, sender: SessionAPI, txs: Sequence[SignedTransactionAPI]) -> None:
-
-        self.logger.debug('Received %d transactions from %s', len(txs), sender)
+        self.logger.debug2('Received %d transactions from %s', len(txs), sender)
 
         self._add_txs_to_bloom(sender, txs)
 


### PR DESCRIPTION
fixes #1132 

### What was wrong?

The transaction pool is off by default.  A good network citizen should relay transactions.

### How was it fixed?

Turned it on by default.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

[//]: # (See: https://trinity-client.readthedocs.io/en/latest/contributing.html#pull-requests)
- [x] Add entry to the [release notes](https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses]()
