### PR TITLE
Fix issue with EthStats Service not reconnecting after failure

### DIFF
--- a/newsfragments/1139.bugfix.rst
+++ b/newsfragments/1139.bugfix.rst
@@ -1,0 +1,1 @@
+Ensure EthStatsService properly handles lost connections to the server

--- a/trinity/components/builtin/ethstats/ethstats_client.py
+++ b/trinity/components/builtin/ethstats/ethstats_client.py
@@ -55,7 +55,11 @@ class EthstatsClient(BaseService):
     # Get messages from websocket, deserialize them and put into queue
     async def recv_handler(self) -> None:
         while self.is_operational:
-            json_string: str = await self.websocket.recv()
+            try:
+                json_string: str = await self.websocket.recv()
+            except websockets.ConnectionClosed as e:
+                self.logger.debug2("Connection closed: %s", e)
+                await self.cancel()
             try:
                 message: EthstatsMessage = self.deserialize_message(json_string)
             except EthstatsException as e:


### PR DESCRIPTION
### What was wrong?

The EthStats Service had some code to handle the case where the EthStats server closes but it didn't turn out to work. #68 

### How was it fixed?

I think I'm doing something wrong but it didn't seem possible to catch the exception from the client service in the parent service (:thinking:). 

I shifted the code around so that the parent service directly runs the client and in case the client service closes while the parent is still operational it will log the disconnect, sleep a bit to eventually try to reconnect.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

[//]: # (See: https://trinity-client.readthedocs.io/en/latest/contributing.html#pull-requests)
- [x] Add entry to the [release notes](https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://hips.hearstapps.com/rbk.h-cdn.co/assets/17/35/1504024434-lionlead.jpg?crop=0.981xw:0.978xh;0.0192xw,0.0224xh&resize=1200:*)
