### PR TITLE
Add behavior api

### DIFF
--- a/newsfragments/1142.feature.rst
+++ b/newsfragments/1142.feature.rst
@@ -1,0 +1,1 @@
+Implement ``p2p.behaviors`` API.

--- a/p2p/abc.py
+++ b/p2p/abc.py
@@ -440,6 +440,32 @@ ProtocolHandlerFn = Callable[['ConnectionAPI', CommandAPI, Payload], Awaitable[A
 CommandHandlerFn = Callable[['ConnectionAPI', Payload], Awaitable[Any]]
 
 
+class BehaviorAPI(ABC):
+    """
+    A behavior is some unit of logic that applies to a `ConnectionAPI`.
+    Typical behaviors may perform an action when a certain command is received
+    such as responding to a `Ping` with a `Pong` message.
+    """
+    @abstractmethod
+    def applies_to(self, connection: 'ConnectionAPI') -> bool:
+        """
+        Return `True` if this Behavior should be applied to the `connection``
+        """
+        ...
+
+    @abstractmethod
+    def apply(self, connection: 'ConnectionAPI') -> AsyncContextManager[None]:
+        """
+        Context manager API used programatically by the `ContextManager` to
+        apply the behavior to the connection during the lifecycle of the
+        connection.
+        """
+        ...
+
+
+TBehavior = TypeVar('TBehavior', bound=BehaviorAPI)
+
+
 class ConnectionAPI(AsyncioServiceAPI):
     protocol_receipts: Tuple[HandshakeReceiptAPI, ...]
 
@@ -487,6 +513,21 @@ class ConnectionAPI(AsyncioServiceAPI):
                             command_type: Type[CommandAPI],
                             handler_fn: CommandHandlerFn,
                             ) -> SubscriptionAPI:
+        ...
+
+    #
+    # Behavior API
+    #
+    def add_api(self, name: str, behavior: BehaviorAPI) -> SubscriptionAPI:
+        ...
+
+    def remove_api(self, name: str) -> None:
+        ...
+
+    def has_api(self, name: str) -> bool:
+        ...
+
+    def get_api(self, name: str, behavior_type: Type[TBehavior]) -> TBehavior:
         ...
 
     #

--- a/p2p/abc.py
+++ b/p2p/abc.py
@@ -518,16 +518,16 @@ class ConnectionAPI(AsyncioServiceAPI):
     #
     # Behavior API
     #
-    def add_api(self, name: str, behavior: BehaviorAPI) -> SubscriptionAPI:
+    def add_behavior(self, name: str, behavior: BehaviorAPI) -> SubscriptionAPI:
         ...
 
-    def remove_api(self, name: str) -> None:
+    def remove_behavior(self, name: str) -> None:
         ...
 
-    def has_api(self, name: str) -> bool:
+    def has_behavior(self, name: str) -> bool:
         ...
 
-    def get_api(self, name: str, behavior_type: Type[TBehavior]) -> TBehavior:
+    def get_behavior(self, name: str, behavior_type: Type[TBehavior]) -> TBehavior:
         ...
 
     #

--- a/p2p/behaviors.py
+++ b/p2p/behaviors.py
@@ -147,6 +147,6 @@ class Application(BehaviorAPI):
                 if behavior.applies_to(connection):
                     await stack.enter_async_context(behavior.apply(connection))
 
-            with connection.add_api(self.name, self):
+            with connection.add_behavior(self.name, self):
                 self.on_apply(connection)
                 yield

--- a/p2p/behaviors.py
+++ b/p2p/behaviors.py
@@ -1,0 +1,152 @@
+from abc import abstractmethod
+import logging
+from typing import (
+    AsyncIterator,
+    Callable,
+    Tuple,
+    Type,
+)
+
+from async_generator import asynccontextmanager
+
+from async_exit_stack import AsyncExitStack
+
+from p2p.abc import (
+    BehaviorAPI,
+    CommandAPI,
+    CommandHandlerFn,
+    ConnectionAPI,
+)
+from p2p.typing import Payload
+
+
+class CommandHandler(BehaviorAPI):
+    """
+    Base class to reduce boilerplate for Behaviors that want to register a
+    handler against a single command.
+    """
+    cmd_type: Type[CommandAPI]
+    logger = logging.getLogger('p2p.behaviors.CommandHandler')
+
+    def applies_to(self, connection: ConnectionAPI) -> bool:
+        return any(
+            protocol.supports_command(self.cmd_type)
+            for protocol
+            in connection.get_multiplexer().get_protocols()
+        )
+
+    def on_apply(self, connection: ConnectionAPI) -> None:
+        """
+        Hook for subclasses to perform some action once the behavior has been
+        applied to the connection.
+        """
+        pass
+
+    @asynccontextmanager
+    async def apply(self, connection: ConnectionAPI) -> AsyncIterator[None]:
+        if self.cmd_type is None:
+            raise TypeError(f"No cmd_type specified for {self}")
+
+        with connection.add_command_handler(self.cmd_type, self.handle):
+            self.on_apply(connection)
+            yield
+
+    @abstractmethod
+    async def handle(self, connection: ConnectionAPI, msg: Payload) -> None:
+        ...
+
+
+def command_handler(command_type: Type[CommandAPI],
+                    *,
+                    name: str = None) -> Callable[[CommandHandlerFn], Type[CommandHandler]]:
+    """
+    Decorator that can be used to construct a CommandHandler from a simple
+    function.
+
+    .. code-block:: python
+
+        @command_handler(Ping)
+        def handle_ping(connection, msg):
+            connection.get_base_protocol().send_pong()
+    """
+    if name is None:
+        name = f'handle_{command_type.__name__}'
+
+    def decorator(fn: CommandHandlerFn) -> Type[CommandHandler]:
+        return type(
+            name,
+            (CommandHandler,),
+            {
+                'cmd_type': command_type,
+                'handle': staticmethod(fn),
+            },
+        )
+    return decorator
+
+
+class ConnectionBehavior(BehaviorAPI):
+    """
+    Base class to simply give access to the `ConnectionAPI`.  It is up to
+    subclasses to implement `applies_to`.  This is primarily for implementing
+    APIs for interacting with the connection object.
+
+    .. code-block:: python
+
+        class Disconnect(ConnectionBehavior):
+            def applies_to(self, connection):
+                return True
+
+            def __call__(self, reason: DisconnectReason):
+                self._connection.get_base_protocol().send_disconnect(reason)
+    """
+    @asynccontextmanager
+    async def apply(self, connection: ConnectionAPI) -> AsyncIterator[None]:
+        if hasattr(self, '_connection'):
+            raise Exception("Reentrance!")
+        self._connection = connection
+        yield
+
+
+class Application(BehaviorAPI):
+    """
+    Wrapper arround a collection of behaviors.  Primarily used to aggregate
+    multiple smaller units of functionality.
+
+    When applied an `Application` registers itself with the `ConnectionAPI`
+    under the defined `name`.
+    """
+    name: str
+
+    @abstractmethod
+    def get_behaviors(self) -> Tuple[BehaviorAPI, ...]:
+        ...
+
+    def on_apply(self, connection: ConnectionAPI) -> None:
+        """
+        Hook for subclasses to perform some action once the behavior has been
+        applied to the connection.
+        """
+        pass
+
+    def applies_to(self, connection: ConnectionAPI) -> bool:
+        return any(
+            behavior.applies_to(connection)
+            for behavior
+            in self.get_behaviors()
+        )
+
+    @asynccontextmanager
+    async def apply(self, connection: ConnectionAPI) -> AsyncIterator[None]:
+        if hasattr(self, '_connection') is True:
+            raise Exception("Reentrance!")
+
+        self._connection = connection
+
+        async with AsyncExitStack() as stack:
+            for behavior in self.get_behaviors():
+                if behavior.applies_to(connection):
+                    await stack.enter_async_context(behavior.apply(connection))
+
+            with connection.add_api(self.name, self):
+                self.on_apply(connection)
+                yield

--- a/p2p/connection.py
+++ b/p2p/connection.py
@@ -55,7 +55,7 @@ class Connection(ConnectionAPI, BaseService):
         Type[CommandAPI],
         Set[CommandHandlerFn]
     ]
-    _apis: Dict[str, BehaviorAPI]
+    _behaviors: Dict[str, BehaviorAPI]
 
     def __init__(self,
                  multiplexer: MultiplexerAPI,
@@ -77,7 +77,7 @@ class Connection(ConnectionAPI, BaseService):
         # before all necessary handlers have been added
         self._handlers_ready = asyncio.Event()
 
-        self._apis = {}
+        self._behaviors = {}
 
     def start_protocol_streams(self) -> None:
         self._handlers_ready.set()
@@ -199,26 +199,26 @@ class Connection(ConnectionAPI, BaseService):
     #
     # API extension
     #
-    def add_api(self, name: str, behavior: BehaviorAPI) -> SubscriptionAPI:
-        if name in self._apis:
+    def add_behavior(self, name: str, behavior: BehaviorAPI) -> SubscriptionAPI:
+        if name in self._behaviors:
             raise DuplicateAPI(
                 f"There is already an API registered under the name '{name}': "
-                f"{self._apis[name]}"
+                f"{self._behaviors[name]}"
             )
-        self._apis[name] = behavior
-        cancel_fn = functools.partial(self.remove_api, name)
+        self._behaviors[name] = behavior
+        cancel_fn = functools.partial(self.remove_behavior, name)
         return Subscription(cancel_fn)
 
-    def remove_api(self, name: str) -> None:
-        self._apis.pop(name)
+    def remove_behavior(self, name: str) -> None:
+        self._behaviors.pop(name)
 
-    def has_api(self, name: str) -> bool:
-        return name in self._apis
+    def has_behavior(self, name: str) -> bool:
+        return name in self._behaviors
 
-    def get_api(self, name: str, behavior_type: Type[TBehavior]) -> TBehavior:
-        if not self.has_api(name):
+    def get_behavior(self, name: str, behavior_type: Type[TBehavior]) -> TBehavior:
+        if not self.has_behavior(name):
             raise UnknownAPI(f"No API registered for the name '{name}'")
-        behavior = self._apis[name]
+        behavior = self._behaviors[name]
         if isinstance(behavior, behavior_type):
             return behavior
         else:

--- a/p2p/exceptions.py
+++ b/p2p/exceptions.py
@@ -197,3 +197,17 @@ class ReceiptNotFound(BaseP2PError):
     Raised when trying to retrieve a protocol receipt that isn't available
     """
     pass
+
+
+class DuplicateAPI(BaseP2PError):
+    """
+    Raised when trying to add an API to a connection under an existing key
+    """
+    pass
+
+
+class UnknownAPI(BaseP2PError):
+    """
+    Raised when trying to retrieve an API from a connection that.
+    """
+    pass

--- a/setup.py
+++ b/setup.py
@@ -9,6 +9,7 @@ PYEVM_DEPENDENCY = "py-evm==0.3.0a6"
 
 deps = {
     'p2p': [
+        "async-exit-stack==1.0.1",
         "async-generator==1.10",
         "asyncio-cancel-token>=0.2,<0.3",
         "async_lru>=0.1.0,<1.0.0",

--- a/tests/p2p/test_behaviors.py
+++ b/tests/p2p/test_behaviors.py
@@ -94,12 +94,12 @@ async def test_behavior_application():
         bob.add_command_handler(Ping, handle_ping)
 
         # ensure the API isn't already registered
-        assert not alice.has_api('ping-test')
+        assert not alice.has_behavior('ping-test')
         async with HasSendPing().apply(alice):
             # ensure it registers with the connect
-            assert alice.has_api('ping-test')
-            has_send_ping = alice.get_api('ping-test', HasSendPing)
+            assert alice.has_behavior('ping-test')
+            has_send_ping = alice.get_behavior('ping-test', HasSendPing)
             has_send_ping.send_ping()
             await asyncio.wait_for(got_ping.wait(), timeout=2)
         # ensure it removes itself from the API on exit
-        assert not alice.has_api('ping-test')
+        assert not alice.has_behavior('ping-test')

--- a/tests/p2p/test_behaviors.py
+++ b/tests/p2p/test_behaviors.py
@@ -1,0 +1,105 @@
+import asyncio
+import pytest
+
+from p2p.p2p_proto import Ping
+from p2p.behaviors import (
+    Application,
+    CommandHandler,
+    ConnectionBehavior,
+    command_handler,
+)
+
+from p2p.tools.factories import ConnectionPairFactory
+
+
+@pytest.mark.asyncio
+async def test_command_handler_behavior():
+    got_ping = asyncio.Event()
+
+    class HandlePing(CommandHandler):
+        cmd_type = Ping
+
+        async def handle(self, connection, msg):
+            got_ping.set()
+
+    async with ConnectionPairFactory() as (alice, bob):
+        ping_handler = HandlePing()
+        async with ping_handler.apply(alice):
+            bob.get_base_protocol().send_ping()
+            await asyncio.wait_for(got_ping.wait(), timeout=2)
+
+
+@pytest.mark.asyncio
+async def test_command_handler_decorator_behavior():
+    got_ping = asyncio.Event()
+
+    @command_handler(Ping)
+    async def HandlePing(connection, msg):
+        got_ping.set()
+
+    async with ConnectionPairFactory() as (alice, bob):
+        ping_handler = HandlePing()
+        async with ping_handler.apply(alice):
+            bob.get_base_protocol().send_ping()
+            await asyncio.wait_for(got_ping.wait(), timeout=2)
+
+
+@pytest.mark.asyncio
+async def test_connection_behavior_helper():
+    got_ping = asyncio.Event()
+
+    class SendPing(ConnectionBehavior):
+        def applies_to(self, connection):
+            return True
+
+        def __call__(self) -> None:
+            self._connection.get_base_protocol().send_ping()
+
+    async def handle_ping(connection, msg):
+        got_ping.set()
+
+    async with ConnectionPairFactory() as (alice, bob):
+        bob.add_command_handler(Ping, handle_ping)
+        send_ping = SendPing()
+
+        async with send_ping.apply(alice):
+            send_ping()
+            await asyncio.wait_for(got_ping.wait(), timeout=2)
+
+
+@pytest.mark.asyncio
+async def test_behavior_application():
+    got_ping = asyncio.Event()
+
+    class SendPing(ConnectionBehavior):
+        def applies_to(self, connection):
+            return True
+
+        def __call__(self) -> None:
+            self._connection.get_base_protocol().send_ping()
+
+    class HasSendPing(Application):
+        name = 'ping-test'
+
+        def __init__(self):
+            self.send_ping = SendPing()
+
+        def get_behaviors(self):
+            return (self.send_ping,)
+
+    async def handle_ping(connection, msg):
+        got_ping.set()
+
+    async with ConnectionPairFactory() as (alice, bob):
+        bob.add_command_handler(Ping, handle_ping)
+
+        # ensure the API isn't already registered
+        assert not alice.has_api('ping-test')
+        async with HasSendPing().apply(alice):
+            # ensure it registers with the connect
+            assert alice.has_api('ping-test')
+            has_send_ping = alice.get_api('ping-test', HasSendPing)
+            has_send_ping.send_ping()
+            await asyncio.wait_for(got_ping.wait(), timeout=2)
+        # ensure it removes itself from the API on exit
+        assert not alice.has_api('ping-test')


### PR DESCRIPTION
extracted from #966 and #1149

builds on #1148 #1145 #1147 #1144 

### What was wrong?

In order to get rid of the Peer classes, we need a way to define units of functionality that are "conditionally" applied to a `ConnectionAPI`.

### How was it fixed?

This introduces the "Behavior" API.  A `BehaviorAPI` is a unit of functionality that applies to a `ConnectionAPI`.

One of the simplest behaviors is the `p2p.behaviors.CommandHandler`.  This behavior installs a handler function via `ConnectionAPI.add_command_handler`.  Here's an example that uses this to implement a "send a pong anytime I get a ping"

```python
class PongWhenPinged(CommandHandler):
    cmd_type = Ping
    async def handle(self, connection, msg):
        connection.get_base_protocol().send_pong()

# or if you like decorators and functions
@command_handler(Ping)
async def send_pong_when_pinged(connection, msg):
    connection.get_base_protocol().send_pong()
```

Here's one that triggers the `ConnectionAPI.cancel_token` when it receives a `Disconnect` msg.

```python
class TriggerCancelOnDisconnect(CommandHandler):
    cmd_type = Disconnect
    disconnect_reason = None
    async def handle(self, connection, msg):
        self.disconnect_reason = DisconnectReason(msg['reason'])
        await connection.cancel()
```

Another built-in helper is the `p2p.behaviors.Application`.  These are designed to be *containers* of multiple behaviors, typically exposing a public API of some sort.

```python
class P2PAPI(Application):
    def get_behaviors():
        return (PongWhenPonged(), TriggerCancelOnDisconnect)
    def disconnect(self, reason):
        ...
    def send_ping(self):
        ...
```

The class above combines usage of both some custom local functions as well as wrapping up some other behaviors.

For a look in how these APIs are actually used, see https://github.com/ethereum/trinity/pull/1149

Here's a more polished version with only the `p2p` APIs: https://github.com/ethereum/trinity/pull/1150

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

[//]: # (See: https://trinity-client.readthedocs.io/en/latest/contributing.html#pull-requests)
- [x] Add entry to the [release notes](https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![f8cb3d88be23b45e54e646d7b17e9d79](https://user-images.githubusercontent.com/824194/64988642-25ee3c80-d889-11e9-9c60-1b8dfe3c193e.jpg)

