### PR TITLE
Rename HandlerSubscription to Subscription

### DIFF
--- a/p2p/abc.py
+++ b/p2p/abc.py
@@ -423,7 +423,7 @@ class HandshakerAPI(ABC):
         ...
 
 
-class HandlerSubscriptionAPI(ContextManager['HandlerSubscriptionAPI']):
+class SubscriptionAPI(ContextManager['SubscriptionAPI']):
     @abstractmethod
     def cancel(self) -> None:
         ...
@@ -467,14 +467,14 @@ class ConnectionAPI(AsyncioServiceAPI):
     def add_protocol_handler(self,
                              protocol_type: Type[ProtocolAPI],
                              handler_fn: ProtocolHandlerFn,
-                             ) -> HandlerSubscriptionAPI:
+                             ) -> SubscriptionAPI:
         ...
 
     @abstractmethod
     def add_command_handler(self,
                             command_type: Type[CommandAPI],
                             handler_fn: CommandHandlerFn,
-                            ) -> HandlerSubscriptionAPI:
+                            ) -> SubscriptionAPI:
         ...
 
     #

--- a/p2p/subscription.py
+++ b/p2p/subscription.py
@@ -5,21 +5,21 @@ from typing import (
 )
 from types import TracebackType
 
-from p2p.abc import HandlerSubscriptionAPI
+from p2p.abc import SubscriptionAPI
 
 
-class HandlerSubscription(HandlerSubscriptionAPI):
-    def __init__(self, remove_fn: Callable[[], Any]) -> None:
-        self._remove_fn = remove_fn
+class Subscription(SubscriptionAPI):
+    def __init__(self, cancel_fn: Callable[[], Any]) -> None:
+        self._cancel_fn = cancel_fn
 
     def cancel(self) -> None:
-        self._remove_fn()
+        self._cancel_fn()
 
-    def __enter__(self) -> HandlerSubscriptionAPI:
+    def __enter__(self) -> SubscriptionAPI:
         return self
 
     def __exit__(self,
                  exc_type: Type[BaseException],
                  exc_value: BaseException,
                  exc_tb: TracebackType) -> None:
-        self._remove_fn()
+        self._cancel_fn()


### PR DESCRIPTION
### What was wrong?

The `HandlerSubscription` that is used by the `ConnectionAPI` for command and protocol handlers is actually generic enough for use elsewhere.

### How was it fixed?

Renamed it to just be called `Subscription` so that the name is adequately generic for re-use with other APIs.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history


#### Cute Animal Picture

![ss-141008-animal-costumes-elvis today-ss-slide-desktop](https://user-images.githubusercontent.com/824194/64973497-5c678f80-d868-11e9-8890-a8a9d81a3502.jpg)

