### PR TITLE
Fix typing for cached_property and expand usage.

### DIFF
--- a/p2p/connection.py
+++ b/p2p/connection.py
@@ -73,11 +73,11 @@ class Connection(ConnectionAPI, BaseService):
     #
     # Primary properties of the connection
     #
-    @property
+    @cached_property
     def is_dial_in(self) -> bool:
         return not self.is_dial_out
 
-    @property
+    @cached_property
     def remote(self) -> NodeAPI:
         return self._multiplexer.remote
 
@@ -202,27 +202,27 @@ class Connection(ConnectionAPI, BaseService):
     #
     # Connection Metadata
     #
-    @property
+    @cached_property
     def remote_capabilities(self) -> Capabilities:
         return self._devp2p_receipt.capabilities
 
-    @property
+    @cached_property
     def remote_p2p_version(self) -> int:
         return self._devp2p_receipt.version
 
-    @property
+    @cached_property
     def negotiated_p2p_version(self) -> int:
         return self.get_base_protocol().version
 
-    @property
+    @cached_property
     def remote_public_key(self) -> keys.PublicKey:
         return keys.PublicKey(self._devp2p_receipt.remote_public_key)
 
-    @property
+    @cached_property
     def client_version_string(self) -> str:
         return self._devp2p_receipt.client_version_string
 
-    @property
+    @cached_property
     def safe_client_version_string(self) -> str:
         # limit number of chars to be displayed, and try to keep printable ones only
         # MAGIC 256: arbitrary, "should be enough for everybody"

--- a/p2p/peer.py
+++ b/p2p/peer.py
@@ -173,7 +173,7 @@ class BasePeer(BaseService):
         """
         pass
 
-    @property
+    @cached_property
     def has_event_bus(self) -> bool:
         return self._event_bus is not None
 
@@ -213,7 +213,7 @@ class BasePeer(BaseService):
     def get_extra_stats(self) -> Tuple[str, ...]:
         return tuple()
 
-    @property
+    @cached_property
     def boot_manager_class(self) -> Type[BasePeerBootManager]:
         return BasePeerBootManager
 
@@ -384,7 +384,7 @@ class PeerSubscriber(ABC):
         """
         pass
 
-    @property
+    @cached_property
     def msg_queue(self) -> 'asyncio.Queue[PeerMessage]':
         """
         Return the ``asyncio.Queue[PeerMessage]`` that this subscriber uses to receive messages.
@@ -393,7 +393,7 @@ class PeerSubscriber(ABC):
             self._msg_queue = asyncio.Queue(maxsize=self.msg_queue_maxsize)
         return self._msg_queue
 
-    @property
+    @cached_property
     def queue_size(self) -> int:
         """
         Return the size of the :meth:`msg_queue`.

--- a/p2p/peer_pool.py
+++ b/p2p/peer_pool.py
@@ -1,6 +1,4 @@
-from abc import (
-    abstractmethod,
-)
+from abc import abstractmethod
 import asyncio
 import operator
 from typing import (
@@ -13,6 +11,8 @@ from typing import (
     Tuple,
     Type,
 )
+
+from cached_property import cached_property
 
 from cancel_token import (
     CancelToken,
@@ -138,7 +138,7 @@ class BasePeerPool(BaseService, AsyncIterable[BasePeer]):
         self.peer_backends = self.setup_peer_backends()
         self.connection_tracker = self.setup_connection_tracker()
 
-    @property
+    @cached_property
     def has_event_bus(self) -> bool:
         return self._event_bus is not None
 

--- a/p2p/tools/paragon/peer.py
+++ b/p2p/tools/paragon/peer.py
@@ -62,7 +62,7 @@ class ParagonMockPeerPoolWithConnectedPeers(ParagonPeerPool):
     def __init__(self, peers: Iterable[ParagonPeer]) -> None:
         super().__init__(privkey=None, context=None)
         for peer in peers:
-            self.connected_nodes[peer.remote] = peer
+            self.connected_nodes[peer.session] = peer
 
     async def _run(self) -> None:
         raise NotImplementedError("This is a mock PeerPool implementation, you must not _run() it")

--- a/stubs/cached_property.pyi
+++ b/stubs/cached_property.pyi
@@ -1,0 +1,1 @@
+cached_property = property

--- a/tox.ini
+++ b/tox.ini
@@ -27,6 +27,8 @@ line_length=88
 
 [testenv]
 usedevelop=True
+setenv =
+    MYPYPATH = {toxinidir}/stubs
 passenv =
     TRAVIS_EVENT_TYPE
 commands=

--- a/trinity/sync/beam/state.py
+++ b/trinity/sync/beam/state.py
@@ -178,7 +178,7 @@ class BeamDownloader(BaseService, PeerSubscriber):
 
     async def download_accounts(
             self,
-            account_addresses: Iterable[Hash32],
+            account_addresses: Iterable[Address],
             root_hash: Hash32,
             urgent: bool=True) -> int:
         """


### PR DESCRIPTION
### What was wrong?

The `cached_property` decorator was causing functions to return `Any` types and it wasn't being used as broadly as it could be.

### How was it fixed?

Added a stub-file to help mypy retain type information when `cached_property` is used and apply it to a few more `@property` methods.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history


#### Cute Animal Picture

![ss-141008-animal-costumes-shrek today-ss-slide-desktop](https://user-images.githubusercontent.com/824194/64975748-f7626880-d86c-11e9-82b4-4b5cfcbd379c.jpg)

