### PR TITLE
add get_protocol_for_command_type

### DIFF
--- a/newsfragments/1145.feature.rst
+++ b/newsfragments/1145.feature.rst
@@ -1,0 +1,1 @@
+Add ``ConnectionAPI.get_protocol_for_command_type``

--- a/p2p/abc.py
+++ b/p2p/abc.py
@@ -327,6 +327,10 @@ class MultiplexerAPI(ABC):
     def get_protocols(self) -> Tuple[ProtocolAPI, ...]:
         ...
 
+    @abstractmethod
+    def get_protocol_for_command_type(self, command_type: Type[CommandAPI]) -> ProtocolAPI:
+        ...
+
     #
     # Streaming API
     #
@@ -456,6 +460,11 @@ class ConnectionAPI(AsyncioServiceAPI):
     def remote(self) -> NodeAPI:
         ...
 
+    @property
+    @abstractmethod
+    def is_closing(self) -> bool:
+        ...
+
     #
     # Subscriptions/Handler API
     #
@@ -493,6 +502,21 @@ class ConnectionAPI(AsyncioServiceAPI):
 
     @abstractmethod
     def get_p2p_receipt(self) -> 'DevP2PReceipt':
+        ...
+
+    #
+    # Protocol APIS
+    #
+    @abstractmethod
+    def get_protocols(self) -> Tuple[ProtocolAPI, ...]:
+        ...
+
+    @abstractmethod
+    def get_protocol_by_type(self, protocol_type: Type[TProtocol]) -> TProtocol:
+        ...
+
+    @abstractmethod
+    def get_protocol_for_command_type(self, command_type: Type[CommandAPI]) -> ProtocolAPI:
         ...
 
     #

--- a/p2p/connection.py
+++ b/p2p/connection.py
@@ -5,6 +5,7 @@ from typing import (
     DefaultDict,
     Sequence,
     Set,
+    Tuple,
     Type,
 )
 
@@ -23,6 +24,7 @@ from p2p.abc import (
     ProtocolAPI,
     ProtocolHandlerFn,
     SessionAPI,
+    TProtocol,
 )
 from p2p.disconnect import DisconnectReason
 from p2p.exceptions import (
@@ -198,6 +200,18 @@ class Connection(ConnectionAPI, BaseService):
 
     def get_p2p_receipt(self) -> DevP2PReceipt:
         return self._devp2p_receipt
+
+    #
+    # Protocol APIS
+    #
+    def get_protocols(self) -> Tuple[ProtocolAPI, ...]:
+        return self._multiplexer.get_protocols()
+
+    def get_protocol_by_type(self, protocol_type: Type[TProtocol]) -> TProtocol:
+        return self._multiplexer.get_protocol_by_type(protocol_type)
+
+    def get_protocol_for_command_type(self, command_type: Type[CommandAPI]) -> ProtocolAPI:
+        return self._multiplexer.get_protocol_for_command_type(command_type)
 
     #
     # Connection Metadata

--- a/p2p/exchange/candidate_stream.py
+++ b/p2p/exchange/candidate_stream.py
@@ -16,7 +16,6 @@ from p2p.abc import (
 from p2p.exceptions import (
     ConnectionBusy,
     PeerConnectionLost,
-    UnknownProtocol,
 )
 from p2p.service import BaseService
 from p2p.typing import TRequestPayload, TResponsePayload
@@ -41,23 +40,12 @@ class ResponseCandidateStream(
     def __init__(
             self,
             connection: ConnectionAPI,
-            request_protocol_type: Type[ProtocolAPI],
+            request_protocol: ProtocolAPI,
             response_cmd_type: Type[CommandAPI]) -> None:
         # This style of initialization keeps `mypy` happy.
         BaseService.__init__(self, token=connection.cancel_token)
         self._connection = connection
-        self.request_protocol_type = request_protocol_type
-        try:
-            self.request_protocol = self._connection.get_multiplexer().get_protocol_by_type(
-                request_protocol_type,
-            )
-        except UnknownProtocol as err:
-            raise UnknownProtocol(
-                f"Response candidate stream configured to use "
-                f"{request_protocol_type} which is not available in the "
-                f"Multiplexer"
-            ) from err
-
+        self.request_protocol = request_protocol
         self.response_cmd_type = response_cmd_type
         self._lock = asyncio.Lock()
 

--- a/p2p/exchange/manager.py
+++ b/p2p/exchange/manager.py
@@ -35,10 +35,10 @@ class ExchangeManager(ExchangeManagerAPI[TRequestPayload, TResponsePayload, TRes
     def __init__(
             self,
             connection: ConnectionAPI,
-            requesting_on: Type[ProtocolAPI],
+            requesting_on: ProtocolAPI,
             listening_for: Type[CommandAPI]) -> None:
         self._connection = connection
-        self._request_protocol_type = requesting_on
+        self._request_protocol = requesting_on
         self._response_command_type = listening_for
 
     async def launch_service(self) -> None:
@@ -49,7 +49,7 @@ class ExchangeManager(ExchangeManagerAPI[TRequestPayload, TResponsePayload, TRes
 
         self._response_stream = ResponseCandidateStream(
             self._connection,
-            self._request_protocol_type,
+            self._request_protocol,
             self._response_command_type,
         )
         self._connection.run_daemon(self._response_stream)

--- a/tests/p2p/test_connection.py
+++ b/tests/p2p/test_connection.py
@@ -162,8 +162,8 @@ async def test_connection_protocol_and_command_handlers():
         alice_connection.start_protocol_streams()
         bob_connection.start_protocol_streams()
 
-        bob_second_protocol = bob_connection.get_multiplexer().get_protocol_by_type(SecondProtocol)
-        bob_third_protocol = bob_connection.get_multiplexer().get_protocol_by_type(ThirdProtocol)
+        bob_second_protocol = bob_connection.get_protocol_by_type(SecondProtocol)
+        bob_third_protocol = bob_connection.get_protocol_by_type(ThirdProtocol)
 
         bob_second_protocol.send_cmd(CommandA)
         bob_second_protocol.send_cmd(CommandB)


### PR DESCRIPTION
fixes #1041

### What was wrong?

Given a command type it was non-trivial to get the appropriate protocol from the `ConnectionAPI` or `MultiplexerAPI`.  Similarly, there are a few APIs on the multiplexer that would be useful if mirrored on the `Connection`.

### How was it fixed?

Added `MultiplexerAPI.get_protocol_for_command_type`.

Mirrored: `get_protocols` and `get_protocol_by_type`, and `get_protocol_for_command_type` on the `ConnectionAPI`

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

[//]: # (See: https://trinity-client.readthedocs.io/en/latest/contributing.html#pull-requests)
- [x] Add entry to the [release notes](https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![facf6d4122c8617a7c698ab5f04fbdcd--dog-costumes-costume-ideas](https://user-images.githubusercontent.com/824194/64976211-f7af3380-d86d-11e9-91c7-d601253da252.jpg)

