### PR TITLE
Minor fix for alphabetical import order

### DIFF
--- a/p2p/exchange/abc.py
+++ b/p2p/exchange/abc.py
@@ -20,14 +20,13 @@ from p2p.abc import (
     RequestAPI,
     ProtocolAPI,
 )
+from p2p.stats.ema import EMA
+from p2p.stats.percentile import Percentile
+from p2p.stats.stddev import StandardDeviation
 from p2p.typing import (
     TRequestPayload,
     TResponsePayload,
 )
-
-from p2p.stats.ema import EMA
-from p2p.stats.percentile import Percentile
-from p2p.stats.stddev import StandardDeviation
 
 from .typing import TResult, TRequest, TResponse
 


### PR DESCRIPTION
### What was wrong?

Import order was wrong

### How was it fixed?

Re-ordered to be alphabetical.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history

#### Cute Animal Picture

![da7a3746736733c3d14398762e3477e5](https://user-images.githubusercontent.com/824194/64976330-3c3acf00-d86e-11e9-83d5-4b89dc3b0b8b.jpg)

