### PR TITLE
Fix incorrect logger name

### DIFF
--- a/p2p/handshake.py
+++ b/p2p/handshake.py
@@ -62,7 +62,7 @@ class Handshaker(HandshakerAPI):
     justification for this class's existence is to house parameters that are
     needed for the protocol handshake.
     """
-    logger = get_extended_debug_logger('p2p.connection.ProtocolHandler')
+    logger = get_extended_debug_logger('p2p.handshake.Handshaker')
 
 
 class DevP2PHandshakeParams(NamedTuple):


### PR DESCRIPTION
### What was wrong?

Incorrect name for a logger

### How was it fixed?

Used correct path.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history

#### Cute Animal Picture

![cutest-dog-costume-ever](https://user-images.githubusercontent.com/824194/64976406-6e4c3100-d86e-11e9-98e5-eb13d27b4ea7.jpg)

