### PR TITLE
Add connection.get receipt by type

### DIFF
--- a/newsfragments/1148.feature.rst
+++ b/newsfragments/1148.feature.rst
@@ -1,0 +1,1 @@
+Add ``ConnectionAPI.get_receipt_by_type(receipt_type: Type[ReceiptAPI])`` API

--- a/p2p/abc.py
+++ b/p2p/abc.py
@@ -412,6 +412,9 @@ class HandshakeReceiptAPI(ABC):
     protocol: ProtocolAPI
 
 
+THandshakeReceipt = TypeVar('THandshakeReceipt', bound=HandshakeReceiptAPI)
+
+
 class HandshakerAPI(ABC):
     logger: ExtendedDebugLogger
 
@@ -517,6 +520,10 @@ class ConnectionAPI(AsyncioServiceAPI):
 
     @abstractmethod
     def get_protocol_for_command_type(self, command_type: Type[CommandAPI]) -> ProtocolAPI:
+        ...
+
+    @abstractmethod
+    def get_receipt_by_type(self, receipt_type: Type[THandshakeReceipt]) -> THandshakeReceipt:
         ...
 
     #

--- a/p2p/connection.py
+++ b/p2p/connection.py
@@ -24,12 +24,14 @@ from p2p.abc import (
     ProtocolAPI,
     ProtocolHandlerFn,
     SessionAPI,
+    THandshakeReceipt,
     TProtocol,
 )
 from p2p.disconnect import DisconnectReason
 from p2p.exceptions import (
     MalformedMessage,
     PeerConnectionLost,
+    ReceiptNotFound,
     UnknownProtocol,
     UnknownProtocolCommand,
 )
@@ -212,6 +214,13 @@ class Connection(ConnectionAPI, BaseService):
 
     def get_protocol_for_command_type(self, command_type: Type[CommandAPI]) -> ProtocolAPI:
         return self._multiplexer.get_protocol_for_command_type(command_type)
+
+    def get_receipt_by_type(self, receipt_type: Type[THandshakeReceipt]) -> THandshakeReceipt:
+        for receipt in self.protocol_receipts:
+            if isinstance(receipt, receipt_type):
+                return receipt
+        else:
+            raise ReceiptNotFound(f"Receipt not found: {receipt_type}")
 
     #
     # Connection Metadata

--- a/p2p/exceptions.py
+++ b/p2p/exceptions.py
@@ -189,3 +189,11 @@ class NoMatchingPeerCapabilities(BaseP2PError):
     """
     Raised during primary p2p handshake if there are no common capabilities with a peer.
     """
+    pass
+
+
+class ReceiptNotFound(BaseP2PError):
+    """
+    Raised when trying to retrieve a protocol receipt that isn't available
+    """
+    pass

--- a/p2p/peer.py
+++ b/p2p/peer.py
@@ -11,7 +11,6 @@ from typing import (
     List,
     NamedTuple,
     FrozenSet,
-    Sequence,
     Tuple,
     Type,
     TYPE_CHECKING,
@@ -35,7 +34,6 @@ from p2p.abc import (
     CommandAPI,
     ConnectionAPI,
     HandshakerAPI,
-    HandshakeReceiptAPI,
     NodeAPI,
     ProtocolAPI,
     SessionAPI,
@@ -49,7 +47,6 @@ from p2p.exceptions import (
 from p2p.handshake import (
     dial_out,
     DevP2PHandshakeParams,
-    DevP2PReceipt,
 )
 from p2p.service import BaseService
 from p2p.p2p_proto import (
@@ -159,14 +156,9 @@ class BasePeer(BaseService):
         self.boot_manager = self.get_boot_manager()
         self.connection_tracker = self.setup_connection_tracker()
 
-        self.process_handshake_receipts(
-            connection.get_p2p_receipt(),
-            connection.protocol_receipts,
-        )
+        self.process_handshake_receipts()
 
-    def process_handshake_receipts(self,
-                                   devp2p_receipt: DevP2PReceipt,
-                                   protocol_receipts: Sequence[HandshakeReceiptAPI]) -> None:
+    def process_handshake_receipts(self) -> None:
         """
         Noop implementation for subclasses to override.
         """

--- a/trinity/protocol/bcc/peer.py
+++ b/trinity/protocol/bcc/peer.py
@@ -1,4 +1,4 @@
-from typing import Sequence, Tuple
+from typing import Tuple
 
 from lahja import EndpointAPI
 
@@ -10,8 +10,7 @@ from lahja import (
     BroadcastConfig,
 )
 
-from p2p.abc import CommandAPI, HandshakeReceiptAPI, SessionAPI
-from p2p.handshake import DevP2PReceipt
+from p2p.abc import CommandAPI, SessionAPI
 from p2p.peer import (
     BasePeer,
     BasePeerFactory,
@@ -76,20 +75,11 @@ class BCCPeer(BasePeer):
 
     _requests: BCCExchangeHandler = None
 
-    def process_handshake_receipts(self,
-                                   devp2p_receipt: DevP2PReceipt,
-                                   protocol_receipts: Sequence[HandshakeReceiptAPI]) -> None:
-        super().process_handshake_receipts(devp2p_receipt, protocol_receipts)
-        for receipt in protocol_receipts:
-            if isinstance(receipt, BCCHandshakeReceipt):
-                self.head_slot = receipt.handshake_params.head_slot
-                self.genesis_root = receipt.handshake_params.genesis_root
-                self.network_id = receipt.handshake_params.network_id
-                break
-        else:
-            raise Exception(
-                "Did not find an `BCCHandshakeReceipt` in {protocol_receipts}"
-            )
+    def process_handshake_receipts(self) -> None:
+        receipt = self.connection.get_receipt_by_type(BCCHandshakeReceipt)
+        self.head_slot = receipt.handshake_params.head_slot
+        self.genesis_root = receipt.handshake_params.genesis_root
+        self.network_id = receipt.handshake_params.network_id
 
     @property
     def requests(self) -> BCCExchangeHandler:

--- a/trinity/protocol/les/peer.py
+++ b/trinity/protocol/les/peer.py
@@ -2,7 +2,6 @@ from typing import (
     cast,
     Dict,
     List,
-    Sequence,
     Tuple,
     Union,
     TYPE_CHECKING,
@@ -25,8 +24,7 @@ from lahja import (
     BroadcastConfig,
 )
 
-from p2p.abc import CommandAPI, ConnectionAPI, HandshakerAPI, HandshakeReceiptAPI, SessionAPI
-from p2p.handshake import DevP2PReceipt
+from p2p.abc import CommandAPI, ConnectionAPI, HandshakerAPI, SessionAPI
 from p2p.peer_pool import BasePeerPool
 from p2p.typing import Payload
 
@@ -81,22 +79,13 @@ class LESPeer(BaseChainPeer):
 
     _requests: LESExchangeHandler = None
 
-    def process_handshake_receipts(self,
-                                   devp2p_receipt: DevP2PReceipt,
-                                   protocol_receipts: Sequence[HandshakeReceiptAPI]) -> None:
-        super().process_handshake_receipts(devp2p_receipt, protocol_receipts)
-        for receipt in protocol_receipts:
-            if isinstance(receipt, LESHandshakeReceipt):
-                self.head_td = receipt.handshake_params.head_td
-                self.head_hash = receipt.handshake_params.head_hash
-                self.head_number = receipt.handshake_params.head_num
-                self.genesis_hash = receipt.handshake_params.genesis_hash
-                self.network_id = receipt.handshake_params.network_id
-                break
-        else:
-            raise Exception(
-                "Did not find an `LES` in {protocol_receipts}"
-            )
+    def process_handshake_receipts(self) -> None:
+        receipt = self.connection.get_receipt_by_type(LESHandshakeReceipt)
+        self.head_td = receipt.handshake_params.head_td
+        self.head_hash = receipt.handshake_params.head_hash
+        self.head_number = receipt.handshake_params.head_num
+        self.genesis_hash = receipt.handshake_params.genesis_hash
+        self.network_id = receipt.handshake_params.network_id
 
     def get_extra_stats(self) -> Tuple[str, ...]:
         stats_pairs = self.requests.get_stats().items()


### PR DESCRIPTION
extracted from #966 

builds on https://github.com/ethereum/trinity/pull/1145

### What was wrong?

Need a generic API for retrieving handshake receipts from the `ConnectionAPI`

### How was it fixed?

Added `Connection.get_receipt_by_type`.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

[//]: # (See: https://trinity-client.readthedocs.io/en/latest/contributing.html#pull-requests)
- [x] Add entry to the [release notes](https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![18d18485f548f5d3b750daac8e7ae09a](https://user-images.githubusercontent.com/824194/64985869-1a981280-d883-11e9-9952-07c0102917ae.jpg)

