### PR TITLE
Add more RPC commands for debugging

### DIFF
--- a/trinity/rpc/modules/beacon.py
+++ b/trinity/rpc/modules/beacon.py
@@ -1,10 +1,19 @@
 from typing import Any, Dict
 
 from eth_utils import (
+    decode_hex,
     encode_hex,
+)
+from ssz.tools import (
+    to_formatted_dict,
 )
 
 from eth2.beacon.types.blocks import BeaconBlock
+from eth2.beacon.typing import SigningRoot, Slot
+from trinity.rpc.format import (
+    format_params,
+    to_int_if_hex,
+)
 from trinity.rpc.modules import BeaconChainRPCModule
 
 
@@ -20,3 +29,36 @@ class Beacon(BeaconChainRPCModule):
             block_root=encode_hex(block.signing_root),
             state_root=encode_hex(block.state_root),
         )
+
+    #
+    # Debug
+    #
+    async def getFinalizedHead(self) -> Dict[Any, Any]:
+        """
+        Return finalized head block.
+        """
+        block = await self.chain.coro_get_finalized_head(BeaconBlock)
+        return to_formatted_dict(block, sedes=BeaconBlock)
+
+    @format_params(to_int_if_hex)
+    async def getCanonicalBlockBySlot(self, slot: Slot) -> Dict[Any, Any]:
+        """
+        Return the canonical block of the given slot.
+        """
+        block = await self.chain.coro_get_canonical_block_by_slot(slot, BeaconBlock)
+        return to_formatted_dict(block, sedes=BeaconBlock)
+
+    @format_params(decode_hex)
+    async def getBlockByRoot(self, root: SigningRoot) -> Dict[Any, Any]:
+        """
+        Return the block of given root.
+        """
+        block = await self.chain.coro_get_block_by_root(root, BeaconBlock)
+        return to_formatted_dict(block, sedes=BeaconBlock)
+
+    async def getGenesisBlockRoot(self) -> str:
+        """
+        Return genesis ``SigningRoot`` in hex string.
+        """
+        block_root = await self.chain.coro_get_genesis_block_root()
+        return encode_hex(block_root)


### PR DESCRIPTION
### What was wrong?

Add some non-standardized command for debugging.

### How was it fixed?

Add
- beacon_getFinalizedHead()
- beacon_getCanonicalBlockBySlot(slot: Slot)
- beacon_getBlockByRoot(root: SigningRoot)
- beacon_getGenesisBlockRoot()

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

[//]: # (See: https://trinity-client.readthedocs.io/en/latest/contributing.html#pull-requests)
- [ ] Add entry to the [release notes](https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![dolphin](https://user-images.githubusercontent.com/9263930/65014328-edb23100-d950-11e9-9d09-4dd9eaad535a.jpg)
