### PR TITLE
Fix the way to get `state` in beacon block topic validator

### DIFF
--- a/tests/libp2p/bcc/test_topic_validator.py
+++ b/tests/libp2p/bcc/test_topic_validator.py
@@ -1,9 +1,16 @@
 import pytest
 
+from eth2.beacon.tools.factories import BeaconChainFactory
+
+from trinity.protocol.bcc_libp2p.topic_validators import (
+    get_ancestor_state,
+)
 from trinity.protocol.bcc_libp2p.configs import (
     PUBSUB_TOPIC_BEACON_ATTESTATION,
     PUBSUB_TOPIC_BEACON_BLOCK,
 )
+
+from tests.libp2p.bcc.test_receive_server import get_blocks
 
 
 @pytest.mark.parametrize("num_nodes", (1,))
@@ -14,3 +21,49 @@ async def test_setup_topic_validators(nodes):
     topic_2 = PUBSUB_TOPIC_BEACON_ATTESTATION
     assert topic_1 in node.pubsub.topic_validators
     assert topic_2 in node.pubsub.topic_validators
+
+
+@pytest.mark.parametrize(
+    "num_blocks, block_slots, target_block_slot, latest_finalized_slot, expected_block_slot",
+    (
+        (5, range(5), 1, 0, 0),
+        (5, range(0, 10, 2), 5, 4, 4),
+        (5, range(0, 10, 2), 4, 4, None),
+    ),
+)
+def test_get_ancestor_state(
+    monkeypatch,
+    num_blocks,
+    block_slots,
+    target_block_slot,
+    latest_finalized_slot,
+    expected_block_slot,
+):
+    chain = BeaconChainFactory()
+    blocks = list(get_blocks(chain, num_blocks=num_blocks))
+    for i, slot in enumerate(block_slots):
+        blocks[i] = blocks[i].copy(slot=slot)
+        if i > 0:
+            blocks[i] = blocks[i].copy(parent_root=blocks[i - 1].signing_root)
+    db = {block.signing_root: block for block in blocks}
+
+    def get_block_by_root(root):
+        return db[root]
+
+    def get_state_by_slot(slot):
+        if slot == expected_block_slot:
+            return True
+        return False
+
+    monkeypatch.setattr(chain, "get_block_by_root", get_block_by_root)
+    monkeypatch.setattr(chain, "get_state_by_slot", get_state_by_slot)
+
+    if expected_block_slot is not None:
+        assert get_ancestor_state(
+            chain, blocks[-1], latest_finalized_slot, target_block_slot
+        )
+    else:
+        with pytest.raises(ValueError):
+            get_ancestor_state(
+                chain, blocks[-1], latest_finalized_slot, target_block_slot
+            )

--- a/tests/libp2p/bcc/test_topic_validator.py
+++ b/tests/libp2p/bcc/test_topic_validator.py
@@ -1,16 +1,12 @@
 import pytest
 
 from eth2.beacon.tools.factories import BeaconChainFactory
-
-from trinity.protocol.bcc_libp2p.topic_validators import (
-    get_ancestor_state,
-)
+from tests.libp2p.bcc.test_receive_server import get_blocks
 from trinity.protocol.bcc_libp2p.configs import (
     PUBSUB_TOPIC_BEACON_ATTESTATION,
     PUBSUB_TOPIC_BEACON_BLOCK,
 )
-
-from tests.libp2p.bcc.test_receive_server import get_blocks
+from trinity.protocol.bcc_libp2p.topic_validators import get_ancestor_state
 
 
 @pytest.mark.parametrize("num_nodes", (1,))

--- a/trinity/protocol/bcc_libp2p/topic_validators.py
+++ b/trinity/protocol/bcc_libp2p/topic_validators.py
@@ -22,7 +22,6 @@ from eth2.beacon.types.states import BeaconState
 from eth2.beacon.state_machines.forks.serenity.block_processing import process_block_header
 from eth2.beacon.state_machines.forks.serenity.block_validation import validate_attestation
 from eth2.beacon.typing import Slot
-from eth2.configs import CommitteeConfig
 
 from libp2p.peer.id import ID
 from libp2p.pubsub.pb import rpc_pb2
@@ -81,7 +80,7 @@ def validate_block_signature(chain: BaseBeaconChain,
     )
 
     process_block_header(
-        state, block, CommitteeConfig(state_machine.config), True
+        state, block, state_machine.config, True
     )
 
 

--- a/trinity/protocol/bcc_libp2p/topic_validators.py
+++ b/trinity/protocol/bcc_libp2p/topic_validators.py
@@ -19,11 +19,8 @@ from eth2.beacon.chains.base import BaseBeaconChain
 from eth2.beacon.helpers import compute_start_slot_of_epoch
 from eth2.beacon.types.blocks import BeaconBlock
 from eth2.beacon.types.states import BeaconState
-from eth2.beacon.state_machines.forks.serenity.block_validation import (
-    validate_attestation,
-    validate_proposer_signature,
-    validate_proposer_is_not_slashed,
-)
+from eth2.beacon.state_machines.forks.serenity.block_processing import process_block_header
+from eth2.beacon.state_machines.forks.serenity.block_validation import validate_attestation
 from eth2.beacon.typing import Slot
 from eth2.configs import CommitteeConfig
 
@@ -80,11 +77,8 @@ def validate_block_signature(chain: BaseBeaconChain, block: BeaconBlock) -> None
         future_slot=block.slot,
     )
 
-    validate_proposer_is_not_slashed(
-        state, block.signing_root, CommitteeConfig(state_machine.config)
-    )
-    validate_proposer_signature(
-        state, block, CommitteeConfig(state_machine.config)
+    process_block_header(
+        state, block, CommitteeConfig(state_machine.config), True
     )
 
 


### PR DESCRIPTION
### What was wrong?
L45: `state = chain.get_state_by_slot(block.slot - 1)` will raise error if the state of that slot is not persisted or if the slot is in the future.


### How was it fixed?
We need to get the state with `state.slot < block.slot` where `block` is the block to be validated. So we first check if head state slot is less than `block.slot`, if not then we check head block slot.
If both slots are greater than `block.slot` then we check the ancestor blocks of head block.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

[//]: # (See: https://trinity-client.readthedocs.io/en/latest/contributing.html#pull-requests)
- [ ] Add entry to the [release notes](https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

#### Cute Animal Picture



![](https://pixnio.com/free-images/2018/11/27/2018-11-27-14-37-01-1200x900.jpg)
