### PR TITLE
Use behavior api for eth protocol

### DIFF
--- a/p2p/qualifiers.py
+++ b/p2p/qualifiers.py
@@ -16,10 +16,10 @@ TQualifierFn = TypeVar("TQualifierFn", bound=QualifierFn)
 
 
 class BaseQualifier(ABC):
-    def __and__(self, other: QualifierFn) -> QualifierFn:
+    def __and__(self, other: QualifierFn) -> 'BaseQualifier':
         return AndQualifier(self, other)
 
-    def __or__(self, other: QualifierFn) -> QualifierFn:
+    def __or__(self, other: QualifierFn) -> 'BaseQualifier':
         return OrQualifier(self, other)
 
     @abstractmethod

--- a/tests/core/p2p-proto/test_eth_api.py
+++ b/tests/core/p2p-proto/test_eth_api.py
@@ -1,0 +1,131 @@
+import asyncio
+
+import pytest
+
+from eth.chains.base import MiningChain
+from eth.tools.builder.chain import (
+    build,
+    disable_pow_check,
+    genesis,
+    latest_mainnet_at,
+    mine_block,
+)
+
+from trinity.db.eth1.header import AsyncHeaderDB
+from trinity.protocol.eth.api import ETHAPI
+from trinity.protocol.eth.commands import NewBlock
+from trinity.protocol.eth.handshaker import ETHHandshakeReceipt
+from trinity.protocol.eth.proto import ETHProtocol
+from trinity.tools.factories import (
+    ChainContextFactory,
+    ETHPeerPairFactory,
+)
+
+
+@pytest.fixture
+def bob_chain():
+    chain = build(
+        MiningChain,
+        latest_mainnet_at(0),
+        disable_pow_check(),
+        genesis(),
+    )
+    return chain
+
+
+@pytest.fixture
+def alice_chain(bob_chain):
+    bob_genesis = bob_chain.headerdb.get_canonical_block_header_by_number(0)
+
+    chain = build(
+        MiningChain,
+        latest_mainnet_at(0),
+        disable_pow_check(),
+        genesis(params={"timestamp": bob_genesis.timestamp}),
+    )
+    return chain
+
+
+@pytest.fixture
+async def alice_and_bob(alice_chain, bob_chain):
+    pair_factory = ETHPeerPairFactory(
+        alice_client_version='alice',
+        alice_peer_context=ChainContextFactory(headerdb=AsyncHeaderDB(alice_chain.headerdb.db)),
+        bob_client_version='bob',
+        bob_peer_context=ChainContextFactory(headerdb=AsyncHeaderDB(bob_chain.headerdb.db)),
+    )
+    async with pair_factory as (alice, bob):
+        yield alice, bob
+
+
+@pytest.fixture
+def alice(alice_and_bob):
+    alice, _ = alice_and_bob
+    return alice
+
+
+@pytest.fixture
+def bob(alice_and_bob):
+    _, bob = alice_and_bob
+    return bob
+
+
+@pytest.mark.asyncio
+async def test_eth_api_properties(alice):
+    assert alice.connection.has_logic(ETHAPI.name)
+    eth_api = alice.connection.get_logic(ETHAPI.name, ETHAPI)
+
+    assert eth_api is alice.eth_api
+
+    eth_receipt = alice.connection.get_receipt_by_type(ETHHandshakeReceipt)
+
+    assert eth_api.network_id == eth_receipt.network_id
+    assert eth_api.genesis_hash == eth_receipt.genesis_hash
+
+    assert eth_api.head_info.head_hash == eth_receipt.head_hash
+    assert eth_api.head_info.head_td == eth_receipt.total_difficulty
+    assert not hasattr(eth_api, 'head_number')
+
+
+@pytest.mark.asyncio
+async def test_eth_api_head_info_updates_with_newblock(alice, bob, bob_chain):
+    # mine two blocks on bob's chain
+    bob_chain = build(
+        bob_chain,
+        mine_block(),
+        mine_block(),
+    )
+
+    got_new_block = asyncio.Event()
+
+    async def _handle_new_block(connection, msg):
+        got_new_block.set()
+
+    alice.connection.add_command_handler(NewBlock, _handle_new_block)
+
+    bob_genesis = bob_chain.headerdb.get_canonical_block_header_by_number(0)
+    eth_api = alice.connection.get_logic(ETHAPI.name, ETHAPI)
+
+    assert eth_api.head_info.head_hash == bob_genesis.hash
+    assert eth_api.head_info.head_td == bob_genesis.difficulty
+    assert not hasattr(eth_api.head_info, 'head_number')
+
+    eth_proto = bob.connection.get_protocol_by_type(ETHProtocol)
+    head = bob_chain.get_canonical_head()
+    assert head.block_number == 2
+    head_block = bob_chain.get_block_by_header(head)
+    total_difficulty = bob_chain.headerdb.get_score(head.hash)
+    eth_proto.send_new_block(
+        head,
+        head_block.transactions,
+        head_block.uncles,
+        total_difficulty,
+    )
+
+    await asyncio.wait_for(got_new_block.wait(), timeout=1)
+
+    assert alice.connection.has_logic(ETHAPI.name)
+
+    assert eth_api.head_info.head_hash == head.parent_hash
+    assert eth_api.head_info.head_td == bob_chain.headerdb.get_score(head.parent_hash)
+    assert eth_api.head_info.head_number == 1

--- a/tests/core/p2p-proto/test_les_api.py
+++ b/tests/core/p2p-proto/test_les_api.py
@@ -1,0 +1,129 @@
+import asyncio
+
+import pytest
+
+from eth.chains.base import MiningChain
+from eth.tools.builder.chain import (
+    build,
+    disable_pow_check,
+    genesis,
+    latest_mainnet_at,
+    mine_block,
+)
+
+from trinity.db.eth1.header import AsyncHeaderDB
+from trinity.protocol.les.api import LESAPI
+from trinity.protocol.les.commands import Announce
+from trinity.protocol.les.handshaker import LESHandshakeReceipt
+from trinity.protocol.les.proto import LESProtocolV2
+from trinity.tools.factories import (
+    ChainContextFactory,
+    LESV2PeerPairFactory,
+)
+
+
+@pytest.fixture
+def bob_chain():
+    chain = build(
+        MiningChain,
+        latest_mainnet_at(0),
+        disable_pow_check(),
+        genesis(),
+    )
+    return chain
+
+
+@pytest.fixture
+def alice_headerdb(bob_chain):
+    bob_genesis = bob_chain.headerdb.get_canonical_block_header_by_number(0)
+
+    chain = build(
+        MiningChain,
+        latest_mainnet_at(0),
+        disable_pow_check(),
+        genesis(params={"timestamp": bob_genesis.timestamp}),
+    )
+    return AsyncHeaderDB(chain.headerdb.db)
+
+
+@pytest.fixture
+async def alice_and_bob(alice_headerdb, bob_chain):
+    pair_factory = LESV2PeerPairFactory(
+        alice_client_version='alice',
+        alice_peer_context=ChainContextFactory(headerdb=alice_headerdb),
+        bob_client_version='bob',
+        bob_peer_context=ChainContextFactory(headerdb=AsyncHeaderDB(bob_chain.headerdb.db)),
+    )
+    async with pair_factory as (alice, bob):
+        yield alice, bob
+
+
+@pytest.fixture
+def alice(alice_and_bob):
+    alice, _ = alice_and_bob
+    return alice
+
+
+@pytest.fixture
+def bob(alice_and_bob):
+    _, bob = alice_and_bob
+    return bob
+
+
+@pytest.mark.asyncio
+async def test_les_api_properties(alice):
+    assert alice.connection.has_logic(LESAPI.name)
+    les_api = alice.connection.get_logic(LESAPI.name, LESAPI)
+
+    assert les_api is alice.les_api
+
+    les_receipt = alice.connection.get_receipt_by_type(LESHandshakeReceipt)
+
+    assert les_api.network_id == les_receipt.network_id
+    assert les_api.genesis_hash == les_receipt.genesis_hash
+
+    assert les_api.head_info.head_hash == les_receipt.head_hash
+    assert les_api.head_info.head_td == les_receipt.head_td
+    assert les_api.head_info.head_number == les_receipt.head_number
+
+
+@pytest.mark.asyncio
+async def test_eth_api_head_info_updates_with_announce(alice, bob, bob_chain):
+    # mine two blocks on bob's chain
+    bob_chain = build(
+        bob_chain,
+        mine_block(),
+        mine_block(),
+    )
+
+    got_announce = asyncio.Event()
+
+    async def _handle_announce(connection, msg):
+        got_announce.set()
+
+    alice.connection.add_command_handler(Announce, _handle_announce)
+
+    bob_genesis = bob_chain.headerdb.get_canonical_block_header_by_number(0)
+    les_api = alice.connection.get_logic(LESAPI.name, LESAPI)
+
+    assert les_api.head_info.head_hash == bob_genesis.hash
+    assert les_api.head_info.head_td == bob_genesis.difficulty
+    assert les_api.head_info.head_number == 0
+
+    les_proto = bob.connection.get_protocol_by_type(LESProtocolV2)
+    head = bob_chain.get_canonical_head()
+    assert head.block_number == 2
+    total_difficulty = bob_chain.headerdb.get_score(head.hash)
+    les_proto.send_announce(
+        head.hash,
+        head.block_number,
+        total_difficulty,
+    )
+
+    await asyncio.wait_for(got_announce.wait(), timeout=1)
+
+    assert alice.connection.has_logic(LESAPI.name)
+
+    assert les_api.head_info.head_hash == head.hash
+    assert les_api.head_info.head_td == total_difficulty
+    assert les_api.head_info.head_number == 2

--- a/tests/integration/test_lightchain_integration.py
+++ b/tests/integration/test_lightchain_integration.py
@@ -217,7 +217,7 @@ async def test_lightchain_integration(
 
     assert len(peer_pool) == 1
     peer = peer_pool.highest_td_peer
-    head = await peer_chain.coro_get_block_header_by_hash(peer.head_hash)
+    head = await peer_chain.coro_get_block_header_by_hash(peer.head_info.head_hash)
 
     # In order to answer queries for contract code, geth needs the state trie entry for the block
     # we specify in the query, but because of fast sync we can only assume it has that for recent

--- a/trinity/components/builtin/network_db/eth1_peer_db/tracker.py
+++ b/trinity/components/builtin/network_db/eth1_peer_db/tracker.py
@@ -107,10 +107,10 @@ class BaseEth1PeerTracker(BasePeerBackend, PeerSubscriber):
             remote=peer.remote,
             is_outbound=not peer.inbound,
             last_connected_at=None,
-            genesis_hash=peer.genesis_hash,
+            genesis_hash=peer.chain_info.genesis_hash,
             protocol=peer.sub_proto.name,
             protocol_version=peer.sub_proto.version,
-            network_id=peer.network_id,
+            network_id=peer.chain_info.network_id,
         )
 
     def deregister_peer(self, peer: BasePeer) -> None:
@@ -154,10 +154,10 @@ class BaseEth1PeerTracker(BasePeerBackend, PeerSubscriber):
             remote=peer.remote,
             is_outbound=not peer.inbound,
             last_connected_at=datetime.datetime.utcnow(),
-            genesis_hash=peer.genesis_hash,
+            genesis_hash=peer.chain_info.genesis_hash,
             protocol=peer.sub_proto.name,
             protocol_version=peer.sub_proto.version,
-            network_id=peer.network_id,
+            network_id=peer.chain_info.network_id,
         )
 
     @abstractmethod

--- a/trinity/protocol/common/abc.py
+++ b/trinity/protocol/common/abc.py
@@ -1,0 +1,32 @@
+from abc import ABC, abstractmethod
+
+from eth_typing import BlockNumber, Hash32
+
+
+class ChainInfoAPI(ABC):
+    @property
+    @abstractmethod
+    def network_id(self) -> int:
+        ...
+
+    @property
+    @abstractmethod
+    def genesis_hash(self) -> Hash32:
+        ...
+
+
+class HeadInfoAPI(ABC):
+    @property
+    @abstractmethod
+    def head_td(self) -> int:
+        ...
+
+    @property
+    @abstractmethod
+    def head_hash(self) -> Hash32:
+        ...
+
+    @property
+    @abstractmethod
+    def head_number(self) -> BlockNumber:
+        ...

--- a/trinity/protocol/common/api.py
+++ b/trinity/protocol/common/api.py
@@ -1,0 +1,67 @@
+from typing import Union
+from cached_property import cached_property
+
+from eth_typing import BlockNumber, Hash32
+
+from p2p.logic import Application
+from p2p.qualifiers import HasProtocol
+
+from trinity.protocol.eth.api import ETHAPI
+from trinity.protocol.eth.proto import ETHProtocol
+from trinity.protocol.les.api import LESAPI
+from trinity.protocol.les.proto import LESProtocol, LESProtocolV2
+
+from .abc import ChainInfoAPI, HeadInfoAPI
+
+AnyETHLES = HasProtocol(ETHProtocol) | HasProtocol(LESProtocolV2) | HasProtocol(LESProtocol)
+
+
+class ChainInfo(Application, ChainInfoAPI):
+    name = 'eth1-chain-info'
+
+    qualifier = AnyETHLES
+
+    @cached_property
+    def network_id(self) -> int:
+        return self._get_logic().network_id
+
+    @cached_property
+    def genesis_hash(self) -> Hash32:
+        return self._get_logic().genesis_hash
+
+    def _get_logic(self) -> Union[ETHAPI, LESAPI]:
+        if self.connection.has_protocol(ETHProtocol):
+            return self.connection.get_logic(ETHAPI.name, ETHAPI)
+        elif self.connection.has_protocol(LESProtocolV2) or self.connection.has_protocol(LESProtocol):  # noqa: E501
+            return self.connection.get_logic(LESAPI.name, LESAPI)
+        else:
+            raise Exception("Unreachable code path")
+
+
+class HeadInfo(Application, HeadInfoAPI):
+    name = 'eth1-head-info'
+
+    qualifier = AnyETHLES
+
+    @cached_property
+    def _tracker(self) -> HeadInfoAPI:
+        if self.connection.has_protocol(ETHProtocol):
+            eth_logic = self.connection.get_logic(ETHAPI.name, ETHAPI)
+            return eth_logic.head_info
+        elif self.connection.has_protocol(LESProtocolV2) or self.connection.has_protocol(LESProtocol):  # noqa: E501
+            les_logic = self.connection.get_logic(LESAPI.name, LESAPI)
+            return les_logic.head_info
+        else:
+            raise Exception("Unreachable code path")
+
+    @property
+    def head_td(self) -> int:
+        return self._tracker.head_td
+
+    @property
+    def head_hash(self) -> Hash32:
+        return self._tracker.head_hash
+
+    @property
+    def head_number(self) -> BlockNumber:
+        return self._tracker.head_number

--- a/trinity/protocol/common/boot.py
+++ b/trinity/protocol/common/boot.py
@@ -89,7 +89,7 @@ class DAOCheckBootManager(BasePeerBootManager):
     async def _get_tip_header(self) -> BlockHeader:
         try:
             headers = await self.peer.requests.get_block_headers(
-                self.peer.head_hash,
+                self.peer.head_info.head_hash,
                 max_headers=1,
                 timeout=CHAIN_SPLIT_CHECK_TIMEOUT,
             )

--- a/trinity/protocol/eth/api.py
+++ b/trinity/protocol/eth/api.py
@@ -1,0 +1,83 @@
+from typing import cast, Any, Dict
+
+from cached_property import cached_property
+
+from eth_typing import BlockNumber, Hash32
+
+from p2p.abc import ConnectionAPI
+from p2p.logic import Application, CommandHandler
+from p2p.qualifiers import HasProtocol
+from p2p.typing import Payload
+
+from trinity.protocol.common.abc import HeadInfoAPI
+
+from .commands import NewBlock
+from .handshaker import ETHHandshakeReceipt
+from .proto import ETHProtocol
+
+
+class HeadInfoTracker(CommandHandler, HeadInfoAPI):
+    command_type = NewBlock
+
+    _head_td: int = None
+    _head_hash: Hash32 = None
+    _head_number: BlockNumber = None
+
+    async def handle(self, connection: ConnectionAPI, msg: Payload) -> None:
+        msg = cast(Dict[str, Any], msg)
+        header, _, _ = msg['block']
+        actual_td = msg['total_difficulty'] - header.difficulty
+
+        if actual_td > self.head_td:
+            self._head_hash = header.parent_hash
+            self._head_td = actual_td
+            self._head_number = header.block_number - 1
+
+    #
+    # HeadInfoAPI
+    #
+    @cached_property
+    def _eth_receipt(self) -> ETHHandshakeReceipt:
+        return self.connection.get_receipt_by_type(ETHHandshakeReceipt)
+
+    @property
+    def head_td(self) -> int:
+        if self._head_td is None:
+            self._head_td = self._eth_receipt.total_difficulty
+        return self._head_td
+
+    @property
+    def head_hash(self) -> Hash32:
+        if self._head_hash is None:
+            self._head_hash = self._eth_receipt.head_hash
+        return self._head_hash
+
+    @property
+    def head_number(self) -> BlockNumber:
+        if self._head_number is None:
+            # TODO: fetch on demand using request/response API
+            raise AttributeError("Head block number is not currently known")
+        return self._head_number
+
+
+class ETHAPI(Application):
+    name = 'eth'
+    qualifier = HasProtocol(ETHProtocol)
+
+    head_info: HeadInfoTracker
+
+    def __init__(self) -> None:
+        self.head_info = HeadInfoTracker()
+        self.add_child_behavior(self.head_info.as_behavior())
+
+    @cached_property
+    def receipt(self) -> ETHHandshakeReceipt:
+        return self.connection.get_receipt_by_type(ETHHandshakeReceipt)
+
+    @cached_property
+    def network_id(self) -> int:
+        return self.receipt.network_id
+
+    @cached_property
+    def genesis_hash(self) -> Hash32:
+        return self.receipt.genesis_hash

--- a/trinity/protocol/eth/proto.py
+++ b/trinity/protocol/eth/proto.py
@@ -179,6 +179,22 @@ class ETHProtocol(Protocol):
         header, body = cmd.encode(transactions)
         self.transport.send(header, body)
 
+    #
+    # NewBlock
+    #
+    def send_new_block(self,
+                       block_header: BlockHeaderAPI,
+                       transactions: Sequence[SignedTransactionAPI],
+                       uncles: Sequence[BlockHeaderAPI],
+                       total_difficulty: int) -> None:
+        cmd = NewBlock(self.cmd_id_offset, self.snappy_support)
+        # mypy doesn't recognize the following as a valid `Payload` type
+        header, body = cmd.encode({  # type: ignore
+            'block': (block_header, transactions, uncles),
+            'total_difficulty': total_difficulty,
+        })
+        self.transport.send(header, body)
+
 
 class ProxyETHProtocol:
     """

--- a/trinity/protocol/les/api.py
+++ b/trinity/protocol/les/api.py
@@ -1,0 +1,83 @@
+from typing import cast, Dict, Union
+
+from cached_property import cached_property
+
+from eth_typing import BlockNumber, Hash32
+
+from p2p.abc import ConnectionAPI
+from p2p.logic import Application, CommandHandler
+from p2p.qualifiers import HasProtocol
+from p2p.typing import Payload
+
+from trinity.protocol.common.abc import HeadInfoAPI
+
+from .commands import Announce
+from .handshaker import LESHandshakeReceipt
+from .proto import LESProtocol, LESProtocolV2
+
+
+class HeadInfoTracker(CommandHandler, HeadInfoAPI):
+    command_type = Announce
+
+    _head_td: int = None
+    _head_hash: Hash32 = None
+    _head_number: BlockNumber = None
+
+    async def handle(self, connection: ConnectionAPI, msg: Payload) -> None:
+        head_info = cast(Dict[str, Union[int, Hash32, BlockNumber]], msg)
+        head_td = cast(int, head_info['head_td'])
+        if head_td > self.head_td:
+            self._head_td = head_td
+            self._head_hash = cast(Hash32, head_info['head_hash'])
+            self._head_number = cast(BlockNumber, head_info['head_number'])
+
+    #
+    # HeadInfoAPI
+    #
+    @cached_property
+    def _les_receipt(self) -> LESHandshakeReceipt:
+        return self.connection.get_receipt_by_type(LESHandshakeReceipt)
+
+    @property
+    def head_td(self) -> int:
+        if self._head_td is None:
+            self._head_td = self._les_receipt.head_td
+        return self._head_td
+
+    @property
+    def head_hash(self) -> Hash32:
+        if self._head_hash is None:
+            self._head_hash = self._les_receipt.head_hash
+        return self._head_hash
+
+    @property
+    def head_number(self) -> BlockNumber:
+        if self._head_number is None:
+            self._head_number = self._les_receipt.head_number
+        return self._head_number
+
+
+class LESAPI(Application):
+    name = 'les'
+    qualifier = HasProtocol(LESProtocol) | HasProtocol(LESProtocolV2)
+
+    network_id: int
+    genesis_hash: Hash32
+
+    head_info: HeadInfoTracker
+
+    def __init__(self) -> None:
+        self.head_info = HeadInfoTracker()
+        self.add_child_behavior(self.head_info.as_behavior())
+
+    @property
+    def receipt(self) -> LESHandshakeReceipt:
+        return self.connection.get_receipt_by_type(LESHandshakeReceipt)
+
+    @cached_property
+    def network_id(self) -> int:
+        return self.receipt.network_id
+
+    @cached_property
+    def genesis_hash(self) -> Hash32:
+        return self.receipt.genesis_hash

--- a/trinity/protocol/les/proto.py
+++ b/trinity/protocol/les/proto.py
@@ -4,6 +4,7 @@ from typing import (
     List,
     NamedTuple,
     Optional,
+    Sequence,
     Tuple,
     TYPE_CHECKING,
     Union,
@@ -135,6 +136,23 @@ class LESProtocol(Protocol):
         cmd = Status(self.cmd_id_offset, self.snappy_support)
         self.transport.send(*cmd.encode(resp))
         self.logger.debug("Sending LES/Status msg: %s", resp)
+
+    def send_announce(self,
+                      head_hash: Hash32,
+                      head_number: BlockNumber,
+                      head_td: int,
+                      reorg_depth: int = 0,
+                      params: Sequence[Any] = ()) -> None:
+        data = {
+            'head_hash': head_hash,
+            'head_number': head_number,
+            'head_td': head_td,
+            'reorg_depth': reorg_depth,
+            'params': params,
+        }
+        cmd = Announce(self.cmd_id_offset, self.snappy_support)
+        self.logger.debug("Sending LES/Announce msg: %s", data)
+        self.transport.send(*cmd.encode(data))
 
     def send_get_block_bodies(self, block_hashes: List[bytes], request_id: int=None) -> int:
         if request_id is None:

--- a/trinity/protocol/les/proto.py
+++ b/trinity/protocol/les/proto.py
@@ -25,6 +25,7 @@ from eth_utils import (
     ValidationError,
 )
 
+from eth.abc import BlockHeaderAPI
 from eth.rlp.headers import BlockHeader
 
 from p2p.abc import SessionAPI
@@ -138,14 +139,13 @@ class LESProtocol(Protocol):
         self.logger.debug("Sending LES/Status msg: %s", resp)
 
     def send_announce(self,
-                      head_hash: Hash32,
-                      head_number: BlockNumber,
+                      header: BlockHeaderAPI,
                       head_td: int,
                       reorg_depth: int = 0,
                       params: Sequence[Any] = ()) -> None:
         data = {
-            'head_hash': head_hash,
-            'head_number': head_number,
+            'head_hash': header.hash,
+            'head_number': header.block_number,
             'head_td': head_td,
             'reorg_depth': reorg_depth,
             'params': params,
@@ -201,7 +201,9 @@ class LESProtocol(Protocol):
         return request_id
 
     def send_block_headers(
-            self, headers: Tuple[BlockHeader, ...], buffer_value: int, request_id: int=None) -> int:
+            self, headers: Tuple[BlockHeaderAPI, ...],
+            buffer_value: int,
+            request_id: int=None) -> int:
         if request_id is None:
             request_id = gen_request_id()
         data = {

--- a/trinity/sync/light/service.py
+++ b/trinity/sync/light/service.py
@@ -296,7 +296,7 @@ class LightPeerChain(PeerSubscriber, BaseService, BaseLightPeerChain):
             # our best peer doesn't have the header we want, there are no eligible peers.
             raise NoEligiblePeers(f"Our best peer does not have the header {block_hash}")
 
-        head_number = peer.head_number
+        head_number = peer.les_api.head_info.head_number
         if head_number - header.block_number > MAX_REORG_DEPTH:
             # The peer claims to be far ahead of the header we requested
             if await self.headerdb.coro_get_canonical_block_hash(header.block_number) == block_hash:

--- a/trinity/sync/light/service.py
+++ b/trinity/sync/light/service.py
@@ -296,7 +296,7 @@ class LightPeerChain(PeerSubscriber, BaseService, BaseLightPeerChain):
             # our best peer doesn't have the header we want, there are no eligible peers.
             raise NoEligiblePeers(f"Our best peer does not have the header {block_hash}")
 
-        head_number = peer.les_api.head_info.head_number
+        head_number = peer.head_info.head_number
         if head_number - header.block_number > MAX_REORG_DEPTH:
             # The peer claims to be far ahead of the header we requested
             if await self.headerdb.coro_get_canonical_block_hash(header.block_number) == block_hash:


### PR DESCRIPTION
builds on #1150 

### What was wrong?

We need to get rid of `ETHPeer` and `LESPeer`.  These both have functionality that can be replaced by behaviors.

### How was it fixed?

Create `LESAPI` and `ETHAPI` and move the handling of `NewBlock/Announce` messages into these.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history


#### Cute Animal Picture

![17248b8aad8eb5c834f2206acfb53fd2--corgi-costume-cute-dog-costumes](https://user-images.githubusercontent.com/824194/65067061-e126dc00-d942-11e9-84d1-fccd04e5eea1.jpg)

