### PR TITLE
Add snapcraft.yaml, for building snap packages

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -113,7 +113,6 @@ deps = {
         PYEVM_DEPENDENCY,
         "ssz==0.1.5",
         "milagro-bls-binding==0.1.3",
-        "blspy>=0.1.8,<1",  # for `bls_chia`
     ],
     'eth2-lint': [
         "black==19.3b0",

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,0 +1,28 @@
+name: trinity-client
+base: core18 # the base snap is the execution environment for this snap
+version: '0.1.0-alpha.28'
+summary: An extensible client for the Ethereum network
+description: |
+  Trinity is a client for the Ethereum network with support for beam syncing, which allows
+  interacting with the chain within minutes of starting Trinity.
+
+grade: devel # must be 'stable' to release into candidate/stable channels
+confinement: devmode # use 'strict' once you have the right plugs and slots
+
+parts:
+  trinity:
+    plugin: python
+    python-version: python3
+    source: .
+    stage-packages:
+      - libsnappy-dev
+      - libgmp3-dev
+    build-packages:
+      - git
+
+apps:
+  trinity:
+    command: trinity
+    environment:
+      PYTHONWARNINGS: ignore::DeprecationWarning
+    plugs: [network, network-bind]


### PR DESCRIPTION
At part of https://github.com/ethereum/trinity/issues/1158 I'm experimenting with making installing Trinity a `snap install trinity` away.

To build this:

```bash
$ sudo snap install snapcraft --classic  # installs snapcraft, the snap build tool
$ snapcraft  # (from inside the trinity root dir), this builds the snap
$ sudo snap install --devmode --dangerous trinity-client_0.1.0-alpha.29_amd64.snap
# now you're ready to run trinity!
$ trinity-client.trinity  # This name is ugly, I'm hoping we can get approval for the command to be "trinity"
```

To try out the snap for yourself (I've built the package and uploaded it):

```bash
$ sudo snap install --edge --devmode trinity-client
```

### To-Do

- [ ] After installing the snap it's slower than usual to start, look into why it's slower and whether that's resolvable. 
- [ ] I've asked for the "trinity" name, I should eventually followup if they don't respond.
- [ ] Lahja is failing to connect to itself, so the processes can't talk to each other. Figure out why!
- [ ] Also expose the `trinity-beacon` command and make sure it works.
- [ ] To publish this snap we need to switch to strict confinement, which means somehow giving the snap access to `/dev/shm/sem.*` and `/proc/*/mounts`, those two things are currently failing because of confinement. (Related: https://lists.ubuntu.com/archives/snapcraft/2017-February/003093.html)
- [ ] Add some kind of github action which automatically publishes a snap when master is updated or when a release is made.
- [ ] Add some kind of test that the package builds correctly?

[//]: # (Stay ahead of things, add list items here!)
- [ ] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

[//]: # (See: https://trinity-client.readthedocs.io/en/latest/contributing.html#pull-requests)
- [ ] Add entry to the [release notes](https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses]()
