### PR TITLE
Implement proper handshake crypto

### DIFF
--- a/p2p/discv5/constants.py
+++ b/p2p/discv5/constants.py
@@ -26,6 +26,7 @@ IP_V4_ADDRESS_ENR_KEY = b"ip"
 UDP_PORT_ENR_KEY = b"udp"
 
 WHO_ARE_YOU_MAGIC_SUFFIX = b"WHOAREYOU"
+HKDF_INFO = b"discovery v5 key agreement"
 
 # buffer size used for incoming UDP datagrams (should be larger than MAX_PACKET_SIZE)
 DATAGRAM_BUFFER_SIZE = 2048

--- a/tests-trio/p2p-trio/test_packer.py
+++ b/tests-trio/p2p-trio/test_packer.py
@@ -294,6 +294,7 @@ async def test_peer_packer_sends_who_are_you(peer_packer,
 @pytest.mark.trio
 async def test_peer_packer_sends_auth_header(peer_packer,
                                              enr,
+                                             remote_private_key,
                                              remote_enr,
                                              remote_endpoint,
                                              incoming_packet_channels,


### PR DESCRIPTION
### What was wrong?

Handshake cryptography was stubbed.

### How was it fixed?

Implement proper handshake crypto. The spec isn't very detailed for this part yet, so I had to guess a little: For the key agreement step, I just reused `ecdh_agree` from the old discovery implementation which I think hasn't been changed. For the key expansion step, I guessed the hash function (SHA256, which is used everywhere else). 

#### Cute Animal Picture

![1](https://user-images.githubusercontent.com/29854669/65133209-894faa00-da02-11e9-9e75-1fb38cee978e.jpg)