### PR TITLE
Slightly cleaner shutdown, CancelledError's are expected

### DIFF
--- a/p2p/service.py
+++ b/p2p/service.py
@@ -159,6 +159,8 @@ class BaseService(CancellableMixin, AsyncioServiceAPI):
                 await awaitable
             except OperationCancelled:
                 pass
+            except asyncio.CancelledError:
+                pass
             except Exception as e:
                 self.logger.warning("Task %s finished unexpectedly: %r", awaitable, e)
                 self.logger.debug("Task failure traceback", exc_info=True)


### PR DESCRIPTION
Part of the eth2 `interop` cleanup.

From @lithp 

Catch `CancelledError`


#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://proxy.duckduckgo.com/iu/?u=https%3A%2F%2Ftse3.mm.bing.net%2Fth%3Fid%3DOIP.tlI8TOkpqz1EBeoLrN65qQHaIu%26pid%3DApi&f=1)
