### PR TITLE
Fix bug in crosslink processing

### DIFF
--- a/eth2/beacon/state_machines/forks/serenity/epoch_processing.py
+++ b/eth2/beacon/state_machines/forks/serenity/epoch_processing.py
@@ -266,6 +266,8 @@ def process_crosslinks(state: BeaconState, config: Eth2Config) -> BeaconState:
     current_epoch = state.current_epoch(config.SLOTS_PER_EPOCH)
     previous_epoch = state.previous_epoch(config.SLOTS_PER_EPOCH, config.GENESIS_EPOCH)
 
+    state = state.copy(previous_crosslinks=state.current_crosslinks)
+
     new_current_crosslinks = state.current_crosslinks
 
     for epoch in (previous_epoch, current_epoch):
@@ -296,14 +298,14 @@ def process_crosslinks(state: BeaconState, config: Eth2Config) -> BeaconState:
                 state, attesting_indices, crosslink_committee
             )
             if threshold_met:
-                new_current_crosslinks = update_tuple_item(
-                    new_current_crosslinks, shard, winning_crosslink
+                state = state.copy(
+                    current_crosslinks=update_tuple_item(
+                        new_current_crosslinks, shard, winning_crosslink
+                    )
                 )
+                new_current_crosslinks = state.current_crosslinks
 
-    return state.copy(
-        previous_crosslinks=state.current_crosslinks,
-        current_crosslinks=new_current_crosslinks,
-    )
+    return state
 
 
 def get_attestation_deltas(

--- a/eth2/beacon/state_machines/forks/serenity/epoch_processing.py
+++ b/eth2/beacon/state_machines/forks/serenity/epoch_processing.py
@@ -268,8 +268,6 @@ def process_crosslinks(state: BeaconState, config: Eth2Config) -> BeaconState:
 
     state = state.copy(previous_crosslinks=state.current_crosslinks)
 
-    new_current_crosslinks = state.current_crosslinks
-
     for epoch in (previous_epoch, current_epoch):
         active_validators_indices = get_active_validator_indices(
             state.validators, epoch
@@ -300,10 +298,9 @@ def process_crosslinks(state: BeaconState, config: Eth2Config) -> BeaconState:
             if threshold_met:
                 state = state.copy(
                     current_crosslinks=update_tuple_item(
-                        new_current_crosslinks, shard, winning_crosslink
+                        state.current_crosslinks, shard, winning_crosslink
                     )
                 )
-                new_current_crosslinks = state.current_crosslinks
 
     return state
 


### PR DESCRIPTION
Part of the eth2 interop cleanup.

Fixes a bug due to not respecting the mutability found in the spec definition of `process_crosslinks`.

Crosslinks that can be accepted earlier should be favored over crosslinks that can be accepted later during a single epoch processing.

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://proxy.duckduckgo.com/iu/?u=http%3A%2F%2Fcdn.akc.org%2Fakcdoglovers%2FShibaInu_hero.jpg&f=1&nofb=1)
