### PR TITLE
Standardize how types are printed

### DIFF
--- a/eth2/beacon/types/attestation_data.py
+++ b/eth2/beacon/types/attestation_data.py
@@ -36,10 +36,10 @@ class AttestationData(ssz.Serializable):
 
     def __str__(self) -> str:
         return (
-            f"beacon_block_root={humanize_hash(self.beacon_block_root)[2:10]}"
-            f" source={self.source}"
-            f" target={self.target}"
-            f" | CL={self.crosslink}"
+            f"beacon_block_root={humanize_hash(self.beacon_block_root)},"
+            f" source=({self.source}),"
+            f" target=({self.target}),"
+            f" crosslink=({self.crosslink})"
         )
 
 

--- a/eth2/beacon/types/attestation_data_and_custody_bits.py
+++ b/eth2/beacon/types/attestation_data_and_custody_bits.py
@@ -19,3 +19,6 @@ class AttestationDataAndCustodyBit(ssz.Serializable):
         custody_bit: bool = False,
     ) -> None:
         super().__init__(data=data, custody_bit=custody_bit)
+
+    def __str__(self) -> str:
+        return f"data=({self.data}), custody_bit={'0b1' if self.custody_bit else '0b0'}"

--- a/eth2/beacon/types/attestations.py
+++ b/eth2/beacon/types/attestations.py
@@ -32,9 +32,9 @@ class Attestation(ssz.Serializable):
 
     def __str__(self) -> str:
         return (
-            f"aggregation_bits={self.aggregation_bits},"
+            f"aggregation_bits={str(self.aggregation_bits)},"
             f" data=({self.data}),"
-            f" custody_bits={self.custody_bits},"
+            f" custody_bits={str(self.custody_bits)},"
             f" signature={humanize_hash(self.signature)}"
         )
 
@@ -62,8 +62,8 @@ class IndexedAttestation(ssz.Serializable):
 
     def __str__(self) -> str:
         return (
-            f"custody_bit_0_indices={self.custody_bit_0_indices},"
-            f" custody_bit_1_indices={self.custody_bit_1_indices},"
+            f"custody_bit_0_indices={str(self.custody_bit_0_indices)},"
+            f" custody_bit_1_indices={str(self.custody_bit_1_indices)},"
             f" data=({self.data}),"
             f" signature={humanize_hash(self.signature)}"
         )

--- a/eth2/beacon/types/attestations.py
+++ b/eth2/beacon/types/attestations.py
@@ -1,6 +1,7 @@
 from typing import Sequence
 
 from eth_typing import BLSSignature
+from eth_utils import humanize_hash
 import ssz
 from ssz.sedes import Bitlist, List, bytes96, uint64
 
@@ -29,8 +30,13 @@ class Attestation(ssz.Serializable):
     ) -> None:
         super().__init__(aggregation_bits, data, custody_bits, signature)
 
-    def __repr__(self) -> str:
-        return f"<Attestation {self.data} >"
+    def __str__(self) -> str:
+        return (
+            f"aggregation_bits={self.aggregation_bits},"
+            f" data=({self.data}),"
+            f" custody_bits={self.custody_bits},"
+            f" signature={humanize_hash(self.signature)}"
+        )
 
 
 class IndexedAttestation(ssz.Serializable):
@@ -54,8 +60,13 @@ class IndexedAttestation(ssz.Serializable):
     ) -> None:
         super().__init__(custody_bit_0_indices, custody_bit_1_indices, data, signature)
 
-    def __repr__(self) -> str:
-        return f"<IndexedAttestation {self.data}>"
+    def __str__(self) -> str:
+        return (
+            f"custody_bit_0_indices={self.custody_bit_0_indices},"
+            f" custody_bit_1_indices={self.custody_bit_1_indices},"
+            f" data=({self.data}),"
+            f" signature={humanize_hash(self.signature)}"
+        )
 
 
 default_indexed_attestation = IndexedAttestation()

--- a/eth2/beacon/types/attestations.py
+++ b/eth2/beacon/types/attestations.py
@@ -32,9 +32,9 @@ class Attestation(ssz.Serializable):
 
     def __str__(self) -> str:
         return (
-            f"aggregation_bits={str(self.aggregation_bits)},"
+            f"aggregation_bits={self.aggregation_bits},"
             f" data=({self.data}),"
-            f" custody_bits={str(self.custody_bits)},"
+            f" custody_bits={self.custody_bits},"
             f" signature={humanize_hash(self.signature)}"
         )
 
@@ -62,8 +62,8 @@ class IndexedAttestation(ssz.Serializable):
 
     def __str__(self) -> str:
         return (
-            f"custody_bit_0_indices={str(self.custody_bit_0_indices)},"
-            f" custody_bit_1_indices={str(self.custody_bit_1_indices)},"
+            f"custody_bit_0_indices={self.custody_bit_0_indices},"
+            f" custody_bit_1_indices={self.custody_bit_1_indices},"
             f" data=({self.data}),"
             f" signature={humanize_hash(self.signature)}"
         )

--- a/eth2/beacon/types/attester_slashings.py
+++ b/eth2/beacon/types/attester_slashings.py
@@ -18,3 +18,9 @@ class AttesterSlashing(ssz.Serializable):
         attestation_2: IndexedAttestation = default_indexed_attestation,
     ) -> None:
         super().__init__(attestation_1, attestation_2)
+
+    def __str__(self) -> str:
+        return (
+            f"attestation_1=({self.attestation_1}),"
+            f" attestation_2=({self.attestation_2})"
+        )

--- a/eth2/beacon/types/block_headers.py
+++ b/eth2/beacon/types/block_headers.py
@@ -1,6 +1,6 @@
 from eth.constants import ZERO_HASH32
 from eth_typing import BLSSignature, Hash32
-from eth_utils import encode_hex
+from eth_utils import encode_hex, humanize_hash
 import ssz
 from ssz.sedes import bytes32, bytes96, uint64
 
@@ -37,12 +37,19 @@ class BeaconBlockHeader(ssz.SignedSerializable):
             signature=signature,
         )
 
-    def __repr__(self) -> str:
+    def __str__(self) -> str:
         return (
-            f"<Block #{self.slot} "
-            f"signing_root={encode_hex(self.signing_root)[2:10]} "
-            f"hash_tree_root={encode_hex(self.hash_tree_root)[2:10]}>"
+            f"[signing_root]={humanize_hash(self.signing_root)},"
+            f" [hash_tree_root]={humanize_hash(self.hash_tree_root)},"
+            f" slot={self.slot},"
+            f" parent_root={humanize_hash(self.parent_root)},"
+            f" state_root={humanize_hash(self.state_root)},"
+            f" body_root={humanize_hash(self.body_root)},"
+            f" signature={humanize_hash(self.signature)}"
         )
+
+    def __repr__(self) -> str:
+        return f"<{self.__class__.__name__}: {str(self)}>"
 
 
 default_beacon_block_header = BeaconBlockHeader()

--- a/eth2/beacon/types/block_headers.py
+++ b/eth2/beacon/types/block_headers.py
@@ -1,6 +1,6 @@
 from eth.constants import ZERO_HASH32
 from eth_typing import BLSSignature, Hash32
-from eth_utils import encode_hex, humanize_hash
+from eth_utils import humanize_hash
 import ssz
 from ssz.sedes import bytes32, bytes96, uint64
 

--- a/eth2/beacon/types/blocks.py
+++ b/eth2/beacon/types/blocks.py
@@ -4,7 +4,7 @@ from typing import TYPE_CHECKING, Sequence
 from eth._utils.datatypes import Configurable
 from eth.constants import ZERO_HASH32
 from eth_typing import BLSSignature, Hash32
-from eth_utils import encode_hex, humanize_hash
+from eth_utils import humanize_hash
 import ssz
 from ssz.sedes import List, bytes32, bytes96, uint64
 

--- a/eth2/beacon/types/blocks.py
+++ b/eth2/beacon/types/blocks.py
@@ -4,7 +4,7 @@ from typing import TYPE_CHECKING, Sequence
 from eth._utils.datatypes import Configurable
 from eth.constants import ZERO_HASH32
 from eth_typing import BLSSignature, Hash32
-from eth_utils import encode_hex
+from eth_utils import encode_hex, humanize_hash
 import ssz
 from ssz.sedes import List, bytes32, bytes96, uint64
 
@@ -72,6 +72,21 @@ class BeaconBlockBody(ssz.Serializable):
     def is_empty(self) -> bool:
         return self == BeaconBlockBody()
 
+    def __str__(self) -> str:
+        return (
+            f"randao_reveal={humanize_hash(self.randao_reveal)},"
+            f" graffiti={humanize_hash(self.graffiti)},"
+            f" proposer_slashings={self.proposer_slashings},"
+            f" attester_slashings={self.attester_slashings},"
+            f" attestations={self.attestations},"
+            f" deposits={self.deposits},"
+            f" voluntary_exits={self.voluntary_exits},"
+            f" transfers={self.transfers}"
+        )
+
+    def __repr__(self) -> str:
+        return f"<{self.__class__.__name__}: {str(self)}>"
+
 
 default_beacon_block_body = BeaconBlockBody()
 
@@ -102,15 +117,15 @@ class BaseBeaconBlock(ssz.SignedSerializable, Configurable, ABC):
             signature=signature,
         )
 
-    def __repr__(self) -> str:
+    def __str__(self) -> str:
         return (
-            f"<Block #{self.slot} "
-            f"parent_root={encode_hex(self.parent_root)[2:10]} "
-            f"signing_root={encode_hex(self.signing_root)[2:10]} "
-            f"hash_tree_root={encode_hex(self.hash_tree_root)[2:10]} "
-            f"state_root={encode_hex(self.state_root)[2:10]} "
-            f"attestations={self.body.attestations} "
-            ">"
+            f"[signing_root]={humanize_hash(self.signing_root)},"
+            f" [hash_tree_root]={humanize_hash(self.hash_tree_root)},"
+            f" slot={self.slot},"
+            f" parent_root={humanize_hash(self.parent_root)},"
+            f" state_root={humanize_hash(self.state_root)},"
+            f" body=({self.body}),"
+            f" signature={humanize_hash(self.signature)}"
         )
 
     @property
@@ -136,6 +151,9 @@ class BaseBeaconBlock(ssz.SignedSerializable, Configurable, ABC):
         Return the block denoted by the given block root.
         """
         ...
+
+    def __repr__(self) -> str:
+        return f"<{self.__class__.__name__}: {str(self)}>"
 
 
 class BeaconBlock(BaseBeaconBlock):

--- a/eth2/beacon/types/checkpoints.py
+++ b/eth2/beacon/types/checkpoints.py
@@ -1,4 +1,4 @@
-from eth_utils import encode_hex
+from eth_utils import encode_hex, humanize_hash
 import ssz
 from ssz.sedes import bytes32, uint64
 
@@ -18,7 +18,7 @@ class Checkpoint(ssz.Serializable):
         super().__init__(epoch=epoch, root=root)
 
     def __str__(self) -> str:
-        return f"({self.epoch}, {encode_hex(self.root)[0:8]})"
+        return f"{self.epoch}, {humanize_hash(self.root)}"
 
 
 default_checkpoint = Checkpoint()

--- a/eth2/beacon/types/checkpoints.py
+++ b/eth2/beacon/types/checkpoints.py
@@ -1,4 +1,4 @@
-from eth_utils import encode_hex, humanize_hash
+from eth_utils import humanize_hash
 import ssz
 from ssz.sedes import bytes32, uint64
 

--- a/eth2/beacon/types/compact_committees.py
+++ b/eth2/beacon/types/compact_committees.py
@@ -18,5 +18,8 @@ class CompactCommittee(ssz.Serializable):
     ) -> None:
         super().__init__(pubkeys=pubkeys, compact_validators=compact_validators)
 
+    def __str__(self) -> str:
+        return f"pubkeys={self.pubkeys}, compact_validators={self.compact_validators}"
+
 
 default_compact_committee = CompactCommittee()

--- a/eth2/beacon/types/crosslinks.py
+++ b/eth2/beacon/types/crosslinks.py
@@ -39,17 +39,10 @@ class Crosslink(ssz.Serializable):
 
     def __str__(self) -> str:
         return (
-            f"<Crosslink shard={self.shard}"
-            f" start_epoch={self.start_epoch} end_epoch={self.end_epoch}"
-            f" parent_root={humanize_hash(self.parent_root)}"
-            f" data_root={humanize_hash(self.data_root)}>"
-        )
-
-    def __repr__(self) -> str:
-        return (
-            f"<Crosslink shard={self.shard}"
-            f" start_epoch={self.start_epoch} end_epoch={self.end_epoch}"
-            f" parent_root={encode_hex(self.parent_root)} data_root={encode_hex(self.data_root)}>"
+            f"shard={self.shard},"
+            f" parent_root={humanize_hash(self.parent_root)},"
+            f" start_epoch={self.start_epoch}, end_epoch={self.end_epoch},"
+            f" data_root={humanize_hash(self.data_root)}"
         )
 
 

--- a/eth2/beacon/types/crosslinks.py
+++ b/eth2/beacon/types/crosslinks.py
@@ -1,5 +1,5 @@
 from eth_typing import Hash32
-from eth_utils import encode_hex, humanize_hash
+from eth_utils import humanize_hash
 import ssz
 from ssz.sedes import bytes32, uint64
 

--- a/eth2/beacon/types/deposit_data.py
+++ b/eth2/beacon/types/deposit_data.py
@@ -1,6 +1,6 @@
 from eth.constants import ZERO_HASH32
 from eth_typing import BLSPubkey, BLSSignature, Hash32
-from eth_utils import encode_hex
+from eth_utils import encode_hex, humanize_hash
 import ssz
 from ssz.sedes import bytes32, bytes48, bytes96, uint64
 
@@ -39,8 +39,15 @@ class DepositData(ssz.SignedSerializable):
             signature=signature,
         )
 
+    def __str__(self) -> str:
+        return (
+            f"pubkey={humanize_hash(self.pubkey)},"
+            f" withdrawal_credentials={humanize_hash(self.withdrawal_credentials)},"
+            f" amount={self.amount}, signature={humanize_hash(self.signature)}"
+        )
+
     def __repr__(self) -> str:
-        return f"<DepositData root: {encode_hex(self.hash_tree_root)[0:8]}>"
+        return f"<{self.__class__.__name__}: {str(self)}>"
 
 
 default_deposit_data = DepositData()

--- a/eth2/beacon/types/deposit_data.py
+++ b/eth2/beacon/types/deposit_data.py
@@ -1,6 +1,6 @@
 from eth.constants import ZERO_HASH32
 from eth_typing import BLSPubkey, BLSSignature, Hash32
-from eth_utils import encode_hex, humanize_hash
+from eth_utils import humanize_hash
 import ssz
 from ssz.sedes import bytes32, bytes48, bytes96, uint64
 

--- a/eth2/beacon/types/deposits.py
+++ b/eth2/beacon/types/deposits.py
@@ -2,7 +2,7 @@ from typing import Sequence
 
 from eth.constants import ZERO_HASH32
 from eth_typing import Hash32
-from eth_utils import encode_hex
+from eth_utils import encode_hex, humanize_hash
 import ssz
 from ssz.sedes import Vector, bytes32
 
@@ -36,5 +36,7 @@ class Deposit(ssz.Serializable):
     ) -> None:
         super().__init__(proof, data)
 
-    def __repr__(self) -> str:
-        return f"<Deposit hash_tree_root: {encode_hex(self.hash_tree_root)[0:8]} data: {self.data}>"
+    def __str__(self) -> str:
+        return (
+            f"[hash_tree_root]={humanize_hash(self.hash_tree_root)}, data=({self.data})"
+        )

--- a/eth2/beacon/types/deposits.py
+++ b/eth2/beacon/types/deposits.py
@@ -2,7 +2,7 @@ from typing import Sequence
 
 from eth.constants import ZERO_HASH32
 from eth_typing import Hash32
-from eth_utils import encode_hex, humanize_hash
+from eth_utils import humanize_hash
 import ssz
 from ssz.sedes import Vector, bytes32
 

--- a/eth2/beacon/types/eth1_data.py
+++ b/eth2/beacon/types/eth1_data.py
@@ -1,5 +1,6 @@
 from eth.constants import ZERO_HASH32
 from eth_typing import Hash32
+from eth_utils import humanize_hash
 import ssz
 from ssz.sedes import bytes32, uint64
 
@@ -22,6 +23,13 @@ class Eth1Data(ssz.Serializable):
             deposit_root=deposit_root,
             deposit_count=deposit_count,
             block_hash=block_hash,
+        )
+
+    def __str__(self) -> str:
+        return (
+            f"deposit_root={humanize_hash(self.deposit_root)},"
+            f" deposit_count={self.deposit_count},"
+            f" block_hash={humanize_hash(self.block_hash)}"
         )
 
 

--- a/eth2/beacon/types/forks.py
+++ b/eth2/beacon/types/forks.py
@@ -1,3 +1,4 @@
+from eth_utils import humanize_hash
 import ssz
 from ssz.sedes import bytes4, uint64
 
@@ -25,6 +26,13 @@ class Fork(ssz.Serializable):
             previous_version=previous_version,
             current_version=current_version,
             epoch=epoch,
+        )
+
+    def __str__(self) -> str:
+        return (
+            f"previous_version={humanize_hash(self.previous_version)},"
+            f" current_version={humanize_hash(self.current_version)},"
+            f" epoch={self.epoch}"
         )
 
 

--- a/eth2/beacon/types/pending_attestations.py
+++ b/eth2/beacon/types/pending_attestations.py
@@ -32,7 +32,7 @@ class PendingAttestation(ssz.Serializable):
 
     def __str__(self) -> str:
         return (
-            f"aggregation_bits={self.aggregation_bits},"
+            f"aggregation_bits={str(self.aggregation_bits)},"
             f" data=({self.data}),"
             f" inclusion_delay={self.inclusion_delay},"
             f" proposer_index={self.proposer_index}"

--- a/eth2/beacon/types/pending_attestations.py
+++ b/eth2/beacon/types/pending_attestations.py
@@ -30,5 +30,10 @@ class PendingAttestation(ssz.Serializable):
             proposer_index=proposer_index,
         )
 
-    def __repr__(self) -> str:
-        return f"<PendingAttestation inclusion_delay={self.inclusion_delay} data={self.data}>"
+    def __str__(self) -> str:
+        return (
+            f"aggregation_bits={self.aggregation_bits},"
+            f" data=({self.data}),"
+            f" inclusion_delay={self.inclusion_delay},"
+            f" proposer_index={self.proposer_index}"
+        )

--- a/eth2/beacon/types/pending_attestations.py
+++ b/eth2/beacon/types/pending_attestations.py
@@ -32,7 +32,7 @@ class PendingAttestation(ssz.Serializable):
 
     def __str__(self) -> str:
         return (
-            f"aggregation_bits={str(self.aggregation_bits)},"
+            f"aggregation_bits={self.aggregation_bits},"
             f" data=({self.data}),"
             f" inclusion_delay={self.inclusion_delay},"
             f" proposer_index={self.proposer_index}"

--- a/eth2/beacon/types/proposer_slashings.py
+++ b/eth2/beacon/types/proposer_slashings.py
@@ -27,3 +27,10 @@ class ProposerSlashing(ssz.Serializable):
         super().__init__(
             proposer_index=proposer_index, header_1=header_1, header_2=header_2
         )
+
+    def __str__(self) -> str:
+        return (
+            f"proposer_index={self.proposer_index},"
+            f" header_1=({self.header_1}),"
+            f" header_2=({self.header_2})"
+        )

--- a/eth2/beacon/types/states.py
+++ b/eth2/beacon/types/states.py
@@ -2,7 +2,7 @@ from typing import Any, Callable, Sequence
 
 from eth.constants import ZERO_HASH32
 from eth_typing import Hash32
-from eth_utils import encode_hex
+from eth_utils import encode_hex, humanize_hash
 import ssz
 from ssz.sedes import Bitvector, List, Vector, bytes32, uint64
 
@@ -191,8 +191,10 @@ class BeaconState(ssz.Serializable):
             finalized_checkpoint=finalized_checkpoint,
         )
 
-    def __repr__(self) -> str:
-        return f"<BeaconState #{self.slot} {encode_hex(self.hash_tree_root)[2:10]}>"
+    def __str__(self) -> str:
+        return (
+            f"[hash_tree_root]={humanize_hash(self.hash_tree_root)}, slot={self.slot}"
+        )
 
     @property
     def validator_count(self) -> int:

--- a/eth2/beacon/types/states.py
+++ b/eth2/beacon/types/states.py
@@ -2,7 +2,7 @@ from typing import Any, Callable, Sequence
 
 from eth.constants import ZERO_HASH32
 from eth_typing import Hash32
-from eth_utils import encode_hex, humanize_hash
+from eth_utils import humanize_hash
 import ssz
 from ssz.sedes import Bitvector, List, Vector, bytes32, uint64
 

--- a/eth2/beacon/types/transfers.py
+++ b/eth2/beacon/types/transfers.py
@@ -1,4 +1,5 @@
 from eth_typing import BLSPubkey, BLSSignature
+from eth_utils import humanize_hash
 import ssz
 from ssz.sedes import bytes48, bytes96, uint64
 
@@ -46,3 +47,19 @@ class Transfer(ssz.SignedSerializable):
             pubkey=pubkey,
             signature=signature,
         )
+
+    def __str__(self) -> str:
+        return (
+            f"[signing_root]={humanize_hash(self.signing_root)},"
+            f" [hash_tree_root]={humanize_hash(self.hash_tree_root)},"
+            f" sender={self.sender},"
+            f" recipient={self.recipient},"
+            f" amount={self.amount},"
+            f" fee={self.fee},"
+            f" slot={self.slot},"
+            f" pubkey={humanize_hash(self.pubkey)},"
+            f" signature={humanize_hash(self.signature)}"
+        )
+
+    def __repr__(self) -> str:
+        return f"<{self.__class__.__name__}: {str(self)}>"

--- a/eth2/beacon/types/validators.py
+++ b/eth2/beacon/types/validators.py
@@ -1,4 +1,5 @@
 from eth_typing import BLSPubkey, Hash32
+from eth_utils import humanize_hash
 import ssz
 from ssz.sedes import boolean, bytes32, bytes48, uint64
 
@@ -51,7 +52,7 @@ class Validator(ssz.Serializable):
         activation_eligibility_epoch: Epoch = default_epoch,
         activation_epoch: Epoch = default_epoch,
         exit_epoch: Epoch = default_epoch,
-        withdrawable_epoch: Epoch = default_epoch
+        withdrawable_epoch: Epoch = default_epoch,
     ) -> None:
         super().__init__(
             pubkey=pubkey,
@@ -101,4 +102,16 @@ class Validator(ssz.Serializable):
             activation_epoch=FAR_FUTURE_EPOCH,
             exit_epoch=FAR_FUTURE_EPOCH,
             withdrawable_epoch=FAR_FUTURE_EPOCH,
+        )
+
+    def __str__(self) -> str:
+        return (
+            f"pubkey={humanize_hash(self.pubkey)},"
+            f" withdrawal_credentials={humanize_hash(self.withdrawal_credentials)},"
+            f" effective_balance={self.effective_balance},"
+            f" slashed={self.slashed},"
+            f" activation_eligibility_epoch={self.activation_eligibility_epoch},"
+            f" activation_epoch={self.activation_epoch},"
+            f" exit_epoch={self.exit_epoch},"
+            f" withdrawable_epoch={self.withdrawable_epoch}"
         )

--- a/eth2/beacon/types/voluntary_exits.py
+++ b/eth2/beacon/types/voluntary_exits.py
@@ -1,4 +1,5 @@
 from eth_typing import BLSSignature
+from eth_utils import humanize_hash
 import ssz
 from ssz.sedes import bytes96, uint64
 
@@ -24,3 +25,13 @@ class VoluntaryExit(ssz.SignedSerializable):
         signature: BLSSignature = EMPTY_SIGNATURE,
     ) -> None:
         super().__init__(epoch, validator_index, signature)
+
+    def __str__(self) -> str:
+        return (
+            f"epoch={self.epoch},"
+            f" validator_index={self.validator_index},"
+            f" signature={humanize_hash(self.signature)}"
+        )
+
+    def __repr__(self) -> str:
+        return f"<{self.__class__.__name__}: {str(self)}>"

--- a/eth2/beacon/typing.py
+++ b/eth2/beacon/typing.py
@@ -6,7 +6,14 @@ Slot = NewType("Slot", int)  # uint64
 Epoch = NewType("Epoch", int)  # uint64
 Shard = NewType("Shard", int)  # uint64
 
-Bitfield = NewType("Bitfield", Tuple[bool, ...])
+
+class Bitfield(Tuple[bool, ...]):
+    def __new__(self, *args):
+        return tuple.__new__(Bitfield, *args)
+
+    def __str__(self) -> str:
+        elems = map(lambda elem: "1" if elem else "0", self)
+        return f"0b{''.join(elems)}"
 
 
 ValidatorIndex = NewType("ValidatorIndex", int)  # uint64

--- a/eth2/beacon/typing.py
+++ b/eth2/beacon/typing.py
@@ -1,4 +1,4 @@
-from typing import NamedTuple, NewType, Tuple
+from typing import Any, NamedTuple, NewType, Sequence, Tuple
 
 from eth_typing import Hash32
 
@@ -8,7 +8,7 @@ Shard = NewType("Shard", int)  # uint64
 
 
 class Bitfield(Tuple[bool, ...]):
-    def __new__(self, *args):
+    def __new__(self, *args: Sequence[Any]) -> "Bitfield":
         return tuple.__new__(Bitfield, *args)
 
     def __str__(self) -> str:

--- a/tox.ini
+++ b/tox.ini
@@ -185,6 +185,10 @@ commands=
 deps = {[common-lint-eth2]deps}
 commands= {[common-lint-eth2]commands}
 
+[testenv:py37-lint-eth2]
+deps = {[common-lint-eth2]deps}
+commands= {[common-lint-eth2]commands}
+
 [testenv:py36-eth2-fixtures]
 deps = .[eth2,test]
 commands=


### PR DESCRIPTION
Part of the eth2 interop cleanup.

### What was wrong?

This PR attempts to standardize how types are printed.

I'd prefer to start from a uniform base and then deviate from this format when/if it is necessary.

### How was it fixed?

Fixing how types print.

Adds a `__str__` for a `Bitfield` type, although it seems to only apply through one application of `__str__`, not recursively.

### TODO

- [x] Remove unnecessary `__str__` (thanks @carver !)
- [ ] Calls to `str(TYPE)` via the `logging` package do not seem to apply `str` recursively, only once... consult the `logging` docs to see if we can fix this behavior to improve the logs

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://proxy.duckduckgo.com/iu/?u=https%3A%2F%2Ft1.ea.ltmcdn.com%2Fen%2Fimages%2F1%2F6%2F9%2Fimg_how_to_stop_my_shiba_inu_from_biting_me_961_600.jpg&f=1&nofb=1)
