### PR TITLE
Add dockerfile for trinity build

### DIFF
--- a/Dockerfile.eth2
+++ b/Dockerfile.eth2
@@ -1,0 +1,18 @@
+FROM python:3.7
+# Set up code directory
+RUN mkdir -p /usr/src/app
+WORKDIR /usr/src/app
+
+COPY . /usr/src/app
+
+# Install deps
+RUN apt-get update
+RUN apt-get -y install libsnappy-dev gcc g++ cmake
+
+RUN pip install -e .[dev]  --no-cache-dir
+RUN pip install -U trinity --no-cache-dir
+
+RUN echo "Type \`trinity-beacon\` to boot or \`trinity-beacon --help\` for an overview of commands"
+
+EXPOSE 30303 30303/udp
+ENTRYPOINT ["trinity-beacon"]

--- a/Dockerfile.eth2
+++ b/Dockerfile.eth2
@@ -1,18 +1,18 @@
 FROM python:3.7
-# Set up code directory
+
 RUN mkdir -p /usr/src/app
 WORKDIR /usr/src/app
-
-COPY . /usr/src/app
 
 # Install deps
 RUN apt-get update
 RUN apt-get -y install libsnappy-dev gcc g++ cmake
 
-RUN pip install -e .[dev]  --no-cache-dir
+ARG GITREF=interop
+
+RUN git clone https://github.com/ethereum/trinity.git .
+RUN git checkout $GITREF && pip install -e .[dev] --no-cache-dir
 RUN pip install -U trinity --no-cache-dir
 
-RUN echo "Type \`trinity-beacon\` to boot or \`trinity-beacon --help\` for an overview of commands"
-
 EXPOSE 30303 30303/udp
-ENTRYPOINT ["trinity-beacon"]
+# Trinity shutdowns aren't yet solid enough to avoid the fix-unclean-shutdown
+ENTRYPOINT trinity $EXTRA_OPTS fix-unclean-shutdown && trinity-beacon $EXTRA_OPTS


### PR DESCRIPTION
Part of the eth2 interop cleanup.

Adds dockerfile specifically for the beacon node.

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://proxy.duckduckgo.com/iu/?u=http%3A%2F%2Fd21vu35cjx7sd4.cloudfront.net%2Fdims3%2FMMAH%2Fcrop%2F0x0%2B0%2B0%2Fresize%2F645x380%2Fquality%2F90%2F%3Furl%3Dhttp%3A%2F%2Fs3.amazonaws.com%2Fassets.prod.vetstreet.com%2F05%2Fae6220a81c11e0a0d50050568d634f%2Ffile%2FShiba-Inu-5-645mk070111.jpg&f=1&nofb=1)
