### PR TITLE
Update to PetersburgVM and quiet noisy logging

### DIFF
--- a/tests/core/tx-pool/test_tx_pool.py
+++ b/tests/core/tx-pool/test_tx_pool.py
@@ -83,7 +83,7 @@ async def test_tx_propagation(event_bus,
 
             await asyncio.sleep(0.01)
             assert outgoing_tx == [
-                (node_two, txs_broadcasted_by_peer1),
+                (node_two, tuple(txs_broadcasted_by_peer1)),
             ]
             # Clear the recording, we asserted all we want and would like to have a fresh start
             outgoing_tx.clear()
@@ -118,7 +118,7 @@ async def test_tx_propagation(event_bus,
 
             # Check that Peer1 receives only the one tx that it didn't know about
             assert outgoing_tx == [
-                (node_one, [txs_broadcasted_by_peer2[0]]),
+                (node_one, (txs_broadcasted_by_peer2[0],)),
             ]
 
 
@@ -154,7 +154,7 @@ async def test_does_not_propagate_invalid_tx(event_bus,
 
         # Check that Peer2 received only the second tx which is valid
         assert outgoing_tx == [
-            (node_two, [txs_broadcasted_by_peer1[1]]),
+            (node_two, (txs_broadcasted_by_peer1[1],)),
         ]
 
 

--- a/trinity/components/builtin/tx_pool/component.py
+++ b/trinity/components/builtin/tx_pool/component.py
@@ -7,10 +7,10 @@ import asyncio
 from lahja import EndpointAPI
 
 from eth.chains.mainnet import (
-    BYZANTIUM_MAINNET_BLOCK,
+    PETERSBURG_MAINNET_BLOCK,
 )
 from eth.chains.ropsten import (
-    BYZANTIUM_ROPSTEN_BLOCK,
+    PETERSBURG_ROPSTEN_BLOCK,
 )
 
 from trinity._utils.shutdown import exit_with_services
@@ -78,9 +78,9 @@ class TxComponent(AsyncioIsolatedComponent):
         chain = chain_config.full_chain_class(db)
 
         if self.boot_info.trinity_config.network_id == MAINNET_NETWORK_ID:
-            validator = DefaultTransactionValidator(chain, BYZANTIUM_MAINNET_BLOCK)
+            validator = DefaultTransactionValidator(chain, PETERSBURG_MAINNET_BLOCK)
         elif self.boot_info.trinity_config.network_id == ROPSTEN_NETWORK_ID:
-            validator = DefaultTransactionValidator(chain, BYZANTIUM_ROPSTEN_BLOCK)
+            validator = DefaultTransactionValidator(chain, PETERSBURG_ROPSTEN_BLOCK)
         else:
             raise ValueError("The TxPool component only supports MainnetChain or RopstenChain")
 


### PR DESCRIPTION
### What was wrong?

- The transaction pool was validating against the Byzantium VM
- The transaction pool dominated the DEBUG logs with one of it's logging statements.

### How was it fixed?

- Updated the block number for validation.
- Quiet the logging statement to be `DEBUG2`

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history

#### Cute Animal Picture

![324deec531b486e015782a620a7e4c5e](https://user-images.githubusercontent.com/824194/65262690-1f99d380-dac8-11e9-98f7-3bc00ab019fb.jpg)

