### PR TITLE
Add ConnectionAPI.has_protocol

### DIFF
--- a/newsfragments/1181.feature.rst
+++ b/newsfragments/1181.feature.rst
@@ -1,0 +1,1 @@
+The ``ConnectionAPI`` now has a mirrored version of ``MultiplexerAPI.has_protocol`` via ``ConnectionAPI.has_protocol``

--- a/p2p/abc.py
+++ b/p2p/abc.py
@@ -552,6 +552,10 @@ class ConnectionAPI(AsyncioServiceAPI):
     # Protocol APIS
     #
     @abstractmethod
+    def has_protocol(self, protocol_identifier: Union[ProtocolAPI, Type[ProtocolAPI]]) -> bool:
+        ...
+
+    @abstractmethod
     def get_protocols(self) -> Tuple[ProtocolAPI, ...]:
         ...
 

--- a/p2p/connection.py
+++ b/p2p/connection.py
@@ -8,6 +8,7 @@ from typing import (
     Set,
     Tuple,
     Type,
+    Union,
 )
 
 from cached_property import cached_property
@@ -244,6 +245,9 @@ class Connection(ConnectionAPI, BaseService):
     #
     # Protocol APIS
     #
+    def has_protocol(self, protocol_identifier: Union[ProtocolAPI, Type[ProtocolAPI]]) -> bool:
+        return self._multiplexer.has_protocol(protocol_identifier)
+
     def get_protocols(self) -> Tuple[ProtocolAPI, ...]:
         return self._multiplexer.get_protocols()
 


### PR DESCRIPTION
### What was wrong?

The `Multiplexer.has_protocol` API is useful to mirror on the connection

### How was it fixed?

Added `Connection.has_protocol`

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

[//]: # (See: https://trinity-client.readthedocs.io/en/latest/contributing.html#pull-requests)
- [x] Add entry to the [release notes](https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![6a8a8db960b90d445166d63355b62b69](https://user-images.githubusercontent.com/824194/65271587-b3749b00-dada-11e9-9fd5-30aeb3168918.jpg)

