### PR TITLE
Use secrets.choice over random.choice

### DIFF
--- a/trinity/protocol/common/peer.py
+++ b/trinity/protocol/common/peer.py
@@ -1,6 +1,6 @@
 from abc import abstractmethod
 import operator
-import random
+import secrets
 from typing import (
     Dict,
     List,
@@ -133,7 +133,7 @@ class BaseChainPeerPool(BasePeerPool):
             raise NoConnectedPeers("No connected peers")
         peers_by_td = groupby(operator.attrgetter('head_td'), peers)
         max_td = max(peers_by_td.keys())
-        return random.choice(peers_by_td[max_td])
+        return secrets.choice(peers_by_td[max_td])
 
     def get_peers(self, min_td: int) -> List[BaseChainPeer]:
         # TODO: Consider turning this into a method that returns an AsyncIterator, to make it


### PR DESCRIPTION
### What was wrong?

Use of `random.choice` when we now have the better option of `secrets.choice`

### How was it fixed?

Changed to use `secrets.choice`


#### Cute Animal Picture

![dog-costume-with-guitar-2](https://user-images.githubusercontent.com/824194/65271734-fdf61780-dada-11e9-8b60-05aa47c5d63b.jpg)

