### PR TITLE
Mirror ETH/LES handshake params on receipts

### DIFF
--- a/trinity/protocol/eth/handshaker.py
+++ b/trinity/protocol/eth/handshaker.py
@@ -1,5 +1,8 @@
 from typing import cast, Any, Dict
 
+from cached_property import cached_property
+
+from eth_typing import Hash32
 from eth_utils import encode_hex
 
 from p2p.abc import MultiplexerAPI, ProtocolAPI
@@ -21,6 +24,26 @@ class ETHHandshakeReceipt(HandshakeReceipt):
     def __init__(self, protocol: ETHProtocol, handshake_params: ETHHandshakeParams) -> None:
         super().__init__(protocol)
         self.handshake_params = handshake_params
+
+    @cached_property
+    def head_hash(self) -> Hash32:
+        return self.handshake_params.head_hash
+
+    @cached_property
+    def genesis_hash(self) -> Hash32:
+        return self.handshake_params.genesis_hash
+
+    @cached_property
+    def network_id(self) -> int:
+        return self.handshake_params.network_id
+
+    @cached_property
+    def total_difficulty(self) -> int:
+        return self.handshake_params.total_difficulty
+
+    @cached_property
+    def version(self) -> int:
+        return self.handshake_params.version
 
 
 class ETHHandshaker(Handshaker):

--- a/trinity/protocol/les/handshaker.py
+++ b/trinity/protocol/les/handshaker.py
@@ -6,6 +6,9 @@ from typing import (
     Union,
 )
 
+from cached_property import cached_property
+
+from eth_typing import BlockNumber, Hash32
 from eth_utils import encode_hex
 
 from p2p.abc import MultiplexerAPI, ProtocolAPI
@@ -35,6 +38,26 @@ class LESHandshakeReceipt(HandshakeReceipt):
                  ) -> None:
         super().__init__(protocol)
         self.handshake_params = handshake_params
+
+    @cached_property
+    def network_id(self) -> int:
+        return self.handshake_params.network_id
+
+    @cached_property
+    def head_td(self) -> int:
+        return self.handshake_params.head_td
+
+    @cached_property
+    def head_hash(self) -> Hash32:
+        return self.handshake_params.head_hash
+
+    @cached_property
+    def head_number(self) -> BlockNumber:
+        return self.handshake_params.head_number
+
+    @cached_property
+    def genesis_hash(self) -> Hash32:
+        return self.handshake_params.genesis_hash
 
 
 class BaseLESHandshaker(Handshaker):
@@ -66,7 +89,7 @@ class BaseLESHandshaker(Handshaker):
                 network_id=msg['networkId'],
                 head_td=msg['headTd'],
                 head_hash=msg['headHash'],
-                head_num=msg['headNum'],
+                head_number=msg['headNum'],
                 genesis_hash=msg['genesisHash'],
                 serve_headers=('serveHeaders' in msg),
                 serve_chain_since=msg.get('serveChainSince'),

--- a/trinity/protocol/les/peer.py
+++ b/trinity/protocol/les/peer.py
@@ -83,7 +83,7 @@ class LESPeer(BaseChainPeer):
         receipt = self.connection.get_receipt_by_type(LESHandshakeReceipt)
         self.head_td = receipt.handshake_params.head_td
         self.head_hash = receipt.handshake_params.head_hash
-        self.head_number = receipt.handshake_params.head_num
+        self.head_number = receipt.handshake_params.head_number
         self.genesis_hash = receipt.handshake_params.genesis_hash
         self.network_id = receipt.handshake_params.network_id
 
@@ -149,7 +149,7 @@ class LESPeerFactory(BaseChainPeerFactory):
             network_id=self.context.network_id,
             head_td=total_difficulty,
             head_hash=head.hash,
-            head_num=head.block_number,
+            head_number=head.block_number,
             genesis_hash=genesis_hash,
             serve_headers=True,
             # TODO: these should be configurable to allow us to serve this data.

--- a/trinity/protocol/les/proto.py
+++ b/trinity/protocol/les/proto.py
@@ -64,7 +64,7 @@ class LESHandshakeParams(NamedTuple):
     network_id: int
     head_td: int
     head_hash: Hash32
-    head_num: BlockNumber
+    head_number: BlockNumber
     genesis_hash: Hash32
     serve_headers: bool
     serve_chain_since: Optional[BlockNumber]
@@ -86,7 +86,7 @@ class LESHandshakeParams(NamedTuple):
         yield 'networkId', self.network_id
         yield 'headTd', self.head_td
         yield 'headHash', self.head_hash
-        yield 'headNum', self.head_num
+        yield 'headNum', self.head_number
         yield 'genesisHash', self.genesis_hash
         if self.serve_headers is True:
             yield 'serveHeaders', None

--- a/trinity/tools/factories.py
+++ b/trinity/tools/factories.py
@@ -184,7 +184,7 @@ class LESHandshakeParamsFactory(factory.Factory):
     network_id = MAINNET_NETWORK_ID
     head_td = GENESIS_DIFFICULTY
     head_hash = MAINNET_GENESIS_HASH
-    head_num = GENESIS_BLOCK_NUMBER
+    head_number = GENESIS_BLOCK_NUMBER
     genesis_hash = MAINNET_GENESIS_HASH
     serve_headers = True
     serve_chain_since = 0


### PR DESCRIPTION
### What was wrong?

There are attributes of the handshake params that are useful to have available on the receipt.

### How was it fixed?

Mirror them using `cached_property`

#### Cute Animal Picture

![the-world_s-top-10-best-images-of-animals-dressed-as-spider-man-4](https://user-images.githubusercontent.com/824194/65271857-3564c400-dadb-11e9-908a-70cf6e4c7253.jpg)

