### PR TITLE
Update tests to use PetersburgVM

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -26,7 +26,7 @@ from eth.chains.base import (
 from eth.db.atomic import AtomicDB
 # TODO: tests should not be locked into one set of VM rules.  Look at expanding
 # to all mainnet vms.
-from eth.vm.forks.spurious_dragon import SpuriousDragonVM
+from eth.vm.forks.petersburg import PetersburgVM
 
 from lahja import (
     ConnectionConfig,
@@ -193,7 +193,7 @@ def _chain_with_block_validation(base_db, genesis_state, chain_cls=Chain):
     klass = chain_cls.configure(
         __name__='TestChain',
         vm_configuration=(
-            (eth_constants.GENESIS_BLOCK_NUMBER, SpuriousDragonVM),
+            (eth_constants.GENESIS_BLOCK_NUMBER, PetersburgVM),
         ),
         chain_id=1337,
     )
@@ -245,11 +245,11 @@ def chain_without_block_validation(
         'import_block': import_block_without_validation,
         'validate_block': lambda self, block: None,
     }
-    SpuriousDragonVMForTesting = SpuriousDragonVM.configure(validate_seal=lambda block: None)
+    PetersburgVMForTesting = PetersburgVM.configure(validate_seal=lambda block: None)
     klass = MiningChain.configure(
         __name__='TestChainWithoutBlockValidation',
         vm_configuration=(
-            (eth_constants.GENESIS_BLOCK_NUMBER, SpuriousDragonVMForTesting),
+            (eth_constants.GENESIS_BLOCK_NUMBER, PetersburgVMForTesting),
         ),
         chain_id=1337,
         **overrides,


### PR DESCRIPTION
### What was wrong?

The test suite has been running against Spurious Dragon.

### How was it fixed?

Updated to Petersburg

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

[//]: # (See: https://trinity-client.readthedocs.io/en/latest/contributing.html#pull-requests)
- [ ] Add entry to the [release notes](https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses]()
