### PR TITLE
Handshake timeout

### DIFF
--- a/p2p/discv5/constants.py
+++ b/p2p/discv5/constants.py
@@ -35,4 +35,5 @@ MAX_REQUEST_ID = 2**32 - 1  # highest request id used for outgoing requests
 MAX_REQUEST_ID_ATTEMPTS = 100  # number of attempts we take to guess a available request id
 
 REQUEST_RESPONSE_TIMEOUT = 0.5  # timeout for waiting for response after request was sent
+HANDSHAKE_TIMEOUT = 1  # timeout for performing a handshake
 ROUTING_TABLE_PING_INTERVAL = 5  # interval of outgoing pings sent to maintain the routing table

--- a/p2p/discv5/packer.py
+++ b/p2p/discv5/packer.py
@@ -619,12 +619,12 @@ class Packer(Service):
             raise ValueError(
                 "Peer packer for {encode_hex(remote_node_id)} has already been started"
             ) from lifecycle_error
-        except HandshakeFailure as handshake_failure:
+        except HandshakeFailure:
             # peer packer has logged a warning already
             self.logger.debug(
                 "Peer packer %s has failed to do handshake with %s",
                 managed_peer_packer.peer_packer,
-                handshake_failure,
+                encode_hex(remote_node_id),
             )
         finally:
             self.logger.info("Deregistering peer packer %s", managed_peer_packer.peer_packer)

--- a/p2p/discv5/packer.py
+++ b/p2p/discv5/packer.py
@@ -583,9 +583,9 @@ class Packer(Service):
             enr_db=self.enr_db,
             message_type_registry=self.message_type_registry,
             incoming_packet_receive_channel=incoming_packet_channels[1],
-            incoming_message_send_channel=self.incoming_message_send_channel,
+            incoming_message_send_channel=self.incoming_message_send_channel.clone(),
             outgoing_message_receive_channel=outgoing_message_channels[1],
-            outgoing_packet_send_channel=self.outgoing_packet_send_channel,
+            outgoing_packet_send_channel=self.outgoing_packet_send_channel.clone(),
         )
 
         manager = Manager(peer_packer)

--- a/p2p/discv5/routing_table_manager.py
+++ b/p2p/discv5/routing_table_manager.py
@@ -407,12 +407,12 @@ class RoutingTableManager(Service):
         )
 
     async def run(self) -> None:
-        components = (
+        child_services = (
             self.ping_handler,
             self.find_node_handler,
             self.ping_sender,
         )
-        for component in components:
-            self.manager.run_daemon_task(component.run)
+        for child_service in child_services:
+            self.manager.run_daemon_child_service(child_service)
 
         await self.manager.wait_cancelled()

--- a/p2p/discv5/routing_table_manager.py
+++ b/p2p/discv5/routing_table_manager.py
@@ -54,7 +54,7 @@ from p2p.discv5.typing import (
 class BaseRoutingTableManagerComponent(Service):
     """Base class for services that participate in managing the routing table."""
 
-    logger = logging.getLogger("p2p.discv5.routing_table_manager.BaseRoutingTableManager")
+    logger = logging.getLogger("p2p.discv5.routing_table_manager.BaseRoutingTableManagerComponent")
 
     def __init__(self,
                  local_node_id: NodeID,
@@ -192,10 +192,10 @@ class BaseRoutingTableManagerComponent(Service):
             await self.enr_db.insert_or_update(enr)
 
 
-class PingHandler(BaseRoutingTableManagerComponent):
+class PingHandlerService(BaseRoutingTableManagerComponent):
     """Responds to Pings with Pongs and requests ENR updates."""
 
-    logger = logging.getLogger("p2p.discv5.routing_table_manager.PingHandler")
+    logger = logging.getLogger("p2p.discv5.routing_table_manager.PingHandlerService")
 
     def __init__(self,
                  local_node_id: NodeID,
@@ -243,10 +243,10 @@ class PingHandler(BaseRoutingTableManagerComponent):
         await self.outgoing_message_send_channel.send(outgoing_message)
 
 
-class FindNodeHandler(BaseRoutingTableManagerComponent):
+class FindNodeHandlerService(BaseRoutingTableManagerComponent):
     """Responds to FindNode with Nodes messages."""
 
-    logger = logging.getLogger("p2p.discv5.routing_table_manager.PingHandler")
+    logger = logging.getLogger("p2p.discv5.routing_table_manager.FindNodeHandlerService")
 
     def __init__(self,
                  local_node_id: NodeID,
@@ -296,10 +296,10 @@ class FindNodeHandler(BaseRoutingTableManagerComponent):
         await self.outgoing_message_send_channel.send(outgoing_message)
 
 
-class PingSender(BaseRoutingTableManagerComponent):
+class PingSenderService(BaseRoutingTableManagerComponent):
     """Regularly sends pings to peers to check if they are still alive or not."""
 
-    logger = logging.getLogger("p2p.discv5.routing_table_manager.RoutingTableMaintainer")
+    logger = logging.getLogger("p2p.discv5.routing_table_manager.PingSenderService")
 
     def __init__(self,
                  local_node_id: NodeID,
@@ -393,24 +393,24 @@ class RoutingTableManager(Service):
             "enr_db": enr_db,
         })
 
-        self.ping_handler = PingHandler(
+        self.ping_handler_service = PingHandlerService(
             outgoing_message_send_channel=outgoing_message_send_channel,
             **shared_component_kwargs,
         )
-        self.find_node_handler = FindNodeHandler(
+        self.find_node_handler_service = FindNodeHandlerService(
             outgoing_message_send_channel=outgoing_message_send_channel,
             **shared_component_kwargs,
         )
-        self.ping_sender = PingSender(
+        self.ping_sender_service = PingSenderService(
             endpoint_vote_send_channel=endpoint_vote_send_channel,
             **shared_component_kwargs,
         )
 
     async def run(self) -> None:
         child_services = (
-            self.ping_handler,
-            self.find_node_handler,
-            self.ping_sender,
+            self.ping_handler_service,
+            self.find_node_handler_service,
+            self.ping_sender_service,
         )
         for child_service in child_services:
             self.manager.run_daemon_child_service(child_service)

--- a/tests-trio/p2p-trio/test_routing_table_manager.py
+++ b/tests-trio/p2p-trio/test_routing_table_manager.py
@@ -32,9 +32,9 @@ from p2p.discv5.routing_table import (
     FlatRoutingTable,
 )
 from p2p.discv5.routing_table_manager import (
-    FindNodeHandler,
-    PingHandler,
-    PingSender,
+    FindNodeHandlerService,
+    PingHandlerService,
+    PingSenderService,
 )
 
 from p2p.tools.factories.discovery import (
@@ -113,62 +113,62 @@ async def message_dispatcher(enr_db, incoming_message_channels, outgoing_message
 
 
 @pytest_trio.trio_fixture
-async def ping_handler(local_enr,
-                       routing_table,
-                       message_dispatcher,
-                       enr_db,
-                       incoming_message_channels,
-                       outgoing_message_channels):
-    ping_handler = PingHandler(
+async def ping_handler_service(local_enr,
+                               routing_table,
+                               message_dispatcher,
+                               enr_db,
+                               incoming_message_channels,
+                               outgoing_message_channels):
+    ping_handler_service = PingHandlerService(
         local_node_id=local_enr.node_id,
         routing_table=routing_table,
         message_dispatcher=message_dispatcher,
         enr_db=enr_db,
         outgoing_message_send_channel=outgoing_message_channels[0],
     )
-    async with background_service(ping_handler):
-        yield ping_handler
+    async with background_service(ping_handler_service):
+        yield ping_handler_service
 
 
 @pytest_trio.trio_fixture
-async def find_node_handler(local_enr,
-                            routing_table,
-                            message_dispatcher,
-                            enr_db,
-                            incoming_message_channels,
-                            outgoing_message_channels,
-                            endpoint_vote_channels):
-    find_node_handler = FindNodeHandler(
+async def find_node_handler_service(local_enr,
+                                    routing_table,
+                                    message_dispatcher,
+                                    enr_db,
+                                    incoming_message_channels,
+                                    outgoing_message_channels,
+                                    endpoint_vote_channels):
+    find_node_handler_service = FindNodeHandlerService(
         local_node_id=local_enr.node_id,
         routing_table=routing_table,
         message_dispatcher=message_dispatcher,
         enr_db=enr_db,
         outgoing_message_send_channel=outgoing_message_channels[0],
     )
-    async with background_service(find_node_handler):
-        yield ping_handler
+    async with background_service(find_node_handler_service):
+        yield find_node_handler_service
 
 
 @pytest_trio.trio_fixture
-async def ping_sender(local_enr,
-                      routing_table,
-                      message_dispatcher,
-                      enr_db,
-                      incoming_message_channels,
-                      endpoint_vote_channels):
-    ping_sender = PingSender(
+async def ping_sender_service(local_enr,
+                              routing_table,
+                              message_dispatcher,
+                              enr_db,
+                              incoming_message_channels,
+                              endpoint_vote_channels):
+    ping_sender_service = PingSenderService(
         local_node_id=local_enr.node_id,
         routing_table=routing_table,
         message_dispatcher=message_dispatcher,
         enr_db=enr_db,
         endpoint_vote_send_channel=endpoint_vote_channels[0],
     )
-    async with background_service(ping_sender):
-        yield ping_sender
+    async with background_service(ping_sender_service):
+        yield ping_sender_service
 
 
 @pytest.mark.trio
-async def test_ping_handler_sends_pong(ping_handler,
+async def test_ping_handler_sends_pong(ping_handler_service,
                                        incoming_message_channels,
                                        outgoing_message_channels,
                                        local_enr):
@@ -186,7 +186,7 @@ async def test_ping_handler_sends_pong(ping_handler,
 
 
 @pytest.mark.trio
-async def test_ping_handler_updates_routing_table(ping_handler,
+async def test_ping_handler_updates_routing_table(ping_handler_service,
                                                   incoming_message_channels,
                                                   outgoing_message_channels,
                                                   local_enr,
@@ -208,7 +208,7 @@ async def test_ping_handler_updates_routing_table(ping_handler,
 
 
 @pytest.mark.trio
-async def test_ping_handler_requests_updated_enr(ping_handler,
+async def test_ping_handler_requests_updated_enr(ping_handler_service,
                                                  incoming_message_channels,
                                                  outgoing_message_channels,
                                                  local_enr,
@@ -239,7 +239,7 @@ async def test_ping_handler_requests_updated_enr(ping_handler,
 
 
 @pytest.mark.trio
-async def test_find_node_handler_sends_nodes(find_node_handler,
+async def test_find_node_handler_sends_nodes(find_node_handler_service,
                                              incoming_message_channels,
                                              outgoing_message_channels,
                                              local_enr):
@@ -256,7 +256,7 @@ async def test_find_node_handler_sends_nodes(find_node_handler,
 
 
 @pytest.mark.trio
-async def test_send_ping(ping_sender,
+async def test_send_ping(ping_sender_service,
                          routing_table,
                          incoming_message_channels,
                          outgoing_message_channels,
@@ -272,7 +272,7 @@ async def test_send_ping(ping_sender,
 
 
 @pytest.mark.trio
-async def test_send_endpoint_vote(ping_sender,
+async def test_send_endpoint_vote(ping_sender_service,
                                   routing_table,
                                   incoming_message_channels,
                                   outgoing_message_channels,


### PR DESCRIPTION
### What was wrong?

During handshake, the peer packer was waiting indefinitely for a response.

### How was it fixed?

Raise a `HandshakeFailure` if the handshake takes longer than `1s` (as suggested by the spec).

I also fixed some other small issues:

- use a lock in the peer packer to ensure that we don't send and receive messages simultaneously. This makes the code a little bit simpler.
- `clone` the channels that are shared between multiple peer packers
- use child services instead of tasks in the routing table manager

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://user-images.githubusercontent.com/29854669/65516072-a1cb3300-dee0-11e9-9f8c-6417298150fd.jpg)