### PR TITLE
Increase task pruning timeout

### DIFF
--- a/tests/core/task-queue-utils/test_ordered_task_preparation.py
+++ b/tests/core/task-queue-utils/test_ordered_task_preparation.py
@@ -655,7 +655,7 @@ async def test_pruning_speed():
 
     # make sure pruning was fast enough
     duration = time.perf_counter() - start
-    assert duration < 0.0001
+    assert duration < 0.001
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
### What was wrong?

`test_pruning_speed` was a spurious failure for this test run: https://circleci.com/gh/ethereum/trinity/124946

### How was it fixed?

The timeout was increased. Hopefully it'll now fail less often.

#### Cute Animal Picture

![speedrunner](https://user-images.githubusercontent.com/466333/65554152-94607980-dedd-11e9-8608-e4939f522ab9.png)
