### PR TITLE
Implement gather function with trio

### DIFF
--- a/p2p/trio_utils.py
+++ b/p2p/trio_utils.py
@@ -1,0 +1,49 @@
+import asyncio
+import operator
+from typing import (
+    Any,
+    Awaitable,
+    Callable,
+    Iterable,
+    Tuple,
+    Union,
+)
+
+import trio
+
+
+AsyncFnsAndArgsType = Union[
+    Callable[..., Awaitable[Any]],
+    Tuple[Any, ...],
+]
+
+
+async def gather(*async_fns_and_args: AsyncFnsAndArgsType) -> Tuple[Any, ...]:
+    """Run a collection of async functions in parallel and collect their results.
+
+    The results will be in the same order as the corresponding async functions.
+    """
+    indices_and_results = []
+
+    async def get_result(index: int) -> None:
+        async_fn_and_args = async_fns_and_args[index]
+        if isinstance(async_fn_and_args, Iterable):
+            async_fn, *args = async_fn_and_args
+        elif asyncio.iscoroutinefunction(async_fn_and_args):
+            async_fn = async_fn_and_args
+            args = []
+        else:
+            raise TypeError(
+                "Each argument must be either an async function or a tuple consisting of an "
+                "async function followed by its arguments"
+            )
+
+        result = await async_fn(*args)
+        indices_and_results.append((index, result))
+
+    async with trio.open_nursery() as nursery:
+        for index in range(len(async_fns_and_args)):
+            nursery.start_soon(get_result, index)
+
+    indices_and_results_sorted = sorted(indices_and_results, key=operator.itemgetter(0))
+    return tuple(result for _, result in indices_and_results_sorted)

--- a/tests-trio/p2p-trio/test_trio_utils.py
+++ b/tests-trio/p2p-trio/test_trio_utils.py
@@ -1,0 +1,44 @@
+import pytest
+
+import trio
+
+from p2p.trio_utils import (
+    gather,
+)
+
+
+@pytest.mark.trio
+async def test_empty_gather():
+    result = await gather()
+    assert result == ()
+
+    with trio.testing.assert_checkpoints():
+        await gather()
+
+
+@pytest.mark.trio
+async def test_gather_sorted(autojump_clock):
+    async def f(return_value, sleep_time):
+        await trio.sleep(sleep_time)
+        return return_value
+
+    results = await gather(
+        (f, 0, 0.1),
+        (f, 1, 0.2),
+        (f, 2, 0.05),
+    )
+    assert results == (0, 1, 2)
+
+
+@pytest.mark.trio
+async def test_gather_args():
+    async def return_args(*args):
+        await trio.hazmat.checkpoint()
+        return args
+
+    results = await gather(
+        return_args,
+        (return_args,),
+        (return_args, 1, 2, 3)
+    )
+    assert results == ((), (), (1, 2, 3))


### PR DESCRIPTION
### What was wrong?

Running a bunch of tasks in parallel is easy with trio using nurseries. Getting their return values however is surprisingly cumbersome.

One use case where this is needed in discv5 is during the handling of `FINDNODE` requests: We get up to 16 node ids from the routing table and now have to get the corresponding ENRs from the ENR db which we'd like to do in parallel instead of sequentially.

### How was it fixed?

Implement a function similar to [`asyncio.gather`](https://docs.python.org/3/library/asyncio-task.html#asyncio.gather) that runs async functions in parallel and returns the results as a tuple.

The `FINDNODE` example would be a simple one liner:

```Py
enrs = gather((enr_db.get, node_id) for node_id in node_ids)
```

I've deviated a little from the asyncio API:

- Accept tuples of the form `(async_fn, *args)` as arguments instead of awaitable objects. This mirrors the `nursery.start_soon` syntax.
- Don't implement the `return_exceptions` argument. I'm not sure if it is needed and I didn't want to think about how this would look like with trio's multi errors at the moment.

Unfortunately, I have not managed to come up with an appropriate type hint.

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://user-images.githubusercontent.com/29854669/65606397-1c608500-dfab-11e9-8a04-47c3dc48b0e8.jpg)