### PR TITLE
Fix run beacon nodes

### DIFF
--- a/eth2/beacon/scripts/run_beacon_nodes.py
+++ b/eth2/beacon/scripts/run_beacon_nodes.py
@@ -7,7 +7,16 @@ from pathlib import Path
 import signal
 import sys
 import time
-from typing import ClassVar, Dict, List, MutableSet, NamedTuple, Optional, Tuple
+from typing import (
+    ClassVar,
+    Dict,
+    List,
+    MutableSet,
+    NamedTuple,
+    Optional,
+    Tuple,
+    Sequence,
+)
 
 from eth_utils import encode_hex, remove_0x_prefix
 from libp2p.crypto.secp256k1 import Secp256k1PrivateKey
@@ -62,19 +71,22 @@ class Node:
         name: str,
         node_privkey: str,
         port: int,
+        start_time: float,
+        validators: Sequence[int],
         rpcport: Optional[int] = None,
         preferred_nodes: Optional[Tuple["Node", ...]] = None,
     ) -> None:
         self.name = name
         self.node_privkey = Secp256k1PrivateKey.new(bytes.fromhex(node_privkey))
         self.port = port
+        self.validators = validators
         if preferred_nodes is None:
             preferred_nodes = []
         self.preferred_nodes = preferred_nodes
         self.rpcport = rpcport
 
         self.tasks = []
-        self.start_time = time.monotonic()
+        self.start_time = start_time
         self.logs_expected = {}
         self.logs_expected["stdout"] = set()
         self.logs_expected["stderr"] = set()
@@ -88,7 +100,7 @@ class Node:
 
     @property
     def logging_name(self) -> str:
-        return f"{self.name}@{str(self.peer_id)}"
+        return f"{self.name}@{str(self.peer_id)[:5]}"
 
     @property
     def root_dir(self) -> Path:
@@ -108,14 +120,11 @@ class Node:
     def cmd(self) -> str:
         _cmds = [
             "trinity-beacon",
-            f"--port={self.port}",
             f"--trinity-root-dir={self.root_dir}",
             f"--beacon-nodekey={remove_0x_prefix(encode_hex(self.node_privkey.to_bytes()))}",
+            f"--port={self.port}",
             f"--rpcport={self.rpcport}",
-            "--disable-discovery",
             "--enable-http",
-            "--network-tracking-backend=do-not-track",
-            "--disable-upnp",
             "-l debug2",
         ]
         if len(self.preferred_nodes) != 0:
@@ -123,6 +132,12 @@ class Node:
                 [str(node.maddr) for node in self.preferred_nodes]
             )
             _cmds.append(f"--preferred_nodes={preferred_nodes_str}")
+        _cmds += [
+            "interop",
+            f"--validators={','.join([str(v) for v in self.validators])}",
+            f"--start-time={self.start_time}",
+            "--wipedb",
+        ]
         _cmd = " ".join(_cmds)
         return _cmd
 
@@ -191,25 +206,12 @@ class Node:
 
 async def main():
     num_validators = 9
-    genesis_delay = 20
+    start_delay = 20
+    start_time = int(time.time()) + start_delay
 
     proc = await run(f"rm -rf {Node.dir_root}")
     await proc.wait()
     proc = await run(f"mkdir -p {Node.dir_root}")
-    await proc.wait()
-
-    print("Generating genesis file")
-    proc = await run(
-        " ".join(
-            (
-                "trinity-beacon",
-                "testnet",
-                f"--num={num_validators}",
-                f"--network-dir={Node.dir_root}",
-                f"--genesis-delay={genesis_delay}",
-            )
-        )
-    )
     await proc.wait()
 
     def sigint_handler(sig, frame):
@@ -223,15 +225,21 @@ async def main():
         node_privkey="6b94ffa2d9b8ee85afb9d7153c463ea22789d3bbc5d961cc4f63a41676883c19",
         port=30304,
         preferred_nodes=[],
+        validators=[0, 1, 2, 3, 4, 5, 6, 7],
         rpcport=8555,
+        start_time=start_time,
     )
     node_bob = Node(
         name="bob",
         node_privkey="f5ad1c57b5a489fc8f21ad0e5a19c1f1a60b8ab357a2100ff7e75f3fa8a4fd2e",
         port=30305,
         preferred_nodes=[node_alice],
+        validators=[8, 9, 10, 11, 12, 13, 14, 15],
         rpcport=8666,
+        start_time=start_time,
     )
+    print(node_alice.cmd)
+    print(node_bob.cmd)
 
     asyncio.ensure_future(node_alice.run())
     asyncio.ensure_future(node_bob.run())

--- a/eth2/beacon/scripts/run_beacon_nodes.py
+++ b/eth2/beacon/scripts/run_beacon_nodes.py
@@ -14,8 +14,8 @@ from typing import (
     MutableSet,
     NamedTuple,
     Optional,
-    Tuple,
     Sequence,
+    Tuple,
 )
 
 from eth_utils import encode_hex, remove_0x_prefix
@@ -120,21 +120,15 @@ class Node:
     def cmd(self) -> str:
         _cmds = [
             "trinity-beacon",
+            f"--port={self.port}",
             f"--trinity-root-dir={self.root_dir}",
             f"--beacon-nodekey={remove_0x_prefix(encode_hex(self.node_privkey.to_bytes()))}",
-            f"--port={self.port}",
+            f"--preferred_nodes={','.join(str(node.maddr) for node in self.preferred_nodes)}",
             f"--rpcport={self.rpcport}",
             "--enable-http",
             "-l debug2",
-        ]
-        if len(self.preferred_nodes) != 0:
-            preferred_nodes_str = ",".join(
-                [str(node.maddr) for node in self.preferred_nodes]
-            )
-            _cmds.append(f"--preferred_nodes={preferred_nodes_str}")
-        _cmds += [
             "interop",
-            f"--validators={','.join([str(v) for v in self.validators])}",
+            f"--validators={','.join(str(v) for v in self.validators)}",
             f"--start-time={self.start_time}",
             "--wipedb",
         ]
@@ -205,7 +199,6 @@ class Node:
 
 
 async def main():
-    num_validators = 9
     start_delay = 20
     start_time = int(time.time()) + start_delay
 
@@ -238,8 +231,6 @@ async def main():
         rpcport=8666,
         start_time=start_time,
     )
-    print(node_alice.cmd)
-    print(node_bob.cmd)
 
     asyncio.ensure_future(node_alice.run())
     asyncio.ensure_future(node_bob.run())

--- a/trinity/components/builtin/json_rpc/component.py
+++ b/trinity/components/builtin/json_rpc/component.py
@@ -3,7 +3,7 @@ from argparse import (
     _SubParsersAction,
 )
 import asyncio
-from typing import Union
+from typing import Union, Tuple
 
 from lahja import EndpointAPI
 
@@ -42,6 +42,7 @@ from trinity.rpc.http import (
 from trinity._utils.shutdown import (
     exit_with_services,
 )
+from p2p.service import BaseService
 
 
 class JsonRpcServerComponent(AsyncioIsolatedComponent):
@@ -125,7 +126,7 @@ class JsonRpcServerComponent(AsyncioIsolatedComponent):
         # Run IPC Server
         ipc_server = IPCServer(rpc, self.boot_info.trinity_config.jsonrpc_ipc_path)
         asyncio.ensure_future(ipc_server.run())
-        services_to_exit = (
+        services_to_exit: Tuple[BaseService, ...] = (
             ipc_server,
             self._event_bus_service,
         )

--- a/trinity/components/eth2/interop/component.py
+++ b/trinity/components/eth2/interop/component.py
@@ -143,8 +143,7 @@ class InteropComponent(BaseMainProcessComponent):
         now = int(time.time())
         if args.start_time:
             if args.start_time <= now:
-                logger.info(f"--start-time must be a time in the future. Current time is {now}")
-                sys.exit(1)
+                logger.warning(f"--start-time must be a time in the future. Current time is {now}")
 
             delta = args.start_time - now
             logger.info("Time will begin %d seconds from now", delta)

--- a/trinity/rpc/http.py
+++ b/trinity/rpc/http.py
@@ -78,8 +78,8 @@ class HTTPServer(BaseService):
         await runner.setup()
         site = web.TCPSite(runner, self.host, self.port)
         await site.start()
-
-        await self.cancel_token.wait()
+        self.logger.info('HTTP started at: %s', site.name)
+        await self.cancellation()
 
     async def _cleanup(self) -> None:
         await self.server.shutdown()


### PR DESCRIPTION
### What was wrong?

`python eth2/beacon/scripts/run_beacon_nodes.py` breaks after interops merged.

### How was it fixed?

- Use the new interops command in `run_beacon_nodes`
- Also fix a jsonrpc component bug

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://preview.redd.it/v2pbjnt0nwo31.jpg?width=640&crop=smart&auto=webp&s=a116aec6bfb46ba373423f0d137af93dbec01adf)
