### PR TITLE
Upgrade ipython to 7.8.0 which supports async / await

### DIFF
--- a/newsfragments/1203.feature.rst
+++ b/newsfragments/1203.feature.rst
@@ -1,0 +1,2 @@
+Upgrade `ipython` shell to `7.8.0` which supports `async` / `await` hence improves
+the UI/UX of `trinity attach` and `trinity db-shell`.

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ deps = {
         "coincurve>=10.0.0,<11.0.0",
         "dataclasses>=0.6, <1;python_version<'3.7'",
         "eth-utils>=1.7,<2",
-        "ipython>=6.2.1,<7.0.0",
+        "ipython>=7.8.0,<8.0.0",
         "plyvel==1.0.5",
         PYEVM_DEPENDENCY,
         "web3==4.4.1",


### PR DESCRIPTION
### What was wrong?

IPython >7 supports `async` / `await` which enhances the usefulness of trinitys REPLs

### How was it fixed?

Upgraded to newer version.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

[//]: # (See: https://trinity-client.readthedocs.io/en/latest/contributing.html#pull-requests)
- [x] Add entry to the [release notes](https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://live.staticflickr.com/7429/11331139983_ef02d9a843_b.jpg)
