### PR TITLE
Use Kademlia Routing Table

### DIFF
--- a/p2p/discv5/constants.py
+++ b/p2p/discv5/constants.py
@@ -39,3 +39,4 @@ HANDSHAKE_TIMEOUT = 1  # timeout for performing a handshake
 ROUTING_TABLE_PING_INTERVAL = 5  # interval of outgoing pings sent to maintain the routing table
 
 NUM_ROUTING_TABLE_BUCKETS = 256  # number of buckets in the routing table
+ROUTING_TABLE_BUCKET_SIZE = 16  # size of each bucket in the routing table

--- a/p2p/discv5/routing_table.py
+++ b/p2p/discv5/routing_table.py
@@ -2,6 +2,7 @@ import collections
 import functools
 import itertools
 import logging
+import random
 import secrets
 from typing import (
     Any,
@@ -260,3 +261,15 @@ class KademliaRoutingTable:
         sorted_node_ids = sorted(all_node_ids, key=distance_to_reference)
         for node_id in sorted_node_ids:
             yield node_id
+
+    def get_random_node(self) -> NodeID:
+        if self.is_empty:
+            raise ValueError("The routing table is empty")
+
+        bucket = random.choices(
+            self.buckets,
+            weights=tuple(len(bucket) for bucket in self.buckets),
+        )[0]
+        node_id = random.choice(bucket)
+
+        return node_id

--- a/p2p/discv5/routing_table_manager.py
+++ b/p2p/discv5/routing_table_manager.py
@@ -44,7 +44,7 @@ from p2p.discv5.messages import (
     PongMessage,
 )
 from p2p.discv5.routing_table import (
-    FlatRoutingTable,
+    KademliaRoutingTable,
 )
 from p2p.discv5.typing import (
     NodeID,
@@ -58,7 +58,7 @@ class BaseRoutingTableManagerComponent(Service):
 
     def __init__(self,
                  local_node_id: NodeID,
-                 routing_table: FlatRoutingTable,
+                 routing_table: KademliaRoutingTable,
                  message_dispatcher: MessageDispatcherAPI,
                  enr_db: EnrDbApi,
                  ) -> None:
@@ -73,7 +73,7 @@ class BaseRoutingTableManagerComponent(Service):
         This method should be called, whenever we receive a message from them.
         """
         self.logger.debug("Updating %s in routing table", encode_hex(node_id))
-        self.routing_table.add_or_update(node_id)
+        self.routing_table.update(node_id)
 
     async def get_local_enr(self) -> ENR:
         """Get the local enr from the ENR DB."""
@@ -199,7 +199,7 @@ class PingHandlerService(BaseRoutingTableManagerComponent):
 
     def __init__(self,
                  local_node_id: NodeID,
-                 routing_table: FlatRoutingTable,
+                 routing_table: KademliaRoutingTable,
                  message_dispatcher: MessageDispatcherAPI,
                  enr_db: EnrDbApi,
                  outgoing_message_send_channel: SendChannel[OutgoingMessage]
@@ -250,7 +250,7 @@ class FindNodeHandlerService(BaseRoutingTableManagerComponent):
 
     def __init__(self,
                  local_node_id: NodeID,
-                 routing_table: FlatRoutingTable,
+                 routing_table: KademliaRoutingTable,
                  message_dispatcher: MessageDispatcherAPI,
                  enr_db: EnrDbApi,
                  outgoing_message_send_channel: SendChannel[OutgoingMessage]
@@ -303,7 +303,7 @@ class PingSenderService(BaseRoutingTableManagerComponent):
 
     def __init__(self,
                  local_node_id: NodeID,
-                 routing_table: FlatRoutingTable,
+                 routing_table: KademliaRoutingTable,
                  message_dispatcher: MessageDispatcherAPI,
                  enr_db: EnrDbApi,
                  endpoint_vote_send_channel: SendChannel[EndpointVote]
@@ -315,8 +315,8 @@ class PingSenderService(BaseRoutingTableManagerComponent):
         while True:
             deadline = trio.current_time() + ROUTING_TABLE_PING_INTERVAL
 
-            if len(self.routing_table) > 0:
-                node_id = self.routing_table.get_oldest_entry()
+            if not self.routing_table.is_empty:
+                node_id = self.routing_table.get_random_node()
                 self.logger.debug("Pinging %s", encode_hex(node_id))
                 await self.ping(node_id)
             else:
@@ -374,7 +374,7 @@ class RoutingTableManager(Service):
 
     def __init__(self,
                  local_node_id: NodeID,
-                 routing_table: FlatRoutingTable,
+                 routing_table: KademliaRoutingTable,
                  message_dispatcher: MessageDispatcherAPI,
                  enr_db: EnrDbApi,
                  outgoing_message_send_channel: SendChannel[OutgoingMessage],
@@ -382,7 +382,7 @@ class RoutingTableManager(Service):
                  ) -> None:
         SharedComponentKwargType = TypedDict("SharedComponentKwargType", {
             "local_node_id": NodeID,
-            "routing_table": FlatRoutingTable,
+            "routing_table": KademliaRoutingTable,
             "message_dispatcher": MessageDispatcherAPI,
             "enr_db": EnrDbApi,
         })

--- a/tests/p2p/discv5/test_kademlia_routing_table.py
+++ b/tests/p2p/discv5/test_kademlia_routing_table.py
@@ -171,3 +171,17 @@ def test_get_nodes_at_log_distance(routing_table, center_node_id, bucket_size):
         routing_table.update(node_id)
 
     assert set(routing_table.get_nodes_at_log_distance(200)) == set(nodes)
+
+
+def test_get_random_node(routing_table):
+    with pytest.raises(ValueError):
+        routing_table.get_random_node()
+
+    node_id_1 = NodeIDFactory()
+    routing_table.update(node_id_1)
+    assert routing_table.get_random_node() == node_id_1
+
+    node_id_2 = NodeIDFactory()
+    routing_table.update(node_id_2)
+    random_node_ids = set(routing_table.get_random_node() for _ in range(100))
+    assert random_node_ids == {node_id_1, node_id_2}


### PR DESCRIPTION
### What was wrong?

The routing table manager used the flat routing table.

### How was it fixed?

Migrate it to use the Kademlia table.

In addition, I had to add a `get_random_node` method which I forgot earlier so that the ping sender can find someone to ping. The old implementation actually pinged the oldest node instead of a random one, but this was a bad idea as we would just end up repeatedly pinging the peer that's offline the longest. We can't rely on them being replaced quickly as they might by chance be in a mostly empty bucket.

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://user-images.githubusercontent.com/29854669/65773576-df2bfc80-e13c-11e9-83f3-31be9ebbe546.jpg)