### PR TITLE
Handle find node requests for remote ENRs

### DIFF
--- a/p2p/discv5/constants.py
+++ b/p2p/discv5/constants.py
@@ -39,3 +39,4 @@ HANDSHAKE_TIMEOUT = 1  # timeout for performing a handshake
 ROUTING_TABLE_PING_INTERVAL = 5  # interval of outgoing pings sent to maintain the routing table
 
 NUM_ROUTING_TABLE_BUCKETS = 256  # number of buckets in the routing table
+ROUTING_TABLE_BUCKET_SIZE = 16  # size of each bucket in the routing table

--- a/p2p/discv5/routing_table.py
+++ b/p2p/discv5/routing_table.py
@@ -242,6 +242,10 @@ class KademliaRoutingTable:
     def is_empty(self) -> bool:
         return all(len(bucket) == 0 for bucket in self.buckets)
 
+    @property
+    def is_not_empty(self) -> bool:
+        return not self.is_empty
+
     def get_least_recently_updated_log_distance(self) -> int:
         """Get the log distance whose corresponding bucket was updated least recently.
 

--- a/p2p/discv5/routing_table.py
+++ b/p2p/discv5/routing_table.py
@@ -2,6 +2,7 @@ import collections
 import functools
 import itertools
 import logging
+import random
 import secrets
 from typing import (
     Any,
@@ -260,3 +261,15 @@ class KademliaRoutingTable:
         sorted_node_ids = sorted(all_node_ids, key=distance_to_reference)
         for node_id in sorted_node_ids:
             yield node_id
+
+    def get_random_node(self) -> NodeID:
+        if self.is_empty:
+            raise ValueError("The routing table is empty")
+
+        bucket = random.choices(
+            self.buckets,
+            weights=tuple(len(bucket) for bucket in self.buckets),
+        )[0]
+        node_id = random.choice(bucket)
+
+        return node_id

--- a/p2p/trio_utils.py
+++ b/p2p/trio_utils.py
@@ -1,4 +1,3 @@
-import asyncio
 import operator
 from typing import (
     Any,
@@ -29,14 +28,9 @@ async def gather(*async_fns_and_args: AsyncFnsAndArgsType) -> Tuple[Any, ...]:
         async_fn_and_args = async_fns_and_args[index]
         if isinstance(async_fn_and_args, Iterable):
             async_fn, *args = async_fn_and_args
-        elif asyncio.iscoroutinefunction(async_fn_and_args):
+        else:
             async_fn = async_fn_and_args
             args = []
-        else:
-            raise TypeError(
-                "Each argument must be either an async function or a tuple consisting of an "
-                "async function followed by its arguments"
-            )
 
         result = await async_fn(*args)
         indices_and_results.append((index, result))

--- a/tests/p2p/discv5/test_kademlia_routing_table.py
+++ b/tests/p2p/discv5/test_kademlia_routing_table.py
@@ -171,3 +171,17 @@ def test_get_nodes_at_log_distance(routing_table, center_node_id, bucket_size):
         routing_table.update(node_id)
 
     assert set(routing_table.get_nodes_at_log_distance(200)) == set(nodes)
+
+
+def test_get_random_node(routing_table):
+    with pytest.raises(ValueError):
+        routing_table.get_random_node()
+
+    node_id_1 = NodeIDFactory()
+    routing_table.update(node_id_1)
+    assert routing_table.get_random_node() == node_id_1
+
+    node_id_2 = NodeIDFactory()
+    routing_table.update(node_id_2)
+    random_node_ids = set(routing_table.get_random_node() for _ in range(100))
+    assert random_node_ids == {node_id_1, node_id_2}

--- a/tests/p2p/discv5/test_kademlia_routing_table.py
+++ b/tests/p2p/discv5/test_kademlia_routing_table.py
@@ -130,11 +130,14 @@ def test_least_recently_updated_distance(routing_table, center_node_id):
 
 def test_is_empty(routing_table):
     assert routing_table.is_empty
+    assert not routing_table.is_not_empty
     node_id = NodeIDFactory()
     routing_table.update(node_id)
     assert not routing_table.is_empty
+    assert routing_table.is_not_empty
     routing_table.remove(node_id)
     assert routing_table.is_empty
+    assert not routing_table.is_not_empty
 
 
 def test_iter_around(routing_table, center_node_id):


### PR DESCRIPTION
Note: this includes two commits from #1204 

### What was wrong?

We only handled find node requests for our own ENR, but the majority will of course be for ENRs of other nodes.

### How was it fixed?

Update the existing handler for this case. As a temporary shortcut, it only sends one message per ENR instead of bunching them.

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://user-images.githubusercontent.com/29854669/65868762-3a4a3300-e379-11e9-8bfb-67ee736a0b87.jpg)