### PR TITLE
"Every" async generator

### DIFF
--- a/p2p/trio_utils.py
+++ b/p2p/trio_utils.py
@@ -1,10 +1,13 @@
 import asyncio
+import itertools
 import operator
 from typing import (
     Any,
+    AsyncGenerator,
     Awaitable,
     Callable,
     Iterable,
+    Optional,
     Tuple,
     Union,
 )
@@ -47,3 +50,34 @@ async def gather(*async_fns_and_args: AsyncFnsAndArgsType) -> Tuple[Any, ...]:
 
     indices_and_results_sorted = sorted(indices_and_results, key=operator.itemgetter(0))
     return tuple(result for _, result in indices_and_results_sorted)
+
+
+async def every(interval: float,
+                initial_delay: float = 0,
+                ) -> AsyncGenerator[float, Optional[float]]:
+    """Generator used to perform a task in regular intervals.
+
+    The generator will attempt to yield at a sequence of target times, defined as
+    `start_time + initial_delay + N * interval` seconds where `start_time` is trio's current time
+    at instantiation of the generator and `N` starts at `0`. The target time is also the value that
+    is yielded.
+
+    If at a certain iteration the target time has already passed, the generator will yield
+    immediately (with a checkpoint in between). The yield value is still the target time.
+
+    The generator accepts an optional send value which will delay the next and all future
+    iterations of the generator by that amount.
+    """
+    start_time = trio.current_time()
+    undelayed_yield_times = (
+        start_time + interval * iteration for iteration in itertools.count()
+    )
+    delay = initial_delay
+
+    for undelayed_yield_time in undelayed_yield_times:
+        yield_time = undelayed_yield_time + delay
+        await trio.sleep_until(yield_time)
+
+        additional_delay = yield yield_time
+        if additional_delay is not None:
+            delay += additional_delay


### PR DESCRIPTION
This implements another trio utility function: The `every` generator as suggested [here](https://github.com/ethereum/trinity/pull/1028#discussion_r320814270). I'll probably use it for implementing the lookup service.

Basic usage example:

```Py
async for time in every(2, offset=2):
    print(time, trio.current_time())
    await trio.sleep(random.randint(0, 2))
```

outputting

```
200762.82529603032 200762.82812670834
200764.82529603032 200764.82748336735
200766.82529603032 200766.82880680333
200768.82529603032 200768.8274904043
```

One can also send a value back to the generator to delay the next timestamp (as well as all future ones). I think this might be useful in some cases, e.g. if one loop iteration took too long and we don't want to continue immediately but sleep a little, even though that's not allowed according to the original schedule.

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://user-images.githubusercontent.com/29854669/65883677-c703e980-e397-11e9-92b3-5000e717bbcb.jpg)
