### PR TITLE
Fix issue accessing non-existent tracker

### DIFF
--- a/p2p/exchange/exchange.py
+++ b/p2p/exchange/exchange.py
@@ -24,6 +24,9 @@ from .typing import TResult
 class BaseExchange(ExchangeAPI[TRequestPayload, TResponsePayload, TResult]):
     _manager: ExchangeManager[TRequestPayload, TResponsePayload, TResult]
 
+    def __init__(self) -> None:
+        self.tracker = self.tracker_class()
+
     @asynccontextmanager
     async def run_exchange(self, connection: ConnectionAPI) -> AsyncIterator[None]:
         protocol = connection.get_protocol_for_command_type(self.get_request_cmd_type())
@@ -35,7 +38,6 @@ class BaseExchange(ExchangeAPI[TRequestPayload, TResponsePayload, TResult]):
         )
 
         try:
-            self.tracker = self.tracker_class()
             self._manager = ExchangeManager(
                 connection,
                 response_stream,
@@ -44,7 +46,6 @@ class BaseExchange(ExchangeAPI[TRequestPayload, TResponsePayload, TResult]):
                 yield
         finally:
             del self._manager
-            del self.tracker
 
     async def get_result(
             self,


### PR DESCRIPTION
fixes #1210

### What was wrong?

The `BaseExchange.run_exchange` context manager was written to set and then remove the `tracker` attribute.  This wasn't necessary.

### How was it fixed?

Changed to put the tracker in place during class initialization and no longer remove it in `run_exchange`.

#### Cute Animal Picture

![pepper3](https://user-images.githubusercontent.com/824194/65982280-37624780-e438-11e9-8961-41e5d96475f2.jpg)

