### PR TITLE
Make flakey test more permissive

### DIFF
--- a/tests/p2p/test_token_bucket.py
+++ b/tests/p2p/test_token_bucket.py
@@ -35,9 +35,9 @@ async def test_token_bucket_initial_tokens():
     # since the bucket starts out full the loop
     # should take near zero time
     expected = await measure_zero(10)
-    # drift is allowed to be up to 200% since we're working with very small
+    # drift is allowed to be up to 1000% since we're working with very small
     # numbers.
-    assert_fuzzy_equal(delta, expected, allowed_drift=2)
+    assert_fuzzy_equal(delta, expected, allowed_drift=10)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
### What was wrong?

`tests/p2p/test_token_bucket.py::test_token_bucket_initial_tokens` was a little flakey, I ran it 10k times (while compiling rust to simulate a bursty load on the CI box) and it failed 8 times. As a quick solution I've made the test more permissive and it hasn't failed on me again.

A better solution might be to change the test. I think it's making sure that we never sleep when pulling tokens from a full bucket, maybe this test could mock out the time api, and then check that `sleep()` is never called.

#### Cute Animal Picture

![dog-play-snow](https://user-images.githubusercontent.com/466333/66009475-7233a200-e46f-11e9-97a5-0421405ae259.jpg)