### PR TITLE
Method to request ENRs

### DIFF
--- a/p2p/discv5/exceptions.py
+++ b/p2p/discv5/exceptions.py
@@ -1,0 +1,11 @@
+from p2p.exceptions import (
+    BaseP2PError,
+)
+
+
+class DiscV5Error(BaseP2PError):
+    pass
+
+
+class InvalidResponse(DiscV5Error):
+    pass

--- a/p2p/discv5/message_dispatcher.py
+++ b/p2p/discv5/message_dispatcher.py
@@ -1,4 +1,3 @@
-import contextlib
 import logging
 import random
 from types import (
@@ -27,6 +26,9 @@ from trio.hazmat import (
 from aiostream import (
     pipe,
     stream,
+)
+from async_generator import (
+    asynccontextmanager,
 )
 
 from eth_utils import (
@@ -295,7 +297,7 @@ class MessageDispatcher(Service, MessageDispatcherAPI):
 
         return Endpoint(ip_address, udp_port)
 
-    @contextlib.asynccontextmanager
+    @asynccontextmanager
     async def send_request(self,
                            receiver_node_id: NodeID,
                            message: BaseMessage,

--- a/setup.py
+++ b/setup.py
@@ -25,6 +25,7 @@ deps = {
         'trio==0.11.0,<0.12',
         'trio-typing>=0.2.0,<0.3',
         "upnpclient>=0.0.8,<1",
+        'aiostream>=0.3.3,<0.4',
     ],
     'trinity': [
         "aiohttp==3.6.0",


### PR DESCRIPTION
When requesting ENRs (e.g. with `FindNode` or in the future `TOPICQUERY`), the response will consist not of a single, but of a sequence of `Nodes` messages (number given by the `total` attribute). This PR adds a convenience method of waiting for all individual messages and just return the list of all ENRs.

I've added the `aiostream` library as a dependency, mostly so that I can easily `take` the first N response messages (I've noticed I never merged #11 for some reason and `aiostream` was mentioned as possible alternative). It has a single dependency which is just a backport of some Python 3.7 method.

I've also added a custom exception class `InvalidResponse`. Most likely I should have started with this sooner, but here I didn't find a reason not to.

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://user-images.githubusercontent.com/29854669/66063024-d2dfdf00-e542-11e9-86a8-c3bcaf9d8074.jpg)
