### PR TITLE
High-level pass at validator client

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -56,6 +56,10 @@ deps = {
         # The direct dependency resolves a version conflict between multiaddr and libp2p
         "base58>=1.0.3,<2.0.0",
     ],
+    'trinity-validator': [
+        "asks>=2.3.6,<3",
+        "eth-keyfile",
+    ],
     'test': [
         "async-timeout>=3.0.1,<4",
         "hypothesis>=4.45.1,<5",
@@ -162,6 +166,7 @@ deps['dev'] = (
 
 deps['eth2-dev'] = (
     deps['dev'] +
+    deps['trinity-validator'] +
     deps['eth2'] +
     deps['eth2-extra'] +
     deps['eth2-lint']
@@ -205,7 +210,8 @@ setup(
     entry_points={
         'console_scripts': [
             'trinity=trinity:main',
-            'trinity-beacon=trinity:main_beacon'
+            'trinity-beacon=trinity:main_beacon',
+            'trinity-validator=validator_client:main'
         ],
     },
 )

--- a/tox.ini
+++ b/tox.ini
@@ -189,10 +189,13 @@ deps = .[eth2-lint,eth2]
 commands=
     flake8 --config {toxinidir}/.flake8-eth2 {toxinidir}/eth2
     flake8 --config {toxinidir}/.flake8-eth2 {toxinidir}/tests/eth2
+    flake8 --config {toxinidir}/.flake8-eth2 {toxinidir}/validator_client
+    flake8 --config {toxinidir}/.flake8-eth2 {toxinidir}/tests/validator_client
     flake8 --config {toxinidir}/.flake8-eth2 {toxinidir}/tests/libp2p
     mypy -p eth2 --config-file {toxinidir}/mypy-eth2.ini
-    black --check eth2 tests/eth2 tests/libp2p
-    isort --recursive --check-only eth2 tests/eth2 tests/libp2p
+    mypy -p validator_client --config-file {toxinidir}/mypy-eth2.ini
+    black --check eth2 tests/eth2 tests/libp2p validator_client
+    isort --recursive --check-only eth2 tests/eth2 tests/libp2p validator_client
 
 [testenv:py36-lint-eth2]
 deps = {[common-lint-eth2]deps}

--- a/validator_client/__init__.py
+++ b/validator_client/__init__.py
@@ -1,0 +1,1 @@
+from .main import main  # noqa: F401

--- a/validator_client/beacon_node.py
+++ b/validator_client/beacon_node.py
@@ -1,0 +1,174 @@
+from abc import ABC, abstractmethod
+import logging
+import random
+from typing import Collection
+
+from asks import Session
+from eth_typing import BLSPubkey, BLSSignature
+from eth_utils import ValidationError, humanize_hash
+
+from eth2.beacon.types.attestation_data import AttestationData
+from eth2.beacon.types.attestations import Attestation
+from eth2.beacon.types.blocks import BeaconBlock
+from eth2.beacon.typing import CommitteeIndex, Epoch, Slot
+from validator_client.context import Context
+from validator_client.duty import AttestationDuty, BlockProposalDuty, Duty
+
+logger = logging.getLogger("validator_client.beacon_node")
+logger.setLevel(logging.DEBUG)
+
+
+async def _get_duties_from_beacon_node(
+    session: Session,
+    url: str,
+    public_keys: Collection[BLSPubkey],
+    epoch: Epoch,
+    slots_per_epoch: int,
+) -> Collection[Duty]:
+    # TODO
+    # resp = await session.get(url, params={"validator_pubkeys": public_keys, "epoch": epoch})
+    # ... parse resp into duties
+    return ()
+
+
+async def _publish_duty_with_signature(
+    session: Session, url: str, duty: Duty, signature: BLSSignature
+) -> None:
+    # TODO
+    # resp = await session.post(url, params)
+    # ... ensure resp is OK
+    return
+
+
+async def _get_syncing_status(session: Session, url: str) -> bool:
+    # TODO
+    return False
+
+
+class BaseBeaconNode(ABC):
+    @abstractmethod
+    async def fetch_duties(
+        self, public_keys: Collection[BLSPubkey], epoch: Epoch
+    ) -> Collection[Duty]:
+        ...
+
+    @abstractmethod
+    async def fetch_attestation(
+        self, public_key: BLSPubkey, slot: Slot, committee_index: CommitteeIndex
+    ) -> Attestation:
+        ...
+
+    @abstractmethod
+    async def fetch_block_proposal(
+        self, public_key: BLSPubkey, slot: Slot
+    ) -> BeaconBlock:
+        ...
+
+    @abstractmethod
+    async def publish(self, duty: Duty, signature: BLSSignature) -> None:
+        ...
+
+
+class BeaconNode(BaseBeaconNode):
+    async def __init__(self, context: Context) -> None:
+        self._genesis_time = context.genesis_time
+        self._beacon_node_endpoint = context.beacon_node_endpoint
+        self._session = Session()
+
+        await self._connect_to_beacon_node()
+
+    async def _connect_to_beacon_node(self) -> None:
+        """
+        Verify the syncing status and genesis time of the provided
+        beacon node, ensuring it is up-to-date and reachable.
+        """
+        await self._wait_for_synced_beacon_node()
+        await self._verify_matching_genesis_time()
+
+    async def _get_syncing_status(self) -> bool:
+        # TODO
+        url = ...
+        return await _get_syncing_status(self._session, url)
+
+    async def _wait_for_synced_beacon_node(self) -> None:
+        is_syncing = await self._get_syncing_status()
+        if is_syncing:
+            # TODO
+            # some loop +  time-out until synced!
+            pass
+
+    async def _verify_matching_genesis_time(self) -> None:
+        genesis_time = await self._get_genesis_time()
+        if genesis_time != self._genesis_time:
+            raise ValidationError(
+                f"Genesis time of validator client {self._genesis_time} did not match genesis time "
+                "of beacon node {genesis_time} at endpoint {self._beacon_node_endpoint}"
+            )
+
+    async def fetch_duties(
+        self, public_keys: Collection[BLSPubkey], epoch: Epoch
+    ) -> Collection[Duty]:
+        url = self.fetch_duties_endpoint
+        return await _get_duties_from_beacon_node(
+            self._session, url, public_keys, epoch
+        )
+
+    async def fetch_attestation(
+        self, public_key: BLSPubkey, slot: Slot, committee_index: CommitteeIndex
+    ) -> Attestation:
+        # TODO make API call
+        return Attestation.create(data=AttestationData.create(slot=slot))
+
+    async def fetch_block_proposal(
+        self, public_key: BLSPubkey, slot: Slot
+    ) -> BeaconBlock:
+        # TODO make API call
+        return BeaconBlock.create(slot=slot)
+
+    async def publish(self, duty: Duty, signature: BLSSignature) -> None:
+        await _publish_duty_with_signature(self._session, duty, signature)
+
+
+class MockBeaconNode(BeaconNode):
+    """
+    NOTE: For demo purposes, will likely be removed soon...
+    """
+
+    def __init__(self, context: Context) -> None:
+        self._slots_per_epoch = context.slots_per_epoch
+
+    async def fetch_duties(
+        self, public_keys: Collection[BLSPubkey], epoch: Epoch
+    ) -> Collection[Duty]:
+        if not public_keys:
+            return ()
+
+        some_slot = (
+            random.randint(0, self._slots_per_epoch) + epoch * self._slots_per_epoch
+        )
+        is_attestation = bool(random.getrandbits(1))
+        some_validator = random.choice(public_keys)
+        if is_attestation:
+            committee_index = random.randint(0, 64)
+            duties = (AttestationDuty(some_validator, some_slot, committee_index),)
+        else:
+            duties = (BlockProposalDuty(some_validator, some_slot),)
+        logger.debug("got duties %s in epoch %s", duties, epoch)
+        return duties
+
+    async def fetch_attestation(
+        self, public_key: BLSPubkey, slot: Slot, committee_index: CommitteeIndex
+    ) -> Attestation:
+        return Attestation.create(data=AttestationData.create(slot=slot))
+
+    async def fetch_block_proposal(
+        self, public_key: BLSPubkey, slot: Slot
+    ) -> BeaconBlock:
+        return BeaconBlock.create(slot=slot)
+
+    async def publish(self, duty: Duty, signature: BLSSignature) -> None:
+        logger.debug(
+            "publishing %s with signature %s to beacon node",
+            duty,
+            humanize_hash(signature),
+        )

--- a/validator_client/cli_parser.py
+++ b/validator_client/cli_parser.py
@@ -1,0 +1,23 @@
+import argparse
+
+import argcomplete
+
+CLI_PARSER_DESCRIPTION = "Trinity Eth2.0 Validator Client"
+DEMO_MODE_HELP_MSG = "set configuration suitable for demonstration purposes (like ignoring a password). Do NOT use in production."
+IMPORT_PARSER_HELP_MSG = (
+    "import a validator private key to the keystore discovered from the configuration"
+)
+IMPORT_PARSER_KEY_ARGUMENT_HELP_MSG = "private key, encoded as big-endian hex"
+
+
+def parse_cli_args():
+    parser = argparse.ArgumentParser(description=CLI_PARSER_DESCRIPTION)
+    parser.add_argument("--demo-mode", action="store_true", help=DEMO_MODE_HELP_MSG)
+    subparsers = parser.add_subparsers(title="subcommands", dest="subparser_name")
+    import_key_parser = subparsers.add_parser("import-key", help=IMPORT_PARSER_HELP_MSG)
+    import_key_parser.add_argument(
+        "private_key", type=str, help=IMPORT_PARSER_KEY_ARGUMENT_HELP_MSG
+    )
+
+    argcomplete.autocomplete(parser)
+    return parser.parse_args()

--- a/validator_client/client.py
+++ b/validator_client/client.py
@@ -1,0 +1,51 @@
+import logging
+
+from async_service.base import Service
+
+from validator_client.beacon_node import MockBeaconNode as BeaconNode
+from validator_client.clock import Clock
+from validator_client.context import Context
+from validator_client.duty_executor import duty_executor
+from validator_client.duty_scheduler import DutyScheduler
+from validator_client.duty_store import DutyStore
+from validator_client.publisher import publisher
+from validator_client.signatory import Signatory
+from validator_client.streams.tee import Tee
+
+logger = logging.getLogger("validator_client.client")
+logger.setLevel(logging.DEBUG)
+
+
+class Client(Service):
+    def __init__(self, context: Context) -> None:
+        self._context = context
+
+    async def run(self) -> None:
+        logger.info("booting client from the provided context...")
+
+        clock = Clock(self._context)
+        clock_tee = Tee(clock.stream_ticks())
+        duty_store = DutyStore(self._context)
+        beacon_node = BeaconNode(self._context)
+
+        duty_scheduler = DutyScheduler(
+            self._context, await clock_tee.clone(), duty_store, beacon_node
+        )
+        duty_provider = duty_executor(
+            self._context, await clock_tee.clone(), duty_store, beacon_node
+        )
+        signatory = Signatory(self._context, duty_provider)
+
+        try:
+            self.manager.run_daemon_task(clock_tee.run)
+            # TODO: ``publisher`` should run as a daemon task
+            # see: https://github.com/ethereum/async-service/issues/51
+            self.manager.run_task(publisher, self._context, signatory, beacon_node)
+            ds = self.manager.run_child_service(duty_scheduler)
+            ss = self.manager.run_child_service(signatory)
+
+            await ds.wait_finished()
+            await ss.wait_finished()
+            await self.manager.wait_stopping()
+        finally:
+            logger.info("shutting down client...")

--- a/validator_client/clock.py
+++ b/validator_client/clock.py
@@ -1,0 +1,97 @@
+from dataclasses import dataclass, field
+import logging
+import time
+from typing import Callable, Tuple
+
+from cached_property import cached_property
+import trio
+
+from eth2.beacon.typing import Epoch, Slot
+from validator_client.context import Context
+
+logger = logging.getLogger("validator_client.clock")
+logger.setLevel(logging.DEBUG)
+
+TICKS_PER_SLOT = 2
+
+
+@dataclass(eq=True, frozen=True)
+class Tick:
+    t: float = field(repr=False)
+    slot: int
+    epoch: int
+    count: int  # non-negative counter for the tick w/in a slot
+
+    @cached_property
+    def first_in_slot(self) -> bool:
+        return self.tick == 0
+
+
+def _get_unix_time():
+    return time.time()
+
+
+TimeProvider = Callable[[], float]
+
+
+class Clock:
+    def __init__(
+        self, context: Context, time_provider: TimeProvider = _get_unix_time
+    ) -> None:
+        self._context = context
+        self._time_provider = time_provider
+        self._tick_interval = self._compute_tick_interval()
+
+    def _compute_tick_interval(self) -> int:
+        """
+        The validator client needs to take action with sub-slot granularity.
+        Each period on this finer resolution is called a "tick".
+        """
+        return self._context.seconds_per_slot // TICKS_PER_SLOT
+
+    def _compute_slot_and_alignment(self, t: int) -> Tuple[int, bool]:
+        """
+        Compute the slot corresponding to a unix time ``t``.
+        Indicate if ``t`` corresponds to the first tick in the relevant slot
+        with a boolean return value.
+        """
+        time_since_genesis = t - self._context.genesis_time
+        slot, sub_slot = divmod(time_since_genesis, self._context.seconds_per_slot)
+        return slot, sub_slot == 0
+
+    def _compute_epoch(self, slot: Slot) -> Epoch:
+        return Epoch(slot // self._context.slots_per_epoch)
+
+    def _compute_tick(self) -> Tick:
+        t = self._time_provider()
+        slot, aligned = self._compute_slot_and_alignment(int(t))
+        epoch = self._compute_epoch(slot)
+        count = int(not aligned)
+        return Tick(t, slot, epoch, count)
+
+    async def _wait_for_genesis(self) -> None:
+        t = self._time_provider()
+        genesis_time = self._context.genesis_time
+        if t >= genesis_time:
+            return
+
+        logger.info(
+            "genesis time has not elapsed; blocking client until %s", genesis_time
+        )
+        duration = genesis_time - t
+        await trio.sleep(duration)
+
+    async def _wait_until_next_tick(self, tick: Tick) -> None:
+        next_tick_at = tick.t + self._tick_interval
+        t = self._time_provider()
+        duration = next_tick_at - t
+        if duration >= 0:
+            await trio.sleep(duration)
+
+    async def stream_ticks(self) -> None:
+        await self._wait_for_genesis()
+
+        while True:
+            tick = self._compute_tick()
+            yield tick
+            await self._wait_until_next_tick(tick)

--- a/validator_client/config.py
+++ b/validator_client/config.py
@@ -1,0 +1,25 @@
+import os
+from pathlib import Path
+import time
+from typing import Any, Dict
+
+DEFAULT_BEACON_NODE_ENDPOINT = "https://127.0.0.1:30303"
+DEFAULT_VALIDATOR_DATA_DIR = (
+    Path(os.environ["HOME"]) / ".local" / "share" / "trinity" / "validator_client"
+)
+DEFAULT_KEY_STORE_DIR = DEFAULT_VALIDATOR_DATA_DIR / "key_store"
+DEFAULT_SIGNATORY_DB = DEFAULT_VALIDATOR_DATA_DIR / "db" / "signatory"
+
+
+config = dict(
+    beacon_node_endpoint=DEFAULT_BEACON_NODE_ENDPOINT,
+    key_store_dir=DEFAULT_KEY_STORE_DIR,
+    signatory_db_handle=DEFAULT_SIGNATORY_DB,
+    slots_per_epoch=4,
+    seconds_per_slot=2,
+    genesis_time=int(time.time()),
+    demo_mode=False,
+)
+
+# TODO turn into proper class
+Config = Dict[str, Any]

--- a/validator_client/context.py
+++ b/validator_client/context.py
@@ -1,0 +1,53 @@
+from cached_property import cached_property
+from eth_typing import BLSPubkey
+
+from validator_client.key_store import MockKeyStore as KeyStore
+
+
+class Context:
+    """
+    Represents data specific to a particular instance of a ``Client``.
+    """
+
+    def __init__(self, config):
+        self._config = config
+        self._key_store = KeyStore(config)
+
+    @classmethod
+    def from_config(cls, config):
+        return cls(config)
+
+    @cached_property
+    def config(self):
+        return self._config
+
+    @cached_property
+    def genesis_time(self):
+        return self._config["genesis_time"]
+
+    @cached_property
+    def seconds_per_slot(self):
+        return self._config["seconds_per_slot"]
+
+    @cached_property
+    def slots_per_epoch(self):
+        return self._config["slots_per_epoch"]
+
+    @cached_property
+    def beacon_node_endpoint(self):
+        return self._config["beacon_node_endpoint"]
+
+    @cached_property
+    def signatory_db_handle(self):
+        return self._config["signatory_db_handle"]
+
+    @cached_property
+    def validator_public_keys(self):
+        return self._key_store.public_keys
+
+    @cached_property
+    def key_store_location(self):
+        return self._key_store.location
+
+    def private_key_for(self, public_key: BLSPubkey) -> int:
+        return self._key_store.private_key_for(public_key)

--- a/validator_client/duty.py
+++ b/validator_client/duty.py
@@ -1,0 +1,54 @@
+from dataclasses import dataclass, field
+from enum import Enum, auto, unique
+
+from eth_typing import BLSPubkey
+from eth_utils import humanize_hash
+
+from eth2.beacon.signature_domain import SignatureDomain
+from eth2.beacon.typing import CommitteeIndex, DomainType, Slot
+
+
+@unique
+class DutyType(Enum):
+    Attestation = auto()
+    BlockProposal = auto()
+
+
+@dataclass(eq=True, frozen=True)
+class Duty:
+    """
+    A ``Duty`` represents some work that needs to be performed on behalf of some
+    validator, like signing an ``Attestation``.
+    """
+
+    validator_public_key: BLSPubkey
+    slot: Slot
+
+
+@dataclass(eq=True, frozen=True)
+class AttestationDuty(Duty):
+    duty_type: DutyType = field(init=False, default=DutyType.Attestation)
+    domain_type: DomainType = field(
+        init=False, default=SignatureDomain.DOMAIN_BEACON_ATTESTER
+    )
+    committee_index: CommitteeIndex
+
+    def __repr__(self) -> str:
+        return (
+            f"AttestationDuty(validator_public_key={humanize_hash(self.validator_public_key)},"
+            f" slot={self.slot}, committee_index={self.committee_index})"
+        )
+
+
+@dataclass(eq=True, frozen=True)
+class BlockProposalDuty(Duty):
+    duty_type: DutyType = field(init=False, default=DutyType.BlockProposal)
+    domain_type: DomainType = field(
+        init=False, default=SignatureDomain.DOMAIN_BEACON_PROPOSER
+    )
+
+    def __repr__(self) -> str:
+        return (
+            f"BlockProposalDuty(validator_public_key={humanize_hash(self.validator_public_key)},"
+            f" slot={self.slot})"
+        )

--- a/validator_client/duty_executor.py
+++ b/validator_client/duty_executor.py
@@ -1,0 +1,66 @@
+import logging
+from typing import Any, AsyncIterable, Collection, Tuple
+
+import trio
+
+from validator_client.beacon_node import BeaconNode
+from validator_client.clock import Tick
+from validator_client.context import Context
+from validator_client.duty import Duty, DutyType
+from validator_client.duty_store import DutyStore
+
+logger = logging.getLogger("validator_client.duty_executor")
+logger.setLevel(logging.DEBUG)
+
+Signable = Any
+
+
+async def _resolve_duty(
+    beacon_node: BeaconNode, duty: Duty, send_channel: trio.MemorySendChannel
+) -> None:
+    if duty.duty_type == DutyType.Attestation:
+        attestation = await beacon_node.fetch_attestation(
+            duty.validator_public_key, duty.slot, duty.committee_index
+        )
+        await send_channel.send((duty, attestation))
+    elif duty.duty_type == DutyType.BlockProposal:
+        block_proposal = await beacon_node.fetch_block_proposal(
+            duty.validator_public_key, duty.slot
+        )
+        await send_channel.send((duty, block_proposal))
+    else:
+        raise NotImplementedError("request to resolve a non-supported type of duty")
+
+
+async def _resolve_duties(
+    beacon_node: BeaconNode, duties: Collection[Duty]
+) -> Collection[Tuple[Duty, Signable]]:
+    async with trio.open_nursery() as nursery:
+        send_channel, recv_channel = trio.open_memory_channel(0)
+        for duty in duties:
+            nursery.start_soon(_resolve_duty, beacon_node, duty, send_channel)
+
+        results = ()
+        async for value in recv_channel:
+            results += (value,)
+
+            if len(results) == len(duties):
+                break
+
+        await send_channel.aclose()
+        await recv_channel.aclose()
+    return results
+
+
+async def duty_executor(
+    context: Context,
+    clock: AsyncIterable[Tick],
+    duty_store: DutyStore,
+    beacon_node: BeaconNode,
+) -> None:
+    async for tick in clock:
+        duties = await duty_store.duties_at_tick(tick)
+        if not duties:
+            continue
+        logger.info("got duties %s to execute at tick %s", duties, tick)
+        yield await _resolve_duties(beacon_node, duties)

--- a/validator_client/duty_scheduler.py
+++ b/validator_client/duty_scheduler.py
@@ -1,0 +1,63 @@
+import logging
+from typing import AsyncIterable
+
+from async_service.base import Service
+
+from validator_client.beacon_node import MockBeaconNode as BeaconNode
+from validator_client.clock import Tick
+from validator_client.context import Context
+from validator_client.duty_store import DutyStore
+
+logger = logging.getLogger("validator_client.duty_scheduler")
+logger.setLevel(logging.DEBUG)
+
+
+def _filter_new_duties(old, new):
+    return new
+
+
+def _get_duties_for(tick, duties):
+    return duties
+
+
+async def _select_distinct_epochs(clock):
+    current_epoch = None
+    async for tick in clock:
+        if tick.epoch != current_epoch:
+            current_epoch = tick.epoch
+            yield tick
+
+
+class DutyScheduler(Service):
+    """
+    ``DutyScheduler`` manages the set of duties for the validator public keys in the key store.
+
+    This task involves polling the beacon node periodically to get the latest set of assignments
+    based on the beacon chain state.
+    """
+
+    def __init__(
+        self,
+        context: Context,
+        clock: AsyncIterable,
+        duty_store: DutyStore,
+        beacon_node: BeaconNode,
+    ) -> None:
+        self._context = context
+        self._epoch_clock = _select_distinct_epochs(clock)
+        self._validator_public_keys = context.validator_public_keys
+        self._beacon_node = beacon_node
+        self._store = duty_store
+
+    async def _process_tick(self, tick: Tick) -> None:
+        logger.info("checking for new duties in epoch %s", tick.epoch)
+        duties = await self._beacon_node.fetch_duties(
+            self._validator_public_keys, tick.epoch
+        )
+        logger.info("found duties %s in epoch %s", duties, tick.epoch)
+        # TODO manage duties correctly, accounting for re-orgs, etc.
+        await self._store.add_duties_at_tick(duties, tick)
+
+    async def run(self) -> None:
+        async for tick in self._epoch_clock:
+            await self._process_tick(tick)

--- a/validator_client/duty_store.py
+++ b/validator_client/duty_store.py
@@ -1,0 +1,33 @@
+from collections import defaultdict
+from typing import Collection
+
+import trio
+
+from validator_client.clock import Tick
+from validator_client.context import Context
+from validator_client.duty import Duty
+
+
+class DutyStore:
+    """
+    A ``DutyStore`` maintains a record of the current duties discovered by
+    the ``DutyScheduler`` which are intended to be acted upon by the ``DutyExecutor``.
+    """
+
+    def __init__(self, context: Context) -> None:
+        self._context = context
+        self._store = defaultdict(tuple)
+        self._store_lock = trio.Lock()
+
+    async def duties_at_tick(self, tick: Tick) -> Collection[Duty]:
+        async with self._store_lock:
+            return self._store[tick]
+
+    async def add(self, duty: Duty, tick: Tick) -> None:
+        async with self._store_lock:
+            self._store[tick] += (duty,)
+
+    async def add_duties_at_tick(self, duties: Collection[Duty], tick: Tick) -> None:
+        async with self._store_lock:
+            for duty in duties:
+                self._store[tick] += (duty,)

--- a/validator_client/key_store.py
+++ b/validator_client/key_store.py
@@ -1,0 +1,189 @@
+from abc import ABC, abstractmethod
+import getpass
+import json
+import logging
+from pathlib import Path
+import random
+from typing import Collection, Tuple
+
+import eth_keyfile
+from eth_typing import BLSPubkey
+from eth_utils import decode_hex, encode_hex, humanize_hash, int_to_big_endian
+
+from eth2._utils.bls import bls
+from validator_client.config import Config
+
+logger = logging.getLogger("validator_client.key_store")
+logger.setLevel(logging.DEBUG)
+
+EMPTY_PASSWORD = b""
+
+BLSPrivateKey = int
+KeyPair = Tuple[BLSPubkey, BLSPrivateKey]
+
+
+def _compute_key_pair_from_private_key_bytes(private_key_bytes: bytes) -> KeyPair:
+    private_key = int.from_bytes(private_key_bytes, byteorder="big")
+    return (bls.privtopub(private_key), private_key)
+
+
+class BaseKeyStore(ABC):
+    @abstractmethod
+    def __init__(self, config: Config) -> "BaseKeyStore":
+        ...
+
+    @classmethod
+    def from_config(cls, config: Config) -> "BaseKeyStore":
+        return cls(config)
+
+    @property
+    @abstractmethod
+    def location(self) -> str:
+        ...
+
+    @property
+    @abstractmethod
+    def public_keys(self) -> Collection[BLSPubkey]:
+        ...
+
+    @classmethod
+    @abstractmethod
+    def import_private_key(cls, config: Config) -> None:
+        """
+        Persist a private key in the key store for use between runs of the client.
+        """
+        ...
+
+    @abstractmethod
+    def private_key_for(self, public_key: BLSPubkey) -> int:
+        ...
+
+
+def _create_dir_if_missing(path: Path) -> None:
+    if not path.exists():
+        logger.warning(
+            "The key store location provided (%s) is missing. Creating...", path
+        )
+        path.mkdir(parents=True)
+
+
+class KeyStore(BaseKeyStore):
+    """
+    A ``KeyStore`` instance is a read-only repository for the private and public keys
+    corresponding to the validators under the control of a client of this class.
+    """
+
+    def __init__(self, config) -> None:
+        self._location = config["key_store_dir"]
+        self._demo_mode = config["demo_mode"]
+        self._key_pairs = {}
+
+        self._ensure_dirs()
+
+        self._load_validator_key_pairs()
+
+    def _ensure_dirs(self) -> None:
+        _create_dir_if_missing(self._location)
+
+    def _load_validator_key_pairs(self) -> None:
+        """
+        Load all key pairs found in the key store directory.
+        """
+        for key_file in self._location.iterdir():
+            public_key, private_key = self._load_key_file(key_file)
+            self._key_pairs[public_key] = private_key
+
+        logger.info("loaded %s validator(s) from the key store", len(self._key_pairs))
+
+    def _load_key_file(self, key_file: Path) -> KeyPair:
+        with open(key_file) as f:
+            keyfile_json = json.load(f)
+            public_key = decode_hex(keyfile_json["public_key"])
+            if not self._demo_mode:
+                logger.warn(
+                    "please enter password for protected keyfile with public key %s:",
+                    humanize_hash(public_key),
+                )
+                password = getpass.getpass().encode()
+            else:
+                password = EMPTY_PASSWORD
+            private_key = eth_keyfile.decode_keyfile_json(keyfile_json, password)
+            return _compute_key_pair_from_private_key_bytes(private_key)
+
+    @property
+    def location(self) -> str:
+        return self._location
+
+    @property
+    def public_keys(self):
+        return tuple(self._key_pairs.keys())
+
+    @classmethod
+    def import_private_key(cls, config: Config, private_key: str) -> None:
+        """
+        Parse the ``private_key`` provided as a ``str`` and then stores the
+        private key and public key as a key pair in the key store on disk.
+        """
+        key_store_dir = config["key_store_dir"]
+        _create_dir_if_missing(key_store_dir)
+        private_key_bytes = decode_hex(private_key)
+        public_key, _ = _compute_key_pair_from_private_key_bytes(private_key_bytes)
+        logger.warn(
+            "please enter a password to protect the key on-disk (can be empty):"
+        )
+        password = getpass.getpass().encode()
+        key_file_json = eth_keyfile.create_keyfile_json(private_key_bytes, password)
+        key_file_json["public_key"] = encode_hex(public_key)
+        with open(key_store_dir / (key_file_json["id"] + ".json"), "w") as f:
+            json.dump(key_file_json, f)
+
+    def private_key_for(self, public_key: BLSPubkey) -> int:
+        return self._key_pairs[public_key]
+
+
+def _random_private_key(index: int) -> int:
+    """
+    Using the algorithm from:
+    https://github.com/ethereum/eth2.0-pm/blob/master/interop/mocked_start/keygen.py
+    """
+    from py_ecc.optimized_bls12_381 import curve_order
+    from hashlib import sha256
+
+    return (
+        int.from_bytes(
+            sha256(index.to_bytes(length=32, byteorder="little")).digest(),
+            byteorder="little",
+        )
+        % curve_order
+    )
+
+
+def _mk_random_key_pair(index: int) -> KeyPair:
+    private_key = _random_private_key(index)
+    public_key = bls.privtopub(private_key)
+    return (public_key, private_key)
+
+
+class MockKeyStore(BaseKeyStore):
+    def __init__(self, config) -> None:
+        self._config = config
+
+        num_validators = 16
+        self._key_pairs = dict(
+            _mk_random_key_pair(index) for index in range(num_validators)
+        )
+
+    @property
+    def location(self) -> str:
+        return "<in-memory>"
+
+    @property
+    def public_keys(self) -> Collection[BLSPubkey]:
+        return tuple(self._key_pairs.keys())
+
+    @classmethod
+    def import_private_key(cls, config: Config) -> None:
+        pass
+
+    def private_key_for(self, public_key: BLSPubkey) -> int:
+        return self._key_pairs[public_key]

--- a/validator_client/main.py
+++ b/validator_client/main.py
@@ -1,0 +1,85 @@
+import argparse
+import logging
+import signal
+from typing import Optional
+
+from async_service.trio import background_trio_service
+from eth_utils import humanize_hash
+import trio
+
+from trinity._utils.logging import LOG_FORMATTER
+from validator_client.cli_parser import parse_cli_args
+from validator_client.client import Client
+from validator_client.config import Config, config
+from validator_client.context import Context
+from validator_client.key_store import KeyStore
+
+
+def _setup_logging() -> logging.Logger:
+    logger = logging.getLogger()
+    logger.setLevel(logging.INFO)
+
+    stream_handler = logging.StreamHandler()
+    stream_handler.setLevel(logging.DEBUG)
+    stream_handler.setFormatter(LOG_FORMATTER)
+    logger.addHandler(stream_handler)
+
+    return logger
+
+
+async def _wait_for_interrupts(logger: logging.Logger) -> None:
+    with trio.open_signal_receiver(signal.SIGINT) as stream:
+        async for _ in stream:
+            logger.info("received interrupt; shutting down...")
+            return
+
+
+async def _main(
+    logger: logging.Logger, config: Config, arguments: argparse.Namespace
+) -> None:
+
+    # TODO sanity check the validator key pairs we find are valid
+    # perhaps by fetching their indices in the state and adding them to the following
+    # logging statement.
+    context = Context.from_config(config)
+    validator_public_keys = context.validator_public_keys
+    logger.info(
+        "found %d validator key pair(s) at %s for public key(s) %s",
+        len(validator_public_keys),
+        context.key_store_location,
+        tuple(map(humanize_hash, validator_public_keys)),
+    )
+    client = Client(context)
+
+    async with background_trio_service(client):
+        await _wait_for_interrupts(logger)
+
+
+async def _import_key(
+    logger: logging.Logger, config: Config, arguments: argparse.Namespace
+) -> None:
+    logger.info("importing private key...")
+    try:
+        KeyStore.import_private_key(config, arguments.private_key)
+    except Exception as e:
+        logger.warn(e)
+
+
+def _fn_for_command(command: Optional[str]):
+    return {None: _main, "import-key": _import_key}[command]
+
+
+def _set_demo_mode_in_config(config: Config, demo_mode: bool) -> None:
+    config["demo_mode"] = demo_mode
+
+
+def main() -> None:
+    # TODO:
+    # load config from CLI parser
+    # load config from file
+    # ... including logging config which can then go to `_setup_logging`
+    logger = _setup_logging()
+    arguments = parse_cli_args()
+    fn = _fn_for_command(arguments.subparser_name)
+    _set_demo_mode_in_config(config, arguments.demo_mode)
+    trio.run(fn, logger, config, arguments)

--- a/validator_client/publisher.py
+++ b/validator_client/publisher.py
@@ -1,0 +1,12 @@
+import logging
+
+from eth_utils import humanize_hash
+
+logger = logging.getLogger("validator_client.publisher")
+logger.setLevel(logging.DEBUG)
+
+
+async def publisher(context, signatory, beacon_node):
+    async for duty, signature in signatory.signatures():
+        logger.info("got signature %s for duty %s", humanize_hash(signature), duty)
+        await beacon_node.publish(duty, signature)

--- a/validator_client/signatory.py
+++ b/validator_client/signatory.py
@@ -1,0 +1,87 @@
+import logging
+from typing import AsyncIterable, Tuple
+
+from async_service.base import Service
+from eth_typing import BLSSignature
+from eth_utils import ValidationError, humanize_hash
+import trio
+
+from eth2._utils.bls import bls
+from eth2.beacon.helpers import signature_domain_to_domain_type
+from validator_client.context import Context
+from validator_client.duty import Duty
+from validator_client.signatory_db import BaseSignatoryDB, InMemorySignatoryDB
+
+logger = logging.getLogger("validator_client.signatory")
+logger.setLevel(logging.DEBUG)
+
+
+async def _validate_duty(duty: Duty, signable, db: BaseSignatoryDB) -> None:
+    """
+    ``db`` contains a persistent record of all signatures with
+    enough information to prevent the triggering of any slashing conditions.
+    """
+    if await db.is_slashable(duty, signable):
+        raise ValidationError(
+            f"signing the duty {duty} would result in a slashable signature"
+        )
+
+
+class Signatory(Service):
+    def __init__(self, context: Context, duty_provider: AsyncIterable[Duty]) -> None:
+        self._context = context
+        self._duty_provider = duty_provider
+        self._signature_store = InMemorySignatoryDB()
+        self._send_channel, self._recv_channel = trio.open_memory_channel(0)
+
+    async def _validate(self, duty: Duty, signable) -> None:
+        await _validate_duty(duty, signable, self._signature_store)
+
+    async def _sign(self, duty: Duty, signable) -> BLSSignature:
+        message = signable.hash_tree_root
+        private_key = self._context.private_key_for(duty.validator_public_key)
+        # TODO use correct ``domain`` value
+        # NOTE currently only uses part of the domain value
+        # need to get fork from the state and compute the full domain value locally
+        domain = b"\x00" * 4 + signature_domain_to_domain_type(duty.domain_type)
+        return bls.sign(message, private_key, domain)
+
+    async def _record_signature_for(self, duty: Duty, signable) -> None:
+        await self._signature_store.record_signature_for(duty, signable)
+
+    async def _stop(self) -> None:
+        logger.debug("stopping signatory...")
+        await self._send_channel.aclose()
+        await self._signature_store.close()
+
+    async def _process_duty(self, duty: Duty, signable) -> None:
+        try:
+            await self._validate(duty, signable)
+        except ValidationError as e:
+            logger.warn("a duty %s was not valid: %s", duty, e)
+            return
+        else:
+            logger.debug(
+                "received a valid duty %s for the operation with hash tree root %s; signing...",
+                duty,
+                humanize_hash(signable.hash_tree_root),
+            )
+
+        await self._record_signature_for(duty, signable)
+        signature = await self._sign(duty, signable)
+
+        logger.info("signed %s", duty)
+
+        await self._send_channel.send((duty, signature))
+
+    async def run(self) -> None:
+        try:
+            async for duties in self._duty_provider:
+                for duty, signable in duties:
+                    self.manager.run_task(self._process_duty, duty, signable)
+        finally:
+            with trio.CancelScope(shield=True):
+                await self._stop()
+
+    def signatures(self) -> AsyncIterable[Tuple[Duty, BLSSignature]]:
+        return self._recv_channel

--- a/validator_client/signatory_db.py
+++ b/validator_client/signatory_db.py
@@ -1,0 +1,126 @@
+from abc import abstractmethod
+from enum import Enum, unique
+import logging
+
+import ssz
+
+from validator_client.duty import Duty, DutyType
+
+logger = logging.getLogger("validator_client.signatory_db")
+logger.setLevel(logging.DEBUG)
+
+
+@unique
+class OperationTag(Enum):
+    Attestation = b"0"
+    BlockProposal = b"1"
+
+
+class BaseSignatoryDB:
+    """
+    Provides persistence for actions of the client to prevent
+    the publishing of slashable signatures.
+    """
+
+    @abstractmethod
+    async def record_signature_for(self, duty: Duty, signable) -> None:
+        ...
+
+    @abstractmethod
+    async def is_slashable(self, duty: Duty) -> bool:
+        ...
+
+    @abstractmethod
+    def insert(self, key: bytes, value: bytes) -> None:
+        ...
+
+    @abstractmethod
+    def __contains__(self, key: bytes) -> bool:
+        ...
+
+    @abstractmethod
+    async def close(self) -> None:
+        ...
+
+
+def _key_for_attestation(duty: Duty) -> bytes:
+    return (
+        OperationTag.Attestation.value
+        + duty.validator_public_key
+        + ssz.encode(duty.slot, ssz.sedes.uint64)
+    )
+
+
+async def _record_attestation(duty: Duty, signable, db: BaseSignatoryDB) -> None:
+    # TODO temporary; will need more sophisticated logic to avoid slashing
+    db.insert(_key_for_attestation(duty), signable.hash_tree_root)
+
+
+async def _is_attestation_slashable(duty: Duty, signable, db: BaseSignatoryDB) -> bool:
+    # TODO temporary; will need more sophisticated logic to avoid slashing
+    return _key_for_attestation(duty) in db
+
+
+def _key_for_block_proposal(duty: Duty) -> bytes:
+    return (
+        OperationTag.BlockProposal.value
+        + duty.validator_public_key
+        + ssz.encode(duty.slot, ssz.sedes.uint64)
+    )
+
+
+async def _record_block_proposal(duty: Duty, signable, db: BaseSignatoryDB) -> None:
+    db.insert(_key_for_block_proposal(duty), signable.hash_tree_root)
+
+
+async def _is_block_proposal_slashable(
+    duty: Duty, signable, db: BaseSignatoryDB
+) -> bool:
+    """
+    A block proposal is invalid if we already have produced a signature for the proposal's slot.
+    """
+    return _key_for_block_proposal(duty) in db
+
+
+SLASHING_VALIDATIONS = {
+    DutyType.Attestation: _is_attestation_slashable,
+    DutyType.BlockProposal: _is_block_proposal_slashable,
+}
+
+SLASHING_RECORDERS = {
+    DutyType.Attestation: _record_attestation,
+    DutyType.BlockProposal: _record_block_proposal,
+}
+
+
+class InMemorySignatoryDB(BaseSignatoryDB):
+    def __init__(self) -> None:
+        self._store = {}
+
+    async def record_signature_for(self, duty: Duty, signable) -> None:
+        logger.debug("recording signature for duty %s", duty)
+        recorder = SLASHING_RECORDERS.get(duty.duty_type, None)
+        if not recorder:
+            raise NotImplementedError(
+                f"missing a signature recorder handler for the duty type {duty.duty_type}"
+            )
+
+        await recorder(duty, signable, self)
+
+    async def is_slashable(self, duty: Duty, signable) -> bool:
+        validation = SLASHING_VALIDATIONS.get(duty.duty_type, None)
+        if not validation:
+            raise NotImplementedError(
+                f"missing a slashing validation handler for the duty type {duty.duty_type}"
+            )
+
+        return await validation(duty, signable, self)
+
+    def insert(self, key: bytes, value: bytes) -> None:
+        self._store[key] = value
+
+    def __contains__(self, key: bytes) -> bool:
+        return key in self._store
+
+    async def close(self) -> None:
+        logger.debug("closing signatory db...")

--- a/validator_client/streams/tee.py
+++ b/validator_client/streams/tee.py
@@ -1,0 +1,42 @@
+from typing import Any, AsyncIterable
+
+import trio
+
+
+class Stream:
+    def __init__(self) -> None:
+        self._send_channel, self._recv_channel = trio.open_memory_channel(0)
+
+    async def accept(self, event: Any) -> None:
+        await self._send_channel.send(event)
+
+    def __aiter__(self) -> AsyncIterable:
+        return self
+
+    async def __anext__(self) -> Any:
+        event = await self._recv_channel.receive()
+        return event
+
+
+class Tee:
+    """
+    ``Tee`` copies all events on a producing ``stream`` to any consumers
+    who taken a clone of the ``stream`` via ``clone``.
+    """
+
+    def __init__(self, stream: AsyncIterable) -> None:
+        self._stream = stream
+        self._clones = ()
+        self._clones_lock = trio.Lock()
+
+    async def clone(self) -> Stream:
+        new_clone = Stream()
+        async with self._clones_lock:
+            self._clones += (new_clone,)
+        return new_clone
+
+    async def run(self) -> None:
+        async for event in self._stream:
+            async with self._clones_lock:
+                for clone in self._clones:
+                    await clone.accept(event)


### PR DESCRIPTION
This PR is intended to serve as basis for discussion for some ideas around how to integrate trio moving forward; the particulars of the validator client (the "business logic") are missing as this PR just wants to showcase the high-level design.

Some points to note:

- Uses `trio` for the concurrency backend.

- Attempts to abstract over the particulars of `trio` so that different
implementations can be provided. Unclear how useful this is.

- Structures high-level components as single-purpose "tasks" that communicate
by sharing over a channel abstraction. Actions taken by the client are driven
by events/data moving through the channel construction.

Discussion in https://github.com/ethereum/trinity/issues/1138 is relevant.

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://i.pinimg.com/originals/77/70/f0/7770f0d2dca18fe976863bba332244e9.jpg)
