### PR TITLE
Fix up a couple p2p bugs

### DIFF
--- a/docs/guides/quickstart.rst
+++ b/docs/guides/quickstart.rst
@@ -34,7 +34,7 @@ It can be installed through the following command.
 
 .. code:: sh
 
-  apt-get install libsnappy-dev
+  apt-get install libsnappy-dev libgmp3-dev
 
 Finally, we can install the ``trinity`` package via pip.
 

--- a/p2p/exchange/exchange.py
+++ b/p2p/exchange/exchange.py
@@ -37,15 +37,12 @@ class BaseExchange(ExchangeAPI[TRequestPayload, TResponsePayload, TResult]):
             self.get_response_cmd_type(),
         )
 
-        try:
-            self._manager = ExchangeManager(
-                connection,
-                response_stream,
-            )
-            async with run_service(response_stream):
-                yield
-        finally:
-            del self._manager
+        self._manager = ExchangeManager(
+            connection,
+            response_stream,
+        )
+        async with run_service(response_stream):
+            yield
 
     async def get_result(
             self,

--- a/p2p/peer.py
+++ b/p2p/peer.py
@@ -276,7 +276,8 @@ class BasePeer(BaseService):
                 timeout_seconds=BLACKLIST_SECONDS_BAD_PROTOCOL,
                 reason="Bad protocol",
             )
-        await self.p2p_api.disconnect(reason)
+        if hasattr(self, "p2p_api"):
+            await self.p2p_api.disconnect(reason)
         if self.is_operational:
             await self.cancel()
 

--- a/trinity/protocol/common/peer.py
+++ b/trinity/protocol/common/peer.py
@@ -15,11 +15,17 @@ from lahja import EndpointAPI
 
 from cancel_token import CancelToken
 
-from eth_utils.toolz import groupby
+from eth_utils.toolz import (
+    excepts,
+    groupby,
+)
 
 from p2p.abc import BehaviorAPI, NodeAPI, SessionAPI
 from p2p.disconnect import DisconnectReason
-from p2p.exceptions import NoConnectedPeers
+from p2p.exceptions import (
+    NoConnectedPeers,
+    UnknownAPI,
+)
 from p2p.peer import (
     BasePeer,
     BasePeerFactory,
@@ -145,7 +151,8 @@ class BaseChainPeerPool(BasePeerPool):
         if not peers:
             raise NoConnectedPeers("No connected peers")
 
-        peers_by_td = groupby(operator.attrgetter('head_info.head_td'), peers)
+        td_getter = excepts(UnknownAPI, operator.attrgetter('head_info.head_td'), lambda _: 0)
+        peers_by_td = groupby(td_getter, peers)
         max_td = max(peers_by_td.keys())
         return random.choice(peers_by_td[max_td])
 


### PR DESCRIPTION
### What was wrong?

Resolve a couple little random quirks about peer interaction:
- occasional `AttributeError: _manager` exceptions escaping
- occasional `AttributeError: p2p_api` exceptions escaping
- sync to checkpoint can fail way too quickly if you happen to connect to a bad peer (because `disconnect()` exits while the peer is still in the peer pool, so it just gets re-selected and burns through all the attempts to get the checkpoint header from a peer)

### How was it fixed?

- catch if exchange manager is missing and raise `PeerConnectionLost` instead of `AttributeError`
- only disconnect from `p2p_api` if it has been started & attached
- wait for peer to close before exiting `disconnect()` (this just revives the previous behavior)
- plus a bonus doc improvement

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

[//]: # (See: https://trinity-client.readthedocs.io/en/latest/contributing.html#pull-requests)
- [ ] Add entry to the [release notes](https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://i.pinimg.com/236x/9a/e8/69/9ae8696491b2b81354891bde75c284c2--small-dogs-phones.jpg)
