### PR TITLE
Fix #1221, add eth2-extra

### DIFF
--- a/eth2/_utils/bls/backends/milagro.py
+++ b/eth2/_utils/bls/backends/milagro.py
@@ -2,6 +2,10 @@ from typing import Iterator, Sequence, Tuple
 
 from eth_typing import BLSPubkey, BLSSignature, Hash32
 from eth_utils import to_tuple
+from py_ecc.bls.typing import Domain
+
+from eth2._utils.bls.backends.base import BaseBLSBackend
+from eth2.beacon.constants import EMPTY_PUBKEY, EMPTY_SIGNATURE
 from milagro_bls_binding import (
     aggregate_pubkeys,
     aggregate_signatures,
@@ -10,10 +14,6 @@ from milagro_bls_binding import (
     verify,
     verify_multiple,
 )
-from py_ecc.bls.typing import Domain
-
-from eth2._utils.bls.backends.base import BaseBLSBackend
-from eth2.beacon.constants import EMPTY_PUBKEY, EMPTY_SIGNATURE
 
 
 def to_int(domain: Domain) -> int:

--- a/eth2/_utils/bls/backends/milagro.py
+++ b/eth2/_utils/bls/backends/milagro.py
@@ -2,10 +2,6 @@ from typing import Iterator, Sequence, Tuple
 
 from eth_typing import BLSPubkey, BLSSignature, Hash32
 from eth_utils import to_tuple
-from py_ecc.bls.typing import Domain
-
-from eth2._utils.bls.backends.base import BaseBLSBackend
-from eth2.beacon.constants import EMPTY_PUBKEY, EMPTY_SIGNATURE
 from milagro_bls_binding import (
     aggregate_pubkeys,
     aggregate_signatures,
@@ -14,6 +10,10 @@ from milagro_bls_binding import (
     verify,
     verify_multiple,
 )
+from py_ecc.bls.typing import Domain
+
+from eth2._utils.bls.backends.base import BaseBLSBackend
+from eth2.beacon.constants import EMPTY_PUBKEY, EMPTY_SIGNATURE
 
 
 def to_int(domain: Domain) -> int:

--- a/setup.py
+++ b/setup.py
@@ -113,6 +113,8 @@ deps = {
         "rlp>=1.1.0,<2.0.0",
         PYEVM_DEPENDENCY,
         "ssz==0.1.5",
+    ],
+    'eth2-extra': [
         "milagro-bls-binding==0.1.3",
     ],
     'eth2-lint': [
@@ -155,6 +157,7 @@ deps['dev'] = (
 deps['eth2-dev'] = (
     deps['dev'] +
     deps['eth2'] +
+    deps['eth2-extra'] +
     deps['eth2-lint']
 )
 

--- a/tests/eth2/core/beacon/tools/builder/test_validator.py
+++ b/tests/eth2/core/beacon/tools/builder/test_validator.py
@@ -5,7 +5,6 @@ import pytest
 
 from eth2._utils.bitfield import get_empty_bitfield, has_voted
 from eth2._utils.bls import bls
-from eth2._utils.bls.backends.milagro import MilagroBackend
 from eth2.beacon.helpers import compute_domain
 from eth2.beacon.signature_domain import SignatureDomain
 from eth2.beacon.tools.builder.validator import aggregate_votes, verify_votes
@@ -59,7 +58,7 @@ def test_aggregate_votes(votes_count, random, privkeys, pubkeys):
 
     aggregated_pubs = bls.aggregate_pubkeys(pubs)
 
-    if votes_count == 0 and bls.backend == MilagroBackend:
+    if votes_count == 0:
         with pytest.raises(ValidationError):
             bls.validate(message_hash, aggregated_pubs, sigs, domain)
     else:

--- a/tox.ini
+++ b/tox.ini
@@ -18,7 +18,7 @@ ignore=
 
 [isort]
 force_sort_within_sections=True
-known_third_party=hypothesis,pytest,async_generator,cytoolz,trio_typing,pytest_trio,factory
+known_third_party=hypothesis,pytest,async_generator,cytoolz,trio_typing,pytest_trio,factory,milagro_bls_binding
 multi_line_output=3
 include_trailing_comma=True
 force_grid_wrap=0

--- a/tox.ini
+++ b/tox.ini
@@ -190,14 +190,14 @@ deps = {[common-lint-eth2]deps}
 commands= {[common-lint-eth2]commands}
 
 [testenv:py36-eth2-fixtures]
-deps = .[eth2,test]
+deps = .[eth2,eth2-extra,test]
 commands=
     pytest -n 4 --config minimal {posargs:tests/eth2/fixtures/}
     pytest -n 4 --config mainnet {posargs:tests/eth2/fixtures/}
 
 
 [testenv:py37-eth2-fixtures]
-deps = .[eth2,test]
+deps = .[eth2,eth2-extra,test]
 commands=
     pytest -n 4 --config minimal {posargs:tests/eth2/fixtures/}
     pytest -n 4 --config mainnet {posargs:tests/eth2/fixtures/}

--- a/tox.ini
+++ b/tox.ini
@@ -189,6 +189,15 @@ commands= {[common-lint-eth2]commands}
 deps = {[common-lint-eth2]deps}
 commands= {[common-lint-eth2]commands}
 
+[common-eth2-utils]
+deps = .[eth2,eth2-extra,test]
+
+[testenv:py36-eth2-utils]
+deps = {[common-eth2-utils]deps}
+
+[testenv:py37-eth2-utils]
+deps = {[common-eth2-utils]deps}
+
 [testenv:py36-eth2-fixtures]
 deps = .[eth2,eth2-extra,test]
 commands=


### PR DESCRIPTION
### What was wrong?

Modules such as milagro-bls-binding that have no Windows build would make installation experience bad for users.

### How was it fixed?

Move those package to an optional eth2-extra section.

### To-Do

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://preview.redd.it/zolbd6jdc2u31.png?width=640&crop=smart&auto=webp&s=8f5dff2cd98636988daf7aed8802ab5e2289cd67)
