### PR TITLE
Fix #1224, pip3 install error due to plyvel version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ deps = {
         "dataclasses>=0.6, <1;python_version<'3.7'",
         "eth-utils>=1.7,<2",
         "ipython>=7.8.0,<8.0.0",
-        "plyvel==1.0.5",
+        "plyvel==1.1.0",
         PYEVM_DEPENDENCY,
         "web3==4.4.1",
         "lahja>=0.14.5,<0.15.0",

--- a/trinity/_utils/logging.py
+++ b/trinity/_utils/logging.py
@@ -28,6 +28,8 @@ from trinity._utils.shellart import (
     bold_yellow,
 )
 
+from datetime import datetime
+
 if TYPE_CHECKING:
     from multiprocessing import Queue  # noqa: F401
 
@@ -104,6 +106,17 @@ def setup_trinity_file_and_queue_logging(
         level = logging.DEBUG
 
     log_queue = ctx.Queue()
+
+    formatted_logfile = str(logfile_path)
+    str_timestamp = datetime.now().strftime('_%Y%m%d_%H%M%S')
+    idx = formatted_logfile.rfind(
+        ".",
+        len(formatted_logfile) - len(os.path.basename(formatted_logfile))
+    )
+    if idx != -1:
+        formatted_logfile = formatted_logfile[0:idx] + str_timestamp + formatted_logfile[idx:]
+    else:
+        formatted_logfile = formatted_logfile + str_timestamp + ".log"
 
     handler_file = RotatingFileHandler(
         str(logfile_path),


### PR DESCRIPTION
### What was wrong?
#1224, pip3 install error due to plyvel version on OSX


### How was it fixed?
update plyvel version to 1.1.0

