### PR TITLE
Bump `eth2-fixtures` from `v0.8.3` to `v0.8.4`

### DIFF
--- a/.circleci/get_eth2_fixtures.sh
+++ b/.circleci/get_eth2_fixtures.sh
@@ -1,9 +1,9 @@
 #!/usr/bin/env bash
 
 if [ ! -d "./eth2-fixtures/tests" ]; then
-  wget -c https://github.com/ethereum/eth2.0-spec-tests/releases/download/v0.8.3/general.tar.gz
-  wget -c https://github.com/ethereum/eth2.0-spec-tests/releases/download/v0.8.3/mainnet.tar.gz
-  wget -c https://github.com/ethereum/eth2.0-spec-tests/releases/download/v0.8.3/minimal.tar.gz
+  wget -c https://github.com/ethereum/eth2.0-spec-tests/releases/download/v0.8.4/general.tar.gz
+  wget -c https://github.com/ethereum/eth2.0-spec-tests/releases/download/v0.8.4/mainnet.tar.gz
+  wget -c https://github.com/ethereum/eth2.0-spec-tests/releases/download/v0.8.4/minimal.tar.gz
   mkdir eth2-fixtures
   tar zxvf general.tar.gz -C ./eth2-fixtures
   tar zxvf mainnet.tar.gz -C ./eth2-fixtures


### PR DESCRIPTION
### What was wrong?

New test suite released: https://github.com/ethereum/eth2.0-spec-tests/releases/tag/v0.8.4

### How was it fixed?
Bump it.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

[//]: # (See: https://trinity-client.readthedocs.io/en/latest/contributing.html#pull-requests)
- [ ] Add entry to the [release notes](https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![crab-1990198_640](https://user-images.githubusercontent.com/9263930/67556507-e77c5500-f745-11e9-907e-524538a0195c.jpg)
