### PR TITLE
fix eth_syncing endpoint 

### DIFF
--- a/newsfragments/765.bugfix.rst
+++ b/newsfragments/765.bugfix.rst
@@ -1,0 +1,1 @@
+Fix JSON-RPC eth_syncing endpoint that was accidentally removed in v0.1.0-alpha.23

--- a/tests/core/p2p-proto/test_sync.py
+++ b/tests/core/p2p-proto/test_sync.py
@@ -77,7 +77,7 @@ async def test_skeleton_syncer(request, event_loop, event_bus, chaindb_fresh, ch
     )
     async with peer_pair as (client_peer, server_peer):
 
-        client_peer_pool = MockPeerPoolWithConnectedPeers([client_peer])
+        client_peer_pool = MockPeerPoolWithConnectedPeers([client_peer], event_bus=event_bus)
         client = FastChainSyncer(LatestTestChain(chaindb_fresh.db), chaindb_fresh, client_peer_pool)
         server_peer_pool = MockPeerPoolWithConnectedPeers([server_peer], event_bus=event_bus)
 
@@ -190,7 +190,7 @@ async def test_beam_syncer(
         # manually add endpoint for trie data gatherer to serve requests
         gatherer_config = ConnectionConfig.from_name(f"GathererEndpoint-{unique_process_name}")
 
-        client_peer_pool = MockPeerPoolWithConnectedPeers([client_peer])
+        client_peer_pool = MockPeerPoolWithConnectedPeers([client_peer], event_bus=event_bus)
         server_peer_pool = MockPeerPoolWithConnectedPeers([server_peer], event_bus=event_bus)
 
         async with run_peer_pool_event_server(
@@ -260,7 +260,8 @@ async def test_regular_syncer(request, event_loop, event_bus, chaindb_fresh, cha
         client = RegularChainSyncer(
             ByzantiumTestChain(chaindb_fresh.db),
             chaindb_fresh,
-            MockPeerPoolWithConnectedPeers([client_peer]))
+            MockPeerPoolWithConnectedPeers([client_peer], event_bus=event_bus)
+        )
         server_peer_pool = MockPeerPoolWithConnectedPeers([server_peer], event_bus=event_bus)
 
         async with run_peer_pool_event_server(
@@ -381,7 +382,8 @@ async def test_regular_syncer_fallback(request, event_loop, event_bus, chaindb_f
         client = FallbackTesting_RegularChainSyncer(
             ByzantiumTestChain(chaindb_fresh.db),
             chaindb_fresh,
-            MockPeerPoolWithConnectedPeers([client_peer]))
+            MockPeerPoolWithConnectedPeers([client_peer], event_bus=event_bus)
+        )
         server_peer_pool = MockPeerPoolWithConnectedPeers([server_peer], event_bus=event_bus)
 
         async with run_peer_pool_event_server(
@@ -425,7 +427,8 @@ async def test_light_syncer(request,
         client = LightChainSyncer(
             LatestTestChain(chaindb_fresh.db),
             chaindb_fresh,
-            MockPeerPoolWithConnectedPeers([client_peer]))
+            MockPeerPoolWithConnectedPeers([client_peer], event_bus=event_bus)
+        )
         server_peer_pool = MockPeerPoolWithConnectedPeers([server_peer], event_bus=event_bus)
 
         async with run_peer_pool_event_server(

--- a/trinity/sync/common/headers.py
+++ b/trinity/sync/common/headers.py
@@ -1038,7 +1038,7 @@ class BaseHeaderChainSyncer(BaseService, HeaderSyncerAPI, Generic[TChainPeer]):
         return True, self._meat.sync_progress
 
     async def _handle_sync_status_requests(self, event_bus: EndpointAPI) -> None:
-        async for req in event_bus.stream(SyncingRequest):
+        async for req in self.wait_iter(event_bus.stream(SyncingRequest)):
             await event_bus.broadcast(
                 SyncingResponse(*self._get_sync_status()),
                 req.broadcast_config()


### PR DESCRIPTION
### What was wrong?

fixes #765 
`eth_syncing` was removed accidentally in https://github.com/ethereum/trinity/commit/4c87a663a0b426d418045ece74c54cb4d6c1eeb4#diff-8a563f755f9f95bd5dbd1e7b6a0f3c22L160.

### How was it fixed?
added back code that was removed accidentally.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

[//]: # (See: https://trinity-client.readthedocs.io/en/latest/contributing.html#pull-requests)
- [x] Add entry to the [release notes](https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://i.redd.it/8qe4rnnsw5v31.jpg)
