### PR TITLE
Organize trinity tools factories

### DIFF
--- a/p2p/handshake.py
+++ b/p2p/handshake.py
@@ -45,7 +45,7 @@ from p2p.p2p_proto import (
     DevP2PReceipt,
     Hello,
     BaseP2PProtocol,
-    P2PProtocol,
+    P2PProtocolV5,
     P2PProtocolV4,
 )
 from p2p.protocol import get_cmd_offsets
@@ -72,7 +72,7 @@ class DevP2PHandshakeParams(NamedTuple):
 
     def get_base_protocol_class(self) -> Type[BaseP2PProtocol]:
         if self.version == 5:
-            return P2PProtocol
+            return P2PProtocolV5
         elif self.version == 4:
             return P2PProtocolV4
         else:
@@ -142,7 +142,7 @@ async def _do_p2p_handshake(transport: TransportAPI,
                 # Now update the base protocol to support snappy compression
                 # This is needed so that Trinity is compatible with parity since
                 # parity sends Ping immediately after handshake
-                protocol = P2PProtocol(
+                protocol = P2PProtocolV5(
                     transport,
                     cmd_id_offset=0,
                     snappy_support=True,

--- a/p2p/p2p_proto.py
+++ b/p2p/p2p_proto.py
@@ -11,7 +11,7 @@ import rlp
 from rlp import sedes
 
 from p2p.abc import TransportAPI
-from p2p.constants import P2P_PROTOCOL_COMMAND_LENGTH
+from p2p.constants import DEVP2P_V4, DEVP2P_V5, P2P_PROTOCOL_COMMAND_LENGTH
 from p2p.disconnect import DisconnectReason as _DisconnectReason
 from p2p.exceptions import MalformedMessage
 from p2p.receipt import HandshakeReceipt
@@ -136,7 +136,7 @@ class BaseP2PProtocol(Protocol):
 
 
 class P2PProtocolV4(BaseP2PProtocol):
-    version = 4
+    version = DEVP2P_V4
 
     def __init__(self, transport: TransportAPI, cmd_id_offset: int, snappy_support: bool) -> None:
         if snappy_support is True:
@@ -147,8 +147,8 @@ class P2PProtocolV4(BaseP2PProtocol):
         super().__init__(transport, cmd_id_offset=cmd_id_offset, snappy_support=False)
 
 
-class P2PProtocol(BaseP2PProtocol):
-    version = 5
+class P2PProtocolV5(BaseP2PProtocol):
+    version = DEVP2P_V5
 
 
 class DevP2PReceipt(HandshakeReceipt):

--- a/p2p/tools/factories/multiplexer.py
+++ b/p2p/tools/factories/multiplexer.py
@@ -5,9 +5,9 @@ from cancel_token import CancelToken
 from eth_keys import keys
 
 from p2p.abc import MultiplexerAPI, NodeAPI, ProtocolAPI, TransportAPI
-from p2p.constants import DEVP2P_V4, DEVP2P_V5
+from p2p.constants import DEVP2P_V5
 from p2p.multiplexer import Multiplexer
-from p2p.p2p_proto import BaseP2PProtocol, P2PProtocol, P2PProtocolV4
+from p2p.p2p_proto import BaseP2PProtocol, P2PProtocolV4, P2PProtocolV5
 from p2p.protocol import get_cmd_offsets
 
 from .cancel_token import CancelTokenFactory
@@ -18,12 +18,6 @@ TransportPair = Tuple[
     TransportAPI,
     TransportAPI,
 ]
-
-
-BASE_PROTOCOL_CLASS_MAP = {
-    DEVP2P_V4: P2PProtocolV4,
-    DEVP2P_V5: P2PProtocol,
-}
 
 
 def MultiplexerPairFactory(*,
@@ -63,7 +57,7 @@ def MultiplexerPairFactory(*,
     p2p_protocol_class: Type[BaseP2PProtocol]
 
     if snappy_support:
-        p2p_protocol_class = P2PProtocol
+        p2p_protocol_class = P2PProtocolV5
     else:
         p2p_protocol_class = P2PProtocolV4
 

--- a/tests/core/p2p-proto/test_les_protocol_commands.py
+++ b/tests/core/p2p-proto/test_les_protocol_commands.py
@@ -2,7 +2,7 @@ import asyncio
 import pytest
 
 from trinity.protocol.les.proto import (
-    LESProtocol,
+    LESProtocolV1,
     LESProtocolV2,
 )
 
@@ -32,8 +32,8 @@ async def test_les_protocol_methods_request_id(
 
     # Setting up the peers which are just connected by streams
     peer, remote = les_peer_and_remote
-    assert isinstance(peer.sub_proto, LESProtocol)
-    assert isinstance(remote.sub_proto, LESProtocol)
+    assert isinstance(peer.sub_proto, LESProtocolV1)
+    assert isinstance(remote.sub_proto, LESProtocolV1)
 
     # setup message collection
     messages = []

--- a/tests/core/p2p-proto/test_peer.py
+++ b/tests/core/p2p-proto/test_peer.py
@@ -8,7 +8,7 @@ from trinity.protocol.eth.peer import ETHPeer
 from trinity.protocol.eth.proto import ETHProtocol
 from trinity.protocol.les.peer import LESPeer
 from trinity.protocol.les.proto import (
-    LESProtocol,
+    LESProtocolV1,
     LESProtocolV2,
 )
 
@@ -29,8 +29,8 @@ async def test_LES_v1_peers():
         assert isinstance(alice, LESPeer)
         assert isinstance(bob, LESPeer)
 
-        assert isinstance(alice.sub_proto, LESProtocol)
-        assert isinstance(bob.sub_proto, LESProtocol)
+        assert isinstance(alice.sub_proto, LESProtocolV1)
+        assert isinstance(bob.sub_proto, LESProtocolV1)
 
 
 @pytest.mark.asyncio

--- a/tests/core/p2p-proto/test_v5_les_protocol_topics.py
+++ b/tests/core/p2p-proto/test_v5_les_protocol_topics.py
@@ -2,11 +2,11 @@ from eth.chains.ropsten import ROPSTEN_GENESIS_HEADER
 
 from p2p import discovery
 
-from trinity.protocol.les.proto import LESProtocol, LESProtocolV2
+from trinity.protocol.les.proto import LESProtocolV1, LESProtocolV2
 
 
 def test_get_v5_topic():
-    les_topic = discovery.get_v5_topic(LESProtocol, ROPSTEN_GENESIS_HEADER.hash)
+    les_topic = discovery.get_v5_topic(LESProtocolV1, ROPSTEN_GENESIS_HEADER.hash)
     assert les_topic == b'LES@41941023680923e0'
     les2_topic = discovery.get_v5_topic(LESProtocolV2, ROPSTEN_GENESIS_HEADER.hash)
     assert les2_topic == b'LES2@41941023680923e0'

--- a/tests/p2p/test_auth.py
+++ b/tests/p2p/test_auth.py
@@ -20,8 +20,8 @@ from p2p.auth import decode_authentication
 from p2p.constants import DEVP2P_V5, DEVP2P_V4
 from p2p.p2p_proto import (
     Hello,
-    P2PProtocol,
     P2PProtocolV4,
+    P2PProtocolV5,
 )
 from p2p.multiplexer import Multiplexer
 from p2p.transport import Transport
@@ -129,7 +129,7 @@ async def test_handshake():
         egress_mac=initiator_egress_mac,
         ingress_mac=initiator_ingress_mac
     )
-    initiator_p2p_protocol = P2PProtocol(initiator_transport, 0, False)
+    initiator_p2p_protocol = P2PProtocolV5(initiator_transport, 0, False)
     initiator_multiplexer = Multiplexer(
         transport=initiator_transport,
         base_protocol=initiator_p2p_protocol,
@@ -149,7 +149,7 @@ async def test_handshake():
         egress_mac=egress_mac,
         ingress_mac=ingress_mac,
     )
-    responder_p2p_protocol = P2PProtocol(responder_transport, 0, False)
+    responder_p2p_protocol = P2PProtocolV5(responder_transport, 0, False)
     responder_multiplexer = Multiplexer(
         transport=responder_transport,
         base_protocol=responder_p2p_protocol,
@@ -260,7 +260,7 @@ async def test_handshake_eip8():
         egress_mac=initiator_egress_mac,
         ingress_mac=initiator_ingress_mac
     )
-    initiator_p2p_protocol = P2PProtocol(initiator_transport, 0, False)
+    initiator_p2p_protocol = P2PProtocolV5(initiator_transport, 0, False)
     initiator_multiplexer = Multiplexer(
         transport=initiator_transport,
         base_protocol=initiator_p2p_protocol,

--- a/tests/p2p/test_connection_pair_factory.py
+++ b/tests/p2p/test_connection_pair_factory.py
@@ -1,7 +1,7 @@
 import pytest
 
 from p2p.constants import DEVP2P_V4, DEVP2P_V5
-from p2p.p2p_proto import P2PProtocol, P2PProtocolV4
+from p2p.p2p_proto import P2PProtocolV4, P2PProtocolV5
 from p2p.tools.factories import ConnectionPairFactory, ProtocolFactory
 from p2p.tools.connection import do_ping_pong_test
 from p2p.tools.handshake import NoopHandshaker
@@ -39,7 +39,7 @@ async def test_connection_pair_factory_no_protocols_with_different_p2p_versions(
         if expected_base_protocol_version == DEVP2P_V4:
             expected_base_protocol_class = P2PProtocolV4
         elif expected_base_protocol_version == DEVP2P_V5:
-            expected_base_protocol_class = P2PProtocol
+            expected_base_protocol_class = P2PProtocolV5
         else:
             raise Exception(f"unrecognized version: {expected_base_protocol_version}")
 

--- a/tests/p2p/test_handshake.py
+++ b/tests/p2p/test_handshake.py
@@ -7,7 +7,7 @@ from p2p.tools.factories import (
     ProtocolFactory,
     DevP2PHandshakeParamsFactory,
 )
-from p2p.p2p_proto import P2PProtocol, P2PProtocolV4
+from p2p.p2p_proto import P2PProtocolV4, P2PProtocolV5
 from p2p.handshake import (
     negotiate_protocol_handshakes,
     DevP2PHandshakeParams,
@@ -53,7 +53,7 @@ async def test_handshake_with_v4_and_v5_disables_snappy():
     alice_p2p_protocol = alice_p2p_receipt.protocol
     bob_p2p_protocol = bob_p2p_receipt.protocol
 
-    assert isinstance(alice_p2p_protocol, P2PProtocol)
+    assert isinstance(alice_p2p_protocol, P2PProtocolV5)
     assert alice_p2p_protocol.snappy_support is False
 
     assert isinstance(bob_p2p_protocol, P2PProtocolV4)
@@ -106,12 +106,12 @@ async def test_handshake_with_single_protocol():
     assert isinstance(alice_receipt.protocol, protocol_class)
     assert isinstance(bob_receipt.protocol, protocol_class)
 
-    assert isinstance(alice_multiplexer.get_base_protocol(), P2PProtocol)
-    assert isinstance(alice_multiplexer.get_protocols()[0], P2PProtocol)
+    assert isinstance(alice_multiplexer.get_base_protocol(), P2PProtocolV5)
+    assert isinstance(alice_multiplexer.get_protocols()[0], P2PProtocolV5)
     assert isinstance(alice_multiplexer.get_protocols()[1], protocol_class)
 
-    assert isinstance(bob_multiplexer.get_base_protocol(), P2PProtocol)
-    assert isinstance(bob_multiplexer.get_protocols()[0], P2PProtocol)
+    assert isinstance(bob_multiplexer.get_base_protocol(), P2PProtocolV5)
+    assert isinstance(bob_multiplexer.get_protocols()[0], P2PProtocolV5)
     assert isinstance(bob_multiplexer.get_protocols()[1], protocol_class)
 
     alice_p2p_protocol = alice_p2p_receipt.protocol
@@ -172,20 +172,20 @@ async def test_handshake_with_multiple_protocols():
     assert len(alice_receipts) == 2
     assert len(bob_receipts) == 2
 
-    assert isinstance(alice_p2p_receipt.protocol, P2PProtocol)
+    assert isinstance(alice_p2p_receipt.protocol, P2PProtocolV5)
     assert isinstance(alice_receipts[0].protocol, A2)
     assert isinstance(alice_receipts[1].protocol, C3)
 
-    assert isinstance(alice_p2p_receipt.protocol, P2PProtocol)
+    assert isinstance(alice_p2p_receipt.protocol, P2PProtocolV5)
     assert isinstance(bob_receipts[0].protocol, A2)
     assert isinstance(bob_receipts[1].protocol, C3)
 
-    assert isinstance(alice_multiplexer.get_base_protocol(), P2PProtocol)
-    assert isinstance(alice_multiplexer.get_protocols()[0], P2PProtocol)
+    assert isinstance(alice_multiplexer.get_base_protocol(), P2PProtocolV5)
+    assert isinstance(alice_multiplexer.get_protocols()[0], P2PProtocolV5)
     assert isinstance(alice_multiplexer.get_protocols()[1], A2)
     assert isinstance(alice_multiplexer.get_protocols()[2], C3)
 
-    assert isinstance(bob_multiplexer.get_base_protocol(), P2PProtocol)
-    assert isinstance(bob_multiplexer.get_protocols()[0], P2PProtocol)
+    assert isinstance(bob_multiplexer.get_base_protocol(), P2PProtocolV5)
+    assert isinstance(bob_multiplexer.get_protocols()[0], P2PProtocolV5)
     assert isinstance(bob_multiplexer.get_protocols()[1], A2)
     assert isinstance(bob_multiplexer.get_protocols()[2], C3)

--- a/tests/p2p/test_multiplexer.py
+++ b/tests/p2p/test_multiplexer.py
@@ -6,7 +6,7 @@ from eth_utils import ValidationError
 
 from p2p.exceptions import UnknownProtocol
 from p2p.protocol import Command, Protocol
-from p2p.p2p_proto import Ping, Pong, P2PProtocol
+from p2p.p2p_proto import Ping, Pong, P2PProtocolV5
 
 from p2p.tools.factories import MultiplexerPairFactory
 
@@ -71,18 +71,18 @@ async def test_multiplexer_properties():
     )
     transport = multiplexer.get_transport()
 
-    base_protocol = multiplexer.get_protocol_by_type(P2PProtocol)
+    base_protocol = multiplexer.get_protocol_by_type(P2PProtocolV5)
     second_protocol = multiplexer.get_protocol_by_type(SecondProtocol)
     third_protocol = multiplexer.get_protocol_by_type(ThirdProtocol)
 
     assert multiplexer.get_base_protocol() is base_protocol
     assert multiplexer.get_protocols() == (base_protocol, second_protocol, third_protocol)
 
-    assert multiplexer.get_protocol_by_type(P2PProtocol) is base_protocol
+    assert multiplexer.get_protocol_by_type(P2PProtocolV5) is base_protocol
     assert multiplexer.get_protocol_by_type(SecondProtocol) is second_protocol
     assert multiplexer.get_protocol_by_type(ThirdProtocol) is third_protocol
 
-    assert multiplexer.has_protocol(P2PProtocol) is True
+    assert multiplexer.has_protocol(P2PProtocolV5) is True
     assert multiplexer.has_protocol(SecondProtocol) is True
     assert multiplexer.has_protocol(ThirdProtocol) is True
     assert multiplexer.has_protocol(UnsupportedProtocol) is False
@@ -101,11 +101,11 @@ async def test_multiplexer_only_p2p_protocol():
 
     async with alice_multiplexer.multiplex():
         async with bob_multiplexer.multiplex():
-            alice_stream = alice_multiplexer.stream_protocol_messages(P2PProtocol)
-            bob_stream = bob_multiplexer.stream_protocol_messages(P2PProtocol)
+            alice_stream = alice_multiplexer.stream_protocol_messages(P2PProtocolV5)
+            bob_stream = bob_multiplexer.stream_protocol_messages(P2PProtocolV5)
 
-            alice_p2p_protocol = alice_multiplexer.get_protocol_by_type(P2PProtocol)
-            bob_p2p_protocol = bob_multiplexer.get_protocol_by_type(P2PProtocol)
+            alice_p2p_protocol = alice_multiplexer.get_protocol_by_type(P2PProtocolV5)
+            bob_p2p_protocol = bob_multiplexer.get_protocol_by_type(P2PProtocolV5)
 
             alice_p2p_protocol.send_ping()
             cmd, _ = await asyncio.wait_for(bob_stream.asend(None), timeout=0.1)
@@ -123,15 +123,15 @@ async def test_multiplexer_p2p_and_paragon_protocol():
 
     async with alice_multiplexer.multiplex():
         async with bob_multiplexer.multiplex():
-            alice_p2p_stream = alice_multiplexer.stream_protocol_messages(P2PProtocol)
-            bob_p2p_stream = bob_multiplexer.stream_protocol_messages(P2PProtocol)
+            alice_p2p_stream = alice_multiplexer.stream_protocol_messages(P2PProtocolV5)
+            bob_p2p_stream = bob_multiplexer.stream_protocol_messages(P2PProtocolV5)
             alice_second_stream = alice_multiplexer.stream_protocol_messages(SecondProtocol)
             bob_second_stream = bob_multiplexer.stream_protocol_messages(SecondProtocol)
 
-            alice_p2p_protocol = alice_multiplexer.get_protocol_by_type(P2PProtocol)
+            alice_p2p_protocol = alice_multiplexer.get_protocol_by_type(P2PProtocolV5)
             alice_second_protocol = alice_multiplexer.get_protocol_by_type(SecondProtocol)
 
-            bob_p2p_protocol = bob_multiplexer.get_protocol_by_type(P2PProtocol)
+            bob_p2p_protocol = bob_multiplexer.get_protocol_by_type(P2PProtocolV5)
             bob_second_protocol = bob_multiplexer.get_protocol_by_type(SecondProtocol)
 
             alice_second_protocol.send_cmd(CommandA)
@@ -166,18 +166,18 @@ async def test_multiplexer_p2p_and_two_more_protocols():
 
     async with alice_multiplexer.multiplex():
         async with bob_multiplexer.multiplex():
-            alice_p2p_stream = alice_multiplexer.stream_protocol_messages(P2PProtocol)
-            bob_p2p_stream = bob_multiplexer.stream_protocol_messages(P2PProtocol)
+            alice_p2p_stream = alice_multiplexer.stream_protocol_messages(P2PProtocolV5)
+            bob_p2p_stream = bob_multiplexer.stream_protocol_messages(P2PProtocolV5)
             alice_second_stream = alice_multiplexer.stream_protocol_messages(SecondProtocol)
             bob_second_stream = bob_multiplexer.stream_protocol_messages(SecondProtocol)
             alice_third_stream = alice_multiplexer.stream_protocol_messages(ThirdProtocol)
             bob_third_stream = bob_multiplexer.stream_protocol_messages(ThirdProtocol)
 
-            alice_p2p_protocol = alice_multiplexer.get_protocol_by_type(P2PProtocol)
+            alice_p2p_protocol = alice_multiplexer.get_protocol_by_type(P2PProtocolV5)
             alice_second_protocol = alice_multiplexer.get_protocol_by_type(SecondProtocol)
             alice_third_protocol = alice_multiplexer.get_protocol_by_type(ThirdProtocol)
 
-            bob_p2p_protocol = bob_multiplexer.get_protocol_by_type(P2PProtocol)
+            bob_p2p_protocol = bob_multiplexer.get_protocol_by_type(P2PProtocolV5)
             bob_second_protocol = bob_multiplexer.get_protocol_by_type(SecondProtocol)
             bob_third_protocol = bob_multiplexer.get_protocol_by_type(ThirdProtocol)
 

--- a/tests/p2p/test_multiplexer_pair_factory.py
+++ b/tests/p2p/test_multiplexer_pair_factory.py
@@ -1,7 +1,7 @@
 import pytest
 
 from p2p.constants import DEVP2P_V4, DEVP2P_V5
-from p2p.p2p_proto import P2PProtocol, P2PProtocolV4
+from p2p.p2p_proto import P2PProtocolV4, P2PProtocolV5
 from p2p.tools.factories import MultiplexerPairFactory, NodeFactory
 
 
@@ -24,7 +24,7 @@ def test_multiplexer_pair_factory():
         (DEVP2P_V4, DEVP2P_V4, P2PProtocolV4),
         (DEVP2P_V4, DEVP2P_V5, P2PProtocolV4),
         (DEVP2P_V5, DEVP2P_V4, P2PProtocolV4),
-        (DEVP2P_V5, DEVP2P_V5, P2PProtocol),
+        (DEVP2P_V5, DEVP2P_V5, P2PProtocolV5),
     ),
 )
 @pytest.mark.asyncio

--- a/trinity/protocol/common/api.py
+++ b/trinity/protocol/common/api.py
@@ -9,11 +9,11 @@ from p2p.qualifiers import HasProtocol
 from trinity.protocol.eth.api import ETHAPI
 from trinity.protocol.eth.proto import ETHProtocol
 from trinity.protocol.les.api import LESAPI
-from trinity.protocol.les.proto import LESProtocol, LESProtocolV2
+from trinity.protocol.les.proto import LESProtocolV1, LESProtocolV2
 
 from .abc import ChainInfoAPI, HeadInfoAPI
 
-AnyETHLES = HasProtocol(ETHProtocol) | HasProtocol(LESProtocolV2) | HasProtocol(LESProtocol)
+AnyETHLES = HasProtocol(ETHProtocol) | HasProtocol(LESProtocolV2) | HasProtocol(LESProtocolV1)
 
 
 class ChainInfo(Application, ChainInfoAPI):
@@ -32,7 +32,7 @@ class ChainInfo(Application, ChainInfoAPI):
     def _get_logic(self) -> Union[ETHAPI, LESAPI]:
         if self.connection.has_protocol(ETHProtocol):
             return self.connection.get_logic(ETHAPI.name, ETHAPI)
-        elif self.connection.has_protocol(LESProtocolV2) or self.connection.has_protocol(LESProtocol):  # noqa: E501
+        elif self.connection.has_protocol(LESProtocolV2) or self.connection.has_protocol(LESProtocolV1):  # noqa: E501
             return self.connection.get_logic(LESAPI.name, LESAPI)
         else:
             raise Exception("Unreachable code path")
@@ -48,7 +48,7 @@ class HeadInfo(Application, HeadInfoAPI):
         if self.connection.has_protocol(ETHProtocol):
             eth_logic = self.connection.get_logic(ETHAPI.name, ETHAPI)
             return eth_logic.head_info
-        elif self.connection.has_protocol(LESProtocolV2) or self.connection.has_protocol(LESProtocol):  # noqa: E501
+        elif self.connection.has_protocol(LESProtocolV2) or self.connection.has_protocol(LESProtocolV1):  # noqa: E501
             les_logic = self.connection.get_logic(LESAPI.name, LESAPI)
             return les_logic.head_info
         else:

--- a/trinity/protocol/les/api.py
+++ b/trinity/protocol/les/api.py
@@ -14,7 +14,7 @@ from trinity.protocol.common.abc import HeadInfoAPI
 
 from .commands import Announce
 from .handshaker import LESHandshakeReceipt
-from .proto import LESProtocol, LESProtocolV2
+from .proto import LESProtocolV1, LESProtocolV2
 from .exchanges import GetBlockHeadersExchange
 
 
@@ -61,7 +61,7 @@ class HeadInfoTracker(CommandHandler, HeadInfoAPI):
 
 class LESAPI(Application):
     name = 'les'
-    qualifier = HasProtocol(LESProtocol) | HasProtocol(LESProtocolV2)
+    qualifier = HasProtocol(LESProtocolV1) | HasProtocol(LESProtocolV2)
 
     head_info: HeadInfoTracker
 

--- a/trinity/protocol/les/handshaker.py
+++ b/trinity/protocol/les/handshaker.py
@@ -22,11 +22,11 @@ from trinity.exceptions import WrongGenesisFailure, WrongNetworkFailure
 
 from .commands import Status, StatusV2
 
-from .proto import LESHandshakeParams, LESProtocol, LESProtocolV2
+from .proto import LESHandshakeParams, LESProtocolV1, LESProtocolV2
 
 
-AnyLESProtocol = Union[LESProtocol, LESProtocolV2]
-AnyLESProtocolClass = Union[Type[LESProtocol], Type[LESProtocolV2]]
+AnyLESProtocol = Union[LESProtocolV1, LESProtocolV2]
+AnyLESProtocolClass = Union[Type[LESProtocolV1], Type[LESProtocolV2]]
 
 
 class LESHandshakeReceipt(HandshakeReceipt):
@@ -135,7 +135,7 @@ class BaseLESHandshaker(Handshaker):
 
 
 class LESV1Handshaker(BaseLESHandshaker):
-    protocol_class = LESProtocol
+    protocol_class = LESProtocolV1
 
 
 class LESV2Handshaker(BaseLESHandshaker):

--- a/trinity/protocol/les/peer.py
+++ b/trinity/protocol/les/peer.py
@@ -2,6 +2,7 @@ from typing import (
     List,
     Tuple,
     TYPE_CHECKING,
+    Union,
 )
 
 from cached_property import cached_property
@@ -47,7 +48,7 @@ from .events import (
 )
 from .proto import (
     LESHandshakeParams,
-    LESProtocol,
+    LESProtocolV1,
     LESProtocolV2,
     ProxyLESProtocol,
 )
@@ -67,8 +68,8 @@ if TYPE_CHECKING:
 class LESPeer(BaseChainPeer):
     max_headers_fetch = MAX_HEADERS_FETCH
 
-    supported_sub_protocols = (LESProtocol, LESProtocolV2)
-    sub_proto: LESProtocol = None
+    supported_sub_protocols = (LESProtocolV1, LESProtocolV2)
+    sub_proto: Union[LESProtocolV1, LESProtocolV2] = None
 
     def get_behaviors(self) -> Tuple[BehaviorAPI, ...]:
         return super().get_behaviors() + (LESAPI().as_behavior(),)

--- a/trinity/protocol/les/proto.py
+++ b/trinity/protocol/les/proto.py
@@ -112,7 +112,7 @@ class LESHandshakeParams(NamedTuple):
             yield "announceType", self.announce_type
 
 
-class LESProtocol(Protocol):
+class LESProtocolV1(Protocol):
     name = 'les'
     version = 1
     _commands = (
@@ -254,7 +254,7 @@ class LESProtocol(Protocol):
         return request_id
 
 
-class LESProtocolV2(LESProtocol):
+class LESProtocolV2(LESProtocolV1):
     version = 2
     _commands = (  # type: ignore  # mypy doesn't like us overriding this.
         StatusV2,

--- a/trinity/tools/factories.py
+++ b/trinity/tools/factories.py
@@ -37,7 +37,7 @@ from trinity.protocol.eth.proto import ETHHandshakeParams, ETHProtocol
 
 from trinity.protocol.les.handshaker import LESV2Handshaker, LESV1Handshaker
 from trinity.protocol.les.peer import LESPeer, LESPeerFactory
-from trinity.protocol.les.proto import LESHandshakeParams, LESProtocol, LESProtocolV2
+from trinity.protocol.les.proto import LESHandshakeParams, LESProtocolV1, LESProtocolV2
 
 
 try:
@@ -204,7 +204,7 @@ class LESV1HandshakerFactory(factory.Factory):
     class Meta:
         model = LESV1Handshaker
 
-    handshake_params = factory.SubFactory(LESHandshakeParamsFactory, version=LESProtocol.version)
+    handshake_params = factory.SubFactory(LESHandshakeParamsFactory, version=LESProtocolV1.version)
 
 
 class LESV2HandshakerFactory(factory.Factory):
@@ -215,7 +215,7 @@ class LESV2HandshakerFactory(factory.Factory):
 
 
 class LESV1Peer(LESPeer):
-    supported_sub_protocols = (LESProtocol,)  # type: ignore
+    supported_sub_protocols = (LESProtocolV1,)  # type: ignore
 
 
 class LESV1PeerFactory(LESPeerFactory):

--- a/trinity/tools/factories/__init__.py
+++ b/trinity/tools/factories/__init__.py
@@ -1,0 +1,22 @@
+from .block_body import BlockBodyFactory  # noqa: F401
+from .block_hash import BlockHashFactory  # noqa: F401
+from .chain_context import ChainContextFactory  # noqa: F401
+from .db import (  # noqa: F401
+    MemoryDBFactory,
+    AtomicDBFactory,
+    HeaderDBFactory,
+    AsyncHeaderDBFactory,
+)
+from .les.proto import (  # noqa: F401
+    LESV1HandshakerFactory,
+    LESV2HandshakerFactory,
+    LESV1PeerPairFactory,
+    LESV2PeerPairFactory,
+)
+from .eth.proto import (  # noqa: F401
+    ETHHandshakerFactory,
+    ETHPeerPairFactory,
+)
+from .headers import BlockHeaderFactory  # noqa: F401
+from .receipts import ReceiptFactory  # noqa: F401
+from .transactions import BaseTransactionFieldsFactory  # noqa: F401

--- a/trinity/tools/factories/address.py
+++ b/trinity/tools/factories/address.py
@@ -1,0 +1,22 @@
+
+try:
+    import factory
+except ImportError:
+    raise ImportError("The p2p.tools.factories module requires the `factory_boy` library.")
+
+import secrets
+from typing import Any, Type
+
+from eth_typing import Address
+
+
+class AddressFactory(factory.Factory):
+    class Meta:
+        model = bytes
+
+    @classmethod
+    def _create(cls,
+                model_class: Type[bytes],
+                *args: Any,
+                **kwargs: Any) -> Address:
+        return Address(model_class(secrets.token_bytes(20)))

--- a/trinity/tools/factories/block_body.py
+++ b/trinity/tools/factories/block_body.py
@@ -1,0 +1,17 @@
+try:
+    import factory
+except ImportError:
+    raise ImportError("The p2p.tools.factories module requires the `factory_boy` library.")
+
+from trinity.rlp.block_body import BlockBody
+
+from .headers import BlockHeaderFactory
+from .transactions import BaseTransactionFieldsFactory
+
+
+class BlockBodyFactory(factory.Factory):
+    class Meta:
+        model = BlockBody
+
+    transactions = factory.LazyFunction(lambda: BaseTransactionFieldsFactory.create_batch(2))
+    uncles = factory.LazyFunction(lambda: BlockHeaderFactory.create_batch(2))

--- a/trinity/tools/factories/block_hash.py
+++ b/trinity/tools/factories/block_hash.py
@@ -1,0 +1,21 @@
+try:
+    import factory
+except ImportError:
+    raise ImportError("The p2p.tools.factories module requires the `factory_boy` library.")
+
+import secrets
+from typing import Any, Type
+
+from eth_typing import Hash32
+
+
+class BlockHashFactory(factory.Factory):
+    class Meta:
+        model = bytes
+
+    @classmethod
+    def _create(cls,
+                model_class: Type[bytes],
+                *args: Any,
+                **kwargs: Any) -> Hash32:
+        return Hash32(model_class(secrets.token_bytes(32)))

--- a/trinity/tools/factories/chain_context.py
+++ b/trinity/tools/factories/chain_context.py
@@ -1,0 +1,26 @@
+try:
+    import factory
+except ImportError:
+    raise ImportError("The p2p.tools.factories module requires the `factory_boy` library.")
+
+from eth_utils import to_bytes
+
+from eth.chains.mainnet import MAINNET_VM_CONFIGURATION
+
+from trinity.protocol.common.context import ChainContext
+
+from .db import AsyncHeaderDBFactory
+
+MAINNET_GENESIS_HASH = to_bytes(hexstr='0xd4e56740f876aef8c010b86a40d5f56745a118d0906a34e69aec8c0db1cb8fa3')  # noqa: E501
+
+
+class ChainContextFactory(factory.Factory):
+    class Meta:
+        model = ChainContext
+
+    network_id = 1
+    client_version_string = 'test'
+    headerdb = factory.SubFactory(AsyncHeaderDBFactory)
+    vm_configuration = ((0, MAINNET_VM_CONFIGURATION[-1][1]),)
+    listen_port = 30303
+    p2p_version = 5

--- a/trinity/tools/factories/common.py
+++ b/trinity/tools/factories/common.py
@@ -1,0 +1,20 @@
+
+try:
+    import factory
+except ImportError:
+    raise ImportError(
+        "The p2p.tools.factories module requires the `factory_boy` and `faker` libraries."
+    )
+
+
+from trinity.protocol.common.payloads import BlockHeadersQuery
+
+
+class BlockHeadersQueryFactory(factory.Factory):
+    class Meta:
+        model = BlockHeadersQuery
+
+    block_number_or_hash = 0
+    max_headers = 1
+    skip = 0
+    reverse = False

--- a/trinity/tools/factories/db.py
+++ b/trinity/tools/factories/db.py
@@ -57,6 +57,9 @@ class AsyncHeaderDBFactory(factory.Factory):
 
         headerdb = model_class(*args, **kwargs)
 
+        # SIDE EFFECT!
+        # This uses the side effect of initializing a chain using the `builder`
+        # tool to populate the genesis state into the database.
         build(
             Chain,
             latest_mainnet_at(0),

--- a/trinity/tools/factories/db.py
+++ b/trinity/tools/factories/db.py
@@ -1,0 +1,65 @@
+try:
+    import factory
+except ImportError:
+    raise ImportError("The p2p.tools.factories module requires the `factory_boy` library.")
+
+from typing import (
+    Any,
+    Type,
+)
+
+from eth_utils import to_bytes
+
+from eth.db.header import HeaderDB
+from eth.db.backends.memory import MemoryDB
+from eth.db.atomic import AtomicDB
+
+from trinity.db.eth1.header import AsyncHeaderDB
+
+
+MAINNET_GENESIS_HASH = to_bytes(hexstr='0xd4e56740f876aef8c010b86a40d5f56745a118d0906a34e69aec8c0db1cb8fa3')  # noqa: E501
+
+
+class MemoryDBFactory(factory.Factory):
+    class Meta:
+        model = MemoryDB
+
+
+class AtomicDBFactory(factory.Factory):
+    class Meta:
+        model = AtomicDB
+
+    wrapped_db = factory.SubFactory(MemoryDBFactory)
+
+
+class HeaderDBFactory(factory.Factory):
+    class Meta:
+        model = HeaderDB
+
+    db = factory.SubFactory(AtomicDBFactory)
+
+
+class AsyncHeaderDBFactory(factory.Factory):
+    class Meta:
+        model = AsyncHeaderDB
+
+    db = factory.SubFactory(AtomicDBFactory)
+
+    @classmethod
+    def _create(cls,
+                model_class: Type[AsyncHeaderDB],
+                *args: Any,
+                **kwargs: Any) -> AsyncHeaderDB:
+        from eth.chains.base import Chain
+        from eth.tools.builder.chain import build, latest_mainnet_at, genesis
+
+        genesis_params = kwargs.pop('genesis_params', None)
+
+        headerdb = model_class(*args, **kwargs)
+
+        build(
+            Chain,
+            latest_mainnet_at(0),
+            genesis(db=headerdb.db, params=genesis_params),
+        )
+        return headerdb

--- a/trinity/tools/factories/eth/__init__.py
+++ b/trinity/tools/factories/eth/__init__.py
@@ -1,0 +1,4 @@
+from .proto import (  # noqa: F401
+    ETHHandshakerFactory,
+    ETHPeerPairFactory,
+)

--- a/trinity/tools/factories/eth/proto.py
+++ b/trinity/tools/factories/eth/proto.py
@@ -1,0 +1,108 @@
+try:
+    import factory
+except ImportError:
+    raise ImportError("The p2p.tools.factories module requires the `factory_boy` library.")
+
+from typing import (
+    cast,
+    Any,
+    AsyncContextManager,
+    Tuple,
+)
+
+from lahja import EndpointAPI
+
+from cancel_token import CancelToken
+
+from eth_typing import BlockNumber
+from eth_utils import to_bytes
+
+from eth_keys import keys
+from eth.abc import HeaderDatabaseAPI
+from eth.constants import GENESIS_DIFFICULTY, GENESIS_BLOCK_NUMBER
+
+from p2p import kademlia
+from p2p.tools.factories import PeerPairFactory
+
+from trinity.constants import MAINNET_NETWORK_ID
+
+from trinity.protocol.common.context import ChainContext
+
+from trinity.protocol.eth.handshaker import ETHHandshaker
+from trinity.protocol.eth.peer import ETHPeer, ETHPeerFactory
+from trinity.protocol.eth.proto import ETHHandshakeParams, ETHProtocol
+
+from trinity.tools.factories.chain_context import ChainContextFactory
+
+
+MAINNET_GENESIS_HASH = to_bytes(hexstr='0xd4e56740f876aef8c010b86a40d5f56745a118d0906a34e69aec8c0db1cb8fa3')  # noqa: E501
+
+
+class ETHHandshakeParamsFactory(factory.Factory):
+    class Meta:
+        model = ETHHandshakeParams
+
+    head_hash = MAINNET_GENESIS_HASH
+    genesis_hash = MAINNET_GENESIS_HASH
+    network_id = MAINNET_NETWORK_ID
+    total_difficulty = GENESIS_DIFFICULTY
+    version = ETHProtocol.version
+
+    @classmethod
+    def from_headerdb(cls, headerdb: HeaderDatabaseAPI, **kwargs: Any) -> ETHHandshakeParams:
+        head = headerdb.get_canonical_head()
+        head_score = headerdb.get_score(head.hash)
+        # TODO: https://github.com/ethereum/py-evm/issues/1847
+        genesis = headerdb.get_canonical_block_header_by_number(BlockNumber(GENESIS_BLOCK_NUMBER))
+        return cls(
+            head_hash=head.hash,
+            genesis_hash=genesis.hash,
+            total_difficulty=head_score,
+            **kwargs
+        )
+
+
+class ETHHandshakerFactory(factory.Factory):
+    class Meta:
+        model = ETHHandshaker
+
+    handshake_params = factory.SubFactory(ETHHandshakeParamsFactory)
+
+
+def ETHPeerPairFactory(*,
+                       alice_peer_context: ChainContext = None,
+                       alice_remote: kademlia.Node = None,
+                       alice_private_key: keys.PrivateKey = None,
+                       alice_client_version: str = 'bob',
+                       bob_peer_context: ChainContext = None,
+                       bob_remote: kademlia.Node = None,
+                       bob_private_key: keys.PrivateKey = None,
+                       bob_client_version: str = 'bob',
+                       cancel_token: CancelToken = None,
+                       event_bus: EndpointAPI = None,
+                       ) -> AsyncContextManager[Tuple[ETHPeer, ETHPeer]]:
+    if alice_peer_context is None:
+        alice_peer_context = ChainContextFactory()
+
+    if bob_peer_context is None:
+        alice_genesis = alice_peer_context.headerdb.get_canonical_block_header_by_number(
+            BlockNumber(GENESIS_BLOCK_NUMBER),
+        )
+        bob_peer_context = ChainContextFactory(
+            headerdb__genesis_params={'timestamp': alice_genesis.timestamp},
+        )
+
+    return cast(AsyncContextManager[Tuple[ETHPeer, ETHPeer]], PeerPairFactory(
+        alice_peer_context=alice_peer_context,
+        alice_peer_factory_class=ETHPeerFactory,
+        bob_peer_context=bob_peer_context,
+        bob_peer_factory_class=ETHPeerFactory,
+        alice_remote=alice_remote,
+        alice_private_key=alice_private_key,
+        alice_client_version=alice_client_version,
+        bob_remote=bob_remote,
+        bob_private_key=bob_private_key,
+        bob_client_version=bob_client_version,
+        cancel_token=cancel_token,
+        event_bus=event_bus,
+    ))

--- a/trinity/tools/factories/headers.py
+++ b/trinity/tools/factories/headers.py
@@ -1,0 +1,40 @@
+try:
+    import factory
+except ImportError:
+    raise ImportError("The p2p.tools.factories module requires the `factory_boy` library.")
+
+import time
+
+from eth.constants import (
+    BLANK_ROOT_HASH,
+    EMPTY_UNCLE_HASH,
+    GENESIS_BLOCK_NUMBER,
+    GENESIS_COINBASE,
+    GENESIS_DIFFICULTY,
+    GENESIS_EXTRA_DATA,
+    GENESIS_MIX_HASH,
+    GENESIS_NONCE,
+    GENESIS_PARENT_HASH,
+)
+from eth.rlp.headers import BlockHeader
+
+
+class BlockHeaderFactory(factory.Factory):
+    class Meta:
+        model = BlockHeader
+
+    parent_hash = GENESIS_PARENT_HASH
+    uncles_hash = EMPTY_UNCLE_HASH
+    coinbase = GENESIS_COINBASE
+    state_root = BLANK_ROOT_HASH
+    transaction_root = BLANK_ROOT_HASH
+    receipt_root = BLANK_ROOT_HASH
+    bloom = 0
+    difficulty = GENESIS_DIFFICULTY
+    block_number = GENESIS_BLOCK_NUMBER
+    gas_limit = 0
+    gas_used = 0
+    timestamp = factory.LazyFunction(lambda: int(time.time()))
+    extra_data = GENESIS_EXTRA_DATA
+    mix_hash = GENESIS_MIX_HASH
+    nonce = GENESIS_NONCE

--- a/trinity/tools/factories/les/__init__.py
+++ b/trinity/tools/factories/les/__init__.py
@@ -1,0 +1,6 @@
+from .proto import (  # noqa: F401
+    LESV1HandshakerFactory,
+    LESV2HandshakerFactory,
+    LESV1PeerPairFactory,
+    LESV2PeerPairFactory,
+)

--- a/trinity/tools/factories/receipts.py
+++ b/trinity/tools/factories/receipts.py
@@ -1,0 +1,17 @@
+try:
+    import factory
+except ImportError:
+    raise ImportError("The p2p.tools.factories module requires the `factory_boy` library.")
+
+from eth.constants import BLANK_ROOT_HASH
+from eth.rlp.receipts import Receipt
+
+
+class ReceiptFactory(factory.Factory):
+    class Meta:
+        model = Receipt
+
+    state_root = BLANK_ROOT_HASH
+    gas_used = 0
+    bloom = 0
+    logs = ()

--- a/trinity/tools/factories/transactions.py
+++ b/trinity/tools/factories/transactions.py
@@ -1,0 +1,46 @@
+try:
+    import factory
+except ImportError:
+    raise ImportError("The p2p.tools.factories module requires the `factory_boy` library.")
+
+from typing import Any, Type
+
+from eth.constants import ZERO_ADDRESS
+from eth.rlp.transactions import BaseTransactionFields
+from eth.vm.forks.frontier.transactions import FrontierUnsignedTransaction
+
+from p2p.tools.factories import PrivateKeyFactory
+
+
+class BaseTransactionFieldsFactory(factory.Factory):
+    class Meta:
+        model = BaseTransactionFields
+
+    nonce = factory.Sequence(lambda n: n)
+    gas_price = 1
+    gas = 21000
+    to = ZERO_ADDRESS
+    value = 0
+    data = b''
+
+    @classmethod
+    def _create(cls,
+                model_class: Type[BaseTransactionFields],
+                *args: Any,
+                **kwargs: Any) -> BaseTransactionFields:
+        if 'vrs' in kwargs:
+            v, r, s = kwargs.pop('vrs')
+        else:
+            if 'private_key' in kwargs:
+                private_key = kwargs.pop('private_key')
+            else:
+                private_key = PrivateKeyFactory()
+
+            tx_for_signing = FrontierUnsignedTransaction(**kwargs)
+            signed_tx = tx_for_signing.as_signed_transaction(private_key)
+
+            v = signed_tx.v
+            r = signed_tx.r
+            s = signed_tx.s
+
+        return model_class(**kwargs, v=v, r=r, s=s)


### PR DESCRIPTION
Builds on #1238 

Extracted from #1189 


### What was wrong?

The `trinity.tools.factories` module got too big while working on #1189 and needed to be divided up into smaller modules.


### How was it fixed?

Re-organized things by their natural categories.


#### Cute Animal Picture

![hqdefault](https://user-images.githubusercontent.com/824194/67714954-8eebc880-f98e-11e9-8a96-144a2c8ca836.jpg)
