### PR TITLE
Fix root used for beacon block req

### DIFF
--- a/tests/libp2p/bcc/test_req_resp.py
+++ b/tests/libp2p/bcc/test_req_resp.py
@@ -169,11 +169,11 @@ async def test_request_beacon_blocks_invalid_request(monkeypatch):
         # TEST: Can not request blocks with `start_slot` greater than head block slot
         start_slot = 2
 
-        def get_block_by_hash_tree_root(root):
+        def get_block_by_root(root):
             return head_block
 
         monkeypatch.setattr(
-            bob.chain, "get_block_by_hash_tree_root", get_block_by_hash_tree_root
+            bob.chain, "get_block_by_root", get_block_by_root
         )
 
         count = 1
@@ -289,11 +289,11 @@ async def test_request_beacon_blocks_on_nonexist_chain(monkeypatch):
 
         request_head_block_root = b"\x56" * 32
 
-        def get_block_by_hash_tree_root(root):
+        def get_block_by_root(root):
             raise BlockNotFound
 
         monkeypatch.setattr(
-            bob.chain, "get_block_by_hash_tree_root", get_block_by_hash_tree_root
+            bob.chain, "get_block_by_root", get_block_by_root
         )
 
         start_slot = 0
@@ -323,9 +323,9 @@ async def test_request_recent_beacon_blocks(monkeypatch):
             body=BeaconBlockBody(),
         )
         blocks = [head_block.copy(slot=slot) for slot in range(5)]
-        mock_root_to_block_db = {block.hash_tree_root: block for block in blocks}
+        mock_root_to_block_db = {block.signing_root: block for block in blocks}
 
-        def get_block_by_hash_tree_root(root):
+        def get_block_by_root(root):
             validate_word(root)
             if root in mock_root_to_block_db:
                 return mock_root_to_block_db[root]
@@ -333,15 +333,15 @@ async def test_request_recent_beacon_blocks(monkeypatch):
                 raise BlockNotFound
 
         monkeypatch.setattr(
-            bob.chain, "get_block_by_hash_tree_root", get_block_by_hash_tree_root
+            bob.chain, "get_block_by_root", get_block_by_root
         )
 
         requesting_block_roots = [
-            blocks[0].hash_tree_root,
+            blocks[0].signing_root,
             b"\x12" * 32,  # Unknown block root
-            blocks[1].hash_tree_root,
+            blocks[1].signing_root,
             b"\x23" * 32,  # Unknown block root
-            blocks[3].hash_tree_root,
+            blocks[3].signing_root,
         ]
         requested_blocks = await alice.request_recent_beacon_blocks(
             peer_id=bob.peer_id, block_roots=requesting_block_roots

--- a/tests/libp2p/bcc/test_req_resp.py
+++ b/tests/libp2p/bcc/test_req_resp.py
@@ -172,9 +172,7 @@ async def test_request_beacon_blocks_invalid_request(monkeypatch):
         def get_block_by_root(root):
             return head_block
 
-        monkeypatch.setattr(
-            bob.chain, "get_block_by_root", get_block_by_root
-        )
+        monkeypatch.setattr(bob.chain, "get_block_by_root", get_block_by_root)
 
         count = 1
         step = 1
@@ -292,9 +290,7 @@ async def test_request_beacon_blocks_on_nonexist_chain(monkeypatch):
         def get_block_by_root(root):
             raise BlockNotFound
 
-        monkeypatch.setattr(
-            bob.chain, "get_block_by_root", get_block_by_root
-        )
+        monkeypatch.setattr(bob.chain, "get_block_by_root", get_block_by_root)
 
         start_slot = 0
         count = 5
@@ -332,9 +328,7 @@ async def test_request_recent_beacon_blocks(monkeypatch):
             else:
                 raise BlockNotFound
 
-        monkeypatch.setattr(
-            bob.chain, "get_block_by_root", get_block_by_root
-        )
+        monkeypatch.setattr(bob.chain, "get_block_by_root", get_block_by_root)
 
         requesting_block_roots = [
             blocks[0].signing_root,

--- a/trinity/protocol/bcc_libp2p/messages.py
+++ b/trinity/protocol/bcc_libp2p/messages.py
@@ -69,7 +69,7 @@ class BeaconBlocksRequest(ssz.Serializable):
 
     def __init__(
         self,
-        head_block_root: HashTreeRoot,
+        head_block_root: SigningRoot,
         start_slot: Slot,
         count: int,
         step: int,
@@ -96,7 +96,7 @@ class RecentBeaconBlocksRequest(ssz.Serializable):
         ('block_roots', List(bytes32, 1)),
     ]
 
-    def __init__(self, block_roots: Sequence[HashTreeRoot]) -> None:
+    def __init__(self, block_roots: Sequence[SigningRoot]) -> None:
         super().__init__(block_roots)
 
 

--- a/trinity/protocol/bcc_libp2p/node.py
+++ b/trinity/protocol/bcc_libp2p/node.py
@@ -186,7 +186,7 @@ class Peer:
         )
 
     async def request_recent_beacon_blocks(
-        self, block_roots: Sequence[HashTreeRoot]
+        self, block_roots: Sequence[SigningRoot]
     ) -> Tuple[BaseBeaconBlock, ...]:
         return await self.node.request_recent_beacon_blocks(self._id, block_roots)
 
@@ -972,7 +972,7 @@ class Node(BaseService):
 
     async def request_beacon_blocks(self,
                                     peer_id: ID,
-                                    head_block_root: HashTreeRoot,
+                                    head_block_root: SigningRoot,
                                     start_slot: Slot,
                                     count: int,
                                     step: int) -> Tuple[BaseBeaconBlock, ...]:
@@ -1110,7 +1110,7 @@ class Node(BaseService):
     async def request_recent_beacon_blocks(
             self,
             peer_id: ID,
-            block_roots: Sequence[HashTreeRoot]) -> Tuple[BaseBeaconBlock, ...]:
+            block_roots: Sequence[SigningRoot]) -> Tuple[BaseBeaconBlock, ...]:
         if peer_id not in self.handshaked_peers:
             error_msg = f"not handshaked with peer={peer_id} yet"
             self.logger.info("Request recent beacon block failed: %s", error_msg)

--- a/trinity/protocol/bcc_libp2p/node.py
+++ b/trinity/protocol/bcc_libp2p/node.py
@@ -177,9 +177,11 @@ class Peer:
     async def request_beacon_blocks(
         self, start_slot: Slot, count: int, step: int = 1
     ) -> Tuple[BaseBeaconBlock, ...]:
+        head_block_signing_root = self.node.chain.chaindb.get_block_signing_root_by_hash_tree_root(
+            self.head_root)
         return await self.node.request_beacon_blocks(
             self._id,
-            head_block_root=self.head_root,
+            head_block_root=head_block_signing_root,
             start_slot=start_slot,
             count=count,
             step=step,

--- a/trinity/protocol/bcc_libp2p/node.py
+++ b/trinity/protocol/bcc_libp2p/node.py
@@ -885,7 +885,7 @@ class Node(BaseService):
         )
 
         try:
-            requested_head_block = self.chain.get_block_by_hash_tree_root(
+            requested_head_block = self.chain.get_block_by_root(
                 beacon_blocks_request.head_block_root
             )
         except (BlockNotFound, ValidationError) as error:
@@ -1076,7 +1076,7 @@ class Node(BaseService):
         recent_beacon_blocks = []
         for block_root in recent_beacon_blocks_request.block_roots:
             try:
-                block = self.chain.get_block_by_hash_tree_root(block_root)
+                block = self.chain.get_block_by_root(block_root)
             except (BlockNotFound, ValidationError):
                 pass
             else:


### PR DESCRIPTION
### What was wrong?
We use type `HashTreeRoot` for beacon block request which would fail if we only know the block by it's signing root, e.g., parent block of an orphan block or block attested to by an attestation.


### How was it fixed?
Request block by it's signing root

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

[//]: # (See: https://trinity-client.readthedocs.io/en/latest/contributing.html#pull-requests)
- [ ] Add entry to the [release notes](https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

#### Cute Animal Picture


![](https://www.maxpixel.net/static/photo/2x/Pet-Cute-Animal-Dog-Play-Parson-Terrier-Fun-Race-4335352.jpg)
(source: https://www.maxpixel.net/Pet-Cute-Animal-Dog-Play-Parson-Terrier-Fun-Race-4335352)