### PR TITLE
remove superfluous pass

### DIFF
--- a/trinity/sync/common/headers.py
+++ b/trinity/sync/common/headers.py
@@ -1020,7 +1020,6 @@ class BaseHeaderChainSyncer(BaseService, HeaderSyncerAPI, Generic[TChainPeer]):
             self.logger.debug(
                 "%s announced Head TD %d, which is higher than ours (%d), starting sync",
                 peer, peer.head_info.head_td, head_td)
-            pass
 
     def _run_handle_sync_status_requests(self) -> None:
         if self._peer_pool.has_event_bus:


### PR DESCRIPTION
### What was wrong?

A superfluous pass was pointed out over [here](https://github.com/ethereum/trinity/pull/1237#discussion_r341410606).

### How was it fixed?

removed the superfluous pass.
### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

[//]: # (See: https://trinity-client.readthedocs.io/en/latest/contributing.html#pull-requests)
- [ ] Add entry to the [release notes](https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://i.redd.it/bzupderrmaw31.jpg)
