### PR TITLE
Mention pipx in virtualenv explainer

### DIFF
--- a/docs/fragments/virtualenv_explainer.rst
+++ b/docs/fragments/virtualenv_explainer.rst
@@ -1,6 +1,6 @@
 **Optional:** Often, the best way to guarantee a clean Python 3 environment is with
-`virtualenv <https://virtualenv.pypa.io/en/stable/>`_. If we don't have ``virtualenv`` installed
-already, we first need to install it via pip.
+`virtualenv <https://virtualenv.pypa.io/en/stable/>`_. If ``virtualenv`` isn't installed
+yet, we first need to install it via ``pip``.
 
 .. code:: sh
 
@@ -20,3 +20,6 @@ To activate the virtual directory we have to *source* it
 .. code:: sh
 
   . venv/bin/activate
+
+**Protip:** Consider using `pipx <https://pipxproject.github.io/pipx/>`_ instead. It's like ``pip`` but
+handles virtual environments behind the scenes so we don't have to deal with them directly anymore.

--- a/newsfragments/1248.doc.rst
+++ b/newsfragments/1248.doc.rst
@@ -1,0 +1,2 @@
+Mention `pipx <https://pipxproject.github.io/pipx/>`_ in the docs as an alternative to manually dealing
+with virtual environments.


### PR DESCRIPTION
### What was wrong?

[pipx](https://pipxproject.github.io/pipx/) can make the installation experience much nicer as it kinda combines `pip` and `virtualenv`

### How was it fixed?

Squeezed in `pipx` as a **Protip** where we explain `virtualenv`

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

[//]: # (See: https://trinity-client.readthedocs.io/en/latest/contributing.html#pull-requests)
- [ ] Add entry to the [release notes](https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://static.boredpanda.com/blog/wp-content/uploads/2016/01/cute-squirrel-photography-17__700.jpg)
