### PR TITLE
Missing beacon block root type update

### DIFF
--- a/trinity/protocol/bcc_libp2p/messages.py
+++ b/trinity/protocol/bcc_libp2p/messages.py
@@ -17,11 +17,8 @@ from eth2.beacon.typing import (
     default_version,
 )
 from eth2.beacon.types.blocks import BeaconBlock
-from eth2.beacon.typing import SigningRoot, HashTreeRoot, Slot, Epoch
-from eth2.beacon.constants import (
-    ZERO_HASH_TREE_ROOT,
-    ZERO_SIGNING_ROOT,
-)
+from eth2.beacon.typing import SigningRoot, Slot, Epoch
+from eth2.beacon.constants import ZERO_SIGNING_ROOT
 
 
 class HelloRequest(ssz.Serializable):
@@ -38,7 +35,7 @@ class HelloRequest(ssz.Serializable):
         fork_version: Version = default_version,
         finalized_root: SigningRoot = ZERO_SIGNING_ROOT,
         finalized_epoch: Epoch = default_epoch,
-        head_root: HashTreeRoot = ZERO_HASH_TREE_ROOT,
+        head_root: SigningRoot = ZERO_SIGNING_ROOT,
         head_slot: Slot = default_slot,
     ) -> None:
         super().__init__(

--- a/trinity/protocol/bcc_libp2p/node.py
+++ b/trinity/protocol/bcc_libp2p/node.py
@@ -39,7 +39,6 @@ from eth2.beacon.types.blocks import (
 from eth2.beacon.typing import (
     Epoch,
     Slot,
-    HashTreeRoot,
     Version,
     SigningRoot,
 )
@@ -157,7 +156,7 @@ class Peer:
     fork_version: Version  # noqa: E701
     finalized_root: SigningRoot
     finalized_epoch: Epoch
-    head_root: HashTreeRoot
+    head_root: SigningRoot
     head_slot: Slot
 
     @classmethod
@@ -177,11 +176,9 @@ class Peer:
     async def request_beacon_blocks(
         self, start_slot: Slot, count: int, step: int = 1
     ) -> Tuple[BaseBeaconBlock, ...]:
-        head_block_signing_root = self.node.chain.chaindb.get_block_signing_root_by_hash_tree_root(
-            self.head_root)
         return await self.node.request_beacon_blocks(
             self._id,
-            head_block_root=head_block_signing_root,
+            head_block_root=self.head_root,
             start_slot=start_slot,
             count=count,
             step=step,
@@ -517,7 +514,7 @@ class Node(BaseService):
             fork_version=state.fork.current_version,
             finalized_root=finalized_checkpoint.root,
             finalized_epoch=finalized_checkpoint.epoch,
-            head_root=head.hash_tree_root,
+            head_root=head.signing_root,
             head_slot=head.slot,
         )
 


### PR DESCRIPTION

### What was wrong?
My bad, the update on `HelloRequest.head_root` slip through #1242 .
ref: https://github.com/ethereum/eth2.0-specs/pull/1459

### How was it fixed?
Update to type `SigningRoot` for `HelloRequest.head_root`

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

[//]: # (See: https://trinity-client.readthedocs.io/en/latest/contributing.html#pull-requests)
- [ ] Add entry to the [release notes](https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

#### Cute Animal Picture




![](https://www.maxpixel.net/static/photo/2x/Cute-Animal-Pet-Quadruped-View-Dog-Portrait-3747718.jpg)
(source: https://www.maxpixel.net/Cute-Animal-Pet-Quadruped-View-Dog-Portrait-3747718)