### PR TITLE
Deduplicate CI jobs

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -117,7 +117,9 @@ commands=
     pip install -e {toxinidir}/trinity-external-components/examples/peer_count_reporter
     # We don't want to run these tests concurrently to avoid running into errors
     # due to multiple Trinity instances competing for the same ports
-    pytest --integration -n 1 {posargs:tests/integration/ -k 'not lightchain_integration'}
+
+    # The `trinity_cli` tests are already run by the pyxx-wheel-cli jobs. No need to repeat them here
+    pytest --integration -n 1 {posargs:tests/integration/ -k 'not lightchain_integration and not trinity_cli'}
 
 [testenv:py36-integration]
 deps = {[common-integration]deps}


### PR DESCRIPTION
### What was wrong?

We currently run the `trinity_cli` tests as part of the `pyxx-wheel-cli` jobs as well as part of the `pyxx-integration` jobs. This is wasting resources especially since these tests can sometimes be a little flaky.

### How was it fixed?

Exclude them from the `py-xx-integration` jobs


#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://blazepress.com/.image/t_share/MTQyOTkyMzA1NjUyMTE0NjM3/cute-baby-seal-photography-3jpg.jpg)
