### PR TITLE
Experiment with an asyncio based service that doesn't use CancelToken

### DIFF
--- a/p2p/asyncio_service.py
+++ b/p2p/asyncio_service.py
@@ -1,0 +1,362 @@
+import asyncio
+import logging
+import sys
+from types import TracebackType
+from typing import (
+    Any,
+    AsyncIterator,
+    Awaitable,
+    Callable,
+    List,
+    Optional,
+    Set,
+    Tuple,
+    Type,
+)
+
+from async_generator import asynccontextmanager
+
+from trio import MultiError
+
+from p2p.trio_service import (
+    DaemonTaskExit,
+    LifecycleError,
+    ServiceAPI,
+    ManagerAPI,
+)
+
+
+class Manager(ManagerAPI):
+    logger = logging.getLogger('p2p.service.Manager')
+
+    _service: ServiceAPI
+
+    _errors: List[Tuple[
+        Optional[Type[BaseException]],
+        Optional[BaseException],
+        Optional[TracebackType],
+    ]]
+
+    # Tracking of the system level background tasks.
+    _system_tasks: Set[asyncio.Task]
+
+    # Tracking of the background tasks that the service has initiated.
+    _service_tasks: Set[asyncio.Task]
+
+    def __init__(self,
+                 service: ServiceAPI,
+                 loop: asyncio.AbstractEventLoop = None) -> None:
+        if hasattr(service, 'manager'):
+            raise LifecycleError("Service already has a manager.")
+        else:
+            service.manager = self
+
+        self._service = service
+
+        self._loop = loop
+
+        # events
+        self._started = asyncio.Event()
+        self._cancelled = asyncio.Event()
+        self._stopped = asyncio.Event()
+
+        # locks
+        self._run_lock = asyncio.Lock()
+
+        # errors
+        self._errors = []
+
+        # task tracking
+        self._service_tasks = set()
+        self._system_tasks = set()
+
+    #
+    # System Tasks
+    #
+    async def _handle_cancelled(self) -> None:
+        """
+        Handles the cancellation triggering cancellation of the task nursery.
+        """
+        self.logger.debug('%s: _handle_cancelled waiting for cancellation', self)
+        await self.wait_cancelled()
+        self.logger.debug('%s: _handle_cancelled triggering task nursery cancellation', self)
+
+        # trigger cancellation of all of the service tasks
+        for task in self._service_tasks:
+            task.cancel()
+            try:
+                await task
+            except asyncio.CancelledError:
+                pass
+            except Exception:
+                self._errors.append(sys.exc_info())
+
+    async def _handle_stopped(self) -> None:
+        """
+        Once the `_stopped` event is set this triggers cancellation of the system nursery.
+        """
+        self.logger.debug('%s: _handle_stopped waiting for stopped', self)
+        await self.wait_stopped()
+        self.logger.debug('%s: _handle_stopped triggering system nursery cancellation', self)
+
+        # trigger cancellation of all of the system tasks
+        for task in self._system_tasks:
+            task.cancel()
+            try:
+                await task
+            except asyncio.CancelledError:
+                pass
+            except Exception:
+                self._errors.append(sys.exc_info())
+
+    async def _handle_run(self) -> None:
+        """
+        Run and monitor the actual :meth:`ServiceAPI.run` method.
+
+        In the event that it throws an exception the service will be cancelled.
+
+        Upon a clean exit
+        Triggers cancellation in the case where the service exits normally or
+        throws an exception.
+        """
+        try:
+            await self._service.run()
+        except asyncio.CancelledError:
+            raise
+        except Exception as err:
+            self.logger.debug(
+                '%s: _handle_run got error, storing exception and setting cancelled',
+                self
+            )
+            self._errors.append(sys.exc_info())
+            self.cancel()
+        else:
+            # NOTE: Any service which uses daemon tasks will need to trigger
+            # cancellation in order for the service to exit since this code
+            # path does not trigger task cancellation.  It might make sense to
+            # trigger cancellation if all of the running tasks are daemon
+            # tasks.
+            self.logger.debug(
+                '%s: _handle_run exited cleanly, waiting for full stop...',
+                self
+            )
+
+    @classmethod
+    async def run_service(cls, service: ServiceAPI, loop: asyncio.AbstractEventLoop = None) -> None:
+        manager = cls(service, loop=loop)
+        await manager.run()
+
+    async def run(self) -> None:
+        if self._run_lock.locked():
+            raise LifecycleError(
+                "Cannot run a service with the run lock already engaged.  Already started?"
+            )
+        elif self.is_started:
+            raise LifecycleError("Cannot run a service which is already started.")
+
+        async with self._run_lock:
+            try:
+                handle_cancelled_task = asyncio.ensure_future(
+                    self._handle_cancelled(),
+                    loop=self._loop,
+                )
+                handle_stopped_task = asyncio.ensure_future(self._handle_stopped(), loop=self._loop)
+
+                self._system_tasks.add(handle_cancelled_task)
+                self._system_tasks.add(handle_stopped_task)
+
+                handle_run_task = asyncio.ensure_future(self._handle_run(), loop=self._loop)
+                self._service_tasks.add(handle_run_task)
+
+                self._started.set()
+
+                # block here until all service tasks have finished
+                await self._wait_service_tasks()
+            finally:
+                # Mark as having stopped
+                self._stopped.set()
+
+            # block here until all system tasks have finished.
+            await asyncio.wait(
+                (handle_cancelled_task, handle_stopped_task),
+                return_when=asyncio.ALL_COMPLETED,
+            )
+        self.logger.debug('%s stopped', self)
+
+        # If an error occured, re-raise it here
+        if self.did_error:
+            raise MultiError(tuple(
+                exc_value.with_traceback(exc_tb)
+                for _, exc_value, exc_tb
+                in self._errors
+            ))
+
+    async def _wait_service_tasks(self) -> None:
+        while True:
+            done, pending = await asyncio.wait(
+                self._service_tasks,
+                return_when=asyncio.ALL_COMPLETED,
+            )
+            if all(task.done() for task in self._service_tasks):
+                break
+
+    #
+    # Event API mirror
+    #
+    @property
+    def is_started(self) -> bool:
+        return self._started.is_set()
+
+    @property
+    def is_running(self) -> bool:
+        return self.is_started and not self.is_stopped
+
+    @property
+    def is_cancelled(self) -> bool:
+        return self._cancelled.is_set()
+
+    @property
+    def is_stopped(self) -> bool:
+        return self._stopped.is_set()
+
+    @property
+    def did_error(self) -> bool:
+        return len(self._errors) > 0
+
+    #
+    # Control API
+    #
+    def cancel(self) -> None:
+        if not self.is_started:
+            raise LifecycleError("Cannot cancel as service which was never started.")
+        self._cancelled.set()
+
+    async def stop(self) -> None:
+        self.cancel()
+        await self.wait_stopped()
+
+    #
+    # Wait API
+    #
+    async def wait_started(self) -> None:
+        await self._started.wait()
+
+    async def wait_cancelled(self) -> None:
+        await self._cancelled.wait()
+
+    async def wait_stopped(self) -> None:
+        await self._stopped.wait()
+
+    async def _run_and_manage_task(self,
+                                   async_fn: Callable[..., Awaitable[Any]],
+                                   *args: Any,
+                                   daemon: bool,
+                                   name: str) -> None:
+        try:
+            await async_fn(*args)
+        except asyncio.CancelledError:
+            raise
+        except Exception as err:
+            self.logger.debug(
+                "task '%s[daemon=%s]' exited with error: %s",
+                name,
+                daemon,
+                err,
+                exc_info=True,
+            )
+            self._errors.append(sys.exc_info())
+            self.cancel()
+        else:
+            self.logger.debug(
+                "task '%s[daemon=%s]' finished.",
+                name,
+                daemon,
+            )
+            if daemon:
+                self.logger.debug(
+                    "daemon task '%s' exited unexpectedly.  Cancelling service: %s",
+                    name,
+                    self,
+                )
+                self.cancel()
+                raise DaemonTaskExit(f"Daemon task {name} exited")
+
+    def run_task(self,
+                 async_fn: Callable[..., Awaitable[Any]],
+                 *args: Any,
+                 daemon: bool = False,
+                 name: str = None) -> None:
+
+        task = asyncio.ensure_future(self._run_and_manage_task(
+            async_fn,
+            *args,
+            daemon=daemon,
+            name=name or repr(async_fn),
+        ), loop=self._loop)
+        self._service_tasks.add(task)
+
+    def run_daemon_task(self,
+                        async_fn: Callable[..., Awaitable[Any]],
+                        *args: Any,
+                        name: str = None) -> None:
+
+        self.run_task(async_fn, *args, daemon=True, name=name)
+
+    def run_child_service(self,
+                          service: ServiceAPI,
+                          daemon: bool = False,
+                          name: str = None) -> "Manager":
+        child_manager = Manager(
+            service,
+            loop=self._loop,
+        )
+        self.run_task(
+            child_manager.run,
+            daemon=daemon,
+            name=name or repr(service)
+        )
+        return child_manager
+
+    def run_daemon_child_service(self,
+                                 service: ServiceAPI,
+                                 name: str = None) -> "Manager":
+        return self.run_child_service(service, daemon=True, name=name)
+
+
+@asynccontextmanager
+async def background_service(service: ServiceAPI,
+                             loop: asyncio.AbstractEventLoop = None,
+                             ) -> AsyncIterator[ManagerAPI]:
+    """
+    This is the primary API for running a service without explicitely managing
+    its lifecycle with a nursery.  The service is running within the context
+    block and will be properly cleaned up upon exiting the context block.
+    """
+    manager = Manager(service, loop=loop)
+    task = asyncio.ensure_future(manager.run(), loop=loop)
+
+    try:
+        await manager.wait_started()
+
+        try:
+            yield manager
+        finally:
+            await manager.stop()
+
+        assert not manager.did_error, 'ARST ARST ARST'
+
+    finally:
+        task.cancel()
+
+        try:
+            await task
+        except asyncio.CancelledError:
+            pass
+
+        if manager.did_error:
+            # TODO: better place for this.
+            raise MultiError(tuple(
+                exc_value.with_traceback(exc_tb)
+                for _, exc_value, exc_tb
+                in manager._errors
+            ))

--- a/tests/p2p/test_new_service.py
+++ b/tests/p2p/test_new_service.py
@@ -1,0 +1,362 @@
+import asyncio
+
+import pytest
+
+from p2p.trio_service import (
+    DaemonTaskExit,
+    Service,
+    as_service,
+)
+from p2p.asyncio_service import (
+    Manager,
+    background_service,
+)
+
+
+class WaitCancelledService(Service):
+    async def run(self) -> None:
+        await self.manager.wait_cancelled()
+
+
+async def do_service_lifecycle_check(manager,
+                                     manager_run_fn,
+                                     trigger_exit_condition_fn,
+                                     should_be_cancelled):
+    assert manager.is_started is False
+    assert manager.is_running is False
+    assert manager.is_cancelled is False
+    assert manager.is_stopped is False
+
+    asyncio.ensure_future(manager_run_fn())
+
+    await asyncio.wait_for(manager.wait_started(), timeout=0.1)
+
+    assert manager.is_started is True
+    assert manager.is_running is True
+    assert manager.is_cancelled is False
+    assert manager.is_stopped is False
+
+    # trigger the service to exit
+    trigger_exit_condition_fn()
+
+    if should_be_cancelled:
+        await asyncio.wait_for(manager.wait_cancelled(), timeout=0.01)
+
+        assert manager.is_started is True
+        # We cannot determine whether the service should be running at this
+        # stage because a service is considered running until it has
+        # stopped.  Since it may be cancelled but still not stopped we
+        # can't know.
+        assert manager.is_cancelled is True
+        # We cannot determine whether a service should be stopped at this
+        # stage as it could have exited cleanly and is now stopped or it
+        # might be doing some cleanup after which it will register as being
+        # stopped.
+
+    await asyncio.wait_for(manager.wait_stopped(), timeout=0.1)
+
+    assert manager.is_started is True
+    assert manager.is_running is False
+    assert manager.is_cancelled is should_be_cancelled
+    assert manager.is_stopped is True
+
+
+def test_service_manager_initial_state():
+    service = WaitCancelledService()
+    manager = Manager(service)
+
+    assert manager.is_started is False
+    assert manager.is_running is False
+    assert manager.is_cancelled is False
+    assert manager.is_stopped is False
+
+
+@pytest.mark.asyncio
+async def test_asyncio_service_lifecycle_run_and_clean_exit():
+    trigger_exit = asyncio.Event()
+
+    @as_service
+    async def ServiceTest(manager):
+        await trigger_exit.wait()
+
+    service = ServiceTest()
+    manager = Manager(service)
+
+    await do_service_lifecycle_check(
+        manager=manager,
+        manager_run_fn=manager.run,
+        trigger_exit_condition_fn=trigger_exit.set,
+        should_be_cancelled=False,
+    )
+
+
+@pytest.mark.asyncio
+async def test_asyncio_service_lifecycle_run_and_external_cancellation():
+
+    @as_service
+    async def ServiceTest(manager):
+        while True:
+            await asyncio.sleep(0)
+
+    service = ServiceTest()
+    manager = Manager(service)
+
+    await do_service_lifecycle_check(
+        manager=manager,
+        manager_run_fn=manager.run,
+        trigger_exit_condition_fn=manager.cancel,
+        should_be_cancelled=True,
+    )
+
+
+@pytest.mark.asyncio
+async def test_asyncio_service_lifecycle_run_and_exception():
+    trigger_error = asyncio.Event()
+
+    @as_service
+    async def ServiceTest(manager):
+        await trigger_error.wait()
+        raise RuntimeError("Service throwing error")
+
+    service = ServiceTest()
+    manager = Manager(service)
+
+    async def do_service_run():
+        with pytest.raises(RuntimeError, match="Service throwing error"):
+            await manager.run()
+
+    await do_service_lifecycle_check(
+        manager=manager,
+        manager_run_fn=do_service_run,
+        trigger_exit_condition_fn=trigger_error.set,
+        should_be_cancelled=True,
+    )
+
+
+@pytest.mark.asyncio
+async def test_asyncio_service_lifecycle_run_and_task_exception():
+    trigger_error = asyncio.Event()
+
+    @as_service
+    async def ServiceTest(manager):
+        async def task_fn():
+            await trigger_error.wait()
+            raise RuntimeError("Service throwing error")
+        manager.run_task(task_fn)
+
+    service = ServiceTest()
+    manager = Manager(service)
+
+    async def do_service_run():
+        with pytest.raises(RuntimeError, match="Service throwing error"):
+            await manager.run()
+
+    await do_service_lifecycle_check(
+        manager=manager,
+        manager_run_fn=do_service_run,
+        trigger_exit_condition_fn=trigger_error.set,
+        should_be_cancelled=True,
+    )
+
+
+@pytest.mark.asyncio
+async def test_asyncio_service_lifecycle_run_and_daemon_task_exit():
+    trigger_error = asyncio.Event()
+
+    @as_service
+    async def ServiceTest(manager):
+        async def daemon_task_fn():
+            await trigger_error.wait()
+        manager.run_daemon_task(daemon_task_fn)
+
+    service = ServiceTest()
+    manager = Manager(service)
+
+    async def do_service_run():
+        with pytest.raises(DaemonTaskExit, match="Daemon task"):
+            await manager.run()
+
+    await do_service_lifecycle_check(
+        manager=manager,
+        manager_run_fn=do_service_run,
+        trigger_exit_condition_fn=trigger_error.set,
+        should_be_cancelled=True,
+    )
+
+
+@pytest.mark.asyncio
+async def test_asyncio_service_background_service_context_manager():
+    service = WaitCancelledService()
+
+    async with background_service(service) as manager:
+        # ensure the manager property is set.
+        assert hasattr(service, 'manager')
+        assert service.manager is manager
+
+        assert manager.is_started is True
+        assert manager.is_running is True
+        assert manager.is_cancelled is False
+        assert manager.is_stopped is False
+
+    assert manager.is_started is True
+    assert manager.is_running is False
+    assert manager.is_cancelled is True
+    assert manager.is_stopped is True
+
+
+@pytest.mark.asyncio
+async def test_asyncio_service_manager_stop():
+    service = WaitCancelledService()
+
+    async with background_service(service) as manager:
+        assert manager.is_started is True
+        assert manager.is_running is True
+        assert manager.is_cancelled is False
+        assert manager.is_stopped is False
+
+        await manager.stop()
+
+        assert manager.is_started is True
+        assert manager.is_running is False
+        assert manager.is_cancelled is True
+        assert manager.is_stopped is True
+
+
+@pytest.mark.asyncio
+async def test_asyncio_service_manager_run_task():
+    task_event = asyncio.Event()
+
+    @as_service
+    async def RunTaskService(manager):
+        async def task_fn():
+            task_event.set()
+        manager.run_task(task_fn)
+        await manager.wait_cancelled()
+
+    async with background_service(RunTaskService()):
+        await asyncio.wait_for(task_event.wait(), timeout=0.1)
+
+
+@pytest.mark.asyncio
+async def test_asyncio_service_manager_run_task_waits_for_task_completion():
+    task_event = asyncio.Event()
+
+    @as_service
+    async def RunTaskService(manager):
+        async def task_fn():
+            await asyncio.sleep(0.01)
+            task_event.set()
+        manager.run_task(task_fn)
+        # the task is set to run in the background but then  the service exits.
+        # We want to be sure that the task is allowed to continue till
+        # completion unless explicitely cancelled.
+
+    async with background_service(RunTaskService()):
+        await asyncio.wait_for(task_event.wait(), timeout=0.1)
+
+
+@pytest.mark.asyncio
+async def test_asyncio_service_manager_run_task_can_still_cancel_after_run_finishes():
+    task_event = asyncio.Event()
+    service_finished = asyncio.Event()
+
+    @as_service
+    async def RunTaskService(manager):
+        async def task_fn():
+            # this will never complete
+            await task_event.wait()
+
+        manager.run_task(task_fn)
+        # the task is set to run in the background but then  the service exits.
+        # We want to be sure that the task is allowed to continue till
+        # completion unless explicitely cancelled.
+        service_finished.set()
+
+    async with background_service(RunTaskService()) as manager:
+        await asyncio.wait_for(service_finished.wait(), timeout=0.01)
+
+        # show that the service hangs waiting for the task to complete.
+        with pytest.raises(asyncio.TimeoutError):
+            await asyncio.wait_for(manager.wait_stopped(), timeout=0.01)
+
+        # trigger cancellation and see that the service actually stops
+        manager.cancel()
+        await asyncio.wait_for(manager.wait_stopped(), timeout=0.01)
+
+
+@pytest.mark.asyncio
+async def test_asyncio_service_manager_run_task_reraises_exceptions():
+    task_event = asyncio.Event()
+
+    @as_service
+    async def RunTaskService(manager):
+        async def task_fn():
+            await task_event.wait()
+            raise Exception("task exception in run_task")
+        manager.run_task(task_fn)
+        await asyncio.wait_for(asyncio.sleep(100), timeout=1)
+
+    with pytest.raises(BaseException, match="task exception in run_task"):
+        async with background_service(RunTaskService()) as manager:
+            task_event.set()
+            await manager.wait_stopped()
+            pass
+
+
+@pytest.mark.asyncio
+async def test_asyncio_service_manager_run_daemon_task_cancels_if_exits():
+    task_event = asyncio.Event()
+
+    @as_service
+    async def RunTaskService(manager):
+        async def daemon_task_fn():
+            await task_event.wait()
+
+        manager.run_daemon_task(daemon_task_fn, name='daemon_task_fn')
+        await asyncio.wait_for(asyncio.sleep(100), timeout=1)
+
+    with pytest.raises(DaemonTaskExit, match="Daemon task daemon_task_fn exited"):
+        async with background_service(RunTaskService()) as manager:
+            task_event.set()
+            await manager.wait_stopped()
+
+
+@pytest.mark.asyncio
+async def test_asyncio_service_manager_propogates_and_records_exceptions():
+    @as_service
+    async def ThrowErrorService(manager):
+        raise RuntimeError('this is the error')
+
+    service = ThrowErrorService()
+    manager = Manager(service)
+
+    assert manager.did_error is False
+
+    with pytest.raises(RuntimeError, match='this is the error'):
+        await manager.run()
+
+    assert manager.did_error is True
+
+
+@pytest.mark.asyncio
+async def test_asyncio_service_lifecycle_run_and_clean_exit_with_child_service():
+    trigger_exit = asyncio.Event()
+
+    @as_service
+    async def ChildServiceTest(manager):
+        await trigger_exit.wait()
+
+    @as_service
+    async def ServiceTest(manager):
+        child_manager = manager.run_child_service(ChildServiceTest())
+        await child_manager.wait_started()
+
+    service = ServiceTest()
+    manager = Manager(service)
+
+    await do_service_lifecycle_check(
+        manager=manager,
+        manager_run_fn=manager.run,
+        trigger_exit_condition_fn=trigger_exit.set,
+        should_be_cancelled=False,
+    )


### PR DESCRIPTION
This is me running with an idea.  Here's an `asyncio` based service that doesn't use a `CancelToken` and yields clean shutdowns and resilient exception handling (the same pattern used in the `TrioService`).  I'm not really sure what this proves but it *might* be a way to reduce or eliminate our use of cancel tokens...

### What was wrong?



### How was it fixed?


### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

[//]: # (See: https://trinity-client.readthedocs.io/en/latest/contributing.html#pull-requests)
- [ ] Add entry to the [release notes](https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses]()
