### PR TITLE
Refactor handling of pre-configured networks

### DIFF
--- a/newsfragments/1260.internal.rst
+++ b/newsfragments/1260.internal.rst
@@ -1,0 +1,2 @@
+Refactor handling and code organization of pre-configured networks to make it easier to
+add support for new networks.

--- a/tests/core/eip1085-utils/test_preconfigured_genesis_files.py
+++ b/tests/core/eip1085-utils/test_preconfigured_genesis_files.py
@@ -1,5 +1,3 @@
-import json
-
 import pytest
 
 from eth_utils import ValidationError
@@ -16,8 +14,11 @@ from eth.rlp.headers import BlockHeader
 from eth.vm.forks.homestead import HomesteadVM
 
 from trinity.config import (
-    MAINNET_EIP1085_PATH,
-    ROPSTEN_EIP1085_PATH,
+    _load_preconfigured_genesis_config,
+)
+from trinity.constants import (
+    MAINNET_NETWORK_ID,
+    ROPSTEN_NETWORK_ID,
 )
 from trinity._utils.eip1085 import (
     validate_raw_eip1085_genesis_config,
@@ -27,9 +28,7 @@ from trinity._utils.eip1085 import (
 
 @pytest.fixture
 def mainnet_genesis_config():
-    with MAINNET_EIP1085_PATH.open() as mainnet_eip1085_file:
-        mainnet_genesis_config = json.load(mainnet_eip1085_file)
-    return mainnet_genesis_config
+    return _load_preconfigured_genesis_config(MAINNET_NETWORK_ID)
 
 
 def test_mainnet_eip1085_validity(mainnet_genesis_config):
@@ -133,9 +132,7 @@ def test_mainnet_eip1085_rejects_etc_homestead_header(mainnet_genesis_config):
 
 @pytest.fixture
 def ropsten_genesis_config():
-    with ROPSTEN_EIP1085_PATH.open() as ropsten_eip1085_file:
-        ropsten_genesis_config = json.load(ropsten_eip1085_file)
-    return ropsten_genesis_config
+    return _load_preconfigured_genesis_config(ROPSTEN_NETWORK_ID)
 
 
 def test_ropsten_eip1085_validity(ropsten_genesis_config):

--- a/trinity/_utils/chains.py
+++ b/trinity/_utils/chains.py
@@ -27,16 +27,11 @@ from p2p.constants import DEFAULT_MAX_PEERS
 from p2p.kademlia import Node as KademliaNode
 
 from trinity.constants import (
-    MAINNET_NETWORK_ID,
-    ROPSTEN_NETWORK_ID,
     SYNC_LIGHT,
 )
-
-
-DEFAULT_DATA_DIRS = {
-    ROPSTEN_NETWORK_ID: 'ropsten',
-    MAINNET_NETWORK_ID: 'mainnet',
-}
+from trinity.network_configurations import (
+    PRECONFIGURED_NETWORKS,
+)
 
 
 #
@@ -58,7 +53,9 @@ def get_data_dir_for_network_id(network_id: int, trinity_root_dir: Path) -> Path
     id.  If the network id is unknown, raises a KeyError.
     """
     try:
-        return get_local_data_dir(DEFAULT_DATA_DIRS[network_id], trinity_root_dir)
+        return get_local_data_dir(
+            PRECONFIGURED_NETWORKS[network_id].data_dir_name, trinity_root_dir
+        )
     except KeyError:
         raise KeyError(f"Unknown network id: `{network_id}`")
 

--- a/trinity/bootstrap.py
+++ b/trinity/bootstrap.py
@@ -31,14 +31,13 @@ from trinity.config import (
     BaseAppConfig,
     TrinityConfig,
 )
-from trinity.constants import (
-    MAINNET_NETWORK_ID,
-    ROPSTEN_NETWORK_ID,
-)
 from trinity.event_bus import ComponentManagerService
 from trinity.extensibility import (
     BaseComponent,
     TrinityBootInfo,
+)
+from trinity.network_configurations import (
+    PRECONFIGURED_NETWORKS,
 )
 from trinity._utils.ipc import (
     kill_process_gracefully,
@@ -57,9 +56,6 @@ from trinity._utils.version import (
     construct_trinity_client_identifier,
     is_prerelease,
 )
-
-
-PRECONFIGURED_NETWORKS = {MAINNET_NETWORK_ID, ROPSTEN_NETWORK_ID}
 
 
 TRINITY_HEADER = "\n".join((

--- a/trinity/network_configurations.py
+++ b/trinity/network_configurations.py
@@ -1,0 +1,40 @@
+from typing import (
+    NamedTuple,
+    Tuple,
+)
+
+from p2p.constants import (
+    MAINNET_BOOTNODES,
+    ROPSTEN_BOOTNODES,
+)
+from trinity.constants import (
+    MAINNET_NETWORK_ID,
+    ROPSTEN_NETWORK_ID
+)
+
+
+class Eth1NetworkConfiguration(NamedTuple):
+
+    network_id: int
+    chain_name: str
+    data_dir_name: str
+    eip1085_filename: str
+    bootnodes: Tuple[str, ...]
+
+
+PRECONFIGURED_NETWORKS = {
+    MAINNET_NETWORK_ID: Eth1NetworkConfiguration(
+        MAINNET_NETWORK_ID,
+        'MainnetChain',
+        'mainnet',
+        'mainnet.json',
+        MAINNET_BOOTNODES
+    ),
+    ROPSTEN_NETWORK_ID: Eth1NetworkConfiguration(
+        ROPSTEN_NETWORK_ID,
+        'RopstenChain',
+        'ropsten',
+        'ropsten.json',
+        ROPSTEN_BOOTNODES
+    ),
+}


### PR DESCRIPTION
### What was wrong?

We currently have quite a bit of hard coded branching logic spread across multiple files that deal with the different pre-configured networks (currently `mainnet` and `ropsten`). With Görli being around the corner I wanted to take the chance to clean this up so that adding new pre-configured networks would be less involved and error prone.

### How was it fixed?

Basically I've put everything that was spread across different files into a constant `PRECONFIGURED_NETWORKS` that holds entries of `Eth1NetworkConfiguration` and updated the affected places to use that and be network agnostic.

### To-Do

[//]: # (See: https://trinity-client.readthedocs.io/en/latest/contributing.html#pull-requests)
- [x] Add entry to the [release notes](https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://static.boredpanda.com/blog/wp-content/uploads/2015/06/cute-reptiles-fb__700.jpg)
