### PR TITLE
Improve stability and debug-ability of integration tests

### DIFF
--- a/tests/integration/test_trinity_cli.py
+++ b/tests/integration/test_trinity_cli.py
@@ -154,6 +154,9 @@ async def test_web3_commands_via_attached_console(command,
         for fragment
         in command
     )
+    # The test mostly fails because the JSON-RPC requests time out. We slim down
+    # services to make the application less busy and improve the overall answer rate.
+    command += ('--sync-mode=none', '--disable-discovery', '--disable-upnp')
     command = amend_command_for_unused_port(command, unused_tcp_port)
     attach_cmd = list(command[1:] + ('attach',))
 

--- a/tox.ini
+++ b/tox.ini
@@ -93,7 +93,7 @@ commands=
     /bin/rm -rf build dist
     python setup.py sdist bdist_wheel
     /bin/bash -c 'pip install --upgrade "$(ls dist/*.whl)""[p2p,trinity]"'
-    pytest {posargs:tests/integration/ -k 'trinity_cli'}
+    pytest {posargs:tests/integration/ -k 'trinity_cli' --log-cli-level 0}
 
 [testenv:py36-wheel-cli]
 deps = {[common-wheel-cli]deps}


### PR DESCRIPTION
### What was wrong?

1. @lithp figured out a while ago that some of our integration tests fail because a previous integration test may leave the Trinity default port blocked and so it is beneficial to always run these tests with random ports assigned. When that was discovered it was only applied to one of the integration tests but I just figured out that it is helpful to nearly all of them. E.g. the test that ensures our logging config works as expected may fail sporadically because it can not find the logging output from the `DiscoveryService` that is is expecting to be there. Surprise surprise, the `DiscoveryService` sometimes fails to boot when the port is taken.

2. I turned on full logging output for these tests so that everyone has an easier time figuring out what went wrong if one of these tests fails

3. One of the main problems why the web3 integration test usually fails is because requests time out. I believe this is a real problem not with the tests but with Trinity.

### How was it fixed?

1. Use an unused port for nearly all integration tests
2. Turn on logging output for the integration tests
3. I've cut down the work that Trinity performs in the web3 integration tests. I disabled sync, discovery and upnp leaving more resources to reliably answer these JSON-RPC requests.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

[//]: # (See: https://trinity-client.readthedocs.io/en/latest/contributing.html#pull-requests)
- [ ] Add entry to the [release notes](https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://i.pinimg.com/originals/50/14/7f/50147f00f076bbb74b6bf75e02798aa4.jpg)
