### PR TITLE
Properly handle different networks when resolving checkpoints

### DIFF
--- a/newsfragments/1269.bugfix.rst
+++ b/newsfragments/1269.bugfix.rst
@@ -1,0 +1,1 @@
+Turn leaking exceptions into properly formatted user errors.

--- a/newsfragments/1269.feature.rst
+++ b/newsfragments/1269.feature.rst
@@ -1,0 +1,3 @@
+Properly handle Ropsten and Goerli when using
+`--beam-from-checkpoint eth://block/byetherscan/latest` to resolve a checkpoint. Also,
+propagate a proper error to the user in case the syntax is used for an unsupported networḱ.

--- a/tests/core/cli/test_parse_checkpoint_uri.py
+++ b/tests/core/cli/test_parse_checkpoint_uri.py
@@ -6,8 +6,9 @@ from eth_utils import (
 )
 
 from trinity.components.builtin.syncer.cli import (
-    parse_checkpoint_uri
+    parse_checkpoint_uri,
 )
+from trinity.constants import MAINNET_NETWORK_ID
 
 
 @pytest.mark.parametrize(
@@ -29,7 +30,7 @@ from trinity.components.builtin.syncer.cli import (
 )
 def test_parse_checkpoint(uri, expected):
     block_hash, block_number, block_score = expected
-    checkpoint = parse_checkpoint_uri(uri)
+    checkpoint = parse_checkpoint_uri(uri, MAINNET_NETWORK_ID)
     assert encode_hex(checkpoint.block_hash) == block_hash
     assert checkpoint.score == block_score
 
@@ -48,4 +49,4 @@ def test_parse_checkpoint(uri, expected):
 )
 def test_throws_validation_error(uri):
     with pytest.raises(ValidationError):
-        parse_checkpoint_uri(uri)
+        parse_checkpoint_uri(uri, MAINNET_NETWORK_ID)

--- a/tests/integration/test_etherscan_checkpoint_resolver.py
+++ b/tests/integration/test_etherscan_checkpoint_resolver.py
@@ -5,6 +5,8 @@ from trinity.components.builtin.syncer.cli import (
     parse_checkpoint_uri,
     is_block_hash,
 )
+from trinity.constants import MAINNET_NETWORK_ID
+
 
 # This is just the score at the tip as it was at some point on August 26th 2019
 # It serves as anchor so that we have *some* minimal expected score to test against.
@@ -18,6 +20,6 @@ MIN_EXPECTED_SCORE = 11631608640717612820968
     )
 )
 def test_parse_checkpoint(uri):
-    checkpoint = parse_checkpoint_uri(uri)
+    checkpoint = parse_checkpoint_uri(uri, MAINNET_NETWORK_ID)
     assert checkpoint.score >= MIN_EXPECTED_SCORE
     assert is_block_hash(encode_hex(checkpoint.block_hash))

--- a/trinity/bootstrap.py
+++ b/trinity/bootstrap.py
@@ -103,7 +103,7 @@ def main_entry(trinity_boot: BootFn,
     args = parser.parse_args()
 
     if not args.genesis and args.network_id not in PRECONFIGURED_NETWORKS:
-        raise NotImplementedError(
+        parser.error(
             f"Unsupported network id: {args.network_id}. To use a network besides "
             "mainnet or ropsten, you must supply a genesis file with a flag, like "
             "`--genesis path/to/genesis.json`, also you must specify a data "

--- a/trinity/components/builtin/syncer/cli.py
+++ b/trinity/components/builtin/syncer/cli.py
@@ -106,5 +106,9 @@ class NormalizeCheckpointURI(argparse.Action):
                  namespace: argparse.Namespace,
                  value: Any,
                  option_string: str=None) -> None:
-        parsed = parse_checkpoint_uri(value)
+
+        try:
+            parsed = parse_checkpoint_uri(value)
+        except ValidationError as exc:
+            raise argparse.ArgumentError(self, str(exc))
         setattr(namespace, self.dest, parsed)

--- a/trinity/constants.py
+++ b/trinity/constants.py
@@ -41,7 +41,7 @@ TO_NETWORKING_BROADCAST_CONFIG = BroadcastConfig(filter_endpoint=NETWORKING_EVEN
 # Network IDs: https://ethereum.stackexchange.com/questions/17051/how-to-select-a-network-id-or-is-there-a-list-of-network-ids/17101#17101  # noqa: E501
 MAINNET_NETWORK_ID = 1
 ROPSTEN_NETWORK_ID = 3
-
+GOERLI_NETWORK_ID = 5
 
 # Default preferred enodes
 DEFAULT_PREFERRED_NODES: Dict[int, Tuple[Node, ...]] = {


### PR DESCRIPTION
### What was wrong?

As mentioned in #1209, currently when using `--beam-from-checkpoint eth://block/byetherscan/latest` with non-mainnet networks it will silently try to do the wrong thing.

### How was it fixed?

Use the correct Etherscan API for every supported network. Also, tell the user when a network does not support this API.

**Bonus**: There were some leaking exceptions that I turned into a proper user facing error. That's in a separate commit but I sneaked it into this PR.

### To-Do

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

[//]: # (See: https://trinity-client.readthedocs.io/en/latest/contributing.html#pull-requests)
- [x] Add entry to the [release notes](https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://pbs.twimg.com/media/C8VfUQ8WsAA_fX_.jpg)
