### PR TITLE
Persist `DepositData` in `Eth1Monitor`

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -232,6 +232,12 @@ jobs:
       - image: circleci/python:3.6
         environment:
           TOXENV: py36-p2p-trio
+  py36-eth1-monitor-trio:
+    <<: *common
+    docker:
+      - image: circleci/python:3.6
+        environment:
+          TOXENV: py36-eth1-monitor-trio
   py36-eth2-core:
     <<: *common
     docker:
@@ -318,6 +324,12 @@ jobs:
       - image: circleci/python:3.7
         environment:
           TOXENV: py37-p2p-trio
+  py37-eth1-monitor-trio:
+    <<: *common
+    docker:
+      - image: circleci/python:3.7
+        environment:
+          TOXENV: py37-eth1-monitor-trio
   py37-eth2-core:
     <<: *common
     docker:
@@ -390,6 +402,7 @@ workflows:
       - py37-eth1-core
       - py37-p2p
       - py37-p2p-trio
+      - py37-eth1-monitor-trio
       - py37-eth2-core
       - py37-eth2-utils
       - py37-eth2-fixtures
@@ -413,6 +426,7 @@ workflows:
       - py36-eth1-core
       - py36-p2p
       - py36-p2p-trio
+      - py36-eth1-monitor-trio
       - py36-eth2-core
       - py36-eth2-utils
       - py36-eth2-fixtures

--- a/tests-trio/eth1-monitor/conftest.py
+++ b/tests-trio/eth1-monitor/conftest.py
@@ -61,11 +61,6 @@ def polling_period():
 
 
 @pytest.fixture
-def start_block_number():
-    return 0
-
-
-@pytest.fixture
 def deposit_contract(w3, tester, contract_json):
     contract_bytecode = contract_json["bytecode"]
     contract_abi = contract_json["abi"]
@@ -86,12 +81,7 @@ def func_do_deposit(w3, deposit_contract):
 
 @pytest.fixture
 async def eth1_monitor(
-    w3,
-    deposit_contract,
-    num_blocks_confirmed,
-    polling_period,
-    start_block_number,
-    endpoint_server,
+    w3, deposit_contract, num_blocks_confirmed, polling_period, endpoint_server
 ):
     m = Eth1Monitor(
         w3=w3,
@@ -99,7 +89,6 @@ async def eth1_monitor(
         deposit_contract_abi=deposit_contract.abi,
         num_blocks_confirmed=num_blocks_confirmed,
         polling_period=polling_period,
-        start_block_number=start_block_number,
         event_bus=endpoint_server,
         db=DepositDataDBFactory(),
     )

--- a/tests-trio/eth1-monitor/test_deposit_data_db.py
+++ b/tests-trio/eth1-monitor/test_deposit_data_db.py
@@ -31,6 +31,16 @@ def test_deposit_data_db():
     for i, data in enumerate(sequence_deposit_data):
         assert db.get_deposit_data(i) == data
 
+    # Test: Range access
+    for i, _ in enumerate(sequence_deposit_data):
+        assert sequence_deposit_data[i:] == db.get_deposit_data_range(
+            i, db.deposit_count
+        )
+        upper_index = i + 1
+        assert sequence_deposit_data[0:upper_index] == db.get_deposit_data_range(
+            0, upper_index
+        )
+
     # Test: Data is persisted in `DepositDataDB.db`, and can be retrieved when
     #   a new `DepositDataDB` instance takes the same `AtomicDB`.
     new_db: DepositDataDB = DepositDataDBFactory(db=db.db)

--- a/tests-trio/eth1-monitor/test_deposit_data_db.py
+++ b/tests-trio/eth1-monitor/test_deposit_data_db.py
@@ -1,0 +1,38 @@
+import pytest
+
+from trinity.components.eth2.eth1_monitor.db import DepositDataDB
+from trinity.components.eth2.eth1_monitor.exceptions import DepositDataNotFound
+from trinity.components.eth2.eth1_monitor.factories import (
+    DepositDataDBFactory,
+    DepositDataFactory,
+)
+
+
+def test_deposit_data_db():
+    db: DepositDataDB = DepositDataDBFactory()
+    # Test: Initial `deposit_count == 0`.
+    assert db.deposit_count == 0
+
+    # Test: `DepositDataNotFound` is raised when a `DepositData` at the given `index` is not found.
+    with pytest.raises(DepositDataNotFound):
+        db.get_deposit_data(0)
+
+    # Test: Ensure `add_deposit_data` works and `deposit_count` is updated and saved as well.
+    target_deposit_count = 5
+    sequence_deposit_data = tuple(
+        DepositDataFactory() for _ in range(target_deposit_count)
+    )
+    for i, data in enumerate(sequence_deposit_data):
+        db.add_deposit_data(data)
+        assert db.deposit_count == i + 1
+        assert db.get_deposit_count() == db.deposit_count
+
+    # Test: Ensure `get_deposit_data` works.
+    for i, data in enumerate(sequence_deposit_data):
+        assert db.get_deposit_data(i) == data
+
+    # Test: Data is persisted in `DepositDataDB.db`, and can be retrieved when
+    #   a new `DepositDataDB` instance takes the same `AtomicDB`.
+    new_db: DepositDataDB = DepositDataDBFactory(db=db.db)
+    for i, data in enumerate(sequence_deposit_data):
+        assert new_db.get_deposit_data(i) == data

--- a/tests-trio/eth1-monitor/test_deposit_data_db.py
+++ b/tests-trio/eth1-monitor/test_deposit_data_db.py
@@ -1,10 +1,7 @@
 import pytest
 
 from trinity.components.eth2.eth1_monitor.db import DepositDataDB
-from trinity.components.eth2.eth1_monitor.exceptions import (
-    DepositDataNotFound,
-    DepositDataDBValidationError,
-)
+from trinity.components.eth2.eth1_monitor.exceptions import DepositDataDBValidationError
 from trinity.components.eth2.eth1_monitor.factories import (
     DepositDataDBFactory,
     DepositDataFactory,
@@ -17,8 +14,9 @@ def test_deposit_data_db():
     assert db.deposit_count == 0
     assert db.highest_processed_block_number == 0
 
-    # Test: `DepositDataNotFound` is raised when a `DepositData` at the given `index` is not found.
-    with pytest.raises(DepositDataNotFound):
+    # Test: `DepositDataDBValidationError` is raised when a `DepositData` at the given `index`
+    #   is not found.
+    with pytest.raises(DepositDataDBValidationError):
         db.get_deposit_data(0)
 
     # Test: Ensure `add_deposit_data_batch` works and `deposit_count` is updated and saved as well.

--- a/tests-trio/eth1-monitor/test_eth1_monitor.py
+++ b/tests-trio/eth1-monitor/test_eth1_monitor.py
@@ -20,8 +20,8 @@ from trinity.components.eth2.eth1_monitor.exceptions import (
     Eth1MonitorValidationError,
 )
 from trinity.components.eth2.eth1_monitor.factories import (
-    DepositDataDBFactory,
     DepositDataFactory,
+    ListCachedDepositDataDBFactory,
 )
 from trinity.tools.factories.db import AtomicDBFactory
 
@@ -244,7 +244,7 @@ async def test_get_eth1_data(
     #   `deposit_data` mismatches the one got from the deposit contract.
     with monkeypatch.context() as m_context:
         # Create another `DepositDataDB` with the same number but different `DepositData`s.
-        corrupted_deposit_data_db = DepositDataDBFactory()
+        corrupted_deposit_data_db = ListCachedDepositDataDBFactory()
         corrupted_list_deposit_data = [
             DepositDataFactory() for _ in range(eth1_monitor.total_deposit_count)
         ]

--- a/tests-trio/eth1-monitor/test_eth1_monitor.py
+++ b/tests-trio/eth1-monitor/test_eth1_monitor.py
@@ -23,6 +23,7 @@ from trinity.components.eth2.eth1_monitor.factories import (
     DepositDataDBFactory,
     DepositDataFactory,
 )
+from trinity.tools.factories.db import AtomicDBFactory
 
 
 @pytest.mark.trio
@@ -34,6 +35,7 @@ async def test_logs_handling(
     polling_period,
     endpoint_server,
     func_do_deposit,
+    start_block_number,
 ):
     amount_0 = func_do_deposit()
     amount_1 = func_do_deposit()
@@ -43,8 +45,9 @@ async def test_logs_handling(
         deposit_contract_abi=deposit_contract.abi,
         num_blocks_confirmed=num_blocks_confirmed,
         polling_period=polling_period,
+        start_block_number=start_block_number,
         event_bus=endpoint_server,
-        db=DepositDataDBFactory(),
+        base_db=AtomicDBFactory(),
     )
     async with background_service(m):
         # Test: logs emitted prior to starting `Eth1Monitor` can still be queried.

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist=
-    py{36,37}-{eth1-core,p2p,p2p-trio,integration,lightchain_integration,eth2-core,eth2-fixtures,eth2-integration,eth1-components,eth2-components,eth2-utils}
+    py{36,37}-{eth1-core,p2p,p2p-trio,eth1-monitor-trio,integration,lightchain_integration,eth2-core,eth2-fixtures,eth2-integration,eth1-components,eth2-components,eth2-utils}
     py36-long_run_integration
     py36-rpc-blockchain
     py36-rpc-state-{frontier,homestead,tangerine_whistle,spurious_dragon,byzantium,constantinople,petersburg}
@@ -69,6 +69,14 @@ commands = pytest -n 4 {posargs:tests-trio/p2p-trio}
 [testenv:py37-p2p-trio]
 deps = .[p2p,test,test-trio]
 commands = pytest -n 4 {posargs:tests-trio/p2p-trio}
+
+[testenv:py36-eth1-monitor-trio]
+deps = .[p2p,trinity,test,test-trio]
+commands = pytest -n 4 {posargs:tests-trio/eth1-monitor}
+
+[testenv:py37-eth1-monitor-trio]
+deps = .[p2p,trinity,test,test-trio]
+commands = pytest -n 4 {posargs:tests-trio/eth1-monitor}
 
 [testenv:py36-docs]
 whitelist_externals=

--- a/trinity/components/eth2/eth1_monitor/db.py
+++ b/trinity/components/eth2/eth1_monitor/db.py
@@ -160,12 +160,12 @@ class DepositDataDB(BaseDepositDataDB):
         key = SchemaV1.make_deposit_data_lookup_key(index)
         try:
             raw_bytes = self.db[key]
-        except KeyError:
+        except KeyError as error:
             # Should never enter here. Something strange must have happened.
             raise Exception(
                 f"`index < self.deposit_count` but failed to find `DepositData` at key {key}: "
                 f"index={index}, self.deposit_count={self.deposit_count}"
-            )
+            ) from error
         return ssz.decode(raw_bytes, DepositData)
 
     def get_deposit_data_range(

--- a/trinity/components/eth2/eth1_monitor/db.py
+++ b/trinity/components/eth2/eth1_monitor/db.py
@@ -1,0 +1,101 @@
+from abc import ABC, abstractmethod
+
+import ssz
+
+from eth.abc import AtomicDatabaseAPI, DatabaseAPI
+
+from eth2.beacon.types.deposit_data import DepositData
+
+from .exceptions import DepositDataNotFound
+
+
+class BaseSchema(ABC):
+    @staticmethod
+    @abstractmethod
+    def make_deposit_data_lookup_key(index: int) -> bytes:
+        ...
+
+    @staticmethod
+    @abstractmethod
+    def make_deposit_data_count_lookup_key() -> bytes:
+        ...
+
+
+class SchemaV1(BaseSchema):
+    @staticmethod
+    def make_deposit_data_lookup_key(index: int) -> bytes:
+        index_in_str = str(index)
+        return b"v1:deposit_data:" + index_in_str.encode()
+
+    @staticmethod
+    def make_deposit_data_count_lookup_key() -> bytes:
+        return b"v1:deposit_data:count"
+
+
+class BaseDepositDataDB(ABC):
+    @property
+    @abstractmethod
+    def deposit_count(self) -> int:
+        pass
+
+    @abstractmethod
+    def add_deposit_data(self, deposit_data: DepositData) -> None:
+        pass
+
+    @abstractmethod
+    def get_deposit_data(self, index: int) -> DepositData:
+        pass
+
+    @abstractmethod
+    def get_deposit_count(self) -> int:
+        pass
+
+
+class DepositDataDB(BaseDepositDataDB):
+    db: AtomicDatabaseAPI
+
+    _deposit_count: int
+
+    def __init__(self, db: AtomicDatabaseAPI) -> None:
+        self.db = db
+        self._deposit_count = self.get_deposit_count()
+
+    @property
+    def deposit_count(self) -> int:
+        return self._deposit_count
+
+    def add_deposit_data(self, deposit_data: DepositData) -> None:
+        count = self.deposit_count
+        new_count = count + 1
+        with self.db.atomic_batch() as db:
+            self._set_deposit_data(db, count, deposit_data)
+            self._set_deposit_count(db, new_count)
+        self._deposit_count = new_count
+
+    def get_deposit_data(self, index: int) -> DepositData:
+        key = SchemaV1.make_deposit_data_lookup_key(index)
+        try:
+            raw_bytes = self.db[key]
+        except KeyError:
+            raise DepositDataNotFound(f"DepositData at index={index} is not found")
+        return ssz.decode(raw_bytes, DepositData)
+
+    def get_deposit_count(self) -> int:
+        key = SchemaV1.make_deposit_data_count_lookup_key()
+        try:
+            raw_bytes = self.db[key]
+        except KeyError:
+            return 0
+        return ssz.decode(raw_bytes, sedes=ssz.sedes.uint64)
+
+    @staticmethod
+    def _set_deposit_data(
+        db: DatabaseAPI, index: int, deposit_data: DepositData
+    ) -> None:
+        db[SchemaV1.make_deposit_data_lookup_key(index)] = ssz.encode(deposit_data)
+
+    @staticmethod
+    def _set_deposit_count(db: DatabaseAPI, deposit_count: int) -> None:
+        db[SchemaV1.make_deposit_data_count_lookup_key()] = ssz.encode(
+            deposit_count, sedes=ssz.sedes.uint64
+        )

--- a/trinity/components/eth2/eth1_monitor/db.py
+++ b/trinity/components/eth2/eth1_monitor/db.py
@@ -1,12 +1,14 @@
 from abc import ABC, abstractmethod
 
+from typing import Tuple
+
 import ssz
 
 from eth.abc import AtomicDatabaseAPI, DatabaseAPI
 
 from eth2.beacon.types.deposit_data import DepositData
 
-from .exceptions import DepositDataNotFound
+from .exceptions import DepositDataNotFound, DepositDataDBValidationError
 
 
 class BaseSchema(ABC):
@@ -36,19 +38,25 @@ class BaseDepositDataDB(ABC):
     @property
     @abstractmethod
     def deposit_count(self) -> int:
-        pass
+        ...
 
     @abstractmethod
     def add_deposit_data(self, deposit_data: DepositData) -> None:
-        pass
+        ...
 
     @abstractmethod
     def get_deposit_data(self, index: int) -> DepositData:
-        pass
+        ...
+
+    @abstractmethod
+    def get_deposit_data_range(
+        self, from_index: int, to_index: int
+    ) -> Tuple[DepositData, ...]:
+        ...
 
     @abstractmethod
     def get_deposit_count(self) -> int:
-        pass
+        ...
 
 
 class DepositDataDB(BaseDepositDataDB):
@@ -77,8 +85,31 @@ class DepositDataDB(BaseDepositDataDB):
         try:
             raw_bytes = self.db[key]
         except KeyError:
-            raise DepositDataNotFound(f"DepositData at index={index} is not found")
+            raise DepositDataNotFound(f"`DepositData` at index={index} is not found")
         return ssz.decode(raw_bytes, DepositData)
+
+    def get_deposit_data_range(
+        self, from_index: int, to_index: int
+    ) -> Tuple[DepositData, ...]:
+        if (from_index < 0) or (to_index < 0):
+            raise DepositDataDBValidationError(
+                "both `from_index` and `to_index` should be non-negative: "
+                f"from_index={from_index}, to_index={to_index}"
+            )
+        if from_index >= to_index:
+            raise DepositDataDBValidationError(
+                "`to_index` should be larger than `from_index`: "
+                f"from_index={from_index}, to_index={to_index}"
+            )
+        if (from_index >= self.deposit_count) or (to_index > self.deposit_count):
+            raise DepositDataDBValidationError(
+                "either `from_index` or `to_index` is larger or equaled to `self.deposit_count`: "
+                f"from_index={from_index}, to_index={to_index}, "
+                f"self.deposit_count={self.deposit_count}"
+            )
+        return tuple(
+            self.get_deposit_data(index) for index in range(from_index, to_index)
+        )
 
     def get_deposit_count(self) -> int:
         key = SchemaV1.make_deposit_data_count_lookup_key()

--- a/trinity/components/eth2/eth1_monitor/db.py
+++ b/trinity/components/eth2/eth1_monitor/db.py
@@ -24,6 +24,11 @@ class BaseSchema(ABC):
     def make_deposit_count_lookup_key() -> bytes:
         ...
 
+    @staticmethod
+    @abstractmethod
+    def make_highest_processed_block_number_lookup_key() -> bytes:
+        ...
+
 
 class SchemaV1(BaseSchema):
     @staticmethod

--- a/trinity/components/eth2/eth1_monitor/db.py
+++ b/trinity/components/eth2/eth1_monitor/db.py
@@ -28,8 +28,7 @@ class BaseSchema(ABC):
 class SchemaV1(BaseSchema):
     @staticmethod
     def make_deposit_data_lookup_key(index: int) -> bytes:
-        index_in_str = str(index)
-        return b"v1:deposit_data:" + index_in_str.encode()
+        return b"v1:deposit_data:" + index.to_bytes(8, "big")
 
     @staticmethod
     def make_deposit_count_lookup_key() -> bytes:

--- a/trinity/components/eth2/eth1_monitor/eth1_monitor.py
+++ b/trinity/components/eth2/eth1_monitor/eth1_monitor.py
@@ -35,7 +35,7 @@ from eth2.beacon.tools.builder.validator import (
 
 from p2p.trio_service import Service
 
-from .db import BaseDepositDataDB, DepositDataDB
+from .db import BaseDepositDataDB, ListCachedDepositDataDB
 from .events import (
     GetDepositResponse,
     GetDepositRequest,
@@ -134,7 +134,7 @@ class Eth1Monitor(Service):
         self._num_blocks_confirmed = num_blocks_confirmed
         self._polling_period = polling_period
         self._event_bus = event_bus
-        self._db: BaseDepositDataDB = DepositDataDB(
+        self._db: BaseDepositDataDB = ListCachedDepositDataDB(
             base_db, BlockNumber(start_block_number - 1)
         )
 

--- a/trinity/components/eth2/eth1_monitor/eth1_monitor.py
+++ b/trinity/components/eth2/eth1_monitor/eth1_monitor.py
@@ -217,10 +217,10 @@ class Eth1Monitor(Service):
             raise Eth1MonitorValidationError(
                 f"failed to make `Eth1Data`: `deposit_count = 0` at block #{target_block_number}"
             )
-        deposit_data_at_count = self._db.get_deposit_data_range(
+        deposit_data_in_range = self._db.get_deposit_data_range(
             0, accumulated_deposit_count
         )
-        _, deposit_root = make_deposit_tree_and_root(deposit_data_at_count)
+        _, deposit_root = make_deposit_tree_and_root(deposit_data_in_range)
         contract_deposit_root = self._get_deposit_root_from_contract(
             target_block_number
         )
@@ -246,7 +246,7 @@ class Eth1Monitor(Service):
                 "`deposit_index` should be smaller than `deposit_count`: "
                 f"deposit_index={deposit_index}, deposit_count={deposit_count}"
             )
-        len_deposit_data = self._db.deposit_count
+        len_deposit_data = self.total_deposit_count
         if deposit_count <= 0 or deposit_count > len_deposit_data:
             raise Eth1MonitorValidationError(
                 f"invalid `deposit_count`: deposit_count={deposit_count}"
@@ -255,10 +255,10 @@ class Eth1Monitor(Service):
             raise Eth1MonitorValidationError(
                 f"invalid `deposit_index`: deposit_index={deposit_index}"
             )
-        deposit_data_at_count = self._db.get_deposit_data_range(0, deposit_count)
-        tree, root = make_deposit_tree_and_root(deposit_data_at_count)
+        deposit_data_in_range = self._db.get_deposit_data_range(0, deposit_count)
+        tree, root = make_deposit_tree_and_root(deposit_data_in_range)
         return Deposit(
-            proof=make_deposit_proof(deposit_data_at_count, tree, root, deposit_index),
+            proof=make_deposit_proof(deposit_data_in_range, tree, root, deposit_index),
             data=self._db.get_deposit_data(deposit_index),
         )
 

--- a/trinity/components/eth2/eth1_monitor/exceptions.py
+++ b/trinity/components/eth2/eth1_monitor/exceptions.py
@@ -17,3 +17,11 @@ class DepositDataCorrupted(Eth1MonitorError):
     """
     `DepositData` which we have locally is not consistent with the deposit tree on chain.
     """
+
+
+class DepositDataDBError(Eth1MonitorError):
+    pass
+
+
+class DepositDataNotFound(DepositDataDBError):
+    pass

--- a/trinity/components/eth2/eth1_monitor/exceptions.py
+++ b/trinity/components/eth2/eth1_monitor/exceptions.py
@@ -23,9 +23,5 @@ class DepositDataDBError(Exception):
     ...
 
 
-class DepositDataNotFound(DepositDataDBError):
-    ...
-
-
 class DepositDataDBValidationError(ValidationError, DepositDataDBError):
     ...

--- a/trinity/components/eth2/eth1_monitor/exceptions.py
+++ b/trinity/components/eth2/eth1_monitor/exceptions.py
@@ -19,9 +19,13 @@ class DepositDataCorrupted(Eth1MonitorError):
     """
 
 
-class DepositDataDBError(Eth1MonitorError):
-    pass
+class DepositDataDBError(Exception):
+    ...
 
 
 class DepositDataNotFound(DepositDataDBError):
-    pass
+    ...
+
+
+class DepositDataDBValidationError(ValidationError, DepositDataDBError):
+    ...

--- a/trinity/components/eth2/eth1_monitor/factories.py
+++ b/trinity/components/eth2/eth1_monitor/factories.py
@@ -16,8 +16,21 @@ class DepositDataDBFactory(factory.Factory):
     db = factory.SubFactory(AtomicDBFactory)
 
 
+MIN_DEPOSIT_AMOUNT = 1000000000  # Gwei
+FULL_DEPOSIT_AMOUNT = 32000000000  # Gwei
+
+SAMPLE_PUBKEY = b"\x11" * 48
+SAMPLE_WITHDRAWAL_CREDENTIALS = b"\x22" * 32
+SAMPLE_VALID_SIGNATURE = b"\x33" * 96
+
+
 class DepositDataFactory(factory.Factory):
     class Meta:
         model = DepositData
 
-    amount = factory.LazyFunction(lambda: random.randint(0, 2 ** 32 - 1))
+    pubkey = SAMPLE_PUBKEY
+    withdrawal_credentials = SAMPLE_WITHDRAWAL_CREDENTIALS
+    amount = factory.LazyFunction(
+        lambda: random.randint(MIN_DEPOSIT_AMOUNT, FULL_DEPOSIT_AMOUNT + 1)
+    )
+    signature = SAMPLE_VALID_SIGNATURE

--- a/trinity/components/eth2/eth1_monitor/factories.py
+++ b/trinity/components/eth2/eth1_monitor/factories.py
@@ -1,0 +1,23 @@
+import random
+
+import factory
+
+from eth2.beacon.types.deposit_data import DepositData
+
+from trinity.tools.factories.db import AtomicDBFactory
+
+from .db import DepositDataDB
+
+
+class DepositDataDBFactory(factory.Factory):
+    class Meta:
+        model = DepositDataDB
+
+    db = factory.SubFactory(AtomicDBFactory)
+
+
+class DepositDataFactory(factory.Factory):
+    class Meta:
+        model = DepositData
+
+    amount = factory.LazyFunction(lambda: random.randint(0, 2 ** 32 - 1))

--- a/trinity/components/eth2/eth1_monitor/factories.py
+++ b/trinity/components/eth2/eth1_monitor/factories.py
@@ -6,12 +6,19 @@ from eth2.beacon.types.deposit_data import DepositData
 
 from trinity.tools.factories.db import AtomicDBFactory
 
-from .db import DepositDataDB
+from .db import DepositDataDB, ListCachedDepositDataDB
 
 
 class DepositDataDBFactory(factory.Factory):
     class Meta:
         model = DepositDataDB
+
+    db = factory.SubFactory(AtomicDBFactory)
+
+
+class ListCachedDepositDataDBFactory(factory.Factory):
+    class Meta:
+        model = ListCachedDepositDataDB
 
     db = factory.SubFactory(AtomicDBFactory)
 


### PR DESCRIPTION
Depends on https://github.com/ethereum/trinity/pull/1233

### What was wrong?
We need to persist `DepositData` received from eth1 chain.

### How was it fixed?
- Have a `DepositDataDB` and put the received `DepositData` inside.
- `Eth1Monitor` uses a `ListCachedDepositDataDB` to store `DepositData`. `ListCachedDepositDataDB` stores the whole sequence of `DepositData` in a `List` in memory and also in a `DepositDataDB` as its backup.

### To-Do
- [x] Make `Eth1Monitor` use of `BaseDepositDataDB`.
- [x] Also persist the "latest synced block number"?
- ~[ ] Investigate how to make use of locality. At least range access helps.~
  - It seems we don't have `db_iterator` in [`eth.db.backends.LevelDB`](https://github.com/ethereum/py-evm/blob/master/eth/db/backends/level.py#L28). Will need to have a new interface for db, which I'm not sure if it is worthy.

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://i.imgur.com/iAL0Dkx.jpg)
