### PR TITLE
Add some aggregator helpers

### DIFF
--- a/eth2/beacon/tools/builder/aggregator.py
+++ b/eth2/beacon/tools/builder/aggregator.py
@@ -8,14 +8,14 @@ from eth2.beacon.helpers import compute_epoch_at_slot, get_domain
 from eth2.beacon.signature_domain import SignatureDomain
 from eth2.beacon.types.states import BeaconState
 from eth2.beacon.typing import CommitteeIndex, Slot
-from eth2.configs import CommitteeConfig, Eth2Config
+from eth2.configs import CommitteeConfig
 
 # TODO: TARGET_AGGREGATORS_PER_COMMITTEE is not in Eth2Config now.
 TARGET_AGGREGATORS_PER_COMMITTEE = 16
 
 
 def slot_signature(
-    state: BeaconState, slot: Slot, privkey: int, config: Eth2Config
+    state: BeaconState, slot: Slot, privkey: int, config: CommitteeConfig
 ) -> BLSSignature:
     """
     Sign on ``slot`` and return the signature.
@@ -34,7 +34,7 @@ def is_aggregator(
     slot: Slot,
     index: CommitteeIndex,
     signature: BLSSignature,
-    config: Eth2Config,
+    config: CommitteeConfig,
 ) -> bool:
     """
     Check if the validator is one of the aggregators of the given ``slot``.
@@ -51,6 +51,6 @@ def is_aggregator(
 
         - Chart analysis: https://docs.google.com/spreadsheets/d/1C7pBqEWJgzk3_jesLkqJoDTnjZOODnGTOJUrxUMdxMA  # noqa: E501
     """
-    committee = get_beacon_committee(state, slot, index, CommitteeConfig(config))
+    committee = get_beacon_committee(state, slot, index, config)
     modulo = max(1, len(committee) // TARGET_AGGREGATORS_PER_COMMITTEE)
     return int.from_bytes(hash_eth2(signature)[0:8], byteorder="little") % modulo == 0

--- a/eth2/beacon/tools/builder/aggregator.py
+++ b/eth2/beacon/tools/builder/aggregator.py
@@ -17,6 +17,9 @@ TARGET_AGGREGATORS_PER_COMMITTEE = 16
 def slot_signature(
     state: BeaconState, slot: Slot, privkey: int, config: Eth2Config
 ) -> BLSSignature:
+    """
+    Sign on ``slot`` and return the signature.
+    """
     domain = get_domain(
         state,
         SignatureDomain.DOMAIN_BEACON_ATTESTER,
@@ -33,6 +36,21 @@ def is_aggregator(
     signature: BLSSignature,
     config: Eth2Config,
 ) -> bool:
+    """
+    Check if the validator is one of the aggregators of the given ``slot``.
+
+      .. note::
+        - Probabilistically, with enought validators, the aggregator count should
+        approach ``TARGET_AGGREGATORS_PER_COMMITTEE``.
+
+        - With ``len(committee)`` is 128 and ``TARGET_AGGREGATORS_PER_COMMITTEE`` is 16,
+        the expected length of selected validators is 16.
+
+        - It's possible that this algorithm selects *no one* as the aggregator, but with the
+        above parameters, the chance of having no aggregator has a probability of 3.78E-08.
+
+        - Chart analysis: https://docs.google.com/spreadsheets/d/1C7pBqEWJgzk3_jesLkqJoDTnjZOODnGTOJUrxUMdxMA  # noqa: E501
+    """
     committee = get_beacon_committee(state, slot, index, CommitteeConfig(config))
     modulo = max(1, len(committee) // TARGET_AGGREGATORS_PER_COMMITTEE)
     return int.from_bytes(hash_eth2(signature)[0:8], byteorder="little") % modulo == 0

--- a/eth2/beacon/types/aggregate_and_proof.py
+++ b/eth2/beacon/types/aggregate_and_proof.py
@@ -1,0 +1,38 @@
+from eth_typing import BLSSignature
+from eth_utils import humanize_hash
+import ssz
+from ssz.sedes import bytes96, uint64
+
+from eth2.beacon.constants import EMPTY_SIGNATURE
+from eth2.beacon.types.attestations import Attestation, default_attestation
+from eth2.beacon.types.defaults import default_validator_index
+from eth2.beacon.typing import ValidatorIndex
+
+
+class AggregateAndProof(ssz.Serializable):
+
+    fields = [
+        ("index", uint64),
+        ("selection_proof", bytes96),
+        ("aggregate", Attestation),
+    ]
+
+    def __init__(
+        self,
+        index: ValidatorIndex = default_validator_index,
+        selection_proof: BLSSignature = EMPTY_SIGNATURE,
+        aggregate: Attestation = default_attestation,
+    ) -> None:
+        super().__init__(
+            index=index, selection_proof=selection_proof, aggregate=aggregate
+        )
+
+    def __str__(self) -> str:
+        return (
+            f"index={self.index},"
+            f" selection_proof={humanize_hash(self.selection_proof)},"
+            f" aggregate={self.aggregate},"
+        )
+
+
+default_aggregate_and_proof = AggregateAndProof()

--- a/eth2/beacon/types/attestations.py
+++ b/eth2/beacon/types/attestations.py
@@ -36,6 +36,9 @@ class Attestation(ssz.Serializable):
         )
 
 
+default_attestation = Attestation()
+
+
 class IndexedAttestation(ssz.Serializable):
 
     fields = [

--- a/eth2/beacon/types/defaults.py
+++ b/eth2/beacon/types/defaults.py
@@ -21,6 +21,7 @@ if TYPE_CHECKING:
 
 
 default_bls_pubkey = EMPTY_PUBKEY
+default_bls_pubkey = EMPTY_PUBKEY
 
 # NOTE: there is a bug in our current version of ``flake8`` (==3.5.0)
 # which does not recognize the inline typing:

--- a/eth2/beacon/types/defaults.py
+++ b/eth2/beacon/types/defaults.py
@@ -21,7 +21,6 @@ if TYPE_CHECKING:
 
 
 default_bls_pubkey = EMPTY_PUBKEY
-default_bls_pubkey = EMPTY_PUBKEY
 
 # NOTE: there is a bug in our current version of ``flake8`` (==3.5.0)
 # which does not recognize the inline typing:

--- a/tests/eth2/core/beacon/conftest.py
+++ b/tests/eth2/core/beacon/conftest.py
@@ -19,7 +19,7 @@ from eth2.beacon.tools.builder.initializer import create_mock_validator
 from eth2.beacon.tools.builder.state import create_mock_genesis_state_from_validators
 from eth2.beacon.tools.misc.ssz_vector import override_lengths
 from eth2.beacon.types.attestation_data import AttestationData
-from eth2.beacon.types.attestations import IndexedAttestation
+from eth2.beacon.types.attestations import Attestation, IndexedAttestation
 from eth2.beacon.types.blocks import BeaconBlock, BeaconBlockBody, BeaconBlockHeader
 from eth2.beacon.types.checkpoints import Checkpoint
 from eth2.beacon.types.deposit_data import DepositData
@@ -559,6 +559,15 @@ def sample_block(sample_beacon_block_params):
 @pytest.fixture()
 def sample_state(sample_beacon_state_params):
     return BeaconState(**sample_beacon_state_params)
+
+
+@pytest.fixture
+def sample_aggregate_and_proof_params(sample_attestation_params):
+    return {
+        "index": 5,
+        "selection_proof": 1,
+        "aggregate": Attestation(**sample_attestation_params),
+    }
 
 
 #

--- a/tests/eth2/core/beacon/tools/builder/test_aggregator.py
+++ b/tests/eth2/core/beacon/tools/builder/test_aggregator.py
@@ -9,6 +9,7 @@ from eth2.beacon.tools.builder.aggregator import (
     is_aggregator,
     slot_signature,
 )
+from eth2.configs import CommitteeConfig
 
 
 @pytest.mark.slow
@@ -16,8 +17,10 @@ from eth2.beacon.tools.builder.aggregator import (
     ("validator_count", "target_committee_size", "slots_per_epoch"), [(1000, 100, 10)]
 )
 def test_aggregate_votes(validator_count, privkeys, genesis_state, config):
+    config = CommitteeConfig(config)
     state = genesis_state
     epoch = compute_epoch_at_slot(state.slot, config.SLOTS_PER_EPOCH)
+
     sum_aggregator_count = 0
     for committee, committee_index, slot in iterate_committees_at_epoch(
         state, epoch, config

--- a/tests/eth2/core/beacon/tools/builder/test_aggregator.py
+++ b/tests/eth2/core/beacon/tools/builder/test_aggregator.py
@@ -34,8 +34,11 @@ def test_aggregate_votes(validator_count, privkeys, genesis_state, config):
                     aggregator_count += 1
         assert aggregator_count > 0
         sum_aggregator_count += aggregator_count
+    # The average aggregator count per slot should be around
+    # `TARGET_AGGREGATORS_PER_COMMITTEE`.
+    average_aggregator_count = sum_aggregator_count / config.SLOTS_PER_EPOCH
     assert (
         TARGET_AGGREGATORS_PER_COMMITTEE - 3
-        < sum_aggregator_count / config.SLOTS_PER_EPOCH
+        < average_aggregator_count
         < TARGET_AGGREGATORS_PER_COMMITTEE + 3
     )

--- a/tests/eth2/core/beacon/tools/builder/test_aggregator.py
+++ b/tests/eth2/core/beacon/tools/builder/test_aggregator.py
@@ -1,0 +1,41 @@
+import pytest
+
+from eth2.beacon.committee_helpers import (
+    compute_epoch_at_slot,
+    iterate_committees_at_epoch,
+)
+from eth2.beacon.tools.builder.aggregator import (
+    TARGET_AGGREGATORS_PER_COMMITTEE,
+    is_aggregator,
+    slot_signature,
+)
+
+
+@pytest.mark.slow
+@pytest.mark.parametrize(
+    ("validator_count", "target_committee_size", "slots_per_epoch"), [(1000, 100, 10)]
+)
+def test_aggregate_votes(validator_count, privkeys, genesis_state, config):
+    state = genesis_state
+    epoch = compute_epoch_at_slot(state.slot, config.SLOTS_PER_EPOCH)
+    sum_aggregator_count = 0
+    for committee, committee_index, slot in iterate_committees_at_epoch(
+        state, epoch, config
+    ):
+        assert config.TARGET_COMMITTEE_SIZE == len(committee)
+        aggregator_count = 0
+        for index in range(validator_count):
+            if index in committee:
+                signature = slot_signature(genesis_state, slot, privkeys[index], config)
+                attester_is_aggregator = is_aggregator(
+                    state, slot, committee_index, signature, config
+                )
+                if attester_is_aggregator:
+                    aggregator_count += 1
+        assert aggregator_count > 0
+        sum_aggregator_count += aggregator_count
+    assert (
+        TARGET_AGGREGATORS_PER_COMMITTEE - 3
+        < sum_aggregator_count / config.SLOTS_PER_EPOCH
+        < TARGET_AGGREGATORS_PER_COMMITTEE + 3
+    )

--- a/tests/eth2/core/beacon/types/test_aggregate_and_proof.py
+++ b/tests/eth2/core/beacon/types/test_aggregate_and_proof.py
@@ -1,0 +1,14 @@
+from eth2.beacon.types.aggregate_and_proof import AggregateAndProof
+
+
+def test_defaults(sample_aggregate_and_proof_params):
+    aggregate_and_proof = AggregateAndProof(**sample_aggregate_and_proof_params)
+
+    assert aggregate_and_proof.index == sample_aggregate_and_proof_params["index"]
+    assert (
+        aggregate_and_proof.selection_proof
+        == sample_aggregate_and_proof_params["selection_proof"]
+    )
+    assert (
+        aggregate_and_proof.aggregate == sample_aggregate_and_proof_params["aggregate"]
+    )


### PR DESCRIPTION
### What was wrong?
Add some aggregator helpers for https://github.com/ethereum/trinity/issues/1241
See https://github.com/ethereum/eth2.0-specs/blob/v09x/specs/validator/0_beacon-chain-validator.md#attestation-aggregation

### How was it fixed?
1. `slot_signature`: a function for the attester to sign on the slot. Then the attester would use this signature as the lottery ticket of aggregators selection of the given slot.
2. `is_aggregator`: a probabilistic function. The attester may get selected with the expected aggregator count per committee = `TARGET_AGGREGATORS_PER_COMMITTEE`. Here is the graph of the expected `len(selected_validators)`: https://docs.google.com/spreadsheets/d/1C7pBqEWJgzk3_jesLkqJoDTnjZOODnGTOJUrxUMdxMA/edit#gid=0
3. Add `AggregateAndProof` SSZ container.


### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

[//]: # (See: https://trinity-client.readthedocs.io/en/latest/contributing.html#pull-requests)
- [ ] Add entry to the [release notes](https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![Dugong](https://user-images.githubusercontent.com/9263930/68789049-9ba33880-067f-11ea-8bf9-45519c13c13c.jpg)
