### PR TITLE
Refactor and update `SlotTicker`

### DIFF
--- a/tests/components/eth2/beacon/test_slot_ticker.py
+++ b/tests/components/eth2/beacon/test_slot_ticker.py
@@ -19,7 +19,6 @@ async def test_slot_ticker_ticking(event_bus, event_loop):
         event_bus=event_bus,
     )
     asyncio.ensure_future(slot_ticker.run(), loop=event_loop)
-    await slot_ticker.events.started.wait()
     try:
         slot_tick_event = await asyncio.wait_for(
             event_bus.wait_for(SlotTickEvent),
@@ -32,33 +31,47 @@ async def test_slot_ticker_ticking(event_bus, event_loop):
     await slot_ticker.cancel()
 
 
+@pytest.mark.slow
 @pytest.mark.asyncio
-async def test_slot_ticker_second_half_tick(event_bus, event_loop):
+async def test_slot_ticker_all_ticks(event_bus, event_loop):
+    seconds_per_slot = 3
     slot_ticker = SlotTicker(
         genesis_slot=0,
-        genesis_time=int(time.time()) + 1,
-        seconds_per_slot=3,
+        genesis_time=int(time.time()) + seconds_per_slot,
+        seconds_per_slot=seconds_per_slot,
         event_bus=event_bus,
     )
     asyncio.ensure_future(slot_ticker.run(), loop=event_loop)
-    await slot_ticker.events.started.wait()
     try:
         first_slot_event = await asyncio.wait_for(
             event_bus.wait_for(SlotTickEvent),
-            timeout=6,
+            timeout=seconds_per_slot,
             loop=event_loop,
         )
     except asyncio.TimeoutError:
         assert False, "Slot not ticking"
     assert first_slot_event.tick_type.is_start
+
     try:
         second_slot_event = await asyncio.wait_for(
             event_bus.wait_for(SlotTickEvent),
-            timeout=6,
+            timeout=seconds_per_slot,
             loop=event_loop,
         )
     except asyncio.TimeoutError:
-        assert False, "No second half tick"
+        assert False, "Should have gotten the second tick"
     assert second_slot_event.slot == first_slot_event.slot
-    assert second_slot_event.tick_type.is_two_third
+    assert second_slot_event.tick_type.is_one_third
+
+    try:
+        third_slot_event = await asyncio.wait_for(
+            event_bus.wait_for(SlotTickEvent),
+            timeout=seconds_per_slot,
+            loop=event_loop,
+        )
+    except asyncio.TimeoutError:
+        assert False, "Should have gotten the third tick"
+    assert third_slot_event.slot == first_slot_event.slot
+    assert third_slot_event.tick_type.is_two_third
+
     await slot_ticker.cancel()

--- a/tests/components/eth2/beacon/test_slot_ticker.py
+++ b/tests/components/eth2/beacon/test_slot_ticker.py
@@ -37,7 +37,7 @@ async def test_slot_ticker_second_half_tick(event_bus, event_loop):
     slot_ticker = SlotTicker(
         genesis_slot=0,
         genesis_time=int(time.time()) + 1,
-        seconds_per_slot=2,
+        seconds_per_slot=3,
         event_bus=event_bus,
     )
     asyncio.ensure_future(slot_ticker.run(), loop=event_loop)
@@ -45,20 +45,20 @@ async def test_slot_ticker_second_half_tick(event_bus, event_loop):
     try:
         first_slot_event = await asyncio.wait_for(
             event_bus.wait_for(SlotTickEvent),
-            timeout=4,
+            timeout=6,
             loop=event_loop,
         )
     except asyncio.TimeoutError:
         assert False, "Slot not ticking"
-    assert not first_slot_event.is_second_tick
+    assert first_slot_event.tick_type.is_start
     try:
         second_slot_event = await asyncio.wait_for(
             event_bus.wait_for(SlotTickEvent),
-            timeout=4,
+            timeout=6,
             loop=event_loop,
         )
     except asyncio.TimeoutError:
         assert False, "No second half tick"
     assert second_slot_event.slot == first_slot_event.slot
-    assert second_slot_event.is_second_tick
+    assert second_slot_event.tick_type.is_two_third
     await slot_ticker.cancel()

--- a/tests/components/eth2/beacon/test_validator.py
+++ b/tests/components/eth2/beacon/test_validator.py
@@ -199,6 +199,7 @@ async def test_validator_handle_slot_tick(event_loop, event_bus, monkeypatch):
 
     event_first_tick_called = asyncio.Event()
     event_second_tick_called = asyncio.Event()
+    event_third_tick_called = asyncio.Event()
 
     async def handle_first_tick(slot):
         event_first_tick_called.set()
@@ -206,8 +207,12 @@ async def test_validator_handle_slot_tick(event_loop, event_bus, monkeypatch):
     async def handle_second_tick(slot):
         event_second_tick_called.set()
 
+    async def handle_third_tick(slot):
+        event_third_tick_called.set()
+
     monkeypatch.setattr(alice, 'handle_first_tick', handle_first_tick)
     monkeypatch.setattr(alice, 'handle_second_tick', handle_second_tick)
+    monkeypatch.setattr(alice, 'handle_third_tick', handle_third_tick)
 
     # sleep for `event_bus` ready
     await asyncio.sleep(0.01)
@@ -226,7 +231,9 @@ async def test_validator_handle_slot_tick(event_loop, event_bus, monkeypatch):
         timeout=2,
         loop=event_loop,
     )
+    assert event_first_tick_called.is_set()
     assert not event_second_tick_called.is_set()
+    assert not event_third_tick_called.is_set()
     event_first_tick_called.clear()
 
     # Second tick
@@ -234,7 +241,7 @@ async def test_validator_handle_slot_tick(event_loop, event_bus, monkeypatch):
         SlotTickEvent(
             slot=1,
             elapsed_time=2,
-            tick_type=TickType.SLOT_TWO_THIRD,
+            tick_type=TickType.SLOT_ONE_THIRD,
         ),
         BroadcastConfig(internal=True),
     )
@@ -244,6 +251,27 @@ async def test_validator_handle_slot_tick(event_loop, event_bus, monkeypatch):
         loop=event_loop,
     )
     assert not event_first_tick_called.is_set()
+    assert event_second_tick_called.is_set()
+    assert not event_third_tick_called.is_set()
+    event_second_tick_called.clear()
+
+    # Third tick
+    await event_bus.broadcast(
+        SlotTickEvent(
+            slot=1,
+            elapsed_time=2,
+            tick_type=TickType.SLOT_TWO_THIRD,
+        ),
+        BroadcastConfig(internal=True),
+    )
+    await asyncio.wait_for(
+        event_third_tick_called.wait(),
+        timeout=2,
+        loop=event_loop,
+    )
+    assert not event_first_tick_called.is_set()
+    assert not event_second_tick_called.is_set()
+    assert event_third_tick_called.is_set()
 
 
 @pytest.mark.asyncio

--- a/tests/components/eth2/beacon/test_validator.py
+++ b/tests/components/eth2/beacon/test_validator.py
@@ -45,6 +45,7 @@ from trinity.components.eth2.beacon.validator import (
 from trinity.components.eth2.beacon.slot_ticker import (
     SlotTickEvent,
 )
+from trinity.components.eth2.misc.tick_type import TickType
 
 
 override_lengths(XIAO_LONG_BAO_CONFIG)
@@ -216,7 +217,7 @@ async def test_validator_handle_slot_tick(event_loop, event_bus, monkeypatch):
         SlotTickEvent(
             slot=1,
             elapsed_time=2,
-            is_second_tick=False,
+            tick_type=TickType.SLOT_START,
         ),
         BroadcastConfig(internal=True),
     )
@@ -233,7 +234,7 @@ async def test_validator_handle_slot_tick(event_loop, event_bus, monkeypatch):
         SlotTickEvent(
             slot=1,
             elapsed_time=2,
-            is_second_tick=True,
+            tick_type=TickType.SLOT_TWO_THIRD,
         ),
         BroadcastConfig(internal=True),
     )

--- a/trinity/components/eth2/beacon/slot_ticker.py
+++ b/trinity/components/eth2/beacon/slot_ticker.py
@@ -24,8 +24,11 @@ from p2p.service import (
 from trinity._utils.shellart import (
     bold_white,
 )
+from trinity.components.eth2.misc.tick_type import TickType
 
-DEFAULT_CHECK_FREQUENCY = 6
+
+# Check twice per second: SECONDS_PER_SLOT * 2
+DEFAULT_CHECK_FREQUENCY = 24
 
 
 @dataclass
@@ -33,7 +36,7 @@ class SlotTickEvent(BaseEvent):
 
     slot: Slot
     elapsed_time: Second
-    is_second_tick: bool
+    tick_type: TickType
 
 
 class SlotTicker(BaseService):
@@ -70,44 +73,56 @@ class SlotTicker(BaseService):
         e.g., if `seconds_per_slot` is `6`, for slot `49` it should tick once
         for the first 3 seconds and once for the last 3 seconds.
         """
-        # `has_sent_second_half_slot_tick` is used to prevent another tick
-        # for the second half of a ticked slot.
-        has_sent_second_half_slot_tick = False
+        # Use `sent_tick_types_at_slot` set to record
+        # the tick types that haven been sent at current slot.
+        sent_tick_types_at_slot = set()
         while self.is_operational:
             elapsed_time = Second(int(time.time()) - self.genesis_time)
             if elapsed_time >= self.seconds_per_slot:
-                slot = Slot(elapsed_time // self.seconds_per_slot + self.genesis_slot)
-                is_second_tick = (
-                    (elapsed_time % self.seconds_per_slot) >= (self.seconds_per_slot / 2)
-                )
+                elapsed_slots = elapsed_time // self.seconds_per_slot
+                slot = Slot(elapsed_slots + self.genesis_slot)
+
+                elapsed_time_in_slot = elapsed_time % self.seconds_per_slot
+                if elapsed_time_in_slot >= (self.seconds_per_slot * 2 / 3):
+                    tick_type = TickType.SLOT_TWO_THIRD
+                elif elapsed_time_in_slot >= (self.seconds_per_slot / 3):
+                    tick_type = TickType.SLOT_ONE_THIRD
+                else:
+                    tick_type = TickType.SLOT_START
+
                 # Case 1: new slot
                 if slot > self.latest_slot:
-                    self.logger.debug(
-                        bold_white("[first] tick for slot %s (elapsed %ss)"),
-                        slot,
-                        elapsed_time,
-                    )
                     self.latest_slot = slot
-                    await self.event_bus.broadcast(
-                        SlotTickEvent(
-                            slot=slot,
-                            elapsed_time=elapsed_time,
-                            is_second_tick=is_second_tick,
-                        ),
-                        BroadcastConfig(internal=True),
-                    )
-                    has_sent_second_half_slot_tick = is_second_tick
-                # Case 2: second half of an already ticked slot and it hasn't tick yet
-                elif is_second_tick and not has_sent_second_half_slot_tick:
-                    self.logger.debug(bold_white("[second] tick for slot %s"), slot)
-                    await self.event_bus.broadcast(
-                        SlotTickEvent(
-                            slot=slot,
-                            elapsed_time=elapsed_time,
-                            is_second_tick=is_second_tick,
-                        ),
-                        BroadcastConfig(internal=True),
-                    )
-                    has_sent_second_half_slot_tick = True
+                    await self._broadcast_slot_tick_event(slot, elapsed_time, tick_type)
+                    # Clear set
+                    sent_tick_types_at_slot = set()
+                    sent_tick_types_at_slot.add(TickType.SLOT_START)
+                # Case 2: 1/3 of the given slot
+                elif (
+                    tick_type.is_one_third
+                    and TickType.SLOT_ONE_THIRD not in sent_tick_types_at_slot
+                ):
+                    # TODO: Add aggregator logic
+                    pass
+                # Case 3: 2/3 of the given slot
+                elif (
+                    tick_type.is_two_third
+                    and TickType.SLOT_TWO_THIRD not in sent_tick_types_at_slot
+                ):
+                    await self._broadcast_slot_tick_event(slot, elapsed_time, tick_type)
+                    sent_tick_types_at_slot.add(TickType.SLOT_TWO_THIRD)
 
             await asyncio.sleep(self.seconds_per_slot // DEFAULT_CHECK_FREQUENCY)
+
+    async def _broadcast_slot_tick_event(self, slot, elapsed_time, tick_type):
+        self.logger.debug(
+            bold_white("[%s] tick for slot %s, elapsed %ds)"), tick_type, slot, elapsed_time
+        )
+        await self.event_bus.broadcast(
+            SlotTickEvent(
+                slot=slot,
+                elapsed_time=elapsed_time,
+                tick_type=tick_type,
+            ),
+            BroadcastConfig(internal=True),
+        )

--- a/trinity/components/eth2/beacon/slot_ticker.py
+++ b/trinity/components/eth2/beacon/slot_ticker.py
@@ -1,5 +1,6 @@
 import asyncio
 import time
+from typing import Set
 
 from cancel_token import (
     CancelToken,
@@ -68,46 +69,43 @@ class SlotTicker(BaseService):
 
     async def _keep_ticking(self) -> None:
         """
-        Ticker should tick twice in one slot:
-        one for a new slot, one for the second half of an already ticked slot,
-        e.g., if `seconds_per_slot` is `6`, for slot `49` it should tick once
-        for the first 3 seconds and once for the last 3 seconds.
+        Ticker should tick three times in one slot:
+        SLOT_START: at the beginning of the slot
+        SLOT_ONE_THIRD: at 1/3 of the slot
+        SLOT_TWO_THIRD: at 2/3 of the slot
         """
         # Use `sent_tick_types_at_slot` set to record
         # the tick types that haven been sent at current slot.
-        sent_tick_types_at_slot = set()
+        sent_tick_types_at_slot: Set[TickType] = set()
         while self.is_operational:
             elapsed_time = Second(int(time.time()) - self.genesis_time)
-            if elapsed_time >= self.seconds_per_slot:
-                elapsed_slots = elapsed_time // self.seconds_per_slot
-                slot = Slot(elapsed_slots + self.genesis_slot)
-                tick_type = self._get_tick_type(elapsed_time)
 
-                # Case 1: new slot
-                if slot > self.latest_slot:
-                    self.latest_slot = slot
-                    await self._broadcast_slot_tick_event(slot, elapsed_time, tick_type)
-                    # Clear set
-                    sent_tick_types_at_slot = set()
-                    sent_tick_types_at_slot.add(TickType.SLOT_START)
-                # Case 2: 1/3 of the given slot
-                elif (
-                    tick_type.is_one_third
-                    and TickType.SLOT_ONE_THIRD not in sent_tick_types_at_slot
-                ):
-                    # TODO: Add aggregator logic
-                    pass
-                # Case 3: 2/3 of the given slot
-                elif (
-                    tick_type.is_two_third
-                    and TickType.SLOT_TWO_THIRD not in sent_tick_types_at_slot
-                ):
-                    await self._broadcast_slot_tick_event(slot, elapsed_time, tick_type)
-                    sent_tick_types_at_slot.add(TickType.SLOT_TWO_THIRD)
+            # Skip genesis slot
+            if elapsed_time < self.seconds_per_slot:
+                continue
+
+            elapsed_slots = elapsed_time // self.seconds_per_slot
+            slot = Slot(elapsed_slots + self.genesis_slot)
+            tick_type = self._get_tick_type(elapsed_time)
+
+            # New slot
+            if slot > self.latest_slot:
+                self.latest_slot = slot
+                await self._broadcast_slot_tick_event(slot, elapsed_time, tick_type)
+                # Clear set
+                sent_tick_types_at_slot = set()
+                sent_tick_types_at_slot.add(TickType.SLOT_START)
+            elif (
+                not tick_type.is_start and tick_type not in sent_tick_types_at_slot
+            ):
+                await self._broadcast_slot_tick_event(slot, elapsed_time, tick_type)
+                sent_tick_types_at_slot.add(tick_type)
 
             await asyncio.sleep(self.seconds_per_slot // DEFAULT_CHECK_FREQUENCY)
 
-    async def _broadcast_slot_tick_event(self, slot, elapsed_time, tick_type):
+    async def _broadcast_slot_tick_event(
+        self, slot: Slot, elapsed_time: Second, tick_type: TickType
+    ) -> None:
         self.logger.debug(
             bold_white("[%s] tick at %ss of slot #%s, total elapsed %ds"),
             tick_type, elapsed_time % self.seconds_per_slot, slot, elapsed_time,
@@ -121,7 +119,7 @@ class SlotTicker(BaseService):
             BroadcastConfig(internal=True),
         )
 
-    def _get_tick_type(self, elapsed_time: int) -> TickType:
+    def _get_tick_type(self, elapsed_time: Second) -> TickType:
         elapsed_time_in_slot = elapsed_time % self.seconds_per_slot
         if elapsed_time_in_slot >= (self.seconds_per_slot * 2 / 3):
             tick_type = TickType.SLOT_TWO_THIRD

--- a/trinity/components/eth2/beacon/validator.py
+++ b/trinity/components/eth2/beacon/validator.py
@@ -74,7 +74,6 @@ from trinity._utils.shellart import (
 from trinity.components.eth2.beacon.slot_ticker import (
     SlotTickEvent,
 )
-from trinity.components.eth2.misc.tick_type import TickType
 from trinity.protocol.bcc_libp2p.node import Node
 
 
@@ -134,10 +133,12 @@ class Validator(BaseService):
         """
         async for event in self.event_bus.stream(SlotTickEvent):
             try:
-                if event.tick_type == TickType.SLOT_START:
+                if event.tick_type.is_start:
                     await self.handle_first_tick(event.slot)
-                else:
+                elif event.tick_type.is_one_third:
                     await self.handle_second_tick(event.slot)
+                elif event.tick_type.is_two_third:
+                    await self.handle_third_tick(event.slot)
             except ValidationError as e:
                 self.logger.warn("%s", e)
                 self.logger.warn(
@@ -236,6 +237,10 @@ class Validator(BaseService):
             )
 
         await self.attest(slot)
+
+    async def handle_third_tick(self, slot: Slot) -> None:
+        # TODO: Add aggregator strategy
+        pass
 
     async def propose_block(self,
                             proposer_index: ValidatorIndex,

--- a/trinity/components/eth2/beacon/validator.py
+++ b/trinity/components/eth2/beacon/validator.py
@@ -74,6 +74,7 @@ from trinity._utils.shellart import (
 from trinity.components.eth2.beacon.slot_ticker import (
     SlotTickEvent,
 )
+from trinity.components.eth2.misc.tick_type import TickType
 from trinity.protocol.bcc_libp2p.node import Node
 
 
@@ -133,7 +134,7 @@ class Validator(BaseService):
         """
         async for event in self.event_bus.stream(SlotTickEvent):
             try:
-                if not event.is_second_tick:
+                if event.tick_type == TickType.SLOT_START:
                     await self.handle_first_tick(event.slot)
                 else:
                     await self.handle_second_tick(event.slot)

--- a/trinity/components/eth2/misc/tick_type.py
+++ b/trinity/components/eth2/misc/tick_type.py
@@ -8,13 +8,13 @@ class TickType(IntEnum):
     SLOT_TWO_THIRD = 2  # SECONDS_PER_SLOT * 2 / 3
 
     @property
-    def is_start(self):
+    def is_start(self) -> bool:
         return self == self.SLOT_START
 
     @property
-    def is_one_third(self):
+    def is_one_third(self) -> bool:
         return self == self.SLOT_ONE_THIRD
 
     @property
-    def is_two_third(self):
+    def is_two_third(self) -> bool:
         return self == self.SLOT_TWO_THIRD

--- a/trinity/components/eth2/misc/tick_type.py
+++ b/trinity/components/eth2/misc/tick_type.py
@@ -1,0 +1,20 @@
+from enum import IntEnum, unique
+
+
+@unique
+class TickType(IntEnum):
+    SLOT_START = 0
+    SLOT_ONE_THIRD = 1  # SECONDS_PER_SLOT / 3
+    SLOT_TWO_THIRD = 2  # SECONDS_PER_SLOT * 2 / 3
+
+    @property
+    def is_start(self):
+        return self == self.SLOT_START
+
+    @property
+    def is_one_third(self):
+        return self == self.SLOT_ONE_THIRD
+
+    @property
+    def is_two_third(self):
+        return self == self.SLOT_TWO_THIRD


### PR DESCRIPTION
### What was wrong?
Part of #1241: `SlotTicker` changes
- Before this PR,  `SlotTicker` should tick twice in one slot: one the beginning, the other is at half of the slot.
- For the new aggregation strategy, we need three ticks per slot:
    1. For validators to check if they are the proposer. If so, propose the block
    2. **[TODO in other PR]** For validators to attest the block. If so, broadcast the attestations to gossipsub attestation subnet
    3. **[TODO in other PR]** For validators to check if they are one of the aggregators of the subnet. If so, aggregate the attestations and then broadcast it to the global channel.

### How was it fixed?
1. Use `TickMessage` to refactor Event message
2. Now there are three ticks per slot:
    1. `SLOT_START`: at the beginning of the slot
    2. `SLOT_ONE_THIRD`: at 1/3 of the slot
    3. `SLOT_TWO_THIRD`: at 2/3 of the slot
3. For now, to implement the part 1 of the new mechanism without breaking things, make attesters broadcast to the global channel at 1/3 of the slot.
strategy.
4. Add a stub for 2/3 slot tick.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

[//]: # (See: https://trinity-client.readthedocs.io/en/latest/contributing.html#pull-requests)
- [ ] Add entry to the [release notes](https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)
- [x] E2E test

#### Cute Animal Picture

![Sea Cow2](https://user-images.githubusercontent.com/9263930/68966731-bd382780-0819-11ea-9817-fa121f1da0d6.jpeg)
