### PR TITLE
Minor refactor of the peer connection

### DIFF
--- a/trinity/components/eth2/beacon/component.py
+++ b/trinity/components/eth2/beacon/component.py
@@ -117,8 +117,6 @@ class BeaconNodeComponent(AsyncioIsolatedComponent):
             chain=chain,
         )
 
-        self.logger.warning(f'Node listening: {libp2p_node.listen_maddr_with_peer_id}')
-
         receive_server = BCCReceiveServer(
             chain=chain,
             p2p_node=libp2p_node,

--- a/trinity/protocol/bcc_libp2p/node.py
+++ b/trinity/protocol/bcc_libp2p/node.py
@@ -314,6 +314,7 @@ class Node(BaseService):
         self._register_rpc_handlers()
         # TODO: Register notifees
         await self.host.get_network().listen(self.listen_maddr)
+        self.logger.warning("Node listening: %s", self.listen_maddr_with_peer_id)
         await self.connect_preferred_nodes()
         # TODO: Connect bootstrap nodes?
 
@@ -340,12 +341,18 @@ class Node(BaseService):
         """
         Dial the peer ``peer_id`` through the IPv4 protocol
         """
-        await self.host.connect(
-            PeerInfo(
-                peer_id=peer_id,
-                addrs=[make_tcp_ip_maddr(ip, port)],
+        try:
+            maddr = make_tcp_ip_maddr(ip, port)
+            self.logger.debug("Dialing peer_id %s maddr %s", peer_id, maddr)
+            await self.host.connect(
+                PeerInfo(
+                    peer_id=peer_id,
+                    addrs=[maddr],
+                )
             )
-        )
+        except Exception as e:
+            raise ConnectionRefusedError() from e
+
         try:
             # TODO: set a time limit on completing handshake
             await self.request_status(peer_id)
@@ -364,8 +371,8 @@ class Node(BaseService):
                 await self.dial_peer(ip, port, peer_id)
                 return
             except ConnectionRefusedError:
-                logger.debug(
-                    "could not connect to peer %s at %s:%d;"
+                self.logger.debug(
+                    "Could not connect to peer %s at %s:%d;"
                     " retrying attempt %d of %d...",
                     peer_id,
                     ip,
@@ -382,7 +389,7 @@ class Node(BaseService):
         """
         try:
             ip = maddr.value_for_protocol(protocols.P_IP4)
-            port = maddr.value_for_protocol(protocols.P_TCP)
+            port = int(maddr.value_for_protocol(protocols.P_TCP))
             peer_id = ID.from_base58(maddr.value_for_protocol(protocols.P_P2P))
             await self.dial_peer_with_retries(ip=ip, port=port, peer_id=peer_id)
         except Exception:

--- a/trinity/protocol/bcc_libp2p/node.py
+++ b/trinity/protocol/bcc_libp2p/node.py
@@ -358,7 +358,7 @@ class Node(BaseService):
             await self.request_status(peer_id)
         except HandshakeFailure as e:
             self.logger.info("HandshakeFailure: %s", str(e))
-            # TODO: handle it
+            raise ConnectionRefusedError() from e
 
     async def dial_peer_with_retries(self, ip: str, port: int, peer_id: ID) -> None:
         """


### PR DESCRIPTION
### What was wrong?
Since `port = maddr.value_for_protocol(protocols.P_TCP)` in `Node` is actually `str` (!!!), the error message `self.logger.debug("Could not connect to peer %s at %s:%d;", peer_id, ip, port)` would be invalid, but it doesn't show any error message of the wrong format bug!

### How was it fixed?
1. IMO it's more common to use `port: int`, so this PR converts it to `int`.
2. Try to catch error from `self.host.connect()`.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

[//]: # (See: https://trinity-client.readthedocs.io/en/latest/contributing.html#pull-requests)
- [ ] Add entry to the [release notes](https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![seal-1235138_640](https://user-images.githubusercontent.com/9263930/68792856-2d627400-0687-11ea-8a4e-422acf1dadcb.jpg)
(doge seal!?)