### PR TITLE
Log cleanups

### DIFF
--- a/p2p/abc.py
+++ b/p2p/abc.py
@@ -401,6 +401,10 @@ class AsyncioServiceAPI(ABC):
         ...
 
     @abstractmethod
+    def call_later(self, delay: float, callback: 'Callable[..., None]', *args: Any) -> None:
+        ...
+
+    @abstractmethod
     async def wait(self,
                    awaitable: Awaitable[TReturn],
                    token: CancelToken = None,

--- a/p2p/tools/memory_transport.py
+++ b/p2p/tools/memory_transport.py
@@ -1,13 +1,13 @@
 import asyncio
-import logging
 import struct
 from typing import Tuple
 
 from cached_property import cached_property
-
-from eth_keys import datatypes
-
 from cancel_token import CancelToken
+from eth_keys import datatypes
+from eth_utils import (
+    get_extended_debug_logger,
+)
 
 from p2p._utils import get_devp2p_cmd_id
 from p2p.abc import NodeAPI, TransportAPI
@@ -25,7 +25,7 @@ CONNECTION_LOST_ERRORS = (
 
 
 class MemoryTransport(TransportAPI):
-    logger = logging.getLogger('p2p.tools.memory_transport.MemoryTransport')
+    logger = get_extended_debug_logger('p2p.tools.memory_transport.MemoryTransport')
     read_state = TransportState.IDLE
 
     def __init__(self,
@@ -64,7 +64,7 @@ class MemoryTransport(TransportAPI):
         return self._private_key.public_key
 
     async def read(self, n: int, token: CancelToken) -> bytes:
-        self.logger.debug("Waiting for %s bytes from %s", n, self.remote)
+        self.logger.debug2("Waiting for %s bytes from %s", n, self.remote)
         try:
             return await token.cancellable_wait(
                 self._reader.readexactly(n),

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -26,12 +26,14 @@ async def scan_for_errors(async_iterable):
     )
 
     lines_since_error = 0
+    last_error = None
     async for line in async_iterable:
 
         # We detect errors by some string at the beginning of the Traceback and keep
         # counting lines from there to be able to read and report more valuable info
         if any(trigger in line for trigger in error_trigger) and lines_since_error == 0:
             lines_since_error = 1
+            last_error = line
         elif lines_since_error > 0:
             lines_since_error += 1
 
@@ -39,5 +41,5 @@ async def scan_for_errors(async_iterable):
         if lines_since_error >= 100:
             break
 
-    if lines_since_error > 0:
-        raise Exception("Exception during Trinity boot detected")
+    if last_error is not None:
+        raise Exception(f"Exception during Trinity boot detected: {last_error}")


### PR DESCRIPTION
### What was wrong?

Just some minor cleanups peeled off of #1250 

### How was it fixed?

- drop a log to debug2
- show the log line that failed your integration test
- add and abstract method to the service API

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

[//]: # (See: https://trinity-client.readthedocs.io/en/latest/contributing.html#pull-requests)
- [x] Add entry to the [release notes](https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://images.pexels.com/photos/146290/pexels-photo-146290.jpeg?auto=compress&cs=tinysrgb&h=750&w=1260)