### PR TITLE
Isolate Queen Tracking logic from backfilling logic

### DIFF
--- a/trinity/sync/beam/queen.py
+++ b/trinity/sync/beam/queen.py
@@ -1,0 +1,81 @@
+from abc import ABC, abstractmethod
+
+from p2p.abc import AsyncioServiceAPI
+from p2p.exchange import PerformanceAPI
+
+from trinity.protocol.eth.commands import (
+    NodeData,
+)
+from trinity.protocol.eth.peer import ETHPeer
+from trinity.sync.beam.constants import (
+    NON_IDEAL_RESPONSE_PENALTY,
+)
+from trinity.sync.common.peers import WaitingPeers
+
+
+def queen_peer_performance_sort(tracker: PerformanceAPI) -> float:
+    return -1 * tracker.items_per_second_ema.value
+
+
+def _peer_sort_key(peer: ETHPeer) -> float:
+    return queen_peer_performance_sort(peer.eth_api.get_node_data.tracker)
+
+
+class QueenTrackerAPI(ABC):
+    """
+    Keep track of the single best peer
+    """
+    @abstractmethod
+    async def get_queen_peer(self) -> ETHPeer:
+        ...
+
+    @abstractmethod
+    def penalize_queen(self, peer: ETHPeer) -> None:
+        ...
+
+
+class QueenTrackerMixin(QueenTrackerAPI, AsyncioServiceAPI):
+    # The best peer gets skipped for backfill, because we prefer to use it for
+    #   urgent beam sync nodes
+    _queen_peer: ETHPeer = None
+    _waiting_peers: WaitingPeers[ETHPeer]
+
+    def __init__(self) -> None:
+        self._waiting_peers = WaitingPeers(NodeData)
+
+    def _update_queen(self, peer: ETHPeer) -> ETHPeer:
+        '''
+        @return peer that is no longer queen
+        '''
+        if self._queen_peer is None:
+            self._queen_peer = peer
+            return None
+        elif peer == self._queen_peer:
+            # nothing to do, peer is already the queen
+            return None
+        elif _peer_sort_key(peer) < _peer_sort_key(self._queen_peer):
+            old_queen, self._queen_peer = self._queen_peer, peer
+            self._waiting_peers.put_nowait(old_queen)
+            return old_queen
+        else:
+            # nothing to do, peer is slower than the queen
+            return None
+
+    async def get_queen_peer(self) -> ETHPeer:
+        while self._queen_peer is None:
+            peer = await self._waiting_peers.get_fastest()
+            self._update_queen(peer)
+
+        return self._queen_peer
+
+    def penalize_queen(self, peer: ETHPeer) -> None:
+        if peer == self._queen_peer:
+            self._queen_peer = None
+
+            delay = NON_IDEAL_RESPONSE_PENALTY
+            self.logger.debug(
+                "Penalizing %s for %.2fs, for minor infraction",
+                peer,
+                delay,
+            )
+            self.call_later(delay, self._waiting_peers.put_nowait, peer)

--- a/trinity/sync/beam/queen.py
+++ b/trinity/sync/beam/queen.py
@@ -1,15 +1,15 @@
 from abc import ABC, abstractmethod
+from typing import Any, FrozenSet, Optional, Type
 
-from p2p.abc import AsyncioServiceAPI
+from cancel_token import CancelToken, OperationCancelled
+
+from p2p.abc import CommandAPI
 from p2p.exchange import PerformanceAPI
-
-from trinity.protocol.eth.commands import (
-    NodeData,
-)
-from trinity.protocol.eth.peer import ETHPeer
-from trinity.sync.beam.constants import (
-    NON_IDEAL_RESPONSE_PENALTY,
-)
+from p2p.peer import BasePeer, PeerSubscriber
+from p2p.service import BaseService
+from trinity.protocol.eth.commands import NodeData
+from trinity.protocol.eth.peer import ETHPeer, ETHPeerPool
+from trinity.sync.beam.constants import NON_IDEAL_RESPONSE_PENALTY
 from trinity.sync.common.peers import WaitingPeers
 
 
@@ -34,14 +34,100 @@ class QueenTrackerAPI(ABC):
         ...
 
 
-class QueenTrackerMixin(QueenTrackerAPI, AsyncioServiceAPI):
+class QueeningQueue(BaseService, PeerSubscriber, QueenTrackerAPI):
     # The best peer gets skipped for backfill, because we prefer to use it for
     #   urgent beam sync nodes
     _queen_peer: ETHPeer = None
     _waiting_peers: WaitingPeers[ETHPeer]
 
-    def __init__(self) -> None:
+    # We are only interested in peers entering or leaving the pool
+    subscription_msg_types: FrozenSet[Type[CommandAPI[Any]]] = frozenset()
+
+    # This is a rather arbitrary value, but when the sync is operating normally we never see
+    # the msg queue grow past a few hundred items, so this should be a reasonable limit for
+    # now.
+    msg_queue_maxsize: int = 2000
+
+    def __init__(self, peer_pool: ETHPeerPool, token: CancelToken = None) -> None:
+        super().__init__(token=token)
+        self._peer_pool = peer_pool
         self._waiting_peers = WaitingPeers(NodeData)
+
+    async def _run(self) -> None:
+        with self.subscribe(self._peer_pool):
+            await self.cancellation()
+
+    def register_peer(self, peer: BasePeer) -> None:
+        super().register_peer(peer)
+        # when a new peer is added to the pool, add it to the idle peer list
+        self._waiting_peers.put_nowait(peer)  # type: ignore
+
+    def deregister_peer(self, peer: BasePeer) -> None:
+        super().deregister_peer(peer)
+        if self._queen_peer == peer:
+            self._queen_peer = None
+
+    async def get_queen_peer(self) -> ETHPeer:
+        """
+        Wait until a queen peer is designated, then return it.
+        """
+        while self._queen_peer is None:
+            peer = await self._waiting_peers.get_fastest()
+            self._update_queen(peer)
+
+        return self._queen_peer
+
+    @property
+    def queen(self) -> Optional[ETHPeer]:
+        """
+        Might be None. If None is unacceptable, use :meth:`get_queen_peer`
+        """
+        return self._queen_peer
+
+    async def pop_fastest_peasant(self) -> ETHPeer:
+        """
+        Get the fastest peer that is not the queen.
+        """
+        while self.is_operational:
+            peer = await self.wait(self._waiting_peers.get_fastest())
+            if not peer.is_operational:
+                # drop any peers that aren't alive anymore
+                self.logger.warning("Dropping %s from beam queue as no longer operational", peer)
+                if peer == self._queen_peer:
+                    self._queen_peer = None
+                continue
+
+            old_queen = self._update_queen(peer)
+            if peer == self._queen_peer:
+                self.logger.debug("Switching queen peer from %s to %s", old_queen, peer)
+                continue
+
+            if peer.eth_api.get_node_data.is_requesting:
+                # skip the peer if there's an active request
+                self.logger.debug("Queen Queuer is skipping active peer %s", peer)
+                self.call_later(10, self._waiting_peers.put_nowait, peer)
+                continue
+
+            return peer
+        raise OperationCancelled("Service ended before a queen peer could be elected")
+
+    def readd_peasant(self, peer: ETHPeer, delay: float = 0) -> None:
+        if delay > 0:
+            self.call_later(delay, self._waiting_peers.put_nowait, peer)
+        else:
+            self._waiting_peers.put_nowait(peer)
+
+    def penalize_queen(self, peer: ETHPeer) -> None:
+        if peer == self._queen_peer:
+            self._queen_peer = None
+
+            delay = NON_IDEAL_RESPONSE_PENALTY
+            self.logger.debug(
+                "Penalizing %s for %.2fs, for minor infraction",
+                peer,
+                delay,
+            )
+            self.call_later(delay, self._waiting_peers.put_nowait, peer)
 
     def _update_queen(self, peer: ETHPeer) -> ETHPeer:
         '''
@@ -60,22 +146,3 @@ class QueenTrackerMixin(QueenTrackerAPI, AsyncioServiceAPI):
         else:
             # nothing to do, peer is slower than the queen
             return None
-
-    async def get_queen_peer(self) -> ETHPeer:
-        while self._queen_peer is None:
-            peer = await self._waiting_peers.get_fastest()
-            self._update_queen(peer)
-
-        return self._queen_peer
-
-    def penalize_queen(self, peer: ETHPeer) -> None:
-        if peer == self._queen_peer:
-            self._queen_peer = None
-
-            delay = NON_IDEAL_RESPONSE_PENALTY
-            self.logger.debug(
-                "Penalizing %s for %.2fs, for minor infraction",
-                peer,
-                delay,
-            )
-            self.call_later(delay, self._waiting_peers.put_nowait, peer)

--- a/trinity/sync/beam/state.py
+++ b/trinity/sync/beam/state.py
@@ -51,7 +51,7 @@ from trinity.protocol.eth.peer import ETHPeer, ETHPeerPool
 from trinity.protocol.eth import (
     constants as eth_constants,
 )
-from trinity.sync.beam.backfill import (
+from trinity.sync.beam.queen import (
     QueenTrackerAPI,
 )
 from trinity.sync.beam.constants import (


### PR DESCRIPTION
### What was wrong?

The queen tracker logic was too embedded in the backfiller. A different queen tracker will appear in #1250 so we want the Queen tracking to have separate logic.

### How was it fixed?

- Peeled these changes out of #1250 
- Folded in the changes in #1274 (for the `call_later()` api)
- Split out Queen tracking logic into new `trinity/sync/beam/queen.py`

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

[//]: # (See: https://trinity-client.readthedocs.io/en/latest/contributing.html#pull-requests)
- [x] Add entry to the [release notes](https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://i.ebayimg.com/images/g/BwIAAOSwEeFVBvBS/s-l300.jpg)