### PR TITLE
New socket based logger and granular logger setup functions

### DIFF
--- a/tests/core/test_ipc_log_listener.py
+++ b/tests/core/test_ipc_log_listener.py
@@ -1,0 +1,61 @@
+import tempfile
+import logging
+from multiprocessing import Process
+from pathlib import Path
+import uuid
+
+import pytest
+
+from trinity._utils.logging import IPCListener, IPCHandler
+
+
+@pytest.fixture
+def ipc_path():
+    with tempfile.TemporaryDirectory() as dir:
+        yield Path(dir) / "logging.ipc"
+
+
+def test_queued_logging(ipc_path):
+    class HandlerForTest(logging.Handler):
+        def __init__(self):
+            self.logs = []
+            super().__init__()
+
+        def handle(self, record):
+            self.logs.append(record)
+
+    def do_other_process_logging(ipc_path):
+        queue_handler = IPCHandler.connect(ipc_path)
+        queue_handler.setLevel(logging.DEBUG)
+        logger = logging.getLogger(str(uuid.uuid4()))
+        logger.addHandler(queue_handler)
+        logger.setLevel(logging.DEBUG)
+
+        logger.error('error log')
+        logger.info('info log')
+        logger.debug('debug log')
+
+        queue_handler.close()
+
+    proc = Process(target=do_other_process_logging, args=(ipc_path,))
+
+    logger = logging.getLogger(str(uuid.uuid4()))
+
+    handler = HandlerForTest()
+    handler.setLevel(logging.DEBUG)
+    logger.addHandler(handler)
+    logger.setLevel(logging.DEBUG)
+
+    queue_listener = IPCListener(handler)
+
+    with queue_listener.run(ipc_path):
+        assert len(handler.logs) == 0
+        proc.start()
+        proc.join()
+        assert len(handler.logs) == 3
+
+    error_log, info_log, debug_log = handler.logs
+
+    assert 'error log' in error_log.message
+    assert 'info log' in info_log.message
+    assert 'debug log' in debug_log.message

--- a/trinity/_utils/logging.py
+++ b/trinity/_utils/logging.py
@@ -143,11 +143,12 @@ def set_logger_levels(log_levels: Dict[str, int],
 def setup_stderr_logging(level: int = None) -> StreamHandler:
     if level is None:
         level = logging.INFO
-    logger = logging.getLogger('trinity')
+    logger = logging.getLogger()
 
     handler_stream = logging.StreamHandler(sys.stderr)
-    handler_stream.setLevel(level)
 
+    if level is not None:
+        handler_stream.setLevel(level)
     handler_stream.setFormatter(LOG_FORMATTER)
 
     logger.addHandler(handler_stream)
@@ -162,7 +163,7 @@ def setup_file_logging(
         level: int = None) -> RotatingFileHandler:
     if level is None:
         level = logging.DEBUG
-    logger = logging.getLogger('trinity')
+    logger = logging.getLogger()
 
     handler_file = RotatingFileHandler(
         str(logfile_path),
@@ -170,7 +171,8 @@ def setup_file_logging(
         backupCount=LOG_BACKUP_COUNT
     )
 
-    handler_file.setLevel(level)
+    if level is not None:
+        handler_file.setLevel(level)
     handler_file.setFormatter(LOG_FORMATTER)
 
     logger.addHandler(handler_file)
@@ -183,6 +185,8 @@ def setup_child_process_logging(boot_info: BootInfo) -> None:
     # pass through this handler
     logger = logging.getLogger()
     logger.setLevel(boot_info.child_process_log_level)
+
+    set_logger_levels(boot_info.logger_levels)
 
     ipc_handler = IPCHandler.connect(boot_info.trinity_config.logging_ipc_path)
     ipc_handler.setLevel(boot_info.child_process_log_level)

--- a/trinity/_utils/logging.py
+++ b/trinity/_utils/logging.py
@@ -1,38 +1,105 @@
-import functools
+import copy
 import logging
 from logging import (
-    Logger,
     StreamHandler
 )
 from logging.handlers import (
-    QueueListener,
-    QueueHandler,
     RotatingFileHandler,
 )
 import os
 from pathlib import Path
+import pickle
+import socket
 import sys
 from typing import (
-    Any,
     Dict,
-    Tuple,
-    TYPE_CHECKING,
-    Callable,
+    Type,
+    TypeVar,
 )
-
-from eth_utils import get_extended_debug_logger
-from eth_utils.toolz import dissoc
 
 from trinity._utils.shellart import (
     bold_red,
     bold_yellow,
 )
-
-if TYPE_CHECKING:
-    from multiprocessing import Queue  # noqa: F401
+from trinity._utils.socket import BufferedSocket, IPCSocketServer
+from trinity._utils.ipc import wait_for_ipc
+from trinity.boot_info import BootInfo
 
 LOG_BACKUP_COUNT = 10
 LOG_MAX_MB = 5
+
+
+THandler = TypeVar("THandler", bound="IPCHandler")
+
+
+class IPCHandler(logging.Handler):
+    logger = logging.getLogger('trinity._utils.logging.IPCHandler')
+
+    def __init__(self, sock: socket.socket):
+        self._socket = BufferedSocket(sock)
+        super().__init__()
+
+    @classmethod
+    def connect(cls: Type[THandler], path: Path) -> THandler:
+        wait_for_ipc(path)
+        s = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        cls.logger.debug("Opened connection to %s: %s", path, s)
+        s.connect(str(path))
+        return cls(s)
+
+    def prepare(self, record: logging.LogRecord) -> logging.LogRecord:
+        msg = self.format(record)
+        new_record = copy.copy(record)
+        new_record.message = msg
+        new_record.msg = msg
+        new_record.args = None
+        new_record.exc_info = None
+        new_record.exc_text = None
+        return new_record
+
+    def emit(self, record: logging.LogRecord) -> None:
+        try:
+            msg_data = pickle.dumps(self.prepare(record))
+            msg_length_data = len(msg_data).to_bytes(4, 'big')
+            self._socket.sendall(msg_length_data + msg_data)
+        except Exception:
+            self.handleError(record)
+
+
+class IPCListener(IPCSocketServer):
+    logger = logging.getLogger('trinity._utils.logging.IPCListener')
+
+    def __init__(self, *handlers: logging.Handler) -> None:
+        super().__init__()
+        self.handlers = handlers
+
+    def serve_conn(self, sock: BufferedSocket) -> None:
+        while self.is_running:
+            try:
+                length_data = sock.read_exactly(4)
+            except OSError as err:
+                self.logger.debug("%s: closing client connection: %s", self, err)
+                break
+            except Exception:
+                self.logger.exception("Error reading serialized record length data")
+                break
+
+            data_length = int.from_bytes(length_data, 'big')
+
+            try:
+                record_bytes = sock.read_exactly(data_length)
+            except OSError as err:
+                self.logger.debug("%s: closing client connection: %s", self, err)
+                break
+            except Exception:
+                self.logger.exception("Error reading serialized log record data")
+                break
+
+            record = pickle.loads(record_bytes)
+
+            for handler in self.handlers:
+                if record.levelno >= handler.level:
+                    handler.handle(record)
 
 
 class TrinityLogFormatter(logging.Formatter):
@@ -56,30 +123,27 @@ LOG_FORMATTER = TrinityLogFormatter(
 )
 
 
-def setup_log_levels(log_levels: Dict[str, int]) -> None:
+def set_logger_levels(log_levels: Dict[str, int],
+                      *handlers: logging.Handler) -> None:
     for name, level in log_levels.items():
 
         # The root logger is configured separately
         if name is None:
             continue
 
-        handler_stream = logging.StreamHandler(sys.stderr)
-        handler_stream.setLevel(level)
-        handler_stream.setFormatter(LOG_FORMATTER)
-
         logger = logging.getLogger(name)
         logger.propagate = False
         logger.setLevel(level)
-        logger.addHandler(handler_stream)
+
+        for handler in handlers:
+            handler.setLevel(level)
+            handler.setFormatter(LOG_FORMATTER)
 
 
-def setup_trinity_stderr_logging(level: int = None,
-                                 ) -> Tuple[Logger, StreamHandler]:
-
+def setup_stderr_logging(level: int = None) -> StreamHandler:
     if level is None:
         level = logging.INFO
-    logger = logging.getLogger()
-    logger.setLevel(level)
+    logger = logging.getLogger('trinity')
 
     handler_stream = logging.StreamHandler(sys.stderr)
     handler_stream.setLevel(level)
@@ -88,22 +152,17 @@ def setup_trinity_stderr_logging(level: int = None,
 
     logger.addHandler(handler_stream)
 
-    logger.debug('Logging initialized: PID=%s', os.getpid())
+    logger.debug('Logging initialized for stderr: PID=%s', os.getpid())
 
-    return logger, handler_stream
+    return handler_stream
 
 
-def setup_trinity_file_and_queue_logging(
-        logger: Logger,
-        handler_stream: StreamHandler,
+def setup_file_logging(
         logfile_path: Path,
-        level: int = None) -> Tuple[Logger, 'Queue[str]', QueueListener]:
-    from .mp import ctx
-
+        level: int = None) -> RotatingFileHandler:
     if level is None:
         level = logging.DEBUG
-
-    log_queue = ctx.Queue()
+    logger = logging.getLogger('trinity')
 
     handler_file = RotatingFileHandler(
         str(logfile_path),
@@ -115,45 +174,26 @@ def setup_trinity_file_and_queue_logging(
     handler_file.setFormatter(LOG_FORMATTER)
 
     logger.addHandler(handler_file)
-    logger.setLevel(level)
 
-    listener = QueueListener(
-        log_queue,
-        handler_stream,
-        handler_file,
-        respect_handler_level=True,
+    return handler_file
+
+
+def setup_child_process_logging(boot_info: BootInfo) -> None:
+    # We get the root logger here to ensure that all logs are given a chance to
+    # pass through this handler
+    logger = logging.getLogger()
+    logger.setLevel(boot_info.child_process_log_level)
+
+    ipc_handler = IPCHandler.connect(boot_info.trinity_config.logging_ipc_path)
+    ipc_handler.setLevel(boot_info.child_process_log_level)
+
+    logger.addHandler(ipc_handler)
+
+    logger.debug(
+        'Logging initialized for file %s: PID=%s',
+        boot_info.trinity_config.logging_ipc_path.resolve(),
+        os.getpid(),
     )
-
-    return logger, log_queue, listener
-
-
-def setup_queue_logging(log_queue: 'Queue[str]', level: int) -> None:
-    queue_handler = QueueHandler(log_queue)
-    queue_handler.setLevel(level)
-
-    logger = get_extended_debug_logger('')
-    logger.addHandler(queue_handler)
-    logger.setLevel(level)
-
-    logger.debug('Logging initialized: PID=%s', os.getpid())
-
-
-def with_queued_logging(fn: Callable[..., Any]) -> Callable[..., Any]:
-    @functools.wraps(fn)
-    def inner(*args: Any, **kwargs: Any) -> Any:
-        try:
-            log_queue = kwargs['log_queue']
-        except KeyError:
-            raise KeyError(f"The `log_queue` argument is required when calling `{fn.__name__}`")
-        else:
-            level = kwargs.get('log_level', logging.INFO)
-            levels = kwargs.get('log_levels', {})
-            setup_queue_logging(log_queue, level)
-            setup_log_levels(levels)
-            inner_kwargs = dissoc(kwargs, 'log_queue', 'log_level', 'log_levels')
-
-            return fn(*args, **inner_kwargs)
-    return inner
 
 
 def _set_environ_if_missing(name: str, val: str) -> None:

--- a/trinity/_utils/socket.py
+++ b/trinity/_utils/socket.py
@@ -1,0 +1,150 @@
+from abc import ABC, abstractmethod
+import contextlib
+import errno
+import logging
+import pathlib
+import socket
+import threading
+from typing import Iterator
+
+
+class BufferedSocket:
+    def __init__(self, sock: socket.socket) -> None:
+        self._socket = sock
+        self._buffer = bytearray()
+        self.sendall = sock.sendall
+        self.close = sock.close
+        self.shutdown = sock.shutdown
+
+    def read_exactly(self, num_bytes: int) -> bytes:
+        while len(self._buffer) < num_bytes:
+
+            data = self._socket.recv(4096)
+
+            if data == b"":
+                raise OSError("Connection closed")
+
+            self._buffer.extend(data)
+        payload = self._buffer[:num_bytes]
+        self._buffer = self._buffer[num_bytes:]
+        return bytes(payload)
+
+
+class IPCSocketServer(ABC):
+    """
+    Implements an interface for serving the BaseAtomicDB API over a socket.
+    """
+    logger = logging.getLogger('trinity._utils.socket.IPCSocketServer')
+
+    def __init__(self) -> None:
+        """
+        The AtomicDatabaseAPI that this wraps must be threadsafe.
+        """
+        self._started = threading.Event()
+        self._stopped = threading.Event()
+
+    @property
+    def is_started(self) -> bool:
+        return self._started.is_set()
+
+    @property
+    def is_running(self) -> bool:
+        return self.is_started and not self.is_stopped
+
+    @property
+    def is_stopped(self) -> bool:
+        return self._stopped.is_set()
+
+    def wait_started(self) -> None:
+        self._started.wait()
+
+    def wait_stopped(self) -> None:
+        self._stopped.wait()
+
+    def start(self, ipc_path: pathlib.Path) -> None:
+        threading.Thread(
+            name=f"{self}:{ipc_path}",
+            target=self.serve,
+            args=(ipc_path,),
+            daemon=True,
+        ).start()
+        self.wait_started()
+
+    def stop(self) -> None:
+        self._stopped.set()
+
+    def _close_socket_on_stop(self, sock: socket.socket) -> None:
+        # This function runs in the background waiting for the `stop` Event to
+        # be set at which point it closes the socket, causing the server to
+        # shutdown.  This allows the server threads to be cleanly closed on
+        # demand.
+        self.wait_stopped()
+
+        try:
+            sock.shutdown(socket.SHUT_RD)
+        except OSError as e:
+            # on mac OS this can result in the following error:
+            # OSError: [Errno 57] Socket is not connected
+            if e.errno != errno.ENOTCONN:
+                raise
+
+        sock.close()
+
+    @contextlib.contextmanager
+    def run(self, ipc_path: pathlib.Path) -> Iterator[None]:
+        self.start(ipc_path)
+        try:
+            yield
+        finally:
+            self.stop()
+
+            if ipc_path.exists():
+                ipc_path.unlink()
+
+    def serve(self, ipc_path: pathlib.Path) -> None:
+        self.logger.debug("Starting %s server over IPC socket: %s", self, ipc_path)
+
+        with socket.socket(socket.AF_UNIX, socket.SOCK_STREAM) as sock:
+            # background task to close the socket.
+            threading.Thread(
+                name="_close_socket_on_stop",
+                target=self._close_socket_on_stop,
+                args=(sock,),
+                daemon=True,
+            ).start()
+
+            # These options help fix an issue with the socket reporting itself
+            # already being used since it accepts many client connection.
+            # https://stackoverflow.com/questions/6380057/python-binding-socket-address-already-in-use
+            sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+            sock.bind(str(ipc_path))
+            sock.listen(1)
+
+            self._started.set()
+
+            while self.is_running:
+                try:
+                    conn, addr = sock.accept()
+                except (ConnectionAbortedError, OSError) as err:
+                    self.logger.debug("Server stopping: %s", err)
+                    self._stopped.set()
+                    break
+                self.logger.debug('Server accepted connection: %r', addr)
+                threading.Thread(
+                    name="_serve_conn",
+                    target=self._serve_conn,
+                    args=(conn,),
+                    daemon=True,
+                ).start()
+
+    @abstractmethod
+    def serve_conn(self, sock: BufferedSocket) -> None:
+        ...
+
+    def _serve_conn(self, raw_socket: socket.socket) -> None:
+        self.logger.debug("%s: starting client handler for %s", self, raw_socket)
+
+        with raw_socket:
+            sock = BufferedSocket(raw_socket)
+
+            self.serve_conn(sock)

--- a/trinity/boot_info.py
+++ b/trinity/boot_info.py
@@ -1,0 +1,12 @@
+from argparse import Namespace
+from typing import Dict, NamedTuple
+
+from trinity.config import TrinityConfig
+
+
+class BootInfo(NamedTuple):
+    args: Namespace
+    trinity_config: TrinityConfig
+    profile: bool
+    child_process_log_level: int
+    logger_levels: Dict[str, int]

--- a/trinity/bootstrap.py
+++ b/trinity/bootstrap.py
@@ -191,6 +191,7 @@ def main_entry(trinity_boot: BootFn,
     child_process_log_level = min(
         stderr_logger_level,
         file_logger_level,
+        *logger_levels.values(),
     )
 
     # Components can provide a subcommand with a `func` which does then control

--- a/trinity/components/builtin/ethstats/ethstats_service.py
+++ b/trinity/components/builtin/ethstats/ethstats_service.py
@@ -27,9 +27,7 @@ from trinity._utils.version import (
     construct_trinity_client_identifier,
 )
 
-from trinity.extensibility.component import (
-    TrinityBootInfo,
-)
+from trinity.boot_info import BootInfo
 from trinity.components.builtin.ethstats.ethstats_client import (
     EthstatsClient,
     EthstatsMessage,
@@ -44,7 +42,7 @@ from trinity.protocol.common.events import (
 class EthstatsService(BaseService):
     def __init__(
         self,
-        boot_info: TrinityBootInfo,
+        boot_info: BootInfo,
         event_bus: EndpointAPI,
         server_url: str,
         server_secret: str,

--- a/trinity/config.py
+++ b/trinity/config.py
@@ -229,6 +229,9 @@ class Eth1ChainConfig:
         return self.genesis_data.vm_configuration
 
 
+LOGGING_IPC_SOCKET_FILENAME = 'logging.ipc'
+
+
 TAppConfig = TypeVar('TAppConfig', bound='BaseAppConfig')
 
 
@@ -385,6 +388,13 @@ class TrinityConfig:
         Return the path for the database IPC socket connection.
         """
         return get_database_socket_path(self.ipc_dir)
+
+    @property
+    def logging_ipc_path(self) -> Path:
+        """
+        Return the path for the database IPC socket connection.
+        """
+        return self.ipc_dir / LOGGING_IPC_SOCKET_FILENAME
 
     @property
     def ipc_dir(self) -> Path:

--- a/trinity/event_bus.py
+++ b/trinity/event_bus.py
@@ -13,6 +13,7 @@ from cancel_token import CancelToken
 
 from p2p.service import BaseService
 
+from trinity.boot_info import BootInfo
 from trinity.config import TrinityConfig
 from trinity.constants import (
     MAIN_EVENTBUS_ENDPOINT,
@@ -25,7 +26,6 @@ from trinity.events import (
 from trinity.extensibility import (
     BaseComponent,
     ComponentManager,
-    TrinityBootInfo,
 )
 
 
@@ -33,12 +33,12 @@ class ComponentManagerService(BaseService):
     _endpoint: EndpointAPI
 
     def __init__(self,
-                 trinity_boot_info: TrinityBootInfo,
+                 boot_info: BootInfo,
                  components: Sequence[Type[BaseComponent]],
                  kill_trinity_fn: Callable[[str], Any],
                  cancel_token: CancelToken = None,
                  loop: asyncio.AbstractEventLoop = None) -> None:
-        self._boot_info = trinity_boot_info
+        self._boot_info = boot_info
         self._components = components
         self._kill_trinity_fn = kill_trinity_fn
         super().__init__(cancel_token, loop)

--- a/trinity/extensibility/__init__.py
+++ b/trinity/extensibility/__init__.py
@@ -11,7 +11,6 @@ from trinity.extensibility.component import (  # noqa: F401
     BaseMainProcessComponent,
     BaseComponent,
     ComponentStatus,
-    TrinityBootInfo,
 )
 from trinity.extensibility.component_manager import (  # noqa: F401
     ComponentManager,

--- a/trinity/extensibility/component_manager.py
+++ b/trinity/extensibility/component_manager.py
@@ -7,10 +7,10 @@ from typing import (
 
 from lahja import EndpointAPI
 
+from trinity.boot_info import BootInfo
 from trinity.extensibility.component import (
     BaseIsolatedComponent,
     BaseComponent,
-    TrinityBootInfo,
 )
 from trinity._utils.ipc import (
     kill_processes_gracefully,
@@ -55,7 +55,7 @@ class ComponentManager:
         """
         return self._endpoint
 
-    def prepare(self, boot_info: TrinityBootInfo) -> None:
+    def prepare(self, boot_info: BootInfo) -> None:
         """
         Create all components and call :meth:`~trinity.extensibility.component.BaseComponent.ready`
         on each of them.


### PR DESCRIPTION
extracted from https://github.com/ethereum/trinity/pull/1265

### What was wrong?

The current facilities that we use to do cross process logging is based on `multiprocessing` under the hood.  In trying to move away from `multiprocessing` for process isolation this ended up being problematic.  The `multiprocessing.Queue` objects can be transparently passed across processes when you are using `multiprocessing.Process`, but otherwise they cannot be pickled, and thus, they can't be passed to child processes.

### How was it fixed?

Re implemented cross process logging using an IPC socket.

This re-uses a the structure that was built for the `DBManager` server into a generic socket server for IPC sockets (which isn't available under the `socketserver` standard library module which only focuses on TCP/Datagram style sockets).

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)


#### Cute Animal Picture

![beautiful-old-dogs-phoenix](https://user-images.githubusercontent.com/824194/68957980-6afaf600-0788-11ea-9754-515863f20423.jpg)

