### PR TITLE
Fix block proposing

### DIFF
--- a/eth2/beacon/tools/builder/proposer.py
+++ b/eth2/beacon/tools/builder/proposer.py
@@ -120,11 +120,6 @@ def advance_to_slot(
     return state
 
 
-def _get_proposer_index(state: BeaconState, config: Eth2Config) -> ValidatorIndex:
-    proposer_index = get_beacon_proposer_index(state, CommitteeConfig(config))
-    return proposer_index
-
-
 def create_mock_block(
     *,
     state: BeaconState,
@@ -142,7 +137,7 @@ def create_mock_block(
     Note that it doesn't return the correct ``state_root``.
     """
     future_state = advance_to_slot(state_machine, state, slot)
-    proposer_index = _get_proposer_index(future_state, config)
+    proposer_index = get_beacon_proposer_index(future_state, CommitteeConfig(config))
     proposer_pubkey = state.validators[proposer_index].pubkey
     proposer_privkey = keymap[proposer_pubkey]
 

--- a/tests/components/eth2/beacon/test_validator.py
+++ b/tests/components/eth2/beacon/test_validator.py
@@ -31,12 +31,13 @@ from eth2.beacon.tools.factories import (
     keymap,
 )
 from eth2.beacon.tools.builder.proposer import (
-    _get_proposer_index,
+    get_beacon_proposer_index,
     is_proposer,
 )
 from eth2.beacon.tools.misc.ssz_vector import (
     override_lengths,
 )
+from eth2.configs import CommitteeConfig
 
 from trinity.components.eth2.beacon.validator import (
     Validator,
@@ -359,11 +360,11 @@ async def test_validator_include_ready_attestations(event_loop, event_bus, monke
     monkeypatch.setattr(alice, 'get_ready_attestations', get_ready_attestations_fn)
 
     proposing_slot = attesting_slot + XIAO_LONG_BAO_CONFIG.MIN_ATTESTATION_INCLUSION_DELAY
-    proposer_index = _get_proposer_index(
+    proposer_index = get_beacon_proposer_index(
         state.copy(
             slot=proposing_slot,
         ),
-        state_machine.config,
+        CommitteeConfig(state_machine.config),
     )
 
     head = alice.chain.get_canonical_head()

--- a/tests/components/eth2/beacon/test_validator.py
+++ b/tests/components/eth2/beacon/test_validator.py
@@ -68,7 +68,7 @@ async def get_validator(event_loop, event_bus, indices) -> Validator:
         for index in indices
     }
 
-    def get_ready_attestations_fn():
+    def get_ready_attestations_fn(slot):
         return ()
 
     v = Validator(
@@ -355,7 +355,7 @@ async def test_validator_include_ready_attestations(event_loop, event_bus, monke
 
     # Mock `get_ready_attestations_fn` so it returns the attestation alice
     # attested to.
-    def get_ready_attestations_fn():
+    def get_ready_attestations_fn(slot):
         return attestations
     monkeypatch.setattr(alice, 'get_ready_attestations', get_ready_attestations_fn)
 

--- a/tests/libp2p/bcc/test_receive_server.py
+++ b/tests/libp2p/bcc/test_receive_server.py
@@ -421,19 +421,19 @@ async def test_bcc_receive_server_get_ready_attestations(receive_server, monkeyp
     state.slot = (
         attesting_slot + XIAO_LONG_BAO_CONFIG.MIN_ATTESTATION_INCLUSION_DELAY - 1
     )
-    ready_attestations = receive_server.get_ready_attestations()
+    ready_attestations = receive_server.get_ready_attestations(state.slot)
     assert len(ready_attestations) == 0
 
     state.slot = attesting_slot + XIAO_LONG_BAO_CONFIG.MIN_ATTESTATION_INCLUSION_DELAY
-    ready_attestations = receive_server.get_ready_attestations()
+    ready_attestations = receive_server.get_ready_attestations(state.slot)
     assert set([a1, a2]) == set(ready_attestations)
 
     state.slot = (
         attesting_slot + XIAO_LONG_BAO_CONFIG.MIN_ATTESTATION_INCLUSION_DELAY + 1
     )
-    ready_attestations = receive_server.get_ready_attestations()
+    ready_attestations = receive_server.get_ready_attestations(state.slot)
     assert set([a1, a2, a3]) == set(ready_attestations)
 
     state.slot = attesting_slot + XIAO_LONG_BAO_CONFIG.SLOTS_PER_EPOCH + 1
-    ready_attestations = receive_server.get_ready_attestations()
+    ready_attestations = receive_server.get_ready_attestations(state.slot)
     assert set([a3]) == set(ready_attestations)

--- a/trinity/components/eth2/beacon/validator.py
+++ b/trinity/components/eth2/beacon/validator.py
@@ -77,7 +77,7 @@ from trinity.components.eth2.beacon.slot_ticker import (
 from trinity.protocol.bcc_libp2p.node import Node
 
 
-GetReadyAttestationsFn = Callable[[], Sequence[Attestation]]
+GetReadyAttestationsFn = Callable[[Slot], Sequence[Attestation]]
 
 
 class Validator(BaseService):
@@ -242,7 +242,7 @@ class Validator(BaseService):
                             state: BeaconState,
                             state_machine: BaseBeaconStateMachine,
                             head_block: BaseBeaconBlock) -> BaseBeaconBlock:
-        ready_attestations = self.get_ready_attestations()
+        ready_attestations = self.get_ready_attestations(slot)
         block = self._make_proposing_block(
             proposer_index=proposer_index,
             slot=slot,

--- a/trinity/protocol/bcc_libp2p/servers.py
+++ b/trinity/protocol/bcc_libp2p/servers.py
@@ -46,6 +46,7 @@ from eth2.beacon.typing import (
 from eth2.beacon.state_machines.forks.serenity.block_validation import (
     validate_attestation_slot,
 )
+from eth2.beacon.typing import Slot
 
 from trinity.protocol.bcc_libp2p.node import Node
 
@@ -351,14 +352,13 @@ class BCCReceiveServer(BaseService):
         return self._is_block_root_seen(block_root=block.signing_root)
 
     @to_tuple
-    def get_ready_attestations(self) -> Iterable[Attestation]:
+    def get_ready_attestations(self, current_slot: Slot) -> Iterable[Attestation]:
         config = self.chain.get_state_machine().config
-        state = self.chain.get_head_state()
         for attestation in self.attestation_pool.get_all():
             try:
                 validate_attestation_slot(
                     attestation.data.slot,
-                    state.slot,
+                    current_slot,
                     config.SLOTS_PER_EPOCH,
                     config.MIN_ATTESTATION_INCLUSION_DELAY,
                 )


### PR DESCRIPTION
### What was wrong?
1. When running `python eth2/beacon/scripts/run_beacon_nodes.py`, sometimes I saw error message `SHOULD NOT GET A VALIDATION ERROR HERE AS IT IS INTERNAL TO OUR OWN CODE`. It's because we used `state.slot` as the slot number to filter attestations, but the new slot has been started.
2. At epoch boundary, sometimes the proposer selection is wrong.

### How was it fixed?
1. Pass current slot number to `get_ready_attestations` and use it to filter attestations.
2. Run state transition for proposer selection.
    - To know more, see https://github.com/ethereum/eth2.0-specs/blob/master/specs/validator/0_beacon-chain-validator.md#validator-assignments

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

[//]: # (See: https://trinity-client.readthedocs.io/en/latest/contributing.html#pull-requests)
- [ ] Add entry to the [release notes](https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![Sea Cow](https://user-images.githubusercontent.com/9263930/68924301-6dc30e80-07bb-11ea-84e4-83b9dbeb32d2.jpeg)
