### PR TITLE
Pin libp2p to 0.1.1

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,7 @@ deps = {
         "argcomplete>=1.10.0,<2",
         "multiaddr>=0.0.8,<0.1.0",
         "pymultihash>=0.8.2",
-        "libp2p>=0.1.1,<0.2",
+        "libp2p==0.1.1",
     ],
     'test': [
         "async-timeout>=3.0.1,<4",


### PR DESCRIPTION
### What was wrong?
CI failed in https://app.circleci.com/jobs/github/hwwhww/trinity/15939.

### How was it fixed?
Pin back to `0.1.1`, and investigate the cause and fix later, to make CI work again.

