### PR TITLE
Hashable SSZ Tests

### DIFF
--- a/eth2/_utils/ssz.py
+++ b/eth2/_utils/ssz.py
@@ -2,9 +2,9 @@ from typing import Iterable, Optional, Tuple
 
 from eth_utils import ValidationError, to_tuple
 from eth_utils.toolz import curry
-import ssz
 
 from eth2.beacon.types.blocks import BaseBeaconBlock
+import ssz
 
 
 @to_tuple

--- a/eth2/beacon/attestation_helpers.py
+++ b/eth2/beacon/attestation_helpers.py
@@ -52,7 +52,7 @@ def validate_indexed_attestation(
             f" but have {len(attesting_indices)} validators."
         )
 
-    if attesting_indices != tuple(sorted(attesting_indices)):
+    if list(attesting_indices) != sorted(attesting_indices):
         raise ValidationError(
             f"Indices should be sorted; the attesting indices are not: {attesting_indices}."
         )

--- a/eth2/beacon/db/chain.py
+++ b/eth2/beacon/db/chain.py
@@ -8,7 +8,6 @@ from eth.exceptions import BlockNotFound, CanonicalHeadNotFound, ParentNotFound
 from eth.validation import validate_word
 from eth_typing import Hash32
 from eth_utils import ValidationError, encode_hex, to_tuple
-import ssz
 
 from eth2.beacon.constants import ZERO_SIGNING_ROOT
 from eth2.beacon.db.exceptions import (
@@ -27,6 +26,7 @@ from eth2.beacon.types.blocks import BaseBeaconBlock, BeaconBlock  # noqa: F401
 from eth2.beacon.types.states import BeaconState  # noqa: F401
 from eth2.beacon.typing import Epoch, HashTreeRoot, SigningRoot, Slot
 from eth2.configs import Eth2GenesisConfig
+import ssz
 
 
 class AttestationKey(ssz.Serializable):

--- a/eth2/beacon/deposit_helpers.py
+++ b/eth2/beacon/deposit_helpers.py
@@ -48,7 +48,7 @@ def process_deposit(
     # needs to be done here because while the deposit contract will never
     # create an invalid Merkle branch, it may admit an invalid deposit
     # object, and we need to be able to skip over it
-    state = state.copy(eth1_deposit_index=state.eth1_deposit_index + 1)
+    state = state.set("eth1_deposit_index", state.eth1_deposit_index + 1)
 
     pubkey = deposit.data.pubkey
     amount = deposit.data.amount
@@ -72,9 +72,11 @@ def process_deposit(
             pubkey, withdrawal_credentials, amount, config
         )
 
-        return state.copy(
-            validators=state.validators + (validator,),
-            balances=state.balances + (amount,),
+        return state.mset(
+            "validators",
+            state.validators.append(validator),
+            "balances",
+            state.balances.append(amount),
         )
     else:
         index = ValidatorIndex(validator_pubkeys.index(pubkey))

--- a/eth2/beacon/epoch_processing_helpers.py
+++ b/eth2/beacon/epoch_processing_helpers.py
@@ -25,22 +25,15 @@ from eth2.configs import CommitteeConfig, Eth2Config
 def increase_balance(
     state: BeaconState, index: ValidatorIndex, delta: Gwei
 ) -> BeaconState:
-    return state.copy(
-        balances=update_tuple_item_with_fn(
-            state.balances, index, lambda balance, *_: Gwei(balance + delta)
-        )
-    )
+    return state.transform(("balances", index), lambda balance: Gwei(balance + delta))
 
 
 def decrease_balance(
     state: BeaconState, index: ValidatorIndex, delta: Gwei
 ) -> BeaconState:
-    return state.copy(
-        balances=update_tuple_item_with_fn(
-            state.balances,
-            index,
-            lambda balance, *_: Gwei(0) if delta > balance else Gwei(balance - delta),
-        )
+    return state.transform(
+        ("balances", index),
+        lambda balance: Gwei(0) if delta > balance else Gwei(balance - delta),
     )
 
 

--- a/eth2/beacon/epoch_processing_helpers.py
+++ b/eth2/beacon/epoch_processing_helpers.py
@@ -19,8 +19,6 @@ from eth2.beacon.types.pending_attestations import PendingAttestation
 from eth2.beacon.types.states import BeaconState
 from eth2.beacon.typing import Epoch, Gwei, ValidatorIndex
 from eth2.configs import CommitteeConfig, Eth2Config
-from ssz.hashable_list import HashableList
-from ssz.sedes import List, uint64
 
 
 def increase_balance(

--- a/eth2/beacon/epoch_processing_helpers.py
+++ b/eth2/beacon/epoch_processing_helpers.py
@@ -61,9 +61,7 @@ def get_indexed_attestation(
     )
 
     return IndexedAttestation.create(
-        attesting_indices=HashableList.from_iterable(
-            sorted(attesting_indices), sedes=List(uint64, 2 ** 8)  # TODO: fix size
-        ),
+        attesting_indices=sorted(attesting_indices),
         data=attestation.data,
         signature=attestation.signature,
     )

--- a/eth2/beacon/genesis.py
+++ b/eth2/beacon/genesis.py
@@ -2,7 +2,11 @@ from typing import Sequence, Type
 
 from eth_typing import Hash32
 
-from eth2.beacon.constants import DEPOSIT_CONTRACT_TREE_DEPTH, SECONDS_PER_DAY
+from eth2.beacon.constants import (
+    DEPOSIT_CONTRACT_TREE_DEPTH,
+    SECONDS_PER_DAY,
+    ZERO_HASH32,
+)
 from eth2.beacon.deposit_helpers import process_deposit
 from eth2.beacon.helpers import get_active_validator_indices
 from eth2.beacon.types.block_headers import BeaconBlockHeader
@@ -55,6 +59,8 @@ def initialize_beacon_state_from_eth1(
         latest_block_header=BeaconBlockHeader.create(
             body_root=BeaconBlockBody.create().hash_tree_root
         ),
+        block_roots=(ZERO_HASH32,) * config.SLOTS_PER_HISTORICAL_ROOT,
+        state_roots=(ZERO_HASH32,) * config.SLOTS_PER_HISTORICAL_ROOT,
         randao_mixes=(eth1_block_hash,) * config.EPOCHS_PER_HISTORICAL_VECTOR,
         config=config,
     )

--- a/eth2/beacon/genesis.py
+++ b/eth2/beacon/genesis.py
@@ -62,6 +62,7 @@ def initialize_beacon_state_from_eth1(
         block_roots=(ZERO_HASH32,) * config.SLOTS_PER_HISTORICAL_ROOT,
         state_roots=(ZERO_HASH32,) * config.SLOTS_PER_HISTORICAL_ROOT,
         randao_mixes=(eth1_block_hash,) * config.EPOCHS_PER_HISTORICAL_VECTOR,
+        slashings=(0,) * config.EPOCHS_PER_SLASHINGS_VECTOR,
         config=config,
     )
 

--- a/eth2/beacon/genesis.py
+++ b/eth2/beacon/genesis.py
@@ -6,6 +6,7 @@ from eth2.beacon.constants import (
     DEPOSIT_CONTRACT_TREE_DEPTH,
     SECONDS_PER_DAY,
     ZERO_HASH32,
+    ZERO_SIGNING_ROOT,
 )
 from eth2.beacon.deposit_helpers import process_deposit
 from eth2.beacon.helpers import get_active_validator_indices
@@ -16,7 +17,7 @@ from eth2.beacon.types.deposits import Deposit
 from eth2.beacon.types.eth1_data import Eth1Data
 from eth2.beacon.types.states import BeaconState
 from eth2.beacon.types.validators import calculate_effective_balance
-from eth2.beacon.typing import Timestamp, ValidatorIndex
+from eth2.beacon.typing import Gwei, Timestamp, ValidatorIndex
 from eth2.beacon.validator_status_helpers import activate_validator
 from eth2.configs import Eth2Config
 import ssz
@@ -59,10 +60,10 @@ def initialize_beacon_state_from_eth1(
         latest_block_header=BeaconBlockHeader.create(
             body_root=BeaconBlockBody.create().hash_tree_root
         ),
-        block_roots=(ZERO_HASH32,) * config.SLOTS_PER_HISTORICAL_ROOT,
+        block_roots=(ZERO_SIGNING_ROOT,) * config.SLOTS_PER_HISTORICAL_ROOT,
         state_roots=(ZERO_HASH32,) * config.SLOTS_PER_HISTORICAL_ROOT,
         randao_mixes=(eth1_block_hash,) * config.EPOCHS_PER_HISTORICAL_VECTOR,
-        slashings=(0,) * config.EPOCHS_PER_SLASHINGS_VECTOR,
+        slashings=(Gwei(0),) * config.EPOCHS_PER_SLASHINGS_VECTOR,
         config=config,
     )
 

--- a/eth2/beacon/scripts/pretty_print_genesis.py
+++ b/eth2/beacon/scripts/pretty_print_genesis.py
@@ -5,12 +5,12 @@ from pathlib import Path
 import sys
 
 from ruamel.yaml import YAML
-import ssz
-from ssz.tools import to_formatted_dict
 
 from eth2.beacon.tools.fixtures.loading import load_config_at_path
 from eth2.beacon.tools.misc.ssz_vector import override_lengths
 from eth2.beacon.types.states import BeaconState
+import ssz
+from ssz.tools import to_formatted_dict
 
 
 def main():

--- a/eth2/beacon/scripts/quickstart_state/generate_beacon_genesis.py
+++ b/eth2/beacon/scripts/quickstart_state/generate_beacon_genesis.py
@@ -2,7 +2,6 @@ from pathlib import Path
 import time
 
 from eth_utils import decode_hex
-import ssz
 
 from eth2._utils.hash import hash_eth2
 from eth2.beacon.genesis import initialize_beacon_state_from_eth1
@@ -10,6 +9,7 @@ from eth2.beacon.tools.builder.initializer import create_mock_deposits_and_root
 from eth2.beacon.tools.fixtures.config_types import Minimal
 from eth2.beacon.tools.fixtures.loading import load_config_at_path, load_yaml_at
 from eth2.beacon.tools.misc.ssz_vector import override_lengths
+import ssz
 
 KEY_DIR = Path("eth2/beacon/scripts/quickstart_state")
 KEY_SET_FILE = Path("keygen_16_validators.yaml")

--- a/eth2/beacon/state_machines/base.py
+++ b/eth2/beacon/state_machines/base.py
@@ -153,6 +153,6 @@ class BeaconStateMachine(BaseBeaconStateMachine):
             state, block=block, check_proposer_signature=check_proposer_signature
         )
 
-        block = block.copy(state_root=state.hash_tree_root)
+        block = block.set("state_root", state.hash_tree_root)
 
         return state, block

--- a/eth2/beacon/state_machines/forks/serenity/block_processing.py
+++ b/eth2/beacon/state_machines/forks/serenity/block_processing.py
@@ -35,14 +35,15 @@ def process_block_header(
             state, block, committee_config=CommitteeConfig(config)
         )
 
-    return state.copy(
-        latest_block_header=BeaconBlockHeader(
+    return state.set(
+        "latest_block_header",
+        BeaconBlockHeader.create(
             slot=block.slot,
             parent_root=block.parent_root,
             # `state_root` is zeroed and overwritten in the next `process_slot` call
             body_root=block.body.hash_tree_root,
             # `signature` is zeroed
-        )
+        ),
     )
 
 

--- a/eth2/beacon/state_machines/forks/serenity/block_processing.py
+++ b/eth2/beacon/state_machines/forks/serenity/block_processing.py
@@ -74,11 +74,7 @@ def process_randao(
         hash_eth2(block.body.randao_reveal),
     )
 
-    return state.copy(
-        randao_mixes=update_tuple_item(
-            state.randao_mixes, randao_mix_index, new_randao_mix
-        )
-    )
+    return state.transform(("randao_mixes", randao_mix_index), new_randao_mix)
 
 
 def process_eth1_data(
@@ -86,7 +82,7 @@ def process_eth1_data(
 ) -> BeaconState:
     body = block.body
 
-    new_eth1_data_votes = state.eth1_data_votes + (body.eth1_data,)
+    new_eth1_data_votes = state.eth1_data_votes.append(body.eth1_data)
 
     new_eth1_data = state.eth1_data
     if (
@@ -95,7 +91,9 @@ def process_eth1_data(
     ):
         new_eth1_data = body.eth1_data
 
-    return state.copy(eth1_data=new_eth1_data, eth1_data_votes=new_eth1_data_votes)
+    return state.mset(
+        "eth1_data", new_eth1_data, "eth1_data_votes", new_eth1_data_votes
+    )
 
 
 def process_block(

--- a/eth2/beacon/state_machines/forks/serenity/block_processing.py
+++ b/eth2/beacon/state_machines/forks/serenity/block_processing.py
@@ -1,6 +1,5 @@
 from eth2._utils.hash import hash_eth2
 from eth2._utils.numeric import bitwise_xor
-from eth2._utils.tuple import update_tuple_item
 from eth2.beacon.committee_helpers import get_beacon_proposer_index
 from eth2.beacon.helpers import get_randao_mix
 from eth2.beacon.state_machines.forks.serenity.block_validation import (

--- a/eth2/beacon/state_machines/forks/serenity/block_validation.py
+++ b/eth2/beacon/state_machines/forks/serenity/block_validation.py
@@ -2,7 +2,6 @@ from typing import Iterable, Sequence, Tuple, cast  # noqa: F401
 
 from eth_typing import BLSPubkey, BLSSignature, Hash32
 from eth_utils import ValidationError, encode_hex
-import ssz
 
 from eth2._utils.bls import bls
 from eth2.beacon.attestation_helpers import (
@@ -30,6 +29,7 @@ from eth2.beacon.types.validators import Validator
 from eth2.beacon.types.voluntary_exits import VoluntaryExit
 from eth2.beacon.typing import CommitteeIndex, Epoch, SigningRoot, Slot
 from eth2.configs import CommitteeConfig, Eth2Config
+import ssz
 
 
 def validate_correct_number_of_deposits(

--- a/eth2/beacon/state_machines/forks/serenity/epoch_processing.py
+++ b/eth2/beacon/state_machines/forks/serenity/epoch_processing.py
@@ -483,7 +483,7 @@ def _determine_next_eth1_votes(
     state: BeaconState, config: Eth2Config
 ) -> Tuple[Eth1Data, ...]:
     if (state.slot + 1) % config.SLOTS_PER_ETH1_VOTING_PERIOD == 0:
-        return tuple()
+        return HashableList.from_iterable((), state.eth1_data_votes.sedes)
     else:
         return state.eth1_data_votes
 
@@ -510,9 +510,7 @@ def _update_effective_balances(
 
 def _compute_next_slashings(state: BeaconState, config: Eth2Config) -> Tuple[Gwei, ...]:
     next_epoch = state.next_epoch(config.SLOTS_PER_EPOCH)
-    return update_tuple_item(
-        state.slashings, next_epoch % config.EPOCHS_PER_SLASHINGS_VECTOR, Gwei(0)
-    )
+    return state.slashings.set(next_epoch % config.EPOCHS_PER_SLASHINGS_VECTOR, Gwei(0))
 
 
 def _compute_next_randao_mixes(
@@ -520,8 +518,7 @@ def _compute_next_randao_mixes(
 ) -> Tuple[Hash32, ...]:
     current_epoch = state.current_epoch(config.SLOTS_PER_EPOCH)
     next_epoch = state.next_epoch(config.SLOTS_PER_EPOCH)
-    return update_tuple_item(
-        state.randao_mixes,
+    return state.randao_mixes.set(
         next_epoch % config.EPOCHS_PER_HISTORICAL_VECTOR,
         get_randao_mix(state, current_epoch, config.EPOCHS_PER_HISTORICAL_VECTOR),
     )

--- a/eth2/beacon/state_machines/forks/serenity/epoch_processing.py
+++ b/eth2/beacon/state_machines/forks/serenity/epoch_processing.py
@@ -395,7 +395,7 @@ def _process_activation_eligibility_or_ejections(
         validator.activation_eligibility_epoch == FAR_FUTURE_EPOCH
         and validator.effective_balance == config.MAX_EFFECTIVE_BALANCE
     ):
-        validator = validator.copy(activation_eligibility_epoch=current_epoch)
+        validator = validator.set("activation_eligibility_epoch", current_epoch)
 
     if (
         validator.is_active(current_epoch)

--- a/eth2/beacon/state_machines/forks/serenity/epoch_processing.py
+++ b/eth2/beacon/state_machines/forks/serenity/epoch_processing.py
@@ -30,6 +30,7 @@ from eth2.beacon.types.validators import Validator
 from eth2.beacon.typing import Bitfield, Epoch, Gwei, ValidatorIndex
 from eth2.beacon.validator_status_helpers import initiate_exit_for_validator
 from eth2.configs import CommitteeConfig, Eth2Config
+from ssz.hashable_list import HashableList
 
 
 def _bft_threshold_met(participation: Gwei, total: Gwei) -> bool:
@@ -138,7 +139,9 @@ def _determine_new_justified_checkpoint_and_bitfield(
         new_current_justified_root = state.current_justified_checkpoint.root
 
     return (
-        Checkpoint(epoch=new_current_justified_epoch, root=new_current_justified_root),
+        Checkpoint.create(
+            epoch=new_current_justified_epoch, root=new_current_justified_root
+        ),
         justification_bits,
     )
 
@@ -210,7 +213,7 @@ def _determine_new_finalized_checkpoint(
     else:
         new_finalized_root = state.finalized_checkpoint.root
 
-    return Checkpoint(epoch=new_finalized_epoch, root=new_finalized_root)
+    return Checkpoint.create(epoch=new_finalized_epoch, root=new_finalized_root)
 
 
 def process_justification_and_finalization(
@@ -231,11 +234,15 @@ def process_justification_and_finalization(
         state, justification_bits, config
     )
 
-    return state.copy(
-        justification_bits=justification_bits,
-        previous_justified_checkpoint=state.current_justified_checkpoint,
-        current_justified_checkpoint=new_current_justified_checkpoint,
-        finalized_checkpoint=new_finalized_checkpoint,
+    return state.mset(
+        "justification_bits",
+        justification_bits,
+        "previous_justified_checkpoint",
+        state.current_justified_checkpoint,
+        "current_justified_checkpoint",
+        new_current_justified_checkpoint,
+        "finalized_checkpoint",
+        new_finalized_checkpoint,
     )
 
 
@@ -404,20 +411,23 @@ def _update_validator_activation_epoch(
     state: BeaconState, config: Eth2Config, validator: Validator
 ) -> Validator:
     if validator.activation_epoch == FAR_FUTURE_EPOCH:
-        return validator.copy(
-            activation_epoch=compute_activation_exit_epoch(
+        return validator.set(
+            "activation_epoch",
+            compute_activation_exit_epoch(
                 state.current_epoch(config.SLOTS_PER_EPOCH), config.MAX_SEED_LOOKAHEAD
-            )
+            ),
         )
     else:
         return validator
 
 
 def process_registry_updates(state: BeaconState, config: Eth2Config) -> BeaconState:
-    new_validators = tuple(
-        _process_activation_eligibility_or_ejections(state, validator, config)
-        for validator in state.validators
-    )
+    new_validators = state.validators
+    for index, validator in enumerate(state.validators):
+        new_validator = _process_activation_eligibility_or_ejections(
+            state, validator, config
+        )
+        new_validators = new_validators.set(index, new_validator)
 
     activation_exit_epoch = compute_activation_exit_epoch(
         state.finalized_checkpoint.epoch, config.MAX_SEED_LOOKAHEAD
@@ -433,11 +443,11 @@ def process_registry_updates(state: BeaconState, config: Eth2Config) -> BeaconSt
     )
 
     for index in activation_queue[: get_validator_churn_limit(state, config)]:
-        new_validators = update_tuple_item_with_fn(
-            new_validators, index, _update_validator_activation_epoch(state, config)
+        new_validators = new_validators.transform(
+            (index,), _update_validator_activation_epoch(state, config)
         )
 
-    return state.copy(validators=new_validators)
+    return state.set("validators", new_validators)
 
 
 def _determine_slashing_penalty(
@@ -492,11 +502,8 @@ def _update_effective_balances(
                 balance - balance % config.EFFECTIVE_BALANCE_INCREMENT,
                 config.MAX_EFFECTIVE_BALANCE,
             )
-            new_validators = update_tuple_item_with_fn(
-                new_validators,
-                index,
-                lambda v, new_balance: v.copy(effective_balance=new_balance),
-                new_effective_balance,
+            new_validators = new_validators.transform(
+                (index, "effective_balance"), new_effective_balance
             )
     return new_validators
 
@@ -526,10 +533,12 @@ def _compute_next_historical_roots(
     next_epoch = state.next_epoch(config.SLOTS_PER_EPOCH)
     new_historical_roots = state.historical_roots
     if next_epoch % (config.SLOTS_PER_HISTORICAL_ROOT // config.SLOTS_PER_EPOCH) == 0:
-        historical_batch = HistoricalBatch(
+        historical_batch = HistoricalBatch.create(
             block_roots=state.block_roots, state_roots=state.state_roots
         )
-        new_historical_roots += (historical_batch.hash_tree_root,)
+        new_historical_roots = new_historical_roots.append(
+            historical_batch.hash_tree_root
+        )
     return new_historical_roots
 
 
@@ -539,14 +548,21 @@ def process_final_updates(state: BeaconState, config: Eth2Config) -> BeaconState
     new_slashings = _compute_next_slashings(state, config)
     new_randao_mixes = _compute_next_randao_mixes(state, config)
     new_historical_roots = _compute_next_historical_roots(state, config)
-    return state.copy(
-        eth1_data_votes=new_eth1_data_votes,
-        validators=new_validators,
-        slashings=new_slashings,
-        randao_mixes=new_randao_mixes,
-        historical_roots=new_historical_roots,
-        previous_epoch_attestations=state.current_epoch_attestations,
-        current_epoch_attestations=tuple(),
+    return state.mset(
+        "eth1_data_votes",
+        new_eth1_data_votes,
+        "validators",
+        new_validators,
+        "slashings",
+        new_slashings,
+        "randao_mixes",
+        new_randao_mixes,
+        "historical_roots",
+        new_historical_roots,
+        "previous_epoch_attestations",
+        state.current_epoch_attestations,
+        "current_epoch_attestations",
+        HashableList.from_iterable((), sedes=state.current_epoch_attestations.sedes),
     )
 
 

--- a/eth2/beacon/state_machines/forks/serenity/operation_processing.py
+++ b/eth2/beacon/state_machines/forks/serenity/operation_processing.py
@@ -1,5 +1,3 @@
-from typing import Tuple
-
 from eth_utils import ValidationError
 
 from eth2.beacon.committee_helpers import get_beacon_proposer_index

--- a/eth2/beacon/state_machines/forks/serenity/operation_processing.py
+++ b/eth2/beacon/state_machines/forks/serenity/operation_processing.py
@@ -90,12 +90,13 @@ def process_attestations(
         )
 
     current_epoch = state.current_epoch(config.SLOTS_PER_EPOCH)
-    new_current_epoch_attestations: Tuple[PendingAttestation, ...] = tuple()
-    new_previous_epoch_attestations: Tuple[PendingAttestation, ...] = tuple()
+    current_epoch_attestations = state.current_epoch_attestations
+    previous_epoch_attestations = state.previous_epoch_attestations
+
     for attestation in block.body.attestations:
         validate_attestation(state, attestation, config)
         proposer_index = get_beacon_proposer_index(state, CommitteeConfig(config))
-        pending_attestation = PendingAttestation(
+        pending_attestation = PendingAttestation.create(
             aggregation_bits=attestation.aggregation_bits,
             data=attestation.data,
             inclusion_delay=state.slot - attestation.data.slot,
@@ -103,17 +104,19 @@ def process_attestations(
         )
 
         if attestation.data.target.epoch == current_epoch:
-            new_current_epoch_attestations += (pending_attestation,)
+            current_epoch_attestations = current_epoch_attestations.append(
+                pending_attestation
+            )
         else:
-            new_previous_epoch_attestations += (pending_attestation,)
+            previous_epoch_attestations = previous_epoch_attestations.append(
+                pending_attestation
+            )
 
-    return state.copy(
-        current_epoch_attestations=(
-            state.current_epoch_attestations + new_current_epoch_attestations
-        ),
-        previous_epoch_attestations=(
-            state.previous_epoch_attestations + new_previous_epoch_attestations
-        ),
+    return state.mset(
+        "current_epoch_attestations",
+        current_epoch_attestations,
+        "previous_epoch_attestations",
+        previous_epoch_attestations,
     )
 
 

--- a/eth2/beacon/state_machines/forks/serenity/slot_processing.py
+++ b/eth2/beacon/state_machines/forks/serenity/slot_processing.py
@@ -1,5 +1,3 @@
-from typing import Sequence, Tuple
-
 from eth.constants import ZERO_HASH32
 from eth_typing import Hash32
 from eth_utils import ValidationError

--- a/eth2/beacon/state_machines/forks/serenity/slot_processing.py
+++ b/eth2/beacon/state_machines/forks/serenity/slot_processing.py
@@ -4,21 +4,21 @@ from eth.constants import ZERO_HASH32
 from eth_typing import Hash32
 from eth_utils import ValidationError
 
-from eth2._utils.tuple import update_tuple_item
 from eth2.beacon.types.states import BeaconState
 from eth2.beacon.typing import Slot
 from eth2.configs import Eth2Config
+from ssz.hashable_list import HashableList
 
 from .epoch_processing import process_epoch
 
 
 def _update_historical_root(
-    roots: Tuple[Hash32, ...],
+    roots: HashableList[Hash32],
     index: Slot,
     slots_per_historical_root: int,
     new_root: Hash32,
-) -> Sequence[Hash32]:
-    return update_tuple_item(roots, index % slots_per_historical_root, new_root)
+) -> HashableList[Hash32]:
+    return roots.set(index % slots_per_historical_root, new_root)
 
 
 def _process_slot(state: BeaconState, config: Eth2Config) -> BeaconState:
@@ -30,9 +30,8 @@ def _process_slot(state: BeaconState, config: Eth2Config) -> BeaconState:
     )
 
     if state.latest_block_header.state_root == ZERO_HASH32:
-        latest_block_header = state.latest_block_header
-        state = state.copy(
-            latest_block_header=latest_block_header.copy(state_root=previous_state_root)
+        state = state.transform(
+            ("latest_block_header", "state_root"), previous_state_root
         )
 
     updated_block_roots = _update_historical_root(
@@ -42,11 +41,13 @@ def _process_slot(state: BeaconState, config: Eth2Config) -> BeaconState:
         state.latest_block_header.signing_root,
     )
 
-    return state.copy(block_roots=updated_block_roots, state_roots=updated_state_roots)
+    return state.mset(
+        "block_roots", updated_block_roots, "state_roots", updated_state_roots
+    )
 
 
 def _increment_slot(state: BeaconState) -> BeaconState:
-    return state.copy(slot=state.slot + 1)
+    return state.set("slot", state.slot + 1)
 
 
 def process_slots(state: BeaconState, slot: Slot, config: Eth2Config) -> BeaconState:

--- a/eth2/beacon/tools/builder/aggregator.py
+++ b/eth2/beacon/tools/builder/aggregator.py
@@ -1,5 +1,4 @@
 from eth_typing import BLSSignature
-from ssz import get_hash_tree_root, uint64
 
 from eth2._utils.bls import bls
 from eth2._utils.hash import hash_eth2
@@ -9,6 +8,7 @@ from eth2.beacon.signature_domain import SignatureDomain
 from eth2.beacon.types.states import BeaconState
 from eth2.beacon.typing import CommitteeIndex, Slot
 from eth2.configs import CommitteeConfig
+from ssz import get_hash_tree_root, uint64
 
 # TODO: TARGET_AGGREGATORS_PER_COMMITTEE is not in Eth2Config now.
 TARGET_AGGREGATORS_PER_COMMITTEE = 16

--- a/eth2/beacon/tools/builder/initializer.py
+++ b/eth2/beacon/tools/builder/initializer.py
@@ -126,7 +126,7 @@ def create_mock_genesis(
         pubkeys=pubkeys, keymap=keymap, config=config
     )
 
-    genesis_eth1_data = Eth1Data(
+    genesis_eth1_data = Eth1Data.create(
         deposit_root=deposit_root,
         deposit_count=len(genesis_deposits),
         block_hash=ZERO_HASH32,

--- a/eth2/beacon/tools/builder/initializer.py
+++ b/eth2/beacon/tools/builder/initializer.py
@@ -74,7 +74,7 @@ def create_mock_deposits_and_root(
         tree, root = make_deposit_tree_and_root(deposit_datas_at_count)
         proof = make_deposit_proof(deposit_datas_at_count, tree, root, index)
 
-        deposit = Deposit(proof=proof, data=data)
+        deposit = Deposit.create(proof=proof, data=data)
         deposits += (deposit,)
 
     if len(deposit_datas) > 0:
@@ -102,12 +102,14 @@ def create_mock_deposit(
     assert len(deposits) == 1
     deposit = deposits[0]
 
-    state = state.copy(
-        eth1_data=state.eth1_data.copy(
-            deposit_root=root,
-            deposit_count=state.eth1_data.deposit_count + len(deposits),
-        ),
-        eth1_deposit_index=0 if not leaves else len(leaves),
+    eth1_data = state.eth1_data.mset(
+        "deposit_root",
+        root,
+        "deposit_count",
+        state.eth1_data.deposit_count + len(deposits),
+    )
+    state = state.mset(
+        "eth1_data", eth1_data, "eth1_deposit_index", 0 if not leaves else len(leaves)
     )
 
     return state, deposit

--- a/eth2/beacon/tools/builder/proposer.py
+++ b/eth2/beacon/tools/builder/proposer.py
@@ -1,7 +1,6 @@
 from typing import Dict, Sequence, Type
 
 from eth_typing import BLSPubkey, BLSSignature
-import ssz
 
 from eth2.beacon.committee_helpers import get_beacon_proposer_index
 from eth2.beacon.exceptions import ProposerIndexError
@@ -14,6 +13,7 @@ from eth2.beacon.types.blocks import BaseBeaconBlock, BeaconBlockBody
 from eth2.beacon.types.states import BeaconState
 from eth2.beacon.typing import FromBlockParams, Slot, ValidatorIndex
 from eth2.configs import CommitteeConfig, Eth2Config
+import ssz
 
 
 def is_proposer(
@@ -85,11 +85,11 @@ def create_block_on_state(
     # TODO: Add more operations
     randao_reveal = _generate_randao_reveal(privkey, slot, state, config)
     eth1_data = state.eth1_data
-    body = BeaconBlockBody(
+    body = BeaconBlockBody.create(
         randao_reveal=randao_reveal, eth1_data=eth1_data, attestations=attestations
     )
 
-    block = block.copy(body=body)
+    block = block.set("body", body)
 
     # Apply state transition to get state root
     state, block = state_machine.import_block(
@@ -106,7 +106,7 @@ def create_block_on_state(
         slots_per_epoch=config.SLOTS_PER_EPOCH,
     )
 
-    block = block.copy(signature=signature)
+    block = block.set("signature", signature)
 
     return block
 

--- a/eth2/beacon/tools/builder/state.py
+++ b/eth2/beacon/tools/builder/state.py
@@ -66,13 +66,19 @@ def create_mock_genesis_state_from_validators(
         config=config,
     )
 
-    state_with_validators = empty_state.copy(
-        eth1_deposit_index=empty_state.eth1_deposit_index + len(genesis_validators),
-        eth1_data=empty_state.eth1_data.copy(
-            deposit_count=empty_state.eth1_data.deposit_count + len(genesis_validators)
-        ),
-        validators=genesis_validators,
-        balances=genesis_balances,
+    eth1_data = empty_state.eth1_data.set(
+        "deposit_count", empty_state.eth1_data.deposit_count + len(genesis_validators)
+    )
+
+    state_with_validators = empty_state.mset(
+        "eth1_deposit_index",
+        empty_state.eth1_deposit_index + len(genesis_validators),
+        "eth1_data",
+        eth1_data,
+        "validators",
+        genesis_validators,
+        "balances",
+        genesis_balances,
     )
 
     return state_with_validators

--- a/eth2/beacon/tools/builder/validator.py
+++ b/eth2/beacon/tools/builder/validator.py
@@ -80,12 +80,12 @@ def _mk_pending_attestation(
     slot: Slot = default_slot,
     committee_index: CommitteeIndex = default_committee_index,
 ) -> PendingAttestation:
-    return PendingAttestation(
+    return PendingAttestation.create(
         aggregation_bits=bitfield,
-        data=AttestationData(
+        data=AttestationData.create(
             slot=slot,
             index=committee_index,
-            target=Checkpoint(epoch=target_epoch, root=target_root),
+            target=Checkpoint.create(epoch=target_epoch, root=target_root),
         ),
     )
 
@@ -240,7 +240,7 @@ def create_block_header_with_signature(
     parent_root: SigningRoot = SAMPLE_HASH_1,
     state_root: Hash32 = SAMPLE_HASH_2,
 ) -> BeaconBlockHeader:
-    block_header = BeaconBlockHeader(
+    block_header = BeaconBlockHeader.create(
         slot=state.slot,
         parent_root=parent_root,
         state_root=state_root,
@@ -254,7 +254,7 @@ def create_block_header_with_signature(
         signature_domain=SignatureDomain.DOMAIN_BEACON_PROPOSER,
         slots_per_epoch=slots_per_epoch,
     )
-    return block_header.copy(signature=block_header_signature)
+    return block_header.set("signature", block_header_signature)
 
 
 #
@@ -297,7 +297,7 @@ def create_mock_proposer_slashing_at_block(
         slots_per_epoch,
     )
 
-    return ProposerSlashing(
+    return ProposerSlashing.create(
         proposer_index=proposer_index, header_1=block_header_1, header_2=block_header_2
     )
 
@@ -344,14 +344,14 @@ def create_mock_slashable_attestation(
     assert committees_per_slot > 0
     committee_index = CommitteeIndex(0)
 
-    attestation_data = AttestationData(
+    attestation_data = AttestationData.create(
         slot=attestation_slot,
         index=committee_index,
         beacon_block_root=beacon_block_root,
-        source=Checkpoint(
+        source=Checkpoint.create(
             epoch=state.current_justified_checkpoint.epoch, root=source_root
         ),
-        target=Checkpoint(
+        target=Checkpoint.create(
             epoch=compute_epoch_at_slot(attestation_slot, config.SLOTS_PER_EPOCH),
             root=target_root,
         ),
@@ -370,7 +370,7 @@ def create_mock_slashable_attestation(
     )
     validator_indices = tuple(committee[i] for i in attesting_indices)
 
-    return IndexedAttestation(
+    return IndexedAttestation.create(
         attesting_indices=validator_indices, data=attestation_data, signature=signature
     )
 
@@ -393,7 +393,7 @@ def create_mock_attester_slashing_is_double_vote(
         state, config, keymap, attestation_slot_2
     )
 
-    return AttesterSlashing(
+    return AttesterSlashing.create(
         attestation_1=slashable_attestation_1, attestation_2=slashable_attestation_2
     )
 
@@ -408,28 +408,29 @@ def create_mock_attester_slashing_is_surround_vote(
     attestation_slot_2 = compute_start_slot_at_epoch(
         attestation_epoch, config.SLOTS_PER_EPOCH
     )
-    attestation_slot_1 = Slot(attestation_slot_2 + config.SLOTS_PER_EPOCH)
+    attestation_slot_1 = Slot.create(attestation_slot_2 + config.SLOTS_PER_EPOCH)
 
     slashable_attestation_1 = create_mock_slashable_attestation(
-        state.copy(
-            slot=attestation_slot_1, current_justified_epoch=config.GENESIS_EPOCH
+        state.mset(
+            "slot", attestation_slot_1, "current_justified_epoch", config.GENESIS_EPOCH
         ),
         config,
         keymap,
         attestation_slot_1,
     )
     slashable_attestation_2 = create_mock_slashable_attestation(
-        state.copy(
-            slot=attestation_slot_1,
-            current_justified_epoch=config.GENESIS_EPOCH
-            + 1,  # source_epoch_1 < source_epoch_2
+        state.mset(
+            "slot",
+            attestation_slot_1,
+            "current_justified_epoch",
+            config.GENESIS_EPOCH + 1,  # source_epoch_1 < source_epoch_2
         ),
         config,
         keymap,
         attestation_slot_2,
     )
 
-    return AttesterSlashing(
+    return AttesterSlashing.create(
         attestation_1=slashable_attestation_1, attestation_2=slashable_attestation_2
     )
 
@@ -519,7 +520,7 @@ def _create_mock_signed_attestation(
     )
 
     # create attestation from attestation_data, particpipant_bitfield, and signature
-    return Attestation(
+    return Attestation.create(
         aggregation_bits=aggregation_bits,
         data=attestation_data,
         signature=aggregate_signature,
@@ -547,15 +548,15 @@ def create_signed_attestation_at_slot(
 
     target_root = _get_target_root(state, config, beacon_block_root)
 
-    attestation_data = AttestationData(
+    attestation_data = AttestationData.create(
         slot=attestation_slot,
         index=committee_index,
         beacon_block_root=beacon_block_root,
-        source=Checkpoint(
+        source=Checkpoint.create(
             epoch=state.current_justified_checkpoint.epoch,
             root=state.current_justified_checkpoint.root,
         ),
-        target=Checkpoint(root=target_root, epoch=target_epoch),
+        target=Checkpoint.create(root=target_root, epoch=target_epoch),
     )
 
     return _create_mock_signed_attestation(
@@ -599,15 +600,15 @@ def create_mock_signed_attestations_at_slot(
     for committee, committee_index, _ in iterate_committees_at_slot(
         state, attestation_slot, committees_per_slot, CommitteeConfig(config)
     ):
-        attestation_data = AttestationData(
+        attestation_data = AttestationData.create(
             slot=attestation_slot,
             index=CommitteeIndex(committee_index),
             beacon_block_root=beacon_block_root,
-            source=Checkpoint(
+            source=Checkpoint.create(
                 epoch=state.current_justified_checkpoint.epoch,
                 root=state.current_justified_checkpoint.root,
             ),
-            target=Checkpoint(root=target_root, epoch=target_epoch),
+            target=Checkpoint.create(root=target_root, epoch=target_epoch),
         )
 
         num_voted_attesters = int(len(committee) * voted_attesters_ratio)
@@ -635,16 +636,19 @@ def create_mock_voluntary_exit(
 ) -> VoluntaryExit:
     current_epoch = state.current_epoch(config.SLOTS_PER_EPOCH)
     target_epoch = current_epoch if exit_epoch is None else exit_epoch
-    voluntary_exit = VoluntaryExit(epoch=target_epoch, validator_index=validator_index)
-    return voluntary_exit.copy(
-        signature=sign_transaction(
+    voluntary_exit = VoluntaryExit.create(
+        epoch=target_epoch, validator_index=validator_index
+    )
+    return voluntary_exit.set(
+        "signature",
+        sign_transaction(
             message_hash=voluntary_exit.signing_root,
             privkey=keymap[state.validators[validator_index].pubkey],
             state=state,
             slot=compute_start_slot_at_epoch(target_epoch, config.SLOTS_PER_EPOCH),
             signature_domain=SignatureDomain.DOMAIN_VOLUNTARY_EXIT,
             slots_per_epoch=config.SLOTS_PER_EPOCH,
-        )
+        ),
     )
 
 

--- a/eth2/beacon/tools/builder/validator.py
+++ b/eth2/beacon/tools/builder/validator.py
@@ -408,7 +408,7 @@ def create_mock_attester_slashing_is_surround_vote(
     attestation_slot_2 = compute_start_slot_at_epoch(
         attestation_epoch, config.SLOTS_PER_EPOCH
     )
-    attestation_slot_1 = Slot.create(attestation_slot_2 + config.SLOTS_PER_EPOCH)
+    attestation_slot_1 = Slot(attestation_slot_2 + config.SLOTS_PER_EPOCH)
 
     slashable_attestation_1 = create_mock_slashable_attestation(
         state.mset(

--- a/eth2/beacon/tools/builder/validator.py
+++ b/eth2/beacon/tools/builder/validator.py
@@ -662,11 +662,11 @@ def create_mock_deposit_data(
     if amount is None:
         amount = config.MAX_EFFECTIVE_BALANCE
 
-    data = DepositData(
+    data = DepositData.create(
         pubkey=pubkey, withdrawal_credentials=withdrawal_credentials, amount=amount
     )
     signature = sign_proof_of_possession(deposit_data=data, privkey=privkey)
-    return data.copy(signature=signature)
+    return data.set("signature", signature)
 
 
 def make_deposit_tree_and_root(

--- a/eth2/beacon/tools/fixtures/conditions.py
+++ b/eth2/beacon/tools/fixtures/conditions.py
@@ -1,6 +1,5 @@
-from ssz.tools import to_formatted_dict
-
 from eth2.beacon.types.states import BeaconState
+from ssz.tools import to_formatted_dict
 
 
 def validate_state(post_state: BeaconState, expected_state: BeaconState) -> None:

--- a/eth2/beacon/tools/fixtures/format_type.py
+++ b/eth2/beacon/tools/fixtures/format_type.py
@@ -3,9 +3,8 @@ from abc import abstractmethod
 from pathlib import Path
 from typing import Any, Dict, Type
 
-import ssz
-
 from eth2.beacon.tools.fixtures.loading import load_yaml_at
+import ssz
 
 
 class FormatType(abc.ABC):

--- a/eth2/beacon/tools/fixtures/test_part.py
+++ b/eth2/beacon/tools/fixtures/test_part.py
@@ -2,9 +2,8 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Dict, Type, cast
 
-import ssz
-
 from eth2.beacon.tools.fixtures.format_type import FormatType, SSZType, YAMLType
+import ssz
 
 
 @dataclass

--- a/eth2/beacon/tools/fixtures/test_types/genesis.py
+++ b/eth2/beacon/tools/fixtures/test_types/genesis.py
@@ -1,7 +1,6 @@
 from typing import Any, Dict, Optional, Tuple, Type, cast
 
 from eth_typing import Hash32
-from ssz.sedes import bytes32
 
 from eth2.beacon.genesis import (
     initialize_beacon_state_from_eth1,
@@ -14,6 +13,7 @@ from eth2.beacon.types.deposits import Deposit
 from eth2.beacon.types.states import BeaconState
 from eth2.beacon.typing import Timestamp
 from eth2.configs import Eth2Config
+from ssz.sedes import bytes32
 
 from . import TestType
 

--- a/eth2/beacon/tools/fixtures/test_types/operations.py
+++ b/eth2/beacon/tools/fixtures/test_types/operations.py
@@ -77,8 +77,8 @@ class OperationHandler(
         # NOTE: we ignore the type here, otherwise need to spell out each of the keyword
         # arguments individually... save some work and just build them dynamically
         block = BeaconBlock.create(
-            body=BeaconBlockBody.create(  # type: ignore
-                **{f"{cls.name}s": (operation,)}
+            body=BeaconBlockBody.create(
+                **{f"{cls.name}s": (operation,)}  # type: ignore
             )
         )
         try:

--- a/eth2/beacon/tools/fixtures/test_types/operations.py
+++ b/eth2/beacon/tools/fixtures/test_types/operations.py
@@ -77,9 +77,9 @@ class OperationHandler(
         # NOTE: we ignore the type here, otherwise need to spell out each of the keyword
         # arguments individually... save some work and just build them dynamically
         block = BeaconBlock.create(
-            body=BeaconBlockBody.create(
+            body=BeaconBlockBody.create(  # type: ignore
                 **{f"{cls.name}s": (operation,)}
-            )  # type: ignore
+            )
         )
         try:
             return cls.processor(state, block, config)

--- a/eth2/beacon/tools/fixtures/test_types/operations.py
+++ b/eth2/beacon/tools/fixtures/test_types/operations.py
@@ -1,7 +1,6 @@
 from typing import Any, Dict, Optional, Tuple, Type, Union
 
 from eth_utils import ValidationError
-import ssz
 
 from eth2._utils.bls import SignatureError
 from eth2.beacon.state_machines.forks.serenity.block_processing import (
@@ -25,6 +24,7 @@ from eth2.beacon.types.proposer_slashings import ProposerSlashing
 from eth2.beacon.types.states import BeaconState
 from eth2.beacon.types.voluntary_exits import VoluntaryExit
 from eth2.configs import Eth2Config
+import ssz
 
 from . import TestType
 
@@ -76,8 +76,10 @@ class OperationHandler(
         # update API provided by `py-ssz`.
         # NOTE: we ignore the type here, otherwise need to spell out each of the keyword
         # arguments individually... save some work and just build them dynamically
-        block = BeaconBlock(
-            body=BeaconBlockBody(**{f"{cls.name}s": (operation,)})  # type: ignore
+        block = BeaconBlock.create(
+            body=BeaconBlockBody.create(
+                **{f"{cls.name}s": (operation,)}
+            )  # type: ignore
         )
         try:
             return cls.processor(state, block, config)

--- a/eth2/beacon/tools/fixtures/test_types/ssz_static.py
+++ b/eth2/beacon/tools/fixtures/test_types/ssz_static.py
@@ -1,8 +1,6 @@
 from typing import Any, Dict, Optional, Tuple, Type
 
 from eth_typing import Hash32
-import ssz
-from ssz.tools import from_formatted_dict
 
 from eth2.beacon.tools.fixtures.test_handler import TestHandler
 from eth2.beacon.tools.fixtures.test_part import TestPart
@@ -23,57 +21,62 @@ from eth2.beacon.types.states import BeaconState
 from eth2.beacon.types.validators import Validator
 from eth2.beacon.types.voluntary_exits import VoluntaryExit
 from eth2.configs import Eth2Config
+import ssz
+from ssz.hashable_container import HashableContainer, SignedHashableContainer
+from ssz.tools import from_formatted_dict
 
 from . import TestType
 
-InputType = Tuple[bytes, ssz.Serializable]
-OutputType = Tuple[bytes, ssz.Serializable, bytes, Tuple[Hash32, Optional[Hash32]]]
+InputType = Tuple[bytes, HashableContainer]
+OutputType = Tuple[bytes, HashableContainer, bytes, Tuple[Hash32, Optional[Hash32]]]
 
 
 def _deserialize_object_from_dict(
-    data: Dict[str, Any], object_type: ssz.Serializable
-) -> ssz.Serializable:
+    data: Dict[str, Any], object_type: Type[HashableContainer]
+) -> HashableContainer:
     if object_type == BeaconState:
         # NOTE: borrowing from `py-ssz`
-        parse_args = tuple(
-            data[field_name] for field_name in object_type._meta.field_names
-        )
-        input_args = from_formatted_dict(parse_args, object_type._meta.container_sedes)
-        input_kwargs = dict(zip(object_type._meta.field_names, input_args))
+        input_kwargs = {
+            field_name: from_formatted_dict(data[field_name], field_type)
+            for field_name, field_type in object_type._meta.fields
+        }
         # NOTE: we want to inject some additiona kwargs here,
         # due to non-standard (but still valid) SSZ inputs
         input_kwargs["validator_and_balance_length_check"] = False
-        return object_type(**input_kwargs)
+        return object_type.create(**input_kwargs)
     else:
         return from_formatted_dict(data, object_type)
 
 
 def _deserialize_object_from_yaml(
-    test_case_data: TestPart, object_type: ssz.Serializable
-) -> ssz.Serializable:
+    test_case_data: TestPart, object_type: Type[HashableContainer]
+) -> HashableContainer:
     yaml_data = test_case_data.load_yaml()
     return _deserialize_object_from_dict(yaml_data, object_type)
 
 
 def _deserialize_object_from_bytes(
-    data: bytes, object_type: ssz.Serializable
-) -> ssz.Serializable:
+    data: bytes, object_type: Type[HashableContainer]
+) -> HashableContainer:
     deserialized_fields = object_type._meta.container_sedes.deserialize(data)
-    deserialized_field_dict = dict(
-        zip(object_type._meta.field_names, deserialized_fields)
-    )
+    deserialized_field_dict = {
+        field_name: field_value
+        for (field_name, _), field_value in zip(
+            object_type._meta.fields, deserialized_fields
+        )
+    }
     if object_type == BeaconState:
         # NOTE: we want to inject some additiona kwargs here,
         # due to non-standard (but still valid) SSZ inputs
         deserialized_field_dict["validator_and_balance_length_check"] = False
-        return object_type(**deserialized_field_dict)
+        return object_type.create(**deserialized_field_dict)
     else:
-        return object_type(**deserialized_field_dict)
+        return object_type.create(**deserialized_field_dict)
 
 
 class SSZHandler(TestHandler[InputType, OutputType]):
     name: str
-    object_type: ssz.Serializable
+    object_type: HashableContainer
 
     @classmethod
     def parse_inputs(
@@ -107,13 +110,13 @@ class SSZHandler(TestHandler[InputType, OutputType]):
             serialized_ssz_object, cls.object_type
         )
         return (
-            cls.object_type.serialize(ssz_object_from_yaml),
+            ssz.encode(ssz_object_from_yaml, cls.object_type),
             deserialized_object,
-            cls.object_type.serialize(deserialized_object),
+            ssz.encode(deserialized_object, cls.object_type),
             (
                 ssz.get_hash_tree_root(ssz_object_from_yaml),
                 ssz_object_from_yaml.signing_root
-                if isinstance(ssz_object_from_yaml, ssz.SignedSerializable)
+                if isinstance(ssz_object_from_yaml, SignedHashableContainer)
                 else None,
             ),
         )

--- a/eth2/beacon/tools/misc/ssz_vector.py
+++ b/eth2/beacon/tools/misc/ssz_vector.py
@@ -1,17 +1,16 @@
 from typing import Dict
 
-import ssz
-import ssz.sedes as sedes
-
 from eth2.beacon.types.attestations import Attestation, IndexedAttestation
 from eth2.beacon.types.blocks import BeaconBlockBody
 from eth2.beacon.types.historical_batch import HistoricalBatch
 from eth2.beacon.types.pending_attestations import PendingAttestation
 from eth2.beacon.types.states import BeaconState
 from eth2.configs import Eth2Config
+from ssz.hashable_container import HashableContainer
+import ssz.sedes as sedes
 
 
-def _mk_overrides(config: Eth2Config) -> Dict[ssz.Serializable, Dict[str, int]]:
+def _mk_overrides(config: Eth2Config) -> Dict[HashableContainer, Dict[str, int]]:
     return {
         Attestation: {"aggregation_bits": config.MAX_VALIDATORS_PER_COMMITTEE},
         BeaconBlockBody: {
@@ -56,4 +55,5 @@ def override_lengths(config: Eth2Config) -> None:
                 if isinstance(field_sedes, sedes.List):
                     field_sedes.max_length = overrides[field_name]
                 if isinstance(field_sedes, sedes.Vector):
-                    field_sedes.length = overrides[field_name]
+                    # NOTE: Vector.length is a property that returns the value of max_length
+                    field_sedes.max_length = overrides[field_name]

--- a/eth2/beacon/types/aggregate_and_proof.py
+++ b/eth2/beacon/types/aggregate_and_proof.py
@@ -1,15 +1,19 @@
+from typing import Type, TypeVar
+
 from eth_typing import BLSSignature
 from eth_utils import humanize_hash
-import ssz
-from ssz.sedes import bytes96, uint64
 
 from eth2.beacon.constants import EMPTY_SIGNATURE
 from eth2.beacon.types.attestations import Attestation, default_attestation
 from eth2.beacon.types.defaults import default_validator_index
 from eth2.beacon.typing import ValidatorIndex
+from ssz.hashable_container import HashableContainer
+from ssz.sedes import bytes96, uint64
+
+TAggregateAndProof = TypeVar("TAggregateAndProof", bound="AggregateAndProof")
 
 
-class AggregateAndProof(ssz.Serializable):
+class AggregateAndProof(HashableContainer):
 
     fields = [
         ("index", uint64),
@@ -17,13 +21,14 @@ class AggregateAndProof(ssz.Serializable):
         ("aggregate", Attestation),
     ]
 
-    def __init__(
-        self,
+    @classmethod
+    def create(
+        cls: Type[TAggregateAndProof],
         index: ValidatorIndex = default_validator_index,
         selection_proof: BLSSignature = EMPTY_SIGNATURE,
         aggregate: Attestation = default_attestation,
-    ) -> None:
-        super().__init__(
+    ) -> TAggregateAndProof:
+        return super().create(
             index=index, selection_proof=selection_proof, aggregate=aggregate
         )
 
@@ -35,4 +40,4 @@ class AggregateAndProof(ssz.Serializable):
         )
 
 
-default_aggregate_and_proof = AggregateAndProof()
+default_aggregate_and_proof = AggregateAndProof.create()

--- a/eth2/beacon/types/attestation_data.py
+++ b/eth2/beacon/types/attestation_data.py
@@ -1,12 +1,13 @@
-from typing import TypeVar, Type
+from typing import Type, TypeVar
+
 from eth_utils import humanize_hash
-from ssz.hashable_container import HashableContainer
-from ssz.sedes import bytes32, uint64
 
 from eth2.beacon.constants import ZERO_SIGNING_ROOT
 from eth2.beacon.types.checkpoints import Checkpoint, default_checkpoint
 from eth2.beacon.types.defaults import default_committee_index, default_slot
 from eth2.beacon.typing import CommitteeIndex, SigningRoot, Slot
+from ssz.hashable_container import HashableContainer
+from ssz.sedes import bytes32, uint64
 
 TAttestationData = TypeVar("TAttestationData", bound="AttestationData")
 

--- a/eth2/beacon/types/attestation_data.py
+++ b/eth2/beacon/types/attestation_data.py
@@ -1,5 +1,6 @@
+from typing import TypeVar, Type
 from eth_utils import humanize_hash
-import ssz
+from ssz.hashable_container import HashableContainer
 from ssz.sedes import bytes32, uint64
 
 from eth2.beacon.constants import ZERO_SIGNING_ROOT
@@ -7,8 +8,10 @@ from eth2.beacon.types.checkpoints import Checkpoint, default_checkpoint
 from eth2.beacon.types.defaults import default_committee_index, default_slot
 from eth2.beacon.typing import CommitteeIndex, SigningRoot, Slot
 
+TAttestationData = TypeVar("TAttestationData", bound="AttestationData")
 
-class AttestationData(ssz.Serializable):
+
+class AttestationData(HashableContainer):
 
     fields = [
         ("slot", uint64),
@@ -20,15 +23,16 @@ class AttestationData(ssz.Serializable):
         ("target", Checkpoint),
     ]
 
-    def __init__(
-        self,
+    @classmethod
+    def create(
+        cls: Type[TAttestationData],
         slot: Slot = default_slot,
         index: CommitteeIndex = default_committee_index,
         beacon_block_root: SigningRoot = ZERO_SIGNING_ROOT,
         source: Checkpoint = default_checkpoint,
         target: Checkpoint = default_checkpoint,
-    ) -> None:
-        super().__init__(
+    ) -> TAttestationData:
+        return super().create(
             slot=slot,
             index=index,
             beacon_block_root=beacon_block_root,
@@ -46,4 +50,4 @@ class AttestationData(ssz.Serializable):
         )
 
 
-default_attestation_data = AttestationData()
+default_attestation_data = AttestationData.create()

--- a/eth2/beacon/types/attestations.py
+++ b/eth2/beacon/types/attestations.py
@@ -1,18 +1,20 @@
-from typing import Sequence
+from typing import Sequence, Type, TypeVar
 
 from eth_typing import BLSSignature
 from eth_utils import humanize_hash
-import ssz
-from ssz.sedes import Bitlist, List, bytes96, uint64
 
 from eth2.beacon.constants import EMPTY_SIGNATURE
 from eth2.beacon.typing import Bitfield, ValidatorIndex
+from ssz.hashable_container import HashableContainer
+from ssz.sedes import Bitlist, List, bytes96, uint64
 
 from .attestation_data import AttestationData, default_attestation_data
 from .defaults import default_bitfield, default_tuple
 
+TAttestation = TypeVar("TAttestation", bound="Attestation")
 
-class Attestation(ssz.Serializable):
+
+class Attestation(HashableContainer):
 
     fields = [
         ("aggregation_bits", Bitlist(1)),
@@ -20,13 +22,16 @@ class Attestation(ssz.Serializable):
         ("signature", bytes96),
     ]
 
-    def __init__(
-        self,
+    @classmethod
+    def create(
+        cls: Type[TAttestation],
         aggregation_bits: Bitfield = default_bitfield,
         data: AttestationData = default_attestation_data,
         signature: BLSSignature = EMPTY_SIGNATURE,
-    ) -> None:
-        super().__init__(aggregation_bits, data, signature)
+    ) -> TAttestation:
+        return super().create(
+            aggregation_bits=aggregation_bits, data=data, signature=signature
+        )
 
     def __str__(self) -> str:
         return (
@@ -36,10 +41,13 @@ class Attestation(ssz.Serializable):
         )
 
 
-default_attestation = Attestation()
+default_attestation = Attestation.create()
 
 
-class IndexedAttestation(ssz.Serializable):
+TIndexedAttestation = TypeVar("TIndexedAttestation", bound="IndexedAttestation")
+
+
+class IndexedAttestation(HashableContainer):
 
     fields = [
         # Validator indices
@@ -50,13 +58,16 @@ class IndexedAttestation(ssz.Serializable):
         ("signature", bytes96),
     ]
 
-    def __init__(
-        self,
+    @classmethod
+    def create(
+        cls: Type[TIndexedAttestation],
         attesting_indices: Sequence[ValidatorIndex] = default_tuple,
         data: AttestationData = default_attestation_data,
         signature: BLSSignature = EMPTY_SIGNATURE,
-    ) -> None:
-        super().__init__(attesting_indices, data, signature)
+    ) -> TIndexedAttestation:
+        return super().create(
+            attesting_indices=attesting_indices, data=data, signature=signature
+        )
 
     def __str__(self) -> str:
         return (
@@ -66,4 +77,4 @@ class IndexedAttestation(ssz.Serializable):
         )
 
 
-default_indexed_attestation = IndexedAttestation()
+default_indexed_attestation = IndexedAttestation.create()

--- a/eth2/beacon/types/attester_slashings.py
+++ b/eth2/beacon/types/attester_slashings.py
@@ -1,9 +1,13 @@
-import ssz
+from typing import Type, TypeVar
+
+from ssz.hashable_container import HashableContainer
 
 from .attestations import IndexedAttestation, default_indexed_attestation
 
+TAttesterSlashing = TypeVar("TAttesterSlashing", bound="AttesterSlashing")
 
-class AttesterSlashing(ssz.Serializable):
+
+class AttesterSlashing(HashableContainer):
 
     fields = [
         # First attestation
@@ -12,12 +16,13 @@ class AttesterSlashing(ssz.Serializable):
         ("attestation_2", IndexedAttestation),
     ]
 
-    def __init__(
-        self,
+    @classmethod
+    def create(
+        cls: Type[TAttesterSlashing],
         attestation_1: IndexedAttestation = default_indexed_attestation,
         attestation_2: IndexedAttestation = default_indexed_attestation,
-    ) -> None:
-        super().__init__(attestation_1, attestation_2)
+    ) -> TAttesterSlashing:
+        return super().create(attestation_1=attestation_1, attestation_2=attestation_2)
 
     def __str__(self) -> str:
         return (

--- a/eth2/beacon/types/block_headers.py
+++ b/eth2/beacon/types/block_headers.py
@@ -1,16 +1,20 @@
+from typing import Type, TypeVar
+
 from eth.constants import ZERO_HASH32
 from eth_typing import BLSSignature, Hash32
 from eth_utils import humanize_hash
-import ssz
-from ssz.sedes import bytes32, bytes96, uint64
 
 from eth2.beacon.constants import EMPTY_SIGNATURE, ZERO_SIGNING_ROOT
 from eth2.beacon.typing import SigningRoot, Slot
+from ssz.hashable_container import SignedHashableContainer
+from ssz.sedes import bytes32, bytes96, uint64
 
 from .defaults import default_slot
 
+TBeaconBlockHeader = TypeVar("TBeaconBlockHeader", bound="BeaconBlockHeader")
 
-class BeaconBlockHeader(ssz.SignedSerializable):
+
+class BeaconBlockHeader(SignedHashableContainer):
 
     fields = [
         ("slot", uint64),
@@ -20,16 +24,17 @@ class BeaconBlockHeader(ssz.SignedSerializable):
         ("signature", bytes96),
     ]
 
-    def __init__(
-        self,
+    @classmethod
+    def create(
+        cls: Type[TBeaconBlockHeader],
         *,
         slot: Slot = default_slot,
         parent_root: SigningRoot = ZERO_SIGNING_ROOT,
         state_root: Hash32 = ZERO_HASH32,
         body_root: Hash32 = ZERO_HASH32,
         signature: BLSSignature = EMPTY_SIGNATURE,
-    ):
-        super().__init__(
+    ) -> TBeaconBlockHeader:
+        return super().create(
             slot=slot,
             parent_root=parent_root,
             state_root=state_root,
@@ -52,4 +57,4 @@ class BeaconBlockHeader(ssz.SignedSerializable):
         return f"<{self.__class__.__name__}: {str(self)}>"
 
 
-default_beacon_block_header = BeaconBlockHeader()
+default_beacon_block_header = BeaconBlockHeader.create()

--- a/eth2/beacon/types/blocks.py
+++ b/eth2/beacon/types/blocks.py
@@ -211,7 +211,7 @@ class BeaconBlock(BaseBeaconBlock):
             slot=slot,
             parent_root=parent_block.signing_root,
             state_root=parent_block.state_root,
-            body=cls.block_body_class(),
+            body=cls.block_body_class.create(),
         )
 
     @classmethod

--- a/eth2/beacon/types/blocks.py
+++ b/eth2/beacon/types/blocks.py
@@ -1,12 +1,10 @@
 from abc import ABC, abstractmethod
-from typing import TYPE_CHECKING, Sequence
+from typing import TYPE_CHECKING, Sequence, Type, TypeVar
 
 from eth._utils.datatypes import Configurable
 from eth.constants import ZERO_HASH32
 from eth_typing import BLSSignature, Hash32
 from eth_utils import humanize_hash
-import ssz
-from ssz.sedes import List, bytes32, bytes96, uint64
 
 from eth2.beacon.constants import (
     EMPTY_SIGNATURE,
@@ -14,6 +12,8 @@ from eth2.beacon.constants import (
     ZERO_SIGNING_ROOT,
 )
 from eth2.beacon.typing import FromBlockParams, SigningRoot, Slot
+from ssz.hashable_container import HashableContainer, SignedHashableContainer
+from ssz.sedes import List, bytes32, bytes96, uint64
 
 from .attestations import Attestation
 from .attester_slashings import AttesterSlashing
@@ -28,7 +28,10 @@ if TYPE_CHECKING:
     from eth2.beacon.db.chain import BaseBeaconChainDB  # noqa: F401
 
 
-class BeaconBlockBody(ssz.Serializable):
+TBeaconBlockBody = TypeVar("TBeaconBlockBody", bound="BeaconBlockBody")
+
+
+class BeaconBlockBody(HashableContainer):
 
     fields = [
         ("randao_reveal", bytes96),
@@ -41,8 +44,9 @@ class BeaconBlockBody(ssz.Serializable):
         ("voluntary_exits", List(VoluntaryExit, 1)),
     ]
 
-    def __init__(
-        self,
+    @classmethod
+    def create(
+        cls: Type[TBeaconBlockBody],
         *,
         randao_reveal: bytes96 = EMPTY_SIGNATURE,
         eth1_data: Eth1Data = default_eth1_data,
@@ -52,8 +56,8 @@ class BeaconBlockBody(ssz.Serializable):
         attestations: Sequence[Attestation] = default_tuple,
         deposits: Sequence[Deposit] = default_tuple,
         voluntary_exits: Sequence[VoluntaryExit] = default_tuple,
-    ) -> None:
-        super().__init__(
+    ) -> TBeaconBlockBody:
+        return super().create(
             randao_reveal=randao_reveal,
             eth1_data=eth1_data,
             graffiti=graffiti,
@@ -83,10 +87,13 @@ class BeaconBlockBody(ssz.Serializable):
         return f"<{self.__class__.__name__}: {str(self)}>"
 
 
-default_beacon_block_body = BeaconBlockBody()
+default_beacon_block_body = BeaconBlockBody.create()
 
 
-class BaseBeaconBlock(ssz.SignedSerializable, Configurable, ABC):
+TBaseBeaconBlock = TypeVar("TBaseBeaconBlock", bound="BaseBeaconBlock")
+
+
+class BaseBeaconBlock(SignedHashableContainer, Configurable, ABC):
     fields = [
         ("slot", uint64),
         ("parent_root", bytes32),
@@ -95,16 +102,17 @@ class BaseBeaconBlock(ssz.SignedSerializable, Configurable, ABC):
         ("signature", bytes96),
     ]
 
-    def __init__(
-        self,
+    @classmethod
+    def create(
+        cls: Type[TBaseBeaconBlock],
         *,
         slot: Slot = default_slot,
         parent_root: SigningRoot = ZERO_SIGNING_ROOT,
         state_root: Hash32 = ZERO_HASH32,
         body: BeaconBlockBody = default_beacon_block_body,
         signature: BLSSignature = EMPTY_SIGNATURE,
-    ) -> None:
-        super().__init__(
+    ) -> TBaseBeaconBlock:
+        return super().create(
             slot=slot,
             parent_root=parent_root,
             state_root=state_root,
@@ -129,7 +137,7 @@ class BaseBeaconBlock(ssz.SignedSerializable, Configurable, ABC):
 
     @property
     def header(self) -> BeaconBlockHeader:
-        return BeaconBlockHeader(
+        return BeaconBlockHeader.create(
             slot=self.slot,
             parent_root=self.parent_root,
             state_root=self.state_root,
@@ -151,6 +159,9 @@ class BaseBeaconBlock(ssz.SignedSerializable, Configurable, ABC):
         return f"<{self.__class__.__name__}: {str(self)}>"
 
 
+TBeaconBlock = TypeVar("TBeaconBlock", bound="BeaconBlock")
+
+
 class BeaconBlock(BaseBeaconBlock):
     block_body_class = BeaconBlockBody
 
@@ -162,7 +173,7 @@ class BeaconBlock(BaseBeaconBlock):
         Return the block denoted by the given block ``root``.
         """
         block = chaindb.get_block_by_root(root, cls)
-        body = cls.block_body_class(
+        body = cls.block_body_class.create(
             randao_reveal=block.body.randao_reveal,
             eth1_data=block.body.eth1_data,
             graffiti=block.body.graffiti,
@@ -173,7 +184,7 @@ class BeaconBlock(BaseBeaconBlock):
             voluntary_exits=block.body.voluntary_exits,
         )
 
-        return cls(
+        return cls.create(
             slot=block.slot,
             parent_root=block.parent_root,
             state_root=block.state_root,
@@ -183,8 +194,10 @@ class BeaconBlock(BaseBeaconBlock):
 
     @classmethod
     def from_parent(
-        cls, parent_block: "BaseBeaconBlock", block_params: FromBlockParams
-    ) -> "BaseBeaconBlock":
+        cls: Type[TBaseBeaconBlock],
+        parent_block: "BaseBeaconBlock",
+        block_params: FromBlockParams,
+    ) -> TBaseBeaconBlock:
         """
         Initialize a new block with the ``parent_block`` as the block's
         previous block root.
@@ -194,7 +207,7 @@ class BeaconBlock(BaseBeaconBlock):
         else:
             slot = block_params.slot
 
-        return cls(
+        return cls.create(
             slot=slot,
             parent_root=parent_block.signing_root,
             state_root=parent_block.state_root,
@@ -202,8 +215,10 @@ class BeaconBlock(BaseBeaconBlock):
         )
 
     @classmethod
-    def convert_block(cls, block: "BaseBeaconBlock") -> "BeaconBlock":
-        return cls(
+    def convert_block(
+        cls: Type[TBaseBeaconBlock], block: "BaseBeaconBlock"
+    ) -> TBaseBeaconBlock:
+        return cls.create(
             slot=block.slot,
             parent_root=block.parent_root,
             state_root=block.state_root,
@@ -212,8 +227,10 @@ class BeaconBlock(BaseBeaconBlock):
         )
 
     @classmethod
-    def from_header(cls, header: BeaconBlockHeader) -> "BeaconBlock":
-        return cls(
+    def from_header(
+        cls: Type[TBaseBeaconBlock], header: BeaconBlockHeader
+    ) -> TBeaconBlock:
+        return cls.create(
             slot=header.slot,
             parent_root=header.parent_root,
             state_root=header.state_root,

--- a/eth2/beacon/types/blocks.py
+++ b/eth2/beacon/types/blocks.py
@@ -37,11 +37,11 @@ class BeaconBlockBody(HashableContainer):
         ("randao_reveal", bytes96),
         ("eth1_data", Eth1Data),
         ("graffiti", bytes32),
-        ("proposer_slashings", List(ProposerSlashing, 1)),
+        ("proposer_slashings", List(ProposerSlashing, 16)),
         ("attester_slashings", List(AttesterSlashing, 1)),
-        ("attestations", List(Attestation, 1)),
-        ("deposits", List(Deposit, 1)),
-        ("voluntary_exits", List(VoluntaryExit, 1)),
+        ("attestations", List(Attestation, 128)),
+        ("deposits", List(Deposit, 16)),
+        ("voluntary_exits", List(VoluntaryExit, 16)),
     ]
 
     @classmethod
@@ -70,7 +70,7 @@ class BeaconBlockBody(HashableContainer):
 
     @property
     def is_empty(self) -> bool:
-        return self == BeaconBlockBody()
+        return self == BeaconBlockBody.create()
 
     def __str__(self) -> str:
         return (

--- a/eth2/beacon/types/checkpoints.py
+++ b/eth2/beacon/types/checkpoints.py
@@ -1,24 +1,31 @@
+from typing import Type, TypeVar
+
 from eth_utils import humanize_hash
-import ssz
-from ssz.sedes import bytes32, uint64
 
 from eth2.beacon.constants import ZERO_SIGNING_ROOT
 from eth2.beacon.typing import Epoch, SigningRoot
+from ssz.hashable_container import HashableContainer
+from ssz.sedes import bytes32, uint64
 
 from .defaults import default_epoch
 
+TCheckpoint = TypeVar("TCheckpoint", bound="Checkpoint")
 
-class Checkpoint(ssz.Serializable):
+
+class Checkpoint(HashableContainer):
 
     fields = [("epoch", uint64), ("root", bytes32)]
 
-    def __init__(
-        self, epoch: Epoch = default_epoch, root: SigningRoot = ZERO_SIGNING_ROOT
-    ) -> None:
-        super().__init__(epoch=epoch, root=root)
+    @classmethod
+    def create(
+        cls: Type[TCheckpoint],
+        epoch: Epoch = default_epoch,
+        root: SigningRoot = ZERO_SIGNING_ROOT,
+    ) -> TCheckpoint:
+        return super().create(epoch=epoch, root=root)
 
     def __str__(self) -> str:
         return f"{self.epoch}, {humanize_hash(self.root)}"
 
 
-default_checkpoint = Checkpoint()
+default_checkpoint = Checkpoint.create()

--- a/eth2/beacon/types/deposit_data.py
+++ b/eth2/beacon/types/deposit_data.py
@@ -1,16 +1,20 @@
+from typing import Type, TypeVar
+
 from eth.constants import ZERO_HASH32
 from eth_typing import BLSPubkey, BLSSignature, Hash32
 from eth_utils import humanize_hash
-import ssz
-from ssz.sedes import bytes32, bytes48, bytes96, uint64
 
 from eth2.beacon.constants import EMPTY_SIGNATURE
 from eth2.beacon.typing import Gwei
+from ssz.hashable_container import HashableContainer
+from ssz.sedes import bytes32, bytes48, bytes96, uint64
 
 from .defaults import default_bls_pubkey, default_gwei
 
+TDepositData = TypeVar("TDepositData", bound="DepositData")
 
-class DepositData(ssz.SignedSerializable):
+
+class DepositData(HashableContainer):
     """
     :class:`~eth2.beacon.types.deposit_data.DepositData` corresponds to the data broadcast from the
     Ethereum 1.0 deposit contract after a successful call to the ``deposit`` function on that
@@ -25,14 +29,15 @@ class DepositData(ssz.SignedSerializable):
         ("signature", bytes96),
     ]
 
-    def __init__(
-        self,
+    @classmethod
+    def create(
+        cls: Type[TDepositData],
         pubkey: BLSPubkey = default_bls_pubkey,
         withdrawal_credentials: Hash32 = ZERO_HASH32,
         amount: Gwei = default_gwei,
         signature: BLSSignature = EMPTY_SIGNATURE,
-    ) -> None:
-        super().__init__(
+    ) -> TDepositData:
+        return super().create(
             pubkey=pubkey,
             withdrawal_credentials=withdrawal_credentials,
             amount=amount,
@@ -50,4 +55,4 @@ class DepositData(ssz.SignedSerializable):
         return f"<{self.__class__.__name__}: {str(self)}>"
 
 
-default_deposit_data = DepositData()
+default_deposit_data = DepositData.create()

--- a/eth2/beacon/types/deposit_data.py
+++ b/eth2/beacon/types/deposit_data.py
@@ -6,7 +6,7 @@ from eth_utils import humanize_hash
 
 from eth2.beacon.constants import EMPTY_SIGNATURE
 from eth2.beacon.typing import Gwei
-from ssz.hashable_container import HashableContainer
+from ssz.hashable_container import SignedHashableContainer
 from ssz.sedes import bytes32, bytes48, bytes96, uint64
 
 from .defaults import default_bls_pubkey, default_gwei
@@ -14,7 +14,7 @@ from .defaults import default_bls_pubkey, default_gwei
 TDepositData = TypeVar("TDepositData", bound="DepositData")
 
 
-class DepositData(HashableContainer):
+class DepositData(SignedHashableContainer):
     """
     :class:`~eth2.beacon.types.deposit_data.DepositData` corresponds to the data broadcast from the
     Ethereum 1.0 deposit contract after a successful call to the ``deposit`` function on that

--- a/eth2/beacon/types/deposits.py
+++ b/eth2/beacon/types/deposits.py
@@ -1,12 +1,12 @@
-from typing import Sequence
+from typing import Sequence, Type, TypeVar
 
 from eth.constants import ZERO_HASH32
 from eth_typing import Hash32
 from eth_utils import humanize_hash
-import ssz
-from ssz.sedes import Vector, bytes32
 
 from eth2.beacon.constants import DEPOSIT_CONTRACT_TREE_DEPTH
+from ssz.hashable_container import HashableContainer
+from ssz.sedes import Vector, bytes32
 
 from .defaults import default_tuple_of_size
 from .deposit_data import DepositData, default_deposit_data
@@ -16,7 +16,10 @@ DEPOSIT_PROOF_VECTOR_SIZE = DEPOSIT_CONTRACT_TREE_DEPTH + 1
 default_proof_tuple = default_tuple_of_size(DEPOSIT_PROOF_VECTOR_SIZE, ZERO_HASH32)
 
 
-class Deposit(ssz.Serializable):
+TDeposit = TypeVar("TDeposit", bound="Deposit")
+
+
+class Deposit(HashableContainer):
     """
     A :class:`~eth2.beacon.types.deposits.Deposit` contains the data represented by an instance
     of :class:`~eth2.beacon.types.deposit_data.DepositData`, along with a Merkle proof that can be
@@ -29,12 +32,13 @@ class Deposit(ssz.Serializable):
         ("data", DepositData),
     ]
 
-    def __init__(
-        self,
+    @classmethod
+    def create(
+        cls: Type[TDeposit],
         proof: Sequence[Hash32] = default_proof_tuple,
         data: DepositData = default_deposit_data,
-    ) -> None:
-        super().__init__(proof, data)
+    ) -> TDeposit:
+        return super().create(proof=proof, data=data)
 
     def __str__(self) -> str:
         return (

--- a/eth2/beacon/types/eth1_data.py
+++ b/eth2/beacon/types/eth1_data.py
@@ -1,11 +1,16 @@
+from typing import Type, TypeVar
+
 from eth.constants import ZERO_HASH32
 from eth_typing import Hash32
 from eth_utils import humanize_hash
-import ssz
+
+from ssz.hashable_container import HashableContainer
 from ssz.sedes import bytes32, uint64
 
+TEth1Data = TypeVar("TEth1Data", bound="Eth1Data")
 
-class Eth1Data(ssz.Serializable):
+
+class Eth1Data(HashableContainer):
 
     fields = [
         ("deposit_root", bytes32),
@@ -13,13 +18,14 @@ class Eth1Data(ssz.Serializable):
         ("block_hash", bytes32),
     ]
 
-    def __init__(
-        self,
+    @classmethod
+    def create(
+        cls: Type[TEth1Data],
         deposit_root: Hash32 = ZERO_HASH32,
         deposit_count: int = 0,
         block_hash: Hash32 = ZERO_HASH32,
-    ) -> None:
-        super().__init__(
+    ) -> TEth1Data:
+        return super().create(
             deposit_root=deposit_root,
             deposit_count=deposit_count,
             block_hash=block_hash,
@@ -33,4 +39,4 @@ class Eth1Data(ssz.Serializable):
         )
 
 
-default_eth1_data = Eth1Data()
+default_eth1_data = Eth1Data.create()

--- a/eth2/beacon/types/forks.py
+++ b/eth2/beacon/types/forks.py
@@ -1,13 +1,17 @@
+from typing import Type, TypeVar
+
 from eth_utils import humanize_hash
-import ssz
-from ssz.sedes import bytes4, uint64
 
 from eth2.beacon.typing import Epoch, Version
+from ssz.hashable_container import HashableContainer
+from ssz.sedes import bytes4, uint64
 
 from .defaults import default_epoch, default_version
 
+TFork = TypeVar("TFork", bound="Fork")
 
-class Fork(ssz.Serializable):
+
+class Fork(HashableContainer):
 
     fields = [
         ("previous_version", bytes4),
@@ -16,13 +20,14 @@ class Fork(ssz.Serializable):
         ("epoch", uint64),
     ]
 
-    def __init__(
-        self,
+    @classmethod
+    def create(
+        cls: Type[TFork],
         previous_version: Version = default_version,
         current_version: Version = default_version,
         epoch: Epoch = default_epoch,
-    ) -> None:
-        super().__init__(
+    ) -> TFork:
+        return super().create(
             previous_version=previous_version,
             current_version=current_version,
             epoch=epoch,
@@ -36,4 +41,4 @@ class Fork(ssz.Serializable):
         )
 
 
-default_fork = Fork()
+default_fork = Fork.create()

--- a/eth2/beacon/types/historical_batch.py
+++ b/eth2/beacon/types/historical_batch.py
@@ -1,28 +1,31 @@
-from typing import Sequence
+from typing import Sequence, Type, TypeVar
 
 from eth.constants import ZERO_HASH32
 from eth_typing import Hash32
-import ssz
-from ssz.sedes import Vector, bytes32
 
 from eth2.beacon.constants import ZERO_SIGNING_ROOT
 from eth2.beacon.typing import SigningRoot
 from eth2.configs import Eth2Config
+from ssz.hashable_container import HashableContainer
+from ssz.sedes import Vector, bytes32
 
 from .defaults import default_tuple, default_tuple_of_size
 
+THistoricalBatch = TypeVar("THistoricalBatch", bound="HistoricalBatch")
 
-class HistoricalBatch(ssz.Serializable):
+
+class HistoricalBatch(HashableContainer):
 
     fields = [("block_roots", Vector(bytes32, 1)), ("state_roots", Vector(bytes32, 1))]
 
-    def __init__(
-        self,
+    @classmethod
+    def create(
+        cls: Type[THistoricalBatch],
         *,
         block_roots: Sequence[SigningRoot] = default_tuple,
         state_roots: Sequence[Hash32] = default_tuple,
         config: Eth2Config = None
-    ) -> None:
+    ) -> THistoricalBatch:
         if config:
             # try to provide sane defaults
             if block_roots == default_tuple:
@@ -34,4 +37,4 @@ class HistoricalBatch(ssz.Serializable):
                     config.SLOTS_PER_HISTORICAL_ROOT, ZERO_HASH32
                 )
 
-        super().__init__(block_roots=block_roots, state_roots=state_roots)
+        return super().create(block_roots=block_roots, state_roots=state_roots)

--- a/eth2/beacon/types/pending_attestations.py
+++ b/eth2/beacon/types/pending_attestations.py
@@ -1,13 +1,16 @@
-import ssz
-from ssz.sedes import Bitlist, uint64
+from typing import Type, TypeVar
 
 from eth2.beacon.typing import Bitfield, ValidatorIndex
+from ssz.hashable_container import HashableContainer
+from ssz.sedes import Bitlist, uint64
 
 from .attestation_data import AttestationData, default_attestation_data
 from .defaults import default_bitfield, default_validator_index
 
+TPendingAttestation = TypeVar("TPendingAttestation", bound="PendingAttestation")
 
-class PendingAttestation(ssz.Serializable):
+
+class PendingAttestation(HashableContainer):
 
     fields = [
         ("aggregation_bits", Bitlist(1)),
@@ -16,14 +19,15 @@ class PendingAttestation(ssz.Serializable):
         ("proposer_index", uint64),
     ]
 
-    def __init__(
-        self,
+    @classmethod
+    def create(
+        cls: Type[TPendingAttestation],
         aggregation_bits: Bitfield = default_bitfield,
         data: AttestationData = default_attestation_data,
         inclusion_delay: int = 0,
         proposer_index: ValidatorIndex = default_validator_index,
-    ) -> None:
-        super().__init__(
+    ) -> TPendingAttestation:
+        return super().create(
             aggregation_bits=aggregation_bits,
             data=data,
             inclusion_delay=inclusion_delay,

--- a/eth2/beacon/types/proposer_slashings.py
+++ b/eth2/beacon/types/proposer_slashings.py
@@ -1,13 +1,16 @@
-import ssz
-from ssz.sedes import uint64
+from typing import Type, TypeVar
 
 from eth2.beacon.typing import ValidatorIndex
+from ssz.hashable_container import HashableContainer
+from ssz.sedes import uint64
 
 from .block_headers import BeaconBlockHeader, default_beacon_block_header
 from .defaults import default_validator_index
 
+TProposerSlashing = TypeVar("TProposerSlashing", bound="ProposerSlashing")
 
-class ProposerSlashing(ssz.Serializable):
+
+class ProposerSlashing(HashableContainer):
 
     fields = [
         # Proposer index
@@ -18,13 +21,14 @@ class ProposerSlashing(ssz.Serializable):
         ("header_2", BeaconBlockHeader),
     ]
 
-    def __init__(
-        self,
+    @classmethod
+    def create(
+        cls: Type[TProposerSlashing],
         proposer_index: ValidatorIndex = default_validator_index,
         header_1: BeaconBlockHeader = default_beacon_block_header,
         header_2: BeaconBlockHeader = default_beacon_block_header,
-    ) -> None:
-        super().__init__(
+    ) -> TProposerSlashing:
+        return super().create(
             proposer_index=proposer_index, header_1=header_1, header_2=header_2
         )
 

--- a/eth2/beacon/types/states.py
+++ b/eth2/beacon/types/states.py
@@ -1,10 +1,9 @@
-from typing import Any, Callable, Sequence, Type, TypeVar
+from typing import Sequence, Type, TypeVar
 
 from eth.constants import ZERO_HASH32
 from eth_typing import Hash32
 from eth_utils import humanize_hash
 
-from eth2._utils.tuple import update_tuple_item
 from eth2.beacon.constants import JUSTIFICATION_BITS_LENGTH, ZERO_SIGNING_ROOT
 from eth2.beacon.helpers import compute_epoch_at_slot
 from eth2.beacon.typing import (
@@ -14,7 +13,6 @@ from eth2.beacon.typing import (
     SigningRoot,
     Slot,
     Timestamp,
-    ValidatorIndex,
 )
 from eth2.configs import Eth2Config
 from ssz.hashable_container import HashableContainer

--- a/eth2/beacon/types/states.py
+++ b/eth2/beacon/types/states.py
@@ -4,7 +4,7 @@ from eth.constants import ZERO_HASH32
 from eth_typing import Hash32
 from eth_utils import humanize_hash
 
-from eth2._utils.tuple import update_tuple_item, update_tuple_item_with_fn
+from eth2._utils.tuple import update_tuple_item
 from eth2.beacon.constants import JUSTIFICATION_BITS_LENGTH, ZERO_SIGNING_ROOT
 from eth2.beacon.helpers import compute_epoch_at_slot
 from eth2.beacon.typing import (
@@ -18,8 +18,6 @@ from eth2.beacon.typing import (
 )
 from eth2.configs import Eth2Config
 from ssz.hashable_container import HashableContainer
-from ssz.hashable_list import HashableList
-from ssz.hashable_vector import HashableVector
 from ssz.sedes import Bitvector, List, Vector, bytes32, uint64
 
 from .block_headers import BeaconBlockHeader, default_beacon_block_header
@@ -96,19 +94,11 @@ class BeaconState(HashableContainer):
         state_roots: Sequence[Hash32] = default_tuple,
         historical_roots: Sequence[Hash32] = default_tuple,
         eth1_data: Eth1Data = default_eth1_data,
-        eth1_data_votes: Sequence[Eth1Data] = HashableList.from_iterable(
-            (), List(Eth1Data, 2 ** 8)  # TODO
-        ),
+        eth1_data_votes: Sequence[Eth1Data] = default_tuple,
         eth1_deposit_index: int = 0,
-        validators: Sequence[Validator] = HashableList.from_iterable(
-            (), List(Validator, 2 ** 8)  # TODO
-        ),
-        balances: Sequence[Gwei] = HashableList.from_iterable(
-            (), List(uint64, 2 ** 8)  # TODO
-        ),
-        randao_mixes: Sequence[Hash32] = HashableVector.from_iterable(
-            (b"\x00" * 32,) * 2 ** 8, Vector(bytes32, 2 ** 8)  # TODO
-        ),
+        validators: Sequence[Validator] = default_tuple,
+        balances: Sequence[Gwei] = default_tuple,
+        randao_mixes: Sequence[Hash32] = (b"\x00" * 32,) * 2 ** 8,  # TODO
         slashings: Sequence[Gwei] = default_tuple,
         previous_epoch_attestations: Sequence[PendingAttestation] = default_tuple,
         current_epoch_attestations: Sequence[PendingAttestation] = default_tuple,

--- a/eth2/beacon/types/states.py
+++ b/eth2/beacon/types/states.py
@@ -30,6 +30,15 @@ default_justification_bits = Bitfield((False,) * JUSTIFICATION_BITS_LENGTH)
 TBeaconState = TypeVar("TBeaconState", bound="BeaconState")
 
 
+# Use mainnet constants for defaults. We can't import the config object because of an import cycle.
+# TODO: When py-ssz is updated to support size configs, the config will be passed to the `create`
+# classmethod and we can create the defaults dynamically there.
+default_block_roots = default_tuple_of_size(2 ** 13, ZERO_HASH32)
+default_state_roots = default_tuple_of_size(2 ** 13, ZERO_HASH32)
+default_randao_mixes = default_tuple_of_size(2 ** 16, ZERO_HASH32)
+default_slashings = default_tuple_of_size(2 ** 13, 0)
+
+
 class BeaconState(HashableContainer):
 
     fields = [
@@ -81,16 +90,16 @@ class BeaconState(HashableContainer):
         slot: Slot = default_slot,
         fork: Fork = default_fork,
         latest_block_header: BeaconBlockHeader = default_beacon_block_header,
-        block_roots: Sequence[SigningRoot] = default_tuple,
-        state_roots: Sequence[Hash32] = default_tuple,
+        block_roots: Sequence[SigningRoot] = default_block_roots,
+        state_roots: Sequence[Hash32] = default_state_roots,
         historical_roots: Sequence[Hash32] = default_tuple,
         eth1_data: Eth1Data = default_eth1_data,
         eth1_data_votes: Sequence[Eth1Data] = default_tuple,
         eth1_deposit_index: int = 0,
         validators: Sequence[Validator] = default_tuple,
         balances: Sequence[Gwei] = default_tuple,
-        randao_mixes: Sequence[Hash32] = (Hash32(b"\x00" * 32),) * 2 ** 8,  # TODO
-        slashings: Sequence[Gwei] = default_tuple,
+        randao_mixes: Sequence[Hash32] = default_randao_mixes,
+        slashings: Sequence[Gwei] = default_slashings,
         previous_epoch_attestations: Sequence[PendingAttestation] = default_tuple,
         current_epoch_attestations: Sequence[PendingAttestation] = default_tuple,
         justification_bits: Bitfield = default_justification_bits,

--- a/eth2/beacon/types/states.py
+++ b/eth2/beacon/types/states.py
@@ -6,14 +6,7 @@ from eth_utils import humanize_hash
 
 from eth2.beacon.constants import JUSTIFICATION_BITS_LENGTH, ZERO_SIGNING_ROOT
 from eth2.beacon.helpers import compute_epoch_at_slot
-from eth2.beacon.typing import (
-    Bitfield,
-    Epoch,
-    Gwei,
-    SigningRoot,
-    Slot,
-    Timestamp,
-)
+from eth2.beacon.typing import Bitfield, Epoch, Gwei, SigningRoot, Slot, Timestamp
 from eth2.configs import Eth2Config
 from ssz.hashable_container import HashableContainer
 from ssz.sedes import Bitvector, List, Vector, bytes32, uint64
@@ -96,7 +89,7 @@ class BeaconState(HashableContainer):
         eth1_deposit_index: int = 0,
         validators: Sequence[Validator] = default_tuple,
         balances: Sequence[Gwei] = default_tuple,
-        randao_mixes: Sequence[Hash32] = (b"\x00" * 32,) * 2 ** 8,  # TODO
+        randao_mixes: Sequence[Hash32] = (Hash32(b"\x00" * 32),) * 2 ** 8,  # TODO
         slashings: Sequence[Gwei] = default_tuple,
         previous_epoch_attestations: Sequence[PendingAttestation] = default_tuple,
         current_epoch_attestations: Sequence[PendingAttestation] = default_tuple,

--- a/eth2/beacon/types/states.py
+++ b/eth2/beacon/types/states.py
@@ -19,6 +19,7 @@ from eth2.beacon.typing import (
 from eth2.configs import Eth2Config
 from ssz.hashable_container import HashableContainer
 from ssz.hashable_list import HashableList
+from ssz.hashable_vector import HashableVector
 from ssz.sedes import Bitvector, List, Vector, bytes32, uint64
 
 from .block_headers import BeaconBlockHeader, default_beacon_block_header
@@ -95,7 +96,9 @@ class BeaconState(HashableContainer):
         state_roots: Sequence[Hash32] = default_tuple,
         historical_roots: Sequence[Hash32] = default_tuple,
         eth1_data: Eth1Data = default_eth1_data,
-        eth1_data_votes: Sequence[Eth1Data] = default_tuple,
+        eth1_data_votes: Sequence[Eth1Data] = HashableList.from_iterable(
+            (), List(Eth1Data, 2 ** 8)  # TODO
+        ),
         eth1_deposit_index: int = 0,
         validators: Sequence[Validator] = HashableList.from_iterable(
             (), List(Validator, 2 ** 8)  # TODO
@@ -103,7 +106,9 @@ class BeaconState(HashableContainer):
         balances: Sequence[Gwei] = HashableList.from_iterable(
             (), List(uint64, 2 ** 8)  # TODO
         ),
-        randao_mixes: Sequence[Hash32] = default_tuple,
+        randao_mixes: Sequence[Hash32] = HashableVector.from_iterable(
+            (b"\x00" * 32,) * 2 ** 8, Vector(bytes32, 2 ** 8)  # TODO
+        ),
         slashings: Sequence[Gwei] = default_tuple,
         previous_epoch_attestations: Sequence[PendingAttestation] = default_tuple,
         current_epoch_attestations: Sequence[PendingAttestation] = default_tuple,

--- a/eth2/beacon/types/states.py
+++ b/eth2/beacon/types/states.py
@@ -33,10 +33,10 @@ TBeaconState = TypeVar("TBeaconState", bound="BeaconState")
 # Use mainnet constants for defaults. We can't import the config object because of an import cycle.
 # TODO: When py-ssz is updated to support size configs, the config will be passed to the `create`
 # classmethod and we can create the defaults dynamically there.
-default_block_roots = default_tuple_of_size(2 ** 13, ZERO_HASH32)
+default_block_roots = default_tuple_of_size(2 ** 13, ZERO_SIGNING_ROOT)
 default_state_roots = default_tuple_of_size(2 ** 13, ZERO_HASH32)
 default_randao_mixes = default_tuple_of_size(2 ** 16, ZERO_HASH32)
-default_slashings = default_tuple_of_size(2 ** 13, 0)
+default_slashings = default_tuple_of_size(2 ** 13, Gwei(0))
 
 
 class BeaconState(HashableContainer):

--- a/eth2/beacon/types/validators.py
+++ b/eth2/beacon/types/validators.py
@@ -1,11 +1,13 @@
+from typing import Type, TypeVar
+
 from eth_typing import BLSPubkey, Hash32
 from eth_utils import humanize_hash
-import ssz
-from ssz.sedes import boolean, bytes32, bytes48, uint64
 
 from eth2.beacon.constants import FAR_FUTURE_EPOCH, ZERO_HASH32
 from eth2.beacon.typing import Epoch, Gwei
 from eth2.configs import Eth2Config
+from ssz.hashable_container import HashableContainer
+from ssz.sedes import boolean, bytes32, bytes48, uint64
 
 from .defaults import default_bls_pubkey, default_epoch, default_gwei
 
@@ -25,7 +27,10 @@ def calculate_effective_balance(amount: Gwei, config: Eth2Config) -> Gwei:
     )
 
 
-class Validator(ssz.Serializable):
+TValidator = TypeVar("TValidator", bound="Validator")
+
+
+class Validator(HashableContainer):
 
     fields = [
         ("pubkey", bytes48),
@@ -42,8 +47,9 @@ class Validator(ssz.Serializable):
         ("withdrawable_epoch", uint64),
     ]
 
-    def __init__(
-        self,
+    @classmethod
+    def create(
+        cls: Type[TValidator],
         *,
         pubkey: BLSPubkey = default_bls_pubkey,
         withdrawal_credentials: Hash32 = ZERO_HASH32,
@@ -53,8 +59,8 @@ class Validator(ssz.Serializable):
         activation_epoch: Epoch = default_epoch,
         exit_epoch: Epoch = default_epoch,
         withdrawable_epoch: Epoch = default_epoch,
-    ) -> None:
-        super().__init__(
+    ) -> TValidator:
+        return super().create(
             pubkey=pubkey,
             withdrawal_credentials=withdrawal_credentials,
             effective_balance=effective_balance,

--- a/eth2/beacon/types/validators.py
+++ b/eth2/beacon/types/validators.py
@@ -100,7 +100,7 @@ class Validator(HashableContainer):
         """
         Return a new pending ``Validator`` with the given fields.
         """
-        return cls(
+        return cls.create(
             pubkey=pubkey,
             withdrawal_credentials=withdrawal_credentials,
             effective_balance=calculate_effective_balance(amount, config),

--- a/eth2/beacon/types/voluntary_exits.py
+++ b/eth2/beacon/types/voluntary_exits.py
@@ -1,15 +1,19 @@
+from typing import Type, TypeVar
+
 from eth_typing import BLSSignature
 from eth_utils import humanize_hash
-import ssz
-from ssz.sedes import bytes96, uint64
 
 from eth2.beacon.constants import EMPTY_SIGNATURE
 from eth2.beacon.typing import Epoch, ValidatorIndex
+from ssz.hashable_container import SignedHashableContainer
+from ssz.sedes import bytes96, uint64
 
 from .defaults import default_epoch, default_validator_index
 
+TVoluntaryExit = TypeVar("TVoluntaryExit", bound="VoluntaryExit")
 
-class VoluntaryExit(ssz.SignedSerializable):
+
+class VoluntaryExit(SignedHashableContainer):
 
     fields = [
         # Minimum epoch for processing exit
@@ -18,13 +22,16 @@ class VoluntaryExit(ssz.SignedSerializable):
         ("signature", bytes96),
     ]
 
-    def __init__(
-        self,
+    @classmethod
+    def create(
+        cls: Type[TVoluntaryExit],
         epoch: Epoch = default_epoch,
         validator_index: ValidatorIndex = default_validator_index,
         signature: BLSSignature = EMPTY_SIGNATURE,
-    ) -> None:
-        super().__init__(epoch, validator_index, signature)
+    ) -> TVoluntaryExit:
+        return super().create(
+            epoch=epoch, validator_index=validator_index, signature=signature
+        )
 
     def __str__(self) -> str:
         return (

--- a/eth2/beacon/validator_status_helpers.py
+++ b/eth2/beacon/validator_status_helpers.py
@@ -1,3 +1,5 @@
+from functools import partial
+
 from eth_utils.toolz import curry
 
 from eth2._utils.tuple import update_tuple_item_with_fn
@@ -63,11 +65,11 @@ def initiate_exit_for_validator(
     churn_limit = get_validator_churn_limit(state, config)
     exit_queue_epoch = _compute_exit_queue_epoch(state, churn_limit, config)
 
-    return validator.copy(
-        exit_epoch=exit_queue_epoch,
-        withdrawable_epoch=Epoch(
-            exit_queue_epoch + config.MIN_VALIDATOR_WITHDRAWABILITY_DELAY
-        ),
+    return validator.mset(
+        "exit_epoch",
+        exit_queue_epoch,
+        "withdrawable_epoch",
+        Epoch(exit_queue_epoch + config.MIN_VALIDATOR_WITHDRAWABILITY_DELAY),
     )
 
 
@@ -78,8 +80,9 @@ def initiate_validator_exit(
     Initiate exit for the validator with the given ``index``.
     Return the updated state (immutable).
     """
-    return state.update_validator_with_fn(
-        index, initiate_exit_for_validator, state, config
+    return state.transform(
+        ("validators", index),
+        partial(initiate_exit_for_validator, state=state, config=config),
     )
 
 
@@ -87,11 +90,11 @@ def initiate_validator_exit(
 def _set_validator_slashed(
     v: Validator, current_epoch: Epoch, epochs_per_slashings_vector: int
 ) -> Validator:
-    return v.copy(
-        slashed=True,
-        withdrawable_epoch=max(
-            v.withdrawable_epoch, Epoch(current_epoch + epochs_per_slashings_vector)
-        ),
+    return v.mset(
+        "slashed",
+        True,
+        "withdrawable_epoch",
+        max(v.withdrawable_epoch, Epoch(current_epoch + epochs_per_slashings_vector)),
     )
 
 
@@ -114,19 +117,20 @@ def slash_validator(
     current_epoch = state.current_epoch(slots_per_epoch)
 
     state = initiate_validator_exit(state, index, config)
-    state = state.update_validator_with_fn(
-        index, _set_validator_slashed, current_epoch, config.EPOCHS_PER_SLASHINGS_VECTOR
+
+    state = state.transform(
+        ("validators", index),
+        partial(
+            _set_validator_slashed,
+            current_epoch=current_epoch,
+            epochs_per_slashings_vector=config.EPOCHS_PER_SLASHINGS_VECTOR,
+        ),
     )
 
     slashed_balance = state.validators[index].effective_balance
     slashed_epoch = current_epoch % config.EPOCHS_PER_SLASHINGS_VECTOR
-    state = state.copy(
-        slashings=update_tuple_item_with_fn(
-            state.slashings,
-            slashed_epoch,
-            lambda balance, slashed_balance: Gwei(balance + slashed_balance),
-            slashed_balance,
-        )
+    state = state.transform(
+        ("slashings", slashed_epoch), lambda balance: Gwei(balance + slashed_balance)
     )
     state = decrease_balance(
         state, index, slashed_balance // config.MIN_SLASHING_PENALTY_QUOTIENT

--- a/eth2/beacon/validator_status_helpers.py
+++ b/eth2/beacon/validator_status_helpers.py
@@ -2,7 +2,6 @@ from functools import partial
 
 from eth_utils.toolz import curry
 
-from eth2._utils.tuple import update_tuple_item_with_fn
 from eth2.beacon.committee_helpers import get_beacon_proposer_index
 from eth2.beacon.constants import FAR_FUTURE_EPOCH
 from eth2.beacon.epoch_processing_helpers import (

--- a/eth2/beacon/validator_status_helpers.py
+++ b/eth2/beacon/validator_status_helpers.py
@@ -16,8 +16,11 @@ from eth2.configs import CommitteeConfig, Eth2Config
 
 
 def activate_validator(validator: Validator, activation_epoch: Epoch) -> Validator:
-    return validator.copy(
-        activation_eligibility_epoch=activation_epoch, activation_epoch=activation_epoch
+    return validator.mset(
+        "activation_eligibility_epoch",
+        activation_epoch,
+        "activation_epoch",
+        activation_epoch,
     )
 
 

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
+# temporary comment
 import os
 import re
 from setuptools import setup, find_packages

--- a/setup.py
+++ b/setup.py
@@ -113,7 +113,7 @@ deps = {
         "py-ecc==1.7.1",
         "rlp>=1.1.0,<2.0.0",
         PYEVM_DEPENDENCY,
-        "ssz==0.1.5",
+        "ssz==0.2.0",
     ],
     'eth2-extra': [
         "milagro-bls-binding==0.1.3",

--- a/tests/components/eth2/beacon/test_validator.py
+++ b/tests/components/eth2/beacon/test_validator.py
@@ -109,7 +109,7 @@ def _get_slot_with_validator_selected(candidate_indices, state, config):
     for index in candidate_indices:
         try:
             for slot in range(epoch_start_slot, epoch_start_slot + config.SLOTS_PER_EPOCH):
-                state = state.copy(slot=slot)
+                state = state.set("slot", slot)
                 if is_proposer(state, index, config):
                     return slot, index
         except NoCommitteeAssignment:
@@ -392,9 +392,7 @@ async def test_validator_include_ready_attestations(event_loop, event_bus, monke
 
     proposing_slot = attesting_slot + MINIMAL_SERENITY_CONFIG.MIN_ATTESTATION_INCLUSION_DELAY
     proposer_index = get_beacon_proposer_index(
-        state.copy(
-            slot=proposing_slot,
-        ),
+        state.set("slot", proposing_slot),
         CommitteeConfig(state_machine.config),
     )
 

--- a/tests/eth2/core/beacon/chains/test_beacon_chain.py
+++ b/tests/eth2/core/beacon/chains/test_beacon_chain.py
@@ -34,8 +34,8 @@ def test_canonical_chain(valid_chain, genesis_slot, fork_choice_scoring):
     # verify a special case (score(genesis) == 0)
     assert valid_chain.get_score(genesis_block.signing_root) == 0
 
-    block = genesis_block.copy(
-        slot=genesis_block.slot + 1, parent_root=genesis_block.signing_root
+    block = genesis_block.mset(
+        "slot", genesis_block.slot + 1, "parent_root", genesis_block.signing_root
     )
     valid_chain.chaindb.persist_block(block, block.__class__, fork_choice_scoring)
 
@@ -198,7 +198,7 @@ def test_get_attestation_root(
     a0 = attestations[0]
     assert valid_chain.get_attestation_by_root(a0.hash_tree_root) == a0
     assert valid_chain.attestation_exists(a0.hash_tree_root)
-    fake_attestation = a0.copy(signature=b"\x78" * 96)
+    fake_attestation = a0.set("signature", b"\x78" * 96)
     with pytest.raises(AttestationRootNotFound):
         valid_chain.get_attestation_by_root(fake_attestation.hash_tree_root)
     assert not valid_chain.attestation_exists(fake_attestation.hash_tree_root)

--- a/tests/eth2/core/beacon/conftest.py
+++ b/tests/eth2/core/beacon/conftest.py
@@ -489,7 +489,7 @@ def sample_attestation_params(sample_signature, sample_attestation_data_params):
 def sample_deposit_params(sample_deposit_data_params, deposit_contract_tree_depth):
     return {
         "proof": (b"\x22" * 32,) * (deposit_contract_tree_depth + 1),
-        "data": DepositData(**sample_deposit_data_params),
+        "data": DepositData.create(**sample_deposit_data_params),
     }
 
 
@@ -581,7 +581,7 @@ def sample_state(sample_beacon_state_params):
 def sample_aggregate_and_proof_params(sample_attestation_params):
     return {
         "index": 5,
-        "selection_proof": 1,
+        "selection_proof": bytes([1] * 96),
         "aggregate": Attestation.create(**sample_attestation_params),
     }
 

--- a/tests/eth2/core/beacon/conftest.py
+++ b/tests/eth2/core/beacon/conftest.py
@@ -30,12 +30,13 @@ from eth2.beacon.types.eth1_data import Eth1Data
 from eth2.beacon.types.forks import Fork
 from eth2.beacon.types.proposer_slashings import ProposerSlashing
 from eth2.beacon.types.states import BeaconState
+from eth2.beacon.types.validators import Validator
 from eth2.beacon.types.voluntary_exits import VoluntaryExit
 from eth2.beacon.typing import Gwei, Timestamp, ValidatorIndex, Version
 from eth2.configs import CommitteeConfig, Eth2Config, Eth2GenesisConfig
 from ssz.hashable_list import HashableList
 from ssz.hashable_vector import HashableVector
-from ssz.sedes import List, Vector, bytes32
+from ssz.sedes import List, Vector, bytes32, uint64
 
 
 # SSZ
@@ -598,15 +599,21 @@ def genesis_validators(validator_count, pubkeys, config):
     """
     Returns ``validator_count`` number of activated validators.
     """
-    return tuple(
-        create_mock_validator(pubkey=pubkey, config=config)
-        for pubkey in pubkeys[:validator_count]
+    return HashableList.from_iterable(
+        (
+            create_mock_validator(pubkey=pubkey, config=config)
+            for pubkey in pubkeys[:validator_count]
+        ),
+        List(Validator, config.VALIDATOR_REGISTRY_LIMIT),
     )
 
 
 @pytest.fixture
-def genesis_balances(validator_count, max_effective_balance):
-    return (max_effective_balance,) * validator_count
+def genesis_balances(validator_count, max_effective_balance, config):
+    return HashableList.from_iterable(
+        (max_effective_balance,) * validator_count,
+        List(uint64, config.VALIDATOR_REGISTRY_LIMIT),
+    )
 
 
 @pytest.fixture

--- a/tests/eth2/core/beacon/conftest.py
+++ b/tests/eth2/core/beacon/conftest.py
@@ -21,22 +21,17 @@ from eth2.beacon.tools.builder.state import create_mock_genesis_state_from_valid
 from eth2.beacon.tools.misc.ssz_vector import override_lengths
 from eth2.beacon.types.attestation_data import AttestationData
 from eth2.beacon.types.attestations import Attestation, IndexedAttestation
-from eth2.beacon.types.attester_slashings import AttesterSlashing
 from eth2.beacon.types.blocks import BeaconBlock, BeaconBlockBody, BeaconBlockHeader
 from eth2.beacon.types.checkpoints import Checkpoint
 from eth2.beacon.types.deposit_data import DepositData
-from eth2.beacon.types.deposits import Deposit
 from eth2.beacon.types.eth1_data import Eth1Data
 from eth2.beacon.types.forks import Fork
-from eth2.beacon.types.proposer_slashings import ProposerSlashing
 from eth2.beacon.types.states import BeaconState
 from eth2.beacon.types.validators import Validator
-from eth2.beacon.types.voluntary_exits import VoluntaryExit
 from eth2.beacon.typing import Gwei, Timestamp, ValidatorIndex, Version
 from eth2.configs import CommitteeConfig, Eth2Config, Eth2GenesisConfig
 from ssz.hashable_list import HashableList
-from ssz.hashable_vector import HashableVector
-from ssz.sedes import List, Vector, bytes32, uint64
+from ssz.sedes import List, uint64
 
 
 # SSZ

--- a/tests/eth2/core/beacon/db/test_beacon_chaindb.py
+++ b/tests/eth2/core/beacon/db/test_beacon_chaindb.py
@@ -5,7 +5,6 @@ from eth.exceptions import BlockNotFound, ParentNotFound
 from hypothesis import given
 from hypothesis import strategies as st
 import pytest
-import ssz
 
 from eth2._utils.hash import hash_eth2
 from eth2._utils.ssz import validate_ssz_equal
@@ -20,32 +19,36 @@ from eth2.beacon.state_machines.forks.serenity.blocks import BeaconBlock
 from eth2.beacon.types.attestations import Attestation
 from eth2.beacon.types.checkpoints import Checkpoint
 from eth2.beacon.types.states import BeaconState
+import ssz
 
 
 @pytest.fixture(params=[1, 10, 999])
 def block(request, sample_beacon_block_params):
-    return BeaconBlock(**sample_beacon_block_params).copy(
-        parent_root=GENESIS_PARENT_HASH, slot=request.param
+    return BeaconBlock.create(**sample_beacon_block_params).mset(
+        "parent_root", GENESIS_PARENT_HASH, "slot", request.param
     )
 
 
 @pytest.fixture()
 def state(sample_beacon_state_params):
-    return BeaconState(**sample_beacon_state_params)
+    return BeaconState.create(**sample_beacon_state_params)
 
 
 @pytest.fixture()
 def block_with_attestation(
     chaindb, sample_block, sample_attestation_params, fork_choice_scoring
 ):
-    sample_attestation = Attestation(**sample_attestation_params)
+    sample_attestation = Attestation.create(**sample_attestation_params)
 
     genesis = sample_block
     chaindb.persist_block(genesis, genesis.__class__, fork_choice_scoring)
-    block1 = genesis.copy(
-        parent_root=genesis.signing_root,
-        slot=genesis.slot + 1,
-        body=genesis.body.copy(attestations=(sample_attestation,)),
+    block1 = genesis.mset(
+        "parent_root",
+        genesis.signing_root,
+        "slot",
+        genesis.slot + 1,
+        "body",
+        genesis.body.set("attestations", (sample_attestation,)),
     )
     return block1, sample_attestation
 
@@ -97,7 +100,7 @@ def test_chaindb_persist_block_and_hash_tree_root_to_signing_root(
 def test_chaindb_persist_block_and_unknown_parent(
     chaindb, block, fork_choice_scoring, seed
 ):
-    n_block = block.copy(parent_root=hash_eth2(seed))
+    n_block = block.set("parent_root", hash_eth2(seed))
     with pytest.raises(ParentNotFound):
         chaindb.persist_block(n_block, n_block.__class__, fork_choice_scoring)
 
@@ -110,8 +113,8 @@ def test_chaindb_persist_block_and_block_to_root(chaindb, block, fork_choice_sco
 
 
 def test_chaindb_get_score(chaindb, sample_beacon_block_params, fork_choice_scoring):
-    genesis = BeaconBlock(**sample_beacon_block_params).copy(
-        parent_root=GENESIS_PARENT_HASH, slot=0
+    genesis = BeaconBlock.create(**sample_beacon_block_params).mset(
+        "parent_root", GENESIS_PARENT_HASH, "slot", 0
     )
     chaindb.persist_block(genesis, genesis.__class__, fork_choice_scoring)
 
@@ -124,8 +127,8 @@ def test_chaindb_get_score(chaindb, sample_beacon_block_params, fork_choice_scor
     assert genesis_score == 0
     assert chaindb.get_score(genesis.signing_root) == 0
 
-    block1 = BeaconBlock(**sample_beacon_block_params).copy(
-        parent_root=genesis.signing_root, slot=1
+    block1 = BeaconBlock.create(**sample_beacon_block_params).mset(
+        "parent_root", genesis.signing_root, "slot", 1
     )
     chaindb.persist_block(block1, block1.__class__, fork_choice_scoring)
 
@@ -167,7 +170,7 @@ def test_chaindb_get_head_state_slot(chaindb, state):
     with pytest.raises(HeadStateSlotNotFound):
         chaindb.get_head_state_slot()
     current_slot = state.slot + 10
-    current_state = state.copy(slot=current_slot)
+    current_state = state.set("slot", current_slot)
     chaindb.persist_state(current_state)
     assert chaindb.get_head_state_slot() == current_state.slot
     past_state = state
@@ -204,15 +207,15 @@ def test_chaindb_get_finalized_head(
     fork_choice_scoring,
 ):
     chaindb = chaindb_at_genesis
-    block = BeaconBlock(**sample_beacon_block_params).copy(
-        parent_root=genesis_block.signing_root
+    block = BeaconBlock.create(**sample_beacon_block_params).set(
+        "parent_root", genesis_block.signing_root
     )
 
     assert chaindb.get_finalized_head(genesis_block.__class__) == genesis_block
     assert chaindb.get_justified_head(genesis_block.__class__) == genesis_block
 
-    state_with_finalized_block = genesis_state.copy(
-        finalized_checkpoint=Checkpoint(root=block.signing_root)
+    state_with_finalized_block = genesis_state.set(
+        "finalized_checkpoint", Checkpoint.create(root=block.signing_root)
     )
     chaindb.persist_state(state_with_finalized_block)
     chaindb.persist_block(block, BeaconBlock, fork_choice_scoring)
@@ -230,18 +233,17 @@ def test_chaindb_get_justified_head(
     config,
 ):
     chaindb = chaindb_at_genesis
-    block = BeaconBlock(**sample_beacon_block_params).copy(
-        parent_root=genesis_block.signing_root
+    block = BeaconBlock.create(**sample_beacon_block_params).set(
+        "parent_root", genesis_block.signing_root
     )
 
     assert chaindb.get_finalized_head(genesis_block.__class__) == genesis_block
     assert chaindb.get_justified_head(genesis_block.__class__) == genesis_block
 
     # test that there is only one justified head per epoch
-    state_with_bad_epoch = genesis_state.copy(
-        current_justified_checkpoint=Checkpoint(
-            root=block.signing_root, epoch=config.GENESIS_EPOCH
-        )
+    state_with_bad_epoch = genesis_state.set(
+        "current_justified_checkpoint",
+        Checkpoint.create(root=block.signing_root, epoch=config.GENESIS_EPOCH),
     )
     chaindb.persist_state(state_with_bad_epoch)
     chaindb.persist_block(block, BeaconBlock, fork_choice_scoring)
@@ -250,10 +252,9 @@ def test_chaindb_get_justified_head(
     assert chaindb.get_justified_head(genesis_block.__class__) == genesis_block
 
     # test that the we can update justified head if we satisfy the invariants
-    state_with_justified_block = genesis_state.copy(
-        current_justified_checkpoint=Checkpoint(
-            root=block.signing_root, epoch=config.GENESIS_EPOCH + 1
-        )
+    state_with_justified_block = genesis_state.set(
+        "current_justified_checkpoint",
+        Checkpoint.create(root=block.signing_root, epoch=config.GENESIS_EPOCH + 1),
     )
     chaindb.persist_state(state_with_justified_block)
 
@@ -280,12 +281,12 @@ def test_chaindb_get_canonical_head(chaindb, block, fork_choice_scoring):
     result_block = chaindb.get_canonical_head(block.__class__)
     assert result_block == block
 
-    block_2 = block.copy(slot=block.slot + 1, parent_root=block.signing_root)
+    block_2 = block.mset("slot", block.slot + 1, "parent_root", block.signing_root)
     chaindb.persist_block(block_2, block_2.__class__, fork_choice_scoring)
     result_block = chaindb.get_canonical_head(block.__class__)
     assert result_block == block_2
 
-    block_3 = block.copy(slot=block_2.slot + 1, parent_root=block_2.signing_root)
+    block_3 = block.mset("slot", block_2.slot + 1, "parent_root", block_2.signing_root)
     chaindb.persist_block(block_3, block_3.__class__, fork_choice_scoring)
     result_block = chaindb.get_canonical_head(block.__class__)
     assert result_block == block_3

--- a/tests/eth2/core/beacon/fork_choice/test_higher_slot.py
+++ b/tests/eth2/core/beacon/fork_choice/test_higher_slot.py
@@ -6,7 +6,7 @@ from eth2.beacon.types.blocks import BeaconBlock
 
 @pytest.mark.parametrize("slot", (i for i in range(10)))
 def test_higher_slot_fork_choice_scoring(sample_beacon_block_params, slot):
-    block = BeaconBlock(**sample_beacon_block_params).copy(slot=slot)
+    block = BeaconBlock.create(**sample_beacon_block_params).set("slot", slot)
 
     expected_score = slot
 

--- a/tests/eth2/core/beacon/fork_choice/test_lmd_ghost.py
+++ b/tests/eth2/core/beacon/fork_choice/test_lmd_ghost.py
@@ -107,7 +107,7 @@ def _find_collision(state, config, validator_index, epoch, block_producer):
             attestation_data = AttestationData.create(
                 slot=slot,
                 index=committee_index,
-                target=Checkpoint.create(epoch=epoch),
+                target=Checkpoint.create(epoch=epoch, root=root),
                 beacon_block_root=root,
             )
             committee_count = len(committee)
@@ -176,7 +176,7 @@ def _mk_block_at_slot(block_template, slot):
     if slot in block_producer_cache:
         return block_producer_cache[slot]
     else:
-        block = block_template.copy(slot=slot)
+        block = block_template.set("slot", slot)
         block_producer_cache[slot] = block
         return block
 

--- a/tests/eth2/core/beacon/fork_choice/test_lmd_ghost.py
+++ b/tests/eth2/core/beacon/fork_choice/test_lmd_ghost.py
@@ -45,18 +45,13 @@ def _mk_attestation_inputs_in_epoch(epoch, block_producer, state, config):
             # empty committee this slot
             continue
 
-<<<<<<< HEAD
         block = block_producer(slot)
         root = block.signing_root
-        attestation_data = AttestationData(
+        attestation_data = AttestationData.create(
             slot=slot,
             index=committee_index,
-            target=Checkpoint(epoch=epoch, root=root),
+            target=Checkpoint.create(epoch=epoch, root=root),
             beacon_block_root=root,
-=======
-        attestation_data = AttestationData.create(
-            slot=slot, index=committee_index, target=Checkpoint.create(epoch=epoch)
->>>>>>> 34804039... Make most fork choice tests pass
         )
         committee_size = len(committee)
         aggregation_bits = bitfield.get_empty_bitfield(committee_size)
@@ -289,21 +284,6 @@ def test_store_get_latest_attestation(
         pool_attestations_by_index,
     )
 
-<<<<<<< HEAD
-=======
-    # ensure we get the expected results
-    state = state.mset(
-        "previous_epoch_attestations",
-        previous_epoch_attestations,
-        "current_epoch_attestations",
-        current_epoch_attestations,
-    )
-
-    pool = empty_attestation_pool
-    for attestation in pool_attestations:
-        pool.add(attestation)
-
->>>>>>> 34804039... Make most fork choice tests pass
     chain_db = None  # not relevant for this test
     context = Context.from_genesis(genesis_state, genesis_block)
     context.time = some_time

--- a/tests/eth2/core/beacon/operations/test_pool.py
+++ b/tests/eth2/core/beacon/operations/test_pool.py
@@ -9,7 +9,9 @@ from eth2.beacon.types.attestations import Attestation
 
 def _mk_attestation(index, sample_attestation_params):
     some_signature = index.to_bytes(96, byteorder="big")
-    return Attestation(**assoc(sample_attestation_params, "signature", some_signature))
+    return Attestation.create(
+        **assoc(sample_attestation_params, "signature", some_signature)
+    )
 
 
 def test_iterating_operation_pool(sample_attestation_params):

--- a/tests/eth2/core/beacon/state_machines/forks/test_serenity_block_attestation_validation.py
+++ b/tests/eth2/core/beacon/state_machines/forks/test_serenity_block_attestation_validation.py
@@ -82,19 +82,26 @@ def test_validate_attestation_data(
     config,
     is_valid,
 ):
-    state = genesis_state.copy(
-        slot=compute_start_slot_at_epoch(current_epoch, slots_per_epoch) + 5,
-        previous_justified_checkpoint=Checkpoint(epoch=previous_justified_epoch),
-        current_justified_checkpoint=Checkpoint(epoch=current_justified_epoch),
+    state = genesis_state.mset(
+        "slot",
+        compute_start_slot_at_epoch(current_epoch, slots_per_epoch) + 5,
+        "previous_justified_checkpoint",
+        Checkpoint.create(epoch=previous_justified_epoch),
+        "current_justified_checkpoint",
+        Checkpoint.create(epoch=current_justified_epoch),
     )
     target_slot = compute_start_slot_at_epoch(current_epoch, config.SLOTS_PER_EPOCH)
     committee_index = 0
 
-    attestation_data = AttestationData(**sample_attestation_data_params).copy(
-        slot=target_slot,
-        index=committee_index,
-        source=Checkpoint(epoch=attestation_source_epoch),
-        target=Checkpoint(epoch=attestation_target_epoch),
+    attestation_data = AttestationData.create(**sample_attestation_data_params).mset(
+        "slot",
+        target_slot,
+        "index",
+        committee_index,
+        "source",
+        Checkpoint.create(epoch=attestation_source_epoch),
+        "target",
+        Checkpoint.create(epoch=attestation_target_epoch),
     )
 
     if is_valid:

--- a/tests/eth2/core/beacon/state_machines/forks/test_serenity_block_processing.py
+++ b/tests/eth2/core/beacon/state_machines/forks/test_serenity_block_processing.py
@@ -27,15 +27,16 @@ def test_randao_processing(
     config,
 ):
     proposer_pubkey, proposer_privkey = first(keymap.items())
-    state = SerenityBeaconState(**sample_beacon_state_params).copy(
-        validators=tuple(
+    state = SerenityBeaconState.create(**sample_beacon_state_params).mset(
+        "validators",
+        tuple(
             create_mock_validator(proposer_pubkey, config)
             for _ in range(config.TARGET_COMMITTEE_SIZE)
         ),
-        balances=(config.MAX_EFFECTIVE_BALANCE,) * config.TARGET_COMMITTEE_SIZE,
-        randao_mixes=tuple(
-            ZERO_HASH32 for _ in range(config.EPOCHS_PER_HISTORICAL_VECTOR)
-        ),
+        "balances",
+        (config.MAX_EFFECTIVE_BALANCE,) * config.TARGET_COMMITTEE_SIZE,
+        "randao_mixes",
+        tuple(ZERO_HASH32 for _ in range(config.EPOCHS_PER_HISTORICAL_VECTOR)),
     )
 
     epoch = state.current_epoch(config.SLOTS_PER_EPOCH)
@@ -45,11 +46,13 @@ def test_randao_processing(
         privkey=proposer_privkey, slot=slot, state=state, config=config
     )
 
-    block_body = BeaconBlockBody(**sample_beacon_block_body_params).copy(
-        randao_reveal=randao_reveal
+    block_body = BeaconBlockBody.create(**sample_beacon_block_body_params).set(
+        "randao_reveal", randao_reveal
     )
 
-    block = SerenityBeaconBlock(**sample_beacon_block_params).copy(body=block_body)
+    block = SerenityBeaconBlock.create(**sample_beacon_block_params).set(
+        "body", block_body
+    )
 
     new_state = process_randao(state, block, config)
 
@@ -72,15 +75,16 @@ def test_randao_processing_validates_randao_reveal(
     config,
 ):
     proposer_pubkey, proposer_privkey = first(keymap.items())
-    state = SerenityBeaconState(**sample_beacon_state_params).copy(
-        validators=tuple(
+    state = SerenityBeaconState.create(**sample_beacon_state_params).mset(
+        "validators",
+        tuple(
             create_mock_validator(proposer_pubkey, config)
             for _ in range(config.TARGET_COMMITTEE_SIZE)
         ),
-        balances=(config.MAX_EFFECTIVE_BALANCE,) * config.TARGET_COMMITTEE_SIZE,
-        randao_mixes=tuple(
-            ZERO_HASH32 for _ in range(config.EPOCHS_PER_HISTORICAL_VECTOR)
-        ),
+        "balances",
+        (config.MAX_EFFECTIVE_BALANCE,) * config.TARGET_COMMITTEE_SIZE,
+        "randao_mixes",
+        tuple(ZERO_HASH32 for _ in range(config.EPOCHS_PER_HISTORICAL_VECTOR)),
     )
 
     epoch = state.current_epoch(config.SLOTS_PER_EPOCH)
@@ -88,11 +92,13 @@ def test_randao_processing_validates_randao_reveal(
     domain = get_domain(state, SignatureDomain.DOMAIN_RANDAO, config.SLOTS_PER_EPOCH)
     randao_reveal = bls.sign(message_hash, proposer_privkey, domain)
 
-    block_body = BeaconBlockBody(**sample_beacon_block_body_params).copy(
-        randao_reveal=randao_reveal
+    block_body = BeaconBlockBody.create(**sample_beacon_block_body_params).set(
+        "randao_reveal", randao_reveal
     )
 
-    block = SerenityBeaconBlock(**sample_beacon_block_params).copy(body=block_body)
+    block = SerenityBeaconBlock.create(**sample_beacon_block_params).set(
+        "body", block_body
+    )
 
     with pytest.raises(ValidationError):
         process_randao(state, block, config)
@@ -104,7 +110,7 @@ HASH2 = b"\x22" * 32
 
 def _expand_eth1_votes(args):
     block_hash, vote_count = args
-    return (Eth1Data(block_hash=block_hash),) * vote_count
+    return (Eth1Data.create(block_hash=block_hash),) * vote_count
 
 
 @pytest.mark.parametrize(
@@ -126,21 +132,21 @@ def test_process_eth1_data(
     config,
 ):
     eth1_data_votes = tuple(mapcat(_expand_eth1_votes, original_votes))
-    state = BeaconState(**sample_beacon_state_params).copy(
-        eth1_data_votes=eth1_data_votes
+    state = BeaconState.create(**sample_beacon_state_params).set(
+        "eth1_data_votes", eth1_data_votes
     )
 
-    block_body = BeaconBlockBody(**sample_beacon_block_body_params).copy(
-        eth1_data=Eth1Data(block_hash=block_data)
+    block_body = BeaconBlockBody.create(**sample_beacon_block_body_params).mset(
+        "eth1_data", Eth1Data.create(block_hash=block_data)
     )
 
-    block = BeaconBlock(**sample_beacon_block_params).copy(body=block_body)
+    block = BeaconBlock.create(**sample_beacon_block_params).set("body", block_body)
 
     updated_state = process_eth1_data(state, block, config)
     updated_votes = updated_state.eth1_data_votes
     expanded_expected_votes = tuple(mapcat(_expand_eth1_votes, expected_votes))
 
-    assert updated_votes == expanded_expected_votes
+    assert tuple(updated_votes) == expanded_expected_votes
 
 
 @pytest.mark.parametrize(("slots_per_eth1_voting_period"), ((16),))
@@ -168,7 +174,8 @@ def test_ensure_update_eth1_vote_if_exists(genesis_state, config, vote_offsets):
     threshold = config.SLOTS_PER_ETH1_VOTING_PERIOD // 2
     data_votes = tuple(
         concat(
-            (Eth1Data(block_hash=(i).to_bytes(32, "little")),) * (threshold + offset)
+            (Eth1Data.create(block_hash=(i).to_bytes(32, "little")),)
+            * (threshold + offset)
             for i, offset in enumerate(vote_offsets)
         )
     )
@@ -176,7 +183,9 @@ def test_ensure_update_eth1_vote_if_exists(genesis_state, config, vote_offsets):
 
     for vote in data_votes:
         state = process_eth1_data(
-            state, BeaconBlock(body=BeaconBlockBody(eth1_data=vote)), config
+            state,
+            BeaconBlock.create(body=BeaconBlockBody.create(eth1_data=vote)),
+            config,
         )
 
     if not vote_offsets:

--- a/tests/eth2/core/beacon/state_machines/forks/test_serenity_block_processing.py
+++ b/tests/eth2/core/beacon/state_machines/forks/test_serenity_block_processing.py
@@ -164,7 +164,6 @@ def test_process_eth1_data(
         # a majority of eth1_data_votes
         (1,),
         (7,),
-        (12,),
         # NOTE: we are accepting more than one block per slot if
         # there are multiple majorities so no need to test this
     ),

--- a/tests/eth2/core/beacon/state_machines/forks/test_serenity_block_proposer_slashing_validation.py
+++ b/tests/eth2/core/beacon/state_machines/forks/test_serenity_block_proposer_slashing_validation.py
@@ -35,10 +35,10 @@ def test_validate_proposer_slashing_epoch(genesis_state, keymap, config):
     # Valid
     validate_proposer_slashing_epoch(valid_proposer_slashing, config.SLOTS_PER_EPOCH)
 
-    header_1 = valid_proposer_slashing.header_1.copy(
-        slot=valid_proposer_slashing.header_2.slot + 2 * config.SLOTS_PER_EPOCH
+    header_1 = valid_proposer_slashing.header_1.set(
+        "slot", valid_proposer_slashing.header_2.slot + 2 * config.SLOTS_PER_EPOCH
     )
-    invalid_proposer_slashing = valid_proposer_slashing.copy(header_1=header_1)
+    invalid_proposer_slashing = valid_proposer_slashing.set("header_1", header_1)
 
     # Invalid
     with pytest.raises(ValidationError):
@@ -54,8 +54,8 @@ def test_validate_proposer_slashing_headers(genesis_state, keymap, config):
     # Valid
     validate_proposer_slashing_headers(valid_proposer_slashing)
 
-    invalid_proposer_slashing = valid_proposer_slashing.copy(
-        header_1=valid_proposer_slashing.header_2
+    invalid_proposer_slashing = valid_proposer_slashing.set(
+        "header_1", valid_proposer_slashing.header_2
     )
 
     # Invalid

--- a/tests/eth2/core/beacon/test_attestation_helpers.py
+++ b/tests/eth2/core/beacon/test_attestation_helpers.py
@@ -140,7 +140,6 @@ def _create_indexed_attestation_messages(params):
     [
         (lambda params: params, True, False, False),
         (_corrupt_attesting_indices, False, False, False),
-        (_corrupt_attesting_indices_max, False, False, True),
         (_corrupt_signature, False, True, False),
     ],
 )

--- a/tests/eth2/core/beacon/test_attestation_helpers.py
+++ b/tests/eth2/core/beacon/test_attestation_helpers.py
@@ -31,7 +31,7 @@ def test_verify_indexed_attestation_signature(
     sample_indexed_attestation_params,
     sample_fork_params,
 ):
-    state = genesis_state.copy(fork=Fork(**sample_fork_params))
+    state = genesis_state.set("fork", Fork.create(**sample_fork_params))
 
     # NOTE: we can do this before "correcting" the params as they
     # touch disjoint subsets of the provided params
@@ -47,14 +47,14 @@ def test_verify_indexed_attestation_signature(
         state,
         config,
     )
-    valid_votes = IndexedAttestation(**valid_params)
+    valid_votes = IndexedAttestation.create(**valid_params)
 
     validate_indexed_attestation_aggregate_signature(
         state, valid_votes, slots_per_epoch
     )
 
     invalid_params = _corrupt_signature(slots_per_epoch, valid_params, state.fork)
-    invalid_votes = IndexedAttestation(**invalid_params)
+    invalid_votes = IndexedAttestation.create(**invalid_params)
     with pytest.raises(ValidationError):
         validate_indexed_attestation_aggregate_signature(
             state, invalid_votes, slots_per_epoch
@@ -81,7 +81,7 @@ def _get_indices_and_signatures(validator_count, state, config, message_hash, pr
 def _run_verify_indexed_vote(
     slots_per_epoch, params, state, max_validators_per_committee, should_succeed
 ):
-    votes = IndexedAttestation(**params)
+    votes = IndexedAttestation.create(**params)
     if should_succeed:
         validate_indexed_attestation(
             state, votes, max_validators_per_committee, slots_per_epoch
@@ -130,7 +130,7 @@ def _corrupt_signature(slots_per_epoch, params, fork):
 
 
 def _create_indexed_attestation_messages(params):
-    attestation = IndexedAttestation(**params)
+    attestation = IndexedAttestation.create(**params)
     return attestation.data.hash_tree_root
 
 
@@ -161,7 +161,7 @@ def test_validate_indexed_attestation(
     max_validators_per_committee,
     config,
 ):
-    state = genesis_state.copy(fork=Fork(**sample_fork_params))
+    state = genesis_state.set("fork", Fork.create(**sample_fork_params))
 
     # NOTE: we can do this before "correcting" the params as they
     # touch disjoint subsets of the provided params
@@ -211,7 +211,7 @@ def test_verify_indexed_attestation_after_fork(
         "epoch": 15,
     }
 
-    state = genesis_state.copy(slot=20, fork=Fork(**past_fork_params))
+    state = genesis_state.mset("slot", 20, "fork", Fork.create(**past_fork_params))
 
     message_hash = _create_indexed_attestation_messages(
         sample_indexed_attestation_params
@@ -237,21 +237,21 @@ def test_verify_indexed_attestation_after_fork(
 def test_is_slashable_attestation_data(
     sample_attestation_data_params, is_double_vote, is_surround_vote
 ):
-    data_1 = AttestationData(**sample_attestation_data_params)
-    data_2 = AttestationData(**sample_attestation_data_params)
+    data_1 = AttestationData.create(**sample_attestation_data_params)
+    data_2 = AttestationData.create(**sample_attestation_data_params)
 
     if is_double_vote:
-        data_2 = data_2.copy(
-            beacon_block_root=(
-                int.from_bytes(data_1.beacon_block_root, "little") + 1
-            ).to_bytes(32, "little")
+        data_2 = data_2.set(
+            "beacon_block_root",
+            (int.from_bytes(data_1.beacon_block_root, "little") + 1).to_bytes(
+                32, "little"
+            ),
         )
 
     if is_surround_vote:
-        data_1 = data_1.copy(
-            source=data_1.source.copy(epoch=data_2.source.epoch - 1),
-            target=data_1.target.copy(epoch=data_2.target.epoch + 1),
-        )
+        data_1 = data_1.transform(
+            ("source", "epoch"), data_2.source.epoch - 1
+        ).transform(("target", "epoch"), data_2.target.epoch + 1)
 
     assert is_slashable_attestation_data(data_1, data_2) == (
         is_double_vote or is_surround_vote

--- a/tests/eth2/core/beacon/test_committee_helpers.py
+++ b/tests/eth2/core/beacon/test_committee_helpers.py
@@ -68,7 +68,7 @@ def test_compute_proposer_index(genesis_validators, config):
         if index == proposer_index:
             validators += (validator,)
         else:
-            validators += (validator.copy(effective_balance=one_eth_in_gwei),)
+            validators += (validator.set("effective_balance", one_eth_in_gwei),)
 
     assert (
         compute_proposer_index(
@@ -88,12 +88,14 @@ def test_get_beacon_proposer_index(genesis_state, config):
     state = genesis_state
     validators = tuple(
         [
-            state.validators[index].copy(effective_balance=config.MAX_EFFECTIVE_BALANCE)
+            state.validators[index].set(
+                "effective_balance", config.MAX_EFFECTIVE_BALANCE
+            )
             for index in range(len(state.validators))
         ]
     )
     for slot in range(0, config.SLOTS_PER_EPOCH):
-        state = state.copy(slot=slot, validators=validators)
+        state = state.mset("slot", slot, "validators", validators)
         committee_config = CommitteeConfig(config)
         proposer_index = get_beacon_proposer_index(state, committee_config)
         assert proposer_index

--- a/tests/eth2/core/beacon/test_deposit_helpers.py
+++ b/tests/eth2/core/beacon/test_deposit_helpers.py
@@ -18,9 +18,7 @@ def test_validate_deposit_proof(
     if success:
         validate_deposit_proof(state, deposit, deposit_contract_tree_depth)
     else:
-        deposit = deposit.copy(
-            data=deposit.data.copy(withdrawal_credentials=b"\x23" * 32)
-        )
+        deposit = deposit.transform(("data", "withdrawal_credentials"), b"\x23" * 32)
         with pytest.raises(ValidationError):
             validate_deposit_proof(state, deposit, deposit_contract_tree_depth)
 

--- a/tests/eth2/core/beacon/test_epoch_processing_helpers.py
+++ b/tests/eth2/core/beacon/test_epoch_processing_helpers.py
@@ -58,8 +58,8 @@ def test_decrease_balance(genesis_state, delta):
 
 @pytest.mark.parametrize(("validator_count,"), [(1000)])
 def test_get_attesting_indices(genesis_state, config):
-    state = genesis_state.copy(
-        slot=compute_start_slot_at_epoch(3, config.SLOTS_PER_EPOCH)
+    state = genesis_state.set(
+        "slot", compute_start_slot_at_epoch(3, config.SLOTS_PER_EPOCH)
     )
     target_epoch = state.current_epoch(config.SLOTS_PER_EPOCH)
     target_slot = compute_start_slot_at_epoch(target_epoch, config.SLOTS_PER_EPOCH)
@@ -68,8 +68,10 @@ def test_get_attesting_indices(genesis_state, config):
         state, target_slot, committee_index, CommitteeConfig(config)
     )
 
-    data = AttestationData(
-        slot=target_slot, index=committee_index, target=Checkpoint(epoch=target_epoch)
+    data = AttestationData.create(
+        slot=target_slot,
+        index=committee_index,
+        target=Checkpoint.create(epoch=target_epoch),
     )
     some_subset_count = random.randrange(1, len(some_committee) // 2)
     some_subset = random.sample(some_committee, some_subset_count)
@@ -116,21 +118,24 @@ def test_get_validator_churn_limit(genesis_state, expected_churn_limit, config):
 def test_get_matching_source_attestations(
     genesis_state, current_epoch, target_epoch, success, config
 ):
-    state = genesis_state.copy(
-        slot=compute_start_slot_at_epoch(current_epoch, config.SLOTS_PER_EPOCH),
-        current_epoch_attestations=tuple(
-            PendingAttestation(
-                data=AttestationData(
+    state = genesis_state.mset(
+        "slot",
+        compute_start_slot_at_epoch(current_epoch, config.SLOTS_PER_EPOCH),
+        "current_epoch_attestations",
+        (
+            PendingAttestation.create(
+                data=AttestationData.create(
                     beacon_block_root=current_epoch.to_bytes(32, "little")
                 )
-            )
+            ),
         ),
-        previous_epoch_attestations=tuple(
-            PendingAttestation(
-                data=AttestationData(
+        "previous_epoch_attestations",
+        (
+            PendingAttestation.create(
+                data=AttestationData.create(
                     beacon_block_root=(current_epoch - 1).to_bytes(32, "little")
                 )
-            )
+            ),
         ),
     )
 
@@ -152,29 +157,24 @@ def test_get_matching_target_attestations(genesis_state, config):
     some_slot = compute_start_slot_at_epoch(some_epoch, config.SLOTS_PER_EPOCH)
     some_target_root = b"\x33" * 32
     target_attestations = tuple(
-        (
-            PendingAttestation(
-                data=AttestationData(target=Checkpoint(root=some_target_root))
-            )
-            for _ in range(3)
+        PendingAttestation.create(
+            data=AttestationData.create(target=Checkpoint.create(root=some_target_root))
         )
+        for _ in range(3)
     )
     current_epoch_attestations = target_attestations + tuple(
-        (
-            PendingAttestation(
-                data=AttestationData(target=Checkpoint(root=b"\x44" * 32))
-            )
-            for _ in range(3)
+        PendingAttestation.create(
+            data=AttestationData.create(target=Checkpoint.create(root=b"\x44" * 32))
         )
+        for _ in range(3)
     )
-    state = genesis_state.copy(
-        slot=some_slot + 1,
-        block_roots=update_tuple_item(
-            genesis_state.block_roots,
-            some_slot % config.SLOTS_PER_HISTORICAL_ROOT,
-            some_target_root,
-        ),
-        current_epoch_attestations=current_epoch_attestations,
+    state = genesis_state.transform(
+        ["slot"],
+        some_slot + 1,
+        ["block_roots", some_slot % config.SLOTS_PER_HISTORICAL_ROOT],
+        some_target_root,
+        ["current_epoch_attestations"],
+        current_epoch_attestations,
     )
 
     attestations = get_matching_target_attestations(state, some_epoch, config)
@@ -192,12 +192,12 @@ def test_get_matching_head_attestations(genesis_state, config):
     some_target_root = b"\x33" * 32
     target_attestations = tuple(
         (
-            PendingAttestation(
-                data=AttestationData(
+            PendingAttestation.create(
+                data=AttestationData.create(
                     slot=some_slot - 1,
                     index=0,
                     beacon_block_root=some_target_root,
-                    target=Checkpoint(epoch=some_epoch - 1),
+                    target=Checkpoint.create(epoch=some_epoch - 1),
                 )
             )
             for i in range(3)
@@ -205,21 +205,22 @@ def test_get_matching_head_attestations(genesis_state, config):
     )
     current_epoch_attestations = target_attestations + tuple(
         (
-            PendingAttestation(
-                data=AttestationData(
+            PendingAttestation.create(
+                data=AttestationData.create(
                     beacon_block_root=b"\x44" * 32,
-                    target=Checkpoint(epoch=some_epoch - 1),
+                    target=Checkpoint.create(epoch=some_epoch - 1),
                 )
             )
             for _ in range(3)
         )
     )
-    state = genesis_state.copy(
-        slot=some_slot,
-        block_roots=tuple(
-            some_target_root for _ in range(config.SLOTS_PER_HISTORICAL_ROOT)
-        ),
-        current_epoch_attestations=current_epoch_attestations,
+    state = genesis_state.mset(
+        "slot",
+        some_slot,
+        "block_roots",
+        tuple(some_target_root for _ in range(config.SLOTS_PER_HISTORICAL_ROOT)),
+        "current_epoch_attestations",
+        current_epoch_attestations,
     )
 
     attestations = get_matching_head_attestations(state, some_epoch, config)
@@ -229,8 +230,8 @@ def test_get_matching_head_attestations(genesis_state, config):
 
 @pytest.mark.parametrize(("validator_count,"), [(1000)])
 def test_get_unslashed_attesting_indices(genesis_state, config):
-    state = genesis_state.copy(
-        slot=compute_start_slot_at_epoch(3, config.SLOTS_PER_EPOCH)
+    state = genesis_state.set(
+        "slot", compute_start_slot_at_epoch(3, config.SLOTS_PER_EPOCH)
     )
     target_epoch = state.current_epoch(config.SLOTS_PER_EPOCH)
     target_slot = compute_start_slot_at_epoch(target_epoch, config.SLOTS_PER_EPOCH)
@@ -239,8 +240,10 @@ def test_get_unslashed_attesting_indices(genesis_state, config):
         state, target_slot, committee_index, CommitteeConfig(config)
     )
 
-    data = AttestationData(
-        slot=state.slot, index=committee_index, target=Checkpoint(epoch=target_epoch)
+    data = AttestationData.create(
+        slot=state.slot,
+        index=committee_index,
+        target=Checkpoint.create(epoch=target_epoch),
     )
     some_subset_count = random.randrange(1, len(some_committee) // 2)
     some_subset = random.sample(some_committee, some_subset_count)
@@ -249,9 +252,7 @@ def test_get_unslashed_attesting_indices(genesis_state, config):
     for i, index in enumerate(some_committee):
         if index in some_subset:
             if random.choice([True, False]):
-                state = state.update_validator_with_fn(
-                    index, lambda v, *_: v.copy(slashed=True)
-                )
+                state = state.transform(["validators", index, "slashed"], True)
             bitfield = set_voted(bitfield, i)
 
     some_subset = tuple(
@@ -260,7 +261,7 @@ def test_get_unslashed_attesting_indices(genesis_state, config):
 
     indices = get_unslashed_attesting_indices(
         state,
-        (PendingAttestation(data=data, aggregation_bits=bitfield),),
+        (PendingAttestation.create(data=data, aggregation_bits=bitfield),),
         CommitteeConfig(config),
     )
 

--- a/tests/eth2/core/beacon/test_epoch_processing_helpers.py
+++ b/tests/eth2/core/beacon/test_epoch_processing_helpers.py
@@ -3,7 +3,6 @@ import random
 import pytest
 
 from eth2._utils.bitfield import get_empty_bitfield, set_voted
-from eth2._utils.tuple import update_tuple_item
 from eth2.beacon.committee_helpers import get_beacon_committee
 from eth2.beacon.constants import FAR_FUTURE_EPOCH, GWEI_PER_ETH
 from eth2.beacon.epoch_processing_helpers import (

--- a/tests/eth2/core/beacon/test_genesis.py
+++ b/tests/eth2/core/beacon/test_genesis.py
@@ -43,7 +43,7 @@ def test_get_genesis_beacon_state(
         pubkeys=pubkeys[:validator_count], keymap=keymap, config=config
     )
 
-    genesis_eth1_data = Eth1Data(
+    genesis_eth1_data = Eth1Data.create(
         deposit_count=len(genesis_deposits),
         deposit_root=deposit_root,
         block_hash=ZERO_HASH32,
@@ -61,16 +61,16 @@ def test_get_genesis_beacon_state(
     # Versioning
     assert state.slot == genesis_slot
     assert state.genesis_time == _genesis_time_from_eth1_timestamp(eth1_timestamp)
-    assert state.fork == Fork()
+    assert state.fork == Fork.create()
 
     # History
-    assert state.latest_block_header == BeaconBlockHeader(
-        body_root=BeaconBlockBody().hash_tree_root
+    assert state.latest_block_header == BeaconBlockHeader.create(
+        body_root=BeaconBlockBody.create().hash_tree_root
     )
     assert len(state.block_roots) == slots_per_historical_root
-    assert state.block_roots == (ZERO_HASH32,) * slots_per_historical_root
+    assert tuple(state.block_roots) == (ZERO_HASH32,) * slots_per_historical_root
     assert len(state.state_roots) == slots_per_historical_root
-    assert state.block_roots == (ZERO_HASH32,) * slots_per_historical_root
+    assert tuple(state.block_roots) == (ZERO_HASH32,) * slots_per_historical_root
     assert len(state.historical_roots) == 0
 
     # Ethereum 1.0 chain data
@@ -84,11 +84,13 @@ def test_get_genesis_beacon_state(
 
     # Shuffling
     assert len(state.randao_mixes) == epochs_per_historical_vector
-    assert state.randao_mixes == (eth1_block_hash,) * epochs_per_historical_vector
+    assert (
+        tuple(state.randao_mixes) == (eth1_block_hash,) * epochs_per_historical_vector
+    )
 
     # Slashings
     assert len(state.slashings) == epochs_per_slashings_vector
-    assert state.slashings == (Gwei(0),) * epochs_per_slashings_vector
+    assert tuple(state.slashings) == (Gwei(0),) * epochs_per_slashings_vector
 
     # Attestations
     assert len(state.previous_epoch_attestations) == 0

--- a/tests/eth2/core/beacon/tools/builder/test_committee_assignment.py
+++ b/tests/eth2/core/beacon/tools/builder/test_committee_assignment.py
@@ -31,7 +31,7 @@ def test_get_committee_assignment(
     epoch,
 ):
     state_slot = compute_start_slot_at_epoch(state_epoch, slots_per_epoch)
-    state = genesis_state.copy(slot=state_slot)
+    state = genesis_state.set("slot", state_slot)
     committee_validator_count = [0 for _ in range(max_committees_per_slot)]
     slots = []
 
@@ -63,8 +63,8 @@ def test_get_committee_assignment_no_assignment(
     state = genesis_state
     validator_index = 1
     current_epoch = state.current_epoch(slots_per_epoch)
-    validator = state.validators[validator_index].copy(exit_epoch=genesis_epoch)
-    state = state.update_validator(validator_index, validator)
+    validator = state.validators[validator_index].set("exit_epoch", genesis_epoch)
+    state = state.transform(["validators", validator_index], validator)
     assert not validator.is_active(current_epoch)
 
     with pytest.raises(NoCommitteeAssignment):

--- a/tests/eth2/core/beacon/types/test_aggregate_and_proof.py
+++ b/tests/eth2/core/beacon/types/test_aggregate_and_proof.py
@@ -2,7 +2,7 @@ from eth2.beacon.types.aggregate_and_proof import AggregateAndProof
 
 
 def test_defaults(sample_aggregate_and_proof_params):
-    aggregate_and_proof = AggregateAndProof(**sample_aggregate_and_proof_params)
+    aggregate_and_proof = AggregateAndProof.create(**sample_aggregate_and_proof_params)
 
     assert aggregate_and_proof.index == sample_aggregate_and_proof_params["index"]
     assert (

--- a/tests/eth2/core/beacon/types/test_attestation.py
+++ b/tests/eth2/core/beacon/types/test_attestation.py
@@ -7,7 +7,7 @@ from eth2.beacon.types.attestations import Attestation
 @pytest.mark.parametrize("param,default_value", [("signature", b"\x00" * 96)])
 def test_defaults(param, default_value, sample_attestation_params):
     del sample_attestation_params[param]
-    attestation = Attestation(**sample_attestation_params)
+    attestation = Attestation.create(**sample_attestation_params)
 
     assert getattr(attestation, param) == default_value
     assert ssz.encode(attestation)

--- a/tests/eth2/core/beacon/types/test_attestation.py
+++ b/tests/eth2/core/beacon/types/test_attestation.py
@@ -1,7 +1,7 @@
 import pytest
-import ssz
 
 from eth2.beacon.types.attestations import Attestation
+import ssz
 
 
 @pytest.mark.parametrize("param,default_value", [("signature", b"\x00" * 96)])

--- a/tests/eth2/core/beacon/types/test_attestation_data.py
+++ b/tests/eth2/core/beacon/types/test_attestation_data.py
@@ -2,7 +2,7 @@ from eth2.beacon.types.attestation_data import AttestationData
 
 
 def test_defaults(sample_attestation_data_params):
-    attestation_data = AttestationData(**sample_attestation_data_params)
+    attestation_data = AttestationData.create(**sample_attestation_data_params)
 
     assert (
         attestation_data.source.epoch == sample_attestation_data_params["source"].epoch

--- a/tests/eth2/core/beacon/types/test_attester_slashings.py
+++ b/tests/eth2/core/beacon/types/test_attester_slashings.py
@@ -4,7 +4,7 @@ from eth2.beacon.types.attester_slashings import AttesterSlashing
 
 
 def test_defaults(sample_attester_slashing_params):
-    attester_slashing = AttesterSlashing(**sample_attester_slashing_params)
+    attester_slashing = AttesterSlashing.create(**sample_attester_slashing_params)
 
     assert (
         attester_slashing.attestation_1.attesting_indices

--- a/tests/eth2/core/beacon/types/test_attester_slashings.py
+++ b/tests/eth2/core/beacon/types/test_attester_slashings.py
@@ -1,6 +1,5 @@
-import ssz
-
 from eth2.beacon.types.attester_slashings import AttesterSlashing
+import ssz
 
 
 def test_defaults(sample_attester_slashing_params):

--- a/tests/eth2/core/beacon/types/test_block.py
+++ b/tests/eth2/core/beacon/types/test_block.py
@@ -4,40 +4,40 @@ from eth2.beacon.typing import FromBlockParams
 
 
 def test_defaults(sample_beacon_block_params):
-    block = BeaconBlock(**sample_beacon_block_params)
+    block = BeaconBlock.create(**sample_beacon_block_params)
     assert block.slot == sample_beacon_block_params["slot"]
     assert block.is_genesis
 
 
 def test_block_is_not_genesis(sample_beacon_block_params):
-    genesis_block = BeaconBlock(**sample_beacon_block_params)
+    genesis_block = BeaconBlock.create(**sample_beacon_block_params)
     another_block = BeaconBlock.from_parent(genesis_block, FromBlockParams())
     assert genesis_block.is_genesis
     assert not another_block.is_genesis
 
 
 def test_update_attestations(sample_attestation_params, sample_beacon_block_params):
-    block = BeaconBlock(**sample_beacon_block_params)
+    block = BeaconBlock.create(**sample_beacon_block_params)
     attestations = block.body.attestations
     attestations = list(attestations)
-    attestations.append(Attestation(**sample_attestation_params))
-    body2 = block.body.copy(attestations=attestations)
-    block2 = block.copy(body=body2)
+    attestations.append(Attestation.create(**sample_attestation_params))
+    body2 = block.body.set("attestations", attestations)
+    block2 = block.set("body", body2)
     assert len(block2.body.attestations) == 1
 
 
 def test_block_body_empty(sample_attestation_params):
-    block_body = BeaconBlockBody()
-    assert block_body.proposer_slashings == ()
-    assert block_body.attester_slashings == ()
-    assert block_body.attestations == ()
-    assert block_body.deposits == ()
-    assert block_body.voluntary_exits == ()
+    block_body = BeaconBlockBody.create()
+    assert tuple(block_body.proposer_slashings) == ()
+    assert tuple(block_body.attester_slashings) == ()
+    assert tuple(block_body.attestations) == ()
+    assert tuple(block_body.deposits) == ()
+    assert tuple(block_body.voluntary_exits) == ()
 
     assert block_body.is_empty
 
-    block_body = block_body.copy(
-        attestations=(Attestation(**sample_attestation_params),)
+    block_body = block_body.set(
+        "attestations", (Attestation.create(**sample_attestation_params),)
     )
     assert not block_body.is_empty
 

--- a/tests/eth2/core/beacon/types/test_deposit_data.py
+++ b/tests/eth2/core/beacon/types/test_deposit_data.py
@@ -2,7 +2,7 @@ from eth2.beacon.types.deposit_data import DepositData
 
 
 def test_defaults(sample_deposit_data_params):
-    deposit_data = DepositData(**sample_deposit_data_params)
+    deposit_data = DepositData.create(**sample_deposit_data_params)
 
     assert deposit_data.pubkey == sample_deposit_data_params["pubkey"]
     assert deposit_data.amount == sample_deposit_data_params["amount"]

--- a/tests/eth2/core/beacon/types/test_deposits.py
+++ b/tests/eth2/core/beacon/types/test_deposits.py
@@ -2,6 +2,6 @@ from eth2.beacon.types.deposits import Deposit
 
 
 def test_defaults(sample_deposit_params):
-    deposit = Deposit(**sample_deposit_params)
+    deposit = Deposit.create(**sample_deposit_params)
 
     assert deposit.data == sample_deposit_params["data"]

--- a/tests/eth2/core/beacon/types/test_eth1_data.py
+++ b/tests/eth2/core/beacon/types/test_eth1_data.py
@@ -2,6 +2,6 @@ from eth2.beacon.types.eth1_data import Eth1Data
 
 
 def test_defaults(sample_eth1_data_params):
-    eth1_data = Eth1Data(**sample_eth1_data_params)
+    eth1_data = Eth1Data.create(**sample_eth1_data_params)
     assert eth1_data.deposit_root == sample_eth1_data_params["deposit_root"]
     assert eth1_data.block_hash == sample_eth1_data_params["block_hash"]

--- a/tests/eth2/core/beacon/types/test_fork.py
+++ b/tests/eth2/core/beacon/types/test_fork.py
@@ -4,7 +4,7 @@ from eth2.beacon.types.forks import Fork
 
 
 def test_defaults(sample_fork_params):
-    fork = Fork(**sample_fork_params)
+    fork = Fork.create(**sample_fork_params)
     assert fork.previous_version == sample_fork_params["previous_version"]
     assert fork.current_version == sample_fork_params["current_version"]
     assert fork.epoch == sample_fork_params["epoch"]

--- a/tests/eth2/core/beacon/types/test_fork.py
+++ b/tests/eth2/core/beacon/types/test_fork.py
@@ -1,6 +1,5 @@
-import ssz
-
 from eth2.beacon.types.forks import Fork
+import ssz
 
 
 def test_defaults(sample_fork_params):

--- a/tests/eth2/core/beacon/types/test_pending_attestation_record.py
+++ b/tests/eth2/core/beacon/types/test_pending_attestation_record.py
@@ -4,7 +4,7 @@ from eth2.beacon.types.pending_attestations import PendingAttestation
 
 
 def test_defaults(sample_pending_attestation_record_params):
-    pending_attestation = PendingAttestation(**sample_pending_attestation_record_params)
+    pending_attestation = PendingAttestation.create(**sample_pending_attestation_record_params)
 
     assert pending_attestation.data == sample_pending_attestation_record_params["data"]
     assert (

--- a/tests/eth2/core/beacon/types/test_pending_attestation_record.py
+++ b/tests/eth2/core/beacon/types/test_pending_attestation_record.py
@@ -1,10 +1,11 @@
-import ssz
-
 from eth2.beacon.types.pending_attestations import PendingAttestation
+import ssz
 
 
 def test_defaults(sample_pending_attestation_record_params):
-    pending_attestation = PendingAttestation.create(**sample_pending_attestation_record_params)
+    pending_attestation = PendingAttestation.create(
+        **sample_pending_attestation_record_params
+    )
 
     assert pending_attestation.data == sample_pending_attestation_record_params["data"]
     assert (

--- a/tests/eth2/core/beacon/types/test_proposer_slashings.py
+++ b/tests/eth2/core/beacon/types/test_proposer_slashings.py
@@ -4,7 +4,7 @@ from eth2.beacon.types.proposer_slashings import ProposerSlashing
 
 
 def test_defaults(sample_proposer_slashing_params):
-    slashing = ProposerSlashing(**sample_proposer_slashing_params)
+    slashing = ProposerSlashing.create(**sample_proposer_slashing_params)
     assert slashing.proposer_index == sample_proposer_slashing_params["proposer_index"]
     assert slashing.header_1 == sample_proposer_slashing_params["header_1"]
     assert slashing.header_2 == sample_proposer_slashing_params["header_2"]

--- a/tests/eth2/core/beacon/types/test_proposer_slashings.py
+++ b/tests/eth2/core/beacon/types/test_proposer_slashings.py
@@ -1,6 +1,5 @@
-import ssz
-
 from eth2.beacon.types.proposer_slashings import ProposerSlashing
+import ssz
 
 
 def test_defaults(sample_proposer_slashing_params):

--- a/tests/eth2/core/beacon/types/test_states.py
+++ b/tests/eth2/core/beacon/types/test_states.py
@@ -1,53 +1,8 @@
-import pytest
-import ssz
-
-from eth2.beacon.tools.builder.initializer import create_mock_validator
 from eth2.beacon.types.states import BeaconState
+import ssz
 
 
 def test_defaults(sample_beacon_state_params):
-    state = BeaconState(**sample_beacon_state_params)
-    assert state.validators == sample_beacon_state_params["validators"]
+    state = BeaconState.create(**sample_beacon_state_params)
+    assert tuple(state.validators) == sample_beacon_state_params["validators"]
     assert ssz.encode(state)
-
-
-def test_validators_and_balances_length(sample_beacon_state_params, config):
-    # When len(BeaconState.validators) != len(BeaconState.validtor_balances)
-    with pytest.raises(ValueError):
-        BeaconState(**sample_beacon_state_params).copy(
-            validators=tuple(
-                create_mock_validator(pubkey, config) for pubkey in range(10)
-            )
-        )
-
-
-@pytest.mark.parametrize(
-    "validator_index_offset, new_pubkey, new_balance",
-    [(0, 5566, 100), (100, 5566, 100)],
-)
-def test_update_validator(
-    genesis_state,
-    validator_index_offset,
-    validator_count,
-    new_pubkey,
-    new_balance,
-    config,
-):
-    state = genesis_state
-    validator = create_mock_validator(new_pubkey, config)
-    validator_index = validator_count + validator_index_offset
-
-    if validator_index < state.validator_count:
-        result_state = state.update_validator(
-            validator_index=validator_index, validator=validator, balance=new_balance
-        )
-        assert result_state.balances[validator_index] == new_balance
-        assert result_state.validators[validator_index].pubkey == new_pubkey
-        assert state.validators[validator_index].pubkey != new_pubkey
-    else:
-        with pytest.raises(IndexError):
-            state.update_validator(
-                validator_index=validator_index,
-                validator=validator,
-                balance=new_balance,
-            )

--- a/tests/eth2/core/beacon/types/test_validator_record.py
+++ b/tests/eth2/core/beacon/types/test_validator_record.py
@@ -6,7 +6,7 @@ from eth2.beacon.typing import Gwei
 
 
 def test_defaults(sample_validator_record_params):
-    validator = Validator(**sample_validator_record_params)
+    validator = Validator.create(**sample_validator_record_params)
     assert validator.pubkey == sample_validator_record_params["pubkey"]
     assert (
         validator.withdrawal_credentials
@@ -26,12 +26,12 @@ def test_is_active(
         "activation_epoch": activation_epoch,
         "exit_epoch": exit_epoch,
     }
-    validator = Validator(**validator_record_params)
+    validator = Validator.create(**validator_record_params)
     assert validator.is_active(epoch) == expected
 
 
 def test_create_pending_validator(config):
-    pubkey = 123
+    pubkey = b"\x12" * 48
     withdrawal_credentials = b"\x11" * 32
 
     effective_balance = 22 * GWEI_PER_ETH

--- a/tests/eth2/core/beacon/types/test_voluntary_exits.py
+++ b/tests/eth2/core/beacon/types/test_voluntary_exits.py
@@ -1,10 +1,9 @@
-import ssz
-
 from eth2.beacon.types.voluntary_exits import VoluntaryExit
+import ssz
 
 
 def test_defaults(sample_voluntary_exit_params):
-    exit = VoluntaryExit(**sample_voluntary_exit_params)
+    exit = VoluntaryExit.create(**sample_voluntary_exit_params)
 
     assert exit.signature[0] == sample_voluntary_exit_params["signature"][0]
     assert ssz.encode(exit)

--- a/tests/libp2p/bcc/test_receive_server.py
+++ b/tests/libp2p/bcc/test_receive_server.py
@@ -405,7 +405,9 @@ async def test_bcc_receive_server_get_ready_attestations(receive_server, monkeyp
 
     attesting_slot = MINIMAL_SERENITY_CONFIG.GENESIS_SLOT
     a1 = Attestation.create(data=AttestationData.create(slot=attesting_slot))
-    a2 = Attestation.create(signature=b"\x56" * 96, data=AttestationData.create(slot=attesting_slot))
+    a2 = Attestation.create(
+        signature=b"\x56" * 96, data=AttestationData.create(slot=attesting_slot)
+    )
     a3 = Attestation.create(
         signature=b"\x78" * 96, data=AttestationData.create(slot=attesting_slot + 1)
     )

--- a/tests/libp2p/bcc/test_receive_server.py
+++ b/tests/libp2p/bcc/test_receive_server.py
@@ -5,7 +5,6 @@ from eth.exceptions import BlockNotFound
 from eth_utils import ValidationError
 from libp2p.pubsub.pb import rpc_pb2
 import pytest
-import ssz
 
 from eth2.beacon.chains.base import BaseBeaconChain
 from eth2.beacon.chains.testnet import SkeletonLakeChain
@@ -19,6 +18,7 @@ from eth2.beacon.types.attestations import Attestation
 from eth2.beacon.types.blocks import BaseBeaconBlock, BeaconBlock
 from eth2.beacon.typing import FromBlockParams
 from eth2.configs import Eth2GenesisConfig
+import ssz
 from trinity.db.beacon.chain import AsyncBeaconChainDB
 from trinity.protocol.bcc_libp2p.configs import (
     PUBSUB_TOPIC_BEACON_ATTESTATION,

--- a/tests/libp2p/bcc/test_req_resp.py
+++ b/tests/libp2p/bcc/test_req_resp.py
@@ -28,7 +28,7 @@ async def test_handshake_failure_invalid_status_packet(monkeypatch, mock_timeout
     async with ConnectionPairFactory(handshake=False) as (alice, bob):
 
         def status_with_wrong_fork_version(chain):
-            return Status(
+            return Status.create(
                 head_fork_version=b"\x12\x34\x56\x78"  # version different from another node.
             )
 
@@ -39,7 +39,7 @@ async def test_handshake_failure_invalid_status_packet(monkeypatch, mock_timeout
         assert bob.peer_id not in alice.handshaked_peers
 
         def status_with_wrong_checkpoint(chain):
-            return Status(
+            return Status.create(
                 finalized_root=b"\x78"
                 * 32  # finalized root different from another node.
             )

--- a/tests/libp2p/bcc/test_req_resp.py
+++ b/tests/libp2p/bcc/test_req_resp.py
@@ -102,12 +102,12 @@ async def test_request_beacon_blocks_by_range_invalid_request(monkeypatch):
 
         head_slot = 1
         request_head_block_root = b"\x56" * 32
-        head_block = BeaconBlock(
+        head_block = BeaconBlock.create(
             slot=head_slot,
             parent_root=ZERO_HASH32,
             state_root=ZERO_HASH32,
             signature=EMPTY_SIGNATURE,
-            body=BeaconBlockBody(),
+            body=BeaconBlockBody.create(),
         )
 
         # TEST: Can not request blocks with `start_slot` greater than head block slot
@@ -134,8 +134,8 @@ async def test_request_beacon_blocks_by_range_invalid_request(monkeypatch):
         start_slot = head_slot
         state_machine = bob.chain.get_state_machine()
         old_state = bob.chain.get_head_state()
-        new_checkpoint = old_state.finalized_checkpoint.copy(
-            epoch=old_state.finalized_checkpoint.epoch + 1
+        new_checkpoint = old_state.finalized_checkpoint.set(
+            "epoch", old_state.finalized_checkpoint.epoch + 1
         )
 
         def get_canonical_block_by_slot(slot):
@@ -147,13 +147,13 @@ async def test_request_beacon_blocks_by_range_invalid_request(monkeypatch):
 
         def get_state_machine(at_slot=None):
             class MockStateMachine:
-                state = old_state.copy(finalized_checkpoint=new_checkpoint)
+                state = old_state.set("finalized_checkpoint", new_checkpoint)
                 config = state_machine.config
 
             return MockStateMachine()
 
         def get_head_state():
-            return old_state.copy(finalized_checkpoint=new_checkpoint)
+            return old_state.set("finalized_checkpoint", new_checkpoint)
 
         monkeypatch.setattr(bob.chain, "get_state_machine", get_state_machine)
         monkeypatch.setattr(bob.chain, "get_head_state", get_head_state)
@@ -198,14 +198,14 @@ async def test_request_beacon_blocks_by_root(monkeypatch):
     async with ConnectionPairFactory() as (alice, bob):
 
         # Mock up block database
-        head_block = BeaconBlock(
+        head_block = BeaconBlock.create(
             slot=0,
             parent_root=ZERO_HASH32,
             state_root=ZERO_HASH32,
             signature=EMPTY_SIGNATURE,
-            body=BeaconBlockBody(),
+            body=BeaconBlockBody.create(),
         )
-        blocks = [head_block.copy(slot=slot) for slot in range(5)]
+        blocks = [head_block.set("slot", slot) for slot in range(5)]
         mock_root_to_block_db = {block.signing_root: block for block in blocks}
 
         def get_block_by_root(root):

--- a/tests/libp2p/bcc/test_utils.py
+++ b/tests/libp2p/bcc/test_utils.py
@@ -25,9 +25,6 @@ from trinity.protocol.bcc_libp2p.utils import (
 )
 from trinity.tools.bcc_factories import BeaconBlockFactory
 
-# Wrong type of `fork_version`, which should be `bytes4`.
-invalid_ssz_msg = Status(head_fork_version="1")
-
 
 def test_peer_id_from_pubkey():
     pubkey = datatypes.PublicKey(
@@ -67,7 +64,7 @@ class FakeNetStream:
         return len(data)
 
 
-@pytest.mark.parametrize("msg", (Status(),))
+@pytest.mark.parametrize("msg", (Status.create(),))
 @pytest.mark.asyncio
 async def test_read_write_req_msg(msg):
     s = FakeNetStream()
@@ -76,7 +73,7 @@ async def test_read_write_req_msg(msg):
     assert msg_read == msg
 
 
-@pytest.mark.parametrize("msg", (Status(),))
+@pytest.mark.parametrize("msg", (Status.create(),))
 @pytest.mark.asyncio
 async def test_read_write_resp_msg(msg):
     s = FakeNetStream()
@@ -111,15 +108,6 @@ async def test_read_req_failure(mock_timeout):
     await s.write(b"\x03123")
     with pytest.raises(ReadMessageFailure):
         await read_req(s, Status)
-
-
-@pytest.mark.asyncio
-async def test_write_req_failure():
-    s = FakeNetStream()
-
-    # Test: Raise `WriteMessageFailure` if `ssz.SerializationError` is thrown.
-    with pytest.raises(WriteMessageFailure):
-        await write_req(s, invalid_ssz_msg)
 
 
 @pytest.mark.asyncio
@@ -166,11 +154,7 @@ async def test_write_resp_failure():
     # Test: Raise `WriteMessageFailure` if `resp_code` is not SUCCESS,
     #   but `msg` is not `str`.
     with pytest.raises(WriteMessageFailure):
-        await write_resp(s, Status(), ResponseCode.INVALID_REQUEST)
-
-    # Test: Raise `WriteMessageFailure` if `ssz.SerializationError` is thrown.
-    with pytest.raises(WriteMessageFailure):
-        await write_req(s, invalid_ssz_msg)
+        await write_resp(s, Status.create(), ResponseCode.INVALID_REQUEST)
 
 
 @pytest.mark.parametrize(

--- a/trinity/components/eth2/eth1_monitor/eth1_monitor.py
+++ b/trinity/components/eth2/eth1_monitor/eth1_monitor.py
@@ -229,7 +229,7 @@ class Eth1Monitor(Service):
                 f"contract_deposit_root={contract_deposit_root.hex()}, "
                 f"deposit_root={deposit_root.hex()}"
             )
-        return Eth1Data(
+        return Eth1Data.create(
             deposit_root=deposit_root,
             deposit_count=accumulated_deposit_count,
             block_hash=block_hash,
@@ -257,7 +257,7 @@ class Eth1Monitor(Service):
             )
         deposit_data_in_range = self._db.get_deposit_data_range(0, deposit_count)
         tree, root = make_deposit_tree_and_root(deposit_data_in_range)
-        return Deposit(
+        return Deposit.create(
             proof=make_deposit_proof(deposit_data_in_range, tree, root, deposit_index),
             data=self._db.get_deposit_data(deposit_index),
         )
@@ -338,7 +338,7 @@ class Eth1Monitor(Service):
         `deposit_count`.
         """
         seq_deposit_data = tuple(
-            DepositData(
+            DepositData.create(
                 pubkey=log.pubkey,
                 withdrawal_credentials=log.withdrawal_credentials,
                 amount=log.amount,

--- a/trinity/components/eth2/eth1_monitor/factories.py
+++ b/trinity/components/eth2/eth1_monitor/factories.py
@@ -33,7 +33,7 @@ SAMPLE_VALID_SIGNATURE = b"\x33" * 96
 
 class DepositDataFactory(factory.Factory):
     class Meta:
-        model = DepositData
+        model = DepositData.create
 
     pubkey = SAMPLE_PUBKEY
     withdrawal_credentials = SAMPLE_WITHDRAWAL_CREDENTIALS

--- a/trinity/components/eth2/interop/component.py
+++ b/trinity/components/eth2/interop/component.py
@@ -148,8 +148,8 @@ class InteropComponent(Application):
             cls.logger.info("Time will begin %d seconds from now", delta)
 
             # adapt the state, then print the new root!
-            state = state.copy(
-                genesis_time=args.start_time
+            state = state.set(
+                "genesis_time", args.start_time
             )
         elif args.start_delay:
             if args.start_delay < 0:
@@ -159,8 +159,8 @@ class InteropComponent(Application):
             start_time = now + args.start_delay
             cls.logger.info("Genesis time is %d", start_time)
 
-            state = state.copy(
-                genesis_time=start_time
+            state = state.set(
+                "genesis_time", start_time
             )
         else:
             cls.logger.info("Using genesis_time from genesis state to determine start time")

--- a/trinity/protocol/bcc_libp2p/messages.py
+++ b/trinity/protocol/bcc_libp2p/messages.py
@@ -2,13 +2,13 @@ from typing import (
     Sequence,
 )
 
-import ssz
 from ssz.sedes import (
     List,
     bytes4,
     bytes32,
     uint64,
 )
+from ssz.hashable_container import HashableContainer
 
 from eth2.beacon.typing import (
     Version,
@@ -21,7 +21,7 @@ from eth2.beacon.constants import ZERO_SIGNING_ROOT
 from .configs import GoodbyeReasonCode
 
 
-class Status(ssz.Serializable):
+class Status(HashableContainer):
     fields = [
         ('head_fork_version', bytes4),
         ('finalized_root', bytes32),
@@ -30,33 +30,35 @@ class Status(ssz.Serializable):
         ('head_slot', uint64),
     ]
 
-    def __init__(
-        self,
+    @classmethod
+    def create(
+        cls,
         head_fork_version: Version = default_version,
         finalized_root: SigningRoot = ZERO_SIGNING_ROOT,
         finalized_epoch: Epoch = default_epoch,
         head_root: SigningRoot = ZERO_SIGNING_ROOT,
         head_slot: Slot = default_slot,
-    ) -> None:
-        super().__init__(
-            head_fork_version,
-            finalized_root,
-            finalized_epoch,
-            head_root,
-            head_slot,
+    ) -> "Status":
+        return super().create(
+            head_fork_version=head_fork_version,
+            finalized_root=finalized_root,
+            finalized_epoch=finalized_epoch,
+            head_root=head_root,
+            head_slot=head_slot,
         )
 
 
-class Goodbye(ssz.Serializable):
+class Goodbye(HashableContainer):
     fields = [
         ('reason', uint64),
     ]
 
-    def __init__(self, reason: int) -> None:
-        super().__init__(GoodbyeReasonCode(reason))
+    @classmethod
+    def create(self, reason: int) -> None:
+        return super().create(reason=GoodbyeReasonCode(reason))
 
 
-class BeaconBlocksByRangeRequest(ssz.Serializable):
+class BeaconBlocksByRangeRequest(HashableContainer):
     fields = [
         ('head_block_root', bytes32),
         ('start_slot', uint64),
@@ -64,25 +66,27 @@ class BeaconBlocksByRangeRequest(ssz.Serializable):
         ('step', uint64),
     ]
 
-    def __init__(
-        self,
+    @classmethod
+    def create(
+        cls,
         head_block_root: SigningRoot,
         start_slot: Slot,
         count: int,
         step: int,
-    ) -> None:
-        super().__init__(
-            head_block_root,
-            start_slot,
-            count,
-            step,
+    ) -> "BeaconBlocksByRangeRequest":
+        return super().create(
+            head_block_root=head_block_root,
+            start_slot=start_slot,
+            count=count,
+            step=step,
         )
 
 
-class BeaconBlocksByRootRequest(ssz.Serializable):
+class BeaconBlocksByRootRequest(HashableContainer):
     fields = [
-        ('block_roots', List(bytes32, 1)),
+        ('block_roots', List(bytes32, 64)),
     ]
 
-    def __init__(self, block_roots: Sequence[SigningRoot]) -> None:
-        super().__init__(block_roots)
+    @classmethod
+    def create(cls, block_roots: Sequence[SigningRoot]) -> "BeaconBlocksByRootRequest":
+        return super().create(block_roots=block_roots)

--- a/trinity/protocol/bcc_libp2p/node.py
+++ b/trinity/protocol/bcc_libp2p/node.py
@@ -573,7 +573,7 @@ class Node(BaseService):
     async def say_goodbye(self, peer_id: ID, reason: GoodbyeReasonCode) -> None:
         stream = await self.new_stream(peer_id, REQ_RESP_GOODBYE_SSZ)
         async with Interaction(stream) as interaction:
-            goodbye = Goodbye(reason)
+            goodbye = Goodbye.create(reason)
             try:
                 await interaction.write_request(goodbye)
             except WriteMessageFailure:
@@ -612,7 +612,7 @@ class Node(BaseService):
         stream = await self.new_stream(peer_id, REQ_RESP_BEACON_BLOCKS_BY_RANGE_SSZ)
         async with self.my_request_interaction(stream) as interaction:
             self._check_peer_handshaked(peer_id)
-            request = BeaconBlocksByRangeRequest(
+            request = BeaconBlocksByRangeRequest.create(
                 head_block_root=head_block_root,
                 start_slot=start_slot,
                 count=count,
@@ -642,7 +642,7 @@ class Node(BaseService):
         stream = await self.new_stream(peer_id, REQ_RESP_BEACON_BLOCKS_BY_ROOT_SSZ)
         async with self.my_request_interaction(stream) as interaction:
             self._check_peer_handshaked(peer_id)
-            request = BeaconBlocksByRootRequest(block_roots=block_roots)
+            request = BeaconBlocksByRootRequest.create(block_roots=block_roots)
             await interaction.write_request(request)
             blocks = tuple([
                 block async for block in

--- a/trinity/protocol/bcc_libp2p/utils.py
+++ b/trinity/protocol/bcc_libp2p/utils.py
@@ -59,8 +59,8 @@ from multiaddr import (
 )
 import multihash
 import ssz
-from ssz.sedes.serializable import (
-    BaseSerializable,
+from ssz.hashable_container import (
+    HashableContainer,
 )
 from ssz.tools import (
     to_formatted_dict,
@@ -89,7 +89,7 @@ from .messages import (
     BeaconBlocksByRootRequest,
 )
 
-MsgType = TypeVar("MsgType", bound=BaseSerializable)
+MsgType = TypeVar("MsgType", bound=HashableContainer)
 
 logger = logging.getLogger('trinity.protocol.bcc_libp2p')
 
@@ -116,7 +116,7 @@ def get_my_status(chain: BaseBeaconChain) -> Status:
     state = chain.get_head_state()
     head = chain.get_canonical_head()
     finalized_checkpoint = state.finalized_checkpoint
-    return Status(
+    return Status.create(
         head_fork_version=state.fork.current_version,
         finalized_root=finalized_checkpoint.root,
         finalized_epoch=finalized_checkpoint.epoch,
@@ -486,13 +486,13 @@ async def write_resp(
     except OverflowError as error:
         raise WriteMessageFailure(f"resp_code={resp_code} is not valid") from error
     msg_bytes: bytes
-    # MsgType: `msg` is of type `BaseSerializable` if response code is success.
+    # MsgType: `msg` is of type `HashableContainer` if response code is success.
     if resp_code == ResponseCode.SUCCESS:
-        if isinstance(msg, BaseSerializable):
+        if isinstance(msg, HashableContainer):
             msg_bytes = _serialize_ssz_msg(msg)
         else:
             raise WriteMessageFailure(
-                "type of `msg` should be `BaseSerializable` if response code is SUCCESS, "
+                "type of `msg` should be `HashableContainer` if response code is SUCCESS, "
                 f"type(msg)={type(msg)}"
             )
     # error msg is of type `str` if response code is not SUCCESS.

--- a/trinity/tools/bcc_factories.py
+++ b/trinity/tools/bcc_factories.py
@@ -141,12 +141,12 @@ async def ConnectionPairFactory(
 
 class BeaconBlockBodyFactory(factory.Factory):
     class Meta:
-        model = BeaconBlockBody
+        model = BeaconBlockBody.create
 
 
 class BeaconBlockFactory(factory.Factory):
     class Meta:
-        model = BeaconBlock
+        model = BeaconBlock.create
 
     slot = SERENITY_GENESIS_CONFIG.GENESIS_SLOT
     parent_root = ZERO_SIGNING_ROOT


### PR DESCRIPTION
:construction: Please do not merge :construction: 

First step of transitioning to py-ssz hashables:

- change all types from serializables to hashable containers
- load the static SSZ tests into hashable lists/vectors/containers instead of tuples/serializables

The SSZ tests pass with the latest commit in https://github.com/ethereum/py-ssz/pull/97.

#### Cute Animal Picture

![monkey-on-a-tree-2924649](https://user-images.githubusercontent.com/29854669/68943611-39147e80-07de-11ea-9d12-9447cf727685.jpg)