### PR TITLE
Update to libp2p 0.1.4

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,7 @@ deps = {
         "argcomplete>=1.10.0,<2",
         "multiaddr>=0.0.8,<0.1.0",
         "pymultihash>=0.8.2",
-        "libp2p==0.1.1",
+        "libp2p==0.1.2",
     ],
     'test': [
         "async-timeout>=3.0.1,<4",

--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,7 @@ deps = {
         "argcomplete>=1.10.0,<2",
         "multiaddr>=0.0.8,<0.1.0",
         "pymultihash>=0.8.2",
-        "libp2p==0.1.2",
+        "libp2p==0.1.4",
     ],
     'test': [
         "async-timeout>=3.0.1,<4",

--- a/tests/libp2p/bcc/test_node.py
+++ b/tests/libp2p/bcc/test_node.py
@@ -1,10 +1,7 @@
 import asyncio
 
-from libp2p.peer.id import ID
 import pytest
 
-from p2p.tools.factories import get_open_port
-from trinity.protocol.bcc_libp2p.exceptions import DialPeerError
 from trinity.tools.bcc_factories import NodeFactory
 
 
@@ -18,28 +15,15 @@ async def test_node(nodes):
 
 @pytest.mark.parametrize("num_nodes", (3,))
 @pytest.mark.asyncio
-async def test_node_dial_peer(nodes):
-    # Test: Exception raised when dialing a wrong addr
-    with pytest.raises(DialPeerError):
-        await nodes[0].dial_peer(nodes[1].listen_ip, get_open_port(), ID("123"))
+async def test_node_dial_peer_maddr(nodes):
     # Test: 0 <-> 1
-    await nodes[0].dial_peer(nodes[1].listen_ip, nodes[1].listen_port, nodes[1].peer_id)
+    await nodes[0].dial_peer_maddr(nodes[1].listen_maddr, nodes[1].peer_id)
     assert nodes[0].peer_id in nodes[1].host.get_network().connections
     assert nodes[1].peer_id in nodes[0].host.get_network().connections
     # Test: Second dial to a connected peer does not open a new connection
     original_conn = nodes[1].host.get_network().connections[nodes[0].peer_id]
-    await nodes[0].dial_peer(nodes[1].listen_ip, nodes[1].listen_port, nodes[1].peer_id)
+    await nodes[0].dial_peer_maddr(nodes[1].listen_maddr, nodes[1].peer_id)
     assert nodes[1].host.get_network().connections[nodes[0].peer_id] is original_conn
-    # Test: 0 <-> 1 <-> 2
-    await nodes[2].dial_peer(nodes[1].listen_ip, nodes[1].listen_port, nodes[1].peer_id)
-    assert nodes[1].peer_id in nodes[2].host.get_network().connections
-    assert nodes[2].peer_id in nodes[1].host.get_network().connections
-    assert len(nodes[1].host.get_network().connections) == 2
-
-
-@pytest.mark.parametrize("num_nodes", (3,))
-@pytest.mark.asyncio
-async def test_node_dial_peer_maddr(nodes):
     # Test: 0 <-> 1 <-> 2
     await nodes[1].dial_peer_maddr(nodes[2].listen_maddr, nodes[2].peer_id)
     await nodes[1].dial_peer_maddr(nodes[0].listen_maddr, nodes[0].peer_id)

--- a/tests/libp2p/bcc/test_node.py
+++ b/tests/libp2p/bcc/test_node.py
@@ -4,6 +4,7 @@ from libp2p.peer.id import ID
 import pytest
 
 from p2p.tools.factories import get_open_port
+from trinity.protocol.bcc_libp2p.exceptions import DialPeerError
 from trinity.tools.bcc_factories import NodeFactory
 
 
@@ -19,7 +20,7 @@ async def test_node(nodes):
 @pytest.mark.asyncio
 async def test_node_dial_peer(nodes):
     # Test: Exception raised when dialing a wrong addr
-    with pytest.raises(ConnectionRefusedError):
+    with pytest.raises(DialPeerError):
         await nodes[0].dial_peer(nodes[1].listen_ip, get_open_port(), ID("123"))
     # Test: 0 <-> 1
     await nodes[0].dial_peer(nodes[1].listen_ip, nodes[1].listen_port, nodes[1].peer_id)
@@ -40,8 +41,8 @@ async def test_node_dial_peer(nodes):
 @pytest.mark.asyncio
 async def test_node_dial_peer_maddr(nodes):
     # Test: 0 <-> 1 <-> 2
-    await nodes[1].dial_peer_maddr(nodes[2].listen_maddr_with_peer_id)
-    await nodes[1].dial_peer_maddr(nodes[0].listen_maddr_with_peer_id)
+    await nodes[1].dial_peer_maddr(nodes[2].listen_maddr, nodes[2].peer_id)
+    await nodes[1].dial_peer_maddr(nodes[0].listen_maddr, nodes[0].peer_id)
     assert nodes[1].peer_id in nodes[2].host.get_network().connections
     assert nodes[2].peer_id in nodes[1].host.get_network().connections
     assert nodes[1].peer_id in nodes[0].host.get_network().connections

--- a/tests/libp2p/bcc/test_utils.py
+++ b/tests/libp2p/bcc/test_utils.py
@@ -40,10 +40,10 @@ def test_peer_id_from_pubkey():
 class FakeNetStream:
     _queue: "asyncio.Queue[bytes]"
 
-    class FakeMplexConn(NamedTuple):
+    class FakeMuxedConn(NamedTuple):
         peer_id: ID = ID(b"\x12\x20" + b"\x00" * 32)
 
-    mplex_conn = FakeMplexConn()
+    muxed_conn = FakeMuxedConn()
 
     def __init__(self) -> None:
         self._queue = asyncio.Queue()

--- a/trinity/protocol/bcc_libp2p/exceptions.py
+++ b/trinity/protocol/bcc_libp2p/exceptions.py
@@ -6,6 +6,10 @@ class HandshakeFailure(BaseLibp2pError):
     ...
 
 
+class DialPeerError(BaseLibp2pError):
+    ...
+
+
 class MessageIOFailure(BaseLibp2pError):
     ...
 

--- a/trinity/protocol/bcc_libp2p/node.py
+++ b/trinity/protocol/bcc_libp2p/node.py
@@ -282,7 +282,7 @@ class Node(BaseService):
             sec_opt=security_protocol_ops,
             peerstore_opt=None,  # let the function initialize it
         )
-        self.host = BasicHost(public_key=key_pair.public_key, network=network)
+        self.host = BasicHost(network=network)
 
         if gossipsub_params is None:
             gossipsub_params = GossipsubParams()

--- a/trinity/protocol/bcc_libp2p/node.py
+++ b/trinity/protocol/bcc_libp2p/node.py
@@ -312,7 +312,10 @@ class Node(BaseService):
         # host
         self._register_rpc_handlers()
         # TODO: Register notifees
-        await self.host.get_network().listen(self.listen_maddr)
+        is_listening = await self.host.get_network().listen(self.listen_maddr)
+        if not is_listening:
+            self.logger.error("Fail to listen on maddr: %s", self.listen_maddr)
+            raise
         self.logger.warning("Node listening: %s", self.listen_maddr_with_peer_id)
         await self.connect_preferred_nodes()
         # TODO: Connect bootstrap nodes?

--- a/trinity/protocol/bcc_libp2p/node.py
+++ b/trinity/protocol/bcc_libp2p/node.py
@@ -273,9 +273,8 @@ class Node(BaseService):
             muxer_opt=muxer_protocol_ops,
             sec_opt=security_protocol_ops,
             peerstore_opt=None,  # let the function initialize it
-            disc_opt=None,  # no routing required here
         )
-        self.host = BasicHost(network=network, router=None)
+        self.host = BasicHost(public_key=key_pair.public_key, network=network)
 
         if gossipsub_params is None:
             gossipsub_params = GossipsubParams()

--- a/trinity/protocol/bcc_libp2p/node.py
+++ b/trinity/protocol/bcc_libp2p/node.py
@@ -347,7 +347,11 @@ class Node(BaseService):
             False,
         )
 
-    async def _connect_and_handshake(self, peer_id: ID, maddr: Multiaddr) -> None:
+    async def dial_peer_maddr(self, maddr: Multiaddr, peer_id: ID) -> None:
+        """
+        Dial the peer with given multi-address
+        """
+        self.logger.debug("Dialing peer_id: %s, maddr: %s", peer_id, maddr)
         try:
             await self.host.connect(
                 PeerInfo(
@@ -365,22 +369,6 @@ class Node(BaseService):
         except HandshakeFailure as e:
             self.logger.debug("Fail to handshake with peer_id: %s, error: %s", peer_id, e)
             raise DialPeerError from e
-
-    async def dial_peer(self, ip: str, port: int, peer_id: ID) -> None:
-        """
-        Dial the peer ``peer_id`` through the IPv4 protocol
-        """
-        maddr = make_tcp_ip_maddr(ip, port)
-        self.logger.debug("Dialing peer_id: %s, maddr: %s", peer_id, maddr)
-        await self._connect_and_handshake(peer_id, maddr)
-        self.logger.debug("Successfully connect to peer_id %s maddr %s", peer_id, maddr)
-
-    async def dial_peer_maddr(self, maddr: Multiaddr, peer_id: ID) -> None:
-        """
-        Dial the peer with given multi-address
-        """
-        self.logger.debug("Dialing peer_id: %s, maddr: %s", peer_id, maddr)
-        await self._connect_and_handshake(peer_id, maddr)
         self.logger.debug("Successfully connect to peer_id %s maddr %s", peer_id, maddr)
 
     async def dial_peer_maddr_with_retries(self, maddr: Multiaddr) -> None:

--- a/trinity/protocol/bcc_libp2p/node.py
+++ b/trinity/protocol/bcc_libp2p/node.py
@@ -390,8 +390,7 @@ class Node(BaseService):
                 return
             except DialPeerError:
                 self.logger.debug(
-                    "Could not dial peer: %s, maddr: %s",
-                    " retrying attempt %d of %d...",
+                    "Could not dial peer: %s, maddr: %s retrying attempt %d of %d...",
                     peer_id,
                     maddr,
                     i,

--- a/trinity/protocol/bcc_libp2p/node.py
+++ b/trinity/protocol/bcc_libp2p/node.py
@@ -417,9 +417,9 @@ class Node(BaseService):
               for node_maddr in self.preferred_nodes),
             return_exceptions=True,
         )
-        for result in results:
+        for result, node_maddr in zip(results, self.preferred_nodes):
             if isinstance(result, Exception):
-                logger.warning("could not connect to %s", result)
+                logger.warning("Could not connect to preferred node at %s", node_maddr)
 
     async def disconnect_peer(self, peer_id: ID) -> None:
         if peer_id in self.handshaked_peers:

--- a/trinity/protocol/bcc_libp2p/utils.py
+++ b/trinity/protocol/bcc_libp2p/utils.py
@@ -357,8 +357,11 @@ class Interaction:
                         exc_value: Optional[BaseException],
                         traceback: Optional[TracebackType],
                         ) -> None:
-        await self.stream.close()
-        self.debug("Ended")
+        if exc_type is None:
+            await self.stream.close()
+            self.debug("Ended")
+        else:
+            self.debug(f"{exc_type}: {exc_value}")
 
     async def write_request(self, message: MsgType) -> None:
         self.debug(f"Request {type(message).__name__}  {to_formatted_dict(message)}")

--- a/trinity/protocol/bcc_libp2p/utils.py
+++ b/trinity/protocol/bcc_libp2p/utils.py
@@ -404,7 +404,7 @@ class Interaction:
 
     @property
     def peer_id(self) -> ID:
-        return self.stream.mplex_conn.peer_id
+        return self.stream.muxed_conn.peer_id
 
     def debug(self, message: str) -> None:
         self.logger.debug(


### PR DESCRIPTION


### How was it fixed?
Update to libp2p-0.1.2.
- [x] Catch `multiaddr` exceptions when dialing a peer for a more detailed error handling
- [x] dialing a peer could raise two type of errors: `SwarmException` and `HandshakeFailure`, so in `dial_peer` we catch these two exceptions and raise a `DialPeerError` exception from there
- [x] Handle `StreamFailure` when opening a `new_stream`
- There are errors regarding pubsub not handled in py-libp2p currently(version `0.1.2`) but is WIP in https://github.com/libp2p/py-libp2p/pull/351 .


### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

[//]: # (See: https://trinity-client.readthedocs.io/en/latest/contributing.html#pull-requests)
- [ ] Add entry to the [release notes](https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

#### Cute Animal Picture


![](https://www.maxpixel.net/static/photo/2x/Cat-Feline-Kitty-Pets-Cute-Animal-Close-up-Animal-3402206.jpg)
(source: https://www.maxpixel.net/Cat-Feline-Kitty-Pets-Cute-Animal-Close-up-Animal-3402206)