### PR TITLE
Update trio to 0.13

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ deps = {
         "pysha3>=1.0.0,<2.0.0",
         "python-snappy>=0.5.3",
         "SQLAlchemy>=1.3.3,<2",
-        'trio==0.11.0,<0.12',
+        'trio==0.13.0,<0.14',
         'trio-typing>=0.2.0,<0.3',
         "upnpclient>=0.0.8,<1",
     ],

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ deps = {
         "plyvel==1.1.0",
         PYEVM_DEPENDENCY,
         "web3==4.4.1",
-        "lahja>=0.14.5,<0.15.0",
+        "lahja>=0.14.6,<0.15.0",
         "termcolor>=1.1.0,<2.0.0",
         "uvloop==0.11.2;platform_system=='Linux' or platform_system=='Darwin' or platform_system=='FreeBSD'",  # noqa: E501
         "websockets==5.0.1",


### PR DESCRIPTION
### What was wrong?

Trio warnings galore!

### How was it fixed?

Updated to latest trio version.  This included an upstream bump to a new `lahja` version that supports the new `trio` version.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history


#### Cute Animal Picture


![seal-xlarge_trans++RtvZRSV037_kYj9aGppl8KoSQRPSZoKNSSXquGEEDe0](https://user-images.githubusercontent.com/824194/69182775-ee8d4d80-0ace-11ea-850f-c02e7c1fd649.jpg)
