### PR TITLE
Correctly handle disconnections from maxed out peers

### DIFF
--- a/p2p/abc.py
+++ b/p2p/abc.py
@@ -201,6 +201,7 @@ class TransportAPI(ABC):
     session: SessionAPI
     remote: NodeAPI
     read_state: TransportState
+    logger: ExtendedDebugLogger
 
     @property
     @abstractmethod

--- a/p2p/commands.py
+++ b/p2p/commands.py
@@ -94,6 +94,9 @@ class BaseCommand(CommandAPI[TCommandPayload]):
     def __init__(self, payload: TCommandPayload) -> None:
         self.payload = payload
 
+    def __repr__(self) -> str:
+        return f"{self.__class__}(payload={self.payload})"
+
     def encode(self, cmd_id: int, snappy_support: bool) -> MessageAPI:
         raw_payload_data = self.serialization_codec.encode(self.payload)
 

--- a/p2p/exceptions.py
+++ b/p2p/exceptions.py
@@ -46,9 +46,9 @@ class HandshakeFailure(BaseP2PError):
     pass
 
 
-class TooManyPeersFailure(HandshakeFailure):
+class HandshakeFailureTooManyPeers(HandshakeFailure):
     """
-    The remote disconnected from us because it has too many peers
+    The remote disconnected from us during a handshake because it has too many peers
     """
     pass
 

--- a/p2p/tracking/connection.py
+++ b/p2p/tracking/connection.py
@@ -9,7 +9,7 @@ from p2p.abc import NodeAPI
 from p2p.exceptions import (
     BaseP2PError,
     HandshakeFailure,
-    TooManyPeersFailure,
+    HandshakeFailureTooManyPeers,
 )
 
 
@@ -23,7 +23,7 @@ def register_error(exception: Type[BaseP2PError], timeout_seconds: int) -> None:
 
 
 register_error(HandshakeFailure, 10)  # 10 seconds
-register_error(TooManyPeersFailure, 60)  # one minute
+register_error(HandshakeFailureTooManyPeers, 60)  # one minute
 
 
 def get_timeout_for_failure(failure: BaseP2PError) -> int:

--- a/p2p/transport.py
+++ b/p2p/transport.py
@@ -110,7 +110,7 @@ class Transport(TransportAPI):
                       remote: NodeAPI,
                       private_key: datatypes.PrivateKey,
                       token: CancelToken) -> TransportAPI:
-        """Perform the auth and P2P handshakes with the given remote.
+        """Perform the auth handshake with the given remote.
 
         Return an instance of the given peer_class (must be a subclass of
         BasePeer) connected to that remote in case both handshakes are
@@ -122,6 +122,7 @@ class Transport(TransportAPI):
         handshake or if none of the sub-protocols supported by us is also
         supported by the remote.
         """
+        cls.logger.debug2("Initiating auth handshake with %s", remote)
         try:
             (aes_secret,
              mac_secret,
@@ -133,6 +134,7 @@ class Transport(TransportAPI):
         except (ConnectionRefusedError, OSError) as e:
             raise UnreachablePeer(f"Can't reach {remote!r}") from e
 
+        cls.logger.debug2("Completed auth handshake with %s", remote)
         return cls(
             remote=remote,
             private_key=private_key,
@@ -203,7 +205,7 @@ class Transport(TransportAPI):
         ip, socket, *_ = peername
         remote_address = Address(ip, socket)
 
-        cls.logger.debug("Receiving handshake from %s", remote_address)
+        cls.logger.debug("Receiving auth handshake from %s", remote_address)
 
         initiator_remote = Node(initiator_pubkey, remote_address)
 

--- a/scripts/peer.py
+++ b/scripts/peer.py
@@ -15,11 +15,12 @@ from typing import (
 )
 
 from eth_typing import BlockNumber
+from eth_utils import DEBUG2_LEVEL_NUM
+
 from eth.chains.mainnet import MainnetChain, MAINNET_GENESIS_HEADER, MAINNET_VM_CONFIGURATION
 from eth.chains.ropsten import RopstenChain, ROPSTEN_GENESIS_HEADER, ROPSTEN_VM_CONFIGURATION
 from eth.db.atomic import AtomicDB
 from eth.db.backends.memory import MemoryDB
-from eth_utils import DEBUG2_LEVEL_NUM
 
 from p2p import ecies
 from p2p.constants import DEVP2P_V5
@@ -35,13 +36,18 @@ from tests.core.integration_test_helpers import connect_to_peers_loop
 
 
 def _main() -> None:
-    logging.basicConfig(level=DEBUG2_LEVEL_NUM, format='%(asctime)s %(levelname)s: %(message)s')
-
     parser = argparse.ArgumentParser()
     parser.add_argument('-enode', type=str, help="The enode we should connect to", required=True)
     parser.add_argument('-mainnet', action='store_true')
     parser.add_argument('-light', action='store_true', help="Connect as a light node")
+    parser.add_argument('-debug', action="store_true")
     args = parser.parse_args()
+
+    log_level = logging.INFO
+    if args.debug:
+        log_level = DEBUG2_LEVEL_NUM
+    logging.basicConfig(
+        level=log_level, format='%(asctime)s %(levelname)s: %(message)s', datefmt='%H:%M:%S')
 
     peer_class: Union[Type[ETHPeer], Type[LESPeer]]
     pool_class: Union[Type[ETHPeerPool], Type[LESPeerPool]]


### PR DESCRIPTION
A maxed out peer will disconnect during the P2P handshake by
sending us a disconnect msg with the TOO_MANY_PEERS reason.  We must
detect that and wait a while before attempting to connect again.

Closes #1167


### What was wrong?

We were not detecting the correct disconnection reason from maxed out
peers and because of that were attempting to connect again too
frequently.


### How was it fixed?

Raise the appropriate exception when a maxed out peer disconnect from us