### PR TITLE
fix #1161, Trinity logs should automatically rotate across runs

### DIFF
--- a/newsfragments/1294.feature.rst
+++ b/newsfragments/1294.feature.rst
@@ -1,0 +1,1 @@
+Automatically rotate logfiles across runs

--- a/tests/integration/test_trinity_cli.py
+++ b/tests/integration/test_trinity_cli.py
@@ -3,6 +3,7 @@ import signal
 import sys
 import tempfile
 import time
+import os
 
 import pexpect
 import pytest
@@ -304,7 +305,8 @@ async def test_logger_configuration(command,
             if contains_substring(stderr_logs, log):
                 raise AssertionError(f"Log should not contain `{log}` but does")
 
-        log_file_path = TrinityConfig(app_identifier="eth1", network_id=1).logfile_path
+        log_dir = TrinityConfig(app_identifier="eth1", network_id=1).log_dir
+        log_file_path = max(log_dir.glob('*'), key=os.path.getctime)
         with open(log_file_path) as log_file:
             file_content = log_file.read()
 

--- a/trinity/_utils/logging.py
+++ b/trinity/_utils/logging.py
@@ -1,4 +1,5 @@
 import copy
+from datetime import datetime
 import logging
 from logging import (
     StreamHandler
@@ -165,11 +166,17 @@ def setup_file_logging(
         level = logging.DEBUG
     logger = logging.getLogger()
 
-    handler_file = RotatingFileHandler(
-        str(logfile_path),
-        maxBytes=(10000000 * LOG_MAX_MB),
-        backupCount=LOG_BACKUP_COUNT
+    log_file_with_timestamp = logfile_path.with_suffix(
+        datetime.now().strftime('.%Y%m%d_%H%M%S.log')
     )
+    handler_file = RotatingFileHandler(
+        str(log_file_with_timestamp),
+        maxBytes=(10000000 * LOG_MAX_MB),
+        backupCount=LOG_BACKUP_COUNT,
+        delay=True
+    )
+    if log_file_with_timestamp.exists():
+        handler_file.doRollover()
 
     if level is not None:
         handler_file.setLevel(level)


### PR DESCRIPTION
### What was wrong?
#1161, Trinity logs should automatically rotate across runs.

PR #1228 is a mass so I re-PR again.

### How was it fixed?
Log rotation per instantiation of the client with format, YYYYMMDD_HHMMSS. File name would look like `trinity.20191024_095854.log`.