### PR TITLE
Enable py37-p2p-trio CI job and fix mypy error

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -389,7 +389,7 @@ workflows:
 
       - py37-eth1-core
       - py37-p2p
-      - py36-p2p-trio
+      - py37-p2p-trio
       - py37-eth2-core
       - py37-eth2-utils
       - py37-eth2-fixtures

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ deps = {
         "cachetools>=3.1.0,<4.0.0",
         "coincurve>=10.0.0,<11.0.0",
         "dataclasses>=0.6, <1;python_version<'3.7'",
-        "eth-utils>=1.7,<2",
+        "eth-utils>=1.8.1,<2",
         "ipython>=7.8.0,<8.0.0",
         "plyvel==1.1.0",
         PYEVM_DEPENDENCY,

--- a/trinity/components/builtin/syncer/cli.py
+++ b/trinity/components/builtin/syncer/cli.py
@@ -8,6 +8,7 @@ from typing import (
 
 from eth_typing import (
     Hash32,
+    HexStr,
 )
 
 from eth_utils import (
@@ -28,7 +29,7 @@ from .etherscan_api import (
 
 
 def is_block_hash(value: str) -> bool:
-    return is_hex(value) and len(remove_0x_prefix(value)) == 64
+    return is_hex(value) and len(remove_0x_prefix(HexStr(value))) == 64
 
 
 def remove_non_digits(value: str) -> str:


### PR DESCRIPTION
### What was wrong?
1. `py37-p2p-trio` job wasn't enabled in CI.
2. mypy check failed in CI

### How was it fixed?
1. Enable `py37-p2p-trio` job in CI
2. Due to https://github.com/ethereum/eth-utils/commit/ff14dae8eac5f17c38ec50606deff14bf1043d31 changes, the mypy check failed when installing `eth-utils>=1.8.1`. I set `eth-utils>=1.8.1,<2` and introduce `HexStr` to Trinity.


### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

[//]: # (See: https://trinity-client.readthedocs.io/en/latest/contributing.html#pull-requests)
- [ ] Add entry to the [release notes](https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

#### Cute Animal Picture
![grey-seal-2164736_640](https://user-images.githubusercontent.com/9263930/69260769-5e98f200-0bfb-11ea-9b44-f460770143fa.jpg)
