### PR TITLE
Add eth1-monitor tests to tox and CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -232,6 +232,12 @@ jobs:
       - image: circleci/python:3.6
         environment:
           TOXENV: py36-p2p-trio
+  py36-eth1-monitor-trio:
+    <<: *common
+    docker:
+      - image: circleci/python:3.6
+        environment:
+          TOXENV: py36-eth1-monitor-trio
   py36-eth2-core:
     <<: *common
     docker:
@@ -318,6 +324,12 @@ jobs:
       - image: circleci/python:3.7
         environment:
           TOXENV: py37-p2p-trio
+  py37-eth1-monitor-trio:
+    <<: *common
+    docker:
+      - image: circleci/python:3.7
+        environment:
+          TOXENV: py37-eth1-monitor-trio
   py37-eth2-core:
     <<: *common
     docker:
@@ -390,6 +402,7 @@ workflows:
       - py37-eth1-core
       - py37-p2p
       - py36-p2p-trio
+      - py37-eth1-monitor-trio
       - py37-eth2-core
       - py37-eth2-utils
       - py37-eth2-fixtures
@@ -413,6 +426,7 @@ workflows:
       - py36-eth1-core
       - py36-p2p
       - py36-p2p-trio
+      - py36-eth1-monitor-trio
       - py36-eth2-core
       - py36-eth2-utils
       - py36-eth2-fixtures

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist=
-    py{36,37}-{eth1-core,p2p,p2p-trio,integration,lightchain_integration,eth2-core,eth2-fixtures,eth2-integration,eth1-components,eth2-components,eth2-utils}
+    py{36,37}-{eth1-core,p2p,p2p-trio,eth1-monitor-trio,integration,lightchain_integration,eth2-core,eth2-fixtures,eth2-integration,eth1-components,eth2-components,eth2-utils}
     py36-long_run_integration
     py36-rpc-blockchain
     py36-rpc-state-{frontier,homestead,tangerine_whistle,spurious_dragon,byzantium,constantinople,petersburg}
@@ -69,6 +69,14 @@ commands = pytest -n 4 {posargs:tests-trio/p2p-trio}
 [testenv:py37-p2p-trio]
 deps = .[p2p,test,test-trio]
 commands = pytest -n 4 {posargs:tests-trio/p2p-trio}
+
+[testenv:py36-eth1-monitor-trio]
+deps = .[p2p,trinity,test,test-trio]
+commands = pytest -n 4 {posargs:tests-trio/eth1-monitor}
+
+[testenv:py37-eth1-monitor-trio]
+deps = .[p2p,trinity,test,test-trio]
+commands = pytest -n 4 {posargs:tests-trio/eth1-monitor}
 
 [testenv:py36-docs]
 whitelist_externals=


### PR DESCRIPTION
### What was wrong?
`tests-trio/eth1-monitor` is not tested at all in tox and CircleCI.

### How was it fixed?
Add `py36-eth1-monitor-trio` and `py37-eth1-monitor-trio` in both tox and CircleCI configs.

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://scontent.ftpe3-2.fna.fbcdn.net/v/t1.0-9/70009827_1404655139728883_4277391795903528960_o.jpg?_nc_cat=101&_nc_ohc=AWGGpZtsDgsAQnpa-IcemB6ByQABsgk-RqRt3RoyPnN11igBxDJBA7jYg&_nc_ht=scontent.ftpe3-2.fna&oh=9748a06f8ec7611054a443d5137f2e9f&oe=5E47BA4C)
