### PR TITLE
Fork choice refactor including v0.9.1. updates

### DIFF
--- a/eth2/beacon/attestation_helpers.py
+++ b/eth2/beacon/attestation_helpers.py
@@ -37,9 +37,12 @@ def validate_indexed_attestation(
     indexed_attestation: IndexedAttestation,
     max_validators_per_committee: int,
     slots_per_epoch: int,
+    validate_signature: bool = True,
 ) -> None:
     """
     Derived from spec: `is_valid_indexed_attestation`.
+
+    Option ``validate_signature`` is used in some testing scenarios, like some fork choice tests.
     """
     attesting_indices = indexed_attestation.attesting_indices
 
@@ -54,14 +57,15 @@ def validate_indexed_attestation(
             f"Indices should be sorted; the attesting indices are not: {attesting_indices}."
         )
 
-    try:
-        validate_indexed_attestation_aggregate_signature(
-            state, indexed_attestation, slots_per_epoch
-        )
-    except SignatureError as error:
-        raise ValidationError(
-            f"Incorrect aggregate signature on the {indexed_attestation}", error
-        )
+    if validate_signature:
+        try:
+            validate_indexed_attestation_aggregate_signature(
+                state, indexed_attestation, slots_per_epoch
+            )
+        except SignatureError as error:
+            raise ValidationError(
+                f"Incorrect aggregate signature on the {indexed_attestation}", error
+            )
 
 
 def is_slashable_attestation_data(

--- a/eth2/beacon/db/chain.py
+++ b/eth2/beacon/db/chain.py
@@ -16,6 +16,7 @@ from eth2.beacon.db.exceptions import (
     FinalizedHeadNotFound,
     HeadStateSlotNotFound,
     JustifiedHeadNotFound,
+    MissingForkChoiceContext,
     MissingForkChoiceScoringFns,
     StateNotFound,
 )
@@ -152,6 +153,17 @@ class BaseBeaconChainDB(ABC):
 
     @abstractmethod
     def attestation_exists(self, attestation_root: HashTreeRoot) -> bool:
+        pass
+
+    #
+    # Fork choice API
+    #
+    @abstractmethod
+    def get_fork_choice_context_data_for(self, fork: str) -> bytes:
+        pass
+
+    @abstractmethod
+    def persist_fork_choice_context(self, serialized_context: bytes, fork: str) -> None:
         pass
 
     #
@@ -860,6 +872,17 @@ class BeaconChainDB(BaseBeaconChainDB):
             attestation_root
         )
         return self.exists(lookup_key)
+
+    #
+    # Fork choice API
+    #
+    def get_fork_choice_context_data_for(self, fork: str) -> bytes:
+        # TODO implement
+        raise MissingForkChoiceContext(f"Missing context for fork `{fork}`")
+
+    def persist_fork_choice_context(self, serialized_context: bytes, fork: str) -> None:
+        # TODO implement
+        pass
 
     #
     # Raw Database API

--- a/eth2/beacon/db/exceptions.py
+++ b/eth2/beacon/db/exceptions.py
@@ -53,3 +53,12 @@ class MissingForkChoiceScoringFns(BeaconDBException):
     """
 
     pass
+
+
+class MissingForkChoiceContext(BeaconDBException):
+    """
+    Exception raised if the database lacks the state required for the
+    chain's fork choice.
+    """
+
+    pass

--- a/eth2/beacon/db/schema.py
+++ b/eth2/beacon/db/schema.py
@@ -67,6 +67,14 @@ class BaseSchema(ABC):
     ) -> bytes:
         ...
 
+    #
+    # Fork choice
+    #
+    @staticmethod
+    @abstractmethod
+    def make_lmd_ghost_context_lookup_key(fork: str) -> bytes:
+        ...
+
 
 class SchemaV1(BaseSchema):
     #
@@ -122,3 +130,10 @@ class SchemaV1(BaseSchema):
         attestaton_root: HashTreeRoot,
     ) -> bytes:
         return b"v1:beacon:attestation-root-to-block:%s" % attestaton_root
+
+    #
+    # Fork choice
+    #
+    @staticmethod
+    def make_lmd_ghost_context_lookup_key(fork: str) -> bytes:
+        return b"v1:beacon:fork-choice-lmd-ghost-context:%s" % fork.encode()

--- a/eth2/beacon/fork_choice/lmd_ghost.py
+++ b/eth2/beacon/fork_choice/lmd_ghost.py
@@ -1,220 +1,383 @@
-from typing import Dict, Iterable, Optional, Sequence, Tuple, Type, Union
+from dataclasses import dataclass, field
+from typing import Dict, Optional, Type
 
-from eth_utils import to_tuple
-from eth_utils.toolz import curry, first, mapcat, merge, merge_with, second, valmap
+from eth_typing import Hash32
+from eth_utils import ValidationError
 
-from eth2.beacon.db.chain import BeaconChainDB
-from eth2.beacon.epoch_processing_helpers import get_attesting_indices
-from eth2.beacon.helpers import compute_epoch_at_slot, get_active_validator_indices
-from eth2.beacon.operations.attestation_pool import AttestationPool
-from eth2.beacon.types.attestation_data import AttestationData
+from eth2.beacon.attestation_helpers import validate_indexed_attestation
+from eth2.beacon.db.chain import BaseBeaconChainDB
+from eth2.beacon.epoch_processing_helpers import get_indexed_attestation
+from eth2.beacon.helpers import (
+    compute_epoch_at_slot,
+    compute_start_slot_at_epoch,
+    get_active_validator_indices,
+)
+from eth2.beacon.state_machines.base import BaseBeaconStateMachine
+from eth2.beacon.state_machines.forks.serenity.slot_processing import process_slots
 from eth2.beacon.types.attestations import Attestation
 from eth2.beacon.types.blocks import BaseBeaconBlock
-from eth2.beacon.types.pending_attestations import PendingAttestation
+from eth2.beacon.types.checkpoints import Checkpoint
 from eth2.beacon.types.states import BeaconState
-from eth2.beacon.typing import Gwei, SigningRoot, Slot, ValidatorIndex
+from eth2.beacon.typing import Epoch, Gwei, SigningRoot, Slot, Timestamp, ValidatorIndex
 from eth2.configs import CommitteeConfig, Eth2Config
 
-# TODO(ralexstokes) integrate `AttestationPool` once it has been merged
-AttestationIndex = Dict[ValidatorIndex, AttestationData]
-PreIndex = Dict[ValidatorIndex, Tuple[Slot, AttestationData]]
-AttestationLike = Union[Attestation, PendingAttestation]
+
+def compute_slots_since_epoch_start(slot: Slot, slots_per_epoch: int) -> Slot:
+    return Slot(
+        slot
+        - compute_start_slot_at_epoch(
+            compute_epoch_at_slot(slot, slots_per_epoch), slots_per_epoch
+        )
+    )
 
 
-def _take_latest_attestation_by_slot(
-    candidates: Sequence[Tuple[Slot, AttestationData]]
-) -> Tuple[Slot, AttestationData]:
-    return max(candidates, key=first)
+@dataclass(eq=True, frozen=True)
+class LatestMessage:
+    epoch: Epoch
+    root: SigningRoot
+
+
+@dataclass
+class Context:
+    time: Timestamp
+    genesis_time: Timestamp
+    justified_checkpoint: Checkpoint
+    finalized_checkpoint: Checkpoint
+    best_justified_checkpoint: Checkpoint
+    blocks: Dict[Hash32, BaseBeaconBlock] = field(default_factory=dict)
+    block_states: Dict[Hash32, BeaconState] = field(default_factory=dict)
+    checkpoint_states: Dict[Checkpoint, BeaconState] = field(default_factory=dict)
+    latest_messages: Dict[ValidatorIndex, LatestMessage] = field(default_factory=dict)
+
+    @classmethod
+    def from_genesis(
+        cls, genesis_state: BeaconState, genesis_block: BaseBeaconBlock
+    ) -> "Context":
+        return cls.at_time(genesis_state.genesis_time, genesis_state, genesis_block)
+
+    @classmethod
+    def at_time(
+        cls, current_time: Timestamp, state: BeaconState, block: BaseBeaconBlock
+    ) -> "Context":
+        """
+        Return a ``Context`` based on the ``current_time`` and the latest known tip of
+        the chain at that point in time.
+        """
+        assert state.slot == block.slot
+        root = block.signing_root
+        justified_checkpoint = state.current_justified_checkpoint
+        finalized_checkpoint = state.finalized_checkpoint
+        return Context(
+            time=current_time,
+            genesis_time=state.genesis_time,
+            justified_checkpoint=justified_checkpoint,
+            finalized_checkpoint=finalized_checkpoint,
+            best_justified_checkpoint=justified_checkpoint,
+            blocks={root: block},
+            block_states={root: state},
+            checkpoint_states={justified_checkpoint: state},
+        )
+
+    def to_bytes(self) -> bytes:
+        raise NotImplementedError()
+
+    @classmethod
+    def from_bytes(cls, data: bytes) -> "Context":
+        raise NotImplementedError()
+
+    @property
+    def finalized_slot(self) -> Slot:
+        return self.blocks[self.finalized_checkpoint.root].slot
+
+    @property
+    def justified_slot(self) -> Slot:
+        return self.blocks[self.justified_checkpoint.root].slot
+
+
+def _effective_balance_for_validator(
+    state: BeaconState, validator_index: ValidatorIndex
+) -> Gwei:
+    return state.validators[validator_index].effective_balance
+
+
+def score_block_by_root(root: SigningRoot) -> int:
+    return int.from_bytes(root, byteorder="big")
 
 
 class Store:
-    """
-    A private class meant to encapsulate data access for the functionality in this module.
-    """
+    _db: BaseBeaconChainDB
+    _block_class: Type[BaseBeaconBlock]
+    _config: Eth2Config
+    _context: Context
 
     def __init__(
         self,
-        chain_db: BeaconChainDB,
-        state: BeaconState,
-        attestation_pool: AttestationPool,
+        chain_db: BaseBeaconChainDB,
         block_class: Type[BaseBeaconBlock],
         config: Eth2Config,
+        context: Context,
     ):
         self._db = chain_db
         self._block_class = block_class
         self._config = config
-        self._attestation_index = self._build_attestation_index(state, attestation_pool)
+        self._context = context
 
-    @curry
-    def _mk_pre_index_from_attestation(
-        self, state: BeaconState, attestation: AttestationLike
-    ) -> Iterable[PreIndex]:
-        attestation_data = attestation.data
-        slot = attestation_data.slot
+    @property
+    def slots_per_epoch(self) -> int:
+        return self._config.SLOTS_PER_EPOCH
 
-        return (
-            {index: (slot, attestation_data)}
-            for index in get_attesting_indices(
-                state,
-                attestation.data,
-                attestation.aggregation_bits,
-                CommitteeConfig(self._config),
-            )
+    def get_current_slot(self) -> Slot:
+        return Slot(
+            (self._context.time - self._context.genesis_time)
+            // self._config.SECONDS_PER_SLOT
         )
-
-    def _mk_pre_index_from_attestations(
-        self, state: BeaconState, attestations: Sequence[AttestationLike]
-    ) -> PreIndex:
-        """
-        A 'pre-index' is a Dict[ValidatorIndex, Tuple[Slot, AttestationData]].
-        """
-        return merge(*mapcat(self._mk_pre_index_from_attestation(state), attestations))
-
-    def _build_attestation_index(
-        self, state: BeaconState, attestation_pool: AttestationPool
-    ) -> AttestationIndex:
-        """
-        Assembles a dictionary of latest attestations keyed by validator index.
-        Any attestation made by a validator in the ``attestation_pool`` that occur after the
-        last known attestation according to the state take precedence.
-
-        We start by building a 'pre-index' from all known attestations which map validator
-        indices to a pair of slot and attestation data. A final index is built from all
-        pre-indices by keeping the entry with the highest slot across the set of all
-        duplicates in the pre-indices keyed by validator index.
-        """
-        previous_epoch_index = self._mk_pre_index_from_attestations(
-            state, state.previous_epoch_attestations
-        )
-
-        current_epoch_index = self._mk_pre_index_from_attestations(
-            state, state.current_epoch_attestations
-        )
-
-        pool_index = self._mk_pre_index_from_attestations(
-            state, tuple(attestation for _, attestation in attestation_pool)
-        )
-
-        index_by_latest_slot = merge_with(
-            _take_latest_attestation_by_slot,
-            previous_epoch_index,
-            current_epoch_index,
-            pool_index,
-        )
-        # convert the index to a mapping of ValidatorIndex -> (latest) Attestation
-        return valmap(second, index_by_latest_slot)
-
-    def _get_latest_attestation(
-        self, index: ValidatorIndex
-    ) -> Optional[AttestationData]:
-        """
-        Return the latest attesation we know from the validator with the
-        given ``index``.
-        """
-        return self._attestation_index.get(index, None)
 
     def _get_block_by_root(self, root: SigningRoot) -> BaseBeaconBlock:
         return self._db.get_block_by_root(root, self._block_class)
 
-    def get_latest_attestation_target(
-        self, index: ValidatorIndex
-    ) -> Optional[BaseBeaconBlock]:
-        attestation = self._get_latest_attestation(index)
-        if not attestation:
-            return None
-        try:
-            target_block = self._get_block_by_root(attestation.beacon_block_root)
-        except KeyError:
-            # attestation made for a block we have not imported
-            return None
-        return target_block
-
-    def _get_parent_block(self, block: BaseBeaconBlock) -> BaseBeaconBlock:
-        return self._db.get_block_by_root(block.parent_root, self._block_class)
-
-    def get_ancestor(self, block: BaseBeaconBlock, slot: Slot) -> BaseBeaconBlock:
+    def get_ancestor_root(self, root: SigningRoot, slot: Slot) -> Optional[Hash32]:
         """
-        Return the block in the chain that is a
-        predecessor of ``block`` at the requested ``slot``.
+        Return the block root in the chain that is a
+        predecessor of the block with ``root`` at the requested ``slot``.
         """
+        block = self._get_block_by_root(root)
         if block.slot > slot:
-            return self.get_ancestor(self._get_parent_block(block), slot)
+            return self.get_ancestor_root(block.parent_root, slot)
         elif block.slot == slot:
-            return block
+            return root
         else:
             return None
 
+    def _get_checkpoint_state_for(self, checkpoint: Checkpoint) -> BeaconState:
+        return self._context.checkpoint_states[checkpoint]
 
-AttestationTarget = Tuple[ValidatorIndex, Optional[BaseBeaconBlock]]
+    def _latest_message_for_index(self, index: ValidatorIndex) -> LatestMessage:
+        return self._context.latest_messages[index]
 
+    def get_latest_attesting_balance(self, root: SigningRoot) -> Gwei:
+        state = self._get_checkpoint_state_for(self._context.justified_checkpoint)
+        active_indices = get_active_validator_indices(
+            state.validators, state.current_epoch(self.slots_per_epoch)
+        )
+        return Gwei(
+            sum(
+                _effective_balance_for_validator(state, i)
+                for i in active_indices
+                if (
+                    i in self._context.latest_messages
+                    and self.get_ancestor_root(
+                        self._latest_message_for_index(i).root,
+                        self._get_block_by_root(root).slot,
+                    )
+                    == root
+                )
+            )
+        )
 
-@curry
-def _find_latest_attestation_target(
-    store: Store, index: ValidatorIndex
-) -> AttestationTarget:
-    return (index, store.get_latest_attestation_target(index))
+    def _should_update_justified_checkpoint(
+        self, new_justified_checkpoint: Checkpoint
+    ) -> bool:
+        """
+        To address the bouncing attack, only update conflicting justified
+        checkpoints in the fork choice if in the early slots of the epoch.
+        Otherwise, delay incorporation of new justified checkpoint until next epoch boundary.
+        See https://ethresear.ch/t/prevention-of-bouncing-attack-on-ffg/6114 for more
+        detailed analysis and discussion.
+        """
+        current_slot = self.get_current_slot()
+        slots_since_epoch_start = compute_slots_since_epoch_start(
+            current_slot, self._config.SLOTS_PER_EPOCH
+        )
+        within_safe_slots = (
+            slots_since_epoch_start < self._config.SAFE_SLOTS_TO_UPDATE_JUSTIFIED
+        )
+        if within_safe_slots:
+            return True
 
+        new_justified_block = self._context.blocks[new_justified_checkpoint.root]
+        justified_epoch = self._context.justified_checkpoint.epoch
+        if new_justified_block.slot <= compute_start_slot_at_epoch(
+            justified_epoch, self._config.SLOTS_PER_EPOCH
+        ):
+            return False
 
-@to_tuple
-def _find_latest_attestation_targets(
-    state: BeaconState, store: Store, config: Eth2Config
-) -> Iterable[AttestationTarget]:
-    epoch = compute_epoch_at_slot(state.slot, config.SLOTS_PER_EPOCH)
-    active_validators = get_active_validator_indices(state.validators, epoch)
-    return filter(
-        second, map(_find_latest_attestation_target(store), active_validators)
-    )
+        justified_root = self._context.justified_checkpoint.root
+        justified_ancestor = self.get_ancestor_root(
+            new_justified_checkpoint.root, self._context.justified_slot
+        )
+        return justified_ancestor == justified_root
 
+    def on_tick(self, time: Timestamp) -> None:
+        previous_slot = self.get_current_slot()
 
-def _get_ancestor(store: Store, block: BaseBeaconBlock, slot: Slot) -> BaseBeaconBlock:
-    return store.get_ancestor(block, slot)
+        self._context.time = time
 
+        current_slot = self.get_current_slot()
 
-def _balance_for_validator(state: BeaconState, validator_index: ValidatorIndex) -> Gwei:
-    return state.validators[validator_index].effective_balance
+        is_new_epoch = (
+            current_slot > previous_slot
+            and compute_slots_since_epoch_start(
+                current_slot, self._config.SLOTS_PER_EPOCH
+            )
+            == 0
+        )
+        if not is_new_epoch:
+            return
 
+        is_better_checkpoint_known = (
+            self._context.best_justified_checkpoint.epoch
+            > self._context.justified_checkpoint.epoch
+        )
+        if is_better_checkpoint_known:
+            self._context.justified_checkpoint = self._context.best_justified_checkpoint
 
-def score_block_by_attestations(
-    state: BeaconState,
-    store: Store,
-    attestation_targets: Sequence[AttestationTarget],
-    block: BaseBeaconBlock,
-) -> int:
-    """
-    Return the total balance attesting to ``block`` based on the ``attestation_targets``.
-    """
-    return sum(
-        _balance_for_validator(state, validator_index)
-        for validator_index, target in attestation_targets
-        if _get_ancestor(store, target, block.slot) == block
-    )
+    def on_block(
+        self,
+        block: BaseBeaconBlock,
+        post_state: BeaconState = None,
+        state_machine: BaseBeaconStateMachine = None,
+    ) -> None:
+        """
+        Handler to update the fork choice context upon receiving a new ``block``.
 
+        This handler requests the ``post_state`` of this block to avoid recomputing
+        it if it is already known.
+        """
+        # NOTE: this invariant should hold based on how we handle
+        # block importing in the chain but we will sanity check for now
+        assert block.parent_root in self._context.block_states
 
-def score_block_by_root(block: BaseBeaconBlock) -> int:
-    return int.from_bytes(block.hash_tree_root[:8], byteorder="big")
+        pre_state = self._context.block_states[block.parent_root]
 
+        # NOTE: this invariant should hold based on how we handle
+        # block importing in the chain but we will sanity check for now
+        assert (
+            self._context.time
+            >= pre_state.genesis_time + block.slot * self._config.SECONDS_PER_SLOT
+        )
 
-@curry
-def lmd_ghost_scoring(
-    chain_db: BeaconChainDB,
-    attestation_pool: AttestationPool,
-    state: BeaconState,
-    config: Eth2Config,
-    block_class: Type[BaseBeaconBlock],
-    block: BaseBeaconBlock,
-) -> int:
-    """
-    Return the score of the ``target_block`` according to the LMD GHOST algorithm,
-    using the lexicographic ordering of the block root to break ties.
-    """
-    store = Store(chain_db, state, attestation_pool, block_class, config)
+        root = block.signing_root
 
-    attestation_targets = _find_latest_attestation_targets(state, store, config)
+        self._context.blocks[root] = block
 
-    attestation_score = score_block_by_attestations(
-        state, store, attestation_targets, block
-    )
+        finalized_slot = self._context.finalized_slot
+        finalized_ancestor = self.get_ancestor_root(root, finalized_slot)
+        is_ancestor_of_finalized_block = (
+            finalized_ancestor == self._context.finalized_checkpoint.root
+        )
+        if not is_ancestor_of_finalized_block:
+            raise ValidationError(
+                f"block with signing root {root.hex()} is not a descendant of the finalized"
+                f" checkpoint with root {finalized_ancestor.hex()}"
+            )
 
-    block_root_score = score_block_by_root(block)
+        # NOTE: sanity check implied by the previous verification on finalized ancestor
+        assert block.slot > compute_start_slot_at_epoch(
+            self._context.finalized_checkpoint.epoch, self._config.SLOTS_PER_EPOCH
+        )
 
-    return attestation_score + block_root_score
+        if not post_state:
+            # NOTE: error to not provide a post_state and not provide a way to compute it
+            assert state_machine is not None
+            post_state, _ = state_machine.import_block(block, pre_state)
+
+        self._context.block_states[root] = post_state
+
+        if (
+            post_state.current_justified_checkpoint.epoch
+            > self._context.justified_checkpoint.epoch
+        ):
+            self._context.best_justified_checkpoint = (
+                post_state.current_justified_checkpoint
+            )
+            if self._should_update_justified_checkpoint(
+                post_state.current_justified_checkpoint
+            ):
+                self._context.justified_checkpoint = (
+                    post_state.current_justified_checkpoint
+                )
+
+        if (
+            post_state.finalized_checkpoint.epoch
+            > self._context.finalized_checkpoint.epoch
+        ):
+            self._context.finalized_checkpoint = post_state.finalized_checkpoint
+
+    def on_attestation(
+        self, attestation: Attestation, validate_signature: bool = True
+    ) -> None:
+        target = attestation.data.target
+        current_epoch = compute_epoch_at_slot(
+            self.get_current_slot(), self._config.SLOTS_PER_EPOCH
+        )
+        previous_epoch = (
+            current_epoch - 1
+            if current_epoch > self._config.GENESIS_EPOCH
+            else self._config.GENESIS_EPOCH
+        )
+        if target.epoch not in (current_epoch, previous_epoch):
+            raise ValidationError(
+                "Attestations must be from the current or previous epoch"
+            )
+
+        if target.root not in self._context.blocks:
+            raise ValidationError("Attestation targets a block we have not seen")
+
+        base_state = self._context.block_states[target.root]
+        time_of_target_epoch = (
+            base_state.genesis_time
+            + compute_start_slot_at_epoch(target.epoch, self._config.SLOTS_PER_EPOCH)
+            * self._config.SECONDS_PER_SLOT
+        )
+        if self._context.time < time_of_target_epoch:
+            raise ValidationError("Attestation cannot be for a future epoch")
+
+        if target not in self._context.checkpoint_states:
+            base_state = process_slots(
+                base_state,
+                compute_start_slot_at_epoch(target.epoch, self._config.SLOTS_PER_EPOCH),
+                self._config,
+            )
+            self._context.checkpoint_states[target] = base_state
+        target_state = self._context.checkpoint_states[target]
+
+        if (
+            self._context.time
+            < (attestation.data.slot + 1) * self._config.SECONDS_PER_SLOT
+        ):
+            raise ValidationError(
+                "Attestations can only affect the fork choice of future slots"
+            )
+
+        # TODO: has this validation already been performed?
+        indexed_attestation = get_indexed_attestation(
+            target_state, attestation, CommitteeConfig(self._config)
+        )
+        validate_indexed_attestation(
+            target_state,
+            indexed_attestation,
+            self._config.MAX_VALIDATORS_PER_COMMITTEE,
+            self._config.SLOTS_PER_EPOCH,
+            validate_signature=validate_signature,
+        )
+
+        for i in indexed_attestation.attesting_indices:
+            if (
+                i not in self._context.latest_messages
+                or target.epoch > self._context.latest_messages[i].epoch
+            ):
+                self._context.latest_messages[i] = LatestMessage(
+                    epoch=target.epoch, root=attestation.data.beacon_block_root
+                )
+
+    def scoring(self, block: BaseBeaconBlock) -> int:
+        """
+        Return the score of the target ``_block`` according to the LMD GHOST algorithm,
+        using the lexicographic ordering of the block root to break ties.
+        """
+        root = block.signing_root
+
+        attestation_score = self.get_latest_attesting_balance(root)
+        block_root_score = score_block_by_root(root)
+
+        return attestation_score + block_root_score

--- a/eth2/beacon/state_machines/base.py
+++ b/eth2/beacon/state_machines/base.py
@@ -6,9 +6,10 @@ from eth._utils.datatypes import Configurable
 
 from eth2.beacon.db.chain import BaseBeaconChainDB
 from eth2.beacon.fork_choice.scoring import ScoringFn as ForkChoiceScoringFn
+from eth2.beacon.types.attestations import Attestation
 from eth2.beacon.types.blocks import BaseBeaconBlock
 from eth2.beacon.types.states import BeaconState
-from eth2.beacon.typing import FromBlockParams
+from eth2.beacon.typing import FromBlockParams, Timestamp
 from eth2.configs import Eth2Config  # noqa: F401
 
 from .state_transitions import BaseStateTransition
@@ -53,6 +54,18 @@ class BaseBeaconStateMachine(Configurable, ABC):
 
     @abstractmethod
     def get_fork_choice_scoring(self) -> ForkChoiceScoringFn:
+        ...
+
+    @abstractmethod
+    def on_tick(self, time: Timestamp) -> None:
+        ...
+
+    @abstractmethod
+    def on_block(self, block: BaseBeaconBlock) -> None:
+        ...
+
+    @abstractmethod
+    def on_attestation(self, attestation: Attestation) -> None:
         ...
 
     #
@@ -117,6 +130,15 @@ class BeaconStateMachine(BaseBeaconStateMachine):
     @property
     def state_transition(self) -> BaseStateTransition:
         return self.get_state_transiton_class()(self.config)
+
+    def on_tick(self, time: Timestamp) -> None:
+        pass
+
+    def on_block(self, block: BaseBeaconBlock) -> None:
+        pass
+
+    def on_attestation(self, attestation: Attestation) -> None:
+        pass
 
     #
     # Import block API

--- a/eth2/beacon/state_machines/forks/serenity/__init__.py
+++ b/eth2/beacon/state_machines/forks/serenity/__init__.py
@@ -1,14 +1,18 @@
 from typing import Type  # noqa: F401
 
-from eth2.beacon.fork_choice.lmd_ghost import lmd_ghost_scoring
+from eth2.beacon.db.chain import BaseBeaconChainDB
+from eth2.beacon.db.exceptions import MissingForkChoiceContext
+from eth2.beacon.fork_choice.lmd_ghost import Context as LMDGHOSTContext
+from eth2.beacon.fork_choice.lmd_ghost import Store
 from eth2.beacon.fork_choice.scoring import ScoringFn as ForkChoiceScoringFn
 from eth2.beacon.state_machines.base import BeaconStateMachine
 from eth2.beacon.state_machines.state_transitions import (  # noqa: F401
     BaseStateTransition,
 )
+from eth2.beacon.types.attestations import Attestation
 from eth2.beacon.types.blocks import BaseBeaconBlock  # noqa: F401
 from eth2.beacon.types.states import BeaconState  # noqa: F401
-from eth2.beacon.typing import FromBlockParams
+from eth2.beacon.typing import FromBlockParams, Timestamp
 
 from .blocks import SerenityBeaconBlock, create_serenity_block_from_parent
 from .configs import SERENITY_CONFIG
@@ -26,6 +30,38 @@ class SerenityStateMachine(BeaconStateMachine):
     state_class = SerenityBeaconState  # type: Type[BeaconState]
     state_transition_class = SerenityStateTransition  # type: Type[BaseStateTransition]
 
+    def __init__(
+        self, chaindb: BaseBeaconChainDB, fork_choice_context: LMDGHOSTContext = None
+    ) -> None:
+        super().__init__(chaindb)
+        self._fork_choice_store = Store(
+            chaindb,
+            self.block_class,
+            self.config,
+            fork_choice_context or self._get_fork_choice_context(),
+        )
+
+    def _get_fork_choice_context(self) -> LMDGHOSTContext:
+        try:
+            fork_choice_context_data = self.chaindb.get_fork_choice_context_data_for(
+                self.fork
+            )
+        except MissingForkChoiceContext:
+            # NOTE: ``MissingForkChoiceContext`` here implies that we are missing the
+            # fork choice context for this fork, which happens to be the genesis fork.
+            # In this situation (possibly uniquely), we want to build a new
+            # fork choice context from the genesis data.
+            genesis_root = self.chaindb.get_genesis_block_root()
+            genesis_block = self.chaindb.get_block_by_root(
+                genesis_root, self.block_class
+            )
+            genesis_state = self.chaindb.get_state_by_root(
+                genesis_block.state_root, self.state_class
+            )
+            return LMDGHOSTContext.from_genesis(genesis_state, genesis_block)
+        else:
+            return LMDGHOSTContext.from_bytes(fork_choice_context_data)
+
     # methods
     @staticmethod
     def create_block_from_parent(
@@ -40,15 +76,13 @@ class SerenityStateMachine(BeaconStateMachine):
         )
 
     def get_fork_choice_scoring(self) -> ForkChoiceScoringFn:
-        state = self._get_justified_head_state()
-        # NOTE: temporary import here
-        from eth2.beacon.operations.attestation_pool import AttestationPool
+        return self._fork_choice_store.scoring
 
-        return lmd_ghost_scoring(
-            # NOTE: temporary ``AttestationPool``
-            self.chaindb,
-            AttestationPool(),
-            state,
-            self.config,
-            self.block_class,
-        )
+    def on_tick(self, time: Timestamp) -> None:
+        self._fork_choice_store.on_tick(time)
+
+    def on_block(self, block: BaseBeaconBlock) -> None:
+        self._fork_choice_store.on_block(block)
+
+    def on_attestation(self, attestation: Attestation) -> None:
+        self._fork_choice_store.on_attestation(attestation)

--- a/tests/eth2/core/beacon/conftest.py
+++ b/tests/eth2/core/beacon/conftest.py
@@ -10,6 +10,7 @@ from eth2.beacon.constants import (
 )
 from eth2.beacon.db.chain import BeaconChainDB
 from eth2.beacon.fork_choice.higher_slot import higher_slot_scoring
+from eth2.beacon.fork_choice.lmd_ghost import Context as LMDGHOSTContext
 from eth2.beacon.genesis import get_genesis_block
 from eth2.beacon.operations.attestation_pool import AttestationPool
 from eth2.beacon.state_machines.forks.serenity import SerenityStateMachine
@@ -657,6 +658,14 @@ def chaindb_at_genesis(chaindb, genesis_state, genesis_block, fork_choice_scorin
 @pytest.fixture
 def empty_attestation_pool():
     return AttestationPool()
+
+
+#
+# Fork choice context
+#
+@pytest.fixture
+def genesis_fork_choice_context(genesis_state, genesis_block):
+    return LMDGHOSTContext.from_genesis(genesis_state, genesis_block)
 
 
 #

--- a/tests/eth2/core/beacon/state_machines/forks/test_serenity_operation_processing.py
+++ b/tests/eth2/core/beacon/state_machines/forks/test_serenity_operation_processing.py
@@ -31,6 +31,7 @@ def test_process_max_attestations(
     keymap,
     fixture_sm_class,
     chaindb,
+    genesis_fork_choice_context,
 ):
     attestation_slot = config.GENESIS_SLOT
     current_slot = attestation_slot + config.MIN_ATTESTATION_INCLUSION_DELAY
@@ -39,7 +40,7 @@ def test_process_max_attestations(
     attestations = create_mock_signed_attestations_at_slot(
         state=state,
         config=config,
-        state_machine=fixture_sm_class(chaindb),
+        state_machine=fixture_sm_class(chaindb, genesis_fork_choice_context),
         attestation_slot=attestation_slot,
         beacon_block_root=genesis_block.signing_root,
         keymap=keymap,
@@ -202,6 +203,7 @@ def test_process_attestations(
     keymap,
     fixture_sm_class,
     chaindb,
+    genesis_fork_choice_context,
     success,
 ):
 
@@ -212,7 +214,7 @@ def test_process_attestations(
     attestations = create_mock_signed_attestations_at_slot(
         state=state,
         config=config,
-        state_machine=fixture_sm_class(chaindb),
+        state_machine=fixture_sm_class(chaindb, genesis_fork_choice_context),
         attestation_slot=attestation_slot,
         beacon_block_root=genesis_block.signing_root,
         keymap=keymap,

--- a/tests/eth2/core/beacon/state_machines/forks/test_state_machine.py
+++ b/tests/eth2/core/beacon/state_machines/forks/test_state_machine.py
@@ -1,10 +1,14 @@
-import pytest
-
 from eth2.beacon.state_machines.forks.serenity import SerenityStateMachine
 from eth2.beacon.state_machines.forks.skeleton_lake import SkeletonLakeStateMachine
 
 
-@pytest.mark.parametrize("sm_klass", (SerenityStateMachine, SkeletonLakeStateMachine))
-def test_sm_class_well_defined(sm_klass):
-    state_machine = sm_klass(chaindb=None)
+def test_serenity_state_machine_class_well_defined(genesis_fork_choice_context):
+    state_machine = SerenityStateMachine(
+        chaindb=None, fork_choice_context=genesis_fork_choice_context
+    )
+    assert state_machine.get_block_class()
+
+
+def test_skeleton_lake_state_machine_class_well_defined():
+    state_machine = SkeletonLakeStateMachine(chaindb=None)
     assert state_machine.get_block_class()


### PR DESCRIPTION
### What was wrong?

Closes #1261. (pretty sure)

We need to update the context for a given fork choice based on some external events. It is not straightforward to add handlers for these events so a refactor is in order.

edit: it was most natural to just go ahead and include the v0.9.1 updates in this refactor so they are in here as well.

edit: also copying the commit message from the commit in this PR as it has helpful rationale:

```
The fork choice on the beacon chain has a very dynamic quality to it
such that it makes sense to implement a "rolling" context per `StateMachine`
to track the current fork choice metadata.

1. This PR introduces the infrastructure needed to update/maintain this context.
2. Adds this context for the phase 0 LMD GHOST fork choice.
3. Implements two fork choice updates from the spec v0.9.1 release.
```

### How was it fixed?

Expose the handlers on the `Chain` abstraction and wire the event through to the underlying `StateMachine` (where a given instance of a fork choice context should live).

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

[//]: # (See: https://trinity-client.readthedocs.io/en/latest/contributing.html#pull-requests)
- [ ] Add entry to the [release notes](https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://i.pinimg.com/originals/e6/44/ea/e644eacfa75ecb5cb73e220bb0c7ef01.jpg)
