### PR TITLE
Update uvloop for 3.8 compatibility.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ deps = {
         "web3==4.4.1",
         "lahja>=0.14.6,<0.15.0",
         "termcolor>=1.1.0,<2.0.0",
-        "uvloop==0.11.2;platform_system=='Linux' or platform_system=='Darwin' or platform_system=='FreeBSD'",  # noqa: E501
+        "uvloop==0.14.0;platform_system=='Linux' or platform_system=='Darwin' or platform_system=='FreeBSD'",  # noqa: E501
         "websockets==5.0.1",
         "jsonschema==3.0.1",
         "mypy_extensions>=0.4.1,<1.0.0",


### PR DESCRIPTION
### What was wrong?

On python 3.8.0, uvloop 0.11.2 is incompatible.

``` pyconsole
>>> import uvloop
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/eth2/test_venv/lib/python3.8/site-packages/uvloop/__init__.py", line 7, in <module>
    from .loop import Loop as __BaseLoop  # NOQA
  File "uvloop/includes/stdlib.pxi", line 114, in init uvloop.loop
AttributeError: module 'sys' has no attribute 'set_coroutine_wrapper'
```

### How was it fixed?

Update dependency to 0.14.0. No known backwards-incompatible changes.


### To-Do

- [ ] Clean up commit history

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://upload.wikimedia.org/wikipedia/commons/4/4a/Tiny_Jelly.jpg)
