### PR TITLE
Remove `AttestationPool` as a dependency of a `StateMachine`

### DIFF
--- a/eth2/beacon/state_machines/base.py
+++ b/eth2/beacon/state_machines/base.py
@@ -6,7 +6,6 @@ from eth._utils.datatypes import Configurable
 
 from eth2.beacon.db.chain import BaseBeaconChainDB
 from eth2.beacon.fork_choice.scoring import ScoringFn as ForkChoiceScoringFn
-from eth2.beacon.operations.attestation_pool import AttestationPool
 from eth2.beacon.types.blocks import BaseBeaconBlock
 from eth2.beacon.types.states import BeaconState
 from eth2.beacon.typing import FromBlockParams
@@ -29,9 +28,7 @@ class BaseBeaconStateMachine(Configurable, ABC):
     state_transition_class: Type[BaseStateTransition] = None
 
     @abstractmethod
-    def __init__(
-        self, chaindb: BaseBeaconChainDB, attestation_pool: AttestationPool
-    ) -> None:
+    def __init__(self, chaindb: BaseBeaconChainDB) -> None:
         ...
 
     @classmethod
@@ -79,11 +76,8 @@ class BaseBeaconStateMachine(Configurable, ABC):
 
 
 class BeaconStateMachine(BaseBeaconStateMachine):
-    def __init__(
-        self, chaindb: BaseBeaconChainDB, attestation_pool: AttestationPool
-    ) -> None:
+    def __init__(self, chaindb: BaseBeaconChainDB) -> None:
         self.chaindb = chaindb
-        self.attestation_pool = attestation_pool
 
     @classmethod
     def get_block_class(cls) -> Type[BaseBeaconBlock]:

--- a/eth2/beacon/state_machines/forks/serenity/__init__.py
+++ b/eth2/beacon/state_machines/forks/serenity/__init__.py
@@ -41,6 +41,14 @@ class SerenityStateMachine(BeaconStateMachine):
 
     def get_fork_choice_scoring(self) -> ForkChoiceScoringFn:
         state = self._get_justified_head_state()
+        # NOTE: temporary import here
+        from eth2.beacon.operations.attestation_pool import AttestationPool
+
         return lmd_ghost_scoring(
-            self.chaindb, self.attestation_pool, state, self.config, self.block_class
+            # NOTE: temporary ``AttestationPool``
+            self.chaindb,
+            AttestationPool(),
+            state,
+            self.config,
+            self.block_class,
         )

--- a/tests/eth2/core/beacon/chains/test_chains.py
+++ b/tests/eth2/core/beacon/chains/test_chains.py
@@ -4,6 +4,6 @@ from eth2.beacon.chains.testnet import SkeletonLakeChain
 
 
 @pytest.mark.parametrize("chain_klass", (SkeletonLakeChain,))
-def test_chain_class_well_defined(base_db, chain_klass, empty_attestation_pool, config):
-    chain = chain_klass(base_db, empty_attestation_pool, config)
+def test_chain_class_well_defined(base_db, chain_klass, config):
+    chain = chain_klass(base_db, config)
     assert chain.sm_configuration is not () and chain.sm_configuration is not None

--- a/tests/eth2/core/beacon/operations/test_pool.py
+++ b/tests/eth2/core/beacon/operations/test_pool.py
@@ -1,19 +1,20 @@
 import itertools
 
-from eth_utils.toolz import take
+from eth_utils.toolz import assoc, take
 
 from eth2._utils.funcs import forever
 from eth2.beacon.operations.attestation_pool import AttestationPool
 from eth2.beacon.types.attestations import Attestation
 
 
-def mk_attestation(index, sample_attestation_params):
-    return Attestation(**sample_attestation_params)
+def _mk_attestation(index, sample_attestation_params):
+    some_signature = index.to_bytes(96, byteorder="big")
+    return Attestation(**assoc(sample_attestation_params, "signature", some_signature))
 
 
 def test_iterating_operation_pool(sample_attestation_params):
     some_attestation_params = zip(itertools.count(), forever(sample_attestation_params))
-    some_attestations = map(lambda x: mk_attestation(*x), some_attestation_params)
+    some_attestations = map(lambda x: _mk_attestation(*x), some_attestation_params)
 
     attestation_count = 20
     attestations = tuple(take(attestation_count, some_attestations))

--- a/tests/eth2/core/beacon/state_machines/forks/test_serenity_operation_processing.py
+++ b/tests/eth2/core/beacon/state_machines/forks/test_serenity_operation_processing.py
@@ -31,7 +31,6 @@ def test_process_max_attestations(
     keymap,
     fixture_sm_class,
     chaindb,
-    empty_attestation_pool,
 ):
     attestation_slot = config.GENESIS_SLOT
     current_slot = attestation_slot + config.MIN_ATTESTATION_INCLUSION_DELAY
@@ -40,7 +39,7 @@ def test_process_max_attestations(
     attestations = create_mock_signed_attestations_at_slot(
         state=state,
         config=config,
-        state_machine=fixture_sm_class(chaindb, empty_attestation_pool),
+        state_machine=fixture_sm_class(chaindb),
         attestation_slot=attestation_slot,
         beacon_block_root=genesis_block.signing_root,
         keymap=keymap,
@@ -203,7 +202,6 @@ def test_process_attestations(
     keymap,
     fixture_sm_class,
     chaindb,
-    empty_attestation_pool,
     success,
 ):
 
@@ -214,7 +212,7 @@ def test_process_attestations(
     attestations = create_mock_signed_attestations_at_slot(
         state=state,
         config=config,
-        state_machine=fixture_sm_class(chaindb, empty_attestation_pool),
+        state_machine=fixture_sm_class(chaindb),
         attestation_slot=attestation_slot,
         beacon_block_root=genesis_block.signing_root,
         keymap=keymap,

--- a/tests/eth2/core/beacon/state_machines/forks/test_state_machine.py
+++ b/tests/eth2/core/beacon/state_machines/forks/test_state_machine.py
@@ -6,5 +6,5 @@ from eth2.beacon.state_machines.forks.skeleton_lake import SkeletonLakeStateMach
 
 @pytest.mark.parametrize("sm_klass", (SerenityStateMachine, SkeletonLakeStateMachine))
 def test_sm_class_well_defined(sm_klass):
-    state_machine = sm_klass(chaindb=None, attestation_pool=None)
+    state_machine = sm_klass(chaindb=None)
     assert state_machine.get_block_class()

--- a/tests/eth2/core/beacon/state_machines/test_state_transition.py
+++ b/tests/eth2/core/beacon/state_machines/test_state_transition.py
@@ -41,7 +41,6 @@ def test_per_slot_transition(
     config,
     state_slot,
     fork_choice_scoring,
-    empty_attestation_pool,
     keymap,
 ):
     chaindb.persist_block(genesis_block, SerenityBeaconBlock, fork_choice_scoring)
@@ -53,7 +52,7 @@ def test_per_slot_transition(
     block = create_mock_block(
         state=state,
         config=config,
-        state_machine=fixture_sm_class(chaindb, empty_attestation_pool),
+        state_machine=fixture_sm_class(chaindb),
         block_class=SerenityBeaconBlock,
         parent_block=genesis_block,
         keymap=keymap,
@@ -64,7 +63,7 @@ def test_per_slot_transition(
     chaindb.persist_block(block, SerenityBeaconBlock, fork_choice_scoring)
 
     # Get state machine instance
-    sm = fixture_sm_class(chaindb, empty_attestation_pool)
+    sm = fixture_sm_class(chaindb)
 
     # Get state transition instance
     st = sm.state_transition_class(sm.config)

--- a/tests/eth2/integration/test_demo.py
+++ b/tests/eth2/integration/test_demo.py
@@ -3,7 +3,6 @@ import pytest
 from eth2._utils.bls import bls
 from eth2.beacon.db.chain import BeaconChainDB
 from eth2.beacon.fork_choice.higher_slot import higher_slot_scoring
-from eth2.beacon.operations.attestation_pool import AttestationPool
 from eth2.beacon.state_machines.forks.serenity import SerenityStateMachine
 from eth2.beacon.state_machines.forks.serenity.blocks import SerenityBeaconBlock
 from eth2.beacon.state_machines.forks.skeleton_lake import MINIMAL_SERENITY_CONFIG
@@ -30,7 +29,6 @@ def test_demo(base_db, validator_count, keymap, pubkeys, fork_choice_scoring):
     genesis_slot = config.GENESIS_SLOT
     genesis_epoch = config.GENESIS_EPOCH
     chaindb = BeaconChainDB(base_db, config)
-    attestation_pool = AttestationPool()
 
     genesis_state, genesis_block = create_mock_genesis(
         pubkeys=pubkeys[:validator_count],
@@ -63,7 +61,7 @@ def test_demo(base_db, validator_count, keymap, pubkeys, fork_choice_scoring):
         block = create_mock_block(
             state=state,
             config=config,
-            state_machine=fixture_sm_class(chaindb, attestation_pool),
+            state_machine=fixture_sm_class(chaindb),
             block_class=SerenityBeaconBlock,
             parent_block=block,
             keymap=keymap,
@@ -72,7 +70,7 @@ def test_demo(base_db, validator_count, keymap, pubkeys, fork_choice_scoring):
         )
 
         # Get state machine instance
-        sm = fixture_sm_class(chaindb, attestation_pool)
+        sm = fixture_sm_class(chaindb)
         state, _ = sm.import_block(block, state)
 
         chaindb.persist_state(state)
@@ -85,7 +83,7 @@ def test_demo(base_db, validator_count, keymap, pubkeys, fork_choice_scoring):
         attestations = create_mock_signed_attestations_at_slot(
             state=state,
             config=config,
-            state_machine=fixture_sm_class(chaindb, attestation_pool),
+            state_machine=fixture_sm_class(chaindb),
             attestation_slot=attestation_slot,
             beacon_block_root=block.signing_root,
             keymap=keymap,

--- a/tests/libp2p/bcc/test_receive_server.py
+++ b/tests/libp2p/bcc/test_receive_server.py
@@ -10,7 +10,6 @@ import ssz
 from eth2.beacon.chains.base import BaseBeaconChain
 from eth2.beacon.chains.testnet import SkeletonLakeChain
 from eth2.beacon.fork_choice.higher_slot import higher_slot_scoring
-from eth2.beacon.operations.attestation_pool import AttestationPool as TempPool
 from eth2.beacon.state_machines.forks.serenity.blocks import SerenityBeaconBlock
 from eth2.beacon.state_machines.forks.skeleton_lake.config import (
     MINIMAL_SERENITY_CONFIG,
@@ -60,9 +59,7 @@ class FakeChain(SkeletonLakeChain):
 async def get_fake_chain() -> FakeChain:
     genesis_config = Eth2GenesisConfig(MINIMAL_SERENITY_CONFIG)
     chain_db = AsyncBeaconChainDBFactory(genesis_config=genesis_config)
-    return FakeChain(
-        base_db=chain_db.db, attestation_pool=TempPool(), genesis_config=genesis_config
-    )
+    return FakeChain(base_db=chain_db.db, genesis_config=genesis_config)
 
 
 def get_blocks(

--- a/trinity/components/builtin/attach/console.py
+++ b/trinity/components/builtin/attach/console.py
@@ -16,7 +16,6 @@ from eth.db.backends.level import LevelDB
 
 from eth2.beacon.db.chain import BeaconChainDB
 from eth2.beacon.types.blocks import BeaconBlock
-from eth2.beacon.operations.attestation_pool import AttestationPool
 
 from trinity.config import (
     Eth1AppConfig,
@@ -186,10 +185,8 @@ def get_beacon_shell_context(database_dir: Path, trinity_config: TrinityConfig) 
         db = LevelDB(database_dir)
 
     chain_config = app_config.get_chain_config()
-    attestation_pool = AttestationPool()
     chain = chain_config.beacon_chain_class(
         db,
-        attestation_pool,
         chain_config.genesis_config
     )
 

--- a/trinity/components/eth2/beacon/component.py
+++ b/trinity/components/eth2/beacon/component.py
@@ -16,7 +16,6 @@ from libp2p.crypto.secp256k1 import create_new_key_pair, Secp256k1PrivateKey
 
 from eth_utils import decode_hex
 
-from eth2.beacon.operations.attestation_pool import AttestationPool
 from eth2.beacon.typing import (
     ValidatorIndex,
 )
@@ -101,10 +100,8 @@ class BeaconNodeComponent(AsyncioIsolatedComponent):
         beacon_app_config = trinity_config.get_app_config(BeaconAppConfig)
         base_db = DBClient.connect(trinity_config.database_ipc_path)
         chain_config = beacon_app_config.get_chain_config()
-        attestation_pool = AttestationPool()
         chain = chain_config.beacon_chain_class(
             base_db,
-            attestation_pool,
             chain_config.genesis_config
         )
 


### PR DESCRIPTION
### What was wrong?

Some time ago, we updated the beacon chain `StateMachine` so that it required an `AttestationPool`; this functionality is (rightfully so imo) in the `Node` class and in fact is not necessary in the `StateMachine` abstraction.

### How was it fixed?

Removed :) Part of a series of refactors to get our beacon chain fork choice in a good place.

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://img.designswan.com/2014/05/fox/10.jpg)
