### PR TITLE
Implement eth_getTransactionByHash endpoint

### DIFF
--- a/newsfragments/1329.feature.rst
+++ b/newsfragments/1329.feature.rst
@@ -1,0 +1,1 @@
+Add support for `eth_getTransactionByHash` JSON-RPC API

--- a/trinity/chains/base.py
+++ b/trinity/chains/base.py
@@ -8,6 +8,7 @@ from eth.abc import (
     ChainAPI,
     BlockHeaderAPI,
     ReceiptAPI,
+    SignedTransactionAPI,
 )
 
 
@@ -60,4 +61,9 @@ class AsyncChainAPI(ChainAPI):
 
     @abstractmethod
     async def coro_get_canonical_head(self) -> BlockHeaderAPI:
+        ...
+
+    @abstractmethod
+    async def coro_get_canonical_transaction(self,
+                                             transaction_hash: Hash32) -> SignedTransactionAPI:
         ...

--- a/trinity/chains/coro.py
+++ b/trinity/chains/coro.py
@@ -18,6 +18,7 @@ class AsyncChainMixin(AsyncChainAPI):
     coro_get_block_header_by_hash = async_method(Chain.get_block_header_by_hash)
     coro_get_canonical_block_by_number = async_method(Chain.get_canonical_block_by_number)
     coro_get_canonical_head = async_method(Chain.get_canonical_head)
+    coro_get_canonical_transaction = async_method(Chain.get_canonical_transaction)
     coro_import_block = async_method(Chain.import_block)
     coro_validate_chain = async_method(Chain.validate_chain)
     coro_validate_receipt = async_method(Chain.validate_receipt)

--- a/trinity/rpc/modules/eth.py
+++ b/trinity/rpc/modules/eth.py
@@ -216,6 +216,12 @@ class Eth(Eth1ChainRPCModule):
         stored_val = state.get_storage(address, position)
         return encode_hex(int_to_big_endian(stored_val))
 
+    @format_params(decode_hex)
+    async def getTransactionByHash(self,
+                                   transaction_hash: Hash32) -> Dict[str, str]:
+        transaction = await self.chain.coro_get_canonical_transaction(transaction_hash)
+        return transaction_to_dict(transaction)
+
     @format_params(decode_hex, to_int_if_hex)
     async def getTransactionByBlockHashAndIndex(self,
                                                 block_hash: Hash32,


### PR DESCRIPTION
### What was wrong?

Trinity does not yet serve the [eth_getTransactionByHash](https://github.com/ethereum/wiki/wiki/JSON-RPC#eth_gettransactionbyhash) RPC.

### How was it fixed?

1. Add support in the `rpc/modules/eth.py`
2. Test it as part of the JSON-RPC fixture tests (simiar to how we test `eth_getTransactionByBlockHashAndIndex` and `eth_getTransactionByBlockNumberAndIndex` today)

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

[//]: # (See: https://trinity-client.readthedocs.io/en/latest/contributing.html#pull-requests)
- [x] Add entry to the [release notes](https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://i.pinimg.com/originals/aa/76/63/aa766327977e2255ec347d09391d16cb.jpg)
