### PR TITLE
Consolidate implementations of the two `AttestationPool`s

### DIFF
--- a/eth2/beacon/operations/pool.py
+++ b/eth2/beacon/operations/pool.py
@@ -1,4 +1,4 @@
-from typing import Dict, Generic, Iterator, Tuple, TypeVar
+from typing import Callable, Dict, Generic, Iterable, Iterator, Tuple, TypeVar, Union
 
 from typing_extensions import Protocol
 
@@ -18,11 +18,40 @@ class OperationPool(Generic[T]):
     def __init__(self) -> None:
         self._pool_storage = {}
 
+    def __len__(self) -> int:
+        return len(self._pool_storage)
+
+    def __iter__(self) -> Iterator[Tuple[HashTreeRoot, T]]:
+        return iter(self._pool_storage.items())
+
+    def __contains__(self, operation_or_root: Union[T, HashTreeRoot]) -> bool:
+        if isinstance(operation_or_root, bytes):
+            root = operation_or_root
+        else:
+            root = operation_or_root.hash_tree_root
+
+        return root in self._pool_storage
+
     def get(self, hash_tree_root: HashTreeRoot) -> T:
         return self._pool_storage[hash_tree_root]
+
+    def get_all(self) -> Tuple[T, ...]:
+        return tuple(self._pool_storage.values())
+
+    def _batch_do(self, f: Callable[[T], None], operations: Iterable[T]) -> None:
+        for operation in operations:
+            f(operation)
 
     def add(self, operation: T) -> None:
         self._pool_storage[operation.hash_tree_root] = operation
 
-    def __iter__(self) -> Iterator[Tuple[HashTreeRoot, T]]:
-        return iter(self._pool_storage.items())
+    def batch_add(self, operations: Iterable[T]) -> None:
+        self._batch_do(self.add, operations)
+
+    def remove(self, operation: T) -> None:
+        root = operation.hash_tree_root
+        if root in self._pool_storage:
+            del self._pool_storage[root]
+
+    def batch_remove(self, operations: Iterable[T]) -> None:
+        self._batch_do(self.remove, operations)


### PR DESCRIPTION
### What was wrong?

Fixes #783.

### How was it fixed?

We had some divergent development some time ago that resulted in two `AttestationPool` implementations. This PR consolidates things.

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://external-content.duckduckgo.com/iu/?u=http%3A%2F%2Fmedia-cache-ak0.pinimg.com%2F736x%2F86%2F9b%2Fb3%2F869bb3a5703ea0b656edcece7881f6bd.jpg&f=1&nofb=1)
