### PR TITLE
Update spec fixtures v0.9.2

### DIFF
--- a/.circleci/get_eth2_fixtures.sh
+++ b/.circleci/get_eth2_fixtures.sh
@@ -1,9 +1,9 @@
 #!/usr/bin/env bash
 
 if [ ! -d "./eth2-fixtures/tests" ]; then
-  wget -c https://github.com/ethereum/eth2.0-spec-tests/releases/download/v0.9.1/general.tar.gz
-  wget -c https://github.com/ethereum/eth2.0-spec-tests/releases/download/v0.9.1/mainnet.tar.gz
-  wget -c https://github.com/ethereum/eth2.0-spec-tests/releases/download/v0.9.1/minimal.tar.gz
+  wget -c https://github.com/ethereum/eth2.0-spec-tests/releases/download/v0.9.2/general.tar.gz
+  wget -c https://github.com/ethereum/eth2.0-spec-tests/releases/download/v0.9.2/mainnet.tar.gz
+  wget -c https://github.com/ethereum/eth2.0-spec-tests/releases/download/v0.9.2/minimal.tar.gz
   mkdir eth2-fixtures
   tar zxvf general.tar.gz -C ./eth2-fixtures
   tar zxvf mainnet.tar.gz -C ./eth2-fixtures

--- a/eth2/beacon/tools/fixtures/loading.py
+++ b/eth2/beacon/tools/fixtures/loading.py
@@ -11,6 +11,10 @@ from eth2.configs import Eth2Config
 def generate_config_by_dict(dict_config: Dict[str, Any]) -> Eth2Config:
     filtered_keys = (
         "DOMAIN_",
+        "ETH1_FOLLOW_DISTANCE",
+        "TARGET_AGGREGATORS_PER_COMMITTEE",
+        "RANDOM_SUBNETS_PER_VALIDATOR",
+        "EPOCHS_PER_RANDOM_SUBNET_SUBSCRIPTION",
         # Phase 1
         "MAX_EPOCHS_PER_CROSSLINK",
         "EARLY_DERIVED_SECRET_PENALTY_MAX_FUTURE_EPOCHS",


### PR DESCRIPTION
### What was wrong?

Part of #1321.

Updates the eth2 fixtures to v0.9.2

### How was it fixed?

Update submodule and CI settings.

NOTE: currently filtering some configuration fields that may be added to the global `Eth2Config` in subsequent PRs.

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://external-content.duckduckgo.com/iu/?u=http%3A%2F%2F1.bp.blogspot.com%2F-FdWTeMMbRFo%2FT2WO_N_BcmI%2FAAAAAAAAANY%2F34TSyoqT630%2Fs1600%2Fwalrus.jpg&f=1&nofb=1)
