### PR TITLE
Implement eth_getTransactionReceipt API

### DIFF
--- a/newsfragments/1337.feature.rst
+++ b/newsfragments/1337.feature.rst
@@ -1,0 +1,3 @@
+Add support for `eth_getTransactionReceipt` JSON-RPC API
+
+See: https://github.com/ethereum/wiki/wiki/JSON-RPC#eth_gettransactionreceipt

--- a/tests/json-fixtures-over-rpc/test_rpc_fixtures.py
+++ b/tests/json-fixtures-over-rpc/test_rpc_fixtures.py
@@ -22,6 +22,7 @@ from eth_utils import (
     is_string,
     to_checksum_address,
     to_tuple,
+    to_int,
 )
 from eth_utils.curried import (
     apply_formatter_if,
@@ -382,7 +383,7 @@ def validate_rpc_transaction_vs_fixture(transaction, fixture):
     assert actual_transaction == expected
 
 
-async def validate_transaction_by_index(rpc, transaction_fixture, at_block, index):
+async def validate_transaction_by_index(rpc, block_fixture, transaction_fixture, at_block, index):
     block_by_hash = is_by_hash(at_block)
     if block_by_hash:
         rpc_method = 'eth_getTransactionByBlockHashAndIndex'
@@ -397,12 +398,25 @@ async def validate_transaction_by_index(rpc, transaction_fixture, at_block, inde
         # that we can refer to by its number. Otherwise, it may be that we try to lookup
         # a transaction by its hash that is not in the canonical chain which isn't supported.
         await validate_transaction_by_hash(rpc, result['hash'], transaction_fixture)
+        await validate_transaction_receipt(rpc, result['hash'], block_fixture, transaction_fixture)
 
 
 async def validate_transaction_by_hash(rpc, tx_hash, transaction_fixture):
     result, error = await call_rpc(rpc, 'eth_getTransactionByHash', [tx_hash])
     assert error is None
     validate_rpc_transaction_vs_fixture(result, transaction_fixture)
+
+
+async def validate_transaction_receipt(rpc, tx_hash, block_fixture, transaction_fixture):
+    result, error = await call_rpc(rpc, 'eth_getTransactionReceipt', [tx_hash])
+    assert error is None
+    header_fixture = fixture_block_in_rpc_format(block_fixture['blockHeader'])
+    tx_index = to_int(hexstr=result['transactionIndex'])
+    tx_fixture = block_fixture['transactions'][tx_index]
+
+    assert result['to'] == add_0x_prefix(tx_fixture['to'])
+    assert result['blockHash'] == header_fixture['hash']
+    assert result['blockNumber'] == header_fixture['number']
 
 
 async def validate_block(rpc, block_fixture, at_block):
@@ -418,7 +432,8 @@ async def validate_block(rpc, block_fixture, at_block):
     assert len(result['transactions']) == len(block_fixture['transactions'])
 
     for index, transaction_fixture in enumerate(block_fixture['transactions']):
-        await validate_transaction_by_index(rpc, transaction_fixture, at_block, index)
+        await validate_transaction_by_index(
+            rpc, block_fixture, transaction_fixture, at_block, index)
 
     await validate_transaction_count(rpc, block_fixture, at_block)
 

--- a/tests/json-fixtures-over-rpc/test_rpc_fixtures.py
+++ b/tests/json-fixtures-over-rpc/test_rpc_fixtures.py
@@ -1,6 +1,5 @@
 import asyncio
 import json
-import os
 from pathlib import Path
 
 import pytest
@@ -60,7 +59,7 @@ from trinity.rpc.modules import (
 ROOT_PROJECT_DIR = Path(__file__).parent.parent.parent
 
 
-BASE_FIXTURE_PATH = os.path.join(ROOT_PROJECT_DIR, 'fixtures', 'BlockchainTests')
+BASE_FIXTURE_PATH = ROOT_PROJECT_DIR / 'fixtures' / 'BlockchainTests'
 
 SLOW_TESTS = (
     'bcExploitTest/SuicideIssue.json',
@@ -495,15 +494,92 @@ class MainnetFullChain(FullChain):
     vm_configuration = MainnetChain.vm_configuration
 
 
-@pytest.mark.asyncio
-async def test_rpc_against_fixtures(event_bus, chain_fixture, fixture_data):
+async def setup_rpc_server(event_bus, chain_fixture, fixture_path):
     chain = MainnetFullChain(None)
     rpc = RPCServer(initialize_eth1_modules(chain, event_bus), chain, event_bus)
 
     setup_result, setup_error = await call_rpc(rpc, 'evm_resetToGenesisFixture', [chain_fixture])
     # We need to advance the event loop for modules to be able to pickup the new chain
     await asyncio.sleep(0)
-    assert setup_error is None and setup_result is True, "cannot load chain for {0}".format(fixture_data)  # noqa: E501
+    assert setup_error is None and setup_result is True, f"cannot load chain for {fixture_path}"
+    return rpc
+
+
+@pytest.mark.parametrize(
+    "tx_hash, fixture, expected_result",
+    (
+        (
+            "0x50406b46b2face98d3b1ccb3e8f1e9b490617d1b366568b4786847867dcdc7e8",
+            ('ValidBlocks/bcValidBlockTest/ExtraData32.json', 'ExtraData32_Homestead'),
+            {
+                'blockHash': '0x047635136e99cd68496efc834378e678538c64445be3c4ce4f1ebec5ca5c5fcf',
+                'blockNumber': '0x1',
+                'contractAddress': None,
+                'cumulativeGasUsed': '0x560b',
+                'from': '0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b',
+                'gasUsed': '0x560b',
+                'logs': [{
+                    'address': '0x095e7baea6a6c7c4c2dfeb977efac326af552d87',
+                    'data': '0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff',
+                    'blockHash': '0x047635136e99cd68496efc834378e678538c64445be3c4ce4f1ebec5ca5c5fcf',  # noqa: E501
+                    'blockNumber': '0x1',
+                    'logIndex': '0x0',
+                    'removed': False,
+                    'topics': ['0x00'],
+                    'transactionHash': '0x50406b46b2face98d3b1ccb3e8f1e9b490617d1b366568b4786847867dcdc7e8',  # noqa: E501
+                    'transactionIndex': '0x0'
+                }],
+                'logsBloom': '0x00000000000000001000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000020000000000000000000800000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000004000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000020000000000040000000000000000000000000000000000000000000000000000000',  # noqa: E501
+                'root': '0x24d2203a1c8ad4d1c75b526aaa429b440208f863d26b599cb016b17bae845167',
+                'to': '0x095e7baea6a6c7c4c2dfeb977efac326af552d87',
+                'transactionHash': '0x50406b46b2face98d3b1ccb3e8f1e9b490617d1b366568b4786847867dcdc7e8',  # noqa: E501
+                'transactionIndex': '0x0'
+            }
+        ),
+        (
+            "0xd6cda738c9f26fdaf805c6335ceec07dd57d1d081142b9c7ec7de2afdb79a5c4",
+            ('ValidBlocks/bcBlockGasLimitTest/TransactionGasHigherThanLimit2p63m1.json', 'TransactionGasHigherThanLimit2p63m1_EIP158'),  # noqa: E501
+            {
+                'blockHash': '0x66649dd76e3155944f61e5f012fd920bbb22dca1ea211d392cbc49992cc1c789',
+                'blockNumber': '0x1',
+                'contractAddress': None,
+                'cumulativeGasUsed': '0xa410',
+                'from': '0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b',
+                'gasUsed': '0x5208',
+                'logs': [],
+                'logsBloom': '0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000',  # noqa: E501
+                'root': '0xd9778a6246f1547ac91548f6ac374d1c3691d70c46186ab2470a2dcd009a54cd',
+                'to': '0xaaaf5374fce5edbc8e2a8697c15331677e6ebf0b',
+                'transactionHash': '0xd6cda738c9f26fdaf805c6335ceec07dd57d1d081142b9c7ec7de2afdb79a5c4',  # noqa: E501
+                'transactionIndex': '0x1'
+            }
+        ),
+    ),
+)
+@pytest.mark.asyncio
+async def test_eth_getTransactionReceipt(event_bus, tx_hash, fixture, expected_result):
+
+    fixture_path = BASE_FIXTURE_PATH / fixture[0]
+    chain_fixture = load_fixture(fixture_path, fixture[1])
+
+    rpc = await setup_rpc_server(event_bus, chain_fixture, fixture_path)
+
+    await validate_accounts(rpc, chain_fixture['pre'])
+
+    for block_fixture in chain_fixture['blocks']:
+
+        block_result, block_error = await call_rpc(rpc, 'evm_applyBlockFixture', [block_fixture])
+        assert block_error is None
+        assert block_result == block_fixture['rlp']
+
+    result, error = await call_rpc(rpc, 'eth_getTransactionReceipt', [tx_hash])
+
+    assert result == expected_result
+
+
+@pytest.mark.asyncio
+async def test_rpc_against_fixtures(event_bus, chain_fixture, fixture_data):
+    rpc = await setup_rpc_server(event_bus, chain_fixture, fixture_data[0])
 
     await validate_accounts(rpc, chain_fixture['pre'])
 

--- a/trinity/_utils/address.py
+++ b/trinity/_utils/address.py
@@ -1,0 +1,23 @@
+import rlp
+
+from eth_hash.auto import keccak
+from eth_typing import Address
+
+
+def force_bytes_to_address(value: bytes) -> Address:
+    """
+    Take any byte value and force it into becoming a valid address by padding it to 20 bytes
+    or returning the first 20 bytes in case the provided value is longer than 20 bytes.
+    """
+    trimmed_value = value[-20:]
+    padded_value = trimmed_value.rjust(20, b'\x00')
+    return Address(padded_value)
+
+
+def generate_contract_address(sender: Address, nonce: int) -> Address:
+    """
+    Take the given ``sender```and ``nonce`` and generate an address in the same way
+    as a *Contract Creation Transaction* creates a contract address when a contract
+    is deployed.
+    """
+    return force_bytes_to_address(keccak(rlp.encode([sender, nonce])))

--- a/trinity/chains/base.py
+++ b/trinity/chains/base.py
@@ -64,6 +64,35 @@ class AsyncChainAPI(ChainAPI):
         ...
 
     @abstractmethod
+    async def coro_get_canonical_block_header_by_number(
+            self,
+            block_number: BlockNumber) -> BlockHeaderAPI:
+        ...
+
+    @abstractmethod
+    async def coro_get_canonical_transaction_index(
+            self,
+            transaction_hash: Hash32) -> Tuple[BlockNumber, int]:
+        ...
+
+    @abstractmethod
     async def coro_get_canonical_transaction(self,
                                              transaction_hash: Hash32) -> SignedTransactionAPI:
+        ...
+
+    @abstractmethod
+    async def coro_get_canonical_transaction_by_index(
+            self,
+            block_number: BlockNumber,
+            index: int) -> SignedTransactionAPI:
+        ...
+
+    @abstractmethod
+    async def coro_get_transaction_receipt(self, transaction_hash: Hash32) -> ReceiptAPI:
+        ...
+
+    @abstractmethod
+    async def coro_get_transaction_receipt_by_index(self,
+                                                    block_number: BlockNumber,
+                                                    index: int) -> ReceiptAPI:
         ...

--- a/trinity/chains/coro.py
+++ b/trinity/chains/coro.py
@@ -18,7 +18,14 @@ class AsyncChainMixin(AsyncChainAPI):
     coro_get_block_header_by_hash = async_method(Chain.get_block_header_by_hash)
     coro_get_canonical_block_by_number = async_method(Chain.get_canonical_block_by_number)
     coro_get_canonical_head = async_method(Chain.get_canonical_head)
+    coro_get_canonical_block_header_by_number = async_method(
+        Chain.get_canonical_block_header_by_number
+    )
+    coro_get_canonical_transaction_index = async_method(Chain.get_canonical_transaction_index)
     coro_get_canonical_transaction = async_method(Chain.get_canonical_transaction)
+    coro_get_canonical_transaction_by_index = async_method(Chain.get_canonical_transaction_by_index)
+    coro_get_transaction_receipt = async_method(Chain.get_transaction_receipt)
+    coro_get_transaction_receipt_by_index = async_method(Chain.get_transaction_receipt_by_index)
     coro_import_block = async_method(Chain.import_block)
     coro_validate_chain = async_method(Chain.validate_chain)
     coro_validate_receipt = async_method(Chain.validate_receipt)

--- a/trinity/chains/light.py
+++ b/trinity/chains/light.py
@@ -111,6 +111,9 @@ class LightDispatchChain(AsyncChainAPI, Chain):
 
     coro_get_block_header_by_hash = async_method(Chain.get_block_header_by_hash)
 
+    coro_get_canonical_block_header_by_number = async_method(
+        Chain.get_canonical_block_header_by_number)
+
     def get_canonical_head(self) -> BlockHeaderAPI:
         return self._headerdb.get_canonical_head()
 
@@ -195,7 +198,27 @@ class LightDispatchChain(AsyncChainAPI, Chain):
     def get_canonical_transaction(self, transaction_hash: Hash32) -> SignedTransactionAPI:
         raise NotImplementedError("Chain classes must implement " + inspect.stack()[0][3])
 
+    async def coro_get_canonical_transaction_by_index(
+            self,
+            block_number: BlockNumber,
+            index: int) -> SignedTransactionAPI:
+        raise NotImplementedError("Chain classes must implement " + inspect.stack()[0][3])
+
+    async def coro_get_canonical_transaction_index(
+            self,
+            transaction_hash: Hash32) -> Tuple[BlockNumber, int]:
+        raise NotImplementedError("Chain classes must implement " + inspect.stack()[0][3])
+
     def get_transaction_receipt(self, transaction_hash: Hash32) -> ReceiptAPI:
+        raise NotImplementedError("Chain classes must implement " + inspect.stack()[0][3])
+
+    async def coro_get_transaction_receipt(self, transaction_hash: Hash32) -> ReceiptAPI:
+        raise NotImplementedError("Chain classes must implement " + inspect.stack()[0][3])
+
+    async def coro_get_transaction_receipt_by_index(
+            self,
+            block_number: BlockNumber,
+            index: int) -> ReceiptAPI:
         raise NotImplementedError("Chain classes must implement " + inspect.stack()[0][3])
 
     #

--- a/trinity/exceptions.py
+++ b/trinity/exceptions.py
@@ -85,3 +85,10 @@ class WrongGenesisFailure(HandshakeFailure):
 
 
 register_error(WrongGenesisFailure, BLACKLIST_SECONDS_WRONG_NETWORK_OR_GENESIS)
+
+
+class RpcError(BaseTrinityError):
+    """
+    Raised when a JSON-RPC API request can not be fulfilled.
+    """
+    pass

--- a/trinity/rpc/modules/eth.py
+++ b/trinity/rpc/modules/eth.py
@@ -34,6 +34,10 @@ from eth.abc import (
 from eth.constants import (
     ZERO_ADDRESS,
 )
+from eth.exceptions import (
+    HeaderNotFound,
+    TransactionNotFound,
+)
 from eth.rlp.blocks import (
     BaseBlock,
 )
@@ -51,12 +55,14 @@ from trinity.chains.base import AsyncChainAPI
 from trinity.constants import (
     TO_NETWORKING_BROADCAST_CONFIG,
 )
+from trinity.exceptions import RpcError
 from trinity.rpc.format import (
     block_to_dict,
     header_to_dict,
     format_params,
     normalize_transaction_dict,
     to_int_if_hex,
+    to_receipt_response,
     transaction_to_dict,
 )
 from trinity.rpc.modules import (
@@ -247,6 +253,57 @@ class Eth(Eth1ChainRPCModule):
         state = await state_at_block(self.chain, at_block)
         nonce = state.get_nonce(address)
         return hex(nonce)
+
+    @format_params(decode_hex)
+    async def getTransactionReceipt(self,
+                                    transaction_hash: Hash32) -> Dict[str, str]:
+
+        tx_block_number, tx_index = await self.chain.coro_get_canonical_transaction_index(
+            transaction_hash,
+        )
+
+        try:
+            block_header = await self.chain.coro_get_canonical_block_header_by_number(
+                tx_block_number
+            )
+        except HeaderNotFound as exc:
+            raise RpcError(
+                f"Block {tx_block_number} is not in the canonical chain"
+            ) from exc
+
+        try:
+            transaction = await self.chain.coro_get_canonical_transaction_by_index(
+                tx_block_number,
+                tx_index
+            )
+        except TransactionNotFound as exc:
+            raise RpcError(
+                f"Transaction {encode_hex(transaction_hash)} is not in the canonical chain"
+            ) from exc
+
+        if transaction.hash != transaction_hash:
+            raise RpcError(
+                f"Unexpected transaction {encode_hex(transaction.hash)} at index {tx_index}"
+            )
+
+        receipt = await self.chain.coro_get_transaction_receipt_by_index(
+            tx_block_number,
+            tx_index
+        )
+
+        if tx_index > 0:
+            previous_receipt = await self.chain.coro_get_transaction_receipt_by_index(
+                tx_block_number,
+                tx_index - 1
+            )
+            # The receipt only tells us the cumulative gas that was used. To find the gas used by
+            # the transaction alone we have to get the previous receipt and calculate the
+            # difference.
+            tx_gas_used = receipt.gas_used - previous_receipt.gas_used
+        else:
+            tx_gas_used = receipt.gas_used
+
+        return to_receipt_response(receipt, transaction, tx_index, block_header, tx_gas_used)
 
     @format_params(decode_hex)
     async def getUncleCountByBlockHash(self, block_hash: Hash32) -> str:


### PR DESCRIPTION
### What was wrong?

We need to implement `eth_getTransactionReceipt` API according to the [spec](https://github.com/ethereum/wiki/wiki/JSON-RPC#eth_gettransactionreceipt)

### How was it fixed?

1. Retrieve the Receipt, Header, Transaction from the chain
2. Calculate all computed fields
3. Serve via the `eth` RPC module

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

[//]: # (See: https://trinity-client.readthedocs.io/en/latest/contributing.html#pull-requests)
- [x] Add entry to the [release notes](https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://i.pinimg.com/originals/92/4d/27/924d273f4b11156e62e50bb6d09b5349.jpg)
