### PR TITLE
remove timestamp from logfile path

### DIFF
--- a/trinity/_utils/logging.py
+++ b/trinity/_utils/logging.py
@@ -1,5 +1,4 @@
 import copy
-from datetime import datetime
 import logging
 from logging import (
     StreamHandler
@@ -166,16 +165,13 @@ def setup_file_logging(
         level = logging.DEBUG
     logger = logging.getLogger()
 
-    log_file_with_timestamp = logfile_path.with_suffix(
-        datetime.now().strftime('.%Y%m%d_%H%M%S.log')
-    )
     handler_file = RotatingFileHandler(
-        str(log_file_with_timestamp),
+        str(logfile_path),
         maxBytes=(10000000 * LOG_MAX_MB),
         backupCount=LOG_BACKUP_COUNT,
         delay=True
     )
-    if log_file_with_timestamp.exists():
+    if logfile_path.exists():
         handler_file.doRollover()
 
     if level is not None:


### PR DESCRIPTION
### What was wrong?

#1161 introduced a change to the filename for logfiles, including a timestamp in the name.

This has the negative result of:

1. making it harder to access the latest log because it doesn't automatically tab-complete in the CLI
2. removing the upper bound on total megabytes of logs since the filename changes everytime and thus the rotating log handler won't cleanup old logs.

### How was it fixed?

Remove the timestamp.


#### Cute Animal Picture

![seal_pup](https://user-images.githubusercontent.com/824194/69976832-e2e65180-14e6-11ea-829f-8b0fb6549f3a.jpg)

