### PR TITLE
bump pyrlp version to get rid of deprecation warnings

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -111,7 +111,7 @@ deps = {
         "eth-typing>=2.1.0,<3.0.0",
         "lru-dict>=1.1.6",
         "py-ecc==1.7.1",
-        "rlp>=1.1.0,<2.0.0",
+        "rlp>=1.2.0,<2.0.0",
         PYEVM_DEPENDENCY,
         "ssz==0.1.5",
     ],


### PR DESCRIPTION
### What was wrong?

`rlp==1.1.0` raises deprecation warnings.

### How was it fixed?

updated to `>=1.2.0` that has the fix for the deprecations warnings.

#### Cute Animal Picture

![2918709_1280x720](https://user-images.githubusercontent.com/824194/69979150-f85d7a80-14ea-11ea-80ad-9eddac1f58a9.jpg)

