### PR TITLE
Upgrade py-evm to v0.3.0a9

### DIFF
--- a/newsfragments/1343.feature.rst
+++ b/newsfragments/1343.feature.rst
@@ -1,0 +1,2 @@
+Upgrade py-evm to v0.3.0-alpha.9, for Istanbul fix. See the `py-evm release notes
+<https://py-evm.readthedocs.io/en/latest/release_notes.html#py-evm-0-3-0-alpha-9-2019-12-02>`_

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ deps = {
         "coincurve>=10.0.0,<11.0.0",
         "dataclasses>=0.6, <1;python_version<'3.7'",
         "eth-utils>=1.8.1,<2",
-        "ipython>=7.8.0,<8.0.0",
+        "ipython>=7.8.0,<7.10.0",  # attach fails with v7.10.{0,1}
         "plyvel==1.1.0",
         PYEVM_DEPENDENCY,
         "web3==4.4.1",

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ import os
 import re
 from setuptools import setup, find_packages
 
-PYEVM_DEPENDENCY = "py-evm==0.3.0a8"
+PYEVM_DEPENDENCY = "py-evm==0.3.0a9"
 
 
 deps = {


### PR DESCRIPTION
### What was wrong?

A bug in the Istanbul implementation is in the pinned version of py-evm.

### How was it fixed?

Upgrade py-evm to latest version which fixes the bug:
https://py-evm.readthedocs.io/en/latest/release_notes.html#py-evm-0-3-0-alpha-9-2019-12-02

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

[//]: # (See: https://trinity-client.readthedocs.io/en/latest/contributing.html#pull-requests)
- [x] Add entry to the [release notes](https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://i.pinimg.com/originals/62/79/31/627931a998b89b2452c069177b8e06cf.jpg)
