### PR TITLE
Show more helpful information in logs

### DIFF
--- a/newsfragments/1344.internal.rst
+++ b/newsfragments/1344.internal.rst
@@ -1,0 +1,6 @@
+Show more helpful information in logs, like:
+
+- show peer info in more logs and exceptions
+- add extra information about exception context & cause
+- show eth_api stats in the "Peer details" again
+- show which service is stuck waiting on subservices

--- a/p2p/kademlia.py
+++ b/p2p/kademlia.py
@@ -118,7 +118,7 @@ class Node(NodeAPI):
         return f'enode://{hexstring}@{self.address.ip}:{self.address.tcp_port}'
 
     def __str__(self) -> str:
-        return f"<Node({self.pubkey.to_hex()[:6]}@{self.address.ip})>"
+        return f"<Node({self.pubkey.to_hex()[:8]}@{self.address.ip})>"
 
     def __repr__(self) -> str:
         return f"<Node({self.pubkey.to_hex()}@{self.address.ip}:{self.address.tcp_port})>"

--- a/p2p/peer_pool.py
+++ b/p2p/peer_pool.py
@@ -463,7 +463,7 @@ class BasePeerPool(BaseService, AsyncIterable[BasePeer]):
         """
         peer = cast(BasePeer, peer)
         if peer.session in self.connected_nodes:
-            self.logger.info(
+            self.logger.debug(
                 "Removing %s from pool: local_reason=%s remote_reason=%s",
                 peer,
                 peer.p2p_api.local_disconnect_reason,
@@ -520,6 +520,8 @@ class BasePeerPool(BaseService, AsyncIterable[BasePeer]):
                     "client_version_string='%s'",
                     peer.p2p_api.safe_client_version_string,
                 )
+                if not hasattr(peer, "eth_api"):
+                    self.logger.warning("Huh? %s doesn't have an eth API", peer)
                 for line in peer.get_extra_stats():
                     self.logger.debug("    %s", line)
             self.logger.debug("== End peer details == ")

--- a/p2p/service.py
+++ b/p2p/service.py
@@ -269,7 +269,7 @@ class BaseService(CancellableMixin, AsyncioServiceAPI):
         their cleanup.
         """
         if self._child_services:
-            self.logger.debug("Waiting for child services: %s", list(self._child_services))
+            self.logger.debug("%s waiting for child services: %s", self, list(self._child_services))
             wait_for_clean_up_tasks = (
                 child_service.events.cleaned_up.wait()
                 for child_service in self._child_services
@@ -295,7 +295,7 @@ class BaseService(CancellableMixin, AsyncioServiceAPI):
             ]))
         else:
             task_display = str(task_list)
-        self.logger.debug("%s (%d): %s", message, len(self._tasks), task_display)
+        self.logger.debug("%s: %s (%d): %s", self, message, len(self._tasks), task_display)
 
     def cancel_nowait(self) -> None:
         if self.is_cancelled:

--- a/trinity/protocol/common/peer_pool_event_bus.py
+++ b/trinity/protocol/common/peer_pool_event_bus.py
@@ -131,11 +131,11 @@ class PeerPoolEventServer(BaseService, PeerSubscriber, Generic[TPeer]):
                 "Peer with session %s does not exist in the pool anymore",
                 session,
             )
-            raise PeerConnectionLost()
+            raise PeerConnectionLost(f"Peer at {session} is gone from the pool")
         else:
             if not peer.is_operational:
                 self.logger.debug("Peer %s is not operational when selecting from pool", peer)
-                raise PeerConnectionLost()
+                raise PeerConnectionLost(f"{peer} is no longer operational")
             else:
                 return cast(TPeer, peer)
 

--- a/trinity/protocol/eth/peer.py
+++ b/trinity/protocol/eth/peer.py
@@ -85,6 +85,11 @@ class ETHPeer(BaseChainPeer):
     def eth_api(self) -> ETHAPI:
         return self.connection.get_logic(ETHAPI.name, ETHAPI)
 
+    def get_extra_stats(self) -> Tuple[str, ...]:
+        basic_stats = super().get_extra_stats()
+        eth_stats = self.eth_api.get_extra_stats()
+        return basic_stats + eth_stats
+
 
 class ETHProxyPeer(BaseProxyPeer):
     """

--- a/trinity/server.py
+++ b/trinity/server.py
@@ -152,14 +152,16 @@ class BaseServer(BaseService, Generic[TPeerPool]):
                 writer.close()
                 raise
         except COMMON_RECEIVE_HANDSHAKE_EXCEPTIONS as e:
-            self.logger.debug("Could not complete handshake: %s", e)
+            peername = writer.get_extra_info("peername")
+            self.logger.debug("Could not complete handshake with %s: %s", peername, e)
         except asyncio.CancelledError:
             # This exception should just bubble.
             raise
         except OperationCancelled:
             pass
         except Exception:
-            self.logger.exception("Unexpected error handling handshake")
+            peername = writer.get_extra_info("peername")
+            self.logger.exception("Unexpected error handling handshake with %s", peername)
 
     async def _receive_handshake(
             self, reader: asyncio.StreamReader, writer: asyncio.StreamWriter) -> None:

--- a/trinity/sync/beam/importer.py
+++ b/trinity/sync/beam/importer.py
@@ -36,6 +36,7 @@ from eth_utils import (
     ExtendedDebugLogger,
     ValidationError,
     get_extended_debug_logger,
+    humanize_seconds,
 )
 from eth_utils.toolz import (
     groupby,
@@ -77,19 +78,23 @@ class BeamStats:
     # How much time is spent waiting on retrieving nodes?
     data_pause_time = 0.0
 
-    def __str__(self) -> str:
-        node_count = self.num_account_nodes + self.num_bytecodes + self.num_storage_nodes
+    @property
+    def num_nodes(self) -> int:
+        return self.num_account_nodes + self.num_bytecodes + self.num_storage_nodes
 
-        if node_count:
-            avg_rtt = self.data_pause_time / node_count
+    def __str__(self) -> str:
+        if self.num_nodes:
+            avg_rtt = self.data_pause_time / self.num_nodes
         else:
             avg_rtt = 0
+
+        wait_time = humanize_seconds(self.data_pause_time)
 
         return (
             f"BeamStat: accts={self.num_accounts}, "
             f"a_nodes={self.num_account_nodes}, codes={self.num_bytecodes}, "
             f"strg={self.num_storages}, s_nodes={self.num_storage_nodes}, "
-            f"nodes={node_count}, rtt={avg_rtt:.3f}s, wait={self.data_pause_time:.2f}s"
+            f"nodes={self.num_nodes}, rtt={avg_rtt:.3f}s, wait={wait_time}"
         )
 
     def __repr__(self) -> str:

--- a/trinity/sync/full/chain.py
+++ b/trinity/sync/full/chain.py
@@ -307,7 +307,7 @@ class BaseBodyChainSyncer(BaseService, PeerSubscriber):
                 completed_headers = trivial_headers + received_headers
 
         except BaseP2PError as exc:
-            self.logger.info("Unexpected p2p perror while downloading body from peer: %s", exc)
+            self.logger.info("Unexpected p2p error while downloading body from %s: %s", peer, exc)
             self.logger.debug("Problem downloading body from peer, dropping...", exc_info=True)
         else:
             if len(non_trivial_headers) == 0:
@@ -412,7 +412,7 @@ class BaseBodyChainSyncer(BaseService, PeerSubscriber):
             self.logger.debug("Peer went away, cancelling the block body request and moving on...")
             return tuple()
         except Exception:
-            self.logger.exception("Unknown error when getting block bodies")
+            self.logger.exception("Unknown error when getting block bodies from %s", peer)
             raise
 
         return block_body_bundles
@@ -790,7 +790,7 @@ class FastChainBodySyncer(BaseBodyChainSyncer):
                 completed_headers,
             )
         except BaseP2PError as exc:
-            self.logger.info("Unexpected p2p perror while downloading receipt from peer: %s", exc)
+            self.logger.info("Unexpected p2p err while downloading receipt from %s: %s", peer, exc)
             self.logger.debug("Problem downloading receipt from peer, dropping...", exc_info=True)
         else:
             # peer completed successfully, so have it get back in line for processing


### PR DESCRIPTION
Especially:

- show peer info in more logs and exceptions
- add extra information about exception context & cause
- show eth_api stats in the Peer details again
- show which service is stuck waiting on subservices

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

[//]: # (See: https://trinity-client.readthedocs.io/en/latest/contributing.html#pull-requests)
- [x] Add entry to the [release notes](https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://www.wallpaperflare.com/static/950/510/384/lion-log-climb-predator-wallpaper.jpg)
