### PR TITLE
Speedups during launch and shutdown

### DIFF
--- a/newsfragments/1345.doc.rst
+++ b/newsfragments/1345.doc.rst
@@ -1,0 +1,1 @@
+Collapse log spam about missing trie nodes

--- a/newsfragments/1345.performance.rst
+++ b/newsfragments/1345.performance.rst
@@ -1,0 +1,1 @@
+Speed up beam sync shutdown, and second launch from checkpoint

--- a/trinity/sync/beam/chain.py
+++ b/trinity/sync/beam/chain.py
@@ -211,7 +211,7 @@ class BeamSyncer(BaseService):
         final_headers = self._header_persister.get_final_headers()
 
         # First, download block bodies for previous 6 blocks, for validation
-        await self._download_blocks(final_headers[0])
+        await self.wait(self._download_blocks(final_headers[0]))
 
         # Now let the beam sync importer kick in
         self._checkpoint_header_syncer.set_checkpoint_headers(final_headers)
@@ -624,12 +624,12 @@ class BeamBlockImporter(BaseBlockImporter, BaseService):
         """
 
         address_timer = Timer()
-        num_accounts, new_account_nodes = await self._request_address_nodes(
+        num_accounts, new_account_nodes = await self.wait(self._request_address_nodes(
             header,
             parent_state_root,
             transactions,
             urgent,
-        )
+        ))
         collection_time = address_timer.elapsed
 
         self.logger.debug(

--- a/trinity/sync/beam/queen.py
+++ b/trinity/sync/beam/queen.py
@@ -72,7 +72,7 @@ class QueeningQueue(BaseService, PeerSubscriber, QueenTrackerAPI):
         Wait until a queen peer is designated, then return it.
         """
         while self._queen_peer is None:
-            peer = await self._waiting_peers.get_fastest()
+            peer = await self.wait(self._waiting_peers.get_fastest())
             self._update_queen(peer)
 
         return self._queen_peer

--- a/trinity/sync/common/strategies.py
+++ b/trinity/sync/common/strategies.py
@@ -15,6 +15,9 @@ from eth_utils import (
     ValidationError,
 )
 
+from eth.abc import (
+    BlockHeaderAPI,
+)
 from eth.constants import (
     GENESIS_BLOCK_NUMBER,
     GENESIS_PARENT_HASH,
@@ -111,15 +114,54 @@ class FromCheckpointLaunchStrategy(SyncLaunchStrategyAPI):
         self._checkpoint = checkpoint
         self._peer_pool = peer_pool
 
+    async def _are_prerequisites_complete(self, checkpoint: BlockHeaderAPI) -> bool:
+        block_numbers_to_download = range(
+            checkpoint.block_number + 1,  # we already have the checkpoint, we can skip it
+            checkpoint.block_number + FULL_BLOCKS_NEEDED_TO_START_BEAM,
+        )
+        last_header = checkpoint
+        for block_int in block_numbers_to_download:
+            block_num = BlockNumber(block_int)
+            try:
+                next_header = await self._db.coro_get_canonical_block_header_by_number(block_num)
+            except HeaderNotFound:
+                self.logger.debug(
+                    "Checkpoint validation header at #%d, parent %s, is missing. "
+                    "Downloading from peers...",
+                    block_num,
+                    last_header,
+                )
+                return False
+            else:
+                if next_header.parent_hash != last_header.hash:
+                    self.logger.warning(
+                        "Checkpoint %s is not on the local canonical chain, which has "
+                        "%s following %s. Forcing the checkpoint to be canonical...",
+                        checkpoint,
+                        next_header,
+                        last_header,
+                    )
+                    # re-download from checkpoint to assert that the checkpoint is canonical
+                    return False
+                else:
+                    self.logger.debug("Validated checkpoint %s locally", next_header)
+                    last_header = next_header
+        else:
+            # if loop never breaks, then all headers are validated.
+            return True
+
     async def fulfill_prerequisites(self) -> None:
         try:
             checkpoint = await self._db.coro_get_block_header_by_hash(self._checkpoint.block_hash)
         except HeaderNotFound:
             pass
         else:
-            self.logger.debug("Skipped checkpoint header download of %s", checkpoint)
+            self.logger.debug("Found checkpoint header %s locally", checkpoint)
             self.min_block_number = checkpoint.block_number
-            return
+
+            if await self._are_prerequisites_complete(checkpoint):
+                self.logger.debug("Found all needed checkpoint headers locally, skipping download")
+                return
 
         max_attempts = 1000
 


### PR DESCRIPTION
### What was wrong?

Two unrelated slow components:
- Some service tasks were hanging and and to be force-killed (which adds a 5 second delay)
- When using a checkpoint to beam sync, if you relaunch with the same checkpoint, you try to download the header from peers no matter what

### How was it fixed?

- Add some `self.wait()` wrappers to make sure subtasks always shut down cleanly when service is cancelled
- Check if header is checkpoint header is present locally before trying to download it from peers

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

[//]: # (See: https://trinity-client.readthedocs.io/en/latest/contributing.html#pull-requests)
- [x] Add entry to the [release notes](https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://i.pinimg.com/originals/32/cb/44/32cb44cc3846beda8dcfb89c9ab69711.jpg)
