### PR TITLE
When resuming a recent beam sync, pick up from tip

### DIFF
--- a/newsfragments/1349.feature.rst
+++ b/newsfragments/1349.feature.rst
@@ -1,0 +1,1 @@
+When resuming beam sync, prefer to pick up from the canonical tip, if it's not too far behind.

--- a/trinity/sync/beam/constants.py
+++ b/trinity/sync/beam/constants.py
@@ -41,6 +41,12 @@ GAP_BETWEEN_TESTS = 0.25
 # when a new peer has excellent service stats. It might take several requests
 # to establish it (partially because we measure using an exponential average).
 
+# About how many seconds after a block can we request trie data from peers?
+# The value is configurable by client, but tends to be around 120 blocks.
+# To make up for clients that are configured low, unusually low block times,
+# and other surprises, we pick half of the 15-second * 120 blocks time window:
+ESTIMATED_BEAMABLE_SECONDS = 900
+
 # We need MAX_UNCLE_DEPTH + 1 headers to check during uncle validation
 # We need to request one more header, to set the starting tip
 FULL_BLOCKS_NEEDED_TO_START_BEAM = MAX_UNCLE_DEPTH + 2


### PR DESCRIPTION
### What was wrong?

When restarting the client quickly, trinity was skipping over the few blocks that came in during restart. This seems unnecessary, and it is ideal to have nice long stretches of imported blocks when collecting statistics, for example.

### How was it fixed?

When starting Beam Sync, check how recent the tip is. If the tip is recent enough, pick it up from there.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

[//]: # (See: https://trinity-client.readthedocs.io/en/latest/contributing.html#pull-requests)
- [ ] Add entry to the [release notes](https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://www.telegraph.co.uk/content/dam/Pets/spark/royal-canin/pug-with-tape-measure-around-waist.jpg?imwidth=450)
