### PR TITLE
Add more flexible fork choice scoring

### DIFF
--- a/eth2/_utils/typing.py
+++ b/eth2/_utils/typing.py
@@ -1,0 +1,29 @@
+from abc import abstractmethod
+import functools
+from typing import Any, TypeVar
+
+from typing_extensions import Protocol
+
+ComparableType = TypeVar("ComparableType", bound="Comparable")
+
+
+@functools.total_ordering
+class Comparable(Protocol):
+    @abstractmethod
+    def __lt__(self: ComparableType, other: ComparableType) -> bool:
+        ...
+
+    @abstractmethod
+    def __eq__(self, other: Any) -> bool:
+        ...
+
+
+class Serializeable(Protocol):
+    @abstractmethod
+    def serialize(self) -> bytes:
+        ...
+
+    @classmethod
+    @abstractmethod
+    def deserialize(cls, data: bytes) -> "Serializeable":
+        ...

--- a/eth2/beacon/db/exceptions.py
+++ b/eth2/beacon/db/exceptions.py
@@ -46,7 +46,7 @@ class AttestationRootNotFound(BeaconDBException):
     pass
 
 
-class MissingForkChoiceScoringFns(BeaconDBException):
+class MissingForkChoiceScorings(BeaconDBException):
     """
     Exception raised if a client tries to score a block without providing
     the ability to generate a score via a ``scoring``.

--- a/eth2/beacon/fork_choice/constant.py
+++ b/eth2/beacon/fork_choice/constant.py
@@ -1,0 +1,29 @@
+from typing import Type
+
+from eth2.beacon.fork_choice.scoring import BaseForkChoiceScoring, BaseScore
+from eth2.beacon.types.blocks import BaseBeaconBlock
+from eth2.beacon.types.states import BeaconState
+
+
+class ConstantScoring(BaseForkChoiceScoring):
+    """
+    ``ConstantScoring`` is a class used to satisfy the API of
+    ``score`` with an arbitrary value of ``BaseScore`` provided during
+    instantiation of the ``ConstantScoring``.
+    """
+
+    def __init__(self, score: BaseScore) -> None:
+        self._score = score
+
+    @classmethod
+    def get_score_class(cls) -> Type[BaseScore]:
+        raise NotImplementedError
+
+    def score(self, block: BaseBeaconBlock) -> BaseScore:
+        return self._score
+
+    @classmethod
+    def from_genesis(
+        cls, genesis_state: BeaconState, genesis_block: BaseBeaconBlock
+    ) -> BaseForkChoiceScoring:
+        raise NotImplementedError

--- a/eth2/beacon/fork_choice/higher_slot.py
+++ b/eth2/beacon/fork_choice/higher_slot.py
@@ -1,8 +1,54 @@
+from typing import Any, Type
+
+import ssz
+
+from eth2.beacon.fork_choice.scoring import BaseForkChoiceScoring, BaseScore
 from eth2.beacon.types.blocks import BaseBeaconBlock
+from eth2.beacon.types.states import BeaconState
 
 
-def higher_slot_scoring(block: BaseBeaconBlock) -> int:
-    """
-    A ``block`` with a higher slot has a higher score.
-    """
+def _score_block_by_higher_slot(block: BaseBeaconBlock) -> int:
     return block.slot
+
+
+class HigherSlotScore(BaseScore):
+    _score: int
+
+    def __init__(self, score: int) -> None:
+        self._score = score
+
+    def __lt__(self, other: "HigherSlotScore") -> bool:
+        return self._score < other._score
+
+    def __eq__(self, other: Any) -> bool:
+        if not isinstance(other, HigherSlotScore):
+            return NotImplemented
+        return self._score == other._score
+
+    def serialize(self) -> bytes:
+        return ssz.encode(self._score, sedes=ssz.sedes.uint64)
+
+    @classmethod
+    def deserialize(cls, data: bytes) -> "HigherSlotScore":
+        score = ssz.decode(data, sedes=ssz.sedes.uint64)
+        return cls(score)
+
+    @classmethod
+    def from_genesis(
+        cls, genesis_state: BeaconState, genesis_block: BaseBeaconBlock
+    ) -> BaseScore:
+        score = _score_block_by_higher_slot(genesis_block)
+        return cls(score)
+
+
+class HigherSlotScoring(BaseForkChoiceScoring):
+    @classmethod
+    def get_score_class(cls) -> Type[BaseScore]:
+        return HigherSlotScore
+
+    def score(self, block: BaseBeaconBlock) -> BaseScore:
+        """
+        A ``block`` with a higher slot has a higher score.
+        """
+        score = _score_block_by_higher_slot(block)
+        return HigherSlotScore(score)

--- a/eth2/beacon/fork_choice/lmd_ghost.py
+++ b/eth2/beacon/fork_choice/lmd_ghost.py
@@ -32,6 +32,7 @@ def score_block_by_root(root: SigningRoot) -> int:
 
 
 class LMDGHOSTScore(BaseScore):
+    # First score by the latest attesting balance, and then score by block root
     _score: Tuple[Gwei, int]
 
     def __init__(self, score: Tuple[Gwei, int]) -> None:
@@ -63,7 +64,7 @@ class LMDGHOSTScore(BaseScore):
         cls, genesis_state: BeaconState, genesis_block: BaseBeaconBlock
     ) -> BaseScore:
         score = (Gwei(0), score_block_by_root(SigningRoot(ZERO_HASH32)))
-        return LMDGHOSTScore(score)
+        return cls(score)
 
 
 def compute_slots_since_epoch_start(slot: Slot, slots_per_epoch: int) -> Slot:
@@ -419,7 +420,7 @@ class Store:
 
     def scoring(self, block: BaseBeaconBlock) -> LMDGHOSTScore:
         """
-        Return the score of the target ``_block`` according to the LMD GHOST algorithm,
+        Return the score of the target ``block`` according to the LMD GHOST algorithm,
         using the lexicographic ordering of the block root to break ties.
         """
         root = block.signing_root

--- a/eth2/beacon/fork_choice/scoring.py
+++ b/eth2/beacon/fork_choice/scoring.py
@@ -10,8 +10,29 @@ This module provides a variety of fork choice rules. Clients can introduce new r
 experiment with alternative fork choice methods.
 """
 
-from typing import Callable
+from abc import ABC, abstractmethod
+from typing import Type
 
+from eth2._utils.typing import Comparable, Serializeable
 from eth2.beacon.types.blocks import BaseBeaconBlock
+from eth2.beacon.types.states import BeaconState
 
-ScoringFn = Callable[[BaseBeaconBlock], int]
+
+class BaseScore(ABC, Comparable, Serializeable):
+    @classmethod
+    @abstractmethod
+    def from_genesis(
+        cls, genesis_state: BeaconState, genesis_block: BaseBeaconBlock
+    ) -> "BaseScore":
+        ...
+
+
+class BaseForkChoiceScoring(ABC):
+    @classmethod
+    @abstractmethod
+    def get_score_class(cls) -> Type[BaseScore]:
+        ...
+
+    @abstractmethod
+    def score(self, block: BaseBeaconBlock) -> BaseScore:
+        ...

--- a/eth2/beacon/state_machines/base.py
+++ b/eth2/beacon/state_machines/base.py
@@ -5,7 +5,7 @@ from typing import Tuple, Type
 from eth._utils.datatypes import Configurable
 
 from eth2.beacon.db.chain import BaseBeaconChainDB
-from eth2.beacon.fork_choice.scoring import ScoringFn as ForkChoiceScoringFn
+from eth2.beacon.fork_choice.scoring import BaseForkChoiceScoring
 from eth2.beacon.types.attestations import Attestation
 from eth2.beacon.types.blocks import BaseBeaconBlock
 from eth2.beacon.types.states import BeaconState
@@ -27,6 +27,8 @@ class BaseBeaconStateMachine(Configurable, ABC):
     block_class: Type[BaseBeaconBlock] = None
     state_class: Type[BeaconState] = None
     state_transition_class: Type[BaseStateTransition] = None
+    fork_choice_scoring_class: Type[BaseForkChoiceScoring] = None
+    fork_choice_scoring: BaseForkChoiceScoring = None
 
     @abstractmethod
     def __init__(self, chaindb: BaseBeaconChainDB) -> None:
@@ -52,8 +54,13 @@ class BaseBeaconStateMachine(Configurable, ABC):
     def state_transition(self) -> BaseStateTransition:
         ...
 
+    @classmethod
     @abstractmethod
-    def get_fork_choice_scoring(self) -> ForkChoiceScoringFn:
+    def get_fork_choice_scoring_class(cls) -> Type[BaseForkChoiceScoring]:
+        ...
+
+    @abstractmethod
+    def get_fork_choice_scoring(self) -> BaseForkChoiceScoring:
         ...
 
     @abstractmethod
@@ -130,6 +137,10 @@ class BeaconStateMachine(BaseBeaconStateMachine):
     @property
     def state_transition(self) -> BaseStateTransition:
         return self.get_state_transiton_class()(self.config)
+
+    @classmethod
+    def get_fork_choice_scoring_class(cls) -> Type[BaseForkChoiceScoring]:
+        return cls.fork_choice_scoring_class
 
     def on_tick(self, time: Timestamp) -> None:
         pass

--- a/eth2/beacon/state_machines/forks/skeleton_lake/__init__.py
+++ b/eth2/beacon/state_machines/forks/skeleton_lake/__init__.py
@@ -1,5 +1,4 @@
-from eth2.beacon.fork_choice.higher_slot import higher_slot_scoring
-from eth2.beacon.fork_choice.scoring import ScoringFn as ForkChoiceScoringFn
+from eth2.beacon.fork_choice.higher_slot import HigherSlotScoring
 from eth2.beacon.state_machines.base import BeaconStateMachine
 from eth2.beacon.state_machines.forks.serenity.blocks import (
     SerenityBeaconBlock,
@@ -23,6 +22,7 @@ class SkeletonLakeStateMachine(BeaconStateMachine):
     block_class = SerenityBeaconBlock
     state_class = SerenityBeaconState
     state_transition_class = SerenityStateTransition
+    fork_choice_scoring_class = HigherSlotScoring
 
     # methods
     @staticmethod
@@ -31,5 +31,5 @@ class SkeletonLakeStateMachine(BeaconStateMachine):
     ) -> BaseBeaconBlock:
         return create_serenity_block_from_parent(parent_block, block_params)
 
-    def get_fork_choice_scoring(self) -> ForkChoiceScoringFn:
-        return higher_slot_scoring
+    def get_fork_choice_scoring(self) -> HigherSlotScoring:
+        return self.fork_choice_scoring_class()

--- a/eth2/beacon/tools/factories.py
+++ b/eth2/beacon/tools/factories.py
@@ -1,11 +1,13 @@
 import time
-from typing import Any, Type
+from typing import Any, Collection, Type
 
 from eth.db.atomic import AtomicDB
 import factory
 
 from eth2.beacon.chains.base import BaseBeaconChain
 from eth2.beacon.chains.testnet import SkeletonLakeChain
+from eth2.beacon.fork_choice.higher_slot import HigherSlotScoring
+from eth2.beacon.genesis import get_genesis_block
 from eth2.beacon.state_machines.forks.serenity.blocks import SerenityBeaconBlock
 from eth2.beacon.state_machines.forks.skeleton_lake.config import (
     MINIMAL_SERENITY_CONFIG,
@@ -13,6 +15,8 @@ from eth2.beacon.state_machines.forks.skeleton_lake.config import (
 from eth2.beacon.tools.builder.initializer import create_mock_genesis
 from eth2.beacon.tools.builder.validator import mk_keymap_of_size
 from eth2.beacon.tools.misc.ssz_vector import override_lengths
+from eth2.beacon.types.blocks import BaseBeaconBlock
+from eth2.beacon.types.states import BeaconState
 from eth2.beacon.typing import Timestamp
 from eth2.configs import Eth2GenesisConfig
 
@@ -21,6 +25,10 @@ class BeaconChainFactory(factory.Factory):
     num_validators = 8
     config = MINIMAL_SERENITY_CONFIG
 
+    branch: Collection[BaseBeaconBlock] = None
+    genesis_state: BeaconState = None
+    genesis_block: SerenityBeaconBlock = None
+
     class Meta:
         model = SkeletonLakeChain
 
@@ -28,26 +36,57 @@ class BeaconChainFactory(factory.Factory):
     def _create(
         cls, model_class: Type[BaseBeaconChain], *args: Any, **kwargs: Any
     ) -> BaseBeaconChain:
+        """
+        Create a BeaconChain according to the factory definition.
+
+        NOTE: clients of this class may provide a ``branch`` keyword in the ``kwargs`` to
+        construct a chain with a ``Collection[BaseBeaconBlock]``. This ``branch`` is NOT
+        assumed to have been constructed according to the full set of validity rules, e.g.
+        lacking a proper signature so the ``perform_validation`` option to ``import_block``
+        is disabled.
+        """
         override_lengths(cls.config)
 
-        keymap = mk_keymap_of_size(cls.num_validators)
-
-        genesis_state, genesis_block = create_mock_genesis(
-            config=cls.config,
-            pubkeys=tuple(keymap.keys()),
-            keymap=keymap,
-            genesis_block_class=SerenityBeaconBlock,
-            genesis_time=Timestamp(int(time.time())),
-        )
+        if kwargs["genesis_state"] is None:
+            keymap = mk_keymap_of_size(cls.num_validators)
+            genesis_state, genesis_block = create_mock_genesis(
+                config=cls.config,
+                pubkeys=tuple(keymap.keys()),
+                keymap=keymap,
+                genesis_block_class=SerenityBeaconBlock,
+                genesis_time=Timestamp(int(time.time())),
+            )
+        elif kwargs["genesis_block"] is None:
+            genesis_state = kwargs["genesis_state"]
+            genesis_block = get_genesis_block(
+                genesis_state.hash_tree_root, SerenityBeaconBlock
+            )
+        else:
+            genesis_state = kwargs["genesis_state"]
+            genesis_block = kwargs["genesis_block"]
 
         db = kwargs.pop("db", AtomicDB())
+        genesis_config = Eth2GenesisConfig(
+            model_class.get_genesis_state_machine_class().config
+        )
         chain = model_class.from_genesis(
             base_db=db,
             genesis_state=genesis_state,
             genesis_block=genesis_block,
-            genesis_config=Eth2GenesisConfig(
-                model_class.get_genesis_state_machine_class().config
-            ),
+            genesis_config=genesis_config,
         )
+
+        if kwargs["branch"] is not None:
+            branch = kwargs["branch"]
+            for block in branch:
+                if block.is_genesis:
+                    continue
+                # NOTE: ideally we use the ``import_block`` method
+                # on ``chain`` but for the time being we skip some
+                # validation corresponding to assumptions made in clients of
+                # this class. A future refactoring should use the external API.
+                chain.chaindb.persist_block(
+                    block, SerenityBeaconBlock, HigherSlotScoring()
+                )
 
         return chain

--- a/tests/components/eth2/apis/test_http.py
+++ b/tests/components/eth2/apis/test_http.py
@@ -5,7 +5,7 @@ import tempfile
 from eth_utils import decode_hex
 
 from eth2.configs import Eth2GenesisConfig
-from eth2.beacon.fork_choice.higher_slot import higher_slot_scoring
+from eth2.beacon.fork_choice.higher_slot import HigherSlotScoring
 from eth2.beacon.state_machines.forks.serenity.configs import SERENITY_CONFIG
 from eth2.beacon.tools.misc.ssz_vector import (
     override_lengths,
@@ -37,7 +37,7 @@ async def test_http_server(aiohttp_raw_server, aiohttp_client, event_bus, base_d
         genesis_config = Eth2GenesisConfig(SERENITY_CONFIG)
         chaindb = AsyncBeaconChainDB(db, genesis_config)
 
-        fork_choice_scoring = higher_slot_scoring
+        fork_choice_scoring = HigherSlotScoring()
         genesis_state, genesis_block = create_mock_genesis(
             pubkeys=(),
             config=SERENITY_CONFIG,

--- a/tests/eth2/core/beacon/chains/test_beacon_chain.py
+++ b/tests/eth2/core/beacon/chains/test_beacon_chain.py
@@ -32,7 +32,9 @@ def test_canonical_chain(valid_chain, genesis_slot, fork_choice_scoring):
     # the canonical chain.
     assert valid_chain.get_canonical_head() == genesis_block
     # verify a special case (score(genesis) == 0)
-    assert valid_chain.get_score(genesis_block.signing_root) == 0
+    assert valid_chain.get_score(
+        genesis_block.signing_root
+    ) == fork_choice_scoring.score(genesis_block)
 
     block = genesis_block.copy(
         slot=genesis_block.slot + 1, parent_root=genesis_block.signing_root
@@ -41,10 +43,10 @@ def test_canonical_chain(valid_chain, genesis_slot, fork_choice_scoring):
 
     assert valid_chain.get_canonical_head() == block
     state_machine = valid_chain.get_state_machine(block.slot)
-    scoring_fn = state_machine.get_fork_choice_scoring()
+    scoring = state_machine.get_fork_choice_scoring()
 
-    assert valid_chain.get_score(block.signing_root) == scoring_fn(block)
-    assert scoring_fn(block) != 0
+    assert valid_chain.get_score(block.signing_root) == scoring.score(block)
+    assert scoring.score(block) != 0
 
     canonical_block_1 = valid_chain.get_canonical_block_by_slot(genesis_block.slot + 1)
     assert canonical_block_1 == block

--- a/tests/eth2/core/beacon/conftest.py
+++ b/tests/eth2/core/beacon/conftest.py
@@ -9,7 +9,7 @@ from eth2.beacon.constants import (
     JUSTIFICATION_BITS_LENGTH,
 )
 from eth2.beacon.db.chain import BeaconChainDB
-from eth2.beacon.fork_choice.higher_slot import higher_slot_scoring
+from eth2.beacon.fork_choice.higher_slot import HigherSlotScoring
 from eth2.beacon.fork_choice.lmd_ghost import Context as LMDGHOSTContext
 from eth2.beacon.genesis import get_genesis_block
 from eth2.beacon.operations.attestation_pool import AttestationPool
@@ -624,17 +624,23 @@ def genesis_block(genesis_state):
 # State machine
 #
 @pytest.fixture
-def fixture_sm_class(config, fork_choice_scoring):
+def fixture_sm_class(config, fork_choice_scoring, fork_choice_scoring_class):
     return SerenityStateMachine.configure(
         __name__="SerenityStateMachineForTesting",
         config=config,
         get_fork_choice_scoring=lambda self: fork_choice_scoring,
+        fork_choice_scoring_class=fork_choice_scoring_class,
     )
 
 
 @pytest.fixture
+def fork_choice_scoring_class():
+    return HigherSlotScoring
+
+
+@pytest.fixture
 def fork_choice_scoring():
-    return higher_slot_scoring
+    return HigherSlotScoring()
 
 
 #

--- a/tests/eth2/core/beacon/fork_choice/test_higher_slot.py
+++ b/tests/eth2/core/beacon/fork_choice/test_higher_slot.py
@@ -1,6 +1,6 @@
 import pytest
 
-from eth2.beacon.fork_choice.higher_slot import higher_slot_scoring
+from eth2.beacon.fork_choice.higher_slot import HigherSlotScore, HigherSlotScoring
 from eth2.beacon.types.blocks import BeaconBlock
 
 
@@ -8,8 +8,9 @@ from eth2.beacon.types.blocks import BeaconBlock
 def test_higher_slot_fork_choice_scoring(sample_beacon_block_params, slot):
     block = BeaconBlock(**sample_beacon_block_params).copy(slot=slot)
 
-    expected_score = slot
+    expected_score = HigherSlotScore(slot)
 
-    score = higher_slot_scoring(block)
+    scoring = HigherSlotScoring()
+    score = scoring.score(block)
 
     assert score == expected_score

--- a/tests/eth2/integration/test_demo.py
+++ b/tests/eth2/integration/test_demo.py
@@ -2,7 +2,7 @@ import pytest
 
 from eth2._utils.bls import bls
 from eth2.beacon.db.chain import BeaconChainDB
-from eth2.beacon.fork_choice.higher_slot import higher_slot_scoring
+from eth2.beacon.fork_choice.higher_slot import HigherSlotScoring
 from eth2.beacon.state_machines.forks.serenity import SerenityStateMachine
 from eth2.beacon.state_machines.forks.serenity.blocks import SerenityBeaconBlock
 from eth2.beacon.state_machines.forks.skeleton_lake import MINIMAL_SERENITY_CONFIG
@@ -14,7 +14,7 @@ from eth2.beacon.tools.misc.ssz_vector import override_lengths
 
 @pytest.fixture
 def fork_choice_scoring():
-    return higher_slot_scoring
+    return HigherSlotScoring()
 
 
 @pytest.mark.parametrize(("validator_count"), ((40),))

--- a/tests/libp2p/bcc/conftest.py
+++ b/tests/libp2p/bcc/conftest.py
@@ -1,7 +1,15 @@
 import asyncio
+import time
 
 import pytest
 
+from eth2.beacon.state_machines.forks.serenity.blocks import SerenityBeaconBlock
+from eth2.beacon.state_machines.forks.skeleton_lake.config import (
+    MINIMAL_SERENITY_CONFIG,
+)
+from eth2.beacon.tools.builder.initializer import create_mock_genesis
+from eth2.beacon.tools.builder.validator import mk_keymap_of_size
+from eth2.beacon.typing import Timestamp
 from trinity.protocol.bcc_libp2p import servers, utils
 from trinity.tools.bcc_factories import NodeFactory
 
@@ -48,3 +56,26 @@ async def make_nodes(num_nodes, chains=None):
         for n in _nodes:
             await n.close()
             await n.cancel()
+
+
+@pytest.fixture
+def config():
+    return MINIMAL_SERENITY_CONFIG
+
+
+@pytest.fixture
+def number_of_validators():
+    return 8
+
+
+@pytest.fixture
+def genesis_state(number_of_validators, config):
+    keymap = mk_keymap_of_size(number_of_validators)
+    genesis_state, _ = create_mock_genesis(
+        config=config,
+        pubkeys=tuple(keymap.keys()),
+        keymap=keymap,
+        genesis_block_class=SerenityBeaconBlock,
+        genesis_time=Timestamp(int(time.time())),
+    )
+    return genesis_state

--- a/tests/libp2p/bcc/test_receive_server.py
+++ b/tests/libp2p/bcc/test_receive_server.py
@@ -9,7 +9,7 @@ import ssz
 
 from eth2.beacon.chains.base import BaseBeaconChain
 from eth2.beacon.chains.testnet import SkeletonLakeChain
-from eth2.beacon.fork_choice.higher_slot import higher_slot_scoring
+from eth2.beacon.fork_choice.higher_slot import HigherSlotScoring
 from eth2.beacon.state_machines.forks.serenity.blocks import SerenityBeaconBlock
 from eth2.beacon.state_machines.forks.skeleton_lake.config import (
     MINIMAL_SERENITY_CONFIG,
@@ -51,7 +51,7 @@ class FakeChain(SkeletonLakeChain):
         except BlockNotFound:
             raise ValidationError
         (new_canonical_blocks, old_canonical_blocks) = self.chaindb.persist_block(
-            block, block.__class__, higher_slot_scoring
+            block, block.__class__, HigherSlotScoring()
         )
         return block, new_canonical_blocks, old_canonical_blocks
 
@@ -59,6 +59,8 @@ class FakeChain(SkeletonLakeChain):
 async def get_fake_chain() -> FakeChain:
     genesis_config = Eth2GenesisConfig(MINIMAL_SERENITY_CONFIG)
     chain_db = AsyncBeaconChainDBFactory(genesis_config=genesis_config)
+    genesis_block = BeaconBlockFactory()
+    chain_db.persist_block(genesis_block, SerenityBeaconBlock, HigherSlotScoring())
     return FakeChain(base_db=chain_db.db, genesis_config=genesis_config)
 
 

--- a/trinity/db/beacon/chain.py
+++ b/trinity/db/beacon/chain.py
@@ -8,7 +8,7 @@ from typing import (
 from eth_typing import Hash32
 
 from eth2.beacon.db.chain import BeaconChainDB
-from eth2.beacon.fork_choice.scoring import ScoringFn as ForkChoiceScoringFn
+from eth2.beacon.fork_choice.scoring import BaseForkChoiceScoring, BaseScore
 from eth2.beacon.types.states import (
     BeaconState,
 )
@@ -30,7 +30,7 @@ class BaseAsyncBeaconChainDB(BeaconChainDB):
             self,
             block: BaseBeaconBlock,
             block_class: Type[BaseBeaconBlock],
-            fork_choice_scoring: ForkChoiceScoringFn,
+            fork_choice_scoring: BaseForkChoiceScoring
     ) -> Tuple[Tuple[bytes, ...], Tuple[bytes, ...]]:
         ...
 
@@ -72,7 +72,7 @@ class BaseAsyncBeaconChainDB(BeaconChainDB):
         ...
 
     @abstractmethod
-    async def coro_get_score(self, block_root: SigningRoot) -> int:
+    async def coro_get_score(self, block_root: SigningRoot) -> BaseScore:
         ...
 
     @abstractmethod
@@ -84,7 +84,7 @@ class BaseAsyncBeaconChainDB(BeaconChainDB):
             self,
             blocks: Iterable[BaseBeaconBlock],
             block_class: Type[BaseBeaconBlock],
-            fork_choice_scorings: Iterable[ForkChoiceScoringFn],
+            fork_choice_scorings: Iterable[BaseForkChoiceScoring],
     ) -> Tuple[Tuple[BaseBeaconBlock, ...], Tuple[BaseBeaconBlock, ...]]:
         ...
 


### PR DESCRIPTION
### What was wrong?

Fixes #782.

### How was it fixed?

Introduces an opaque "score" type so that different forks of the protocol can specify their own format for scoring a block tree when computing the fork choice.

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://external-content.duckduckgo.com/iu/?u=http%3A%2F%2F36.media.tumblr.com%2F7b7c10c25f00fcdb0f3cd28cb995f10c%2Ftumblr_nrav7uUXCW1s9amz4o8_1280.jpg&f=1&nofb=1)
