### PR TITLE
Silence warnings of connection "already cancelled"

### DIFF
--- a/p2p/peer.py
+++ b/p2p/peer.py
@@ -219,7 +219,9 @@ class BasePeer(BaseService):
             self._subscribers.remove(subscriber)
 
     async def _cleanup(self) -> None:
-        self.connection.cancel_nowait()
+        if self.connection.is_operational:
+            # the connection might be closed from when its cancel token triggers
+            self.connection.cancel_nowait()
 
     def setup_protocol_handlers(self) -> None:
         """

--- a/p2p/service.py
+++ b/p2p/service.py
@@ -300,6 +300,7 @@ class BaseService(CancellableMixin, AsyncioServiceAPI):
     def cancel_nowait(self) -> None:
         if self.is_cancelled:
             self.logger.warning("Tried to cancel %s, but it was already cancelled", self)
+            self.logger.debug("Second cancellation of %s: stack trace", self, stack_info=True)
             return
         elif not self.is_running:
             raise ValidationError("Cannot cancel a service that has not been started")

--- a/trinity/protocol/eth/commands.py
+++ b/trinity/protocol/eth/commands.py
@@ -13,9 +13,6 @@ from eth.rlp.headers import BlockHeader
 from eth.rlp.receipts import Receipt
 from eth.rlp.transactions import BaseTransactionFields
 
-from p2p.abc import (
-    SerializationCodecAPI,
-)
 from p2p.commands import BaseCommand, RLPCodec
 
 from trinity.protocol.common.payloads import BlockHeadersQuery
@@ -54,7 +51,7 @@ NEW_BLOCK_HASHES_STRUCTURE = sedes.CountableList(sedes.List([hash_sedes, sedes.b
 
 class NewBlockHashes(BaseCommand[Tuple[NewBlockHash, ...]]):
     protocol_command_id = 1
-    serialization_codec: SerializationCodecAPI[Tuple[NewBlockHash, ...]] = RLPCodec(
+    serialization_codec: RLPCodec[Tuple[NewBlockHash, ...]] = RLPCodec(
         sedes=NEW_BLOCK_HASHES_STRUCTURE,
         process_inbound_payload_fn=apply_formatter_to_array(lambda args: NewBlockHash(*args)),
     )


### PR DESCRIPTION
### What was wrong?

Fixes #1353 

### How was it fixed?

I did the laziest possible thing and skipped the cancel if it's already cancelled.

I *think* one of the other options listed in #1353 would be better, but want some input from @pipermerriam before I go that route.

---

Bonus: I added the log that I used to track down where the second cancellation is happening.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

[//]: # (See: https://trinity-client.readthedocs.io/en/latest/contributing.html#pull-requests)
- [x] Add entry to the [release notes](https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://i.dailymail.co.uk/i/pix/2012/03/28/article-2121659-125DF032000005DC-159_634x397.jpg)
