### PR TITLE
Quiet some *really* noisy errors on exit

### DIFF
--- a/trinity/_utils/decorators.py
+++ b/trinity/_utils/decorators.py
@@ -1,3 +1,4 @@
+import functools
 from typing import (
     Any,
     Awaitable,
@@ -9,8 +10,14 @@ from typing import (
 
 TAsyncFn = TypeVar("TAsyncFn", bound=Callable[..., Awaitable[None]])
 
+# It's only permitted to ignore an exception and return None if
+#   the wrapped function always returns None
+TFn = TypeVar("TFn", bound=Callable[..., None])
 
-def async_suppress_exceptions(*exception_types: Type[BaseException]) -> TAsyncFn:
+
+def async_suppress_exceptions(
+        *exception_types: Type[BaseException]) -> Callable[[TAsyncFn], TAsyncFn]:
+
     def _suppress_decorator(func: TAsyncFn) -> TAsyncFn:
         async def _suppressed_func(*args: Any, **kwargs: Any) -> None:
             try:
@@ -21,4 +28,27 @@ def async_suppress_exceptions(*exception_types: Type[BaseException]) -> TAsyncFn
 
         return _suppressed_func  # type: ignore
 
-    return _suppress_decorator  # type: ignore
+    return _suppress_decorator
+
+
+def suppress_exceptions(*exception_types: Type[BaseException]) -> Callable[[TFn], TFn]:
+    """
+    Sometimes, rarely, it's okay for a function to just stop running,
+    in the case of certain exceptions. Use this decorator, defining the
+    exceptions that are allowed to simply exit.
+    """
+    def _suppress_decorator(func: TFn) -> TFn:
+
+        @functools.wraps(func)
+        def _suppressed_func(*args: Any, **kwargs: Any) -> None:
+            try:
+                func(*args, **kwargs)
+            except exception_types:
+                # these exceptions are expected, and require no handling
+                pass
+
+            return None
+
+        return _suppressed_func  # type: ignore
+
+    return _suppress_decorator

--- a/trinity/protocol/eth/peer.py
+++ b/trinity/protocol/eth/peer.py
@@ -143,7 +143,7 @@ class ETHPeerFactory(BaseChainPeerFactory):
         )
 
 
-async_fire_and_forget = async_suppress_exceptions(PeerConnectionLost, asyncio.TimeoutError)  # type: ignore  # noqa: E501
+async_fire_and_forget = async_suppress_exceptions(PeerConnectionLost, asyncio.TimeoutError)
 
 
 class ETHPeerPoolEventServer(PeerPoolEventServer[ETHPeer]):

--- a/trinity/sync/beam/importer.py
+++ b/trinity/sync/beam/importer.py
@@ -511,6 +511,9 @@ def partial_speculative_execute(
                 preview_time,
                 exc,
             )
+        except BrokenPipeError:
+            vm.logger.info("Got BrokenPipeError while Beam Sync speculatively executed %s", header)
+            vm.logger.debug("BrokenPipeError trace for %s", header, exc_info=True)
         else:
             preview_time = t.elapsed
 

--- a/trinity/sync/beam/importer.py
+++ b/trinity/sync/beam/importer.py
@@ -493,6 +493,7 @@ def partial_speculative_execute(
     Get an argument-free function that will trigger missing state downloads,
     by executing all the transactions, in the context of the given header.
     """
+
     def _trigger_missing_state_downloads() -> None:
         vm = beam_chain.get_vm(header)
         unused_header = header.copy(gas_used=0)


### PR DESCRIPTION
### What was wrong?

Sometimes, there is a `BrokenPipeError` on shutdown. Typically, a long stack trace for each transaction preview that the beam importer is in the middle of. Something recent (maybe the faster shutdowns) is causing this to show up more often.

### How was it fixed?

For now, especially for just the previews, which are basically throwaway actions, we can just completely suppress/ignore this error.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

[//]: # (See: https://trinity-client.readthedocs.io/en/latest/contributing.html#pull-requests)
- [ ] Add entry to the [release notes](https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://i.chzbgr.com/full/6300348160/h9977AF3F/)
