### PR TITLE
Cleaner txpool shutdown

### DIFF
--- a/newsfragments/1356.internal.rst
+++ b/newsfragments/1356.internal.rst
@@ -1,0 +1,2 @@
+Beam Sync now warns in the logs when it skips ahead of headers (relying on light-client-style
+verification of older headers).

--- a/newsfragments/1356.performance.rst
+++ b/newsfragments/1356.performance.rst
@@ -1,0 +1,1 @@
+Speed up the TxPool shutdown a bit: it had hanging tasks that we were waiting 5s to force-close.

--- a/trinity/sync/beam/chain.py
+++ b/trinity/sync/beam/chain.py
@@ -415,6 +415,8 @@ class HeaderOnlyPersist(BaseService):
         if self._is_header_eligible_to_beam_sync(tip):
             self._force_end_block_number = tip.block_number + 1
             self.logger.info("Tip is recent enough, syncing from last synced header at %s", tip)
+        else:
+            self.logger.warning("Tip %s is too far behind to Beam Sync, skipping ahead...", tip)
 
         await self.wait(self._persist_headers())
 


### PR DESCRIPTION
### What was wrong?

The transaction pool was hanging on shutdown, because it had a bare `await` that doesn't get cancelled when the service is cancelled.

This shows up in an INFO log as:

```
Timed out waiting for <...TxPool...> to finish its cleanup, forcibly cancelling pending tasks and exiting anyway
```

### How was it fixed?

Added a couple `self.wait()`s. Now that log doesn't show up anymore, and the shutdown is a bit faster.

Bonus changes:
- ~~Linter fix, as in #1357~~
- Add a warning when beam sync skips ahead. This warning doesn't show up when beam sync is continued from the last synced block.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

[//]: # (See: https://trinity-client.readthedocs.io/en/latest/contributing.html#pull-requests)
- [x] Add entry to the [release notes](https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://premierpoolsandspas.com/wp-content/uploads/2014/07/bear-in-pool.jpg)
