### PR TITLE
Combine DiscoveryProtocol and DiscoveryService

### DIFF
--- a/p2p/tools/factories/__init__.py
+++ b/p2p/tools/factories/__init__.py
@@ -8,7 +8,6 @@ from .discovery import (  # noqa: F401
     AuthHeaderFactory,
     AuthHeaderPacketFactory,
     AuthTagPacketFactory,
-    DiscoveryProtocolFactory,
     EndpointFactory,
     WhoAreYouPacketFactory,
 )

--- a/p2p/tools/factories/discovery.py
+++ b/p2p/tools/factories/discovery.py
@@ -6,8 +6,6 @@ from typing import (
     Tuple,
 )
 
-import trio
-
 import factory
 
 from eth_keys import keys
@@ -15,14 +13,12 @@ from eth_keys import keys
 from eth_utils import (
     big_endian_to_int,
     int_to_big_endian,
-    keccak,
 )
 from eth_utils.toolz import (
     merge,
     reduce,
 )
 
-from p2p.discovery import DiscoveryProtocol
 from p2p.discv5.packets import (
     AuthHeader,
     AuthHeaderPacket,
@@ -65,29 +61,6 @@ from p2p.discv5.routing_table import (
 from p2p.discv5.typing import (
     NodeID,
 )
-from p2p.ecies import generate_privkey
-
-from p2p.kademlia import Address
-
-from .kademlia import AddressFactory
-
-
-class DiscoveryProtocolFactory(factory.Factory):
-    class Meta:
-        model = DiscoveryProtocol
-
-    privkey = factory.LazyFunction(generate_privkey)
-    address = factory.SubFactory(AddressFactory)
-    nursery = trio.open_nursery()
-    socket = None
-    bootstrap_nodes = factory.LazyFunction(tuple)
-
-    @classmethod
-    def from_seed(cls, seed: bytes, *args: Any, **kwargs: Any) -> DiscoveryProtocol:
-        privkey = keys.PrivateKey(keccak(seed))
-        if 'socket' in kwargs:
-            kwargs['address'] = Address(*kwargs['socket'].getsockname())
-        return cls(*args, privkey=privkey, **kwargs)
 
 
 class AuthTagPacketFactory(factory.Factory):

--- a/scripts/discovery.py
+++ b/scripts/discovery.py
@@ -48,8 +48,10 @@ def _test() -> None:
     )
 
     async def run() -> None:
+        socket = trio.socket.socket(family=trio.socket.AF_INET, type=trio.socket.SOCK_DGRAM)
+        await socket.bind(('0.0.0.0', listen_port))
         async with TrioEndpoint.serve(networking_connection_config) as endpoint:
-            service = DiscoveryService(privkey, addr, bootstrap_nodes, endpoint)
+            service = DiscoveryService(privkey, addr, bootstrap_nodes, endpoint, socket)
             await TrioManager.run_service(service)
 
     trio.run(run)

--- a/tests-trio/p2p-trio/conftest.py
+++ b/tests-trio/p2p-trio/conftest.py
@@ -1,6 +1,15 @@
 import trio
 import pytest_trio
 
+from async_service import TrioManager
+
+from eth_hash.auto import keccak
+
+from eth_keys import keys
+
+from p2p.discovery import DiscoveryService
+from p2p.kademlia import Address
+
 
 @pytest_trio.trio_fixture
 async def socket_pair():
@@ -16,3 +25,50 @@ async def socket_pair():
     await sending_socket.bind(("127.0.0.1", 0))
     await receiving_socket.bind(("127.0.0.1", 0))
     return sending_socket, receiving_socket
+
+
+async def _manually_driven_discovery(seed, socket, nursery):
+    discovery = ManuallyDrivenDiscoveryService(
+        keys.PrivateKey(keccak(seed)),
+        Address(*socket.getsockname()),
+        bootstrap_nodes=[],
+        event_bus=None,
+        socket=socket)
+    nursery.start_soon(TrioManager.run_service, discovery)
+    await discovery.ready_to_drive.wait()
+    return discovery
+
+
+@pytest_trio.trio_fixture
+async def manually_driven_discovery(nursery):
+    socket = trio.socket.socket(family=trio.socket.AF_INET, type=trio.socket.SOCK_DGRAM)
+    discovery = await _manually_driven_discovery(b'seed', socket, nursery)
+    yield discovery
+    discovery.manager.cancel()
+    await discovery.manager.wait_finished()
+
+
+@pytest_trio.trio_fixture
+async def manually_driven_discovery_pair(nursery, socket_pair):
+    discovery1 = await _manually_driven_discovery(b'seed1', socket_pair[0], nursery)
+    discovery2 = await _manually_driven_discovery(b'seed2', socket_pair[1], nursery)
+    yield discovery1, discovery2
+    discovery1.manager.cancel()
+    discovery2.manager.cancel()
+    await discovery1.manager.wait_finished()
+    await discovery2.manager.wait_finished()
+
+
+class ManuallyDrivenDiscoveryService(DiscoveryService):
+    """A DiscoveryService that can be executed with TrioManager.run_service() but which doesn't
+    run any background tasks (e.g. bootstrapping) by itself. Instead one must schedule any tasks
+    manually.
+    """
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.ready_to_drive = trio.Event()
+
+    async def run(self) -> None:
+        self.ready_to_drive.set()
+        await self.manager.wait_cancelled()

--- a/tests/integration/test_trinity_cli.py
+++ b/tests/integration/test_trinity_cli.py
@@ -223,33 +223,33 @@ async def test_does_not_throw_errors_on_short_run(command, unused_tcp_port):
             # Expected stderr logs
             {'Started main process'},
             # Unexpected stderr logs
-            {'DiscoveryProtocol  >>> ping'},
+            {'>>> ping'},
             # Expected file logs
             {'Started main process', 'Logging initialized'},
             # Unexpected file logs
-            {'DiscoveryProtocol  >>> ping'},
+            {'>>> ping'},
         ),
         (
             # Enable DEBUG2 logs across the board
             ('trinity', '-l=DEBUG2'),
-            {'Started main process', 'DiscoveryProtocol  >>> ping'},
+            {'Started main process', '>>> ping'},
             {},
-            {'Started main process', 'DiscoveryProtocol  >>> ping'},
+            {'Started main process', '>>> ping'},
             {},
         ),
         (   # Enable DEBUG2 logs for everything except discovery which is reduced to ERROR logs
             ('trinity', '-l=DEBUG2', '-l', 'p2p.discovery=ERROR'),
             {'Started main process', 'ConnectionTrackerServer  Running task <coroutine object'},
-            {'DiscoveryProtocol  >>> ping'},
+            {'>>> ping'},
             {'Started main process', 'ConnectionTrackerServer  Running task <coroutine object'},
-            {'DiscoveryProtocol  >>> ping'},
+            {'>>> ping'},
         ),
         pytest.param(
             # Reduce stderr logging to ERROR logs but report DEBUG2 or higher for file logs
             ('trinity', '--stderr-log-level=ERROR', '--file-log-level=DEBUG2',),
             {},
-            {'Started main process', 'DiscoveryProtocol  >>> ping'},
-            {'Started main process', 'DiscoveryProtocol  >>> ping'},
+            {'Started main process', '>>> ping'},
+            {'Started main process', '>>> ping'},
             {},
             # TODO: investigate in #1347
             marks=(pytest.mark.xfail),
@@ -257,14 +257,14 @@ async def test_does_not_throw_errors_on_short_run(command, unused_tcp_port):
         pytest.param(
             # Reduce everything to ERROR logs, except discovery that should report DEBUG2 or higher
             ('trinity', '-l=ERROR', '-l', 'p2p.discovery=DEBUG2'),
-            {'DiscoveryProtocol  >>> ping'},
+            {'>>> ping'},
             {'Started main process'},
             {},
             {},
             # Increasing per-module log level to a higher value than the general log level does
             # not yet work for file logging. Once https://github.com/ethereum/trinity/issues/689
             # is resolved, the following should work.
-            # {'DiscoveryProtocol  >>> ping'},
+            # {'>>> ping'},
             # {'Started main process'},
             # TODO: investigate in #1347
             marks=(pytest.mark.xfail),
@@ -295,7 +295,7 @@ async def test_logger_configuration(command,
         async for line in runner.stderr:
             if marker_seen_at != 0 and time.time() - marker_seen_at > 3:
                 break
-            if "DiscoveryProtocol" in line:
+            if "DiscoveryService" in line:
                 marker_seen_at = time.time()
                 stderr_logs.append(line)
             else:


### PR DESCRIPTION
In #1325 I'd left a FIXME behind as we were accessing async_service's internal _task_nursery. This addresses that by combining DiscoveryProtocol and DiscoveryService. Another advantage of doing this is that callsites now need less boilerplate code as they no longer need to create a DiscoveryProtocol