### PR TITLE
Migrate component isolation away from multiprocessing

### DIFF
--- a/newsfragments/1328.feature.rst
+++ b/newsfragments/1328.feature.rst
@@ -1,0 +1,1 @@
+Full rework of ``Component`` APIs.  CLI validation is now done during application initialization.  Component lifecycle is well defined and simpler to implement.

--- a/newsfragments/1328.performance.rst
+++ b/newsfragments/1328.performance.rst
@@ -1,0 +1,1 @@
+Refactor ``Component`` APIs to support concurrent starting and stopping.

--- a/newsfragments/1363.feature.rst
+++ b/newsfragments/1363.feature.rst
@@ -1,0 +1,1 @@
+``AsyncioIsolatedComponent`` no longer uses the standard libary ``multiprocessing`` for process isolation, in favor of using the more async friendly ``asyncio-run-in-process``

--- a/setup.py
+++ b/setup.py
@@ -29,6 +29,7 @@ deps = {
     ],
     'trinity': [
         "aiohttp==3.6.0",
+        "asyncio-run-in-process==0.1.0a4",
         "bloom-filter==1.3",
         "cachetools>=3.1.0,<4.0.0",
         "coincurve>=10.0.0,<11.0.0",

--- a/tests/core/components/test_isolated_component.py
+++ b/tests/core/components/test_isolated_component.py
@@ -2,15 +2,9 @@ from argparse import Namespace
 import asyncio
 import logging
 import os
-from pathlib import Path
-import tempfile
 
 from async_service import background_asyncio_service
 import pytest
-
-from lahja import EndpointAPI, BaseEvent
-
-from p2p.service import BaseService, run_service
 
 from trinity._utils.chains import (
     get_local_data_dir,
@@ -18,53 +12,8 @@ from trinity._utils.chains import (
 from trinity._utils.logging import IPCListener
 from trinity.boot_info import BootInfo
 from trinity.config import TrinityConfig
-from trinity.extensibility import AsyncioIsolatedComponent, ComponentManager
-
-
-class IsStarted(BaseEvent):
-    def __init__(self, path):
-        self.path = path
-
-
-class AsyncioComponentService(BaseService):
-    touch_path = None
-
-    def __init__(self, event_bus) -> None:
-        super().__init__()
-        self.event_bus = event_bus
-
-    async def _run(self) -> None:
-        self.logger.debug('Broadcasting `IsStarted`')
-        path = Path(tempfile.NamedTemporaryFile().name)
-        await self.event_bus.broadcast(IsStarted(path))
-        try:
-            self.logger.debug('Waiting for cancellation')
-            await self.cancellation()
-        finally:
-            self.logger.debug('Got cancellation: touching `%s`', self.touch_path)
-            path.touch()
-            self.logger.debug('EXITING')
-
-
-class AsyncioComponentForTest(AsyncioIsolatedComponent):
-    name = "component-test"
-    endpoint_name = 'component-test'
-    logger = logging.getLogger('trinity.testing.ComponentForTest')
-
-    @property
-    def is_enabled(self) -> bool:
-        return True
-
-    @classmethod
-    async def do_run(cls, boot_info: BootInfo, event_bus: EndpointAPI) -> None:
-        cls.logger.debug('Entered `do_run`')
-        service = AsyncioComponentService(event_bus)
-        async with run_service(service):
-            cls.logger.debug('Running service')
-            try:
-                await service.cancellation()
-            finally:
-                cls.logger.debug('Got cancellation')
+from trinity.extensibility import ComponentManager
+from trinity.tools._component_isolation import IsStarted, AsyncioComponentForTest
 
 
 @pytest.fixture
@@ -82,7 +31,7 @@ def boot_info(trinity_config):
         args=Namespace(),
         trinity_config=trinity_config,
         profile=False,
-        child_process_log_level=logging.INFO,
+        child_process_log_level=logging.DEBUG,
         logger_levels={},
     )
 
@@ -113,6 +62,7 @@ async def test_asyncio_isolated_component(boot_info,
 
         touch_path = await asyncio.wait_for(got_started, timeout=10)
         assert not touch_path.exists()
+        component_manager.shutdown('exiting component manager')
 
     for _ in range(1000):
         if not touch_path.exists():

--- a/tox.ini
+++ b/tox.ini
@@ -18,7 +18,7 @@ ignore=W504
 
 [isort]
 force_sort_within_sections=True
-known_third_party=async_service,hypothesis,pytest,async_generator,cytoolz,trio_typing,pytest_trio,factory,milagro_bls_binding
+known_third_party=async_service,asyncio_run_in_process,hypothesis,pytest,async_generator,cytoolz,trio_typing,pytest_trio,factory,milagro_bls_binding
 multi_line_output=3
 include_trailing_comma=True
 force_grid_wrap=0

--- a/trinity/components/builtin/upnp/nat.py
+++ b/trinity/components/builtin/upnp/nat.py
@@ -1,7 +1,5 @@
 import asyncio
-from concurrent.futures import (
-    ThreadPoolExecutor,
-)
+from concurrent.futures import ThreadPoolExecutor
 import ipaddress
 from typing import (
     AsyncGenerator,

--- a/trinity/extensibility/asyncio.py
+++ b/trinity/extensibility/asyncio.py
@@ -1,79 +1,68 @@
 from abc import abstractmethod
 import asyncio
-import concurrent
-import logging
 import signal
+from typing import Optional
 
+from asyncio_run_in_process import open_in_process
+from asyncio_run_in_process.typing import SubprocessKwargs
 from lahja import EndpointAPI
 
 from p2p.service import run_service
 
-from trinity._utils.ipc import kill_process_gracefully
-from trinity._utils.mp import ctx
+from trinity._utils.logging import child_process_logging
+from trinity._utils.profiling import profiler
 from trinity.boot_info import BootInfo
 
 from .component import BaseIsolatedComponent
 from .event_bus import AsyncioEventBusService
 
+import logging
+logger = logging.getLogger('trinity')
+
 
 class AsyncioIsolatedComponent(BaseIsolatedComponent):
+    def get_subprocess_kwargs(self) -> Optional[SubprocessKwargs]:
+        # Note that this method currently only exist to facilitate testing.
+        return None
+
     async def run(self) -> None:
-        """
-        Call chain is:
-
-        - multiprocessing.Process -> _run_process
-            * isolates to a new process
-        - _run_process -> run_process
-            * sets up subprocess logging
-        - run_process -> _do_run
-            * runs the event loop and transitions into async context
-        - _do_run -> do_run
-            * sets up event bus and then enters user function.
-        """
-        process = ctx.Process(
-            target=self._run_process,
-            args=(self._boot_info,),
+        proc_ctx = open_in_process(
+            self._do_run,
+            self._boot_info,
+            subprocess_kwargs=self.get_subprocess_kwargs(),
         )
-        loop = asyncio.get_event_loop()
-
-        with concurrent.futures.ThreadPoolExecutor() as executor:
-            await loop.run_in_executor(executor, process.start)
+        async with proc_ctx as proc:
             try:
-                await loop.run_in_executor(executor, process.join)
-            finally:
-                kill_process_gracefully(
-                    process,
-                    logging.getLogger('trinity.extensibility.AsyncioIsolatedComponent'),
-                )
-
-    @classmethod
-    def run_process(cls, boot_info: BootInfo) -> None:
-        loop = asyncio.get_event_loop()
-        task = asyncio.ensure_future(cls._do_run(boot_info))
-        loop.add_signal_handler(signal.SIGINT, task.cancel)
-        loop.add_signal_handler(signal.SIGTERM, task.cancel)
-        try:
-            loop.run_until_complete(task)
-        except asyncio.CancelledError:
-            pass
-        finally:
-            loop.close()
+                await proc.wait()
+            except asyncio.CancelledError as err:
+                proc.send_signal(signal.SIGINT)
+                try:
+                    await asyncio.wait_for(proc.wait(), timeout=2)
+                except asyncio.TimeoutError:
+                    pass
+                finally:
+                    raise err
 
     @classmethod
     async def _do_run(cls, boot_info: BootInfo) -> None:
-        endpoint_name = cls._get_endpoint_name()
-        event_bus_service = AsyncioEventBusService(
-            boot_info.trinity_config,
-            endpoint_name,
-        )
-        async with run_service(event_bus_service):
-            await event_bus_service.wait_event_bus_available()
-            event_bus = event_bus_service.get_event_bus()
-            try:
-                await cls.do_run(boot_info, event_bus)
-            except asyncio.CancelledError:
-                await event_bus_service.cancel()
-                raise
+        with child_process_logging(boot_info):
+            endpoint_name = cls._get_endpoint_name()
+            event_bus_service = AsyncioEventBusService(
+                boot_info.trinity_config,
+                endpoint_name,
+            )
+            async with run_service(event_bus_service):
+                await event_bus_service.wait_event_bus_available()
+                event_bus = event_bus_service.get_event_bus()
+
+                try:
+                    if boot_info.profile:
+                        with profiler(f'profile_{cls._get_endpoint_name}'):
+                            await cls.do_run(boot_info, event_bus)
+                    else:
+                        await cls.do_run(boot_info, event_bus)
+                except KeyboardInterrupt:
+                    return
 
     @classmethod
     @abstractmethod

--- a/trinity/extensibility/component.py
+++ b/trinity/extensibility/component.py
@@ -12,9 +12,7 @@ from typing import AsyncIterator
 
 from async_generator import asynccontextmanager
 
-from trinity._utils.logging import child_process_logging
 from trinity._utils.os import friendly_filename_or_url
-from trinity._utils.profiling import profiler
 from trinity.boot_info import BootInfo
 
 
@@ -96,25 +94,11 @@ class BaseIsolatedComponent(BaseComponent):
     endpoint_name: str = None
 
     @classmethod
-    def _run_process(cls, boot_info: BootInfo) -> None:
-        with child_process_logging(boot_info):
-            if boot_info.profile:
-                with profiler(f'profile_{cls._get_endpoint_name}'):
-                    cls.run_process(boot_info)
-            else:
-                cls.run_process(boot_info)
-
-    @classmethod
     def _get_endpoint_name(cls) -> str:
         if cls.endpoint_name is None:
             return friendly_filename_or_url(cls.name)
         else:
             return cls.endpoint_name
-
-    @classmethod
-    @abstractmethod
-    def run_process(cls, boot_info: BootInfo) -> None:
-        ...
 
 
 @asynccontextmanager

--- a/trinity/extensibility/component_manager.py
+++ b/trinity/extensibility/component_manager.py
@@ -32,6 +32,7 @@ class ComponentManager(Service):
     logger = logging.getLogger('trinity.extensibility.component_manager.ComponentManager')
 
     _endpoint: EndpointAPI
+    reason = None
 
     def __init__(self,
                  boot_info: BootInfo,
@@ -41,6 +42,7 @@ class ComponentManager(Service):
         self._component_types = component_types
         self._kill_trinity_fn = kill_trinity_fn
         self._endpoint_available = asyncio.Event()
+        self._trigger_component_exit = asyncio.Event()
 
     async def get_event_bus(self) -> EndpointAPI:
         await self._endpoint_available.wait()
@@ -52,61 +54,62 @@ class ComponentManager(Service):
             self._boot_info.trinity_config.ipc_dir
         )
 
-        try:
-            async with AsyncioEndpoint.serve(connection_config) as endpoint:
-                self._endpoint = endpoint
+        async with AsyncioEndpoint.serve(connection_config) as endpoint:
+            self._endpoint = endpoint
 
-                # start the background process that tracks and propagates available
-                # endpoints to the other connected endpoints
-                self.manager.run_daemon_task(self._track_and_propagate_available_endpoints)
-                self.manager.run_daemon_task(self._handle_shutdown_request)
+            # start the background process that tracks and propagates available
+            # endpoints to the other connected endpoints
+            self.manager.run_daemon_task(self._track_and_propagate_available_endpoints)
+            self.manager.run_daemon_task(self._handle_shutdown_request)
 
-                # signal the endpoint is up and running and available
-                self._endpoint_available.set()
+            await endpoint.wait_until_any_endpoint_subscribed_to(ShutdownRequest)
+            await endpoint.wait_until_any_endpoint_subscribed_to(EventBusConnected)
 
-                # instantiate all of the components
-                all_components = tuple(
-                    component_cls(self._boot_info)
-                    for component_cls
-                    in self._component_types
-                )
-                # filter out any components that should not be enabled.
-                enabled_components = tuple(
-                    component
-                    for component in all_components
-                    if component.is_enabled
-                )
+            # signal the endpoint is up and running and available
+            self._endpoint_available.set()
 
-                # a little bit of extra try/finally structure here to produce good
-                # logging messages about the component lifecycle.
-                try:
-                    async with AsyncExitStack() as stack:
-                        self.logger.info(
-                            "Starting components: %s",
-                            '/'.join(component.name for component in enabled_components),
-                        )
-                        # Concurrently start the components.
-                        await asyncio.gather(*(
-                            stack.enter_async_context(run_component(component))
-                            for component in enabled_components
-                        ))
-                        self.logger.info("Components started")
-                        try:
-                            await self.manager.wait_finished()
-                        finally:
-                            self.logger.info("Stopping components")
-                finally:
-                    self.logger.info("Components stopped.")
-        except KeyboardInterrupt:
-            pass
+            # instantiate all of the components
+            all_components = tuple(
+                component_cls(self._boot_info)
+                for component_cls
+                in self._component_types
+            )
+            # filter out any components that should not be enabled.
+            enabled_components = tuple(
+                component
+                for component in all_components
+                if component.is_enabled
+            )
+
+            # a little bit of extra try/finally structure here to produce good
+            # logging messages about the component lifecycle.
+            try:
+                async with AsyncExitStack() as stack:
+                    self.logger.info(
+                        "Starting components: %s",
+                        '/'.join(component.name for component in enabled_components),
+                    )
+                    # Concurrently start the components.
+                    await asyncio.gather(*(
+                        stack.enter_async_context(run_component(component))
+                        for component in enabled_components
+                    ))
+                    self.logger.info("Components started")
+                    try:
+                        await self._trigger_component_exit.wait()
+                    finally:
+                        self.logger.info("Stopping components")
+            finally:
+                self.logger.info("Components stopped.")
+                self.manager.cancel()
 
     def shutdown(self, reason: str) -> None:
-        self._kill_trinity_fn(reason)
+        self.reason = reason
+        self._trigger_component_exit.set()
 
     async def _handle_shutdown_request(self) -> None:
         req = await self._endpoint.wait_for(ShutdownRequest)
         self.shutdown(req.reason)
-        self.manager.cancel()
 
     _available_endpoints: Tuple[ConnectionConfig, ...] = ()
 

--- a/trinity/extensibility/event_bus.py
+++ b/trinity/extensibility/event_bus.py
@@ -66,8 +66,7 @@ class AsyncioEventBusService(BaseService):
                 await endpoint.connect_to_endpoints(main_endpoint_config)
 
                 # announce ourself to the event bus
-                await endpoint.wait_until_endpoint_subscribed_to(
-                    main_endpoint_config.name,
+                await endpoint.wait_until_any_endpoint_subscribed_to(
                     EventBusConnected,
                 )
                 await endpoint.broadcast(

--- a/trinity/sync/beam/chain.py
+++ b/trinity/sync/beam/chain.py
@@ -191,7 +191,7 @@ class BeamSyncer(BaseService):
                 "Timed out while trying to fulfill prerequisites of "
                 f"sync launch strategy: {exc} from {self._launch_strategy}"
             )
-            await self.cancel()
+            self.cancel_nowait()
 
         self.run_daemon(self._header_syncer)
 
@@ -516,7 +516,7 @@ class HeaderOnlyPersist(BaseService):
             self.logger.debug("Final header import before checkpoint: None")
 
         self._final_headers = final_headers
-        self.cancel_nowait()
+        await self.cancel()
 
         return True
 

--- a/trinity/tools/_component_isolation.py
+++ b/trinity/tools/_component_isolation.py
@@ -1,0 +1,71 @@
+"""
+This module exists because these classes end up being unpickleable if defined
+in the tests modules.
+"""
+import logging
+from pathlib import Path
+import subprocess
+import tempfile
+
+from async_service import Service
+from async_service import background_asyncio_service
+from asyncio_run_in_process.typing import SubprocessKwargs
+
+from lahja import EndpointAPI, BaseEvent
+
+from trinity.boot_info import BootInfo
+from trinity.extensibility import AsyncioIsolatedComponent
+
+
+class IsStarted(BaseEvent):
+    def __init__(self, path: Path) -> None:
+        self.path = path
+
+
+class AsyncioComponentService(Service):
+    logger = logging.getLogger('trinity.testing.ServiceForTest')
+
+    def __init__(self, event_bus: EndpointAPI) -> None:
+        self.event_bus = event_bus
+
+    async def run(self) -> None:
+        self.logger.debug('Broadcasting `IsStarted`')
+        path = Path(tempfile.NamedTemporaryFile().name)
+        try:
+            await self.event_bus.broadcast(IsStarted(path))
+            self.logger.debug('Waiting for cancellation')
+            await self.manager.wait_finished()
+        except BaseException as err:
+            self.logger.debug('Exiting due to error: `%r`', err)
+        finally:
+            self.logger.debug('Got cancellation: touching `%s`', path)
+            path.touch()
+
+
+class AsyncioComponentForTest(AsyncioIsolatedComponent):
+    name = "component-test"
+    endpoint_name = 'component-test'
+    logger = logging.getLogger('trinity.testing.ComponentForTest')
+
+    def get_subprocess_kwargs(self) -> SubprocessKwargs:
+        return {
+            'stdin': subprocess.PIPE,
+            'stdout': subprocess.PIPE,
+            'stderr': subprocess.PIPE,
+        }
+
+    @property
+    def is_enabled(self) -> bool:
+        return True
+
+    @classmethod
+    async def do_run(cls, boot_info: BootInfo, event_bus: EndpointAPI) -> None:
+        cls.logger.debug('Entered `do_run`')
+        service = AsyncioComponentService(event_bus)
+        async with background_asyncio_service(service) as manager:
+            cls.logger.debug('Running service')
+            try:
+                await manager.wait_finished()
+            finally:
+                cls.logger.debug('Exiting `do_run`')
+        cls.logger.debug('Finished: `do_run`')


### PR DESCRIPTION
### What was wrong?

Multiprocessing isn't async friendly.

### How was it fixed?

Convert `AsyncioIsolatedComponent` to use `asyncio-run-in-process` for process isolation.

#### Cute Animal Picture

![Adorable two-week-old seal pups show playful side under watchful eye of mother 3](https://user-images.githubusercontent.com/824194/70471442-675a4680-1a8a-11ea-81c1-ac7f821d04c4.jpg)

