### PR TITLE
Bugfix mutual peer connections

### DIFF
--- a/newsfragments/1352.bugfix.rst
+++ b/newsfragments/1352.bugfix.rst
@@ -1,0 +1,2 @@
+Only allow a single connection per peer, even if an outgoing and incoming handshake are initiated
+simultaneously. (Previously, this was sometimes creating duplicate peers in the pool)

--- a/newsfragments/1352.bugfix.rst
+++ b/newsfragments/1352.bugfix.rst
@@ -1,2 +1,2 @@
 Only allow a single connection per peer, even if an outgoing and incoming handshake are initiated
-simultaneously. (Previously, this was sometimes creating duplicate peers in the pool)
+simultaneously. Bonus: squashed UnknownAPI log when talking to a peer that is disconnecting.

--- a/p2p/connection.py
+++ b/p2p/connection.py
@@ -220,6 +220,8 @@ class Connection(ConnectionAPI, BaseService):
         self._logics.pop(name)
 
     def has_logic(self, name: str) -> bool:
+        if self.is_closing:
+            raise PeerConnectionLost("Cannot look up subprotocol when connection is closing")
         return name in self._logics
 
     def get_logic(self, name: str, logic_type: Type[TLogic]) -> TLogic:

--- a/p2p/connection.py
+++ b/p2p/connection.py
@@ -80,6 +80,12 @@ class Connection(ConnectionAPI, BaseService):
 
         self._logics = {}
 
+    def __str__(self) -> str:
+        return f"Connection-{self.session}"
+
+    def __repr__(self) -> str:
+        return f"<Connection {self.session!r} {self._multiplexer!r} dial_out={self.is_dial_out}>"
+
     def start_protocol_streams(self) -> None:
         self._handlers_ready.set()
 


### PR DESCRIPTION
### What was wrong?

Fixes #1352 

### How was it fixed?

Wrap the handshake lock around both inbound and outbound handshake requests.

Plus a couple bonus fixes:
- added a str/repr for `Connection`
- when a peer is closing, and you try to get it's "logic" (eg~ `eth_api` subprotocol), raise `PeerConnectionLost`. Raising `UnknownAPI` is confusing. The peer used to have the API, before it closed.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

[//]: # (See: https://trinity-client.readthedocs.io/en/latest/contributing.html#pull-requests)
- [x] Add entry to the [release notes](https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://roflzoo.com/pics/042010/rabbit-high-five-big.jpg)
