### PR TITLE
Add matomo tracking to docs site

### DIFF
--- a/docs/_static/js/matomo.js
+++ b/docs/_static/js/matomo.js
@@ -1,0 +1,11 @@
+var _paq = window._paq || [];
+/* tracker methods like "setCustomDimension" should be called before "trackPageView" */
+_paq.push(['trackPageView']);
+_paq.push(['enableLinkTracking']);
+(function() {
+  var u="https://matomo.ethereum.org/piwik/";
+  _paq.push(['setTrackerUrl', u+'matomo.php']);
+  _paq.push(['setSiteId', '16']);
+  var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
+  g.type='text/javascript'; g.async=true; g.defer=true; g.src=u+'matomo.js'; s.parentNode.insertBefore(g,s);
+})();

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -120,6 +120,7 @@ html_static_path = ['_static']
 
 def setup(app):
     app.add_stylesheet("css/custom.css")
+    app.add_javascript("js/matomo.js")
 
 # Allows the mod index to function more helpfully (not everything under 'e')
 modindex_common_prefix = ['eth.']

--- a/newsfragments/1365.doc.rst
+++ b/newsfragments/1365.doc.rst
@@ -1,0 +1,7 @@
+Add Matomo Tracking to Docs site.
+
+Matomo is an Open Source web analytics platform that allows us
+to get better insights and optimize for our audience without
+the negative consequences of other compareable platforms.
+
+Read more: https://matomo.org/why-matomo/


### PR DESCRIPTION
### What was wrong?

Currently we do not have a good insight into our target group. In order to improve both Trinity itself and the documentation, it makes sense to aggregate some data.

### How was it fixed?

Add Matomo Tracking to Docs site.

Matomo is an Open Source web analytics platform that allows us
to get better insights and optimize for our audience without
the negative consequences of other compareable platforms.

Read more: https://matomo.org/why-matomo/

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

[//]: # (See: https://trinity-client.readthedocs.io/en/latest/contributing.html#pull-requests)
- [x] Add entry to the [release notes](https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](http://sacramento.cbslocal.com/wp-content/uploads/sites/15909776/2013/04/baby-sea-turtles.jpg)
