### PR TITLE
Use ThreadPoolExecutor with context manager

### DIFF
--- a/newsfragments/1371.bugfix.rst
+++ b/newsfragments/1371.bugfix.rst
@@ -1,0 +1,5 @@
+Ensure ThreadPoolExecutor in beam importer is set up with contextmanager
+
+Without contextmanager one needs to manually call `shutdown` on the
+executor which we weren't doing either. This change may fix some
+warnings during shutdown of the client.


### PR DESCRIPTION
### What was wrong?

There's a `ThreadPoolExecutor` being setup without a contextmanager and without manually calling [`shutdown`](https://docs.python.org/3/library/concurrent.futures.html#concurrent.futures.Executor.shutdown) either.

### How was it fixed?

I'm not sure if this fixes a real problem but I recently noticed @pipermerriam saying that part of the unclean shutdowns seems to be coming from beam sync and then I remembered there was a `ThreadPoolExecutor` being used without `with` statement. I think using it that way is the safe best practice.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

[//]: # (See: https://trinity-client.readthedocs.io/en/latest/contributing.html#pull-requests)
- [x] Add entry to the [release notes](https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://live.staticflickr.com/3086/2531035055_18dac77130_z.jpg)
