### PR TITLE
Do not skip tests for IstanbulVM

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -169,6 +169,12 @@ jobs:
       - image: circleci/python:3.6
         environment:
           TOXENV: py36-rpc-state-homestead
+  py36-rpc-state-istanbul:
+    <<: *common
+    docker:
+      - image: circleci/python:3.6
+        environment:
+          TOXENV: py36-rpc-state-istanbul
   py36-rpc-state-petersburg:
     <<: *common
     docker:

--- a/newsfragments/1372.internal.rst
+++ b/newsfragments/1372.internal.rst
@@ -1,0 +1,1 @@
+Test Trinity against Istanbul tests

--- a/newsfragments/1403.bugfix.rst
+++ b/newsfragments/1403.bugfix.rst
@@ -1,0 +1,4 @@
+Ensure ``eth_getStorageAt`` pads results to 32 byte
+
+See: https://github.com/ethereum/wiki/wiki/JSON-RPC#eth_getstorageat
+Geth Example: https://api.etherscan.io/api?module=proxy&action=eth_getStorageAt&address=0x6e03d9cce9d60f3e9f2597e13cd4c54c55330cfd&position=0x0&tag=latest&apikey=YourApiKeyToken

--- a/tests/core/json-rpc/test_rpc_during_beam_sync.py
+++ b/tests/core/json-rpc/test_rpc_during_beam_sync.py
@@ -281,7 +281,8 @@ async def test_getStorageAt_during_beam_sync(
     # sanity check, by default it works
     response = await ipc_request('eth_getStorageAt', params)
     assert 'error' not in response
-    assert response['result'] == '0x01'  # this was set in the genesis_state fixture
+    # this was set in the genesis_state fixture
+    assert response['result'] == '0x0000000000000000000000000000000000000000000000000000000000000001'  # noqa: E501
 
     missing_node = chain.chaindb.db.pop(storage_root)
 
@@ -294,7 +295,8 @@ async def test_getStorageAt_during_beam_sync(
     async with fake_beam_syncer({storage_root: missing_node}):
         response = await ipc_request('eth_getStorageAt', params)
         assert 'error' not in response
-        assert response['result'] == '0x01'  # this was set in the genesis_state fixture
+        # this was set in the genesis_state fixture
+        assert response['result'] == '0x0000000000000000000000000000000000000000000000000000000000000001'  # noqa: E501
 
 
 @pytest.fixture

--- a/tests/json-fixtures-over-rpc/test_rpc_fixtures.py
+++ b/tests/json-fixtures-over-rpc/test_rpc_fixtures.py
@@ -74,6 +74,7 @@ SLOW_TESTS = (
     'randomStatetest94_Byzantium',
     'randomStatetest94_Constantinople',
     'randomStatetest94_ConstantinopleFix',
+    'randomStatetest94_Istanbul',
     'ShanghaiLove_Homestead',
     'ShanghaiLove_Frontier',
     'static_Call1024PreCalls_d1g0v0',
@@ -146,6 +147,9 @@ INCORRECT_UPSTREAM_TESTS = {
     ('GeneralStateTests/stSStoreTest/InitCollision_d0g0v0.json', 'InitCollision_d0g0v0_ConstantinopleFix'),  # noqa: E501
     ('GeneralStateTests/stSStoreTest/InitCollision_d1g0v0.json', 'InitCollision_d1g0v0_ConstantinopleFix'),  # noqa: E501
     ('GeneralStateTests/stSStoreTest/InitCollision_d3g0v0.json', 'InitCollision_d3g0v0_ConstantinopleFix'),  # noqa: E501
+    ('GeneralStateTests/stSStoreTest/InitCollision.json', 'InitCollision_d0g0v0_Istanbul'),  # noqa: E501
+    ('GeneralStateTests/stSStoreTest/InitCollision.json', 'InitCollision_d1g0v0_Istanbul'),  # noqa: E501
+    ('GeneralStateTests/stSStoreTest/InitCollision.json', 'InitCollision_d3g0v0_Istanbul'),  # noqa: E501
 }
 
 

--- a/tests/json-fixtures-over-rpc/test_rpc_fixtures.py
+++ b/tests/json-fixtures-over-rpc/test_rpc_fixtures.py
@@ -464,8 +464,7 @@ async def validate_uncles(rpc, block_fixture, at_block):
 def chain_fixture(fixture_data):
     fixture_path, fixture_key, fixture_fork = fixture_data
     fixture = load_fixture(fixture_path, fixture_key)
-    if fixture_fork == 'Istanbul':
-        pytest.skip('Istanbul VM rules not yet supported')
+
     return fixture
 
 

--- a/tests/json-fixtures-over-rpc/test_rpc_fixtures.py
+++ b/tests/json-fixtures-over-rpc/test_rpc_fixtures.py
@@ -160,6 +160,10 @@ def pad32_dict_values(some_dict):
     }
 
 
+def map_0x_to_0x0(value):
+    return '0x0' if value == '0x' else value
+
+
 RPC_STATE_NORMALIZERS = {
     'balance': remove_leading_zeros,
     'code': empty_to_0x,
@@ -193,7 +197,7 @@ RPC_TRANSACTION_NORMALIZERS = {
     'nonce': remove_leading_zeros,
     'gasLimit': remove_leading_zeros,
     'gasPrice': remove_leading_zeros,
-    'value': remove_leading_zeros,
+    'value': compose(remove_leading_zeros, map_0x_to_0x0),
     'data': empty_to_0x,
     'to': compose(
         apply_formatter_if(is_address, to_checksum_address),
@@ -315,7 +319,7 @@ async def validate_account_state(rpc, state, addr, at_block):
             at_block=at_block
         )
     for key in state['storage']:
-        position = '0x0' if key == '0x' else key
+        position = map_0x_to_0x0(key)
         expected_storage = standardized_state['storage'][key]
         await assert_rpc_result(
             rpc,

--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,7 @@ envlist=
     py{36,37}-{eth1-core,p2p,p2p-trio,eth1-monitor-trio,integration,lightchain_integration,eth2-core,eth2-fixtures,eth2-integration,eth1-components,eth2-utils}
     py36-long_run_integration
     py36-rpc-blockchain
-    py36-rpc-state-{frontier,homestead,tangerine_whistle,spurious_dragon,byzantium,constantinople,petersburg}
+    py36-rpc-state-{frontier,homestead,tangerine_whistle,spurious_dragon,byzantium,constantinople,petersburg,istanbul}
     py37-rpc-state-{quadratic,sstore,zero_knowledge}
     py37-{libp2p,eth2-components}
     py{36,37}-lint
@@ -50,6 +50,7 @@ commands=
     rpc-state-byzantium: pytest -n 3 {posargs:tests/json-fixtures-over-rpc/test_rpc_fixtures.py --fork Byzantium -k 'GeneralStateTests and not stQuadraticComplexityTest and not stSStoreTest and not stZeroKnowledge'}
     rpc-state-constantinople: pytest -n 3 {posargs:tests/json-fixtures-over-rpc/test_rpc_fixtures.py --fork Constantinople -k 'GeneralStateTests and not stQuadraticComplexityTest and not stSStoreTest and not stZeroKnowledge'}
     rpc-state-petersburg: pytest -n 3 {posargs:tests/json-fixtures-over-rpc/test_rpc_fixtures.py --fork ConstantinopleFix -k 'GeneralStateTests and not stQuadraticComplexityTest and not stSStoreTest and not stZeroKnowledge'}
+    rpc-state-istanbul: pytest -n 3 {posargs:tests/json-fixtures-over-rpc/test_rpc_fixtures.py --fork Istanbul -k 'GeneralStateTests and not stQuadraticComplexityTest and not stSStoreTest and not stZeroKnowledge'}
     # Long-running categories.
     rpc-state-quadratic: pytest -n 4 {posargs:tests/json-fixtures-over-rpc/test_rpc_fixtures.py -k 'GeneralStateTests and stQuadraticComplexityTest'}
     rpc-state-sstore: pytest -n 4 {posargs:tests/json-fixtures-over-rpc/test_rpc_fixtures.py -k 'GeneralStateTests and stSStoreTest'}

--- a/trinity/rpc/modules/eth.py
+++ b/trinity/rpc/modules/eth.py
@@ -43,6 +43,9 @@ from eth.rlp.headers import (
 from eth.vm.spoof import (
     SpoofTransaction,
 )
+from eth._utils.padding import (
+    pad32,
+)
 
 from trinity.chains.base import AsyncChainAPI
 from trinity.constants import (
@@ -214,7 +217,8 @@ class Eth(Eth1ChainRPCModule):
 
         state = await state_at_block(self.chain, at_block)
         stored_val = state.get_storage(address, position)
-        return encode_hex(int_to_big_endian(stored_val))
+
+        return encode_hex(pad32(int_to_big_endian(stored_val)))
 
     @format_params(decode_hex)
     async def getTransactionByHash(self,


### PR DESCRIPTION
### What was wrong?

We aren't testing Trinity against Istanbul yet.

### How was it fixed?

- This builds upon #1403 
- Wire tests up in tox/circle
- Remove skipping of Istanbul tests

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

[//]: # (See: https://trinity-client.readthedocs.io/en/latest/contributing.html#pull-requests)
- [x] Add entry to the [release notes](https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcRmpTnCMDDB7I-6NodjuN6ntGxN93CZn6qAZVzzrRTaRRqjntcnWw&s)
