### PR TITLE
Listen to 0.0.0.0 as default

### DIFF
--- a/trinity/components/eth2/beacon/component.py
+++ b/trinity/components/eth2/beacon/component.py
@@ -106,7 +106,7 @@ class BeaconNodeComponent(AsyncioIsolatedComponent):
         # TODO: Handle `bootstrap_nodes`.
         libp2p_node = Node(
             key_pair=key_pair,
-            listen_ip="127.0.0.1",  # FIXME: Should be configurable
+            listen_ip="0.0.0.0",
             listen_port=boot_info.args.port,
             preferred_nodes=trinity_config.preferred_nodes,
             chain=chain,


### PR DESCRIPTION
### What was wrong?

Trinity can't listen to a remote node if we set 127.0.0.1.

Not sure if we really want it to be configurable. Correct me if I'm wrong, but in contrast to RPC functionality that we want to restrict access for only certain ip addresses, normally we want the p2p module listens to the world.

#### Cute Animal Picture

🐛