### PR TITLE
Fix flaky test

### DIFF
--- a/newsfragments/1382.internal.rst
+++ b/newsfragments/1382.internal.rst
@@ -1,0 +1,9 @@
+Fix flaky interactive web3 console test
+
+Due to the way components cross connect to each
+other, not all logs of that startup routine are
+happening deterministically. We were waiting on
+a log that would sometimes never show up for all
+valid reason. This test is now based on a log that
+is guaranteed to show up unless a serious bug
+happened.

--- a/tests/integration/test_trinity_cli.py
+++ b/tests/integration/test_trinity_cli.py
@@ -173,9 +173,9 @@ async def test_web3_commands_via_attached_console(command,
             "Components started",
             "IPC started at",
             # Ensure we do not start making requests before Trinity is ready.
-            # Waiting for the json-rpc-api event bus to connect to other endpoints
-            # seems to be late enough in the process for this to be the case.
-            "EventBus Endpoint bjson-rpc-api connecting to other Endpoints",
+            # Waiting for the JSON-RPC API to be announced seems to be
+            # late enough in the process for this to be the case.
+            "New EventBus Endpoint connected bjson-rpc-api",
         })
 
         attached_trinity = pexpect.spawn(


### PR DESCRIPTION

### What was wrong?

We currently wait for the json-rpc Endpoint to connect
to other endpoints before we do certain assertions.
But sometimes we might end up in a situation where
al other endpoints have already connected to this
endpoint and so it does not actively connect to
others and the test fails.

### How was it fixed?

It is safer to simply wait for the announcement of the 
JSON-RPC endpoint instead.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://besthqwallpapers.com/Uploads/18-3-2019/83911/thumb2-american-marten-martes-americana-cute-little-animal-snow-wildlife.jpg)
