### PR TITLE
Update web3 to v5.4.0 (latest ATM)

### DIFF
--- a/newsfragments/1383.feature.rst
+++ b/newsfragments/1383.feature.rst
@@ -1,0 +1,1 @@
+Underlying ``web3`` module changed from v4 to v5, including in the console.

--- a/setup.py
+++ b/setup.py
@@ -39,11 +39,11 @@ deps = {
         "ipython>=7.8.0,<7.10.0",  # attach fails with v7.10.{0,1}
         "plyvel==1.1.0",
         PYEVM_DEPENDENCY,
-        "web3==4.4.1",
+        "web3==5.4.0",
         "lahja>=0.15.2,<0.16",
         "termcolor>=1.1.0,<2.0.0",
         "uvloop==0.14.0;platform_system=='Linux' or platform_system=='Darwin' or platform_system=='FreeBSD'",  # noqa: E501
-        "websockets==5.0.1",
+        "websockets>=8.1.0",
         "jsonschema==3.0.1",
         "mypy-extensions>=0.4.3,<0.5.0",
         "typing_extensions>=3.7.2,<4.0.0",

--- a/trinity/components/builtin/ethstats/ethstats_client.py
+++ b/trinity/components/builtin/ethstats/ethstats_client.py
@@ -1,7 +1,12 @@
 import asyncio
 import datetime
 import json
-import typing
+
+from typing import (
+    Any,
+    Dict,
+    NamedTuple,
+)
 
 import websockets
 
@@ -19,10 +24,10 @@ def timestamp_ms() -> int:
     return round(datetime.datetime.utcnow().timestamp() * 1000)
 
 
-EthstatsData = typing.Dict[str, typing.Any]
+EthstatsData = Dict[str, Any]
 
 
-class EthstatsMessage(typing.NamedTuple):
+class EthstatsMessage(NamedTuple):
     command: str
     data: EthstatsData
 
@@ -56,12 +61,12 @@ class EthstatsClient(BaseService):
     async def recv_handler(self) -> None:
         while self.is_operational:
             try:
-                json_string: str = await self.websocket.recv()
+                json_string = await self.websocket.recv()
             except websockets.ConnectionClosed as e:
                 self.logger.debug2("Connection closed: %s", e)
                 await self.cancel()
             try:
-                message: EthstatsMessage = self.deserialize_message(json_string)
+                message: EthstatsMessage = self.deserialize_message(str(json_string))
             except EthstatsException as e:
                 self.logger.warning('Cannot parse message from server: %s' % e)
                 return

--- a/trinity/components/eth2/eth1_monitor/eth1_data_provider.py
+++ b/trinity/components/eth2/eth1_monitor/eth1_data_provider.py
@@ -119,9 +119,13 @@ class Web3Eth1DataProvider(BaseEth1DataProvider):
                 "topics": [self._deposit_event_topic],
             }
         )
-        parsed_logs = tuple(
-            self._deposit_contract.events.DepositEvent().processLog(log)['args']
+        processed_logs = tuple(
+            self._deposit_contract.events.DepositEvent().processLog(log)
             for log in logs
+        )
+        parsed_logs = tuple(
+            DepositLog.from_contract_log_dict(log)
+            for log in processed_logs
         )
         return parsed_logs
 

--- a/trinity/components/eth2/eth1_monitor/eth1_monitor.py
+++ b/trinity/components/eth2/eth1_monitor/eth1_monitor.py
@@ -326,7 +326,7 @@ class Eth1Monitor(Service):
         self, logs: Sequence[DepositLog], block_number: BlockNumber
     ) -> None:
         """
-        Simply store the deposit data from the log, and increase the corresponding block's
+        Store deposit data from the log in database, and increase the corresponding block's
         `deposit_count`.
         """
         seq_deposit_data = tuple(


### PR DESCRIPTION
### What was wrong?

A clean-room install of `[.dev]` produces a `pip` error:

``` sh
virtualenv -p python3.7 .virtualenv/`basename $(pwd)`
source .virtualenv/`basename $(pwd)`/bin/activate
pip install -e .\[dev\]
```

    ERROR: eth-tester 0.2.0b3 has requirement eth-abi<3.0.0,>=2.0.0b4, but you'll have eth-abi 1.3.0 which is incompatible.

### How was it fixed?

The older `eth-abi` is pulled in via `web3` v4. To resolve this, v5 is installed.

`websockets` (AFAIK only used in the `ethstats_client` component) got bumped, too: `web3` wants `>=8.1.0,<9`. Specifying `>5.0.1` would have worked, but installs v8.1.0 anyway.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

[//]: # (See: https://trinity-client.readthedocs.io/en/latest/contributing.html#pull-requests)
- [x] Add entry to the [release notes](https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://www.efoto.lt/files/images/58410/DSC_9562.preview.jpg)

Source: ["Kukutis" by Irmantas Š. at efoto.lt](https://www.efoto.lt/node/1262181)