### PR TITLE
Better handling for child process logging

### DIFF
--- a/trinity/extensibility/component.py
+++ b/trinity/extensibility/component.py
@@ -12,7 +12,7 @@ from typing import AsyncIterator
 
 from async_generator import asynccontextmanager
 
-from trinity._utils.logging import setup_child_process_logging
+from trinity._utils.logging import child_process_logging
 from trinity._utils.os import friendly_filename_or_url
 from trinity._utils.profiling import profiler
 from trinity.boot_info import BootInfo
@@ -97,13 +97,12 @@ class BaseIsolatedComponent(BaseComponent):
 
     @classmethod
     def _run_process(cls, boot_info: BootInfo) -> None:
-        setup_child_process_logging(boot_info)
-
-        if boot_info.profile:
-            with profiler(f'profile_{cls._get_endpoint_name}'):
+        with child_process_logging(boot_info):
+            if boot_info.profile:
+                with profiler(f'profile_{cls._get_endpoint_name}'):
+                    cls.run_process(boot_info)
+            else:
                 cls.run_process(boot_info)
-        else:
-            cls.run_process(boot_info)
 
     @classmethod
     def _get_endpoint_name(cls) -> str:

--- a/trinity/main.py
+++ b/trinity/main.py
@@ -33,7 +33,7 @@ from trinity._utils.ipc import (
     kill_process_gracefully,
 )
 from trinity._utils.logging import (
-    setup_child_process_logging,
+    child_process_logging,
 )
 from trinity._utils.mp import (
     ctx,
@@ -82,22 +82,22 @@ def trinity_boot(boot_info: BootInfo) -> Tuple[multiprocessing.Process]:
 
 
 def run_database_process(boot_info: BootInfo, db_class: Type[LevelDB]) -> None:
-    setup_child_process_logging(boot_info)
-    trinity_config = boot_info.trinity_config
+    with child_process_logging(boot_info):
+        trinity_config = boot_info.trinity_config
 
-    with trinity_config.process_id_file('database'):
-        app_config = trinity_config.get_app_config(Eth1AppConfig)
+        with trinity_config.process_id_file('database'):
+            app_config = trinity_config.get_app_config(Eth1AppConfig)
 
-        base_db = db_class(db_path=app_config.database_dir)
-        chaindb = ChainDB(base_db)
+            base_db = db_class(db_path=app_config.database_dir)
+            chaindb = ChainDB(base_db)
 
-        if not is_database_initialized(chaindb):
-            chain_config = app_config.get_chain_config()
-            initialize_database(chain_config, chaindb, base_db)
+            if not is_database_initialized(chaindb):
+                chain_config = app_config.get_chain_config()
+                initialize_database(chain_config, chaindb, base_db)
 
-        manager = DBManager(base_db)
-        with manager.run(trinity_config.database_ipc_path):
-            try:
-                manager.wait_stopped()
-            except KeyboardInterrupt:
-                pass
+            manager = DBManager(base_db)
+            with manager.run(trinity_config.database_ipc_path):
+                try:
+                    manager.wait_stopped()
+                except KeyboardInterrupt:
+                    pass


### PR DESCRIPTION
fixes https://github.com/ethereum/trinity/issues/1381

### What was wrong?

The *child* processes hook into the main process over an IPC socket to pass logs through.

First, we weren't closing this IPC socket which resulted in lots of errors due to unclosed sockets.

Second, once the socket is closed, the handler was still left on the logger which meant that other things that might use logging, like things in the standard library, which do things during the python shutdown, would cause the handler to throw errors since it wouldn't be able to communicate with the parent process.

### How was it fixed?

Used two context managers, one to close the socket, and another to remove the handler.

#### Cute Animal Picture


![IMG_0164-1024x768](https://user-images.githubusercontent.com/824194/70648401-34d65800-1c08-11ea-9c3d-35f47c1d6245.jpg)
