### PR TITLE
Convert the ethstats service to use the new async-service API

### DIFF
--- a/trinity/components/builtin/ethstats/component.py
+++ b/trinity/components/builtin/ethstats/component.py
@@ -6,11 +6,10 @@ from argparse import (
     _SubParsersAction,
 )
 
+from async_service import run_asyncio_service
 from eth_utils import ValidationError
 
 from lahja.base import EndpointAPI
-
-from p2p.service import run_service
 
 from trinity.boot_info import BootInfo
 from trinity.constants import (
@@ -122,5 +121,4 @@ class EthstatsComponent(AsyncioIsolatedComponent):
             args.ethstats_interval,
         )
 
-        async with run_service(service):
-            await service.cancellation()
+        await run_asyncio_service(service)


### PR DESCRIPTION
### What was wrong?

The new `async-service` library is not being used everywhere.

### How was it fixed?

Converted the services in the `ethstats` component to use the new `async-service` APIs.

#### Cute Animal Picture

![Adorable two-week-old seal pups show playful side under watchful eye of mother 4](https://user-images.githubusercontent.com/824194/70658682-b1befd00-1c1b-11ea-8166-2ddcc4c28df9.jpg)

