### PR TITLE
Update transaction pool component to use async-service APIs

### DIFF
--- a/tests/core/tx-pool/test_tx_pool.py
+++ b/tests/core/tx-pool/test_tx_pool.py
@@ -2,11 +2,11 @@ import asyncio
 import pytest
 import uuid
 
+from async_service import background_asyncio_service
 from eth._utils.address import (
     force_bytes_to_address
 )
 
-from p2p.service import run_service
 from p2p.tools.factories import SessionFactory
 
 from trinity.components.builtin.tx_pool.pool import (
@@ -67,7 +67,7 @@ async def test_tx_propagation(event_bus,
 
     async with run_proxy_peer_pool(event_bus) as peer_pool:
         tx_pool = TxPool(event_bus, peer_pool, tx_validator)
-        async with run_service(tx_pool):
+        async with background_asyncio_service(tx_pool):
 
             run_mock_request_response(
                 GetConnectedPeersRequest, GetConnectedPeersResponse(initial_two_peers), event_bus)
@@ -144,7 +144,7 @@ async def test_does_not_propagate_invalid_tx(event_bus,
 
     async with run_proxy_peer_pool(event_bus) as peer_pool:
         tx_pool = TxPool(event_bus, peer_pool, tx_validator)
-        async with run_service(tx_pool):
+        async with background_asyncio_service(tx_pool):
             run_mock_request_response(
                 GetConnectedPeersRequest, GetConnectedPeersResponse(initial_two_peers), event_bus)
 

--- a/trinity/components/builtin/tx_pool/component.py
+++ b/trinity/components/builtin/tx_pool/component.py
@@ -4,12 +4,11 @@ from argparse import (
 )
 import logging
 
+from async_service import run_asyncio_service
 from eth_utils import ValidationError
 from eth.chains.mainnet import PETERSBURG_MAINNET_BLOCK
 from eth.chains.ropsten import PETERSBURG_ROPSTEN_BLOCK
 from lahja import EndpointAPI
-
-from p2p.service import run_service
 
 from trinity.boot_info import BootInfo
 from trinity.config import (
@@ -91,5 +90,7 @@ class TxComponent(AsyncioIsolatedComponent):
 
         tx_pool = TxPool(event_bus, proxy_peer_pool, validator)
 
-        async with run_service(tx_pool):
-            await tx_pool.cancellation()
+        try:
+            await run_asyncio_service(tx_pool)
+        finally:
+            cls.logger.info("Stopping Tx Pool...")


### PR DESCRIPTION
### What was wrong?

The new `async-service` library is not being used everywhere.

### How was it fixed?

Converted the services in the `txpool` component to use the new `async-service` APIs.

#### Cute Animal Picture

![PuppyDay_AntarcticFurSealPups_ChristopherWillis](https://user-images.githubusercontent.com/824194/70659205-d798d180-1c1c-11ea-891f-9810bb488405.jpg)
