### PR TITLE
Ensure JSON RPC requests end with newline

### DIFF
--- a/newsfragments/1388.feature.rst
+++ b/newsfragments/1388.feature.rst
@@ -1,0 +1,1 @@
+End JSON-RPC responses with `\n` to support dopple.

--- a/trinity/rpc/ipc.py
+++ b/trinity/rpc/ipc.py
@@ -24,6 +24,7 @@ from trinity.rpc.main import (
 )
 
 MAXIMUM_REQUEST_BYTES = 10000
+NEW_LINE = "\n"
 
 
 @curry
@@ -103,6 +104,9 @@ async def connection_loop(execute_rpc: Callable[[Any], Any],
                 write_error(writer, "unknown failure: " + str(e)),
             )
         else:
+            if not result.endswith(NEW_LINE):
+                result += NEW_LINE
+
             writer.write(result.encode())
 
         await cancel_token.cancellable_wait(writer.drain())


### PR DESCRIPTION
### What was wrong?

This is basically #1121 which I can not reopen for some reason.

[dopple](https://github.com/ethereum/dopple) does currently not work with Trinity because it assumes that every response ends with a newline character.

```python
        response = b''
        while True:
            r = self.conn.recv(BUFSIZE)
            if not r:
                break
            if r[-1] == DELIMITER:
                response += r[:-1]
                break
            response += r

        return response
```

### How was it fixed?

We could change dopple to not rely on newlines and match closing brackets instead (this is what web3.py does) but I don't think it's worth is because:

1. Other clients (at least geth and aleth) end responses with new lines so maybe they are right about that?

2. It is very easy to fix this on our part and just add that newline

3. Bracket matching will be slower and it might not feel like a good move to others to make dopple slower just to be compatible to Trinity.

After talking to @carver about this recently, I'm convinced we should just add that newline on our end.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

[//]: # (See: https://trinity-client.readthedocs.io/en/latest/contributing.html#pull-requests)
- [x] Add entry to the [release notes](https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://tailandfur.com/wp-content/uploads/2015/06/40-Cute-Tiny-Animal-Pictures-31.jpg)
