### PR TITLE
Convert JSON-RPC component to use async-service

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,6 +9,7 @@ from async_generator import (
 )
 import pytest
 
+from async_service import background_asyncio_service
 from lahja import AsyncioEndpoint
 
 from eth_utils import (
@@ -286,11 +287,7 @@ async def ipc_server(
         chain_with_block_validation,
         event_bus,
     )
-    ipc_server = IPCServer(rpc, jsonrpc_ipc_pipe_path, loop=event_loop)
+    ipc_server = IPCServer(rpc, jsonrpc_ipc_pipe_path)
 
-    asyncio.ensure_future(ipc_server.run(), loop=event_loop)
-
-    try:
+    async with background_asyncio_service(ipc_server):
         yield ipc_server
-    finally:
-        await ipc_server.cancel()


### PR DESCRIPTION
### What was wrong?

We have a nice new `async-service` library that does the service stuff now without cancel tokens.  The JSON-RPC component wasn't using it.

### How was it fixed?

Updated the services under the JSON-RPC component to be based on the `async-service` APIs.


#### Cute Animal Picture

![catphoto12_a1pl6x](https://user-images.githubusercontent.com/824194/70738280-9ca4a580-1cd1-11ea-9856-a18bd5640b37.jpeg)
