### PR TITLE
Convert request server to use async-service

### DIFF
--- a/tests/core/p2p-proto/test_requests.py
+++ b/tests/core/p2p-proto/test_requests.py
@@ -2,12 +2,16 @@ import asyncio
 
 import pytest
 
+from async_service import background_asyncio_service
+
 from p2p.exceptions import PeerConnectionLost
 
+from trinity.constants import TO_NETWORKING_BROADCAST_CONFIG
 from trinity.db.eth1.chain import AsyncChainDB
 from trinity.protocol.eth.peer import (
     ETHPeerPoolEventServer,
 )
+from trinity.protocol.eth.servers import ETHRequestServer
 
 from trinity.tools.factories import (
     ChainContextFactory,
@@ -17,7 +21,6 @@ from trinity.tools.factories import (
 from tests.core.integration_test_helpers import (
     run_peer_pool_event_server,
     run_proxy_peer_pool,
-    run_request_server,
 )
 from tests.core.peer_helpers import (
     MockPeerPoolWithConnectedPeers,
@@ -52,10 +55,11 @@ async def test_proxy_peer_requests(request,
         client_event_bus, client_peer_pool, handler_type=ETHPeerPoolEventServer
     ), run_peer_pool_event_server(
         server_event_bus, server_peer_pool, handler_type=ETHPeerPoolEventServer
-    ), run_request_server(
+    ), background_asyncio_service(ETHRequestServer(
         server_event_bus,
+        TO_NETWORKING_BROADCAST_CONFIG,
         AsyncChainDB(chaindb_20.db)
-    ), run_proxy_peer_pool(
+    )), run_proxy_peer_pool(
         client_event_bus
     ) as client_proxy_peer_pool, run_proxy_peer_pool(
         server_event_bus
@@ -141,10 +145,11 @@ async def test_requests_when_peer_in_client_vanishs(request,
         client_event_bus, client_peer_pool, handler_type=ETHPeerPoolEventServer
     ), run_peer_pool_event_server(
         server_event_bus, server_peer_pool, handler_type=ETHPeerPoolEventServer
-    ), run_request_server(
+    ), background_asyncio_service(ETHRequestServer(
         server_event_bus,
+        TO_NETWORKING_BROADCAST_CONFIG,
         AsyncChainDB(chaindb_20.db)
-    ), run_proxy_peer_pool(
+    )), run_proxy_peer_pool(
         client_event_bus
     ) as client_proxy_peer_pool, run_proxy_peer_pool(
         server_event_bus

--- a/trinity/components/builtin/request_server/component.py
+++ b/trinity/components/builtin/request_server/component.py
@@ -3,14 +3,10 @@ from argparse import (
     _SubParsersAction,
 )
 
+from async_service import Service, run_asyncio_service
 from lahja import EndpointAPI
 
 from eth.db.backends.base import BaseAtomicDB
-
-from p2p.service import (
-    BaseService,
-    run_service,
-)
 
 from trinity.boot_info import BootInfo
 from trinity.config import (
@@ -59,18 +55,19 @@ class RequestServerComponent(AsyncioIsolatedComponent):
         else:
             raise Exception("Trinity config must have eth1 config")
 
-        async with run_service(server):
-            await server.cancellation()
+        await run_asyncio_service(server)
 
     @classmethod
     def make_eth1_request_server(cls,
                                  app_config: Eth1AppConfig,
                                  base_db: BaseAtomicDB,
-                                 event_bus: EndpointAPI) -> BaseService:
+                                 event_bus: EndpointAPI) -> Service:
+
+        server: Service
 
         if app_config.database_mode is Eth1DbMode.LIGHT:
             header_db = AsyncHeaderDB(base_db)
-            server: BaseService = LightRequestServer(
+            server = LightRequestServer(
                 event_bus,
                 TO_NETWORKING_BROADCAST_CONFIG,
                 header_db

--- a/trinity/protocol/les/servers.py
+++ b/trinity/protocol/les/servers.py
@@ -1,6 +1,5 @@
 from typing import Any
 
-from cancel_token import CancelToken
 from lahja import (
     BroadcastConfig,
     EndpointAPI,
@@ -41,15 +40,13 @@ class LightRequestServer(BaseIsolatedRequestServer):
             self,
             event_bus: EndpointAPI,
             broadcast_config: BroadcastConfig,
-            db: BaseAsyncHeaderDB,
-            token: CancelToken = None) -> None:
+            db: BaseAsyncHeaderDB) -> None:
         super().__init__(
             event_bus,
             broadcast_config,
             (GetBlockHeadersEvent,),
-            token,
         )
-        self._handler = LESPeerRequestHandler(db, self.cancel_token)
+        self._handler = LESPeerRequestHandler(db)
 
     async def _handle_msg(self,
                           session: SessionAPI,


### PR DESCRIPTION
### What was wrong?

The Request Server component isn't using the nice new async-service APIs

### How was it fixed?

Converted the services used by the Request Server component to use the new `async-service` APIs

#### Cute Animal Picture

![o-FANCY-DRESS-CHRISTMAS-facebook](https://user-images.githubusercontent.com/824194/70741022-b1843780-1cd7-11ea-8f11-91b0806af13e.jpg)

