### PR TITLE
Convert network db to use new async-service API

### DIFF
--- a/tests-trio/eth1-monitor/conftest.py
+++ b/tests-trio/eth1-monitor/conftest.py
@@ -28,7 +28,7 @@ from trinity.tools.factories.db import AtomicDBFactory
 # Ref: https://github.com/ethereum/eth2.0-specs/blob/dev/deposit_contract/tests/contracts/conftest.py  # noqa: E501
 
 
-@pytest.fixture("session")
+@pytest.fixture(scope="session")
 def contract_json():
     return json.loads(deposit_contract_json)
 

--- a/tests-trio/p2p-trio/test_packer.py
+++ b/tests-trio/p2p-trio/test_packer.py
@@ -219,8 +219,14 @@ async def packer(enr_db,
         outgoing_message_receive_channel=outgoing_message_channels[1],
         outgoing_packet_send_channel=outgoing_packet_channels[0],
     )
-    async with background_trio_service(packer):
-        yield packer
+    try:
+        async with background_trio_service(packer):
+            yield packer
+    except trio.BrokenResourceError:
+        # TODO: This hack fixes flakyness in some tests.  This try/except
+        # should be dropped once the main issue has been addressed.
+        # ISSUE LINK: https://github.com/ethereum/trinity/issues/1517
+        pass
 
 
 @pytest_trio.trio_fixture

--- a/tests/core/network-db/test_connection_tracker_server.py
+++ b/tests/core/network-db/test_connection_tracker_server.py
@@ -1,6 +1,7 @@
 import asyncio
 import pytest
 
+from async_service import background_asyncio_service
 from lahja import BroadcastConfig
 
 from p2p.tools.factories import NodeFactory
@@ -27,25 +28,23 @@ async def test_connection_tracker_server_and_client(event_loop, event_bus):
     service = ConnectionTrackerServer(event_bus, tracker)
 
     # start the server
-    asyncio.ensure_future(service.run(), loop=event_loop)
-    await service.events.started.wait()
+    async with background_asyncio_service(service):
+        config = BroadcastConfig(filter_endpoint=NETWORKING_EVENTBUS_ENDPOINT)
+        bus_tracker = ConnectionTrackerClient(event_bus, config=config)
 
-    config = BroadcastConfig(filter_endpoint=NETWORKING_EVENTBUS_ENDPOINT)
-    bus_tracker = ConnectionTrackerClient(event_bus, config=config)
+        # Give `bus_tracker` a moment to setup subscriptions
+        await event_bus.wait_until_any_endpoint_subscribed_to(ShouldConnectToPeerRequest)
+        # ensure we can read from the tracker over the event bus
+        assert await bus_tracker.should_connect_to(remote_a) is False
 
-    # Give `bus_tracker` a moment to setup subscriptions
-    await event_bus.wait_until_any_endpoint_subscribed_to(ShouldConnectToPeerRequest)
-    # ensure we can read from the tracker over the event bus
-    assert await bus_tracker.should_connect_to(remote_a) is False
+        # ensure we can write to the tracker over the event bus
+        remote_b = NodeFactory()
 
-    # ensure we can write to the tracker over the event bus
-    remote_b = NodeFactory()
+        assert await bus_tracker.should_connect_to(remote_b) is True
 
-    assert await bus_tracker.should_connect_to(remote_b) is True
+        bus_tracker.record_blacklist(remote_b, 60, "testing")
+        # let the underlying broadcast_nowait execute
+        await asyncio.sleep(0.01)
 
-    bus_tracker.record_blacklist(remote_b, 60, "testing")
-    # let the underlying broadcast_nowait execute
-    await asyncio.sleep(0.01)
-
-    assert await bus_tracker.should_connect_to(remote_b) is False
-    assert await tracker.should_connect_to(remote_b) is False
+        assert await bus_tracker.should_connect_to(remote_b) is False
+        assert await tracker.should_connect_to(remote_b) is False

--- a/tests/integration/test_trinity_cli.py
+++ b/tests/integration/test_trinity_cli.py
@@ -242,9 +242,9 @@ async def test_does_not_throw_errors_on_short_run(command, unused_tcp_port):
         ),
         (   # Enable DEBUG2 logs for everything except discovery which is reduced to ERROR logs
             ('trinity', '-l=DEBUG2', '-l', 'p2p.discovery=ERROR'),
-            {'Started main process', 'ConnectionTrackerServer  Running task <coroutine object'},
+            {'Started main process', '<Manager[ConnectionTrackerServer] SRcfe>: running root task run[daemon=False]'},  # noqa: E501
             {'>>> ping'},
-            {'Started main process', 'ConnectionTrackerServer  Running task <coroutine object'},
+            {'Started main process', '<Manager[ConnectionTrackerServer] SRcfe>: running root task run[daemon=False]'},  # noqa: E501
             {'>>> ping'},
         ),
         pytest.param(

--- a/trinity/components/builtin/network_db/connection/server.py
+++ b/trinity/components/builtin/network_db/connection/server.py
@@ -1,10 +1,8 @@
 from lahja import EndpointAPI
 
-from cancel_token import CancelToken
+from async_service import Service
+from eth_utils import get_extended_debug_logger, humanize_seconds
 
-from eth_utils import humanize_seconds
-
-from p2p.service import BaseService
 from p2p.tracking.connection import BaseConnectionTracker
 
 from .events import (
@@ -14,22 +12,21 @@ from .events import (
 )
 
 
-class ConnectionTrackerServer(BaseService):
+class ConnectionTrackerServer(Service):
     """
     Server to handle the event bus communication for BlacklistEvent and
     ShouldConnectToPeerRequest/Response events
     """
+    logger = get_extended_debug_logger('trinity.components.network_db.ConnectionTrackerServer')
 
     def __init__(self,
                  event_bus: EndpointAPI,
-                 tracker: BaseConnectionTracker,
-                 token: CancelToken = None) -> None:
-        super().__init__(token)
+                 tracker: BaseConnectionTracker) -> None:
         self.tracker = tracker
         self.event_bus = event_bus
 
     async def handle_should_connect_to_requests(self) -> None:
-        async for req in self.wait_iter(self.event_bus.stream(ShouldConnectToPeerRequest)):
+        async for req in self.event_bus.stream(ShouldConnectToPeerRequest):
             self.logger.debug2('Received should connect to request: %s', req.remote)
             should_connect = await self.tracker.should_connect_to(req.remote)
             await self.event_bus.broadcast(
@@ -38,7 +35,7 @@ class ConnectionTrackerServer(BaseService):
             )
 
     async def handle_blacklist_command(self) -> None:
-        async for command in self.wait_iter(self.event_bus.stream(BlacklistEvent)):
+        async for command in self.event_bus.stream(BlacklistEvent):
             self.logger.debug2(
                 'Received blacklist commmand: remote: %s | timeout: %s | reason: %s',
                 command.remote,
@@ -51,10 +48,16 @@ class ConnectionTrackerServer(BaseService):
                 command.reason
             )
 
-    async def _run(self) -> None:
+    async def run(self) -> None:
         self.logger.debug("Running ConnectionTrackerServer")
 
-        self.run_daemon_task(self.handle_should_connect_to_requests())
-        self.run_daemon_task(self.handle_blacklist_command())
+        self.manager.run_daemon_task(
+            self.handle_should_connect_to_requests,
+            name='ConnectionTrackerServer.handle_should_connect_to_requests',
+        )
+        self.manager.run_daemon_task(
+            self.handle_blacklist_command,
+            name='ConnectionTrackerServer.handle_blacklist_command',
+        )
 
-        await self.cancellation()
+        await self.manager.wait_finished()


### PR DESCRIPTION
### What was wrong?

The networkdb component isn't using the nice new `async-service` APIs

### How was it fixed?

Converted the component to use the new `async-service` APIs


#### Cute Animal Picture

![animal-dogs-in-costumes-s-zone-dogs-christmas-funny-animal-in-costumes-s-zone-pictures-images-photos-pi-pictures-christmas-funny-animal-1024x915](https://user-images.githubusercontent.com/824194/70747466-4e010680-1ce5-11ea-9d58-e530ad01f9ae.jpg)
