### PR TITLE
Upgrade py-evm for Istanbul compatibility

### DIFF
--- a/newsfragments/1376.bugfix.rst
+++ b/newsfragments/1376.bugfix.rst
@@ -1,0 +1,4 @@
+Upgraded py-evm to fix the error: `` KeyError: (b'\x03', 'key could not be deleted in JournalDB,
+because it was missing')``, while importing Istanbul blocks. See `other py-evm changes from
+v0.3.0-alpha.11
+<https://py-evm.readthedocs.io/en/latest/release_notes.html#py-evm-0-3-0-alpha-11-2019-12-12>`_

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ import os
 import re
 from setuptools import setup, find_packages
 
-PYEVM_DEPENDENCY = "py-evm==0.3.0a10"
+PYEVM_DEPENDENCY = "py-evm==0.3.0a11"
 
 
 deps = {


### PR DESCRIPTION
### What was wrong?

There's one last (known) critical bug in Istanbul: #1376 

### How was it fixed?

Upgraded py-evm:
See https://py-evm.readthedocs.io/en/latest/release_notes.html#py-evm-0-3-0-alpha-11-2019-12-12

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

[//]: # (See: https://trinity-client.readthedocs.io/en/latest/contributing.html#pull-requests)
- [x] Add entry to the [release notes](https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://cf.ltkcdn.net/dogs/images/std/217266-342x342-Pug-with-tirita.jpg)