### PR TITLE
Set up eth1 monitor component

### DIFF
--- a/eth2/beacon/scripts/quickstart_state/generate_beacon_genesis.py
+++ b/eth2/beacon/scripts/quickstart_state/generate_beacon_genesis.py
@@ -1,12 +1,13 @@
 from pathlib import Path
 import time
 
-from eth_utils import decode_hex
 import ssz
 
-from eth2._utils.hash import hash_eth2
 from eth2.beacon.genesis import initialize_beacon_state_from_eth1
-from eth2.beacon.tools.builder.initializer import create_mock_deposits_and_root
+from eth2.beacon.tools.builder.initializer import (
+    create_keypair_and_mock_withdraw_credentials,
+    create_mock_deposits_and_root,
+)
 from eth2.beacon.tools.fixtures.config_types import Minimal
 from eth2.beacon.tools.fixtures.loading import load_config_at_path, load_yaml_at
 from eth2.beacon.tools.misc.ssz_vector import override_lengths
@@ -30,22 +31,14 @@ def _main():
 
     key_set = load_yaml_at(KEY_DIR / KEY_SET_FILE)
 
-    pubkeys = ()
-    privkeys = ()
-    withdrawal_credentials = ()
-    keymap = {}
-    for key_pair in key_set:
-        pubkey = decode_hex(key_pair["pubkey"])
-        privkey = int.from_bytes(decode_hex(key_pair["privkey"]), "big")
-        withdrawal_credential = (
-            config.BLS_WITHDRAWAL_PREFIX.to_bytes(1, byteorder="big")
-            + hash_eth2(pubkey)[1:]
-        )
-
-        pubkeys += (pubkey,)
-        privkeys += (privkey,)
-        withdrawal_credentials += (withdrawal_credential,)
-        keymap[pubkey] = privkey
+    pubkeys, privkeys, withdrawal_credentials = create_keypair_and_mock_withdraw_credentials(
+        config,
+        key_set,
+    )
+    keymap = {
+        pubkey: privkey
+        for pubkey, privkey in zip(pubkeys, privkeys)
+    }
 
     deposits, _ = create_mock_deposits_and_root(
         pubkeys, keymap, config, withdrawal_credentials

--- a/eth2/beacon/scripts/quickstart_state/generate_beacon_genesis.py
+++ b/eth2/beacon/scripts/quickstart_state/generate_beacon_genesis.py
@@ -32,13 +32,9 @@ def _main():
     key_set = load_yaml_at(KEY_DIR / KEY_SET_FILE)
 
     pubkeys, privkeys, withdrawal_credentials = create_keypair_and_mock_withdraw_credentials(
-        config,
-        key_set,
+        config, key_set
     )
-    keymap = {
-        pubkey: privkey
-        for pubkey, privkey in zip(pubkeys, privkeys)
-    }
+    keymap = {pubkey: privkey for pubkey, privkey in zip(pubkeys, privkeys)}
 
     deposits, _ = create_mock_deposits_and_root(
         pubkeys, keymap, config, withdrawal_credentials

--- a/eth2/beacon/tools/builder/initializer.py
+++ b/eth2/beacon/tools/builder/initializer.py
@@ -1,7 +1,8 @@
-from typing import Dict, Sequence, Tuple, Type
+from typing import Any, Dict, Sequence, Tuple, Type
 
 from eth.constants import ZERO_HASH32
 from eth_typing import BLSPubkey, Hash32
+from eth_utils import decode_hex
 from py_ecc.optimized_bls12_381.optimized_curve import (
     curve_order as BLS12_381_CURVE_ORDER,
 )
@@ -30,6 +31,27 @@ def generate_privkey_from_index(index: int) -> int:
         )
         % BLS12_381_CURVE_ORDER
     )
+
+
+def create_keypair_and_mock_withdraw_credentials(
+    config: Eth2Config,
+    key_set: Dict[str, Any],
+) -> Tuple[Sequence[BLSPubkey], Sequence[int], Sequence[Hash32]]:
+    pubkeys = ()
+    privkeys = ()
+    withdrawal_credentials = ()
+    for key_pair in key_set:
+        pubkey = decode_hex(key_pair["pubkey"])
+        privkey = int.from_bytes(decode_hex(key_pair["privkey"]), "big")
+        withdrawal_credential = (
+            config.BLS_WITHDRAWAL_PREFIX.to_bytes(1, byteorder="big")
+            + hash_eth2(pubkey)[1:]
+        )
+
+        pubkeys += (pubkey,)
+        privkeys += (privkey,)
+        withdrawal_credentials += (withdrawal_credential,)
+    return (pubkeys, privkeys, withdrawal_credentials)
 
 
 def create_mock_deposits_and_root(

--- a/eth2/beacon/tools/builder/initializer.py
+++ b/eth2/beacon/tools/builder/initializer.py
@@ -34,16 +34,15 @@ def generate_privkey_from_index(index: int) -> int:
 
 
 def create_keypair_and_mock_withdraw_credentials(
-    config: Eth2Config,
-    key_set: Dict[str, Any],
-) -> Tuple[Sequence[BLSPubkey], Sequence[int], Sequence[Hash32]]:
-    pubkeys = ()
-    privkeys = ()
-    withdrawal_credentials = ()
+    config: Eth2Config, key_set: Sequence[Dict[str, Any]]
+) -> Tuple[Tuple[BLSPubkey, ...], Tuple[int, ...], Tuple[Hash32, ...]]:
+    pubkeys: Tuple[BLSPubkey, ...] = ()
+    privkeys: Tuple[int, ...] = ()
+    withdrawal_credentials: Tuple[Hash32, ...] = ()
     for key_pair in key_set:
-        pubkey = decode_hex(key_pair["pubkey"])
+        pubkey = BLSPubkey(decode_hex(key_pair["pubkey"]))
         privkey = int.from_bytes(decode_hex(key_pair["privkey"]), "big")
-        withdrawal_credential = (
+        withdrawal_credential = Hash32(
             config.BLS_WITHDRAWAL_PREFIX.to_bytes(1, byteorder="big")
             + hash_eth2(pubkey)[1:]
         )
@@ -51,6 +50,7 @@ def create_keypair_and_mock_withdraw_credentials(
         pubkeys += (pubkey,)
         privkeys += (privkey,)
         withdrawal_credentials += (withdrawal_credential,)
+
     return (pubkeys, privkeys, withdrawal_credentials)
 
 

--- a/tests-trio/eth1-monitor/conftest.py
+++ b/tests-trio/eth1-monitor/conftest.py
@@ -20,6 +20,7 @@ from lahja import ConnectionConfig
 
 from trinity.components.eth2.eth1_monitor.configs import deposit_contract_json
 from trinity.components.eth2.eth1_monitor.eth1_monitor import Eth1Monitor
+from trinity.components.eth2.eth1_monitor.eth1_data_provider import Web3Eth1DataProvider
 from trinity.components.eth2.eth1_monitor.factories import DepositDataFactory
 from trinity.tools.factories.db import AtomicDBFactory
 
@@ -83,18 +84,24 @@ def func_do_deposit(w3, deposit_contract):
 
 
 @pytest.fixture
+async def eth1_data_provider(w3, deposit_contract):
+    return Web3Eth1DataProvider(
+        w3=w3,
+        deposit_contract_address=deposit_contract.address,
+        deposit_contract_abi=deposit_contract.abi,
+    )
+
+
+@pytest.fixture
 async def eth1_monitor(
-    w3,
-    deposit_contract,
+    eth1_data_provider,
     num_blocks_confirmed,
     polling_period,
     endpoint_server,
     start_block_number,
 ):
     m = Eth1Monitor(
-        w3=w3,
-        deposit_contract_address=deposit_contract.address,
-        deposit_contract_abi=deposit_contract.abi,
+        eth1_data_provider=eth1_data_provider,
         num_blocks_confirmed=num_blocks_confirmed,
         polling_period=polling_period,
         start_block_number=start_block_number,

--- a/tests-trio/eth1-monitor/test_eth1_monitor.py
+++ b/tests-trio/eth1-monitor/test_eth1_monitor.py
@@ -28,8 +28,7 @@ from trinity.tools.factories.db import AtomicDBFactory
 
 @pytest.mark.trio
 async def test_logs_handling(
-    w3,
-    deposit_contract,
+    eth1_data_provider,
     tester,
     num_blocks_confirmed,
     polling_period,
@@ -40,9 +39,7 @@ async def test_logs_handling(
     amount_0 = func_do_deposit()
     amount_1 = func_do_deposit()
     m = Eth1Monitor(
-        w3=w3,
-        deposit_contract_address=deposit_contract.address,
-        deposit_contract_abi=deposit_contract.abi,
+        eth1_data_provider=eth1_data_provider,
         num_blocks_confirmed=num_blocks_confirmed,
         polling_period=polling_period,
         start_block_number=start_block_number,

--- a/trinity/components/eth2/beacon/validator.py
+++ b/trinity/components/eth2/beacon/validator.py
@@ -80,6 +80,10 @@ from trinity.protocol.bcc_libp2p.node import Node
 GetReadyAttestationsFn = Callable[[Slot], Sequence[Attestation]]
 
 
+# FIXME: Read this from validator config
+ETH1_FOLLOW_DISTANCE = 16
+
+
 class Validator(BaseService):
     chain: BaseBeaconChain
     p2p_node: Node

--- a/trinity/components/eth2/eth1_monitor/component.py
+++ b/trinity/components/eth2/eth1_monitor/component.py
@@ -1,0 +1,90 @@
+from argparse import (
+    ArgumentParser,
+    _SubParsersAction,
+)
+import json
+import time
+
+from async_service import Service, TrioManager
+
+from lahja import EndpointAPI
+
+# from web3 import Web3
+
+from trinity.components.eth2.eth1_monitor.configs import deposit_contract_json
+from trinity.components.eth2.eth1_monitor.eth1_data_provider import FakeEth1DataProvider
+from trinity.config import BeaconAppConfig
+from trinity.db.manager import DBClient
+from trinity.events import ShutdownRequest
+from trinity.extensibility import (
+    TrioIsolatedComponent,
+)
+
+
+from .eth1_monitor import Eth1Monitor
+
+
+# Fake eth1 monitor config
+# TODO: These configs should be read from a config file, e.g., `eth1_monitor_config.yaml`.
+DEPOSIT_CONTRACT_ABI = json.loads(deposit_contract_json)["abi"]
+DEPOSIT_CONTRACT_ADDRESS = b"\x12" * 20
+NUM_BLOCKS_CONFIRMED = 100
+POLLING_PERIOD = 10
+START_BLOCK_NUMBER = 1
+
+# Configs for fake Eth1DataProvider
+NUM_DEPOSITS_PER_BLOCK = 5
+START_BLOCK_TIMESTAMP = int(time.time()) - 2100  # Around half an hour ago
+
+
+class Eth1MonitorComponent(TrioIsolatedComponent):
+
+    @property
+    def name(self) -> str:
+        return "Eth1 Monitor"
+
+    def on_ready(self, manager_eventbus: EndpointAPI) -> None:
+        if self.boot_info.trinity_config.has_app_config(BeaconAppConfig):
+            self.start()
+
+    @classmethod
+    def configure_parser(cls,
+                         arg_parser: ArgumentParser,
+                         subparser: _SubParsersAction) -> None:
+        # TODO: For now we use fake eth1 monitor.
+        pass
+        # arg_parser.add_argument(
+        #     "--eth1client-rpc",
+        #     help="RPC HTTP endpoint of Eth1 client ",
+        # )
+
+    async def run(self) -> None:
+        trinity_config = self.boot_info.trinity_config
+
+        # TODO: For now we use fake eth1 monitor.
+        # if self.boot_info.args.eth1client_rpc:
+        #     w3: Web3 = Web3.HTTPProvider(self.boot_info.args.eth1client_rpc)
+        # else:
+        #     w3: Web3 = None
+        fake_eth1_data_provider = FakeEth1DataProvider(
+            start_block_number=START_BLOCK_NUMBER,
+            start_block_timestamp=START_BLOCK_TIMESTAMP,
+            num_deposits_per_block=NUM_DEPOSITS_PER_BLOCK,
+        )
+
+        base_db = DBClient.connect(trinity_config.database_ipc_path)
+
+        eth1_monitor_service: Service = Eth1Monitor(
+            eth1_data_provider=fake_eth1_data_provider,
+            num_blocks_confirmed=NUM_BLOCKS_CONFIRMED,
+            polling_period=POLLING_PERIOD,
+            start_block_number=START_BLOCK_NUMBER,
+            event_bus=self.event_bus,
+            base_db=base_db,
+        )
+
+        try:
+            await TrioManager.run_service(eth1_monitor_service)
+        except Exception:
+            await self.event_bus.broadcast(ShutdownRequest("Eth1 Monitor ended unexpectedly"))
+            raise

--- a/trinity/components/eth2/eth1_monitor/component.py
+++ b/trinity/components/eth2/eth1_monitor/component.py
@@ -91,7 +91,7 @@ class Eth1MonitorComponent(TrioIsolatedComponent):
         )
         pubkeys, privkeys, withdrawal_credentials = create_keypair_and_mock_withdraw_credentials(
             config,
-            key_set,
+            key_set,  # type: ignore
         )
         initial_deposits = (
             create_mock_deposit_data(

--- a/trinity/components/eth2/eth1_monitor/db.py
+++ b/trinity/components/eth2/eth1_monitor/db.py
@@ -114,16 +114,17 @@ class DepositDataDB(BaseDepositDataDB):
     ) -> None:
         self.db = db
         self._deposit_count = self._get_deposit_count()
-        # If the parameter `highest_processed_block_number` is given, set it in the database.
+        latest_processed_block_number = self._get_highest_processed_block_number()
         if highest_processed_block_number is not None:
             if highest_processed_block_number < 0:
                 raise DepositDataDBValidationError(
                     "`highest_processed_block_number` should be non-negative: "
                     f"highest_processed_block_number={highest_processed_block_number}"
                 )
-            self._set_highest_processed_block_number(
-                self.db, highest_processed_block_number
-            )
+            elif highest_processed_block_number > latest_processed_block_number:
+                self._set_highest_processed_block_number(
+                    self.db, highest_processed_block_number
+                )
         self._highest_processed_block_number = (
             self._get_highest_processed_block_number()
         )

--- a/trinity/components/eth2/eth1_monitor/eth1_data_provider.py
+++ b/trinity/components/eth2/eth1_monitor/eth1_data_provider.py
@@ -1,21 +1,46 @@
 from abc import ABC, abstractmethod
-from typing import Any, Dict, Optional, Tuple
+from typing import Any, Dict, NamedTuple, Tuple, Union
 
-from eth_typing import Address, BlockNumber, Hash32
+from eth_typing import Address, BLSPubkey, BLSSignature, BlockNumber, Hash32
 
 from eth_utils import encode_hex, event_abi_to_log_topic
 from web3 import Web3
 from web3.utils.events import get_event_data
 
-from eth2.beacon.typing import Timestamp
+from eth2.beacon.typing import Gwei, Timestamp
 
-from .eth1_monitor import Eth1Block, DepositLog
+
+class Eth1Block(NamedTuple):
+    block_hash: Hash32
+    number: BlockNumber
+    timestamp: Timestamp
+
+
+class DepositLog(NamedTuple):
+    block_hash: Hash32
+    pubkey: BLSPubkey
+    # NOTE: The following noqa is to avoid a bug in pycodestyle. We can remove it after upgrading
+    #   `flake8`. Ref: https://github.com/PyCQA/pycodestyle/issues/635#issuecomment-411916058
+    withdrawal_credentials: Hash32  # noqa: E701
+    amount: Gwei
+    signature: BLSSignature
+
+    @classmethod
+    def from_contract_log_dict(cls, log: Dict[Any, Any]) -> "DepositLog":
+        log_args = log["args"]
+        return cls(
+            block_hash=log["blockHash"],
+            pubkey=log_args["pubkey"],
+            withdrawal_credentials=log_args["withdrawal_credentials"],
+            amount=Gwei(int.from_bytes(log_args["amount"], "little")),
+            signature=log_args["signature"],
+        )
 
 
 class BaseEth1DataProvider(ABC):
 
     @abstractmethod
-    def get_block(self, arg: Optional[int, str]) -> Eth1Block:
+    def get_block(self, arg: Union[BlockNumber, str]) -> Eth1Block:
         ...
 
     @abstractmethod
@@ -23,7 +48,7 @@ class BaseEth1DataProvider(ABC):
         ...
 
     @abstractmethod
-    def get_deposit_count(self, block_number: BlockNumber) -> int:
+    def get_deposit_count(self, block_number: BlockNumber) -> bytes:
         ...
 
     @abstractmethod
@@ -46,7 +71,7 @@ class Web3Eth1DataProvider(BaseEth1DataProvider):
         deposit_contract_abi: Dict[str, Any],
     ) -> None:
         self.w3 = w3
-        self._deposit_contract = self._w3.eth.contract(
+        self._deposit_contract = self.w3.eth.contract(
             address=deposit_contract_address, abi=deposit_contract_abi
         )
         self._deposit_event_abi = (
@@ -56,8 +81,8 @@ class Web3Eth1DataProvider(BaseEth1DataProvider):
             event_abi_to_log_topic(self._deposit_event_abi)
         )
 
-    def get_block(self, arg: Optional[int, str]) -> Eth1Block:
-        block_dict = self._w3.eth.getBlock(arg)
+    def get_block(self, arg: Union[int, str]) -> Eth1Block:
+        block_dict = self.w3.eth.getBlock(arg)
         return Eth1Block(
             block_hash=Hash32(block_dict["hash"]),
             number=BlockNumber(block_dict["number"]),
@@ -67,7 +92,7 @@ class Web3Eth1DataProvider(BaseEth1DataProvider):
     def get_logs(self, block_number: BlockNumber) -> Tuple[DepositLog, ...]:
         # NOTE: web3 v4 does not support `contract.events.Event.getLogs`.
         # After upgrading to v5, we can change to use the function.
-        logs = self._w3.eth.getLogs(
+        logs = self.w3.eth.getLogs(
             {
                 "fromBlock": block_number,
                 "toBlock": block_number,
@@ -83,7 +108,7 @@ class Web3Eth1DataProvider(BaseEth1DataProvider):
         )
         return parsed_logs
 
-    def get_deposit_count(self, block_number: BlockNumber) -> int:
+    def get_deposit_count(self, block_number: BlockNumber) -> bytes:
         return self._deposit_contract.functions.get_deposit_count().call(
             block_identifier=block_number
         )

--- a/trinity/components/eth2/eth1_monitor/eth1_data_provider.py
+++ b/trinity/components/eth2/eth1_monitor/eth1_data_provider.py
@@ -2,9 +2,11 @@ from abc import ABC, abstractmethod
 import time
 from typing import Any, Dict, NamedTuple, Optional, Tuple, Union
 
-from eth_typing import Address, BLSPubkey, BLSSignature, BlockNumber, Hash32
+from eth.exceptions import BlockNotFound
 
+from eth_typing import Address, BLSPubkey, BLSSignature, BlockNumber, Hash32
 from eth_utils import encode_hex, event_abi_to_log_topic
+
 from web3 import Web3
 from web3.utils.events import get_event_data
 
@@ -98,7 +100,7 @@ class Web3Eth1DataProvider(BaseEth1DataProvider):
     def get_block(self, arg: Union[Hash32, int, str]) -> Optional[Eth1Block]:
         block_dict = self.w3.eth.getBlock(arg)
         if block_dict is None:
-            return None
+            raise BlockNotFound
         return Eth1Block(
             block_hash=Hash32(block_dict["hash"]),
             number=BlockNumber(block_dict["number"]),

--- a/trinity/components/eth2/eth1_monitor/eth1_data_provider.py
+++ b/trinity/components/eth2/eth1_monitor/eth1_data_provider.py
@@ -1,0 +1,94 @@
+from abc import ABC, abstractmethod
+from typing import Any, Dict, Optional, Tuple
+
+from eth_typing import Address, BlockNumber, Hash32
+
+from eth_utils import encode_hex, event_abi_to_log_topic
+from web3 import Web3
+from web3.utils.events import get_event_data
+
+from eth2.beacon.typing import Timestamp
+
+from .eth1_monitor import Eth1Block, DepositLog
+
+
+class BaseEth1DataProvider(ABC):
+
+    @abstractmethod
+    def get_block(self, arg: Optional[int, str]) -> Eth1Block:
+        ...
+
+    @abstractmethod
+    def get_logs(self, block_number: BlockNumber) -> Tuple[DepositLog, ...]:
+        ...
+
+    @abstractmethod
+    def get_deposit_count(self, block_number: BlockNumber) -> int:
+        ...
+
+    @abstractmethod
+    def get_deposit_root(self, block_number: BlockNumber) -> Hash32:
+        ...
+
+
+class Web3Eth1DataProvider(BaseEth1DataProvider):
+
+    w3: Web3
+
+    _deposit_contract: "Web3.eth.contract"
+    _deposit_event_abi: Dict[str, Any]
+    _deposit_event_topic: str
+
+    def __init__(
+        self,
+        w3: Web3,
+        deposit_contract_address: Address,
+        deposit_contract_abi: Dict[str, Any],
+    ) -> None:
+        self.w3 = w3
+        self._deposit_contract = self._w3.eth.contract(
+            address=deposit_contract_address, abi=deposit_contract_abi
+        )
+        self._deposit_event_abi = (
+            self._deposit_contract.events.DepositEvent._get_event_abi()
+        )
+        self._deposit_event_topic = encode_hex(
+            event_abi_to_log_topic(self._deposit_event_abi)
+        )
+
+    def get_block(self, arg: Optional[int, str]) -> Eth1Block:
+        block_dict = self._w3.eth.getBlock(arg)
+        return Eth1Block(
+            block_hash=Hash32(block_dict["hash"]),
+            number=BlockNumber(block_dict["number"]),
+            timestamp=Timestamp(block_dict["timestamp"]),
+        )
+
+    def get_logs(self, block_number: BlockNumber) -> Tuple[DepositLog, ...]:
+        # NOTE: web3 v4 does not support `contract.events.Event.getLogs`.
+        # After upgrading to v5, we can change to use the function.
+        logs = self._w3.eth.getLogs(
+            {
+                "fromBlock": block_number,
+                "toBlock": block_number,
+                "address": self._deposit_contract.address,
+                "topics": [self._deposit_event_topic],
+            }
+        )
+        parsed_logs = tuple(
+            DepositLog.from_contract_log_dict(
+                get_event_data(self._deposit_event_abi, log)
+            )
+            for log in logs
+        )
+        return parsed_logs
+
+    def get_deposit_count(self, block_number: BlockNumber) -> int:
+        return self._deposit_contract.functions.get_deposit_count().call(
+            block_identifier=block_number
+        )
+
+    def get_deposit_root(self, block_number: BlockNumber) -> Hash32:
+        return self._deposit_contract.functions.get_deposit_root().call(
+            block_identifier=block_number
+        )

--- a/trinity/components/eth2/eth1_monitor/eth1_monitor.py
+++ b/trinity/components/eth2/eth1_monitor/eth1_monitor.py
@@ -222,7 +222,7 @@ class Eth1Monitor(Service):
                     f"deposit_root={deposit_root.hex()}"
                 )
         return Eth1Data(
-            deposit_root=contract_deposit_root,
+            deposit_root=deposit_root,
             deposit_count=accumulated_deposit_count,
             block_hash=block_hash,
         )

--- a/trinity/components/eth2/eth1_monitor/eth1_monitor.py
+++ b/trinity/components/eth2/eth1_monitor/eth1_monitor.py
@@ -213,14 +213,12 @@ class Eth1Monitor(Service):
         contract_deposit_root = self._get_deposit_root_from_contract(
             target_block_number
         )
-        # TODO: Remove this if we no longer need a fake provider
-        if not self._eth1_data_provider.is_fake_provider:
-            if contract_deposit_root != deposit_root:
-                raise DepositDataCorrupted(
-                    "deposit root built locally mismatches the one in the contract on chain: "
-                    f"contract_deposit_root={contract_deposit_root.hex()}, "
-                    f"deposit_root={deposit_root.hex()}"
-                )
+        if contract_deposit_root != deposit_root:
+            raise DepositDataCorrupted(
+                "deposit root built locally mismatches the one in the contract on chain: "
+                f"contract_deposit_root={contract_deposit_root.hex()}, "
+                f"deposit_root={deposit_root.hex()}"
+            )
         return Eth1Data(
             deposit_root=deposit_root,
             deposit_count=accumulated_deposit_count,

--- a/trinity/components/eth2/eth1_monitor/eth1_monitor.py
+++ b/trinity/components/eth2/eth1_monitor/eth1_monitor.py
@@ -62,6 +62,7 @@ def _w3_get_block(w3: Web3, *args: Any, **kwargs: Any) -> Eth1Block:
 
 
 class Eth1Monitor(Service):
+    logger = logging.getLogger('trinity.eth1_monitor')
 
     _eth1_data_provider: BaseEth1DataProvider
 
@@ -281,7 +282,6 @@ class Eth1Monitor(Service):
                 raise Eth1MonitorValidationError(f"Fail to get latest block")
             target_block_number = BlockNumber(block.number - self._num_blocks_confirmed)
             from_block_number = self.highest_processed_block_number
-            self.logger.info("Eth1 Data Provider latest block: %s, %s, %s", block.number, target_block_number, from_block_number)
             if target_block_number > from_block_number:
                 # From `highest_processed_block_number` to `target_block_number`
                 for block_number in range(

--- a/trinity/components/eth2/eth1_monitor/events.py
+++ b/trinity/components/eth2/eth1_monitor/events.py
@@ -4,7 +4,7 @@ import ssz
 
 from lahja import BaseEvent, BaseRequestResponseEvent
 
-from eth_typing import BlockNumber
+from eth_typing import BlockNumber, Hash32
 
 from eth2.beacon.typing import Timestamp
 from eth2.beacon.types.deposits import Deposit
@@ -58,3 +58,19 @@ class GetEth1DataRequest(BaseRequestResponseEvent[GetEth1DataResponse]):
     @staticmethod
     def expected_response_type() -> Type[GetEth1DataResponse]:
         return GetEth1DataResponse
+
+
+@dataclass
+class GetDistanceResponse(BaseEvent):
+    distance: int
+    error: Exception = None
+
+
+@dataclass
+class GetDistanceRequest(BaseRequestResponseEvent[GetDistanceResponse]):
+    block_hash: Hash32
+    eth1_voting_period_start_timestamp: Timestamp
+
+    @staticmethod
+    def expected_response_type() -> Type[GetDistanceResponse]:
+        return GetDistanceResponse

--- a/trinity/components/registry.py
+++ b/trinity/components/registry.py
@@ -49,6 +49,7 @@ from trinity.components.builtin.upnp.component import (
     UpnpComponent,
 )
 from trinity.components.eth2.beacon.component import BeaconNodeComponent
+from trinity.components.eth2.eth1_monitor.component import Eth1MonitorComponent
 from trinity.components.eth2.interop.component import InteropComponent
 from trinity.components.builtin.tx_pool.component import (
     TxComponent,
@@ -68,6 +69,7 @@ BASE_COMPONENTS: Tuple[Type[BaseComponentAPI], ...] = (
 BEACON_NODE_COMPONENTS: Tuple[Type[BaseComponentAPI], ...] = (
     BeaconNodeComponent,
     InteropComponent,
+    Eth1MonitorComponent,
 )
 
 


### PR DESCRIPTION
### How was it fixed?
Set up eth1 monitor so that beacon node can request `Eth1Data` and `Deposit` from eth1 monitor.
This is the first part: set up eth1 monitor component.
- [x] Abstract the eth1 data provider.
    - For local running testnet, a fake eth1 data provider will be used.
        - It deterministically generates eth1 block(block_hash, block_number and timestamp)
    - For interop testnet, provide the eth1 client RPC endpoint info via `--eth1client_rpc` when running `trinity-beacon`
- [x] Add `GetDistanceRequest`/`Response` to `Eth1Monitor`

**NOTE: There are some dirty hacks to get the fake eth1 data provider running. Will get rid of them in subsequent PRs, e.g.,**
- hardcoded initial deposits
    - read validator keys from `eth2/beacon/scripts/quickstart_state/keygen_16_validators.yaml` and generate those initial deposits
        - eth1 monitor need these deposit data but it's not provided in the genesis state
- hardcoded parameters like `START_BLOCK_NUMBER`, `START_BLOCK_TIMESTAMP`
- currently `NUM_DEPOSITS_PER_BLOCK` is set to `0` so no new deposits will be made

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

[//]: # (See: https://trinity-client.readthedocs.io/en/latest/contributing.html#pull-requests)
- [ ] Add entry to the [release notes](https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

#### Cute Animal Picture


![](https://p1.pxfuel.com/preview/616/549/118/cat-sweet-cute-animal.jpg)
