### PR TITLE
Make sure eth_getStorageAt pads result to 32 byte

### DIFF
--- a/newsfragments/1403.bugfix.rst
+++ b/newsfragments/1403.bugfix.rst
@@ -1,0 +1,4 @@
+Ensure ``eth_getStorageAt`` pads results to 32 byte
+
+See: https://github.com/ethereum/wiki/wiki/JSON-RPC#eth_getstorageat
+Geth Example: https://api.etherscan.io/api?module=proxy&action=eth_getStorageAt&address=0x6e03d9cce9d60f3e9f2597e13cd4c54c55330cfd&position=0x0&tag=latest&apikey=YourApiKeyToken

--- a/tests/core/json-rpc/test_rpc_during_beam_sync.py
+++ b/tests/core/json-rpc/test_rpc_during_beam_sync.py
@@ -281,7 +281,8 @@ async def test_getStorageAt_during_beam_sync(
     # sanity check, by default it works
     response = await ipc_request('eth_getStorageAt', params)
     assert 'error' not in response
-    assert response['result'] == '0x01'  # this was set in the genesis_state fixture
+    # this was set in the genesis_state fixture
+    assert response['result'] == '0x0000000000000000000000000000000000000000000000000000000000000001'  # noqa: E501
 
     missing_node = chain.chaindb.db.pop(storage_root)
 
@@ -294,7 +295,8 @@ async def test_getStorageAt_during_beam_sync(
     async with fake_beam_syncer({storage_root: missing_node}):
         response = await ipc_request('eth_getStorageAt', params)
         assert 'error' not in response
-        assert response['result'] == '0x01'  # this was set in the genesis_state fixture
+        # this was set in the genesis_state fixture
+        assert response['result'] == '0x0000000000000000000000000000000000000000000000000000000000000001'  # noqa: E501
 
 
 @pytest.fixture

--- a/trinity/rpc/modules/eth.py
+++ b/trinity/rpc/modules/eth.py
@@ -43,6 +43,9 @@ from eth.rlp.headers import (
 from eth.vm.spoof import (
     SpoofTransaction,
 )
+from eth._utils.padding import (
+    pad32,
+)
 
 from trinity.chains.base import AsyncChainAPI
 from trinity.constants import (
@@ -214,7 +217,8 @@ class Eth(Eth1ChainRPCModule):
 
         state = await state_at_block(self.chain, at_block)
         stored_val = state.get_storage(address, position)
-        return encode_hex(int_to_big_endian(stored_val))
+
+        return encode_hex(pad32(int_to_big_endian(stored_val)))
 
     @format_params(decode_hex)
     async def getTransactionByHash(self,


### PR DESCRIPTION
### What was wrong?

The return value of `eth_getStorageAt` is expected to be padded to 32 byte.
References:

[Spec](https://github.com/ethereum/wiki/wiki/JSON-RPC#eth_getstorageat)
[Geth Example](https://api.etherscan.io/api?module=proxy&action=eth_getStorageAt&address=0x6e03d9cce9d60f3e9f2597e13cd4c54c55330cfd&position=0x0&tag=latest&apikey=YourApiKeyToken)

### How was it fixed?

1. Apply padding to the values before returning them
2. Normalize the state tests as they are inconsistent

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

[//]: # (See: https://trinity-client.readthedocs.io/en/latest/contributing.html#pull-requests)
- [x] Add entry to the [release notes](https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](http://amolife.com/image/images/stories/Animals/cute_little_babies_17.jpg)
