### PR TITLE
Use newer `cimg` docker images for faster builds

### DIFF
--- a/.circleci/build_geth.sh
+++ b/.circleci/build_geth.sh
@@ -7,12 +7,12 @@ export GETH_BINARY="$HOME/.py-geth/geth-$GETH_VERSION/bin/geth"
 if [ ! -e "$GETH_BINARY" ]; then
   curl -O https://storage.googleapis.com/golang/go1.10.linux-amd64.tar.gz
   tar xvf go1.10.linux-amd64.tar.gz
-  sudo chown -R root:root ./go
-  sudo mv go /usr/local
-  sudo ln -s /usr/local/go/bin/go /usr/local/bin/go
-  sudo apt-get update;
-  sudo apt-get install -y build-essential;
+  chown -R root:root ./go
+  mv go /usr/local
+  ln -s /usr/local/go/bin/go /usr/local/bin/go
+  apt-get update;
+  apt-get install -y build-essential;
   python -m geth.install $GETH_VERSION;
 fi
-sudo ln -s $GETH_BINARY /usr/local/bin/geth
+ln -s $GETH_BINARY /usr/local/bin/geth
 geth version

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,6 +34,7 @@ common: &common
         name: run tox
         command: ~/.local/bin/tox
     - save_cache:
+        when: always
         paths:
           - .hypothesis
           - .tox
@@ -63,6 +64,7 @@ geth_steps: &geth_steps
         name: run tox
         command: ~/.local/bin/tox -r
     - save_cache:
+        when: always
         paths:
           - .tox
           - ~/.cache/pip
@@ -103,6 +105,7 @@ eth2_fixtures: &eth2_fixtures
         name: run tox
         command: ~/.local/bin/tox
     - save_cache:
+        when: always
         paths:
           - .hypothesis
           - .tox

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,10 +23,10 @@ common: &common
         when: on_fail
     - restore_cache:
         keys:
-          - cache-v1-{{ arch }}-{{ .Environment.CIRCLE_JOB }}-{{ checksum "setup.py" }}-{{ checksum "tox.ini" }}-{{ checksum "./eth2/beacon/scripts/quickstart_state/keygen_16_validators.yaml" }}
+          - cache-v4-{{ arch }}-{{ .Environment.CIRCLE_JOB }}-{{ checksum "setup.py" }}-{{ checksum "tox.ini" }}-{{ checksum "./eth2/beacon/scripts/quickstart_state/keygen_16_validators.yaml" }}
     - run:
         name: install libsnappy-dev
-        command: sudo apt install -y libsnappy-dev
+        command: apt update && apt install -y libsnappy-dev
     - run:
         name: install dependencies
         command: pip install --user tox
@@ -41,7 +41,7 @@ common: &common
           - ~/.local
           - ./eggs
           - .pytest_cache/v/eth2/bls/key-cache
-        key: cache-v1-{{ arch }}-{{ .Environment.CIRCLE_JOB }}-{{ checksum "setup.py" }}-{{ checksum "tox.ini" }}-{{ checksum "./eth2/beacon/scripts/quickstart_state/keygen_16_validators.yaml" }}
+        key: cache-v4-{{ arch }}-{{ .Environment.CIRCLE_JOB }}-{{ checksum "setup.py" }}-{{ checksum "tox.ini" }}-{{ checksum "./eth2/beacon/scripts/quickstart_state/keygen_16_validators.yaml" }}
 
 geth_steps: &geth_steps
   working_directory: ~/repo
@@ -49,10 +49,10 @@ geth_steps: &geth_steps
     - checkout
     - restore_cache:
         keys:
-          - cache-v2-{{ arch }}-{{ .Environment.CIRCLE_JOB }}-{{ checksum "setup.py" }}-{{ checksum "tox.ini" }}-{{ checksum "./.circleci/build_geth.sh" }}
+          - cache-v4-{{ arch }}-{{ .Environment.CIRCLE_JOB }}-{{ checksum "setup.py" }}-{{ checksum "tox.ini" }}-{{ checksum "./.circleci/build_geth.sh" }}
     - run:
         name: install libsnappy-dev
-        command: sudo apt install -y libsnappy-dev
+        command: apt update && apt install -y libsnappy-dev
     - run:
         name: install dependencies
         command: pip install --user tox
@@ -70,7 +70,7 @@ geth_steps: &geth_steps
           - ./eggs
           - ~/.ethash
           - ~/.py-geth
-        key: cache-v2-{{ arch }}-{{ .Environment.CIRCLE_JOB }}-{{ checksum "setup.py" }}-{{ checksum "tox.ini" }}-{{ checksum "./.circleci/build_geth.sh" }}
+        key: cache-v4-{{ arch }}-{{ .Environment.CIRCLE_JOB }}-{{ checksum "setup.py" }}-{{ checksum "tox.ini" }}-{{ checksum "./.circleci/build_geth.sh" }}
 
 eth2_fixtures: &eth2_fixtures
   working_directory: ~/repo
@@ -89,10 +89,10 @@ eth2_fixtures: &eth2_fixtures
         when: on_fail
     - restore_cache:
         keys:
-          - cache-v3-{{ arch }}-{{ .Environment.CIRCLE_JOB }}-{{ checksum "setup.py" }}-{{ checksum "tox.ini" }}-{{ checksum "./.circleci/get_eth2_fixtures.sh" }}-{{ checksum "./eth2/beacon/scripts/quickstart_state/keygen_16_validators.yaml" }}
+          - cache-v4-{{ arch }}-{{ .Environment.CIRCLE_JOB }}-{{ checksum "setup.py" }}-{{ checksum "tox.ini" }}-{{ checksum "./.circleci/get_eth2_fixtures.sh" }}-{{ checksum "./eth2/beacon/scripts/quickstart_state/keygen_16_validators.yaml" }}
     - run:
         name: install libsnappy-dev
-        command: sudo apt install -y libsnappy-dev
+        command: apt update && apt install -y libsnappy-dev
     - run:
         name: download the required yaml files if missing
         command: ./.circleci/get_eth2_fixtures.sh
@@ -111,265 +111,265 @@ eth2_fixtures: &eth2_fixtures
           - ./eggs
           - .pytest_cache/v/eth2/bls/key-cache
           - ./eth2-fixtures
-        key: cache-v3-{{ arch }}-{{ .Environment.CIRCLE_JOB }}-{{ checksum "setup.py" }}-{{ checksum "tox.ini" }}-{{ checksum "./.circleci/get_eth2_fixtures.sh" }}-{{ checksum "./.circleci/build_geth.sh" }}
+        key: cache-v4-{{ arch }}-{{ .Environment.CIRCLE_JOB }}-{{ checksum "setup.py" }}-{{ checksum "tox.ini" }}-{{ checksum "./.circleci/get_eth2_fixtures.sh" }}-{{ checksum "./.circleci/build_geth.sh" }}
 jobs:
   py36-lint:
     <<: *common
     docker:
-      - image: circleci/python:3.6
+      - image: cimg/python:3.6
         environment:
           TOXENV: py36-lint
   py37-lint:
     <<: *common
     docker:
-      - image: circleci/python:3.7
+      - image: cimg/python:3.7
         environment:
           TOXENV: py37-lint
   py36-lint-eth2:
     <<: *common
     docker:
-      - image: circleci/python:3.6
+      - image: cimg/python:3.6
         environment:
           TOXENV: py36-lint-eth2
   py37-lint-eth2:
     <<: *common
     docker:
-      - image: circleci/python:3.7
+      - image: cimg/python:3.7
         environment:
           TOXENV: py37-lint-eth2
 
   py36-docs:
     <<: *common
     docker:
-      - image: circleci/python:3.6
+      - image: cimg/python:3.6
         environment:
           TOXENV: py36-docs
 
   py36-rpc-state-byzantium:
     <<: *common
     docker:
-      - image: circleci/python:3.6
+      - image: cimg/python:3.6
         environment:
           TOXENV: py36-rpc-state-byzantium
   py36-rpc-state-constantinople:
     <<: *common
     docker:
-      - image: circleci/python:3.6
+      - image: cimg/python:3.6
         environment:
           TOXENV: py36-rpc-state-constantinople
   py36-rpc-state-frontier:
     <<: *common
     docker:
-      - image: circleci/python:3.6
+      - image: cimg/python:3.6
         environment:
           TOXENV: py36-rpc-state-frontier
   py36-rpc-state-homestead:
     <<: *common
     docker:
-      - image: circleci/python:3.6
+      - image: cimg/python:3.6
         environment:
           TOXENV: py36-rpc-state-homestead
   py36-rpc-state-petersburg:
     <<: *common
     docker:
-      - image: circleci/python:3.6
+      - image: cimg/python:3.6
         environment:
           TOXENV: py36-rpc-state-petersburg
 
   py36-rpc-state-tangerine_whistle:
     <<: *common
     docker:
-      - image: circleci/python:3.6
+      - image: cimg/python:3.6
         environment:
           TOXENV: py36-rpc-state-tangerine_whistle
   py36-rpc-state-spurious_dragon:
     <<: *common
     docker:
-      - image: circleci/python:3.6
+      - image: cimg/python:3.6
         environment:
           TOXENV: py36-rpc-state-spurious_dragon
   py36-rpc-blockchain:
     <<: *common
     docker:
-      - image: circleci/python:3.6
+      - image: cimg/python:3.6
         environment:
           TOXENV: py36-rpc-blockchain
 
   py36-eth1-core:
     <<: *common
     docker:
-      - image: circleci/python:3.6
+      - image: cimg/python:3.6
         environment:
           TOXENV: py36-eth1-core
   py36-integration:
     <<: *common
     docker:
-      - image: circleci/python:3.6
+      - image: cimg/python:3.6
         environment:
           TOXENV: py36-integration
   py36-lightchain_integration:
     <<: *geth_steps
     docker:
-      - image: circleci/python:3.6
+      - image: cimg/python:3.6
         environment:
           TOXENV: py36-lightchain_integration
           GETH_VERSION: v1.8.22
   py36-long_run_integration:
     <<: *common
     docker:
-      - image: circleci/python:3.6
+      - image: cimg/python:3.6
         environment:
           TOXENV: py36-long_run_integration
   py36-p2p:
     <<: *common
     docker:
-      - image: circleci/python:3.6
+      - image: cimg/python:3.6
         environment:
           TOXENV: py36-p2p
   py36-p2p-trio:
     <<: *common
     docker:
-      - image: circleci/python:3.6
+      - image: cimg/python:3.6
         environment:
           TOXENV: py36-p2p-trio
   py36-eth1-monitor-trio:
     <<: *common
     docker:
-      - image: circleci/python:3.6
+      - image: cimg/python:3.6
         environment:
           TOXENV: py36-eth1-monitor-trio
   py36-eth2-core:
     <<: *common
     docker:
-      - image: circleci/python:3.6
+      - image: cimg/python:3.6
         environment:
           TOXENV: py36-eth2-core
   py36-eth2-utils:
     <<: *common
     docker:
-      - image: circleci/python:3.6
+      - image: cimg/python:3.6
         environment:
           TOXENV: py36-eth2-utils
   py36-eth2-fixtures:
     <<: *eth2_fixtures
     docker:
-      - image: circleci/python:3.6
+      - image: cimg/python:3.6
         environment:
           TOXENV: py36-eth2-fixtures
   py36-eth2-integration:
     <<: *common
     docker:
-      - image: circleci/python:3.6
+      - image: cimg/python:3.6
         environment:
           TOXENV: py36-eth2-integration
   py36-wheel-cli:
     <<: *common
     docker:
-      - image: circleci/python:3.6
+      - image: cimg/python:3.6
         environment:
           TOXENV: py36-wheel-cli
   py36-eth1-components:
     <<: *common
     docker:
-      - image: circleci/python:3.6
+      - image: cimg/python:3.6
         environment:
           TOXENV: py36-eth1-components
 
   py37-rpc-state-quadratic:
     <<: *common
     docker:
-      - image: circleci/python:3.7
+      - image: cimg/python:3.7
         environment:
           TOXENV: py37-rpc-state-quadratic
   py37-rpc-state-sstore:
     <<: *common
     docker:
-      - image: circleci/python:3.7
+      - image: cimg/python:3.7
         environment:
           TOXENV: py37-rpc-state-sstore
   py37-rpc-state-zero_knowledge:
     <<: *common
     docker:
-      - image: circleci/python:3.7
+      - image: cimg/python:3.7
         environment:
           TOXENV: py37-rpc-state-zero_knowledge
 
   py37-eth1-core:
     <<: *common
     docker:
-      - image: circleci/python:3.7
+      - image: cimg/python:3.7
         environment:
           TOXENV: py37-eth1-core
   py37-integration:
     <<: *common
     docker:
-      - image: circleci/python:3.7
+      - image: cimg/python:3.7
         environment:
           TOXENV: py37-integration
   py37-p2p:
     <<: *common
     docker:
-      - image: circleci/python:3.7
+      - image: cimg/python:3.7
         environment:
           TOXENV: py37-p2p
   py37-p2p-trio:
     <<: *common
     docker:
-      - image: circleci/python:3.7
+      - image: cimg/python:3.7
         environment:
           TOXENV: py37-p2p-trio
   py37-eth1-monitor-trio:
     <<: *common
     docker:
-      - image: circleci/python:3.7
+      - image: cimg/python:3.7
         environment:
           TOXENV: py37-eth1-monitor-trio
   py37-eth2-core:
     <<: *common
     docker:
-      - image: circleci/python:3.7
+      - image: cimg/python:3.7
         environment:
           TOXENV: py37-eth2-core
   py37-eth2-utils:
     <<: *common
     docker:
-      - image: circleci/python:3.7
+      - image: cimg/python:3.7
         environment:
           TOXENV: py37-eth2-utils
   py37-eth2-fixtures:
     <<: *eth2_fixtures
     docker:
-      - image: circleci/python:3.7
+      - image: cimg/python:3.7
         environment:
           TOXENV: py37-eth2-fixtures
   py37-eth2-integration:
     <<: *common
     docker:
-      - image: circleci/python:3.7
+      - image: cimg/python:3.7
         environment:
           TOXENV: py37-eth2-integration
   py37-libp2p:
     <<: *common
     docker:
-      - image: circleci/python:3.7
+      - image: cimg/python:3.7
         environment:
           TOXENV: py37-libp2p
   py37-wheel-cli:
     <<: *common
     docker:
-      - image: circleci/python:3.7
+      - image: cimg/python:3.7
         environment:
           TOXENV: py37-wheel-cli
   py37-eth1-components:
     <<: *common
     docker:
-      - image: circleci/python:3.7
+      - image: cimg/python:3.7
         environment:
           TOXENV: py37-eth1-components
   py37-eth2-components:
     <<: *common
     docker:
-      - image: circleci/python:3.7
+      - image: cimg/python:3.7
         environment:
           TOXENV: py37-eth2-components
 


### PR DESCRIPTION
Will also improve determinism as new images from CircleCI provide more stable versioning.

Uses shared base layers with other languages to hit cache more and reduce build spinup times.

### What was wrong?
Using older CircleCI images that are larger and less deterministic.


### How was it fixed?
Switching docker images to new `cimg` type - https://github.com/CircleCI-Public/cimg-python

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

[//]: # (See: https://trinity-client.readthedocs.io/en/latest/contributing.html#pull-requests)
- [ ] Add entry to the [release notes](https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![Cheetahs are fast, there are many since this image will be better at hitting cached layers.](https://cdn.shopify.com/s/files/1/0078/8575/0369/products/Cute_Cheetah_Cubs_-_Paint_by_Diamonds_300x300.jpg?v=1571713854)
