### PR TITLE
Add support for Muir Glacier fork

### DIFF
--- a/newsfragments/1409.feature.rst
+++ b/newsfragments/1409.feature.rst
@@ -1,0 +1,1 @@
+Upgrade Py-EVM and add support for Muir Glacier fork

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ import os
 import re
 from setuptools import setup, find_packages
 
-PYEVM_DEPENDENCY = "py-evm==0.3.0a11"
+PYEVM_DEPENDENCY = "py-evm==0.3.0a12"
 
 
 deps = {

--- a/trinity/_utils/eip1085.py
+++ b/trinity/_utils/eip1085.py
@@ -54,6 +54,7 @@ from eth.vm.forks import (
     ConstantinopleVM,
     PetersburgVM,
     IstanbulVM,
+    MuirGlacierVM,
 )
 
 
@@ -155,6 +156,8 @@ def _extract_vm_config(vm_config: Dict[str, str]) -> Iterable[VMFork]:
         yield hex_to_block_number(vm_config['petersburgForkBlock']), PetersburgVM
     if 'istanbulForkBlock' in vm_config.keys():
         yield hex_to_block_number(vm_config['istanbulForkBlock']), IstanbulVM
+    if 'muirglacierForkBlock' in vm_config.keys():
+        yield hex_to_block_number(vm_config['muirglacierForkBlock']), MuirGlacierVM
 
 
 @to_tuple
@@ -178,6 +181,7 @@ ALL_VMS = (
     ConstantinopleVM,
     PetersburgVM,
     IstanbulVM,
+    MuirGlacierVM,
 )
 
 

--- a/trinity/assets/eip1085.schema.json
+++ b/trinity/assets/eip1085.schema.json
@@ -82,6 +82,11 @@
           "type": "string",
           "pattern": "^0x([0-9a-fA-F])+$"
         },
+        "muirglacierForkBlock": {
+          "title": "Block number for the Muir Glacier fork",
+          "type": "string",
+          "pattern": "^0x([0-9a-fA-F])+$"
+        },
         "chainId": {
           "title": "The EIP155 chain ID",
           "type": "string",

--- a/trinity/assets/eip1085/mainnet.json
+++ b/trinity/assets/eip1085/mainnet.json
@@ -15,6 +15,7 @@
     "byzantiumForkBlock":"0x42ae50",
     "petersburgForkBlock":"0x6f1580",
     "istanbulForkBlock": "0x8a61c8",
+    "muirglacierForkBlock": "0x8c6180",
     "chainId":"0x1",
     "homesteadForkBlock":"0x118c30",
     "miningMethod":"ethash"

--- a/trinity/assets/eip1085/ropsten.json
+++ b/trinity/assets/eip1085/ropsten.json
@@ -16,6 +16,7 @@
     "constantinopleForkBlock":"0x408b70",
     "petersburgForkBlock":"0x4b5e82",
     "istanbulForkBlock":"0x62f756",
+    "muirglacierForkBlock": "0x6c993d",
     "miningMethod":"ethash"
   },
   "version":"1"

--- a/trinity/components/builtin/tx_pool/component.py
+++ b/trinity/components/builtin/tx_pool/component.py
@@ -6,8 +6,8 @@ import logging
 
 from async_service import run_asyncio_service
 from eth_utils import ValidationError
-from eth.chains.mainnet import PETERSBURG_MAINNET_BLOCK
-from eth.chains.ropsten import PETERSBURG_ROPSTEN_BLOCK
+from eth.chains.mainnet import ISTANBUL_MAINNET_BLOCK
+from eth.chains.ropsten import ISTANBUL_ROPSTEN_BLOCK
 from lahja import EndpointAPI
 
 from trinity.boot_info import BootInfo
@@ -80,9 +80,9 @@ class TxComponent(AsyncioIsolatedComponent):
             chain = chain_config.full_chain_class(db)
 
             if boot_info.trinity_config.network_id == MAINNET_NETWORK_ID:
-                validator = DefaultTransactionValidator(chain, PETERSBURG_MAINNET_BLOCK)
+                validator = DefaultTransactionValidator(chain, ISTANBUL_MAINNET_BLOCK)
             elif boot_info.trinity_config.network_id == ROPSTEN_NETWORK_ID:
-                validator = DefaultTransactionValidator(chain, PETERSBURG_ROPSTEN_BLOCK)
+                validator = DefaultTransactionValidator(chain, ISTANBUL_ROPSTEN_BLOCK)
             else:
                 raise Exception("This code path should not be reachable")
 

--- a/trinity/tools/chain.py
+++ b/trinity/tools/chain.py
@@ -4,7 +4,7 @@ from eth.chains.base import (
 )
 from eth.constants import GENESIS_BLOCK_NUMBER
 from eth.vm.forks.byzantium import ByzantiumVM
-from eth.vm.forks.istanbul import IstanbulVM
+from eth.vm.forks.muir_glacier import MuirGlacierVM
 
 from trinity.chains.coro import AsyncChainMixin
 from trinity.chains.full import FullChain
@@ -27,7 +27,7 @@ class LatestTestChain(FullChain):
     A test chain that uses the most recent mainnet VM from block 0.
     That means the VM will explicitly change when a new network upgrade is locked in.
     """
-    vm_configuration = ((GENESIS_BLOCK_NUMBER, IstanbulVM),)
+    vm_configuration = ((GENESIS_BLOCK_NUMBER, MuirGlacierVM),)
     network_id = 999
 
 


### PR DESCRIPTION
### What was wrong?

Muir Glacier is expected to arrive shorty after the dawn of 2020. We aren't prepared yet.

### How was it fixed?

1. Upgrade to the next Py-EVM version (which isn't released yet)
2. Configure `MuirGlacierVM` where the most recent VM is expected.
3. Make Istanbul the minimal supported transaction type

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

[//]: # (See: https://trinity-client.readthedocs.io/en/latest/contributing.html#pull-requests)
- [x] Add entry to the [release notes](https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://cumbrepuebloscop20.org/wp-content/uploads/2018/09/Foca-Cangrejera2.jpg)
