### PR TITLE
Fix exception escaping Upnp Service

### DIFF
--- a/newsfragments/1410.bugfix.rst
+++ b/newsfragments/1410.bugfix.rst
@@ -1,0 +1,1 @@
+Catch exception leaking out of the `UpnpService` and log it as warning.


### PR DESCRIPTION
### What was wrong?

There's an exception leaking out of the Upnp service.

```
Traceback (most recent call last):
  File "/home/cburgdorf/Documents/hacking/ef/trinity/venv/lib/python3.7/site-packages/upnpclient/soap.py", line 107, in call
    resp.raise_for_status()
  File "/home/cburgdorf/Documents/hacking/ef/trinity/venv/lib/python3.7/site-packages/requests/models.py", line 940, in raise_for_status
    raise HTTPError(http_error_msg, response=self)
requests.exceptions.HTTPError: 500 Server Error: Internal Server Error for url: http://192.168.1.1:2555/upnp/5bd06fee-2a8a-39de-8740-4197b2048728/WANIPConn1.ctl

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/cburgdorf/Documents/hacking/ef/trinity/trinity/components/builtin/upnp/nat.py", line 98, in add_nat_portmap
    external_ip = await self._add_nat_portmap(upnp_dev)
  File "/home/cburgdorf/Documents/hacking/ef/trinity/trinity/components/builtin/upnp/nat.py", line 141, in _add_nat_portmap
    NewLeaseDuration=self._nat_portmap_lifetime,
  File "/home/cburgdorf/Documents/hacking/ef/trinity/venv/lib/python3.7/site-packages/upnpclient/upnp.py", line 443, in __call__
    http_headers or self.service.device.http_headers
  File "/home/cburgdorf/Documents/hacking/ef/trinity/venv/lib/python3.7/site-packages/upnpclient/soap.py", line 115, in call
    raise SOAPError(*self._extract_upnperror(err_xml))
upnpclient.soap.SOAPError: (726, 'RemoteHostOnlySupportsWildcard')
```

### How was it fixed?

The exception is caught and properly logged as warnings.

```
 WARNING  2019-12-19 11:25:57,667           UPnPService  Failed to setup port mapping for TCP/ethereum p2p: (726, 'RemoteHostOnlySupportsWildcard')
 WARNING  2019-12-19 11:25:57,687           UPnPService  Failed to setup port mapping for UDP/ethereum discovery: (726, 'RemoteHostOnlySupportsWildcard')
```

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

[//]: # (See: https://trinity-client.readthedocs.io/en/latest/contributing.html#pull-requests)
- [ ] Add entry to the [release notes](https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://worldinsidepictures.com/wp-content/uploads/2013/06/Cute-Little-Animals8.jpg)
