### PR TITLE
Cleanup even bus mocking

### DIFF
--- a/tests/core/integration_test_helpers.py
+++ b/tests/core/integration_test_helpers.py
@@ -11,9 +11,6 @@ from async_service import background_asyncio_service
 from cancel_token import OperationCancelled
 from eth_keys import keys
 from eth_utils import decode_hex
-from eth_utils.toolz import (
-    curry,
-)
 
 from eth.constants import ZERO_ADDRESS
 from eth.db.backends.level import LevelDB
@@ -36,18 +33,6 @@ from trinity.tools.chain import AsyncMiningChain
 
 
 ZIPPED_FIXTURES_PATH = Path(__file__).parent.parent / 'integration' / 'fixtures'
-
-
-@curry
-async def mock_request_response(request_type, response, bus):
-    async for req in bus.stream(request_type):
-        await bus.broadcast(response, req.broadcast_config())
-        break
-
-
-@curry
-def run_mock_request_response(request_type, response, bus):
-    asyncio.ensure_future(mock_request_response(request_type, response, bus))
 
 
 async def connect_to_peers_loop(peer_pool, nodes):

--- a/tests/core/p2p-proto/test_base_proxy_peer_pool.py
+++ b/tests/core/p2p-proto/test_base_proxy_peer_pool.py
@@ -1,18 +1,18 @@
 import asyncio
 import pytest
 
+from p2p.tools.factories import SessionFactory
+
 from trinity.protocol.common.events import (
     GetConnectedPeersRequest,
     GetConnectedPeersResponse,
     PeerJoinedEvent,
     PeerLeftEvent,
 )
-
-from p2p.tools.factories import SessionFactory
+from trinity.tools.event_bus import mock_request_response
 
 from tests.core.integration_test_helpers import (
     run_proxy_peer_pool,
-    run_mock_request_response,
 )
 
 TEST_NODES = tuple(SessionFactory.create_batch(4))
@@ -33,12 +33,12 @@ async def test_can_instantiate_proxy_pool(event_bus):
 )
 @pytest.mark.asyncio
 async def test_fetch_initial_peers(event_bus, response, expected_count):
+    do_mock = mock_request_response(GetConnectedPeersRequest, response, event_bus)
 
-    run_mock_request_response(GetConnectedPeersRequest, response, event_bus)
-
-    async with run_proxy_peer_pool(event_bus) as proxy_peer_pool:
-        peers = await proxy_peer_pool.fetch_initial_peers()
-        assert len(peers) == expected_count
+    async with do_mock:
+        async with run_proxy_peer_pool(event_bus) as proxy_peer_pool:
+            peers = await proxy_peer_pool.fetch_initial_peers()
+            assert len(peers) == expected_count
 
 
 @pytest.mark.parametrize(
@@ -50,43 +50,51 @@ async def test_fetch_initial_peers(event_bus, response, expected_count):
 )
 @pytest.mark.asyncio
 async def test_get_peers(event_bus, response, expected_count):
+    do_mock = mock_request_response(GetConnectedPeersRequest, response, event_bus)
 
-    run_mock_request_response(GetConnectedPeersRequest, response, event_bus)
-
-    async with run_proxy_peer_pool(event_bus) as proxy_peer_pool:
-        peers = await proxy_peer_pool.get_peers()
-        assert len(peers) == expected_count
+    async with do_mock:
+        async with run_proxy_peer_pool(event_bus) as proxy_peer_pool:
+            peers = await proxy_peer_pool.get_peers()
+            assert len(peers) == expected_count
 
 
 @pytest.mark.asyncio
 async def test_adds_new_peers(event_bus):
 
-    async with run_proxy_peer_pool(event_bus) as proxy_peer_pool:
-        run_mock_request_response(
-            GetConnectedPeersRequest, GetConnectedPeersResponse((TEST_NODES[0],)), event_bus)
+    do_mock = mock_request_response(
+        GetConnectedPeersRequest,
+        GetConnectedPeersResponse((TEST_NODES[0],)),
+        event_bus,
+    )
+    async with do_mock:
+        async with run_proxy_peer_pool(event_bus) as proxy_peer_pool:
 
-        assert len(await proxy_peer_pool.get_peers()) == 1
+            assert len(await proxy_peer_pool.get_peers()) == 1
 
-        await event_bus.broadcast(PeerJoinedEvent(TEST_NODES[1]))
-        # Give the peer a moment to pickup the peer
-        await asyncio.sleep(0.01)
+            await event_bus.broadcast(PeerJoinedEvent(TEST_NODES[1]))
+            # Give the peer a moment to pickup the peer
+            await asyncio.sleep(0.01)
 
-        assert len(await proxy_peer_pool.get_peers()) == 2
+            assert len(await proxy_peer_pool.get_peers()) == 2
 
 
 @pytest.mark.asyncio
 async def test_removes_peers(event_bus):
+    do_mock = mock_request_response(
+        GetConnectedPeersRequest,
+        GetConnectedPeersResponse(TEST_NODES[:2]),
+        event_bus,
+    )
 
-    async with run_proxy_peer_pool(event_bus) as proxy_peer_pool:
-        run_mock_request_response(
-            GetConnectedPeersRequest, GetConnectedPeersResponse(TEST_NODES[:2]), event_bus)
+    async with do_mock:
+        async with run_proxy_peer_pool(event_bus) as proxy_peer_pool:
 
-        assert len(await proxy_peer_pool.get_peers()) == 2
+            assert len(await proxy_peer_pool.get_peers()) == 2
 
-        await event_bus.broadcast(PeerLeftEvent(TEST_NODES[0]))
-        # Give the peer a moment to remove the peer
-        await asyncio.sleep(0.01)
+            await event_bus.broadcast(PeerLeftEvent(TEST_NODES[0]))
+            # Give the peer a moment to remove the peer
+            await asyncio.sleep(0.01)
 
-        peers = await proxy_peer_pool.get_peers()
-        assert len(peers) == 1
-        assert peers[0].session == TEST_NODES[1]
+            peers = await proxy_peer_pool.get_peers()
+            assert len(peers) == 1
+            assert peers[0].session == TEST_NODES[1]

--- a/trinity/tools/event_bus.py
+++ b/trinity/tools/event_bus.py
@@ -1,0 +1,34 @@
+import asyncio
+from typing import AsyncIterator, Type
+
+from async_generator import asynccontextmanager
+from lahja import BaseEvent, EndpointAPI
+
+
+@asynccontextmanager
+async def mock_request_response(request_type: Type[BaseEvent],
+                                response: BaseEvent,
+                                event_bus: EndpointAPI) -> AsyncIterator[None]:
+    ready = asyncio.Event()
+    task = asyncio.ensure_future(_do_mock_response(request_type, response, event_bus, ready))
+    await ready.wait()
+    try:
+        yield
+    finally:
+        if not task.done():
+            task.cancel()
+
+        try:
+            await task
+        except asyncio.CancelledError:
+            pass
+
+
+async def _do_mock_response(request_type: Type[BaseEvent],
+                            response: BaseEvent,
+                            event_bus: EndpointAPI,
+                            ready: asyncio.Event) -> None:
+    ready.set()
+    async for req in event_bus.stream(request_type):
+        await event_bus.broadcast(response, req.broadcast_config())
+        break


### PR DESCRIPTION
extracted from #1411 

### What was wrong?

1. The tool for mocking out event bus responses was being imported from a module within the `./tests` directory which we're trying to move away from.
2. The tool allowed for a race condition where it *appears* that the mocking is in place but it hasn't actually setup the stream so the `request` event wouldn't get handled by the handler.
3. There was nothing to cancel the task that gets setup by the `ensure_future` call so this occasionally contributed to noisy test run output.

### How was it fixed?

Moved the tool to live under `trinity.tools.event_bus`

Updated the tool to be an async context manager so that 1) waits for the stream to be setup and ready before returning and 2) cleans up the task on exit.

#### Cute Animal Picture

![e6b58caa1f2b7a297edf0b86219c9078--christmas-kitty-christmas-animals](https://user-images.githubusercontent.com/824194/71290374-e40fdf00-232c-11ea-91fc-73ab7858e3a3.jpg)
