### PR TITLE
Drain writer before closing transport

### DIFF
--- a/newsfragments/1417.bugfix.rst
+++ b/newsfragments/1417.bugfix.rst
@@ -1,0 +1,1 @@
+The ``p2p.abc.TransportAPI.close`` and ``p2p.abc.MultiplexerAPI.close`` methods are now coroutines to allow ``p2p.abc.TransportAPI.close()`` to drain the underlying ``StreamWriter`` before closing it, ensuring that any pending messages are written over the socket before closing it.

--- a/p2p/abc.py
+++ b/p2p/abc.py
@@ -230,7 +230,7 @@ class TransportAPI(ABC):
         ...
 
     @abstractmethod
-    def close(self) -> None:
+    async def close(self) -> None:
         ...
 
 
@@ -311,7 +311,7 @@ class MultiplexerAPI(ABC):
         ...
 
     @abstractmethod
-    def close(self) -> None:
+    async def close(self) -> None:
         ...
 
     #

--- a/p2p/connection.py
+++ b/p2p/connection.py
@@ -127,7 +127,7 @@ class Connection(ConnectionAPI, BaseService):
             pass
 
     async def _cleanup(self) -> None:
-        self._multiplexer.close()
+        await self._multiplexer.close()
 
     #
     # Subscriptions/Handler API

--- a/p2p/multiplexer.py
+++ b/p2p/multiplexer.py
@@ -184,8 +184,8 @@ class Multiplexer(CancellableMixin, MultiplexerAPI):
     def is_closing(self) -> bool:
         return self._transport.is_closing
 
-    def close(self) -> None:
-        self._transport.close()
+    async def close(self) -> None:
+        await self._transport.close()
         self.cancel_token.trigger()
 
     #

--- a/p2p/peer.py
+++ b/p2p/peer.py
@@ -221,7 +221,7 @@ class BasePeer(BaseService):
     async def _cleanup(self) -> None:
         if self.connection.is_operational:
             # the connection might be closed from when its cancel token triggers
-            self.connection.cancel_nowait()
+            await self.connection.cancel()
 
     def setup_protocol_handlers(self) -> None:
         """

--- a/p2p/tools/memory_transport.py
+++ b/p2p/tools/memory_transport.py
@@ -103,7 +103,7 @@ class MemoryTransport(TransportAPI):
             return
         self.write(encoded_sizes + message.header + message.body)
 
-    def close(self) -> None:
+    async def close(self) -> None:
         """Close this peer's reader/writer streams.
 
         This will cause the peer to stop in case it is running.
@@ -112,6 +112,7 @@ class MemoryTransport(TransportAPI):
         """
         if not self._reader.at_eof():
             self._reader.feed_eof()
+        await self._writer.drain()
         self._writer.close()
 
     @property

--- a/p2p/transport.py
+++ b/p2p/transport.py
@@ -333,7 +333,7 @@ class Transport(TransportAPI):
 
         self.write(self._encrypt(header, body))
 
-    def close(self) -> None:
+    async def close(self) -> None:
         """Close this peer's reader/writer streams.
 
         This will cause the peer to stop in case it is running.
@@ -342,6 +342,7 @@ class Transport(TransportAPI):
         """
         if not self._reader.at_eof():
             self._reader.feed_eof()
+        await self._writer.drain()
         self._writer.close()
 
     @property


### PR DESCRIPTION
extracted from #1411 

builds on: https://github.com/ethereum/trinity/pull/1419

### What was wrong?

The closing of a `Transport` was just directly closing the writer without draining it.  This resulted in unwanted behavior like not actually transmitting the disconnect reason before closing connections with other peers.

### How was it fixed?

Changed the `Transport.close()` to be asynchronous and added a call to `writer.drain()` to ensure that any pending data gets written to the socket before closing it.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

[//]: # (See: https://trinity-client.readthedocs.io/en/latest/contributing.html#pull-requests)
- [x] Add entry to the [release notes](https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![4285](https://user-images.githubusercontent.com/824194/71290851-1ff77400-232e-11ea-87f8-be30806ac8b2.jpg)

