### PR TITLE
Get rid of run_proxy_peer_pool testing utility.

### DIFF
--- a/tests/core/components/test_isolated_component.py
+++ b/tests/core/components/test_isolated_component.py
@@ -64,7 +64,7 @@ async def test_asyncio_isolated_component(boot_info,
         assert not touch_path.exists()
         component_manager.shutdown('exiting component manager')
 
-    for _ in range(1000):
+    for _ in range(10000):
         if not touch_path.exists():
             await asyncio.sleep(0.001)
         else:

--- a/tests/core/integration_test_helpers.py
+++ b/tests/core/integration_test_helpers.py
@@ -21,13 +21,9 @@ from eth.tools.builder.chain import (
     latest_mainnet_at,
 )
 
-from trinity.constants import TO_NETWORKING_BROADCAST_CONFIG
 
 from trinity.protocol.common.peer_pool_event_bus import (
     DefaultPeerPoolEventServer,
-)
-from trinity.protocol.eth.peer import (
-    ETHProxyPeerPool,
 )
 from trinity.tools.chain import AsyncMiningChain
 
@@ -109,21 +105,3 @@ async def run_peer_pool_event_server(event_bus, peer_pool, handler_type=None):
     )
     async with background_asyncio_service(event_server):
         yield event_server
-
-
-@asynccontextmanager
-async def run_proxy_peer_pool(event_bus, peer_pool_type=None):
-
-    peer_pool_type = ETHProxyPeerPool if peer_pool_type is None else peer_pool_type
-
-    proxy_peer_pool = peer_pool_type(
-        event_bus,
-        TO_NETWORKING_BROADCAST_CONFIG,
-    )
-    asyncio.ensure_future(proxy_peer_pool.run())
-
-    await proxy_peer_pool.events.started.wait()
-    try:
-        yield proxy_peer_pool
-    finally:
-        await proxy_peer_pool.cancel()

--- a/tests/core/tx-pool/test_tx_pool.py
+++ b/tests/core/tx-pool/test_tx_pool.py
@@ -9,7 +9,9 @@ from eth._utils.address import (
 )
 
 from p2p.tools.factories import SessionFactory
+from p2p.service import run_service
 
+from trinity.constants import TO_NETWORKING_BROADCAST_CONFIG
 from trinity.components.builtin.tx_pool.pool import (
     TxPool,
 )
@@ -29,8 +31,8 @@ from trinity.protocol.eth.events import (
 )
 from trinity.tools.event_bus import mock_request_response
 
-from tests.core.integration_test_helpers import (
-    run_proxy_peer_pool,
+from trinity.protocol.eth.peer import (
+    ETHProxyPeerPool,
 )
 
 
@@ -72,7 +74,10 @@ async def test_tx_propagation(event_bus,
             GetConnectedPeersResponse(initial_two_peers),
             event_bus,
         ))
-        peer_pool = await stack.enter_async_context(run_proxy_peer_pool(event_bus))
+
+        peer_pool = ETHProxyPeerPool(event_bus, TO_NETWORKING_BROADCAST_CONFIG)
+        await stack.enter_async_context(run_service(peer_pool))
+
         tx_pool = TxPool(event_bus, peer_pool, tx_validator)
         await stack.enter_async_context(background_asyncio_service(tx_pool))
 
@@ -153,7 +158,10 @@ async def test_does_not_propagate_invalid_tx(event_bus,
             GetConnectedPeersResponse(initial_two_peers),
             event_bus,
         ))
-        peer_pool = await stack.enter_async_context(run_proxy_peer_pool(event_bus))
+
+        peer_pool = ETHProxyPeerPool(event_bus, TO_NETWORKING_BROADCAST_CONFIG)
+        await stack.enter_async_context(run_service(peer_pool))
+
         tx_pool = TxPool(event_bus, peer_pool, tx_validator)
         await stack.enter_async_context(background_asyncio_service(tx_pool))
 


### PR DESCRIPTION
builds on https://github.com/ethereum/trinity/pull/1419

### What was wrong?

The `run_proxy_peer_pool` testing utility isn't needed and it is located in the `./tests` module which we're trying to get away from importing from.

### How was it fixed?

Replaced usage of the tool with direct calls to `p2p.service.run_service`

#### Cute Animal Picture

![1449455169851_AnimalsinChristmascostumesfacebook](https://user-images.githubusercontent.com/824194/71292227-09065100-2331-11ea-969e-bb199a3767c3.JPG)
