### PR TITLE
Fix web3py dependencies

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ deps = {
         "cachetools>=3.1.0,<4.0.0",
         "coincurve>=10.0.0,<11.0.0",
         "dataclasses>=0.6, <1;python_version<'3.7'",
-        "eth-utils>=1.8.1,<2",
+        "eth-utils>=1.8.4,<2",
         "ipython>=7.8.0,<7.10.0",  # attach fails with v7.10.{0,1}
         "plyvel==1.1.0",
         PYEVM_DEPENDENCY,
@@ -46,7 +46,7 @@ deps = {
         "websockets>=8.1.0",
         "jsonschema==3.0.1",
         "mypy-extensions>=0.4.3,<0.5.0",
-        "typing_extensions>=3.7.2,<4.0.0",
+        "typing_extensions>=3.7.4,<4.0.0",
         "ruamel.yaml==0.15.98",
         "argcomplete>=1.10.0,<2",
         "multiaddr>=0.0.8,<0.1.0",


### PR DESCRIPTION
### What was wrong?

Web3.py 5.4.0 requires `eth-utils>=1.8.4` and `typing-extensions>=3.7.4.1`

### How was it fixed?

Update setup.py

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

[//]: # (See: https://trinity-client.readthedocs.io/en/latest/contributing.html#pull-requests)
- [ ] Add entry to the [release notes](https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses]()
