### PR TITLE
Integrate eth1 monitor and implement eth1data voting

### DIFF
--- a/eth2/beacon/state_machines/forks/serenity/block_validation.py
+++ b/eth2/beacon/state_machines/forks/serenity/block_validation.py
@@ -44,7 +44,7 @@ def validate_correct_number_of_deposits(
     if deposit_count_in_block != expected_deposit_count:
         raise ValidationError(
             f"Incorrect number of deposits ({deposit_count_in_block})"
-            f" in block (encode_hex(block_root));"
+            f" in block {encode_hex(block.signing_root)};"
             f" expected {expected_deposit_count} based on"
             f" the state {encode_hex(state.hash_tree_root)}"
         )

--- a/eth2/beacon/tools/builder/proposer.py
+++ b/eth2/beacon/tools/builder/proposer.py
@@ -11,6 +11,8 @@ from eth2.beacon.state_machines.base import BaseBeaconStateMachine
 from eth2.beacon.tools.builder.validator import sign_transaction
 from eth2.beacon.types.attestations import Attestation
 from eth2.beacon.types.blocks import BaseBeaconBlock, BeaconBlockBody
+from eth2.beacon.types.deposits import Deposit
+from eth2.beacon.types.eth1_data import Eth1Data
 from eth2.beacon.types.states import BeaconState
 from eth2.beacon.typing import FromBlockParams, Slot, ValidatorIndex
 from eth2.configs import CommitteeConfig, Eth2Config
@@ -70,6 +72,8 @@ def create_block_on_state(
     validator_index: ValidatorIndex,
     privkey: int,
     attestations: Sequence[Attestation],
+    eth1_data: Eth1Data = None,
+    deposits: Sequence[Deposit] = None,
     check_proposer_index: bool = True
 ) -> BaseBeaconBlock:
     """
@@ -87,10 +91,13 @@ def create_block_on_state(
 
     # TODO: Add more operations
     randao_reveal = _generate_randao_reveal(privkey, slot, state, config)
-    eth1_data = state.eth1_data
+    if eth1_data is None:
+        eth1_data = state.eth1_data
     body = BeaconBlockBody.create(
         randao_reveal=randao_reveal, eth1_data=eth1_data, attestations=attestations
     )
+    if deposits is not None and len(deposits) > 0:
+        body = body.copy(deposits=deposits)
 
     block = block.set("body", body)
 

--- a/eth2/beacon/tools/builder/proposer.py
+++ b/eth2/beacon/tools/builder/proposer.py
@@ -97,7 +97,7 @@ def create_block_on_state(
         randao_reveal=randao_reveal, eth1_data=eth1_data, attestations=attestations
     )
     if deposits is not None and len(deposits) > 0:
-        body = body.copy(deposits=deposits)
+        body = body.set("deposits", deposits)
 
     block = block.set("body", body)
 

--- a/tests-trio/eth1-monitor/test_eth1_monitor.py
+++ b/tests-trio/eth1-monitor/test_eth1_monitor.py
@@ -224,18 +224,16 @@ async def test_get_eth1_data(
     assert_get_eth1_data(block_numbers[2], 2, 1)
     assert_get_eth1_data_raises(block_numbers[2], 3)
 
-    # Assert b3, b4, b5.
-    # Since these blocks are still within `num_blocks_confirmed`,
-    # queries with `distance == 0` will return eth1_data at b2.
-    # `num_blocks_confirmed` blocks.
+    # Assert b3, b4, b5
+    # We do not have these blocks at db yet but we can still get these eth1 data.
     assert_get_eth1_data(
-        block_numbers[3], 0, 2, expected_block_number_at_distance=block_numbers[2]
+        block_numbers[3], 1, 2, expected_block_number_at_distance=block_numbers[2]
     )
     assert_get_eth1_data(
-        block_numbers[4], 0, 2, expected_block_number_at_distance=block_numbers[2]
+        block_numbers[4], 1, 2, expected_block_number_at_distance=block_numbers[3]
     )
     assert_get_eth1_data(
-        block_numbers[5], 0, 2, expected_block_number_at_distance=block_numbers[2]
+        block_numbers[5], 1, 2, expected_block_number_at_distance=block_numbers[4]
     )
 
     # Test: `DepositDataCorrupted` is raised when the calculated `deposit_root` from
@@ -248,10 +246,11 @@ async def test_get_eth1_data(
         ]
         corrupted_deposit_data_db.add_deposit_data_batch(corrupted_list_deposit_data, 1)
         m_context.setattr(eth1_monitor, "_db", corrupted_deposit_data_db)
+        latest_processed_block_number = current_height - num_blocks_confirmed
         with pytest.raises(DepositDataCorrupted):
             eth1_monitor._get_eth1_data(
                 distance=0,
-                eth1_voting_period_start_timestamp=w3.eth.getBlock(current_height)[
+                eth1_voting_period_start_timestamp=w3.eth.getBlock(latest_processed_block_number)[
                     "timestamp"
                 ],
             )

--- a/tests/components/eth2/beacon/test_validator.py
+++ b/tests/components/eth2/beacon/test_validator.py
@@ -103,7 +103,6 @@ async def get_validator(
             unaggregated_attestation_pool.add(attestation)
 
     v = Validator(
-        genesis_time=0,
         chain=chain,
         p2p_node=FakeNode(),
         validator_privkeys=validator_privkeys,

--- a/trinity/components/eth2/beacon/component.py
+++ b/trinity/components/eth2/beacon/component.py
@@ -171,7 +171,6 @@ class BeaconNodeComponent(AsyncioIsolatedComponent):
                 validator_privkeys[validator_index] = validator_keymap[pubkey]
 
             validator = Validator(
-                genesis_time=chain_config.genesis_data.genesis_time,
                 chain=chain,
                 p2p_node=libp2p_node,
                 validator_privkeys=validator_privkeys,

--- a/trinity/components/eth2/beacon/component.py
+++ b/trinity/components/eth2/beacon/component.py
@@ -171,6 +171,7 @@ class BeaconNodeComponent(AsyncioIsolatedComponent):
                 validator_privkeys[validator_index] = validator_keymap[pubkey]
 
             validator = Validator(
+                genesis_time=chain_config.genesis_data.genesis_time,
                 chain=chain,
                 p2p_node=libp2p_node,
                 validator_privkeys=validator_privkeys,

--- a/trinity/components/eth2/beacon/validator.py
+++ b/trinity/components/eth2/beacon/validator.py
@@ -328,6 +328,13 @@ class Validator(BaseService):
             )
             if resp.error is None:
                 deposits = deposits + (resp.to_data(),)
+            else:
+                self.logger.error(
+                    "Fail to get deposit data with `deposit_count`=%s,"
+                    "`deposit_index`=%s",
+                    request_params["deposit_count"],
+                    request_params["deposit_index"],
+                )
         return tuple(deposits)
 
     async def _request_eth1_data(self,
@@ -346,6 +353,13 @@ class Validator(BaseService):
             )
             if resp.error is None:
                 eth1_data = eth1_data + (resp.to_data(),)
+            else:
+                self.logger.error(
+                    "Fail to get eth1 data with `distance`=%s,"
+                    "`eth1_voting_period_start_timestamp`=%s",
+                    distance,
+                    eth1_voting_period_start_timestamp,
+                )
         return eth1_data
 
     async def _get_eth1_vote(self,

--- a/trinity/components/eth2/beacon/validator.py
+++ b/trinity/components/eth2/beacon/validator.py
@@ -120,7 +120,7 @@ ETH1_FOLLOW_DISTANCE = 16
 
 
 class Validator(BaseService):
-    genesis_time: int
+    genesis_time: Timestamp
     chain: BaseBeaconChain
     p2p_node: Node
     validator_privkeys: Dict[ValidatorIndex, int]
@@ -134,7 +134,6 @@ class Validator(BaseService):
 
     def __init__(
             self,
-            genesis_time: int,
             chain: BaseBeaconChain,
             p2p_node: Node,
             validator_privkeys: Dict[ValidatorIndex, int],
@@ -144,7 +143,7 @@ class Validator(BaseService):
             import_attestation_fn: ImportAttestationFn,
             token: CancelToken = None) -> None:
         super().__init__(token)
-        self.genesis_time = genesis_time
+        self.genesis_time = chain.get_head_state().genesis_time
         self.chain = chain
         self.p2p_node = p2p_node
         self.validator_privkeys = validator_privkeys

--- a/trinity/components/eth2/eth1_monitor/component.py
+++ b/trinity/components/eth2/eth1_monitor/component.py
@@ -1,7 +1,6 @@
 from argparse import ArgumentParser, _SubParsersAction
 import json
 from pathlib import Path
-import time
 
 from async_service import Service, TrioManager
 
@@ -104,7 +103,7 @@ class Eth1MonitorComponent(TrioIsolatedComponent):
         with base_db:
             fake_eth1_data_provider = FakeEth1DataProvider(
                 start_block_number=START_BLOCK_NUMBER,
-                start_block_timestamp=start_block_timestamp,
+                start_block_timestamp=Timestamp(start_block_timestamp),
                 num_deposits_per_block=NUM_DEPOSITS_PER_BLOCK,
                 initial_deposits=tuple(initial_deposits),
             )
@@ -113,7 +112,7 @@ class Eth1MonitorComponent(TrioIsolatedComponent):
                 eth1_data_provider=fake_eth1_data_provider,
                 num_blocks_confirmed=NUM_BLOCKS_CONFIRMED,
                 polling_period=POLLING_PERIOD,
-                start_block_number=START_BLOCK_NUMBER - 1,
+                start_block_number=BlockNumber(START_BLOCK_NUMBER - 1),
                 event_bus=event_bus,
                 base_db=base_db,
             )

--- a/trinity/components/eth2/eth1_monitor/component.py
+++ b/trinity/components/eth2/eth1_monitor/component.py
@@ -37,7 +37,7 @@ POLLING_PERIOD = AVERAGE_BLOCK_TIME // 2
 START_BLOCK_NUMBER = BlockNumber(1000)
 
 # Configs for fake Eth1DataProvider
-NUM_DEPOSITS_PER_BLOCK = 0
+NUM_DEPOSITS_PER_BLOCK = 1
 
 
 class Eth1MonitorComponent(TrioIsolatedComponent):

--- a/trinity/components/eth2/eth1_monitor/eth1_data_provider.py
+++ b/trinity/components/eth2/eth1_monitor/eth1_data_provider.py
@@ -43,7 +43,7 @@ class DepositLog(NamedTuple):
 
 
 def convert_deposit_log_to_deposit_data(deposit_log: DepositLog) -> DepositData:
-    return DepositData(
+    return DepositData.create(
         pubkey=deposit_log.pubkey,
         withdrawal_credentials=deposit_log.withdrawal_credentials,
         amount=deposit_log.amount,
@@ -219,7 +219,9 @@ class FakeEth1DataProvider(BaseEth1DataProvider):
 
     def get_logs(self, block_number: BlockNumber) -> Tuple[DepositLog, ...]:
         block_hash = block_number.to_bytes(32, byteorder="big")
-        if block_number == self.start_block_number:
+        if block_number < self.start_block_number:
+            return tuple()
+        elif block_number == self.start_block_number:
             logs = (
                 DepositLog(
                     block_hash=Hash32(block_hash),

--- a/trinity/components/eth2/eth1_monitor/eth1_data_provider.py
+++ b/trinity/components/eth2/eth1_monitor/eth1_data_provider.py
@@ -197,6 +197,7 @@ class FakeEth1DataProvider(BaseEth1DataProvider):
             latest_block_number = self._get_latest_block_number()
             # Block that's way in the future is presumed to be fake eth1 block in genesis state.
             # Return the block at `start_block_number` in this case.
+            # The magic number `100` here stands for distance that's way in the future.
             if block_number > latest_block_number + 100:
                 return Eth1Block(
                     block_hash=Hash32(
@@ -241,6 +242,9 @@ class FakeEth1DataProvider(BaseEth1DataProvider):
         else:
             amount: Gwei = Gwei(32 * GWEI_PER_ETH)
             for seed in range(self.num_deposits_per_block):
+                # Multiply `block_number` by 10 to shift it one digit to the left so
+                # the input to the function is generated deterministically but does not
+                # conflict with blocks in the future.
                 pubkey, privkey = mk_key_pair_from_seed_index(block_number * 10 + seed)
                 withdrawal_credentials = Hash32(b'\x12' * 32)
                 deposit_data = DepositData.create(

--- a/trinity/components/eth2/eth1_monitor/eth1_data_provider.py
+++ b/trinity/components/eth2/eth1_monitor/eth1_data_provider.py
@@ -178,8 +178,8 @@ class FakeEth1DataProvider(BaseEth1DataProvider):
 
     def _get_block_time(self, block_number: BlockNumber) -> Timestamp:
         return Timestamp(
-            self.start_block_timestamp
-            + (block_number - self.start_block_number) * AVERAGE_BLOCK_TIME
+            self.start_block_timestamp +
+            (block_number - self.start_block_number) * AVERAGE_BLOCK_TIME
         )
 
     def get_block(self, arg: Union[Hash32, int, str]) -> Optional[Eth1Block]:
@@ -223,10 +223,11 @@ class FakeEth1DataProvider(BaseEth1DataProvider):
 
     def get_logs(self, block_number: BlockNumber) -> Tuple[DepositLog, ...]:
         block_hash = block_number.to_bytes(32, byteorder="big")
+        logs: Tuple[DepositLog, ...] = tuple()
         if block_number < self.start_block_number:
-            return tuple()
+            return logs
         elif block_number == self.start_block_number:
-            logs = (
+            logs = tuple(
                 DepositLog(
                     block_hash=Hash32(block_hash),
                     pubkey=deposit.pubkey,
@@ -236,9 +237,8 @@ class FakeEth1DataProvider(BaseEth1DataProvider):
                 )
                 for deposit in self.deposits
             )
-            return tuple(logs)
+            return logs
         else:
-            logs: Tuple[DepositLog, ...] = tuple()
             amount: Gwei = Gwei(32 * GWEI_PER_ETH)
             for seed in range(self.num_deposits_per_block):
                 pubkey, privkey = mk_key_pair_from_seed_index(block_number * 10 + seed)
@@ -250,7 +250,7 @@ class FakeEth1DataProvider(BaseEth1DataProvider):
                 )
                 signature = sign_proof_of_possession(deposit_data=deposit_data, privkey=privkey)
                 deposit_data = deposit_data.set("signature", signature)
-                logs += (
+                logs = logs + (
                     DepositLog(
                         block_hash=Hash32(block_hash),
                         pubkey=pubkey,
@@ -259,14 +259,14 @@ class FakeEth1DataProvider(BaseEth1DataProvider):
                         amount=amount,
                     ),
                 )
-            return tuple(logs)
+            return logs
 
     def get_deposit_count(self, block_number: BlockNumber) -> bytes:
         if block_number <= self.start_block_number:
             return self.num_initial_deposits.to_bytes(32, byteorder="little")
         deposit_count = (
-            self.num_initial_deposits
-            + (block_number - self.start_block_number) * self.num_deposits_per_block
+            self.num_initial_deposits +
+            (block_number - self.start_block_number) * self.num_deposits_per_block
         )
         return deposit_count.to_bytes(32, byteorder="little")
 

--- a/trinity/components/eth2/eth1_monitor/eth1_data_provider.py
+++ b/trinity/components/eth2/eth1_monitor/eth1_data_provider.py
@@ -13,7 +13,6 @@ from eth2.beacon.constants import GWEI_PER_ETH
 from eth2.beacon.tools.builder.validator import make_deposit_tree_and_root
 from eth2.beacon.types.deposit_data import DepositData
 from eth2.beacon.typing import Gwei, Timestamp
-from trinity.components.eth2.beacon.validator import ETH1_FOLLOW_DISTANCE
 
 
 class Eth1Block(NamedTuple):
@@ -53,7 +52,6 @@ def convert_deposit_log_to_deposit_data(deposit_log: DepositLog) -> DepositData:
 
 
 class BaseEth1DataProvider(ABC):
-
     @abstractmethod
     def get_block(self, arg: Union[Hash32, int, str]) -> Optional[Eth1Block]:
         ...
@@ -141,7 +139,7 @@ class Web3Eth1DataProvider(BaseEth1DataProvider):
 
 
 # NOTE: This constant is for `FakeEth1DataProvider`
-AVERAGE_BLOCK_TIME = 20
+AVERAGE_BLOCK_TIME = 5
 
 
 class FakeEth1DataProvider(BaseEth1DataProvider):
@@ -176,8 +174,8 @@ class FakeEth1DataProvider(BaseEth1DataProvider):
 
     def _get_block_time(self, block_number: BlockNumber) -> Timestamp:
         return Timestamp(
-            self.start_block_timestamp +
-            (block_number - self.start_block_number) * AVERAGE_BLOCK_TIME
+            self.start_block_timestamp
+            + (block_number - self.start_block_number) * AVERAGE_BLOCK_TIME
         )
 
     def get_block(self, arg: Union[Hash32, int, str]) -> Optional[Eth1Block]:
@@ -185,26 +183,23 @@ class FakeEth1DataProvider(BaseEth1DataProvider):
         if isinstance(arg, int):
             block_time = self._get_block_time(BlockNumber(arg))
             return Eth1Block(
-                block_hash=Hash32(int(arg).to_bytes(32, byteorder='big')),
+                block_hash=Hash32(int(arg).to_bytes(32, byteorder="big")),
                 number=BlockNumber(arg),
                 timestamp=Timestamp(block_time),
             )
         # If `arg` is block hash
         elif isinstance(arg, bytes):
-            block_number = int.from_bytes(arg, byteorder='big')
+            block_number = int.from_bytes(arg, byteorder="big")
             latest_block_number = self._get_latest_block_number()
-            # Check if provided block number is in valid range
-            earliest_follow_block_number = self.start_block_number - ETH1_FOLLOW_DISTANCE
-            is_beyond_follow_distance = block_number < earliest_follow_block_number
-            if (is_beyond_follow_distance or block_number > latest_block_number):
-                # If provided block number does not make sense,
-                # assume it's the block at `earliest_follow_block_number`.
+            # Block that's way in the future is presumed to be fake eth1 block in genesis state.
+            # Return the block at `start_block_number` in this case.
+            if block_number > latest_block_number + 100:
                 return Eth1Block(
-                    block_hash=Hash32(earliest_follow_block_number.to_bytes(32, byteorder='big')),
-                    number=BlockNumber(earliest_follow_block_number),
-                    timestamp=Timestamp(
-                        self.start_block_timestamp - ETH1_FOLLOW_DISTANCE * AVERAGE_BLOCK_TIME,
+                    block_hash=Hash32(
+                        self.start_block_number.to_bytes(32, byteorder="big")
                     ),
+                    number=BlockNumber(self.start_block_number),
+                    timestamp=Timestamp(self.start_block_timestamp),
                 )
             block_time = self._get_block_time(BlockNumber(block_number))
             return Eth1Block(
@@ -217,13 +212,13 @@ class FakeEth1DataProvider(BaseEth1DataProvider):
             latest_block_number = self._get_latest_block_number()
             block_time = self._get_block_time(latest_block_number)
             return Eth1Block(
-                block_hash=Hash32(latest_block_number.to_bytes(32, byteorder='big')),
+                block_hash=Hash32(latest_block_number.to_bytes(32, byteorder="big")),
                 number=BlockNumber(latest_block_number),
                 timestamp=block_time,
             )
 
     def get_logs(self, block_number: BlockNumber) -> Tuple[DepositLog, ...]:
-        block_hash = block_number.to_bytes(32, byteorder='big')
+        block_hash = block_number.to_bytes(32, byteorder="big")
         if block_number == self.start_block_number:
             logs = (
                 DepositLog(
@@ -240,9 +235,9 @@ class FakeEth1DataProvider(BaseEth1DataProvider):
             logs = (
                 DepositLog(
                     block_hash=Hash32(block_hash),
-                    pubkey=BLSPubkey(b'\x12' * 48),
-                    withdrawal_credentials=Hash32(b'\x23' * 32),
-                    signature=BLSSignature(b'\x34' * 96),
+                    pubkey=BLSPubkey(b"\x12" * 48),
+                    withdrawal_credentials=Hash32(b"\x23" * 32),
+                    signature=BLSSignature(b"\x34" * 96),
                     amount=Gwei(32 * GWEI_PER_ETH),
                 )
                 for _ in range(self.num_deposits_per_block)
@@ -251,12 +246,12 @@ class FakeEth1DataProvider(BaseEth1DataProvider):
 
     def get_deposit_count(self, block_number: BlockNumber) -> bytes:
         if block_number <= self.start_block_number:
-            return self.num_initial_deposits.to_bytes(32, byteorder='little')
+            return self.num_initial_deposits.to_bytes(32, byteorder="little")
         deposit_count = (
-            self.num_initial_deposits +
-            (block_number - self.start_block_number) * self.num_deposits_per_block
+            self.num_initial_deposits
+            + (block_number - self.start_block_number) * self.num_deposits_per_block
         )
-        return deposit_count.to_bytes(32, byteorder='little')
+        return deposit_count.to_bytes(32, byteorder="little")
 
     def get_deposit_root(self, block_number: BlockNumber) -> Hash32:
         # Check and update deposit data when deposit root is requested
@@ -269,7 +264,7 @@ class FakeEth1DataProvider(BaseEth1DataProvider):
                 )
             self.latest_processed_block_number = block_number
         deposit_count_bytes = self.get_deposit_count(block_number)
-        deposit_count = int.from_bytes(deposit_count_bytes, byteorder='little')
+        deposit_count = int.from_bytes(deposit_count_bytes, byteorder="little")
         deposits = self.deposits[:deposit_count]
         _, deposit_root = make_deposit_tree_and_root(deposits)
         return deposit_root

--- a/trinity/components/eth2/eth1_monitor/eth1_monitor.py
+++ b/trinity/components/eth2/eth1_monitor/eth1_monitor.py
@@ -186,7 +186,7 @@ class Eth1Monitor(Service):
         )
         if target_block_number < 0:
             raise Eth1MonitorValidationError(
-                f"target block number at`distance`={distance} is smaller than 0,",
+                f"target block number at `distance`={distance} is smaller than 0,",
                 f"eth1_voting_period_start_block_number={eth1_voting_period_start_block_number}",
             )
         try:
@@ -355,7 +355,8 @@ class Eth1Monitor(Service):
         Assume `self._block_timestamp_to_number` is in ascending order, the most naive way to find
         the timestamp is to traverse from the tail of `self._block_timestamp_to_number`.
         """
-        # Compare with largest recoreded block timestamp first before query for latest block.
+        # Compare with the largest recoreded block timestamp first before querying
+        # for the latest block.
         # If timestamp larger than largest block timestamp, request block from eth1 provider.
         if self._largest_block_timestamp is None or timestamp > self._largest_block_timestamp:
             try:

--- a/trinity/components/eth2/eth1_monitor/eth1_monitor.py
+++ b/trinity/components/eth2/eth1_monitor/eth1_monitor.py
@@ -54,7 +54,7 @@ def _w3_get_block(w3: Web3, *args: Any, **kwargs: Any) -> Eth1Block:
 
 
 class Eth1Monitor(Service):
-    logger = logging.getLogger("trinity.Eth1Monitor")
+    logger = logging.getLogger("trinity.components.eth2.eth1_monitor.Eth1Monitor")
 
     _eth1_data_provider: BaseEth1DataProvider
 

--- a/trinity/components/eth2/eth1_monitor/eth1_monitor.py
+++ b/trinity/components/eth2/eth1_monitor/eth1_monitor.py
@@ -185,8 +185,7 @@ class Eth1Monitor(Service):
         )
         if target_block_number < 0:
             raise Eth1MonitorValidationError(
-                f"`distance` is larger than `eth1_voting_period_start_block_number`: "
-                f"`distance`={distance}, ",
+                f"target block number at`distance`={distance} is smaller than 0,",
                 f"eth1_voting_period_start_block_number={eth1_voting_period_start_block_number}",
             )
         try:

--- a/trinity/components/eth2/eth1_monitor/eth1_monitor.py
+++ b/trinity/components/eth2/eth1_monitor/eth1_monitor.py
@@ -1,16 +1,7 @@
 import bisect
 from collections import OrderedDict
 import logging
-from typing import (
-    Any,
-    AsyncGenerator,
-    Callable,
-    Sequence,
-    Tuple,
-    Type,
-    TypeVar,
-    Union,
-)
+from typing import Any, AsyncGenerator, Callable, Sequence, Tuple, Type, TypeVar, Union
 
 from async_service import Service
 from eth_typing import BlockNumber, Hash32
@@ -63,7 +54,7 @@ def _w3_get_block(w3: Web3, *args: Any, **kwargs: Any) -> Eth1Block:
 
 
 class Eth1Monitor(Service):
-    logger = logging.getLogger('trinity.eth1_monitor')
+    logger = logging.getLogger("trinity.Eth1Monitor")
 
     _eth1_data_provider: BaseEth1DataProvider
 
@@ -81,6 +72,7 @@ class Eth1Monitor(Service):
     _db: BaseDepositDataDB
     # Mapping from `block.timestamp` to `block.number`.
     _block_timestamp_to_number: "OrderedDict[Timestamp, BlockNumber]"
+    _largest_block_timestamp: Timestamp
 
     def __init__(
         self,
@@ -101,6 +93,7 @@ class Eth1Monitor(Service):
         )
 
         self._block_timestamp_to_number = OrderedDict()
+        self._largest_block_timestamp = None
 
     @property
     def total_deposit_count(self) -> int:
@@ -135,9 +128,11 @@ class Eth1Monitor(Service):
                 f"Block does not exist for block_hash={humanize_hash(req.block_hash)}"
             )
         eth1_voting_period_start_block_number = self._get_closest_eth1_voting_period_start_block(
-            req.eth1_voting_period_start_timestamp,
+            req.eth1_voting_period_start_timestamp
         )
-        return GetDistanceResponse(distance=(eth1_voting_period_start_block_number - block.number))
+        return GetDistanceResponse(
+            distance=(eth1_voting_period_start_block_number - block.number)
+        )
 
     async def _handle_new_logs(self) -> None:
         """
@@ -269,7 +264,8 @@ class Eth1Monitor(Service):
                     )
                 else:
                     await self._event_bus.broadcast(
-                        req.expected_response_type()(None, None, e), req.broadcast_config()
+                        req.expected_response_type()(None, None, e),
+                        req.broadcast_config(),
                     )
             else:
                 await self._event_bus.broadcast(resp, req.broadcast_config())
@@ -307,14 +303,15 @@ class Eth1Monitor(Service):
         """
         # Check timestamp.
         if len(self._block_timestamp_to_number) != 0:
-            latest_timestamp = next(reversed(self._block_timestamp_to_number))
             # Sanity check.
-            if block.timestamp < latest_timestamp:
+            if block.timestamp < self._largest_block_timestamp:
                 raise Eth1MonitorValidationError(
-                    "Later blocks with earlier timestamp: "
-                    f"latest_timestamp={latest_timestamp}, timestamp={block.timestamp}"
+                    "Later block with earlier timestamp: "
+                    f"largest_timestamp={self._largest_block_timestamp}, "
+                    f"block.timestamp={block.timestamp}"
                 )
         self._block_timestamp_to_number[block.timestamp] = block.number
+        self._largest_block_timestamp = block.timestamp
 
     def _get_logs_from_block(self, block_number: BlockNumber) -> Tuple[DepositLog, ...]:
         """
@@ -349,36 +346,57 @@ class Eth1Monitor(Service):
         Assume `self._block_timestamp_to_number` is in ascending order, the most naive way to find
         the timestamp is to traverse from the tail of `self._block_timestamp_to_number`.
         """
-        # NOTE: It can be done by binary search with web3 queries.
-        # Regarding the current block number is around `9000000`, not sure if it is worthwhile to
-        # do it through web3 with `log(9000000, 2)` ~= 24 `getBlock` queries. It's quite expensive
-        # compared to calculating it by the cached data which involves 0 query.
-
-        # Binary search for the right-most timestamp smaller than `timestamp`.
-        all_timestamps = tuple(self._block_timestamp_to_number.keys())
-        target_timestamp_index = bisect.bisect_right(all_timestamps, timestamp)
-        # Though `index < 0` should never happen, check it for safety.
-        if target_timestamp_index <= 0:
-            raise Eth1BlockNotFound(
-                "Failed to find the closest eth1 voting period start block to "
-                f"timestamp {timestamp}"
-            )
+        # Compare with largest recoreded block timestamp first before query for latest block.
+        # If timestamp larger than largest block timestamp, request block from eth1 provider.
+        if self._largest_block_timestamp is None or timestamp > self._largest_block_timestamp:
+            try:
+                block = self._eth1_data_provider.get_block("latest")
+            except BlockNotFound:
+                raise Eth1MonitorValidationError("Fail to get latest block")
+            if block.timestamp <= timestamp:
+                return block.number
+            else:
+                block_number = block.number
+                # Try the latest `self._num_blocks_confirmed` blocks until we give up
+                for i in range(1, self._num_blocks_confirmed + 1):
+                    block = self._eth1_data_provider.get_block(block_number - i)
+                    if block.timestamp <= timestamp:
+                        return block.number
+                raise Eth1BlockNotFound(
+                    "Can not find block with timestamp closest"
+                    "to voting period start timestamp: %s",
+                    timestamp,
+                )
         else:
-            # `bisect.bisect_right` returns the index we should insert `timestamp` into
-            # `all_timestamps`, to make `all_timestamps` still in order. The element we are
-            # looking for is actually `index - 1`
-            index = target_timestamp_index - 1
-            target_key = all_timestamps[index]
-            return self._block_timestamp_to_number[target_key]
+            # NOTE: It can be done by binary search with web3 queries.
+            # Regarding the current block number is around `9000000`, not sure if it is worthwhile
+            # to do it through web3 with `log(9000000, 2)` ~= 24 `getBlock` queries.
+            # It's quite expensive compared to calculating it by the cached data
+            # which involves 0 query.
+
+            # Binary search for the right-most timestamp smaller than `timestamp`.
+            all_timestamps = tuple(self._block_timestamp_to_number.keys())
+            target_timestamp_index = bisect.bisect_right(all_timestamps, timestamp)
+            # Though `index < 0` should never happen, check it for safety.
+            if target_timestamp_index <= 0:
+                raise Eth1BlockNotFound(
+                    "Failed to find the closest eth1 voting period start block to "
+                    f"timestamp {timestamp}"
+                )
+            else:
+                # `bisect.bisect_right` returns the index we should insert `timestamp` into
+                # `all_timestamps`, to make `all_timestamps` still in order. The element we are
+                # looking for is actually `index - 1`
+                index = target_timestamp_index - 1
+                target_key = all_timestamps[index]
+                return self._block_timestamp_to_number[target_key]
 
     def _get_accumulated_deposit_count(self, block_number: BlockNumber) -> int:
         """
         Get the accumulated deposit count from deposit contract with `get_deposit_count`
         at block `block_number`.
         """
-        deposit_count_bytes = self._eth1_data_provider.get_deposit_count(
-            block_number=block_number,
-        )
+        deposit_count_bytes = self._eth1_data_provider.get_deposit_count(block_number=block_number)
         return int.from_bytes(deposit_count_bytes, "little")
 
     def _get_deposit_root_from_contract(self, block_number: BlockNumber) -> Hash32:
@@ -386,6 +404,4 @@ class Eth1Monitor(Service):
         Get the deposit root from deposit contract with `get_deposit_root`
         at block `block_number`.
         """
-        return self._eth1_data_provider.get_deposit_root(
-            block_number=block_number,
-        )
+        return self._eth1_data_provider.get_deposit_root(block_number=block_number)


### PR DESCRIPTION
### What was wrong?
Beacon node needs to get `Eth1Data` and `Deposit`(i.e., `DepositData` with proof) to vote and process new deposits.


### How was it fixed?
- [x] Add `_get_eth1_vote ` which request `Eth1Data` candidates from `Eth1Monitor` and vote for one of them when proposing a new block
- [x] Add `_get_deposit_data` which request `Deposit`s that should be processed from `Eth1Monitor` when proposing a new block
- [x] Add `_check_and_update_data_per_slot` which is called at every `SlotTick` event. It checks if any data should be updated at that slot. For example
    - Since voting on `Eth1Data` could ended halfway during the voting period if everything goes well and `state.eth1_data` will be updated accordingly, so we need to cache `state.eth1_data` at the beginning of each voting period because we still need that data for the rest of votes during that voting period.
        - we cache this data in `starting_eth1_block_hash` and it's updated at the beginning of every voting period.
- [x] Also fix the problem in `Eth1Monitor` where requesting for eth1 block with timestamp closest to the beginning of each voting period will return incorrect block because it only searches the processed blocks.

- running `run_beacon_nodes.py` can successfully getting majority vote in every voting period and processing new (fake) deposits on my end


### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

[//]: # (See: https://trinity-client.readthedocs.io/en/latest/contributing.html#pull-requests)
- [ ] Add entry to the [release notes](https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

#### Cute Animal Picture



![](https://cdn.pixabay.com/photo/2019/12/09/17/14/cat-4683940_1280.jpg)
