### PR TITLE
remove dangling undefined variable: attestation

### DIFF
--- a/trinity/components/eth2/beacon/validator.py
+++ b/trinity/components/eth2/beacon/validator.py
@@ -461,7 +461,6 @@ class Validator(BaseService):
 
             metrics.validator_sent_attestation.inc()
 
-            attestations = attestations + (attestation,)
         # TODO: Aggregate attestations
 
         return attestations


### PR DESCRIPTION
### What was wrong?

`attestation` referenced before assigned. Related #1406

### How was it fixed?


### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

[//]: # (See: https://trinity-client.readthedocs.io/en/latest/contributing.html#pull-requests)
- [ ] Add entry to the [release notes](https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses]()
