### PR TITLE
Remove slot to state mapping

### DIFF
--- a/eth2/beacon/chains/base.py
+++ b/eth2/beacon/chains/base.py
@@ -112,10 +112,6 @@ class BaseBeaconChain(Configurable, ABC):
     # State API
     #
     @abstractmethod
-    def get_state_by_slot(self, slot: Slot) -> BeaconState:
-        ...
-
-    @abstractmethod
     def get_head_state_slot(self) -> Slot:
         ...
 
@@ -318,17 +314,6 @@ class BeaconChain(BaseBeaconChain):
     #
     # State API
     #
-    def get_state_by_slot(self, slot: Slot) -> BeaconState:
-        """
-        Return the requested state as specified by slot number.
-
-        Raise ``StateNotFound`` if there's no state with the given slot number in the db.
-        """
-        sm_class = self.get_state_machine_class_for_block_slot(slot)
-        state_class = sm_class.get_state_class()
-        state_root = self.chaindb.get_state_root_by_slot(slot)
-        return self.chaindb.get_state_by_root(state_root, state_class)
-
     def get_head_state_slot(self) -> Slot:
         return self.chaindb.get_head_state_slot()
 

--- a/eth2/beacon/chains/base.py
+++ b/eth2/beacon/chains/base.py
@@ -478,9 +478,7 @@ class BeaconChain(BaseBeaconChain):
 
         # Set the state of new (canonical) block as head state.
         if len(new_canonical_blocks) > 0:
-            self.chaindb.update_head_slot_and_state_root(
-                state.slot, state.hash_tree_root
-            )
+            self.chaindb.update_head_state(state.slot, state.hash_tree_root)
 
         self.logger.debug(
             "successfully imported block at slot %s with signing root %s",

--- a/eth2/beacon/db/chain.py
+++ b/eth2/beacon/db/chain.py
@@ -137,6 +137,10 @@ class BaseBeaconChainDB(ABC):
     # Beacon State
     #
     @abstractmethod
+    def update_head_slot_and_state_root(self, slot: Slot, root: Hash32) -> None:
+        ...
+
+    @abstractmethod
     def get_head_state_slot(self) -> Slot:
         ...
 

--- a/eth2/beacon/db/chain.py
+++ b/eth2/beacon/db/chain.py
@@ -137,7 +137,7 @@ class BaseBeaconChainDB(ABC):
     # Beacon State
     #
     @abstractmethod
-    def update_head_slot_and_state_root(self, slot: Slot, root: Hash32) -> None:
+    def update_head_state(self, slot: Slot, root: Hash32) -> None:
         ...
 
     @abstractmethod
@@ -713,7 +713,7 @@ class BeaconChainDB(BaseBeaconChainDB):
         """
         self.db.set(SchemaV1.make_head_state_root_lookup_key(), root)
 
-    def update_head_slot_and_state_root(self, slot: Slot, root: Hash32) -> None:
+    def update_head_state(self, slot: Slot, root: Hash32) -> None:
         """
         Write head state slot and head state root into the database.
         """
@@ -791,7 +791,7 @@ class BeaconChainDB(BaseBeaconChainDB):
             self.get_head_state_root()
         except HeadStateSlotNotFound:
             # Hasn't store any head state slot yet.
-            self.update_head_slot_and_state_root(state.slot, state.hash_tree_root)
+            self.update_head_state(state.slot, state.hash_tree_root)
 
         # For metrics
         # TODO: only persist per epoch transition

--- a/eth2/beacon/db/schema.py
+++ b/eth2/beacon/db/schema.py
@@ -12,11 +12,6 @@ class BaseSchema(ABC):
     def make_head_state_slot_lookup_key() -> bytes:
         ...
 
-    @staticmethod
-    @abstractmethod
-    def make_slot_to_state_root_lookup_key(slot: int) -> bytes:
-        ...
-
     #
     # Block
     #
@@ -83,10 +78,6 @@ class SchemaV1(BaseSchema):
     @staticmethod
     def make_head_state_slot_lookup_key() -> bytes:
         return b"v1:beacon:head-state-slot"
-
-    @staticmethod
-    def make_slot_to_state_root_lookup_key(slot: int) -> bytes:
-        return b"v1:beacon:slot-to-state-root%d" % slot
 
     @staticmethod
     def make_canonical_epoch_info_lookup_key() -> bytes:

--- a/eth2/beacon/db/schema.py
+++ b/eth2/beacon/db/schema.py
@@ -12,6 +12,11 @@ class BaseSchema(ABC):
     def make_head_state_slot_lookup_key() -> bytes:
         ...
 
+    @staticmethod
+    @abstractmethod
+    def make_head_state_root_lookup_key() -> bytes:
+        ...
+
     #
     # Block
     #
@@ -78,6 +83,10 @@ class SchemaV1(BaseSchema):
     @staticmethod
     def make_head_state_slot_lookup_key() -> bytes:
         return b"v1:beacon:head-state-slot"
+
+    @staticmethod
+    def make_head_state_root_lookup_key() -> bytes:
+        return b"v1:beacon:head-state-root"
 
     @staticmethod
     def make_canonical_epoch_info_lookup_key() -> bytes:

--- a/tests/eth2/core/beacon/chains/test_beacon_chain.py
+++ b/tests/eth2/core/beacon/chains/test_beacon_chain.py
@@ -3,7 +3,7 @@ import copy
 import pytest
 
 from eth2.beacon.chains.base import BeaconChain
-from eth2.beacon.db.exceptions import AttestationRootNotFound, StateNotFound
+from eth2.beacon.db.exceptions import AttestationRootNotFound
 from eth2.beacon.exceptions import BlockClassError
 from eth2.beacon.state_machines.forks.serenity.blocks import SerenityBeaconBlock
 from eth2.beacon.tools.builder.proposer import create_mock_block
@@ -58,51 +58,6 @@ def test_canonical_chain(valid_chain, genesis_slot, fork_choice_scoring):
     assert result_block_2 == block
 
 
-@pytest.mark.parametrize(
-    (
-        "validator_count,"
-        "slots_per_epoch,"
-        "target_committee_size,"
-        "max_committees_per_slot,"
-    ),
-    [(100, 16, 10, 16)],
-)
-def test_get_state_by_slot(valid_chain, genesis_block, genesis_state, config, keymap):
-    # Fisrt, skip block and check if `get_state_by_slot` returns the expected state
-    state_machine = valid_chain.get_state_machine(genesis_block.slot)
-    state = valid_chain.get_head_state()
-    block_skipped_slot = genesis_block.slot + 1
-    block_skipped_state = state_machine.state_transition.apply_state_transition(
-        state, future_slot=block_skipped_slot
-    )
-    with pytest.raises(StateNotFound):
-        valid_chain.get_state_by_slot(block_skipped_slot)
-    valid_chain.chaindb.persist_state(block_skipped_state)
-    assert (
-        valid_chain.get_state_by_slot(block_skipped_slot).hash_tree_root
-        == block_skipped_state.hash_tree_root
-    )
-
-    # Next, import proposed block and check if `get_state_by_slot` returns the expected state
-    proposed_slot = block_skipped_slot + 1
-    block = create_mock_block(
-        state=block_skipped_state,
-        config=config,
-        state_machine=state_machine,
-        block_class=genesis_block.__class__,
-        parent_block=genesis_block,
-        keymap=keymap,
-        slot=proposed_slot,
-        attestations=(),
-    )
-    valid_chain.import_block(block)
-    state = valid_chain.get_head_state()
-    assert (
-        valid_chain.get_state_by_slot(proposed_slot).hash_tree_root
-        == state.hash_tree_root
-    )
-
-
 @pytest.mark.long
 @pytest.mark.parametrize(
     ("validator_count,slots_per_epoch,target_committee_size,max_committees_per_slot"),
@@ -126,7 +81,7 @@ def test_import_blocks(valid_chain, genesis_block, genesis_state, config, keymap
         valid_chain.import_block(block)
         assert valid_chain.get_canonical_head() == block
 
-        state = valid_chain.get_state_by_slot(block.slot)
+        state = valid_chain.get_head_state()
 
         assert block == valid_chain.get_canonical_block_by_slot(block.slot)
         assert block.signing_root == valid_chain.get_canonical_block_root(block.slot)
@@ -138,10 +93,8 @@ def test_import_blocks(valid_chain, genesis_block, genesis_state, config, keymap
         valid_chain_2.import_block(block)
 
     assert valid_chain.get_canonical_head() == valid_chain_2.get_canonical_head()
-    assert valid_chain.get_state_by_slot(blocks[-1].slot).slot != 0
-    assert valid_chain.get_state_by_slot(
-        blocks[-1].slot
-    ) == valid_chain_2.get_state_by_slot(blocks[-1].slot)
+    assert valid_chain.get_head_state().slot != 0
+    assert valid_chain.get_head_state() == valid_chain_2.get_head_state()
 
 
 def test_from_genesis(base_db, genesis_block, genesis_state, fixture_sm_class, config):

--- a/tests/eth2/core/beacon/db/test_beacon_chaindb.py
+++ b/tests/eth2/core/beacon/db/test_beacon_chaindb.py
@@ -180,7 +180,7 @@ def test_chaindb_get_genesis_block_root(chaindb, genesis_block, fork_choice_scor
     assert block_root == genesis_block.signing_root
 
 
-def test_chaindb_get_head_state_slot(chaindb, state):
+def test_chaindb_get_head_state_slot_and_root(chaindb, state):
     # No head state slot stored in the beginning
     with pytest.raises(HeadStateSlotNotFound):
         chaindb.get_head_state_slot()
@@ -188,9 +188,18 @@ def test_chaindb_get_head_state_slot(chaindb, state):
     current_state = state.set("slot", current_slot)
     chaindb.persist_state(current_state)
     assert chaindb.get_head_state_slot() == current_state.slot
-    past_state = state
-    chaindb.persist_state(past_state)
-    assert chaindb.get_head_state_slot() == current_state.slot
+    assert chaindb.get_head_state_root() == current_state.hash_tree_root
+
+
+def test_chaindb_update_head_slot_and_state_root(chaindb, state):
+    chaindb.persist_state(state)
+    assert chaindb.get_head_state_slot() == state.slot
+    assert chaindb.get_head_state_root() == state.hash_tree_root
+
+    post_state = state.set("slot", state.slot + 1)
+    chaindb.update_head_slot_and_state_root(post_state.slot, post_state.hash_tree_root)
+    assert chaindb.get_head_state_slot() == post_state.slot
+    assert chaindb.get_head_state_root() == post_state.hash_tree_root
 
 
 def test_chaindb_state(chaindb, state):

--- a/tests/eth2/core/beacon/db/test_beacon_chaindb.py
+++ b/tests/eth2/core/beacon/db/test_beacon_chaindb.py
@@ -197,7 +197,7 @@ def test_chaindb_update_head_slot_and_state_root(chaindb, state):
     assert chaindb.get_head_state_root() == state.hash_tree_root
 
     post_state = state.set("slot", state.slot + 1)
-    chaindb.update_head_slot_and_state_root(post_state.slot, post_state.hash_tree_root)
+    chaindb.update_head_state(post_state.slot, post_state.hash_tree_root)
     assert chaindb.get_head_state_slot() == post_state.slot
     assert chaindb.get_head_state_root() == post_state.hash_tree_root
 

--- a/tests/eth2/core/beacon/db/test_beacon_chaindb.py
+++ b/tests/eth2/core/beacon/db/test_beacon_chaindb.py
@@ -196,8 +196,6 @@ def test_chaindb_get_head_state_slot(chaindb, state):
 def test_chaindb_state(chaindb, state):
     chaindb.persist_state(state)
     state_class = BeaconState
-    result_state_root = chaindb.get_state_root_by_slot(state.slot)
-    assert result_state_root == state.hash_tree_root
     result_state = chaindb.get_state_by_root(state.hash_tree_root, state_class)
     assert result_state.hash_tree_root == state.hash_tree_root
 

--- a/trinity/components/eth2/beacon/component.py
+++ b/trinity/components/eth2/beacon/component.py
@@ -158,7 +158,6 @@ class BeaconNodeComponent(AsyncioIsolatedComponent):
             )
 
             state = chain.get_head_state()
-            assert state.slot == chain_config.genesis_config.GENESIS_SLOT
             registry_pubkeys = [v_record.pubkey for v_record in state.validators]
 
             validator_privkeys = {}

--- a/trinity/components/eth2/beacon/component.py
+++ b/trinity/components/eth2/beacon/component.py
@@ -157,7 +157,7 @@ class BeaconNodeComponent(AsyncioIsolatedComponent):
                 cancel_token=libp2p_node.cancel_token,
             )
 
-            state = chain.get_head_state()
+            state = chain.get_state_by_slot(chain_config.genesis_config.GENESIS_SLOT)
             registry_pubkeys = [v_record.pubkey for v_record in state.validators]
 
             validator_privkeys = {}

--- a/trinity/components/eth2/beacon/component.py
+++ b/trinity/components/eth2/beacon/component.py
@@ -157,7 +157,8 @@ class BeaconNodeComponent(AsyncioIsolatedComponent):
                 cancel_token=libp2p_node.cancel_token,
             )
 
-            state = chain.get_state_by_slot(chain_config.genesis_config.GENESIS_SLOT)
+            state = chain.get_head_state()
+            assert state.slot == chain_config.genesis_config.GENESIS_SLOT
             registry_pubkeys = [v_record.pubkey for v_record in state.validators]
 
             validator_privkeys = {}

--- a/trinity/components/eth2/beacon/validator.py
+++ b/trinity/components/eth2/beacon/validator.py
@@ -319,6 +319,10 @@ class Validator(BaseService):
         # FIXME: We might not need to persist state for skip slots since `create_block_on_state`
         # will run the state transition which also includes the state transition for skipped slots.
         self.chain.chaindb.persist_state(post_state)
+        self.chain.chaindb.update_head_slot_and_state_root(
+            post_state.slot,
+            post_state.hash_tree_root,
+        )
         return post_state
 
     #

--- a/trinity/components/eth2/beacon/validator.py
+++ b/trinity/components/eth2/beacon/validator.py
@@ -319,10 +319,7 @@ class Validator(BaseService):
         # FIXME: We might not need to persist state for skip slots since `create_block_on_state`
         # will run the state transition which also includes the state transition for skipped slots.
         self.chain.chaindb.persist_state(post_state)
-        self.chain.chaindb.update_head_slot_and_state_root(
-            post_state.slot,
-            post_state.hash_tree_root,
-        )
+        self.chain.chaindb.update_head_state(post_state.slot, post_state.hash_tree_root)
         return post_state
 
     #


### PR DESCRIPTION
### What was wrong?
slot to state mapping is rarely used. We rarely use it to get state from past slot. Mostly used in `chain.get_head_state()`.

And also this mapping is not easy to maintain. We currently only `persist_state` when importing a new block or when validator skip a slot. So when re-org happens, outdated slot to state entry will not be updated. For example if old chain map slot 111 to state S' and new canonical chain skip slot 111, then `get_state_by_slot(111)` would return state S'.
Or another example if tip of old chain is at slot 100 but tip of new canonical chain is at slot 80, state from slot 80-100 are not pruned.

So IMO it's not worth the effort to keep track of this mapping.
This PR supersedes #1154 .


### How was it fixed?
- [x] Remove slot to state mapping
- [x] We still keep head state info, i.e., head state slot and head state root. And these info are updated when
    1. imported a new canonical block
    2. validator skip a slot
    - basically updated in the same circumstances as before but the difference is that these info are not updated in `chain.persist_state` but instead updated in `chaindb. update_head_slot_and_state_root`.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

[//]: # (See: https://trinity-client.readthedocs.io/en/latest/contributing.html#pull-requests)
- [ ] Add entry to the [release notes](https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

#### Cute Animal Picture


![](https://cdn.pixabay.com/photo/2019/12/08/17/01/rabbit-4681639_1280.jpg)
