### PR TITLE
Fix discv4 lookup() to not return duplicate nodes

### DIFF
--- a/p2p/discovery.py
+++ b/p2p/discovery.py
@@ -368,7 +368,9 @@ class DiscoveryService(Service):
             results = await trio_utils.gather(*next_find_node_queries)
             for candidates in results:
                 closest.extend(candidates)
-            closest = sort_by_distance(closest, node_id)[:constants.KADEMLIA_BUCKET_SIZE]
+            # Need to sort again and pick just the closest k nodes to ensure we converge.
+            closest = sort_by_distance(
+                eth_utils.toolz.unique(closest), node_id)[:constants.KADEMLIA_BUCKET_SIZE]
             nodes_to_ask = _exclude_if_asked(closest)
 
         self.logger.debug(

--- a/p2p/kademlia.py
+++ b/p2p/kademlia.py
@@ -392,5 +392,5 @@ def _compute_shared_prefix_bits(nodes: List[NodeAPI]) -> int:
     raise AssertionError("Unable to calculate number of shared prefix bits")
 
 
-def sort_by_distance(nodes: List[NodeAPI], target_id: int) -> List[NodeAPI]:
+def sort_by_distance(nodes: Iterable[NodeAPI], target_id: int) -> List[NodeAPI]:
     return sorted(nodes, key=operator.methodcaller('distance_to', target_id))


### PR DESCRIPTION
That method could in some cases return duplicate nodes