### PR TITLE
Remove create_block_from_parent

### DIFF
--- a/eth2/beacon/chains/base.py
+++ b/eth2/beacon/chains/base.py
@@ -17,12 +17,7 @@ from eth2.beacon.types.attestations import Attestation
 from eth2.beacon.types.blocks import BaseBeaconBlock
 from eth2.beacon.types.nonspec.epoch_info import EpochInfo
 from eth2.beacon.types.states import BeaconState
-from eth2.beacon.typing import (
-    HashTreeRoot,
-    SigningRoot,
-    Slot,
-    Timestamp,
-)
+from eth2.beacon.typing import HashTreeRoot, SigningRoot, Slot, Timestamp
 from eth2.configs import Eth2Config, Eth2GenesisConfig
 
 if TYPE_CHECKING:

--- a/eth2/beacon/chains/base.py
+++ b/eth2/beacon/chains/base.py
@@ -18,7 +18,6 @@ from eth2.beacon.types.blocks import BaseBeaconBlock
 from eth2.beacon.types.nonspec.epoch_info import EpochInfo
 from eth2.beacon.types.states import BeaconState
 from eth2.beacon.typing import (
-    FromBlockParams,
     HashTreeRoot,
     SigningRoot,
     Slot,
@@ -132,12 +131,6 @@ class BaseBeaconChain(Configurable, ABC):
     #
     @abstractmethod
     def get_block_class(self, block_root: SigningRoot) -> Type[BaseBeaconBlock]:
-        ...
-
-    @abstractmethod
-    def create_block_from_parent(
-        self, parent_block: BaseBeaconBlock, block_params: FromBlockParams
-    ) -> BaseBeaconBlock:
         ...
 
     @abstractmethod
@@ -356,18 +349,6 @@ class BeaconChain(BaseBeaconChain):
         sm_class = self.get_state_machine_class_for_block_slot(slot)
         block_class = sm_class.block_class
         return block_class
-
-    def create_block_from_parent(
-        self, parent_block: BaseBeaconBlock, block_params: FromBlockParams
-    ) -> BaseBeaconBlock:
-        """
-        Passthrough helper to the ``StateMachine`` class of the block descending from the
-        given block.
-        """
-        slot = parent_block.slot + 1 if block_params.slot is None else block_params.slot
-        return self.get_state_machine_class_for_block_slot(
-            slot=slot
-        ).create_block_from_parent(parent_block, block_params)
 
     def get_block_by_root(self, block_root: SigningRoot) -> BaseBeaconBlock:
         """

--- a/eth2/beacon/state_machines/base.py
+++ b/eth2/beacon/state_machines/base.py
@@ -9,8 +9,8 @@ from eth2.beacon.fork_choice.scoring import BaseForkChoiceScoring
 from eth2.beacon.types.attestations import Attestation
 from eth2.beacon.types.blocks import BaseBeaconBlock
 from eth2.beacon.types.states import BeaconState
-from eth2.beacon.typing import FromBlockParams, Timestamp
-from eth2.configs import Eth2Config  # noqa: F401
+from eth2.beacon.typing import Timestamp
+from eth2.configs import Eth2Config
 
 from .state_transitions import BaseStateTransition
 
@@ -85,13 +85,6 @@ class BaseBeaconStateMachine(Configurable, ABC):
         state: BeaconState,
         check_proposer_signature: bool = True,
     ) -> Tuple[BeaconState, BaseBeaconBlock]:
-        ...
-
-    @staticmethod
-    @abstractmethod
-    def create_block_from_parent(
-        parent_block: BaseBeaconBlock, block_params: FromBlockParams
-    ) -> BaseBeaconBlock:
         ...
 
 

--- a/eth2/beacon/state_machines/forks/serenity/__init__.py
+++ b/eth2/beacon/state_machines/forks/serenity/__init__.py
@@ -12,9 +12,9 @@ from eth2.beacon.state_machines.state_transitions import (  # noqa: F401
 from eth2.beacon.types.attestations import Attestation
 from eth2.beacon.types.blocks import BaseBeaconBlock  # noqa: F401
 from eth2.beacon.types.states import BeaconState  # noqa: F401
-from eth2.beacon.typing import FromBlockParams, Timestamp
+from eth2.beacon.typing import Timestamp
 
-from .blocks import SerenityBeaconBlock, create_serenity_block_from_parent
+from .blocks import SerenityBeaconBlock
 from .configs import SERENITY_CONFIG
 from .state_transitions import SerenityStateTransition
 from .states import SerenityBeaconState
@@ -65,12 +65,6 @@ class SerenityStateMachine(BeaconStateMachine):
             return LMDGHOSTContext.from_bytes(fork_choice_context_data)
 
     # methods
-    @staticmethod
-    def create_block_from_parent(
-        parent_block: BaseBeaconBlock, block_params: FromBlockParams
-    ) -> BaseBeaconBlock:
-        return create_serenity_block_from_parent(parent_block, block_params)
-
     def _get_justified_head_state(self) -> BeaconState:
         justified_head = self.chaindb.get_justified_head(self.block_class)
         return self.chaindb.get_state_by_root(

--- a/eth2/beacon/state_machines/forks/serenity/blocks.py
+++ b/eth2/beacon/state_machines/forks/serenity/blocks.py
@@ -1,14 +1,5 @@
-from eth2.beacon.types.blocks import BaseBeaconBlock, BeaconBlock
-from eth2.beacon.typing import FromBlockParams
+from eth2.beacon.types.blocks import BeaconBlock
 
 
 class SerenityBeaconBlock(BeaconBlock):
     pass
-
-
-def create_serenity_block_from_parent(
-    parent_block: BaseBeaconBlock, block_params: FromBlockParams
-) -> BaseBeaconBlock:
-    block = SerenityBeaconBlock.from_parent(parent_block, block_params)
-
-    return block

--- a/eth2/beacon/state_machines/forks/skeleton_lake/__init__.py
+++ b/eth2/beacon/state_machines/forks/skeleton_lake/__init__.py
@@ -1,8 +1,6 @@
 from eth2.beacon.fork_choice.higher_slot import HigherSlotScoring
 from eth2.beacon.state_machines.base import BeaconStateMachine
-from eth2.beacon.state_machines.forks.serenity.blocks import (
-    SerenityBeaconBlock,
-)
+from eth2.beacon.state_machines.forks.serenity.blocks import SerenityBeaconBlock
 from eth2.beacon.state_machines.forks.serenity.state_transitions import (
     SerenityStateTransition,
 )

--- a/eth2/beacon/state_machines/forks/skeleton_lake/__init__.py
+++ b/eth2/beacon/state_machines/forks/skeleton_lake/__init__.py
@@ -2,14 +2,11 @@ from eth2.beacon.fork_choice.higher_slot import HigherSlotScoring
 from eth2.beacon.state_machines.base import BeaconStateMachine
 from eth2.beacon.state_machines.forks.serenity.blocks import (
     SerenityBeaconBlock,
-    create_serenity_block_from_parent,
 )
 from eth2.beacon.state_machines.forks.serenity.state_transitions import (
     SerenityStateTransition,
 )
 from eth2.beacon.state_machines.forks.serenity.states import SerenityBeaconState
-from eth2.beacon.types.blocks import BaseBeaconBlock
-from eth2.beacon.typing import FromBlockParams
 
 from .config import MINIMAL_SERENITY_CONFIG
 
@@ -23,13 +20,6 @@ class SkeletonLakeStateMachine(BeaconStateMachine):
     state_class = SerenityBeaconState
     state_transition_class = SerenityStateTransition
     fork_choice_scoring_class = HigherSlotScoring
-
-    # methods
-    @staticmethod
-    def create_block_from_parent(
-        parent_block: BaseBeaconBlock, block_params: FromBlockParams
-    ) -> BaseBeaconBlock:
-        return create_serenity_block_from_parent(parent_block, block_params)
 
     def get_fork_choice_scoring(self) -> HigherSlotScoring:
         return self.fork_choice_scoring_class()

--- a/trinity/components/eth2/beacon/validator.py
+++ b/trinity/components/eth2/beacon/validator.py
@@ -280,7 +280,7 @@ class Validator(BaseService):
             state=state,
             config=state_machine.config,
             state_machine=state_machine,
-            block_class=SerenityBeaconBlock,
+            block_class=SerenityBeaconBlock,  # TODO: Should get block class from slot
             parent_block=head_block,
             slot=slot,
             validator_index=proposer_index,


### PR DESCRIPTION
### What was wrong?

We actually don't have functions that depend on `create_block_from_parent` and the API is not so useful too.

The API builds a new empty block with the new block class upon a parent block. I argue that is not so useful. First reason is that most of the time we want to build a new block on a "state", and the second reason is if we can conveniently use `BaseBeaconBlock.from_parent` to achieve exactly the same thing.

### How was it fixed?

Remove them and things that depend on them.

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://preview.redd.it/n711skz80j841.jpg?width=640&crop=smart&auto=webp&s=e4935a689d3cecc64b69d606a5fa55ace6f9d96f)
