### PR TITLE
Ensure Kbucket's replacement cache doesn't contain duplicates

### DIFF
--- a/p2p/kademlia.py
+++ b/p2p/kademlia.py
@@ -223,6 +223,10 @@ class KBucket(Sized):
         elif len(self) < self.size:
             self.nodes.append(node)
         else:
+            if node in self.replacement_cache:
+                self.replacement_cache.remove(node)
+            elif len(self.replacement_cache) >= self.size:
+                self.replacement_cache.pop(0)
             self.replacement_cache.append(node)
             return self.head
         return None


### PR DESCRIPTION
Also enforce a size limit on them.