### PR TITLE
Extend `BeaconChain.get_state_by_slot` by adding `get_state_at_slot` helper

### DIFF
--- a/eth2/beacon/helpers.py
+++ b/eth2/beacon/helpers.py
@@ -69,6 +69,20 @@ def _get_historical_root(
     return historical_roots[slot % slots_per_historical_root]
 
 
+def get_state_root_at_slot(
+    state: "BeaconState", slot: Slot, slots_per_historical_root: int
+) -> Hash32:
+    """
+    Return state root at recent ``slot``.
+    """
+    if slot == state.slot:
+        return state.hash_tree_root
+    else:
+        return _get_historical_root(
+            state.state_roots, state.slot, slot, slots_per_historical_root
+        )
+
+
 def get_block_root_at_slot(
     state: "BeaconState", slot: Slot, slots_per_historical_root: int
 ) -> SigningRoot:

--- a/tests/eth2/core/beacon/chains/test_beacon_chain.py
+++ b/tests/eth2/core/beacon/chains/test_beacon_chain.py
@@ -65,7 +65,7 @@ def test_canonical_chain(valid_chain, genesis_slot, fork_choice_scoring):
     [(100, 16, 10, 16)],
 )
 def test_get_state_by_slot(valid_chain, genesis_block, genesis_state, config, keymap):
-    # Fisrt, skip block and check if `get_state_by_slot` returns the expected state
+    # First, skip block and check if `get_state_by_slot` returns the expected state
     state_machine = valid_chain.get_state_machine(genesis_block.slot)
     state = valid_chain.get_head_state()
     block_skipped_slot = genesis_block.slot + 1

--- a/tests/eth2/core/beacon/test_helpers.py
+++ b/tests/eth2/core/beacon/test_helpers.py
@@ -29,7 +29,14 @@ def get_pseudo_chain(length, genesis_block):
     block = genesis_block
     yield genesis_block
     for slot in range(1, length * 3):
-        block = genesis_block.mset("slot", slot, "parent_root", block.signing_root)
+        block = genesis_block.mset(
+            "slot",
+            slot,
+            "parent_root",
+            block.signing_root,
+            "state_root",
+            slot.to_bytes(32, "big"),
+        )
         yield block
 
 


### PR DESCRIPTION
### What was wrong?
It's easy to get recent state roots from head state. This PR extends `BeaconChain.get_state_by_slot` with `BeaconState` helper.

### How was it fixed?
1. Add `get_state_root_at_slot` helper
2. Use `get_state_root_at_slot` helper in
   `BeaconChain.get_state_by_slot`
3. Add `get_state_by_root` for HTTP APIs


### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

[//]: # (See: https://trinity-client.readthedocs.io/en/latest/contributing.html#pull-requests)
- [ ] Add entry to the [release notes](https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![dark-night-river-forest-minimal-art](https://user-images.githubusercontent.com/9263930/71881482-56762100-316d-11ea-8887-08f60510ca40.jpg)
