### PR TITLE
DiscoveryService.consume_datagram() now runs receive() in the bg

### DIFF
--- a/p2p/discovery.py
+++ b/p2p/discovery.py
@@ -521,7 +521,7 @@ class DiscoveryService(Service):
             constants.DISCOVERY_DATAGRAM_BUFFER_SIZE)
         address = Address(ip_address, port)
         self.logger.debug2("Received datagram from %s", address)
-        await self.receive(address, datagram)
+        self.manager.run_task(self.receive, address, datagram)
 
     async def receive(self, address: AddressAPI, message: bytes) -> None:
         try:

--- a/tests-trio/p2p-trio/conftest.py
+++ b/tests-trio/p2p-trio/conftest.py
@@ -72,3 +72,10 @@ class ManuallyDrivenDiscoveryService(DiscoveryService):
     async def run(self) -> None:
         self.ready_to_drive.set()
         await self.manager.wait_finished()
+
+    async def consume_datagram(self) -> None:
+        await super().consume_datagram()
+        # Our parent's consume_datagram() starts a background task to process the msg, so we yield
+        # control here to give that a chance to run. This avoid us having to do so in every test
+        # that calls consume_datagram().
+        await trio.hazmat.checkpoint()


### PR DESCRIPTION
That way we don't have to wait until a msg is processed before consuming 
the next

This depends on my discv4-enr branch, which has already been through review, so just the last
commit needs reviewing here