### PR TITLE
Rework `Validator` service for BN/VC separation

### DIFF
--- a/trinity/components/eth2/beacon/base_validator.py
+++ b/trinity/components/eth2/beacon/base_validator.py
@@ -1,0 +1,227 @@
+# Add a base class to share the same logic
+# It's a temporary stage
+
+from typing import (
+    Callable,
+    Tuple,
+)
+
+from cancel_token import (
+    CancelToken,
+)
+from eth_typing import (
+    BlockNumber,
+    Hash32,
+)
+from lahja import EndpointAPI
+
+from eth2._utils.numeric import integer_squareroot
+from eth2.beacon.chains.base import (
+    BaseBeaconChain,
+)
+from eth2.beacon.state_machines.base import (
+    BaseBeaconStateMachine,
+)
+from eth2.beacon.types.attestations import (
+    Attestation,
+)
+from eth2.beacon.types.deposits import (
+    Deposit,
+)
+from eth2.beacon.types.eth1_data import (
+    Eth1Data,
+)
+from eth2.beacon.types.states import (
+    BeaconState,
+)
+from eth2.beacon.typing import (
+    CommitteeIndex,
+    Slot,
+    Timestamp,
+)
+from p2p.service import (
+    BaseService,
+)
+from trinity.components.eth2.eth1_monitor.events import (
+    GetDistanceRequest,
+    GetDistanceResponse,
+    GetDepositRequest,
+    GetDepositResponse,
+    GetEth1DataRequest,
+    GetEth1DataResponse,
+)
+from trinity.protocol.bcc_libp2p.node import Node
+
+
+GetReadyAttestationsFn = Callable[[Slot, bool], Tuple[Attestation, ...]]
+GetAggregatableAttestationsFn = Callable[[Slot, CommitteeIndex], Tuple[Attestation, ...]]
+ImportAttestationFn = Callable[[Attestation, bool], None]
+
+
+# FIXME: Read this from validator config
+ETH1_FOLLOW_DISTANCE = 16
+
+
+class BaseValidator(BaseService):
+    genesis_time: Timestamp
+    chain: BaseBeaconChain
+    p2p_node: Node
+    event_bus: EndpointAPI
+
+    starting_eth1_block_hash: Hash32
+
+    def __init__(
+            self,
+            chain: BaseBeaconChain,
+            p2p_node: Node,
+            event_bus: EndpointAPI,
+            get_ready_attestations_fn: GetReadyAttestationsFn,
+            get_aggregatable_attestations_fn: GetAggregatableAttestationsFn,
+            import_attestation_fn: ImportAttestationFn,
+            token: CancelToken = None) -> None:
+        super().__init__(token)
+        self.genesis_time = chain.get_head_state().genesis_time
+        self.chain = chain
+        self.p2p_node = p2p_node
+        self.event_bus = event_bus
+        self.get_ready_attestations: GetReadyAttestationsFn = get_ready_attestations_fn
+        self.get_aggregatable_attestations: GetAggregatableAttestationsFn = get_aggregatable_attestations_fn  # noqa: E501
+        self.import_attestation: ImportAttestationFn = import_attestation_fn
+
+        # `state.eth1_data` can be updated in the middle of voting period and thus
+        # the starting `eth1_data.block_hash` must be stored separately.
+        self.starting_eth1_block_hash = chain.get_head_state().eth1_data.block_hash
+
+    #
+    # Proposing block
+    #
+    async def _get_deposit_data(self,
+                                state: BeaconState,
+                                state_machine: BaseBeaconStateMachine,
+                                eth1_vote: Eth1Data) -> Tuple[Deposit, ...]:
+        eth1_data = state.eth1_data
+        # Check if the eth1 vote pass the threshold
+        slots_per_eth1_voting_period = state_machine.config.SLOTS_PER_ETH1_VOTING_PERIOD
+        eth1_data_votes = state.eth1_data_votes.append(eth1_vote)
+        if eth1_data_votes.count(eth1_vote) * 2 > slots_per_eth1_voting_period:
+            eth1_data = eth1_vote
+
+        deposits: Tuple[Deposit, ...] = ()
+        expected_deposit_count = min(
+            state_machine.config.MAX_DEPOSITS,
+            eth1_data.deposit_count - state.eth1_deposit_index,
+        )
+        for i in range(expected_deposit_count):
+            request_params = {
+                "deposit_count": eth1_data.deposit_count,
+                "deposit_index": state.eth1_deposit_index + i,
+            }
+            resp: GetDepositResponse = await self.event_bus.request(
+                GetDepositRequest(**request_params)
+            )
+            if resp.error is None:
+                deposits = deposits + (resp.to_data(),)
+            else:
+                self.logger.error(
+                    "Fail to get deposit data with `deposit_count`=%s,"
+                    "`deposit_index`=%s",
+                    request_params["deposit_count"],
+                    request_params["deposit_index"],
+                )
+        return tuple(deposits)
+
+    async def _request_eth1_data(self,
+                                 eth1_voting_period_start_timestamp: Timestamp,
+                                 start: int,
+                                 end: int) -> Tuple[Eth1Data, ...]:
+        eth1_data: Tuple[Eth1Data, ...] = ()
+        for distance in range(start, end):
+            resp: GetEth1DataResponse = await self.event_bus.request(
+                GetEth1DataRequest(
+                    distance=BlockNumber(distance),
+                    eth1_voting_period_start_timestamp=Timestamp(
+                        eth1_voting_period_start_timestamp
+                    ),
+                )
+            )
+            if resp.error is None:
+                eth1_data = eth1_data + (resp.to_data(),)
+            else:
+                self.logger.error(
+                    "Fail to get eth1 data with `distance`=%s,"
+                    "`eth1_voting_period_start_timestamp`=%s",
+                    distance,
+                    eth1_voting_period_start_timestamp,
+                )
+        return eth1_data
+
+    async def _get_eth1_vote(self,
+                             slot: Slot,
+                             state: BeaconState,
+                             state_machine: BaseBeaconStateMachine) -> Eth1Data:
+        slots_per_eth1_voting_period = state_machine.config.SLOTS_PER_ETH1_VOTING_PERIOD
+        seconds_per_slot = state_machine.config.SECONDS_PER_SLOT
+        eth1_follow_distance = ETH1_FOLLOW_DISTANCE
+        eth1_voting_period_start_timestamp = (
+            self.genesis_time +
+            (slot - slot % slots_per_eth1_voting_period) * seconds_per_slot
+        )
+
+        new_eth1_data = await self._request_eth1_data(
+            Timestamp(eth1_voting_period_start_timestamp),
+            eth1_follow_distance,
+            2 * eth1_follow_distance,
+        )
+        # Default is the `Eth1Data` at `ETH1_FOLLOW_DISTANCE`
+        default_eth1_data = new_eth1_data[0]
+
+        # Compute `previous_eth1_distance` which is the distance between current block and
+        # `state.eth1_data`.
+        resp: GetDistanceResponse = await self.event_bus.request(
+            GetDistanceRequest(
+                block_hash=self.starting_eth1_block_hash,
+                eth1_voting_period_start_timestamp=Timestamp(eth1_voting_period_start_timestamp),
+            )
+        )
+        if resp.error is not None:
+            return default_eth1_data
+
+        previous_eth1_distance = resp.distance
+
+        # Request all eth1 data within `previous_eth1_distance`
+        all_eth1_data: Tuple[Eth1Data, ...] = ()
+        # Copy overlapped eth1 data from `new_eth1_data`
+        if 2 * eth1_follow_distance >= previous_eth1_distance:
+            all_eth1_data = new_eth1_data[
+                : (previous_eth1_distance - eth1_follow_distance)
+            ]
+        else:
+            all_eth1_data = new_eth1_data[:]
+            all_eth1_data += await self._request_eth1_data(
+                Timestamp(eth1_voting_period_start_timestamp),
+                2 * eth1_follow_distance,
+                previous_eth1_distance,
+            )
+
+        # Filter out invalid votes
+        voting_period_int_sqroot = integer_squareroot(slots_per_eth1_voting_period)
+        period_tail = slot % slots_per_eth1_voting_period >= voting_period_int_sqroot
+        if period_tail:
+            votes_to_consider = all_eth1_data
+        else:
+            votes_to_consider = new_eth1_data
+
+        valid_votes: Tuple[Eth1Data, ...] = tuple(
+            vote for vote in state.eth1_data_votes if vote in votes_to_consider
+        )
+
+        # Vote with most count wins. Otherwise vote for defaute eth1 data.
+        win_vote = max(
+            valid_votes,
+            key=lambda v: (
+                valid_votes.count(v),
+                -all_eth1_data.index(v),
+            ),  # Tiebreak by smallest distance
+            default=default_eth1_data,
+        )
+        return win_vote

--- a/trinity/components/eth2/beacon/chain_maintainer.py
+++ b/trinity/components/eth2/beacon/chain_maintainer.py
@@ -1,0 +1,136 @@
+from typing import (
+    Callable,
+    Tuple,
+)
+
+from cancel_token import (
+    CancelToken,
+)
+from eth_typing import (
+    Hash32,
+)
+from eth_utils import (
+    ValidationError,
+)
+from lahja import EndpointAPI
+
+from eth2.beacon.chains.base import (
+    BaseBeaconChain,
+)
+from eth2.beacon.state_machines.base import (
+    BaseBeaconStateMachine,
+)
+from eth2.beacon.types.attestations import (
+    Attestation,
+)
+from eth2.beacon.types.states import (
+    BeaconState,
+)
+from eth2.beacon.typing import (
+    CommitteeIndex,
+    Slot,
+    Timestamp,
+)
+from p2p.service import (
+    BaseService,
+)
+from trinity._utils.shellart import (
+    bold_green,
+)
+from trinity.components.eth2.beacon.slot_ticker import (
+    SlotTickEvent,
+)
+
+GetReadyAttestationsFn = Callable[[Slot, bool], Tuple[Attestation, ...]]
+GetAggregatableAttestationsFn = Callable[[Slot, CommitteeIndex], Tuple[Attestation, ...]]
+ImportAttestationFn = Callable[[Attestation, bool], None]
+
+
+class ChainMaintainer(BaseService):
+    genesis_time: Timestamp
+    chain: BaseBeaconChain
+    event_bus: EndpointAPI
+    slots_per_epoch: int
+
+    starting_eth1_block_hash: Hash32
+
+    def __init__(
+            self,
+            chain: BaseBeaconChain,
+            event_bus: EndpointAPI,
+            token: CancelToken = None) -> None:
+        super().__init__(token)
+        self.genesis_time = chain.get_head_state().genesis_time
+        self.chain = chain
+        self.event_bus = event_bus
+        config = self.chain.get_state_machine().config
+        self.slots_per_epoch = config.SLOTS_PER_EPOCH
+
+    async def _run(self) -> None:
+        self.logger.info(bold_green("ChainMaintainer is running"))
+        self.run_daemon_task(self.handle_slot_tick())
+
+        await self.cancellation()
+
+    def _check_and_update_data_per_slot(self, slot: Slot) -> None:
+        state_machine = self.chain.get_state_machine()
+        state = self.chain.get_head_state()
+        slots_per_eth1_voting_period = state_machine.config.SLOTS_PER_ETH1_VOTING_PERIOD
+        # Update eth1 block_hash in the beginning of each voting period
+        if (
+            slot % slots_per_eth1_voting_period == 0 and
+            self.starting_eth1_block_hash != state.eth1_data.block_hash
+        ):
+            self.starting_eth1_block_hash = state.eth1_data.block_hash
+
+    async def handle_slot_tick(self) -> None:
+        """
+        The callback for `SlotTicker` and it's expected to be called twice for one slot.
+        """
+        async for event in self.event_bus.stream(SlotTickEvent):
+            try:
+                self._check_and_update_data_per_slot(event.slot)
+                if event.tick_type.is_start:
+                    pass
+                elif event.tick_type.is_one_third:
+                    await self.handle_second_tick(event.slot)
+                elif event.tick_type.is_two_third:
+                    pass
+            except ValidationError as e:
+                self.logger.warn("%s", e)
+                self.logger.warn(
+                    "SHOULD NOT GET A VALIDATION ERROR"
+                    " HERE AS IT IS INTERNAL TO OUR OWN CODE"
+                )
+
+    async def handle_second_tick(self, slot: Slot) -> None:
+        state_machine = self.chain.get_state_machine()
+        state = self.chain.get_head_state()
+        if state.slot < slot:
+            self.skip_block(
+                slot=slot,
+                state=state,
+                state_machine=state_machine,
+            )
+
+    def skip_block(self,
+                   slot: Slot,
+                   state: BeaconState,
+                   state_machine: BaseBeaconStateMachine) -> BeaconState:
+        """
+        Forward state to the target ``slot`` and persist the state.
+        """
+        post_state = state_machine.state_transition.apply_state_transition(
+            state,
+            future_slot=slot,
+        )
+        self.logger.debug(
+            bold_green("Skip block at slot=%s  post_state=%s"),
+            slot,
+            repr(post_state),
+        )
+        # FIXME: We might not need to persist state for skip slots since `create_block_on_state`
+        # will run the state transition which also includes the state transition for skipped slots.
+        self.chain.chaindb.persist_state(post_state)
+        self.chain.chaindb.update_head_state(post_state.slot, post_state.hash_tree_root)
+        return post_state

--- a/trinity/components/eth2/beacon/validator.py
+++ b/trinity/components/eth2/beacon/validator.py
@@ -2,30 +2,25 @@ from itertools import (
     groupby,
 )
 from typing import (
-    Callable,
     Dict,
     Iterable,
     Set,
     Tuple,
 )
 
-from lahja import EndpointAPI
-
 from cancel_token import (
     CancelToken,
 )
 from eth_typing import (
-    BlockNumber,
     BLSSignature,
-    Hash32,
 )
 from eth_utils import (
     humanize_hash,
     to_tuple,
     ValidationError,
 )
+from lahja import EndpointAPI
 
-from eth2._utils.numeric import integer_squareroot
 from eth2.beacon.chains.base import (
     BaseBeaconChain,
 )
@@ -46,12 +41,12 @@ from eth2.beacon.tools.builder.aggregator import (
 from eth2.beacon.tools.builder.committee_assignment import (
     CommitteeAssignment,
 )
+from eth2.beacon.tools.builder.committee_assignment import (
+    get_committee_assignment,
+)
 from eth2.beacon.tools.builder.proposer import (
     create_block_on_state,
     get_beacon_proposer_index,
-)
-from eth2.beacon.tools.builder.committee_assignment import (
-    get_committee_assignment,
 )
 from eth2.beacon.tools.builder.validator import (
     create_signed_attestations_at_slot,
@@ -65,12 +60,6 @@ from eth2.beacon.types.attestations import (
 from eth2.beacon.types.blocks import (
     BaseBeaconBlock,
 )
-from eth2.beacon.types.deposits import (
-    Deposit,
-)
-from eth2.beacon.types.eth1_data import (
-    Eth1Data,
-)
 from eth2.beacon.types.states import (
     BeaconState,
 )
@@ -80,57 +69,32 @@ from eth2.beacon.typing import (
     Epoch,
     Slot,
     SubnetId,
-    Timestamp,
     ValidatorIndex,
 )
 from eth2.configs import CommitteeConfig
-from p2p.service import (
-    BaseService,
-)
 from trinity._utils.shellart import (
     bold_green,
 )
-from trinity.components.eth2.eth1_monitor.events import (
-    GetDistanceRequest,
-    GetDistanceResponse,
-    GetDepositRequest,
-    GetDepositResponse,
-    GetEth1DataRequest,
-    GetEth1DataResponse,
-)
-from trinity.components.eth2.metrics.events import (
-    Libp2pPeersRequest,
-    Libp2pPeersResponse,
+from trinity.components.eth2.beacon.base_validator import (
+    BaseValidator,
+    GetReadyAttestationsFn,
+    GetAggregatableAttestationsFn,
+    ImportAttestationFn,
 )
 from trinity.components.eth2.beacon.slot_ticker import (
     SlotTickEvent,
 )
 from trinity.components.eth2.metrics.registry import metrics
-from trinity.protocol.bcc_libp2p.node import Node
 from trinity.protocol.bcc_libp2p.configs import ATTESTATION_SUBNET_COUNT
+from trinity.protocol.bcc_libp2p.node import Node
 
 
-GetReadyAttestationsFn = Callable[[Slot, bool], Tuple[Attestation, ...]]
-GetAggregatableAttestationsFn = Callable[[Slot, CommitteeIndex], Tuple[Attestation, ...]]
-ImportAttestationFn = Callable[[Attestation, bool], None]
-
-
-# FIXME: Read this from validator config
-ETH1_FOLLOW_DISTANCE = 16
-
-
-class Validator(BaseService):
-    genesis_time: Timestamp
-    chain: BaseBeaconChain
-    p2p_node: Node
+class Validator(BaseValidator):
     validator_privkeys: Dict[ValidatorIndex, int]
-    event_bus: EndpointAPI
     slots_per_epoch: int
     latest_proposed_epoch: Dict[ValidatorIndex, Epoch]
     latest_attested_epoch: Dict[ValidatorIndex, Epoch]
     local_validator_epoch_assignment: Dict[ValidatorIndex, Tuple[Epoch, CommitteeAssignment]]
-
-    starting_eth1_block_hash: Hash32
 
     def __init__(
             self,
@@ -142,12 +106,17 @@ class Validator(BaseService):
             get_aggregatable_attestations_fn: GetAggregatableAttestationsFn,
             import_attestation_fn: ImportAttestationFn,
             token: CancelToken = None) -> None:
-        super().__init__(token)
-        self.genesis_time = chain.get_head_state().genesis_time
-        self.chain = chain
-        self.p2p_node = p2p_node
+        super().__init__(
+            chain,
+            p2p_node,
+            event_bus,
+            get_ready_attestations_fn,
+            get_aggregatable_attestations_fn,
+            import_attestation_fn,
+            token,
+        )
+
         self.validator_privkeys = validator_privkeys
-        self.event_bus = event_bus
         config = self.chain.get_state_machine().config
         self.slots_per_epoch = config.SLOTS_PER_EPOCH
         # TODO: `latest_proposed_epoch` and `latest_attested_epoch` should be written
@@ -162,13 +131,6 @@ class Validator(BaseService):
                 Epoch(-1),
                 CommitteeAssignment((), CommitteeIndex(-1), Slot(-1)),
             )
-        self.get_ready_attestations: GetReadyAttestationsFn = get_ready_attestations_fn
-        self.get_aggregatable_attestations: GetAggregatableAttestationsFn = get_aggregatable_attestations_fn  # noqa: E501
-        self.import_attestation: ImportAttestationFn = import_attestation_fn
-
-        # `state.eth1_data` can be updated in the middle of voting period and thus
-        # the starting `eth1_data.block_hash` must be stored separately.
-        self.starting_eth1_block_hash = chain.get_head_state().eth1_data.block_hash
 
     async def _run(self) -> None:
         self.logger.info(
@@ -176,9 +138,6 @@ class Validator(BaseService):
             sorted(tuple(self.validator_privkeys.keys()))
         )
         self.run_daemon_task(self.handle_slot_tick())
-
-        # Metrics
-        self.run_daemon_task(self.handle_libp2p_peers_requests())
 
         await self.cancellation()
 
@@ -302,137 +261,6 @@ class Validator(BaseService):
     #
     # Proposing block
     #
-    async def _get_deposit_data(self,
-                                state: BeaconState,
-                                state_machine: BaseBeaconStateMachine,
-                                eth1_vote: Eth1Data) -> Tuple[Deposit, ...]:
-        eth1_data = state.eth1_data
-        # Check if the eth1 vote pass the threshold
-        slots_per_eth1_voting_period = state_machine.config.SLOTS_PER_ETH1_VOTING_PERIOD
-        eth1_data_votes = state.eth1_data_votes.append(eth1_vote)
-        if eth1_data_votes.count(eth1_vote) * 2 > slots_per_eth1_voting_period:
-            eth1_data = eth1_vote
-
-        deposits: Tuple[Deposit, ...] = ()
-        expected_deposit_count = min(
-            state_machine.config.MAX_DEPOSITS,
-            eth1_data.deposit_count - state.eth1_deposit_index,
-        )
-        for i in range(expected_deposit_count):
-            request_params = {
-                "deposit_count": eth1_data.deposit_count,
-                "deposit_index": state.eth1_deposit_index + i,
-            }
-            resp: GetDepositResponse = await self.event_bus.request(
-                GetDepositRequest(**request_params)
-            )
-            if resp.error is None:
-                deposits = deposits + (resp.to_data(),)
-            else:
-                self.logger.error(
-                    "Fail to get deposit data with `deposit_count`=%s,"
-                    "`deposit_index`=%s",
-                    request_params["deposit_count"],
-                    request_params["deposit_index"],
-                )
-        return tuple(deposits)
-
-    async def _request_eth1_data(self,
-                                 eth1_voting_period_start_timestamp: Timestamp,
-                                 start: int,
-                                 end: int) -> Tuple[Eth1Data, ...]:
-        eth1_data: Tuple[Eth1Data, ...] = ()
-        for distance in range(start, end):
-            resp: GetEth1DataResponse = await self.event_bus.request(
-                GetEth1DataRequest(
-                    distance=BlockNumber(distance),
-                    eth1_voting_period_start_timestamp=Timestamp(
-                        eth1_voting_period_start_timestamp
-                    ),
-                )
-            )
-            if resp.error is None:
-                eth1_data = eth1_data + (resp.to_data(),)
-            else:
-                self.logger.error(
-                    "Fail to get eth1 data with `distance`=%s,"
-                    "`eth1_voting_period_start_timestamp`=%s",
-                    distance,
-                    eth1_voting_period_start_timestamp,
-                )
-        return eth1_data
-
-    async def _get_eth1_vote(self,
-                             slot: Slot,
-                             state: BeaconState,
-                             state_machine: BaseBeaconStateMachine) -> Eth1Data:
-        slots_per_eth1_voting_period = state_machine.config.SLOTS_PER_ETH1_VOTING_PERIOD
-        seconds_per_slot = state_machine.config.SECONDS_PER_SLOT
-        eth1_follow_distance = ETH1_FOLLOW_DISTANCE
-        eth1_voting_period_start_timestamp = (
-            self.genesis_time +
-            (slot - slot % slots_per_eth1_voting_period) * seconds_per_slot
-        )
-
-        new_eth1_data = await self._request_eth1_data(
-            Timestamp(eth1_voting_period_start_timestamp),
-            eth1_follow_distance,
-            2 * eth1_follow_distance,
-        )
-        # Default is the `Eth1Data` at `ETH1_FOLLOW_DISTANCE`
-        default_eth1_data = new_eth1_data[0]
-
-        # Compute `previous_eth1_distance` which is the distance between current block and
-        # `state.eth1_data`.
-        resp: GetDistanceResponse = await self.event_bus.request(
-            GetDistanceRequest(
-                block_hash=self.starting_eth1_block_hash,
-                eth1_voting_period_start_timestamp=Timestamp(eth1_voting_period_start_timestamp),
-            )
-        )
-        if resp.error is not None:
-            return default_eth1_data
-
-        previous_eth1_distance = resp.distance
-
-        # Request all eth1 data within `previous_eth1_distance`
-        all_eth1_data: Tuple[Eth1Data, ...] = ()
-        # Copy overlapped eth1 data from `new_eth1_data`
-        if 2 * eth1_follow_distance >= previous_eth1_distance:
-            all_eth1_data = new_eth1_data[
-                : (previous_eth1_distance - eth1_follow_distance)
-            ]
-        else:
-            all_eth1_data = new_eth1_data[:]
-            all_eth1_data += await self._request_eth1_data(
-                Timestamp(eth1_voting_period_start_timestamp),
-                2 * eth1_follow_distance,
-                previous_eth1_distance,
-            )
-
-        # Filter out invalid votes
-        voting_period_int_sqroot = integer_squareroot(slots_per_eth1_voting_period)
-        period_tail = slot % slots_per_eth1_voting_period >= voting_period_int_sqroot
-        if period_tail:
-            votes_to_consider = all_eth1_data
-        else:
-            votes_to_consider = new_eth1_data
-
-        valid_votes: Tuple[Eth1Data, ...] = tuple(
-            vote for vote in state.eth1_data_votes if vote in votes_to_consider
-        )
-
-        # Vote with most count wins. Otherwise vote for defaute eth1 data.
-        win_vote = max(
-            valid_votes,
-            key=lambda v: (
-                valid_votes.count(v),
-                -all_eth1_data.index(v),
-            ),  # Tiebreak by smallest distance
-            default=default_eth1_data,
-        )
-        return win_vote
-
     async def propose_block(self,
                             proposer_index: ValidatorIndex,
                             slot: Slot,
@@ -719,11 +547,3 @@ class Validator(BaseService):
                     aggregate_and_proofs += (aggregate_and_proof,)
 
         return aggregate_and_proofs
-
-    async def handle_libp2p_peers_requests(self) -> None:
-        async for req in self.wait_iter(self.event_bus.stream(Libp2pPeersRequest)):
-            peer_count = len(self.p2p_node.handshaked_peers.peers)
-            await self.event_bus.broadcast(
-                Libp2pPeersResponse(peer_count),
-                req.broadcast_config(),
-            )

--- a/trinity/components/eth2/beacon/validator_handler.py
+++ b/trinity/components/eth2/beacon/validator_handler.py
@@ -1,0 +1,110 @@
+from cancel_token import (
+    CancelToken,
+)
+from eth_typing import (
+    BLSSignature,
+)
+from lahja import EndpointAPI
+
+from eth2.beacon.chains.base import (
+    BaseBeaconChain,
+)
+from eth2.beacon.tools.builder.proposer import create_unsigned_block_on_state
+from eth2.beacon.types.blocks import BaseBeaconBlock
+from eth2.beacon.typing import (
+    Slot,
+)
+from trinity._utils.shellart import (
+    bold_green,
+)
+from trinity.components.eth2.beacon.base_validator import (
+    BaseValidator,
+    GetReadyAttestationsFn,
+    GetAggregatableAttestationsFn,
+    ImportAttestationFn,
+)
+from trinity.http.api.events import (
+    GetBeaconBlockRequest,
+    GetBeaconBlockResponse,
+)
+from trinity.protocol.bcc_libp2p.node import Node
+
+
+class ValidatorHandler(BaseValidator):
+    def __init__(
+            self,
+            chain: BaseBeaconChain,
+            p2p_node: Node,
+            event_bus: EndpointAPI,
+            get_ready_attestations_fn: GetReadyAttestationsFn,
+            get_aggregatable_attestations_fn: GetAggregatableAttestationsFn,
+            import_attestation_fn: ImportAttestationFn,
+            token: CancelToken = None) -> None:
+        super().__init__(
+            chain,
+            p2p_node,
+            event_bus,
+            get_ready_attestations_fn,
+            get_aggregatable_attestations_fn,
+            import_attestation_fn,
+            token,
+        )
+
+    async def _run(self) -> None:
+        self.logger.info(
+            bold_green("ValidatorHandler is running"),
+        )
+        self.run_daemon_task(self.handle_get_block_requests())
+
+        await self.cancellation()
+
+    async def generate_unsigned_block(
+        self,
+        slot: Slot,
+        randao_reveal: BLSSignature,
+    ) -> BaseBeaconBlock:
+        """
+        Generate an unsigned block of the given ``slot`` with ``randao_reaveal``.
+        """
+        head_block = self.chain.get_canonical_head()
+        state_machine = self.chain.get_state_machine()
+        state = self.chain.get_head_state()
+
+        eth1_vote = await self._get_eth1_vote(slot, state, state_machine)
+        deposits = await self._get_deposit_data(state, state_machine, eth1_vote)
+
+        # TODO(hwwhww): Check if need to aggregate and if they are overlapping.
+
+        aggregated_attestations = self.get_ready_attestations(slot, True)
+        unaggregated_attestations = self.get_ready_attestations(slot, False)
+        ready_attestations = aggregated_attestations + unaggregated_attestations
+
+        block = create_unsigned_block_on_state(
+            state=state,
+            config=state_machine.config,
+            block_class=state_machine.block_class,
+            parent_block=head_block.block_class,
+            slot=slot,
+            attestations=ready_attestations,
+            eth1_data=eth1_vote,
+            deposits=deposits,
+        )
+
+        # Fill randao_reveal
+        block = block.set(
+            'body',
+            block.body.set('randao_reveal', randao_reveal)
+        )
+
+        return block
+
+    #
+    # Handle API Request
+    #
+    async def handle_get_block_requests(self) -> None:
+        async for req in self.wait_iter(self.event_bus.stream(GetBeaconBlockRequest)):
+            block = await self.generate_unsigned_block(req.slot, req.randao_reveal)
+            await self.event_bus.broadcast(
+                GetBeaconBlockResponse(block),
+                req.broadcast_config(),
+            )

--- a/trinity/components/eth2/eth1_monitor/component.py
+++ b/trinity/components/eth2/eth1_monitor/component.py
@@ -19,7 +19,7 @@ from eth2.beacon.typing import Timestamp
 from trinity.boot_info import BootInfo
 from trinity.components.eth2.eth1_monitor.configs import deposit_contract_json
 from trinity.components.eth2.eth1_monitor.eth1_data_provider import FakeEth1DataProvider
-from trinity.components.eth2.beacon.validator import ETH1_FOLLOW_DISTANCE
+from trinity.components.eth2.beacon.base_validator import ETH1_FOLLOW_DISTANCE
 from trinity.config import BeaconAppConfig
 from trinity.db.manager import DBClient
 from trinity.events import ShutdownRequest

--- a/trinity/components/eth2/metrics/events.py
+++ b/trinity/components/eth2/metrics/events.py
@@ -2,6 +2,7 @@ from dataclasses import (
     dataclass,
 )
 from typing import (
+    Tuple,
     Type,
 )
 
@@ -10,13 +11,15 @@ from lahja import (
     BaseRequestResponseEvent,
 )
 
+from libp2p.peer.id import ID
+
 
 @dataclass
 class Libp2pPeersResponse(BaseEvent):
     """
-    libp2p_peers: Tracks number of libp2p peers
+    libp2p_peers: Handshaked Peer IDs.
     """
-    result: int
+    result: Tuple[ID, ...]
 
 
 class Libp2pPeersRequest(BaseRequestResponseEvent[Libp2pPeersResponse]):

--- a/trinity/http/api/events.py
+++ b/trinity/http/api/events.py
@@ -1,0 +1,45 @@
+from dataclasses import (
+    dataclass,
+)
+from typing import (
+    Type,
+)
+
+from eth_typing import BLSSignature
+from lahja import (
+    BaseEvent,
+    BaseRequestResponseEvent,
+)
+
+from eth2.beacon.types.blocks import BaseBeaconBlock
+from eth2.beacon.typing import Slot
+from libp2p.peer.id import ID
+
+
+@dataclass
+class Libp2pPeerIDResponse(BaseEvent):
+    """
+    libp2p_peers: The peer ID of the beacon node.
+    """
+    result: ID
+
+
+class Libp2pPeerIDRequest(BaseRequestResponseEvent[Libp2pPeerIDResponse]):
+    @staticmethod
+    def expected_response_type() -> Type[Libp2pPeerIDResponse]:
+        return Libp2pPeerIDResponse
+
+
+@dataclass
+class GetBeaconBlockResponse(BaseEvent):
+    result: BaseBeaconBlock
+
+
+@dataclass
+class GetBeaconBlockRequest(BaseRequestResponseEvent[GetBeaconBlockResponse]):
+    slot: Slot
+    randao_reveal: BLSSignature
+
+    @staticmethod
+    def expected_response_type() -> Type[GetBeaconBlockResponse]:
+        return GetBeaconBlockResponse

--- a/trinity/http/handlers/metrics_handler.py
+++ b/trinity/http/handlers/metrics_handler.py
@@ -28,7 +28,7 @@ def root_to_int(root: Hash32) -> int:
 async def process_metrics(chain: BaseBeaconChain, event_bus: EndpointAPI) -> None:
     # Networking
     libp2p_peers = await event_bus.request(Libp2pPeersRequest())
-    metrics.libp2p_peers.set(libp2p_peers.result)
+    metrics.libp2p_peers.set(len(libp2p_peers.result))
 
     # Per slot info
     beacon_slot = chain.get_head_state_slot()


### PR DESCRIPTION
### What was wrong?
The current `Validator` service could be replaced with `ChainMaintainer`, `ValidatorHandler` (probably needs better names), and the `ValidatorClient`:
- `ChainMaintainer`: process slot-ticking related logic. e.g., skip slot
- `ValidatorHandler`: process validator API requests.

### How was it fixed?

- This PR refactors `Validator` by extracting the shared logic into `BaseValidator`, then we get:
    - `Validator(BaseValidator)`
    - `ValidatorHandler(BaseValidator)`
- Once VC <-> BN is done, we can delete the current `Validator` service from BN.
- For metrics API, move `handle_libp2p_peers_requests` from `Validator(BaseValidator)` to `Node`.
- For HTTP RESTful API, move `handle_libp2p_peer_id_requests` from `Validator(BaseValidator)` to `Node`.
- To display the functionality, add `GetBeaconBlockRequest` handler in `ValidatorHandler(BaseValidator)`.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

[//]: # (See: https://trinity-client.readthedocs.io/en/latest/contributing.html#pull-requests)
- [ ] Add entry to the [release notes](https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![hare-2135472_640](https://user-images.githubusercontent.com/9263930/71922382-c57f6400-31c5-11ea-9b1c-e231f5495e56.jpg)