### PR TITLE
convert event bus service to use async-service APIs

### DIFF
--- a/tests-trio/eth1-monitor/conftest.py
+++ b/tests-trio/eth1-monitor/conftest.py
@@ -28,7 +28,7 @@ from trinity.tools.factories.db import AtomicDBFactory
 # Ref: https://github.com/ethereum/eth2.0-specs/blob/dev/deposit_contract/tests/contracts/conftest.py  # noqa: E501
 
 
-@pytest.fixture("session")
+@pytest.fixture(scope="session")
 def contract_json():
     return json.loads(deposit_contract_json)
 

--- a/tests-trio/p2p-trio/test_packer.py
+++ b/tests-trio/p2p-trio/test_packer.py
@@ -219,8 +219,14 @@ async def packer(enr_db,
         outgoing_message_receive_channel=outgoing_message_channels[1],
         outgoing_packet_send_channel=outgoing_packet_channels[0],
     )
-    async with background_trio_service(packer):
-        yield packer
+    try:
+        async with background_trio_service(packer):
+            yield packer
+    except trio.BrokenResourceError:
+        # TODO: This hack fixes flakyness in some tests.  This try/except
+        # should be dropped once the main issue has been addressed.
+        # ISSUE LINK: https://github.com/ethereum/trinity/issues/1517
+        pass
 
 
 @pytest_trio.trio_fixture

--- a/trinity/extensibility/asyncio.py
+++ b/trinity/extensibility/asyncio.py
@@ -6,9 +6,9 @@ from typing import Optional
 
 from asyncio_run_in_process import open_in_process
 from asyncio_run_in_process.typing import SubprocessKwargs
+from async_service import background_asyncio_service
 from lahja import EndpointAPI
 
-from p2p.service import run_service
 
 from trinity._utils.logging import child_process_logging
 from trinity._utils.profiling import profiler
@@ -59,9 +59,8 @@ class AsyncioIsolatedComponent(BaseIsolatedComponent):
                 boot_info.trinity_config,
                 endpoint_name,
             )
-            async with run_service(event_bus_service):
-                await event_bus_service.wait_event_bus_available()
-                event_bus = event_bus_service.get_event_bus()
+            async with background_asyncio_service(event_bus_service):
+                event_bus = await event_bus_service.get_event_bus()
 
                 try:
                     if boot_info.profile:

--- a/trinity/extensibility/event_bus.py
+++ b/trinity/extensibility/event_bus.py
@@ -1,6 +1,6 @@
 import asyncio
 import logging
-from typing import AsyncGenerator
+from typing import Type, Union
 
 import trio
 
@@ -12,116 +12,43 @@ from lahja import (
     TrioEndpoint,
 )
 
-from cancel_token import CancelToken
-
 from async_service import Service
-
-from p2p.service import BaseService
 
 from trinity.config import TrinityConfig
 from trinity.constants import MAIN_EVENTBUS_ENDPOINT
 from trinity.events import AvailableEndpointsUpdated, EventBusConnected
 
 
-class AsyncioEventBusService(BaseService):
-    endpoint: AsyncioEndpoint
+class BaseEventBusService(Service):
+    logger = logging.getLogger('trinity.extensibility.event_bus.EventBusService')
+
+    _endpoint: EndpointAPI
+    EndpointType: Union[Type[TrioEndpoint], Type[AsyncioEndpoint]]
+
+    EventType: Union[Type[trio.Event], Type[asyncio.Event]]
+    _endpoint_available: Union[trio.Event, asyncio.Event]
 
     def __init__(
         self,
         trinity_config: TrinityConfig,
         endpoint_name: str,
-        cancel_token: CancelToken = None,
-        loop: asyncio.AbstractEventLoop = None,
     ) -> None:
         self._trinity_config = trinity_config
-        self._endpoint_available = asyncio.Event()
-        self._connection_config = ConnectionConfig.from_name(
-            endpoint_name, self._trinity_config.ipc_dir
-        )
-        super().__init__(cancel_token, loop)
-
-    async def wait_event_bus_available(self) -> None:
-        await self._endpoint_available.wait()
-
-    def get_event_bus(self) -> AsyncioEndpoint:
-        return self._endpoint
-
-    async def _run(self) -> None:
-        try:
-            async with AsyncioEndpoint.serve(self._connection_config) as endpoint:
-                self._endpoint = endpoint
-
-                # run background task that automatically connects to newly announced endpoints
-                self.run_daemon_task(
-                    _auto_connect_new_announced_endpoints(
-                        self._endpoint, self._new_available_endpoints(), self.logger,
-                    )
-                )
-
-                # connect to the *main* endpoint which communicates information
-                # about other endpoints that come online.
-                main_endpoint_config = ConnectionConfig.from_name(
-                    MAIN_EVENTBUS_ENDPOINT, self._trinity_config.ipc_dir
-                )
-                await endpoint.connect_to_endpoints(main_endpoint_config)
-
-                # announce ourself to the event bus
-                await endpoint.wait_until_any_endpoint_subscribed_to(
-                    EventBusConnected,
-                )
-                await endpoint.broadcast(
-                    EventBusConnected(self._connection_config),
-                    BroadcastConfig(filter_endpoint=main_endpoint_config.name)
-                )
-
-                # signal that the endpoint is now available
-                self._endpoint_available.set()
-
-                # run until the endpoint exits
-                await self.cancellation()
-        except KeyboardInterrupt:
-            pass
-
-    async def _new_available_endpoints(
-        self
-    ) -> AsyncGenerator[AvailableEndpointsUpdated, None]:
-        async for ev in self.wait_iter(
-            self._endpoint.stream(AvailableEndpointsUpdated)
-        ):
-            yield ev
-
-
-class TrioEventBusService(Service):
-    logger = logging.getLogger('trinity.extensibility.event_bus.TrioEventBusService')
-
-    endpoint: TrioEndpoint
-
-    def __init__(self, trinity_config: TrinityConfig, endpoint_name: str) -> None:
-        self._trinity_config = trinity_config
-        self._endpoint_available = trio.Event()
+        self._endpoint_available = self.EventType()
         self._connection_config = ConnectionConfig.from_name(
             endpoint_name, self._trinity_config.ipc_dir
         )
 
-    async def wait_event_bus_available(self) -> None:
+    async def get_event_bus(self) -> EndpointAPI:
         await self._endpoint_available.wait()
-
-    def get_event_bus(self) -> TrioEndpoint:
         return self._endpoint
 
     async def run(self) -> None:
-        async with TrioEndpoint.serve(self._connection_config) as endpoint:
+        async with self.EndpointType.serve(self._connection_config) as endpoint:
             self._endpoint = endpoint
-            # signal that the endpoint is now available
-            self._endpoint_available.set()
 
             # run background task that automatically connects to newly announced endpoints
-            self.manager.run_daemon_task(
-                _auto_connect_new_announced_endpoints,
-                self._endpoint,
-                self._new_available_endpoints(),
-                self.logger,
-            )
+            self.manager.run_daemon_task(self._auto_connect_new_announced_endpoints, endpoint)
 
             # connect to the *main* endpoint which communicates information
             # about other endpoints that come online.
@@ -131,59 +58,64 @@ class TrioEventBusService(Service):
             await endpoint.connect_to_endpoints(main_endpoint_config)
 
             # announce ourself to the event bus
-            await endpoint.wait_until_endpoint_subscribed_to(
-                MAIN_EVENTBUS_ENDPOINT, EventBusConnected
+            await endpoint.wait_until_any_endpoint_subscribed_to(
+                EventBusConnected,
             )
             await endpoint.broadcast(
                 EventBusConnected(self._connection_config),
-                BroadcastConfig(filter_endpoint=MAIN_EVENTBUS_ENDPOINT),
+                BroadcastConfig(filter_endpoint=main_endpoint_config.name)
             )
+
+            # signal that the endpoint is now available
+            self._endpoint_available.set()
 
             # run until the endpoint exits
             await self.manager.wait_finished()
 
-    async def _new_available_endpoints(
-        self
-    ) -> AsyncGenerator[AvailableEndpointsUpdated, None]:
-        async for ev in self._endpoint.stream(AvailableEndpointsUpdated):
-            yield ev
+    async def _auto_connect_new_announced_endpoints(
+        self,
+        endpoint: EndpointAPI,
+    ) -> None:
+        """
+        Connect the given endpoint to all new endpoints on the given stream
+        """
+        async for ev in endpoint.stream(AvailableEndpointsUpdated):
+            # We only connect to Endpoints that appear after our own Endpoint in the set.
+            # This ensures that we don't try to connect to an Endpoint while that remote
+            # Endpoint also wants to connect to us.
+            endpoints_to_connect_to = tuple(
+                connection_config
+                for index, val in enumerate(ev.available_endpoints)
+                if val.name == endpoint.name
+                for connection_config in ev.available_endpoints[index:]
+                if not endpoint.is_connected_to(connection_config.name)
+            )
+            if not endpoints_to_connect_to:
+                continue
 
-
-async def _auto_connect_new_announced_endpoints(
-    endpoint: EndpointAPI,
-    new_available_endpoints_stream: AsyncGenerator[AvailableEndpointsUpdated, None],
-    logger: logging.Logger,
-) -> None:
-    """
-    Connect the given endpoint to all new endpoints on the given stream
-    """
-    async for ev in new_available_endpoints_stream:
-        # We only connect to Endpoints that appear after our own Endpoint in the set.
-        # This ensures that we don't try to connect to an Endpoint while that remote
-        # Endpoint also wants to connect to us.
-        endpoints_to_connect_to = tuple(
-            connection_config
-            for index, val in enumerate(ev.available_endpoints)
-            if val.name == endpoint.name
-            for connection_config in ev.available_endpoints[index:]
-            if not endpoint.is_connected_to(connection_config.name)
-        )
-        if not endpoints_to_connect_to:
-            continue
-
-        endpoint_names = ",".join((config.name for config in endpoints_to_connect_to))
-        logger.debug(
-            "EventBus Endpoint %s connecting to other Endpoints: %s",
-            endpoint.name,
-            endpoint_names,
-        )
-        try:
-            await endpoint.connect_to_endpoints(*endpoints_to_connect_to)
-        except Exception as e:
-            logger.warning(
-                "Failed to connect %s to one of %s: %s",
+            endpoint_names = ",".join((config.name for config in endpoints_to_connect_to))
+            self.logger.debug(
+                "EventBus Endpoint %s connecting to other Endpoints: %s",
                 endpoint.name,
                 endpoint_names,
-                e,
             )
-            raise
+            try:
+                await endpoint.connect_to_endpoints(*endpoints_to_connect_to)
+            except Exception as e:
+                self.logger.warning(
+                    "Failed to connect %s to one of %s: %s",
+                    endpoint.name,
+                    endpoint_names,
+                    e,
+                )
+                raise
+
+
+class AsyncioEventBusService(BaseEventBusService):
+    EventType = asyncio.Event
+    EndpointType = AsyncioEndpoint
+
+
+class TrioEventBusService(BaseEventBusService):
+    EventType = trio.Event
+    EndpointType = TrioEndpoint

--- a/trinity/extensibility/trio.py
+++ b/trinity/extensibility/trio.py
@@ -68,8 +68,7 @@ class TrioIsolatedComponent(BaseIsolatedComponent):
         )
         with trio.open_signal_receiver(signal.SIGINT, signal.SIGTERM) as signal_aiter:
             async with background_trio_service(event_bus_service):
-                await event_bus_service.wait_event_bus_available()
-                event_bus = event_bus_service.get_event_bus()
+                event_bus = await event_bus_service.get_event_bus()
                 async with trio.open_nursery() as nursery:
                     nursery.start_soon(cls.do_run, boot_info, event_bus)
                     async for sig in signal_aiter:


### PR DESCRIPTION
### What was wrong?

The services we use to manage the event bus were still using the legacy asyncio service.

### How was it fixed?

Updated it to use the new `async-service` APIs.


#### Cute Animal Picture

![733290aee704addb395ea9b961a2e6dc](https://user-images.githubusercontent.com/824194/72000556-ced9f200-3200-11ea-9a84-d25f73eb5ab2.jpg)
