### PR TITLE
File ENR DB

### DIFF
--- a/p2p/discv5/abc.py
+++ b/p2p/discv5/abc.py
@@ -125,11 +125,6 @@ class EnrDbApi(ABC):
         ...
 
     @abstractmethod
-    async def remove(self, node_id: NodeID) -> None:
-        """Remove an ENR from the db."""
-        ...
-
-    @abstractmethod
     async def insert_or_update(self, enr: ENR) -> None:
         """Insert or update an ENR depending if it is already present already or not."""
         ...

--- a/p2p/discv5/enr_db.py
+++ b/p2p/discv5/enr_db.py
@@ -1,7 +1,18 @@
+import binascii
+from collections import defaultdict
 import logging
+import operator
+import pathlib
+import re
+import time
 from typing import (
+    DefaultDict,
     Dict,
 )
+
+from eth_utils import ValidationError
+
+import rlp
 
 import trio
 
@@ -11,6 +22,9 @@ from p2p.discv5.abc import EnrDbApi
 from p2p.discv5.enr import ENR
 from p2p.discv5.identity_schemes import IdentitySchemeRegistry
 from p2p.discv5.typing import NodeID
+
+
+ACCEPTABLE_ENR_LOAD_TIME = 1.0
 
 
 class BaseEnrDb(EnrDbApi):
@@ -44,6 +58,138 @@ class BaseEnrDb(EnrDbApi):
             await self.update(enr)
         except KeyError:
             await self.insert(enr)
+
+
+def get_enr_filename(enr: ENR) -> str:
+    return f"enr_{encode_hex(enr.node_id)}_{enr.sequence_number}"
+
+
+def is_valid_enr_filename(filename: str) -> bool:
+    return bool(re.match(r"^enr_0x[0-9a-f]{64}_\d+$", filename))
+
+
+class FileEnrDb(BaseEnrDb):
+    def __init__(self,
+                 identity_scheme_registry: IdentitySchemeRegistry,
+                 directory: pathlib.Path) -> None:
+        super().__init__(identity_scheme_registry)
+        self.directory = directory
+        self.enrs: DefaultDict[NodeID, Dict[int, ENR]] = defaultdict(dict)
+        self.load_enrs_timed()
+
+    def load_enrs_timed(self) -> None:
+        start_time = time.time()
+
+        self.load_enrs()
+
+        end_time = time.time()
+        total_time = end_time - start_time
+
+        if total_time > ACCEPTABLE_ENR_LOAD_TIME:
+            self.logger.warning("Loading ENRs took a very long time: %.1f seconds", total_time)
+        else:
+            self.logger.debug("Loading ENRs took %.1f seconds", total_time)
+
+    def load_enrs(self) -> None:
+        enr_paths = tuple(
+            path for path in self.directory.iterdir()
+            if path.is_file()
+        )
+
+        invalid_enr_paths = tuple(
+            path for path in enr_paths
+            if not is_valid_enr_filename(path.name)
+        )
+        for invalid_enr_path in invalid_enr_paths:
+            self.logger.warning(
+                "Encountered invalid ENR filename %s in ENR directory %s",
+                invalid_enr_path,
+                self.directory
+            )
+
+        valid_enr_paths = tuple(
+            path for path in enr_paths
+            if path not in invalid_enr_paths
+        )
+        for path in valid_enr_paths:
+            try:
+                enr = self.load_enr_file(path)
+            except (binascii.Error, rlp.DeserializationError, ValidationError) as error:
+                self.logger.warning("Encountered invalid ENR in file %s: %s", path, error)
+                continue
+
+            if get_enr_filename(enr) != path.name:
+                self.logger.warning(
+                    "ENR in %s has inconsistent name (actual node id: %s, actual seq num: %d)",
+                    path,
+                    encode_hex(enr.node_id),
+                    enr.sequence_number
+                )
+
+            self.enrs[enr.node_id][enr.sequence_number] = enr
+
+    def load_enr_file(self, path: pathlib.Path) -> ENR:
+        enr_base64 = path.read_text()
+        enr = ENR.from_repr(enr_base64, self.identity_scheme_registry)
+        return enr
+
+    def write_enr_file(self, enr: ENR) -> None:
+        path = self.directory / get_enr_filename(enr)
+        path.write_text(repr(enr))
+
+    async def insert(self, enr: ENR) -> None:
+        self.validate_identity_scheme(enr)
+
+        if await self.contains(enr.node_id):
+            raise ValueError("ENR with node id %s already exists", encode_hex(enr.node_id))
+        else:
+            self.logger.debug(
+                "Inserting new ENR of %s with sequence number %d",
+                encode_hex(enr.node_id),
+                enr.sequence_number,
+            )
+            self.enrs[enr.node_id][enr.sequence_number] = enr
+            self.write_enr_file(enr)
+
+    async def update(self, enr: ENR) -> None:
+        self.validate_identity_scheme(enr)
+
+        existing_enr = await self.get(enr.node_id)
+        if existing_enr.sequence_number < enr.sequence_number:
+            self.logger.debug(
+                "Updating ENR of %s from sequence number %d to %d",
+                encode_hex(enr.node_id),
+                existing_enr.sequence_number,
+                enr.sequence_number,
+            )
+            self.enrs[enr.node_id][enr.sequence_number] = enr
+            self.write_enr_file(enr)
+        else:
+            self.logger.debug(
+                "Not updating ENR of %s as new sequence number %d is not higher than the current "
+                "one %d",
+                encode_hex(enr.node_id),
+                enr.sequence_number,
+                existing_enr.sequence_number,
+            )
+
+    async def get(self, node_id: NodeID) -> ENR:
+        await trio.hazmat.checkpoint()
+        enrs = self.enrs[node_id]
+        if not enrs:
+            raise KeyError(f"No ENR for node {encode_hex(node_id)} present in DB")
+        else:
+            # get enr with highest sequence number
+            _, enr = max(enrs.items(), key=operator.itemgetter(0))
+            return enr
+
+    async def contains(self, node_id: NodeID) -> bool:
+        await trio.hazmat.checkpoint()
+        return bool(self.enrs[node_id])
+
+    def __len__(self) -> int:
+        return len(self.enrs)
+
 
 class MemoryEnrDb(BaseEnrDb):
 

--- a/p2p/discv5/enr_db.py
+++ b/p2p/discv5/enr_db.py
@@ -39,6 +39,11 @@ class BaseEnrDb(EnrDbApi):
                 f"identity scheme registry"
             )
 
+    async def insert_or_update(self, enr: ENR) -> None:
+        try:
+            await self.update(enr)
+        except KeyError:
+            await self.insert(enr)
 
 class MemoryEnrDb(BaseEnrDb):
 
@@ -85,12 +90,6 @@ class MemoryEnrDb(BaseEnrDb):
         self.logger.debug("Removing ENR of %s", encode_hex(node_id))
 
         await trio.sleep(0)  # add checkpoint to make this a proper async function
-
-    async def insert_or_update(self, enr: ENR) -> None:
-        try:
-            await self.update(enr)
-        except KeyError:
-            await self.insert(enr)
 
     async def get(self, node_id: NodeID) -> ENR:
         await trio.sleep(0)  # add checkpoint to make this a proper async function

--- a/tests-trio/p2p-trio/test_enr_db.py
+++ b/tests-trio/p2p-trio/test_enr_db.py
@@ -1,7 +1,12 @@
+import pathlib
+
 import pytest
 
+from p2p.discv5.enr import ENR
 from p2p.discv5.enr_db import (
+    FileEnrDb,
     MemoryEnrDb,
+    get_enr_filename,
 )
 from p2p.discv5.identity_schemes import (
     default_identity_scheme_registry,
@@ -21,55 +26,70 @@ def memory_db():
     return MemoryEnrDb(default_identity_scheme_registry)
 
 
+@pytest.fixture
+def file_db_dir(tmp_path):
+    return pathlib.Path(tmp_path)
+
+
+@pytest.fixture
+def file_db(file_db_dir):
+    return FileEnrDb(default_identity_scheme_registry, file_db_dir)
+
+
+@pytest.fixture(params=["file_db", "memory_db"])
+def db(request):
+    return request.getfixturevalue(request.param)
+
+
 @pytest.mark.trio
-async def test_memory_insert(memory_db):
+async def test_insert(db):
     private_key = PrivateKeyFactory().to_bytes()
     enr = ENRFactory(private_key=private_key)
 
-    await memory_db.insert(enr)
-    assert await memory_db.contains(enr.node_id)
-    assert await memory_db.get(enr.node_id) == enr
+    await db.insert(enr)
+    assert await db.contains(enr.node_id)
+    assert await db.get(enr.node_id) == enr
 
     with pytest.raises(ValueError):
-        await memory_db.insert(enr)
+        await db.insert(enr)
 
     updated_enr = ENRFactory(private_key=private_key, sequence_number=enr.sequence_number + 1)
     with pytest.raises(ValueError):
-        await memory_db.insert(updated_enr)
+        await db.insert(updated_enr)
 
 
 @pytest.mark.trio
-async def test_memory_update(memory_db):
+async def test_update(db):
     private_key = PrivateKeyFactory().to_bytes()
     enr = ENRFactory(private_key=private_key)
 
     with pytest.raises(KeyError):
-        await memory_db.update(enr)
+        await db.update(enr)
 
-    await memory_db.insert(enr)
+    await db.insert(enr)
 
-    await memory_db.update(enr)
-    assert await memory_db.get(enr.node_id) == enr
+    await db.update(enr)
+    assert await db.get(enr.node_id) == enr
 
     updated_enr = ENRFactory(private_key=private_key, sequence_number=enr.sequence_number + 1)
-    await memory_db.update(updated_enr)
-    assert await memory_db.get(enr.node_id) == updated_enr
+    await db.update(updated_enr)
+    assert await db.get(enr.node_id) == updated_enr
 
 
 @pytest.mark.trio
-async def test_memory_insert_or_update(memory_db):
+async def test_insert_or_update(db):
     private_key = PrivateKeyFactory().to_bytes()
     enr = ENRFactory(private_key=private_key)
 
-    await memory_db.insert_or_update(enr)
-    assert await memory_db.get(enr.node_id) == enr
+    await db.insert_or_update(enr)
+    assert await db.get(enr.node_id) == enr
 
-    await memory_db.insert_or_update(enr)
-    assert await memory_db.get(enr.node_id) == enr
+    await db.insert_or_update(enr)
+    assert await db.get(enr.node_id) == enr
 
     updated_enr = ENRFactory(private_key=private_key, sequence_number=enr.sequence_number + 1)
-    await memory_db.insert_or_update(updated_enr)
-    assert await memory_db.get(enr.node_id) == updated_enr
+    await db.insert_or_update(updated_enr)
+    assert await db.get(enr.node_id) == updated_enr
 
 
 @pytest.mark.trio
@@ -86,23 +106,23 @@ async def test_memory_remove(memory_db):
 
 
 @pytest.mark.trio
-async def test_memory_get(memory_db):
+async def test_get(db):
     enr = ENRFactory()
 
     with pytest.raises(KeyError):
-        await memory_db.get(enr.node_id)
+        await db.get(enr.node_id)
 
-    await memory_db.insert(enr)
-    assert await memory_db.get(enr.node_id) == enr
+    await db.insert(enr)
+    assert await db.get(enr.node_id) == enr
 
 
 @pytest.mark.trio
-async def test_memory_contains(memory_db):
+async def test_contains(db):
     enr = ENRFactory()
 
-    assert not await memory_db.contains(enr.node_id)
-    await memory_db.insert(enr)
-    assert await memory_db.contains(enr.node_id)
+    assert not await db.contains(enr.node_id)
+    await db.insert(enr)
+    assert await db.contains(enr.node_id)
 
 
 @pytest.mark.trio
@@ -115,3 +135,40 @@ async def test_memory_checks_identity_scheme():
         await memory_db.insert(enr)
     with pytest.raises(ValueError):
         await memory_db.insert_or_update(enr)
+
+
+@pytest.mark.trio
+async def test_file_db_loads_existing_enrs(file_db_dir):
+    enr = ENRFactory()
+    filename = get_enr_filename(enr)
+    (file_db_dir / filename).write_text(repr(enr))
+    file_db = FileEnrDb(default_identity_scheme_registry, file_db_dir)
+    assert await file_db.get(enr.node_id) == enr
+
+
+@pytest.mark.trio
+async def test_file_db_ignores_bad_names(file_db_dir):
+    enr = ENRFactory()
+    filename = "not_a_valid_enr_name"
+    (file_db_dir / filename).write_text(repr(enr))
+    file_db = FileEnrDb(default_identity_scheme_registry, file_db_dir)
+    assert not await file_db.contains(enr.node_id)
+
+
+@pytest.mark.trio
+async def test_file_db_ignores_invalid_enrs(file_db_dir):
+    enr = ENRFactory()
+    filename = get_enr_filename(enr)
+    (file_db_dir / filename).write_text("invalid_encoding")
+    file_db = FileEnrDb(default_identity_scheme_registry, file_db_dir)
+    assert not await file_db.contains(enr.node_id)
+
+
+@pytest.mark.trio
+async def test_file_db_saves_enrs(file_db_dir, file_db):
+    enr = ENRFactory()
+    await file_db.insert(enr)
+    filename = get_enr_filename(enr)
+    assert (file_db_dir / filename).exists()
+    assert (file_db_dir / filename).is_file()
+    assert ENR.from_repr((file_db_dir / filename).read_text()) == enr


### PR DESCRIPTION
### What was wrong?

See #1444

### How was it fixed?

Implemented `FileEnrDb` which

- stores ENRs as files in a given directory
- ignores files with invalid contents or unexpected names
- reraises `IOError`s
- does not bother cleaning up old records
- has the same interface as the old `MemoryEnrDb`, except for a removed `remove` method

I'm not really sure anymore if the API is the right one or not. In particular, it doesn't allow getting ENRs by sequence number, it only ever provides the newest record for any given peer. But I think figuring this out is a separate issue.



#### Cute Animal Picture

![put a cute animal picture link inside the parentheses]()
