### PR TITLE
Implement include_transactions param for getBlockBy* RPC APIs

### DIFF
--- a/newsfragments/1465.feature.rst
+++ b/newsfragments/1465.feature.rst
@@ -1,0 +1,1 @@
+Support ``include_transactions`` param in ``eth_getBlockBy*`` APIs

--- a/tests/json-fixtures-over-rpc/test_rpc_fixtures.py
+++ b/tests/json-fixtures-over-rpc/test_rpc_fixtures.py
@@ -436,12 +436,24 @@ async def validate_block(rpc, block_fixture, at_block):
 
     await validate_transaction_count(rpc, block_fixture, at_block)
 
-    # TODO validate transaction bodies
     result, error = await call_rpc(rpc, rpc_method, [at_block, True])
     # assert error is None
-    # assert result['transactions'] == block_fixture['transactions']
 
+    validate_rpc_block_tx_vs_fixture(result['transactions'], block_fixture)
     await validate_uncles(rpc, block_fixture, at_block)
+
+
+def validate_rpc_block_tx_vs_fixture(transactions, block_fixture):
+
+    fixture_transactions = block_fixture['transactions']
+    fixture_header = fixture_block_in_rpc_format(block_fixture['blockHeader'])
+
+    for index, fixture_tx in enumerate(fixture_transactions):
+        result_tx = transactions[index]
+        result_tx_without_extra_fields = dissoc(result_tx, 'blockNumber', 'blockHash')
+        validate_rpc_transaction_vs_fixture(result_tx_without_extra_fields, fixture_tx)
+        assert result_tx['blockNumber'] == fixture_header['number']
+        assert result_tx['blockHash'] == fixture_header['hash']
 
 
 async def validate_last_block(rpc, block_fixture):

--- a/trinity/rpc/modules/eth.py
+++ b/trinity/rpc/modules/eth.py
@@ -57,6 +57,7 @@ from trinity.constants import (
 )
 from trinity.exceptions import RpcError
 from trinity.rpc.format import (
+    ApiBlockResponse,
     block_to_dict,
     header_to_dict,
     format_params,
@@ -187,14 +188,14 @@ class Eth(Eth1ChainRPCModule):
     @format_params(decode_hex, identity)
     async def getBlockByHash(self,
                              block_hash: Hash32,
-                             include_transactions: bool) -> Dict[str, Union[str, List[str]]]:
+                             include_transactions: bool) -> ApiBlockResponse:
         block = await self.chain.coro_get_block_by_hash(block_hash)
         return block_to_dict(block, self.chain, include_transactions)
 
     @format_params(to_int_if_hex, identity)
     async def getBlockByNumber(self,
                                at_block: Union[str, int],
-                               include_transactions: bool) -> Dict[str, Union[str, List[str]]]:
+                               include_transactions: bool) -> ApiBlockResponse:
         block = await get_block_at_number(self.chain, at_block)
         return block_to_dict(block, self.chain, include_transactions)
 

--- a/trinity/rpc/modules/eth.py
+++ b/trinity/rpc/modules/eth.py
@@ -57,7 +57,6 @@ from trinity.constants import (
 )
 from trinity.exceptions import RpcError
 from trinity.rpc.format import (
-    ApiBlockResponse,
     block_to_dict,
     header_to_dict,
     format_params,
@@ -70,6 +69,12 @@ from trinity.rpc.modules import (
     Eth1ChainRPCModule,
 )
 from trinity.rpc.retry import retryable
+from trinity.rpc.typing import (
+    RpcBlockResponse,
+    RpcHeaderResponse,
+    RpcReceiptResponse,
+    RpcTransactionResponse,
+)
 from trinity.sync.common.events import (
     SyncingRequest,
 )
@@ -188,14 +193,14 @@ class Eth(Eth1ChainRPCModule):
     @format_params(decode_hex, identity)
     async def getBlockByHash(self,
                              block_hash: Hash32,
-                             include_transactions: bool) -> ApiBlockResponse:
+                             include_transactions: bool) -> RpcBlockResponse:
         block = await self.chain.coro_get_block_by_hash(block_hash)
         return block_to_dict(block, self.chain, include_transactions)
 
     @format_params(to_int_if_hex, identity)
     async def getBlockByNumber(self,
                                at_block: Union[str, int],
-                               include_transactions: bool) -> ApiBlockResponse:
+                               include_transactions: bool) -> RpcBlockResponse:
         block = await get_block_at_number(self.chain, at_block)
         return block_to_dict(block, self.chain, include_transactions)
 
@@ -229,14 +234,14 @@ class Eth(Eth1ChainRPCModule):
 
     @format_params(decode_hex)
     async def getTransactionByHash(self,
-                                   transaction_hash: Hash32) -> Dict[str, str]:
+                                   transaction_hash: Hash32) -> RpcTransactionResponse:
         transaction = await self.chain.coro_get_canonical_transaction(transaction_hash)
         return transaction_to_dict(transaction)
 
     @format_params(decode_hex, to_int_if_hex)
     async def getTransactionByBlockHashAndIndex(self,
                                                 block_hash: Hash32,
-                                                index: int) -> Dict[str, str]:
+                                                index: int) -> RpcTransactionResponse:
         block = await self.chain.coro_get_block_by_hash(block_hash)
         transaction = block.transactions[index]
         return transaction_to_dict(transaction)
@@ -244,7 +249,7 @@ class Eth(Eth1ChainRPCModule):
     @format_params(to_int_if_hex, to_int_if_hex)
     async def getTransactionByBlockNumberAndIndex(self,
                                                   at_block: Union[str, int],
-                                                  index: int) -> Dict[str, str]:
+                                                  index: int) -> RpcTransactionResponse:
         block = await get_block_at_number(self.chain, at_block)
         transaction = block.transactions[index]
         return transaction_to_dict(transaction)
@@ -257,7 +262,7 @@ class Eth(Eth1ChainRPCModule):
 
     @format_params(decode_hex)
     async def getTransactionReceipt(self,
-                                    transaction_hash: Hash32) -> Dict[str, str]:
+                                    transaction_hash: Hash32) -> RpcReceiptResponse:
 
         tx_block_number, tx_index = await self.chain.coro_get_canonical_transaction_index(
             transaction_hash,
@@ -317,7 +322,9 @@ class Eth(Eth1ChainRPCModule):
         return hex(len(block.uncles))
 
     @format_params(decode_hex, to_int_if_hex)
-    async def getUncleByBlockHashAndIndex(self, block_hash: Hash32, index: int) -> Dict[str, str]:
+    async def getUncleByBlockHashAndIndex(self,
+                                          block_hash: Hash32,
+                                          index: int) -> RpcHeaderResponse:
         block = await self.chain.coro_get_block_by_hash(block_hash)
         uncle = block.uncles[index]
         return header_to_dict(uncle)
@@ -325,7 +332,7 @@ class Eth(Eth1ChainRPCModule):
     @format_params(to_int_if_hex, to_int_if_hex)
     async def getUncleByBlockNumberAndIndex(self,
                                             at_block: Union[str, int],
-                                            index: int) -> Dict[str, str]:
+                                            index: int) -> RpcHeaderResponse:
         block = await get_block_at_number(self.chain, at_block)
         uncle = block.uncles[index]
         return header_to_dict(uncle)

--- a/trinity/rpc/typing.py
+++ b/trinity/rpc/typing.py
@@ -1,0 +1,98 @@
+from typing import (
+    Sequence,
+    Union,
+)
+from eth_typing import HexStr
+from typing_extensions import TypedDict
+
+
+RpcTransactionResponse = TypedDict('RpcTransactionResponse', {
+    'hash': HexStr,
+    'nonce': str,
+    'gas': str,
+    'gasPrice': str,
+    # `from` being a reserved word forces us to use the alternate syntax for this type
+    'from': HexStr,
+    'to': HexStr,
+    'value': str,
+    'input': HexStr,
+    'r': str,
+    's': str,
+    'v': str,
+})
+
+
+class RpcBlockTransactionResponse(RpcTransactionResponse):
+    blockNumber: str
+    blockHash: HexStr
+
+
+class RpcHeaderResponse(TypedDict):
+    difficulty: str
+    extraData: HexStr
+    gasLimit: str
+    gasUsed: str
+    hash: HexStr
+    logsBloom: str
+    mixHash: HexStr
+    nonce: HexStr
+    number: str
+    parentHash: HexStr
+    receiptsRoot: HexStr
+    sha3Uncles: HexStr
+    stateRoot: HexStr
+    timestamp: str
+    transactionsRoot: HexStr
+    miner: HexStr
+
+
+class RpcBlockResponse(TypedDict):
+    difficulty: HexStr
+    extraData: HexStr
+    gasLimit: HexStr
+    gasUsed: HexStr
+    hash: HexStr
+    logsBloom: HexStr
+    mixHash: HexStr
+    nonce: HexStr
+    number: HexStr
+    parentHash: HexStr
+    receiptsRoot: HexStr
+    sha3Uncles: HexStr
+    stateRoot: HexStr
+    timestamp: HexStr
+    transactionsRoot: HexStr
+    miner: HexStr
+    totalDifficulty: str
+    uncles: Sequence[HexStr]
+    size: str
+    transactions: Union[Sequence[str], Sequence[RpcBlockTransactionResponse]]
+
+
+class RpcLogResponse(TypedDict):
+    address: HexStr
+    data: HexStr
+    blockHash: HexStr
+    blockNumber: str
+    logIndex: str
+    removed: bool
+    topics: Sequence[HexStr]
+    transactionHash: HexStr
+    transactionIndex: str
+
+
+RpcReceiptResponse = TypedDict('RpcReceiptResponse', {
+    'blockHash': HexStr,
+    'blockNumber': str,
+    'contractAddress': HexStr,
+    'cumulativeGasUsed': str,
+    # `from` being a reserved word forces us to use the alternate syntax for this type
+    'from': HexStr,
+    'gasUsed': str,
+    'logs': Sequence[RpcLogResponse],
+    'logsBloom': str,
+    'root': HexStr,
+    'to': HexStr,
+    'transactionHash': HexStr,
+    'transactionIndex': str,
+})


### PR DESCRIPTION
### What was wrong?

Our `eth_getBlockBy*` APIs do not yet support the `include_transactions` param

### How was it fixed?

Implemented functionality + tests.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

[//]: # (See: https://trinity-client.readthedocs.io/en/latest/contributing.html#pull-requests)
- [x] Add entry to the [release notes](https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

#### Cute (but tragic) Animal Picture

![put a cute animal picture link inside the parentheses](https://cdn.junglecreations.com/wp/junglecms/2019/11/17a5d33a-yjthmf-compressor.jpg)

In memory of [Lewis, who died because of the bushfires of Australia](https://vt.co/animals/stories/lewis-the-koala-saved-from-bushfires-by-grandma-has-sadly-died/).
