### PR TITLE
convert exchange API to use async-service

### DIFF
--- a/p2p/exchange/abc.py
+++ b/p2p/exchange/abc.py
@@ -8,7 +8,6 @@ from typing import (
     Generic,
     Iterable,
     Optional,
-    Tuple,
     Type,
     TYPE_CHECKING,
 )
@@ -93,8 +92,6 @@ class PerformanceTrackerAPI(PerformanceAPI, Generic[TRequestCommand, TResult]):
 
 class ResponseCandidateStreamAPI(ServiceAPI, Generic[TRequestCommand, TResponseCommand]):
     response_timeout: float
-
-    pending_request: Optional[Tuple[float, 'asyncio.Queue[TResponseCommand]']]
 
     request_protocol_type: Type[ProtocolAPI]
     response_cmd_type: Type[TResponseCommand]

--- a/p2p/exchange/abc.py
+++ b/p2p/exchange/abc.py
@@ -13,9 +13,9 @@ from typing import (
     TYPE_CHECKING,
 )
 
+from async_service import ServiceAPI
 
 from p2p.abc import (
-    AsyncioServiceAPI,
     ConnectionAPI,
     ProtocolAPI,
 )
@@ -91,10 +91,10 @@ class PerformanceTrackerAPI(PerformanceAPI, Generic[TRequestCommand, TResult]):
         ...
 
 
-class ResponseCandidateStreamAPI(AsyncioServiceAPI, Generic[TRequestCommand, TResponseCommand]):
+class ResponseCandidateStreamAPI(ServiceAPI, Generic[TRequestCommand, TResponseCommand]):
     response_timeout: float
 
-    pending_request: Optional[Tuple[float, 'asyncio.Future[TResponseCommand]']]
+    pending_request: Optional[Tuple[float, 'asyncio.Queue[TResponseCommand]']]
 
     request_protocol_type: Type[ProtocolAPI]
     response_cmd_type: Type[TResponseCommand]
@@ -108,6 +108,11 @@ class ResponseCandidateStreamAPI(AsyncioServiceAPI, Generic[TRequestCommand, TRe
             request_protocol_type: Type[ProtocolAPI],
             response_cmd_type: Type[TResponseCommand]) -> None:
         ...
+
+    @property
+    @abstractmethod
+    def is_alive(self) -> bool:
+        pass
 
     @abstractmethod
     def payload_candidates(
@@ -136,10 +141,6 @@ class ResponseCandidateStreamAPI(AsyncioServiceAPI, Generic[TRequestCommand, TRe
     @property
     @abstractmethod
     def is_pending(self) -> bool:
-        ...
-
-    @abstractmethod
-    def __del__(self) -> None:
         ...
 
 

--- a/p2p/exchange/candidate_stream.py
+++ b/p2p/exchange/candidate_stream.py
@@ -1,4 +1,5 @@
 import asyncio
+import logging
 import time
 from typing import (
     Any,
@@ -7,15 +8,15 @@ from typing import (
     Type,
 )
 
+from async_service import Service
+
 from p2p.abc import (
     ConnectionAPI,
     ProtocolAPI,
 )
 from p2p.exceptions import (
     ConnectionBusy,
-    PeerConnectionLost,
 )
-from p2p.service import BaseService
 
 from .abc import (
     PerformanceTrackerAPI,
@@ -33,10 +34,12 @@ from .typing import (
 
 class ResponseCandidateStream(
         ResponseCandidateStreamAPI[TRequestCommand, TResponseCommand],
-        BaseService):
+        Service):
+    logger = logging.getLogger('p2p.exchange.ResponseCandidateStream')
+
     response_timeout: float = ROUND_TRIP_TIMEOUT
 
-    pending_request: Tuple[float, 'asyncio.Future[TResponseCommand]'] = None
+    pending_request: Tuple[float, 'asyncio.Queue[TResponseCommand]'] = None
 
     def __init__(
             self,
@@ -44,8 +47,6 @@ class ResponseCandidateStream(
             request_protocol: ProtocolAPI,
             response_cmd_type: Type[TResponseCommand]) -> None:
         # This style of initialization keeps `mypy` happy.
-        BaseService.__init__(self, token=connection.cancel_token)
-
         self._connection = connection
         self.request_protocol = request_protocol
         self.response_cmd_type = response_cmd_type
@@ -53,6 +54,10 @@ class ResponseCandidateStream(
 
     def __repr__(self) -> str:
         return f'<ResponseCandidateStream({self._connection!s}, {self.response_cmd_type!r})>'
+
+    @property
+    def is_alive(self) -> bool:
+        return self.manager.is_running
 
     async def payload_candidates(
             self,
@@ -71,7 +76,10 @@ class ResponseCandidateStream(
         # The _lock ensures that we never have two concurrent requests to a
         # single peer for a single command pair in flight.
         try:
-            await self.wait(self._lock.acquire(), timeout=total_timeout * NUM_QUEUED_REQUESTS)
+            await asyncio.wait_for(
+                self._lock.acquire(),
+                timeout=total_timeout * NUM_QUEUED_REQUESTS,
+            )
         except asyncio.TimeoutError:
             raise ConnectionBusy(
                 f"Timed out waiting for {self.response_cmd_name} request lock "
@@ -81,12 +89,12 @@ class ResponseCandidateStream(
         start_at = time.perf_counter()
 
         try:
-            self._request(request)
+            queue = self._request(request)
             while self.is_pending:
                 timeout_remaining = max(0, total_timeout - (time.perf_counter() - start_at))
 
                 try:
-                    yield await self._get_payload(timeout_remaining)
+                    yield await asyncio.wait_for(queue.get(), timeout=timeout_remaining)
                 except asyncio.TimeoutError:
                     tracker.record_timeout(total_timeout)
                     raise
@@ -105,13 +113,13 @@ class ResponseCandidateStream(
     #
     # Service API
     #
-    async def _run(self) -> None:
+    async def run(self) -> None:
         self.logger.debug("Launching %r", self)
 
         # mypy doesn't recognizet the `TResponseCommand` as being an allowed
         # variant of the expected `Payload` type.
         with self._connection.add_command_handler(self.response_cmd_type, self._handle_msg):  # type: ignore  # noqa: E501
-            await self.cancellation()
+            await self.manager.wait_finished()
 
     async def _handle_msg(self, connection: ConnectionAPI, cmd: TResponseCommand) -> None:
         if self.pending_request is None:
@@ -120,29 +128,11 @@ class ResponseCandidateStream(
             )
             return
 
-        send_time, future = self.pending_request
+        send_time, queue = self.pending_request
         self.last_response_time = time.perf_counter() - send_time
-        try:
-            future.set_result(cmd)
-        except asyncio.InvalidStateError:
-            self.logger.debug(
-                "%s received a message response, but future was already done",
-                self,
-            )
+        queue.put_nowait(cmd)
 
-    async def _get_payload(self, timeout: float) -> TResponseCommand:
-        send_time, future = self.pending_request
-        try:
-            payload = await self.wait(future, timeout=timeout)
-        finally:
-            self.pending_request = None
-
-        # payload might be invalid, so prepare for another call to _get_payload()
-        self.pending_request = (send_time, asyncio.Future())
-
-        return payload
-
-    def _request(self, request: TRequestCommand) -> None:
+    def _request(self, request: TRequestCommand) -> 'asyncio.Queue[TResponseCommand]':
         if not self._lock.locked():
             # This is somewhat of an invariant check but since there the
             # linkage between the lock and this method are loose this sanity
@@ -152,29 +142,10 @@ class ResponseCandidateStream(
         # TODO: better API for getting at the protocols from the connection....
         self.request_protocol.send(request)
 
-        future: 'asyncio.Future[TResponseCommand]' = asyncio.Future()
-        self.pending_request = (time.perf_counter(), future)
+        queue: 'asyncio.Queue[TResponseCommand]' = asyncio.Queue()
+        self.pending_request = (time.perf_counter(), queue)
+        return queue
 
     @property
     def is_pending(self) -> bool:
         return self.pending_request is not None
-
-    async def _cleanup(self) -> None:
-        if self.pending_request is not None:
-            self.logger.debug("Stream %r shutting down, cancelling the pending request", self)
-            _, future = self.pending_request
-            try:
-                future.set_exception(PeerConnectionLost(
-                    f"Pending request can't complete: {self} is shutting down"
-                ))
-            except asyncio.InvalidStateError:
-                self.logger.debug(
-                    "%s cancelled pending future in cleanup, but it was already done",
-                    self,
-                )
-
-    def __del__(self) -> None:
-        if self.pending_request is not None:
-            _, future = self.pending_request
-            if future.cancel():
-                self.logger.debug("Forcefully cancelled a pending response in %s", self)

--- a/p2p/exchange/exchange.py
+++ b/p2p/exchange/exchange.py
@@ -6,9 +6,9 @@ from typing import (
 )
 
 from async_generator import asynccontextmanager
+from async_service import background_asyncio_service
 
 from p2p.abc import ConnectionAPI
-from p2p.service import run_service
 
 from .abc import ExchangeAPI, NormalizerAPI, ValidatorAPI
 from .candidate_stream import ResponseCandidateStream
@@ -34,11 +34,11 @@ class BaseExchange(ExchangeAPI[TRequestCommand, TResponseCommand, TResult]):
             protocol,
             self.get_response_cmd_type(),
         )
-        self._manager = ExchangeManager(
-            connection,
-            response_stream,
-        )
-        async with run_service(response_stream):
+        async with background_asyncio_service(response_stream):
+            self._manager = ExchangeManager(
+                connection,
+                response_stream,
+            )
             yield
 
     async def get_result(

--- a/p2p/exchange/manager.py
+++ b/p2p/exchange/manager.py
@@ -1,3 +1,6 @@
+import asyncio
+from concurrent import futures
+import logging
 from typing import (
     Callable,
     TypeVar,
@@ -24,6 +27,8 @@ TResult = TypeVar('TResult')
 
 
 class ExchangeManager(ExchangeManagerAPI[TRequestCommand, TResponseCommand, TResult]):
+    logger = logging.getLogger('p2p.exchange.ExchangeManager')
+
     _response_stream: ResponseCandidateStreamAPI[TRequestCommand, TResponseCommand] = None
 
     def __init__(self,
@@ -43,44 +48,47 @@ class ExchangeManager(ExchangeManagerAPI[TRequestCommand, TResponseCommand, TRes
             timeout: float = None) -> TResult:
 
         stream = self._response_stream
-        if not stream.is_operational:
+        if not stream.is_alive:
             raise PeerConnectionLost(
                 f"Response stream closed before sending request to {self._connection}"
             )
 
-        async for payload in stream.payload_candidates(request, tracker, timeout=timeout):
-            try:
-                payload_validator(payload)
+        loop = asyncio.get_event_loop()
 
-                if normalizer.is_normalization_slow:
-                    # We don't expose the `_run_in_executor` API as part of the formal service ABC
-                    result = await stream._run_in_executor(  # type: ignore
-                        None,
-                        normalizer.normalize_result,
-                        payload
+        with futures.ThreadPoolExecutor() as executor:
+            async for payload in stream.payload_candidates(request, tracker, timeout=timeout):
+                try:
+                    payload_validator(payload)
+
+                    if normalizer.is_normalization_slow:
+                        result = await loop.run_in_executor(
+                            executor,
+                            normalizer.normalize_result,
+                            payload
+                        )
+                    else:
+                        result = normalizer.normalize_result(payload)
+
+                    validate_result(result)
+                except ValidationError as err:
+                    self.logger.debug(
+                        "Response validation failed for pending %s request from connection %s: %s",
+                        stream.response_cmd_name,
+                        self._connection,
+                        err,
                     )
+                    # If this response was just for the wrong request, we'll
+                    # catch the right one later.  Otherwise, this request will
+                    # eventually time out.
+                    continue
                 else:
-                    result = normalizer.normalize_result(payload)
-
-                validate_result(result)
-            except ValidationError as err:
-                self.service.logger.debug(
-                    "Response validation failed for pending %s request from connection %s: %s",
-                    stream.response_cmd_name,
-                    self._connection,
-                    err,
-                )
-                # If this response was just for the wrong request, we'll catch the right one later.
-                # Otherwise, this request will eventually time out.
-                continue
-            else:
-                tracker.record_response(
-                    stream.last_response_time,
-                    request,
-                    result,
-                )
-                stream.complete_request()
-                return result
+                    tracker.record_response(
+                        stream.last_response_time,
+                        request,
+                        result,
+                    )
+                    stream.complete_request()
+                    return result
 
         raise PeerConnectionLost(f"Response stream of {self._connection} was apparently closed")
 


### PR DESCRIPTION
### What was wrong?

The `p2p.exchange` APIs use the old service model.

While fixing this I also encountered a race condition bug in the `ResponseCandidateStream` logic which is fixed here as well.

### How was it fixed?

Updated them to use the new `async-service` APIS

The `ResponseCandidateStream` registers the `_handle_msg` as a handler which is called by the `Connection` anytime the proper message type is received.  The previous implementation used a `Future` to communicate potential response candidates back to the coroutine which is waiting for a response.

That listening couroutine runs in a loop, Repeatedly calling `_get_payload` to retrieve a response candidate.  After retrieving the result of the pending future,  `_get_payload` creates a new future for subsequent messages to be placed.  

The architecture above only works if calls to `_handle_msg` and `_get_payload` are evenly interspersed, always being called one after the other.  This refactor surfaced a bug where `_handle_msg` is called in quick succession before `_get_payload` can re-stock the future, resulting in us dropping what could be the right response due to the future already having a result set on it.

This was fixed by replacing the `Future` with a `Queue`.  This way if multiple responses arrive in quick succession, they end up being placed into the queue and consumed correctly.

#### Cute Animal Picture

![Pets-Wearing-Christmas-Costumes](https://user-images.githubusercontent.com/824194/72105196-4f285200-32ea-11ea-94e7-f3b0d29a72ba.jpg)
