### PR TITLE
Update beam exec and preview plugins to use async-service

### DIFF
--- a/trinity/components/builtin/beam_exec/component.py
+++ b/trinity/components/builtin/beam_exec/component.py
@@ -1,8 +1,7 @@
 import asyncio
 
+from async_service import run_asyncio_service
 from lahja import EndpointAPI
-
-from p2p.service import run_service
 
 from trinity.boot_info import BootInfo
 from trinity.config import Eth1AppConfig
@@ -54,5 +53,4 @@ class BeamChainExecutionComponent(AsyncioIsolatedComponent):
 
             import_server = BlockImportServer(event_bus, beam_chain)
 
-            async with run_service(import_server):
-                await import_server.cancellation()
+            await run_asyncio_service(import_server)

--- a/trinity/components/builtin/beam_preview/component.py
+++ b/trinity/components/builtin/beam_preview/component.py
@@ -1,8 +1,7 @@
 import asyncio
 
+from async_service import run_asyncio_service
 from lahja import EndpointAPI
-
-from p2p.service import run_service
 
 from trinity.boot_info import BootInfo
 from trinity.config import (
@@ -61,8 +60,7 @@ class BeamChainPreviewComponent(AsyncioIsolatedComponent):
 
             preview_server = BlockPreviewServer(event_bus, beam_chain, cls.shard_num)
 
-            async with run_service(preview_server):
-                await preview_server.cancellation()
+            await run_asyncio_service(preview_server)
 
 
 class BeamChainPreviewComponent0(BeamChainPreviewComponent):

--- a/trinity/extensibility/asyncio.py
+++ b/trinity/extensibility/asyncio.py
@@ -48,7 +48,6 @@ class AsyncioIsolatedComponent(BaseIsolatedComponent):
                         proc.pid,
                     )
                     proc.send_signal(signal.SIGTERM)
-                    pass
                 finally:
                     raise err
 


### PR DESCRIPTION
### What was wrong?

The beam sync "preview" and "exec" plugins were using the old service API

### How was it fixed?

Updated to use the new `async-service` API.

#### Cute Animal Picture


![ewechair0306_468x492](https://user-images.githubusercontent.com/824194/72107910-96651180-32ef-11ea-8f06-514cd8c3ff90.jpg)

