### PR TITLE
Discv5 Test Vectors

### DIFF
--- a/p2p/discv5/constants.py
+++ b/p2p/discv5/constants.py
@@ -26,6 +26,7 @@ TCP_PORT_ENR_KEY = b"tcp"
 
 WHO_ARE_YOU_MAGIC_SUFFIX = b"WHOAREYOU"
 HKDF_INFO = b"discovery v5 key agreement"
+ID_NONCE_SIGNATURE_PREFIX = b"discovery-id-nonce"
 
 MAX_REQUEST_ID = 2**32 - 1  # highest request id used for outgoing requests
 MAX_REQUEST_ID_ATTEMPTS = 100  # number of attempts we take to guess a available request id

--- a/p2p/discv5/handshake.py
+++ b/p2p/discv5/handshake.py
@@ -144,6 +144,7 @@ class HandshakeInitiator(BaseHandshakeParticipant):
         # prepare response packet
         id_nonce_signature = self.identity_scheme.create_id_nonce_signature(
             id_nonce=who_are_you_packet.id_nonce,
+            ephemeral_public_key=ephemeral_public_key,
             private_key=self.local_private_key,
         )
 
@@ -312,6 +313,7 @@ class HandshakeRecipient(BaseHandshakeParticipant):
             self.identity_scheme.validate_id_nonce_signature(
                 signature=id_nonce_signature,
                 id_nonce=id_nonce,
+                ephemeral_public_key=auth_header_packet.auth_header.ephemeral_public_key,
                 public_key=current_remote_enr.public_key,
             )
         except ValidationError as error:

--- a/p2p/discv5/packets.py
+++ b/p2p/discv5/packets.py
@@ -115,15 +115,11 @@ class AuthHeaderPacket(NamedTuple):
             encrypted_auth_response=encrypted_auth_response,
         )
 
-        authenticated_data = b"".join((
-            tag,
-            rlp.encode(auth_header),
-        ))
         encrypted_message = compute_encrypted_message(
             key=initiator_key,
             auth_tag=auth_tag,
             message=message,
-            authenticated_data=authenticated_data,
+            authenticated_data=tag,
         )
 
         return cls(
@@ -195,7 +191,7 @@ class AuthHeaderPacket(NamedTuple):
             key=key,
             auth_tag=self.auth_header.auth_tag,
             encrypted_message=self.encrypted_message,
-            authenticated_data=self.tag + rlp.encode(self.auth_header),
+            authenticated_data=self.tag,
             message_type_registry=message_type_registry,
         )
 

--- a/setup.py
+++ b/setup.py
@@ -16,6 +16,7 @@ deps = {
         "asyncio-cancel-token>=0.2,<0.3",
         "async_lru>=0.1.0,<1.0.0",
         "cached-property>=1.5.1,<2",
+        "coincurve>=10.0.0,<11.0.0",
         # cryptography does not use semver and allows breaking changes within `0.3` version bumps.
         "cryptography>=2.5,<2.7",
         "eth-hash>=0.1.4,<1",

--- a/tests/p2p/discv5/test_encryption.py
+++ b/tests/p2p/discv5/test_encryption.py
@@ -6,6 +6,7 @@ from hypothesis import (
 )
 
 from eth_utils import (
+    decode_hex,
     ValidationError,
 )
 
@@ -82,3 +83,18 @@ def test_roundtrip(key, nonce, plain_text, aad):
     cipher_text = aesgcm_encrypt(key, nonce, plain_text, aad)
     plain_text_recovered = aesgcm_decrypt(key, nonce, cipher_text, aad)
     assert plain_text_recovered == plain_text
+
+
+@pytest.mark.parametrize(["key", "nonce", "plain_text", "aad", "cipher_text"], [
+    [
+        decode_hex("0x9f2d77db7004bf8a1a85107ac686990b"),
+        decode_hex("0x27b5af763c446acd2749fe8e"),
+        decode_hex("0x01c20101"),
+        decode_hex("0x93a7400fa0d6a694ebc24d5cf570f65d04215b6ac00757875e3f3a5f42107903"),
+        decode_hex("0xa5d12a2d94b8ccb3ba55558229867dc13bfa3648"),
+    ]
+])
+def test_encryption_official(key, nonce, plain_text, aad, cipher_text):
+    encrypted = aesgcm_encrypt(key, nonce, plain_text, aad)
+    assert encrypted == cipher_text
+    assert aesgcm_decrypt(key, nonce, cipher_text, aad) == plain_text

--- a/tests/p2p/discv5/test_identity_schemes.py
+++ b/tests/p2p/discv5/test_identity_schemes.py
@@ -8,12 +8,14 @@ from hypothesis import (
 )
 
 from eth_utils import (
+    decode_hex,
     keccak,
     ValidationError,
 )
 
 from eth_keys.datatypes import (
     PrivateKey,
+    PublicKey,
     NonRecoverableSignature,
 )
 
@@ -334,4 +336,32 @@ def test_official_key_derivation(secret,
     assert derived_keys[0] == initiator_key
     assert derived_keys[1] == recipient_key
     assert derived_keys[2] == auth_response_key
->>>>>>> d39410a6... Use coincurve to perform discv5 ECDH
+
+
+@pytest.mark.parametrize(
+    ["id_nonce", "ephemeral_public_key", "local_secret_key", "id_nonce_signature"],
+    [
+        [
+            decode_hex("0xa77e3aa0c144ae7c0a3af73692b7d6e5b7a2fdc0eda16e8d5e6cb0d08e88dd04"),
+            decode_hex(
+                "0x9961e4c2356d61bedb83052c115d311acb3a96f5777296dcf297351130266231503061ac4aaee666"
+                "073d7e5bc2c80c3f5c5b500c1cb5fd0a76abbb6b675ad157"
+            ),
+            decode_hex("0xfb757dc581730490a1d7a00deea65e9b1936924caaea8f44d476014856b68736"),
+            decode_hex(
+                "0xc5036e702a79902ad8aa147dabfe3958b523fd6fa36cc78e2889b912d682d8d35fdea142e141f690"
+                "736d86f50b39746ba2d2fc510b46f82ee08f08fd55d133a4"
+            ),
+        ],
+    ],
+)
+def test_official_id_nonce_signature(id_nonce,
+                                     ephemeral_public_key,
+                                     local_secret_key,
+                                     id_nonce_signature):
+    created_signature = V4IdentityScheme.create_id_nonce_signature(
+        id_nonce=id_nonce,
+        ephemeral_public_key=ephemeral_public_key,
+        private_key=local_secret_key,
+    )
+    assert created_signature == id_nonce_signature

--- a/tests/p2p/discv5/test_messages.py
+++ b/tests/p2p/discv5/test_messages.py
@@ -1,15 +1,25 @@
 import inspect
 
+from eth_utils import (
+    decode_hex,
+)
+
+import pytest
+
 import rlp
 from rlp.sedes import (
     big_endian_int,
 )
 
 from p2p.discv5 import messages
+from p2p.discv5.enr import ENR
 from p2p.discv5.messages import (
     default_message_type_registry,
     BaseMessage,
     PingMessage,
+    PongMessage,
+    NodesMessage,
+    FindNodeMessage,
 )
 
 
@@ -42,3 +52,78 @@ def test_message_encoding():
     encoded_message = message.to_bytes()
     assert encoded_message[0] == message.message_type
     assert encoded_message[1:] == rlp.encode(message)
+
+
+# Official test vectors from
+# https://github.com/ethereum/devp2p/blob/master/discv5/discv5-wire-test-vectors.md
+# TODO: Add official test vectors for topic messages once they are aligned with the current
+# version of the spec
+@pytest.mark.parametrize(["message_type", "params", "message_rlp"], [
+    [
+        PingMessage,
+        {
+            "request_id": 0x01,
+            "enr_seq": 0x01,
+        },
+        decode_hex("0x01c20101"),
+    ],
+    [
+        PongMessage,
+        {
+            "request_id": 0x01,
+            "enr_seq": 0x01,
+            "packet_ip": bytes([127, 0, 0, 1]),
+            "packet_port": 5000,
+        },
+        decode_hex("0x02ca0101847f000001821388"),
+    ],
+    [
+        FindNodeMessage,
+        {
+            "request_id": 0x01,
+            "distance": 0x0100,
+        },
+        decode_hex("0x03c401820100"),
+    ],
+    [
+        NodesMessage,
+        {
+            "request_id": 0x01,
+            "total": 0x01,
+            "enrs": [],
+        },
+        decode_hex("0x04c30101c0"),
+    ],
+    [
+        NodesMessage,
+        {
+            "request_id": 0x01,
+            "total": 0x01,
+            "enrs": [
+                ENR.from_repr(
+                    "enr:-HW4QBzimRxkmT18hMKaAL3IcZF1UcfTMPyi3Q1pxwZZbcZVRI8DC5infUAB_UauARLOJtYTxa"
+                    "agKoGmIjzQxO2qUygBgmlkgnY0iXNlY3AyNTZrMaEDymNMrg1JrLQB2KTGtv6MVbcNEVv0AHacwUAP"
+                    "MljNMTg"
+                ),
+                ENR.from_repr(
+                    "enr:-HW4QNfxw543Ypf4HXKXdYxkyzfcxcO-6p9X986WldfVpnVTQX1xlTnWrktEWUbeTZnmgOuAY_"
+                    "KUhbVV1Ft98WoYUBMBgmlkgnY0iXNlY3AyNTZrMaEDDiy3QkHAxPyOgWbxp5oF1bDdlYE6dLCUUp8x"
+                    "fVw50jU"
+                ),
+            ]
+        },
+        decode_hex(
+            "0x04f8f20101f8eef875b8401ce2991c64993d7c84c29a00bdc871917551c7d330fca2dd0d69c706596dc6"
+            "55448f030b98a77d4001fd46ae0112ce26d613c5a6a02a81a6223cd0c4edaa532801826964827634897365"
+            "63703235366b31a103ca634cae0d49acb401d8a4c6b6fe8c55b70d115bf400769cc1400f3258cd3138f875"
+            "b840d7f1c39e376297f81d7297758c64cb37dcc5c3beea9f57f7ce9695d7d5a67553417d719539d6ae4b44"
+            "5946de4d99e680eb8063f29485b555d45b7df16a1850130182696482763489736563703235366b31a1030e"
+            "2cb74241c0c4fc8e8166f1a79a05d5b0dd95813a74b094529f317d5c39d235"
+        ),
+    ],
+])
+def test_official_message_encodings(message_type, params, message_rlp):
+    message = message_type(**params)
+    assert message.to_bytes() == message_rlp
+    assert message_rlp[0] == message_type.message_type
+    assert rlp.decode(message_rlp[1:], message_type) == message

--- a/tests/p2p/discv5/test_packet_encoding.py
+++ b/tests/p2p/discv5/test_packet_encoding.py
@@ -6,6 +6,7 @@ from hypothesis import (
 )
 
 from eth_utils import (
+    decode_hex,
     ValidationError,
 )
 
@@ -13,6 +14,7 @@ import rlp
 
 from p2p.discv5.packets import (
     AuthTagPacket,
+    AuthHeader,
     AuthHeaderPacket,
     WhoAreYouPacket,
     decode_message_packet,
@@ -286,3 +288,109 @@ def test_packet_decoding(packet):
     encoded_packet = packet.to_wire_bytes()
     decoded_packet = decode_packet(encoded_packet)
     assert decoded_packet == packet
+
+
+# official test vectors from the ethereum/devp2p repository
+@pytest.mark.parametrize(
+    ["prep_function", "params", "encoded"],
+    [
+        [
+            AuthTagPacket,
+            {
+                "tag": decode_hex(
+                    "0x0101010101010101010101010101010101010101010101010101010101010101"
+                ),
+                "auth_tag": decode_hex("0x020202020202020202020202"),
+                "encrypted_message": decode_hex(
+                    "0x0404040404040404040404040404040404040404040404040404040404040404040404040404"
+                    "040404040404"
+                ),
+            },
+            decode_hex(
+                "0x01010101010101010101010101010101010101010101010101010101010101018c02020202020202"
+                "0202020202040404040404040404040404040404040404040404040404040404040404040404040404"
+                "0404040404040404"
+            ),
+        ],
+        [
+            WhoAreYouPacket,
+            {
+                "magic": decode_hex(
+                    "0x0101010101010101010101010101010101010101010101010101010101010101"
+                ),
+                "token": decode_hex(
+                    "0x020202020202020202020202"
+                ),
+                "id_nonce": decode_hex(
+                    "0x0303030303030303030303030303030303030303030303030303030303030303"
+                ),
+                "enr_sequence_number": 0x01,
+            },
+            decode_hex(
+                "0101010101010101010101010101010101010101010101010101010101010101ef8c02020202020202"
+                "0202020202a0030303030303030303030303030303030303030303030303030303030303030301"
+            ),
+        ],
+    ]
+)
+def test_official_basic(prep_function, params, encoded):
+    packet = prep_function(**params)
+    assert packet.to_wire_bytes() == encoded
+    assert decode_packet(encoded) == packet
+
+
+@pytest.mark.parametrize(
+    [
+        "tag",
+        "auth_tag",
+        "id_nonce",
+        "ephemeral_pubkey",
+        "auth_response_cipher_text",
+        "message_cipher_text",
+        "encoded_packet",
+    ],
+    [
+        [
+            decode_hex("0x93a7400fa0d6a694ebc24d5cf570f65d04215b6ac00757875e3f3a5f42107903"),
+            decode_hex("0x27b5af763c446acd2749fe8e"),
+            decode_hex("0xe551b1c44264ab92bc0b3c9b26293e1ba4fed9128f3c3645301e8e119f179c65"),
+            decode_hex(
+                "0xb35608c01ee67edff2cffa424b219940a81cf2fb9b66068b1cf96862a17d353e22524fbdcdebc609"
+                "f85cbd58ebe7a872b01e24a3829b97dd5875e8ffbc4eea81"
+            ),
+            decode_hex(
+                "0x570fbf23885c674867ab00320294a41732891457969a0f14d11c995668858b2ad731aa7836888020"
+                "e2ccc6e0e5776d0d4bc4439161798565a4159aa8620992fb51dcb275c4f755c8b8030c82918898f1ac"
+                "387f606852"
+            ),
+            decode_hex("0xa5d12a2d94b8ccb3ba55558229867dc13bfa3648"),
+            decode_hex(
+                "0x93a7400fa0d6a694ebc24d5cf570f65d04215b6ac00757875e3f3a5f42107903f8cc8c27b5af763c"
+                "446acd2749fe8ea0e551b1c44264ab92bc0b3c9b26293e1ba4fed9128f3c3645301e8e119f179c6583"
+                "67636db840b35608c01ee67edff2cffa424b219940a81cf2fb9b66068b1cf96862a17d353e22524fbd"
+                "cdebc609f85cbd58ebe7a872b01e24a3829b97dd5875e8ffbc4eea81b856570fbf23885c674867ab00"
+                "320294a41732891457969a0f14d11c995668858b2ad731aa7836888020e2ccc6e0e5776d0d4bc44391"
+                "61798565a4159aa8620992fb51dcb275c4f755c8b8030c82918898f1ac387f606852a5d12a2d94b8cc"
+                "b3ba55558229867dc13bfa3648"
+            ),
+        ]
+    ]
+)
+def test_official_message(tag,
+                          auth_tag,
+                          id_nonce,
+                          ephemeral_pubkey,
+                          auth_response_cipher_text,
+                          message_cipher_text,
+                          encoded_packet):
+
+    header = AuthHeader(
+        auth_tag,
+        id_nonce,
+        AUTH_SCHEME_NAME,
+        ephemeral_pubkey,
+        auth_response_cipher_text,
+    )
+    packet = AuthHeaderPacket(tag, header, message_cipher_text)
+    assert packet.to_wire_bytes() == encoded_packet
+    assert decode_packet(encoded_packet) == packet

--- a/tests/p2p/discv5/test_packet_preparation.py
+++ b/tests/p2p/discv5/test_packet_preparation.py
@@ -104,10 +104,7 @@ def test_auth_header_preparation(tag,
         key=initiator_key,
         nonce=auth_tag,
         cipher_text=packet.encrypted_message,
-        authenticated_data=b"".join((
-            tag,
-            rlp.encode(packet.auth_header),
-        ))
+        authenticated_data=tag,
     )
     assert decrypted_message[0] == message.message_type
     assert rlp.decode(decrypted_message[1:], PingMessage) == message


### PR DESCRIPTION
### What was wrong?

[There](https://github.com/ethereum/devp2p/blob/master/discv5/discv5-wire-test-vectors.md) are official discv5 test vectors for encoding and crypto by now, which we're not using yet.

### How was it fixed?

Add tests using *some* of the test vectors:

- all packet encoding
- ping, pong, getnodes, and nodes messages
- ecdh and key derivation
- encryption

But not:

- the remaining message types (as both test vectors and ourselves are behind the current spec version)
- nonce signing tests (as we're behind the current spec version)
- authentication header construction test (includes nonce signing, so we can't do this at the moment, and I have the feeling we're doing something wrong there as well)

All tests except for the ECDH tests are passing, which I'm still trying to fix.

### To-Do

- [ ] Clean up commit history
- [x] Fix ECDH test

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://pixabay.com/get/52e1d44a4253a914f6da8c7dda6d49214b6ac3e45656794f75267ad192/joey-4119815_1280.jpg)
