### PR TITLE
DiscoveryService now supports a way to add extra fields to local ENR

### DIFF
--- a/p2p/abc.py
+++ b/p2p/abc.py
@@ -40,6 +40,7 @@ if TYPE_CHECKING:
     )
 
 
+ENR_FieldProvider = Callable[[], Awaitable[Tuple[bytes, Any]]]
 TAddress = TypeVar('TAddress', bound='AddressAPI')
 
 

--- a/p2p/discv5/enr.py
+++ b/p2p/discv5/enr.py
@@ -25,7 +25,6 @@ from rlp.sedes import (
     big_endian_int,
     binary,
     Binary,
-    CountableList,
     List,
     raw,
 )
@@ -53,6 +52,7 @@ from p2p.discv5.constants import (
     IP_V4_SIZE,
     IP_V6_SIZE,
 )
+from p2p.forkid import ForkID
 
 
 class ENRContentSedes:
@@ -370,8 +370,6 @@ class ENR(BaseENR, ENRSedes):
         ))
 
 
-# https://eips.ethereum.org/EIPS/eip-2124
-FORK_ID_SEDES = CountableList(List([Binary.fixed_length(4), big_endian_int]))
 IDENTITY_SCHEME_ENR_KEY = b"id"
 
 ENR_KEY_SEDES_MAPPING = {
@@ -383,7 +381,9 @@ ENR_KEY_SEDES_MAPPING = {
     b"ip6": Binary.fixed_length(IP_V6_SIZE),
     b"tcp6": big_endian_int,
     b"udp6": big_endian_int,
-    b"eth": FORK_ID_SEDES,
+    # For now this key is used only for ForkIDs (https://eips.ethereum.org/EIPS/eip-2124) but it
+    # is represented as a List because more stuff (e.g. network-id) may be added in the future.
+    b"eth": List([ForkID]),
 }
 
 # Must use raw for values with an unknown key as they may be lists or individual values.

--- a/p2p/forkid.py
+++ b/p2p/forkid.py
@@ -11,7 +11,7 @@ from eth.vm.forks.homestead import HomesteadVM
 
 from eth_typing import BlockNumber, Hash32
 
-from eth_utils import to_bytes, to_tuple
+from eth_utils import encode_hex, to_tuple
 
 from p2p.exceptions import RemoteChainIsStale, LocalChainIncompatibleOrStale
 
@@ -25,6 +25,9 @@ class ForkID(rlp.Serializable):
         if len(hash) != 4:
             raise ValueError("Hash {hash!r} length is not 4")
         super().__init__(hash, next)
+
+    def __repr__(self) -> str:
+        return f"ForkID(hash={encode_hex(self.hash)}, next={self.next})"
 
 
 @to_tuple
@@ -46,7 +49,7 @@ def make_forkid(
         vm_config: Tuple[Tuple[BlockNumber, Type[VirtualMachineAPI]], ...]
 ) -> ForkID:
     fork_blocks = _extract_fork_blocks(vm_config)
-    pre_hash_bytes = to_bytes(hexstr=genesis_hash)
+    pre_hash_bytes = bytes(genesis_hash)
     next_fork = 0
     for block_number in fork_blocks:
         if block_number > current_head:
@@ -71,7 +74,7 @@ def validate_forkid(
     """
 
     fork_blocks = list(_extract_fork_blocks(vm_config))
-    checksums = [binascii.crc32(to_bytes(hexstr=genesis_hash))]
+    checksums = [binascii.crc32(genesis_hash)]
     for block_number in fork_blocks:
         block_number_as_bytes = block_number.to_bytes(8, 'big')
         checksums.append(binascii.crc32(block_number_as_bytes, checksums[-1]))

--- a/tests/p2p/discv5/test_enr.py
+++ b/tests/p2p/discv5/test_enr.py
@@ -6,6 +6,7 @@ import rlp
 
 from eth_utils import (
     decode_hex,
+    to_bytes,
     ValidationError,
 )
 from eth_utils.toolz import (
@@ -23,6 +24,7 @@ from p2p.discv5.identity_schemes import (
     V4IdentityScheme,
     IdentitySchemeRegistry,
 )
+from p2p.forkid import ForkID
 
 
 # Source: https://github.com/fjl/EIPs/blob/0acb5939555cbd0efcdd04da0d3acb0cc81d049a/EIPS/eip-778.md
@@ -60,7 +62,7 @@ REAL_LIFE_TEST_DATA = {
     "identity_scheme": V4IdentityScheme,
     "sequence_number": 40,
     "kv_pairs": {
-        b"eth": ((b'cv\x01\x90', 1700000), ),
+        b"eth": (ForkID(hash=to_bytes(hexstr='0x63760190'), next=1700000), ),
         b"id": b"v4",
         b"ip": decode_hex("5e3fc0bb"),
         b"secp256k1": decode_hex(

--- a/tests/p2p/test_forkid.py
+++ b/tests/p2p/test_forkid.py
@@ -12,8 +12,10 @@ from eth.chains.ropsten import ROPSTEN_VM_CONFIGURATION
 from p2p.exceptions import RemoteChainIsStale, LocalChainIncompatibleOrStale
 from p2p.forkid import ForkID, make_forkid, validate_forkid
 
-MAINNET_GENESIS_HASH = '0xd4e56740f876aef8c010b86a40d5f56745a118d0906a34e69aec8c0db1cb8fa3'
-ROPSTEN_GENESIS_HASH = '0x41941023680923e0fe4d74a34bdac8141f2540e3ae90623718e47d66d1ca4a2d'
+MAINNET_GENESIS_HASH = to_bytes(
+    hexstr='0xd4e56740f876aef8c010b86a40d5f56745a118d0906a34e69aec8c0db1cb8fa3')
+ROPSTEN_GENESIS_HASH = to_bytes(
+    hexstr='0x41941023680923e0fe4d74a34bdac8141f2540e3ae90623718e47d66d1ca4a2d')
 
 
 @pytest.mark.parametrize(

--- a/trinity/_utils/async_dispatch.py
+++ b/trinity/_utils/async_dispatch.py
@@ -7,6 +7,8 @@ from typing import (
     TypeVar,
 )
 
+import trio
+
 TReturn = TypeVar('TReturn')
 
 
@@ -22,4 +24,13 @@ def async_method(method: Callable[..., TReturn],
             functools.partial(cls_method, **kwargs),
             *args
         )
+    return wrapper
+
+
+def trio_method(method: Callable[..., TReturn],
+                ) -> Callable[..., Coroutine[Any, Any, TReturn]]:
+    @functools.wraps(method)
+    async def wrapper(cls_or_self: Any, *args: Any, **kwargs: Any) -> TReturn:
+        cls_method = getattr(cls_or_self, method.__name__)
+        return await trio.to_thread.run_sync(functools.partial(cls_method, **kwargs), *args)
     return wrapper

--- a/trinity/components/builtin/peer_discovery/component.py
+++ b/trinity/components/builtin/peer_discovery/component.py
@@ -2,21 +2,19 @@ from argparse import (
     ArgumentParser,
     _SubParsersAction,
 )
-from typing import (
-    Type,
-)
+import functools
 
 import trio
 
-from async_service import Service, TrioManager
+import async_service
 
 from lahja import EndpointAPI
 
-from p2p.abc import ProtocolAPI
 from p2p.constants import (
     DISCOVERY_EVENTBUS_ENDPOINT,
 )
 from p2p.discovery import (
+    generate_eth_cap_enr_field,
     PreferredNodeDiscoveryService,
     StaticDiscoveryService,
 )
@@ -25,34 +23,13 @@ from p2p.kademlia import (
 )
 
 from trinity.boot_info import BootInfo
-from trinity.config import (
-    Eth1AppConfig,
-    Eth1DbMode,
-    TrinityConfig,
-)
+from trinity.config import Eth1AppConfig
+from trinity.db.manager import DBClient
+from trinity.db.eth1.header import TrioHeaderDB
 from trinity.events import ShutdownRequest
 from trinity.extensibility import (
     TrioIsolatedComponent,
 )
-from trinity.protocol.eth.proto import (
-    ETHProtocol,
-)
-from trinity.protocol.les.proto import (
-    LESProtocolV2,
-)
-
-
-def get_protocol(trinity_config: TrinityConfig) -> Type[ProtocolAPI]:
-    # For now DiscoveryByTopicProtocol supports a single topic, so we use the latest
-    # version of our supported protocols. Maybe this could be more generic?
-    # TODO: This needs to support the beacon protocol when we have a way to
-    # check the config, if trinity is being run as a beacon node.
-
-    eth1_config = trinity_config.get_app_config(Eth1AppConfig)
-    if eth1_config.database_mode is Eth1DbMode.LIGHT:
-        return LESProtocolV2
-    else:
-        return ETHProtocol
 
 
 class PeerDiscoveryComponent(TrioIsolatedComponent):
@@ -79,29 +56,35 @@ class PeerDiscoveryComponent(TrioIsolatedComponent):
     @classmethod
     async def do_run(cls, boot_info: BootInfo, event_bus: EndpointAPI) -> None:
         config = boot_info.trinity_config
+        db = DBClient.connect(config.database_ipc_path)
         external_ip = "0.0.0.0"
         address = Address(external_ip, config.port, config.port)
 
         if boot_info.args.disable_discovery:
-            discovery_service: Service = StaticDiscoveryService(
+            discovery_service: async_service.Service = StaticDiscoveryService(
                 event_bus,
                 config.preferred_nodes,
             )
         else:
+            vm_config = config.get_app_config(Eth1AppConfig).get_chain_config().vm_configuration
+            headerdb = TrioHeaderDB(db)
+            eth_cap_provider = functools.partial(generate_eth_cap_enr_field, vm_config, headerdb)
             external_ip = "0.0.0.0"
             socket = trio.socket.socket(family=trio.socket.AF_INET, type=trio.socket.SOCK_DGRAM)
             await socket.bind((external_ip, config.port))
             discovery_service = PreferredNodeDiscoveryService(
-                boot_info.trinity_config.nodekey,
+                config.nodekey,
                 address,
                 config.bootstrap_nodes,
                 config.preferred_nodes,
                 event_bus,
                 socket,
+                (eth_cap_provider,),
             )
 
         try:
-            await TrioManager.run_service(discovery_service)
+            with db:
+                await async_service.run_trio_service(discovery_service)
         except Exception:
             await event_bus.broadcast(ShutdownRequest("Discovery ended unexpectedly"))
             raise

--- a/trinity/db/eth1/header.py
+++ b/trinity/db/eth1/header.py
@@ -15,7 +15,7 @@ from eth.abc import (
 )
 from eth.db.header import HeaderDB
 
-from trinity._utils.async_dispatch import async_method
+from trinity._utils.async_dispatch import async_method, trio_method
 
 
 TReturn = TypeVar('TReturn')
@@ -83,3 +83,16 @@ class AsyncHeaderDB(BaseAsyncHeaderDB):
     coro_persist_checkpoint_header = async_method(BaseAsyncHeaderDB.persist_checkpoint_header)
     coro_persist_header = async_method(BaseAsyncHeaderDB.persist_header)
     coro_persist_header_chain = async_method(BaseAsyncHeaderDB.persist_header_chain)
+
+
+class TrioHeaderDB(BaseAsyncHeaderDB):
+    coro_get_block_header_by_hash = trio_method(BaseAsyncHeaderDB.get_block_header_by_hash)
+    coro_get_canonical_block_hash = trio_method(BaseAsyncHeaderDB.get_canonical_block_hash)
+    coro_get_canonical_block_header_by_number = trio_method(BaseAsyncHeaderDB.get_canonical_block_header_by_number)  # noqa: E501
+    coro_get_canonical_head = trio_method(BaseAsyncHeaderDB.get_canonical_head)
+    coro_get_score = trio_method(BaseAsyncHeaderDB.get_score)
+    coro_header_exists = trio_method(BaseAsyncHeaderDB.header_exists)
+    coro_get_canonical_block_hash = trio_method(BaseAsyncHeaderDB.get_canonical_block_hash)
+    coro_persist_checkpoint_header = trio_method(BaseAsyncHeaderDB.persist_checkpoint_header)
+    coro_persist_header = trio_method(BaseAsyncHeaderDB.persist_header)
+    coro_persist_header_chain = trio_method(BaseAsyncHeaderDB.persist_header_chain)

--- a/trinity/network_configurations.py
+++ b/trinity/network_configurations.py
@@ -1,7 +1,16 @@
 from typing import (
     NamedTuple,
     Tuple,
+    Type,
 )
+
+from eth.abc import VirtualMachineAPI
+
+from eth_typing.evm import BlockNumber
+
+from eth.chains.mainnet import MAINNET_GENESIS_HEADER, MAINNET_VM_CONFIGURATION
+from eth.chains.ropsten import ROPSTEN_GENESIS_HEADER, ROPSTEN_VM_CONFIGURATION
+from eth.rlp.headers import BlockHeader
 
 from p2p.constants import (
     MAINNET_BOOTNODES,
@@ -20,6 +29,8 @@ class Eth1NetworkConfiguration(NamedTuple):
     data_dir_name: str
     eip1085_filename: str
     bootnodes: Tuple[str, ...]
+    genesis_header: BlockHeader
+    vm_configuration: Tuple[Tuple[BlockNumber, Type[VirtualMachineAPI]], ...]
 
 
 PRECONFIGURED_NETWORKS = {
@@ -28,13 +39,17 @@ PRECONFIGURED_NETWORKS = {
         'MainnetChain',
         'mainnet',
         'mainnet.json',
-        MAINNET_BOOTNODES
+        MAINNET_BOOTNODES,
+        MAINNET_GENESIS_HEADER,
+        MAINNET_VM_CONFIGURATION,
     ),
     ROPSTEN_NETWORK_ID: Eth1NetworkConfiguration(
         ROPSTEN_NETWORK_ID,
         'RopstenChain',
         'ropsten',
         'ropsten.json',
-        ROPSTEN_BOOTNODES
+        ROPSTEN_BOOTNODES,
+        ROPSTEN_GENESIS_HEADER,
+        ROPSTEN_VM_CONFIGURATION,
     ),
 }


### PR DESCRIPTION
This allows us to add our ForkID to our ENR so that peers can decide whether or not to connect with us.

Also implement versioning of the local ENR so that a new one is generated with a higher sequence number every time anything in our ENR changes.
