### PR TITLE
Remove invalid use_develop option for wheel-cli tests

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -109,14 +109,12 @@ deps = {[common-wheel-cli]deps}
 whitelist_externals = {[common-wheel-cli]whitelist_externals}
 commands = {[common-wheel-cli]commands}
 skip_install=true
-use_develop=false
 
 [testenv:py37-wheel-cli]
 deps = {[common-wheel-cli]deps}
 whitelist_externals = {[common-wheel-cli]whitelist_externals}
 commands = {[common-wheel-cli]commands}
 skip_install=true
-use_develop=false
 
 [common-integration]
 deps = .[p2p,trinity,eth2,test,test-asyncio]

--- a/tox.ini
+++ b/tox.ini
@@ -109,12 +109,14 @@ deps = {[common-wheel-cli]deps}
 whitelist_externals = {[common-wheel-cli]whitelist_externals}
 commands = {[common-wheel-cli]commands}
 skip_install=true
+usedevelop=false
 
 [testenv:py37-wheel-cli]
 deps = {[common-wheel-cli]deps}
 whitelist_externals = {[common-wheel-cli]whitelist_externals}
 commands = {[common-wheel-cli]commands}
 skip_install=true
+usedevelop=false
 
 [common-integration]
 deps = .[p2p,trinity,eth2,test,test-asyncio]


### PR DESCRIPTION
### What was wrong?
When I was updating the web3 script that I stole to do the same thing, I noticed tox doesn't have a use_develop configuration flag. The actual flag doesn't have an underscore (`usedevelop`) and it's default is false anyway, so I don't think you need it. Docs [here](https://tox.readthedocs.io/en/stable/config.html#conf-usedevelop) :)


### How was it fixed?
Removed it!

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)


[//]: # (See: https://trinity-client.readthedocs.io/en/latest/contributing.html#pull-requests)
- [ ] Add entry to the [release notes](https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)
- Probably doesn't deserve a newsfragment, but let me know if you feel differently!

#### Cute Animal Picture
<img width="399" alt="image" src="https://user-images.githubusercontent.com/6540608/72170991-2f973500-338f-11ea-8711-2012aa81c91e.png">

