### PR TITLE
Improve UX of some JSON-RPC endpoints

### DIFF
--- a/newsfragments/1475.feature.rst
+++ b/newsfragments/1475.feature.rst
@@ -2,3 +2,5 @@ Improve error message for when the parameters to JSON-RPC calls are invalid
 
 Improve error message for ``eth_getWork``, ``eth_submitWork`` and ``eth_submitHashrate``
 APIs which Trinity does not support as it generally does not support mining operations.
+
+Change ``eth_hashrate`` and ``eth_coinbase`` to also return errors instead of default values.

--- a/newsfragments/1475.feature.rst
+++ b/newsfragments/1475.feature.rst
@@ -1,0 +1,1 @@
+Improve error message for when the parameters to JSON-RPC calls are invalid

--- a/newsfragments/1475.feature.rst
+++ b/newsfragments/1475.feature.rst
@@ -1,1 +1,4 @@
 Improve error message for when the parameters to JSON-RPC calls are invalid
+
+Improve error message for ``eth_getWork``, ``eth_submitWork`` and ``eth_submitHashrate``
+APIs which Trinity does not support as it generally does not support mining operations.

--- a/tests/core/json-rpc/test_ipc.py
+++ b/tests/core/json-rpc/test_ipc.py
@@ -201,6 +201,37 @@ def uint256_to_bytes(uint):
             {'result': '0x0', 'id': 3, 'jsonrpc': '2.0'},
         ),
         (
+            build_request('eth_getWork'),
+            {
+                'error': 'Method not implemented: \'eth_getWork\' Trinity does not support mining',
+                'id': 3,
+                'jsonrpc': '2.0'
+            },
+        ),
+        (
+            build_request('eth_submitWork', [
+                "0x0000000000000001",
+                "0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef",
+                "0xD1FE5700000000000000000000000000D1FE5700000000000000000000000000"
+            ]),
+            {
+                'error': 'Method not implemented: \'eth_submitWork\' Trinity does not support mining',  # noqa: E501
+                'id': 3,
+                'jsonrpc': '2.0'
+            },
+        ),
+        (
+            build_request('eth_submitHashrate', [
+                "0x0000000000000000000000000000000000000000000000000000000000500000",
+                "0x59daa26581d0acd1fce254fb7e85952f4c09d0915afd33d3886cd914bc7d283c"
+            ]),
+            {
+                'error': 'Method not implemented: \'eth_submitHashrate\' Trinity does not support mining',  # noqa: E501
+                'id': 3,
+                'jsonrpc': '2.0'
+            },
+        ),
+        (
             build_request('web3_clientVersion'),
             {'result': construct_trinity_client_identifier(), 'id': 3, 'jsonrpc': '2.0'},
         ),

--- a/tests/core/json-rpc/test_ipc.py
+++ b/tests/core/json-rpc/test_ipc.py
@@ -194,11 +194,19 @@ def uint256_to_bytes(uint):
         ),
         (
             build_request('eth_coinbase'),
-            {'result': '0x0000000000000000000000000000000000000000', 'id': 3, 'jsonrpc': '2.0'},
+            {
+                'error': 'Method not implemented: \'eth_coinbase\' Trinity does not support mining',  # noqa: E501
+                'id': 3,
+                'jsonrpc': '2.0'
+            },
         ),
         (
             build_request('eth_hashrate'),
-            {'result': '0x0', 'id': 3, 'jsonrpc': '2.0'},
+            {
+                'error': 'Method not implemented: \'eth_hashrate\' Trinity does not support mining',  # noqa: E501
+                'id': 3,
+                'jsonrpc': '2.0'
+            },
         ),
         (
             build_request('eth_getWork'),

--- a/trinity/rpc/main.py
+++ b/trinity/rpc/main.py
@@ -124,6 +124,9 @@ class RPCServer:
             if request['method'] == 'evm_resetToGenesisFixture':
                 result = True
 
+        except TypeError as exc:
+            error = f"Invalid parameters. Check parameter count and types. {exc}"
+            return None, error
         except NotImplementedError as exc:
             error = "Method not implemented: %r %s" % (request['method'], exc)
             return None, error

--- a/trinity/rpc/modules/eth.py
+++ b/trinity/rpc/modules/eth.py
@@ -8,6 +8,7 @@ from typing import (
     cast,
     Dict,
     List,
+    NoReturn,
     Union,
 )
 from mypy_extensions import (
@@ -189,6 +190,17 @@ class Eth(Eth1ChainRPCModule):
         balance = state.get_balance(address)
 
         return hex(balance)
+
+    async def getWork(self) -> NoReturn:
+        raise NotImplementedError("Trinity does not support mining")
+
+    @format_params(decode_hex, decode_hex, decode_hex)
+    async def submitWork(self, nonce: bytes, pow_hash: Hash32, mix_digest: Hash32) -> NoReturn:
+        raise NotImplementedError("Trinity does not support mining")
+
+    @format_params(decode_hex, decode_hex)
+    async def submitHashrate(self, hashrate: Hash32, id: Hash32) -> NoReturn:
+        raise NotImplementedError("Trinity does not support mining")
 
     @format_params(decode_hex, identity)
     async def getBlockByHash(self,

--- a/trinity/rpc/modules/eth.py
+++ b/trinity/rpc/modules/eth.py
@@ -167,9 +167,7 @@ class Eth(Eth1ChainRPCModule):
         return encode_hex(result)
 
     async def coinbase(self) -> str:
-        # Trinity doesn't support mining yet and hence coinbase_address is default (ZERO_ADDRESS)
-        coinbase_address = ZERO_ADDRESS
-        return encode_hex(coinbase_address)
+        raise NotImplementedError("Trinity does not support mining")
 
     @retryable(which_block_arg_name='at_block')
     @format_params(identity, to_int_if_hex)
@@ -350,9 +348,7 @@ class Eth(Eth1ChainRPCModule):
         return header_to_dict(uncle)
 
     async def hashrate(self) -> str:
-        # Trinity doesn't support mining yet and hence hashrate is default (0)
-        hashrate = 0
-        return hex(hashrate)
+        raise NotImplementedError("Trinity does not support mining")
 
     async def mining(self) -> bool:
         return False


### PR DESCRIPTION
### What was wrong?

1. When a JSON-RPC API was called with the wrong number of parameters, the error wasn't as clear as it could be.

2. We currently return a generic not implemented error for `eth_getWork`, `eth_submitWork` and `eth_submitHashrate`. A more friendlier UX would be to hint that this is intended as Trinity does not support mining. This fixes #1016 

### How was it fixed?

1. Catch `TypeError` and suggest to check the count and type of the parameter and then concat the original exception.

2. Implement `eth_getWork`, `eth_submitWork` and `eth_submitHashrate` but raise `NotImplemtedError` with the message `Trinity does not support mining`.

3. Change existing `eth_hashrate` and `eth_coinbase` to also return errors instead of default values to be aligned with the rest of the mining related APIs.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

[//]: # (See: https://trinity-client.readthedocs.io/en/latest/contributing.html#pull-requests)
- [x] Add entry to the [release notes](https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://i.guim.co.uk/img/media/de4c8ed37f2746043f5a30556118f81cc6d22966/0_233_3500_2101/master/3500.jpg?width=620&quality=85&auto=format&fit=max&s=84a77676b57ab02d86fdf892252758ba)
