### PR TITLE
DiscV5 Component

### DIFF
--- a/p2p/discv5/handshake.py
+++ b/p2p/discv5/handshake.py
@@ -9,6 +9,8 @@ from eth_utils import (
     ValidationError,
 )
 
+from eth_keys.datatypes import PublicKey
+
 from p2p.exceptions import (
     DecryptionError,
     HandshakeFailure,
@@ -132,9 +134,10 @@ class HandshakeInitiator(BaseHandshakeParticipant):
             ephemeral_public_key,
         ) = self.identity_scheme.create_handshake_key_pair()
 
+        remote_public_key = PublicKey.from_compressed_bytes(self.remote_enr.public_key).to_bytes()
         session_keys = self.identity_scheme.compute_session_keys(
             local_private_key=ephemeral_private_key,
-            remote_public_key=self.remote_enr.public_key,
+            remote_public_key=remote_public_key,
             local_node_id=self.local_enr.node_id,
             remote_node_id=self.remote_node_id,
             id_nonce=who_are_you_packet.id_nonce,

--- a/p2p/discv5/handshake.py
+++ b/p2p/discv5/handshake.py
@@ -134,10 +134,11 @@ class HandshakeInitiator(BaseHandshakeParticipant):
             ephemeral_public_key,
         ) = self.identity_scheme.create_handshake_key_pair()
 
-        remote_public_key = PublicKey.from_compressed_bytes(self.remote_enr.public_key).to_bytes()
+        remote_public_key_object = PublicKey.from_compressed_bytes(self.remote_enr.public_key)
+        remote_public_key_uncompressed = remote_public_key_object.to_bytes()
         session_keys = self.identity_scheme.compute_session_keys(
             local_private_key=ephemeral_private_key,
-            remote_public_key=remote_public_key,
+            remote_public_key=remote_public_key_uncompressed,
             local_node_id=self.local_enr.node_id,
             remote_node_id=self.remote_node_id,
             id_nonce=who_are_you_packet.id_nonce,

--- a/tests/p2p/discv5/test_identity_schemes.py
+++ b/tests/p2p/discv5/test_identity_schemes.py
@@ -15,7 +15,6 @@ from eth_utils import (
 
 from eth_keys.datatypes import (
     PrivateKey,
-    PublicKey,
     NonRecoverableSignature,
 )
 

--- a/tests/p2p/discv5/test_identity_schemes.py
+++ b/tests/p2p/discv5/test_identity_schemes.py
@@ -147,13 +147,14 @@ def test_enr_node_id():
 
 def test_handshake_key_generation():
     private_key, public_key = V4IdentityScheme.create_handshake_key_pair()
-    V4IdentityScheme.validate_public_key(public_key)
-    assert PrivateKey(private_key).public_key.to_compressed_bytes() == public_key
+    V4IdentityScheme.validate_uncompressed_public_key(public_key)
+    V4IdentityScheme.validate_handshake_public_key(public_key)
+    assert PrivateKey(private_key).public_key.to_bytes() == public_key
 
 
 @pytest.mark.parametrize("public_key", (
-    PrivateKey(b"\x01" * 32).public_key.to_compressed_bytes(),
-    PrivateKey(b"\x02" * 32).public_key.to_compressed_bytes(),
+    b"\x01" * 64,
+    b"\x02" * 64,
 ))
 def test_handshake_public_key_validation_valid(public_key):
     V4IdentityScheme.validate_handshake_public_key(public_key)
@@ -161,9 +162,11 @@ def test_handshake_public_key_validation_valid(public_key):
 
 @pytest.mark.parametrize("public_key", (
     b"",
-    b"\x01" * 33,
+    b"\x02" * 31,
     b"\x02" * 32,
-    b"\x02" * 34,
+    b"\x02" * 33,
+    b"\x02" * 63,
+    b"\x02" * 65,
 ))
 def test_handshake_public_key_validation_invalid(public_key):
     with pytest.raises(ValidationError):
@@ -259,8 +262,8 @@ def test_session_key_derivation(initiator_private_key, recipient_private_key, id
     initiator_private_key_object = PrivateKey(initiator_private_key)
     recipient_private_key_object = PrivateKey(recipient_private_key)
 
-    initiator_public_key = initiator_private_key_object.public_key.to_compressed_bytes()
-    recipient_public_key = recipient_private_key_object.public_key.to_compressed_bytes()
+    initiator_public_key = initiator_private_key_object.public_key.to_bytes()
+    recipient_public_key = recipient_private_key_object.public_key.to_bytes()
 
     initiator_node_id = keccak(initiator_private_key_object.public_key.to_bytes())
     recipient_node_id = keccak(recipient_private_key_object.public_key.to_bytes())
@@ -298,9 +301,7 @@ def test_session_key_derivation(initiator_private_key, recipient_private_key, id
     ]
 ])
 def test_official_key_agreement(local_secret_key, remote_public_key, shared_secret_key):
-    public_key_object = PublicKey(remote_public_key)
-    public_key_compressed = public_key_object.to_compressed_bytes()
-    assert ecdh_agree(local_secret_key, public_key_compressed) == shared_secret_key
+    assert ecdh_agree(local_secret_key, remote_public_key) == shared_secret_key
 
 
 @pytest.mark.parametrize(

--- a/trinity/components/eth2/discv5/component.py
+++ b/trinity/components/eth2/discv5/component.py
@@ -1,0 +1,256 @@
+from argparse import (
+    ArgumentParser,
+    _SubParsersAction,
+)
+import logging
+import pathlib
+import secrets
+
+import async_service
+
+from eth_keys.datatypes import (
+    PrivateKey,
+)
+from eth_utils import (
+    decode_hex,
+    encode_hex,
+)
+from eth_utils.toolz import (
+    merge,
+)
+
+from lahja import EndpointAPI
+
+from p2p.discv5.abc import (
+    EnrDbApi,
+)
+from p2p.discv5.channel_services import (
+    DatagramReceiver,
+    DatagramSender,
+    IncomingDatagram,
+    IncomingMessage,
+    IncomingPacket,
+    OutgoingDatagram,
+    OutgoingMessage,
+    OutgoingPacket,
+    PacketDecoder,
+    PacketEncoder,
+)
+from p2p.discv5.endpoint_tracker import (
+    EndpointTracker,
+    EndpointVote,
+)
+from p2p.discv5.enr import ENR
+from p2p.discv5.enr import UnsignedENR
+from p2p.discv5.enr_db import FileEnrDb
+from p2p.discv5.identity_schemes import default_identity_scheme_registry
+from p2p.discv5.message_dispatcher import (
+    MessageDispatcher,
+)
+from p2p.discv5.messages import default_message_type_registry
+from p2p.discv5.packer import (
+    Packer,
+)
+from p2p.discv5.routing_table import (
+    FlatRoutingTable,
+)
+from p2p.discv5.routing_table_manager import (
+    RoutingTableManager,
+)
+
+from trinity.boot_info import BootInfo
+from trinity.extensibility import TrioIsolatedComponent
+
+import trio
+
+
+DEFAULT_ENR_DIR_NAME = "enrs"
+
+
+logger = logging.getLogger(__name__)
+
+
+def get_enr_dir(boot_info: BootInfo) -> pathlib.Path:
+    if boot_info.args.enr_dir is None:
+        return boot_info.trinity_config.data_dir / DEFAULT_ENR_DIR_NAME
+    else:
+        return pathlib.Path(boot_info.args.enr_dir)
+
+
+def get_local_private_key(boot_info: BootInfo) -> PrivateKey:
+    if boot_info.args.discovery_private_key:
+        local_private_key_bytes = decode_hex(boot_info.args.discovery_private_key)
+    else:
+        logger.debug("No private key given, using random one")
+        local_private_key_bytes = secrets.token_bytes(32)
+    return PrivateKey(local_private_key_bytes)
+
+
+async def get_local_enr(boot_info: BootInfo,
+                        enr_db: EnrDbApi,
+                        local_private_key: PrivateKey,
+                        ) -> ENR:
+    minimal_enr = UnsignedENR(
+        sequence_number=1,
+        kv_pairs={
+            b"id": b"v4",
+            b"secp256k1": local_private_key.public_key.to_compressed_bytes(),
+            b"udp": boot_info.args.discovery_port,
+        },
+        identity_scheme_registry=default_identity_scheme_registry,
+    ).to_signed_enr(local_private_key.to_bytes())
+    node_id = minimal_enr.node_id
+
+    try:
+        base_enr = await enr_db.get(node_id)
+    except KeyError:
+        logger.info(f"No ENR for {encode_hex(node_id)} found, creating new one")
+        return minimal_enr
+    else:
+        if any(base_enr[key] != value for key, value in minimal_enr.items()):
+            logger.debug(f"Updating local ENR")
+            return UnsignedENR(
+                sequence_number=base_enr.sequence_number + 1,
+                kv_pairs=merge(dict(base_enr), dict(minimal_enr)),
+                identity_scheme_registry=default_identity_scheme_registry,
+            ).to_signed_enr(local_private_key.to_bytes())
+        else:
+            return base_enr
+
+
+class DiscV5Component(TrioIsolatedComponent):
+    name = "DiscV5"
+
+    @classmethod
+    def configure_parser(cls, arg_parser: ArgumentParser, subparser: _SubParsersAction) -> None:
+        discovery_parser = arg_parser.add_argument_group("discovery")
+
+        discovery_parser.add_argument(
+            "--enr-dir",
+            help="Path to the directory in which ENRs are stored",
+        )
+        discovery_parser.add_argument(
+            "--discovery-boot-enrs",
+            nargs="+",
+            help="An arbitrary number of ENRs to populate the initial routing table with",
+        )
+        discovery_parser.add_argument(
+            "--discovery-port",
+            help="UDP port on which to listen for discovery messages",
+            type=int,
+            default=9000,
+        )
+        discovery_parser.add_argument(
+            "--discovery-private-key",
+            help="hex encoded 32 byte private key representing the discovery network identity",
+        )
+
+    @property
+    def is_enabled(self) -> bool:
+        return True
+
+    @classmethod
+    async def do_run(cls, boot_info: BootInfo, event_bus: EndpointAPI) -> None:
+        identity_scheme_registry = default_identity_scheme_registry
+        message_type_registry = default_message_type_registry
+
+        routing_table = FlatRoutingTable()
+        enr_dir = get_enr_dir(boot_info)
+        enr_dir.mkdir(exist_ok=True)
+        enr_db = FileEnrDb(default_identity_scheme_registry, enr_dir)
+
+        local_private_key = get_local_private_key(boot_info)
+        local_enr = await get_local_enr(boot_info, enr_db, local_private_key)
+        local_node_id = local_enr.node_id
+
+        await enr_db.insert_or_update(local_enr)
+        for enr_repr in boot_info.args.discovery_boot_enrs or ():
+            enr = ENR.from_repr(enr_repr)
+            await enr_db.insert_or_update(enr)
+            routing_table.add(enr.node_id)
+
+        port = boot_info.args.discovery_port
+
+        socket = trio.socket.socket(
+            family=trio.socket.AF_INET,
+            type=trio.socket.SOCK_DGRAM,
+        )
+        outgoing_datagram_channels = trio.open_memory_channel[OutgoingDatagram](0)
+        incoming_datagram_channels = trio.open_memory_channel[IncomingDatagram](0)
+        outgoing_packet_channels = trio.open_memory_channel[OutgoingPacket](0)
+        incoming_packet_channels = trio.open_memory_channel[IncomingPacket](0)
+        outgoing_message_channels = trio.open_memory_channel[OutgoingMessage](0)
+        incoming_message_channels = trio.open_memory_channel[IncomingMessage](0)
+        endpoint_vote_channels = trio.open_memory_channel[EndpointVote](0)
+
+        # types ignored due to https://github.com/ethereum/async-service/issues/5
+        datagram_sender = DatagramSender(  # type: ignore
+            outgoing_datagram_channels[1],
+            socket,
+        )
+        datagram_receiver = DatagramReceiver(  # type: ignore
+            socket,
+            incoming_datagram_channels[0],
+        )
+
+        packet_encoder = PacketEncoder(  # type: ignore
+            outgoing_packet_channels[1],
+            outgoing_datagram_channels[0],
+        )
+        packet_decoder = PacketDecoder(  # type: ignore
+            incoming_datagram_channels[1],
+            incoming_packet_channels[0],
+        )
+
+        packer = Packer(
+            local_private_key=local_private_key.to_bytes(),
+            local_node_id=local_node_id,
+            enr_db=enr_db,
+            message_type_registry=message_type_registry,
+            incoming_packet_receive_channel=incoming_packet_channels[1],
+            incoming_message_send_channel=incoming_message_channels[0],
+            outgoing_message_receive_channel=outgoing_message_channels[1],
+            outgoing_packet_send_channel=outgoing_packet_channels[0],
+        )
+
+        message_dispatcher = MessageDispatcher(
+            enr_db=enr_db,
+            incoming_message_receive_channel=incoming_message_channels[1],
+            outgoing_message_send_channel=outgoing_message_channels[0],
+        )
+
+        endpoint_tracker = EndpointTracker(
+            local_private_key=local_private_key.to_bytes(),
+            local_node_id=local_node_id,
+            enr_db=enr_db,
+            identity_scheme_registry=identity_scheme_registry,
+            vote_receive_channel=endpoint_vote_channels[1],
+        )
+
+        routing_table_manager = RoutingTableManager(
+            local_node_id=local_node_id,
+            routing_table=routing_table,
+            message_dispatcher=message_dispatcher,
+            enr_db=enr_db,
+            outgoing_message_send_channel=outgoing_message_channels[0],
+            endpoint_vote_send_channel=endpoint_vote_channels[0],
+        )
+
+        logger.info(f"Starting discovery, listening on port {port}")
+        logger.info(f"Local Node ID: {encode_hex(local_enr.node_id)}")
+        logger.info(f"Local ENR: {local_enr}")
+
+        await socket.bind(("0.0.0.0", port))
+        services = (
+            datagram_sender,
+            datagram_receiver,
+            packet_encoder,
+            packet_decoder,
+            packer,
+            message_dispatcher,
+            endpoint_tracker,
+            routing_table_manager,
+        )
+        async with trio.open_nursery() as nursery:
+            for service in services:
+                nursery.start_soon(async_service.TrioManager.run_service, service)

--- a/trinity/components/registry.py
+++ b/trinity/components/registry.py
@@ -49,6 +49,7 @@ from trinity.components.builtin.upnp.component import (
     UpnpComponent,
 )
 from trinity.components.eth2.beacon.component import BeaconNodeComponent
+from trinity.components.eth2.discv5.component import DiscV5Component
 from trinity.components.eth2.eth1_monitor.component import Eth1MonitorComponent
 from trinity.components.eth2.interop.component import InteropComponent
 from trinity.components.builtin.tx_pool.component import (
@@ -70,6 +71,7 @@ BEACON_NODE_COMPONENTS: Tuple[Type[BaseComponentAPI], ...] = (
     BeaconNodeComponent,
     InteropComponent,
     Eth1MonitorComponent,
+    DiscV5Component,
 )
 
 


### PR DESCRIPTION
### What was wrong?

A Trio component for discv5.

The PR builds on top of #1468, only the last two commits are new.

It successfully connects to https://github.com/sigp/rust-libp2p/tree/discv5. There is one [fix](https://github.com/ethereum/trinity/commit/1cb1438b9399040c0b728daa08b8e9d38d10c7bc) I had to apply to make it work, but in my opinion this is an inconsistency in the spec, so we will probably be able to revert it in the future.

There's still some things missing (most importantly: responding to find node requests properly, exposing peer information to other components, CLI parameter validation, NAT stuff), but going from here should be much easier now.

The component provides the following CLI options:

- `--enr-dir`: Path to the directory in which ENRs are stored (default `<data-dir>/enrs`)
- `--discovery-private-key`: The node's private key (default random)
- `--discovery-boot-enrs`: list of ENRs of peers to populate the ENR DB and the routing table with
- `--discovery-port`: the port

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://ichef.bbci.co.uk/news/660/cpsprodpb/429B/production/_103515071_mediaitem103515070.jpg)
