### PR TITLE
DiscV5 FindNode response

### DIFF
--- a/p2p/discv5/constants.py
+++ b/p2p/discv5/constants.py
@@ -1,3 +1,6 @@
+from p2p.constants import (
+    DISCOVERY_MAX_PACKET_SIZE,
+)
 from p2p.discv5.typing import (
     Nonce,
 )
@@ -9,6 +12,8 @@ TAG_SIZE = 32  # size of the tag packet prefix
 MAGIC_SIZE = 32  # size of the magic hash in the who are you packet
 ID_NONCE_SIZE = 32  # size of the id nonce in who are you and auth tag packets
 RANDOM_ENCRYPTED_DATA_SIZE = 12  # size of random data we send to initiate a handshake
+# safe upper bound on the size of the ENR list in a nodes message
+NODES_MESSAGE_PAYLOAD_SIZE = DISCOVERY_MAX_PACKET_SIZE - 200
 
 ZERO_NONCE = Nonce(b"\x00" * NONCE_SIZE)  # nonce used for the auth header packet
 AUTH_RESPONSE_VERSION = 5  # version number used in auth response

--- a/p2p/tools/factories/discovery.py
+++ b/p2p/tools/factories/discovery.py
@@ -138,12 +138,12 @@ class NodeIDFactory(factory.Factory):
     def at_log_distance(cls, reference: NodeID, log_distance: int) -> NodeID:
         num_bits = len(reference) * 8
 
-        if log_distance >= num_bits:
-            raise ValueError("Log distance must be less than number of bits in the node id")
+        if log_distance > num_bits:
+            raise ValueError("Log distance must not be greater than number of bits in the node id")
         elif log_distance < 0:
             raise ValueError("Log distance cannot be negative")
 
-        num_common_bits = num_bits - log_distance - 1
+        num_common_bits = num_bits - log_distance
         flipped_bit_index = num_common_bits
         num_random_bits = num_bits - num_common_bits - 1
 

--- a/tests/p2p/discv5/test_kademlia_routing_table.py
+++ b/tests/p2p/discv5/test_kademlia_routing_table.py
@@ -38,15 +38,15 @@ def test_distance(left_node_id, right_node_id, distance):
 
 
 @pytest.mark.parametrize(("left_node_id", "right_node_id", "log_distance"), (
-    (b"\x00\x00", b"\x00\x01", 0),
-    (b"\x00\x00", b"\x00\x02", 1),
-    (b"\x00\x00", b"\x00\x03", 1),
-    (b"\x00\x00", b"\x00\x04", 2),
-    (b"\x00\x00", b"\x00\x08", 3),
-    (b"\x00\x00", b"\x00\xff", 7),
-    (b"\x00\x00", b"\x01\x00", 8),
-    (b"\x00\x00", b"\xf0\x00", 15),
-    (b"\x00\x00", b"\xff\xff", 15),
+    (b"\x00\x00", b"\x00\x01", 1),
+    (b"\x00\x00", b"\x00\x02", 2),
+    (b"\x00\x00", b"\x00\x03", 2),
+    (b"\x00\x00", b"\x00\x04", 3),
+    (b"\x00\x00", b"\x00\x08", 4),
+    (b"\x00\x00", b"\x00\xff", 8),
+    (b"\x00\x00", b"\x01\x00", 9),
+    (b"\x00\x00", b"\xf0\x00", 16),
+    (b"\x00\x00", b"\xff\xff", 16),
 ))
 def test_log_distance(left_node_id, right_node_id, log_distance):
     assert compute_log_distance(left_node_id, right_node_id) == log_distance


### PR DESCRIPTION
### What was wrong?

We only responded to the special case distance=0 (i.e. requesting our own ENR). The typical FindNode request with some non-zero distance was ignored.

### How was it fixed?

Plug in the kademlia routing table implementation in favor of the flat one and extend the FindNode handler. In addition, we computed the log distance between two node ids in a different way than other implementations, so I fixed this (even though I still think our implementation makes more sense).

Only the last three commits are new (extends #1468 #1479).

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://upload.wikimedia.org/wikipedia/commons/thumb/a/ac/Probable_leech_from_the_Waukesha_Biota.jpg/571px-Probable_leech_from_the_Waukesha_Biota.jpg)
