### PR TITLE
Introduce MVP validator client

### DIFF
--- a/eth2/_utils/humanize.py
+++ b/eth2/_utils/humanize.py
@@ -1,0 +1,22 @@
+# The number of characters to display from the prefix and suffix in the resulting abbreviation
+DISPLAY_CHARS = 4
+# The number of bytes that result in an abbreviation of the
+# same length; consequently, just inline the value
+INLINE_LENGTH = 6
+
+
+def humanize_bytes(value: bytes) -> str:
+    """
+    Cribbed from ``eth_utils`` implementation of ``humanize_hash``.
+
+    This function accepts a ``bytes`` value of any length, rather than only a ``Hash32``.
+    """
+    if len(value) < INLINE_LENGTH:
+        payload = value.hex()
+    else:
+        hex = value.hex()
+        head = hex[:DISPLAY_CHARS]
+        tail = hex[-1 * DISPLAY_CHARS :]
+        payload = f"{head}..{tail}"
+
+    return f"bytes{len(value)}({payload})"

--- a/eth2/beacon/operations/pool.py
+++ b/eth2/beacon/operations/pool.py
@@ -1,15 +1,8 @@
 from typing import Callable, Dict, Generic, Iterable, Iterator, Tuple, TypeVar, Union
 
-from typing_extensions import Protocol
+from eth2.beacon.typing import Operation, Root
 
-from eth2.beacon.typing import Root
-
-
-class Operation(Protocol):
-    hash_tree_root: Root
-
-
-T = TypeVar("T", bound="Operation")
+T = TypeVar("T", bound=Operation)
 
 
 class OperationPool(Generic[T]):

--- a/eth2/beacon/typing.py
+++ b/eth2/beacon/typing.py
@@ -1,6 +1,7 @@
 from typing import Any, NamedTuple, NewType, Sequence, Tuple
 
 from eth_typing import Hash32
+from typing_extensions import Protocol
 
 Slot = NewType("Slot", int)  # uint64
 Epoch = NewType("Epoch", int)  # uint64
@@ -63,3 +64,7 @@ default_timestamp = Timestamp(0)
 default_second = Second(0)
 default_bitfield = Bitfield(tuple())
 default_version = Version(b"\x00" * 4)
+
+
+class Operation(Protocol):
+    hash_tree_root: Root

--- a/eth2/validator_client/abc.py
+++ b/eth2/validator_client/abc.py
@@ -1,0 +1,78 @@
+from abc import abstractmethod
+from typing import AsyncContextManager, Collection, Container, ContextManager
+
+from eth_typing import BLSPubkey, BLSSignature
+
+from eth2.beacon.types.attestations import Attestation
+from eth2.beacon.types.blocks import BeaconBlock
+from eth2.beacon.typing import CommitteeIndex, Epoch, Operation, Slot
+from eth2.validator_client.duty import Duty
+from eth2.validator_client.tick import Tick
+from eth2.validator_client.typing import BLSPrivateKey
+
+
+class BeaconNodeAPI(AsyncContextManager["BeaconNodeAPI"]):
+    """
+    ``BeaconNodeAPI`` represents a remote beacon node the validator client
+    can query for information about the beacon state and supply
+    signed messages to.
+    """
+
+    @abstractmethod
+    async def fetch_duties(
+        self,
+        current_tick: Tick,
+        public_keys: Collection[BLSPubkey],
+        target_epoch: Epoch,
+    ) -> Collection[Duty]:
+        ...
+
+    @abstractmethod
+    async def fetch_attestation(
+        self, public_key: BLSPubkey, slot: Slot, committee_index: CommitteeIndex
+    ) -> Attestation:
+        ...
+
+    @abstractmethod
+    async def fetch_block_proposal(
+        self, public_key: BLSPubkey, slot: Slot
+    ) -> BeaconBlock:
+        ...
+
+    @abstractmethod
+    async def publish(self, duty: Duty, signature: BLSSignature) -> None:
+        ...
+
+
+class SignatoryDatabaseAPI(Container[bytes]):
+    """
+    Provides persistence for actions of the client to prevent
+    the publishing of slashable signatures.
+    """
+
+    @abstractmethod
+    async def record_signature_for(self, duty: Duty, operation: Operation) -> None:
+        ...
+
+    @abstractmethod
+    async def is_slashable(self, duty: Duty, operation: Operation) -> bool:
+        ...
+
+    @abstractmethod
+    def insert(self, key: bytes, value: bytes) -> None:
+        ...
+
+
+class KeyStoreAPI(ContextManager["KeyStoreAPI"]):
+    @property
+    @abstractmethod
+    def public_keys(self) -> Collection[BLSPubkey]:
+        ...
+
+    @abstractmethod
+    def import_private_key(self, encoded_private_key: str, password: bytes) -> None:
+        ...
+
+    @abstractmethod
+    def private_key_for(self, public_key: BLSPubkey) -> BLSPrivateKey:
+        ...

--- a/eth2/validator_client/beacon_node.py
+++ b/eth2/validator_client/beacon_node.py
@@ -1,0 +1,298 @@
+import logging
+import random
+from types import TracebackType
+from typing import Callable, Collection, Dict, Optional, Set, Tuple, Type
+
+from asks import Session
+from eth_typing import BLSPubkey, BLSSignature
+from eth_utils import ValidationError
+import trio
+
+from eth2._utils.humanize import humanize_bytes
+from eth2.beacon.types.attestation_data import AttestationData
+from eth2.beacon.types.attestations import Attestation
+from eth2.beacon.types.blocks import BeaconBlock
+from eth2.beacon.typing import CommitteeIndex, Epoch, Slot
+from eth2.validator_client.abc import BeaconNodeAPI
+from eth2.validator_client.config import Config
+from eth2.validator_client.duty import (
+    AttestationDuty,
+    BlockProposalDuty,
+    Duty,
+    DutyType,
+)
+from eth2.validator_client.tick import Tick
+
+
+async def _get_duties_from_beacon_node(
+    session: Session,
+    url: str,
+    public_keys: Collection[BLSPubkey],
+    epoch: Epoch,
+    slots_per_epoch: int,
+) -> Tuple[Duty, ...]:
+    # TODO
+    # resp = await session.get(url, params={"validator_pubkeys": public_keys, "epoch": epoch})
+    # ... parse resp into duties
+    return ()
+
+
+async def _publish_duty_with_signature(
+    session: Session, url: str, duty: Duty, signature: BLSSignature
+) -> None:
+    # TODO
+    # resp = await session.post(url, params)
+    # ... ensure resp is OK
+    return
+
+
+async def _get_syncing_status(session: Session, url: str) -> bool:
+    # TODO
+    return False
+
+
+async def _get_genesis_time(session: Session, url: str) -> int:
+    # TODO
+    return 0
+
+
+class BeaconNode(BeaconNodeAPI):
+    logger = logging.getLogger("eth2.validator_client.beacon_node")
+
+    def __init__(
+        self, genesis_time: int, beacon_node_endpoint: str, slots_per_epoch: Slot
+    ) -> None:
+        self._genesis_time = genesis_time
+        self._beacon_node_endpoint = beacon_node_endpoint
+        self._slots_per_epoch = slots_per_epoch
+        self._session = Session()
+        self._connection_lock = trio.Lock()
+        self._is_connected = False
+
+    @classmethod
+    def from_config(cls, config: Config) -> "BeaconNode":
+        return cls(
+            config.genesis_time, config.beacon_node_endpoint, config.slots_per_epoch
+        )
+
+    async def __aenter__(self) -> BeaconNodeAPI:
+        if self._is_connected:
+            return self
+        async with self._connection_lock:
+            await self._connect()
+        return self
+
+    async def __aexit__(
+        self,
+        exc_type: Optional[Type[BaseException]],
+        exc_value: Optional[BaseException],
+        traceback: Optional[TracebackType],
+    ) -> None:
+        pass
+
+    async def _connect(self) -> None:
+        """
+        Verify the syncing status and genesis time of the provided
+        beacon node, ensuring it is up-to-date and reachable.
+        """
+        await self._wait_for_synced_beacon_node()
+        await self._validate_genesis_time()
+        self._is_connected = True
+
+    async def _get_syncing_status(self) -> bool:
+        # TODO
+        url = ""  # self._syncing_endpoint
+        return await _get_syncing_status(self._session, url)
+
+    async def _wait_for_synced_beacon_node(self) -> None:
+        is_syncing = await self._get_syncing_status()
+        if is_syncing:
+            # TODO
+            # some loop +  time-out until synced!
+            pass
+
+    async def _validate_genesis_time(self) -> None:
+        """
+        Ensure the connected beacon node has the same genesis time
+        as was provided during instantiation of ``self``.
+        """
+        genesis_url = ""  # self._genesis_endpoint
+        genesis_time = await _get_genesis_time(self._session, genesis_url)
+        if genesis_time != self._genesis_time:
+            raise ValidationError(
+                f"Genesis time of validator client {self._genesis_time} did not match genesis time"
+                f" of beacon node {genesis_time} at endpoint {self._beacon_node_endpoint}"
+            )
+
+    async def fetch_duties(
+        self,
+        current_tick: Tick,
+        public_keys: Collection[BLSPubkey],
+        target_epoch: Epoch,
+    ) -> Collection[Duty]:
+        url = ""  # self._fetch_duties_endpoint
+        return await _get_duties_from_beacon_node(
+            self._session, url, public_keys, target_epoch, self._slots_per_epoch
+        )
+
+    async def fetch_attestation(
+        self, public_key: BLSPubkey, slot: Slot, committee_index: CommitteeIndex
+    ) -> Attestation:
+        # TODO make API call
+        return Attestation.create(data=AttestationData.create(slot=slot))
+
+    async def fetch_block_proposal(
+        self, public_key: BLSPubkey, slot: Slot
+    ) -> BeaconBlock:
+        # TODO make API call
+        return BeaconBlock.create(slot=slot)
+
+    async def publish(self, duty: Duty, signature: BLSSignature) -> None:
+        url = ""  # self._publish_endpoint
+        await _publish_duty_with_signature(self._session, url, duty, signature)
+
+
+DutyFetcher = Callable[
+    [Tick, Collection[BLSPubkey], Epoch, Slot, int], Tuple[Duty, ...]
+]
+
+
+def _fetch_some_random_duties(
+    current_tick: Tick,
+    public_keys: Collection[BLSPubkey],
+    target_epoch: Epoch,
+    slots_per_epoch: Slot,
+    seconds_per_slot: int,
+) -> Tuple[Duty, ...]:
+    if not public_keys:
+        return ()
+    if target_epoch < 0:
+        return ()
+    some_slot = Slot(
+        random.randint(0, slots_per_epoch) + target_epoch * slots_per_epoch
+    )
+    execution_time = seconds_per_slot * (some_slot - current_tick.slot) + current_tick.t
+    is_attestation = bool(random.getrandbits(1))
+    # NOTE: use of ``tuple`` here is satisfy ``mypy``.
+    some_validator = random.choice(tuple(public_keys))
+    if is_attestation:
+        committee_index = random.randint(0, 64)
+        some_tick_count = 1
+        attestation_duty = AttestationDuty(
+            some_validator,
+            Tick(execution_time, some_slot, target_epoch, some_tick_count),
+            current_tick,
+            CommitteeIndex(committee_index),
+        )
+        return (attestation_duty,)
+    else:
+        some_tick_count = 0
+        block_proposal_duty = BlockProposalDuty(
+            some_validator,
+            Tick(execution_time, some_slot, target_epoch, some_tick_count),
+            current_tick,
+        )
+        return (block_proposal_duty,)
+
+
+class MockBeaconNode(BeaconNodeAPI):
+    """
+    An in-memory beacon node satisfying the ``BeaconNodeAPI``.
+
+    Accepts custom logic to fetch duties with the ``duty_fetcher`` argument.
+    Attempts to filter duties that would violate a slashing condition.
+    Records signatures submitted for broadcast.
+    """
+
+    logger = logging.getLogger("eth2.validator_client.mock_beacon_node")
+
+    def __init__(
+        self,
+        slots_per_epoch: Slot,
+        seconds_per_slot: int,
+        duty_fetcher: DutyFetcher = _fetch_some_random_duties,
+    ) -> None:
+        self._slots_per_epoch = slots_per_epoch
+        self._seconds_per_slot = seconds_per_slot
+        self._duty_fetcher = duty_fetcher
+        # NOTE: emulate only one block proposal per validator per slot
+        # and only one attestation per validator per epoch
+        self._block_duty_tracker: Set[Slot] = set()
+        self._attestation_duty_tracker: Dict[BLSPubkey, Set[Epoch]] = {}
+        self.given_duties: Set[Duty] = set()
+        self.published_signatures: Dict[Duty, BLSSignature] = {}
+
+    @classmethod
+    def from_config(cls, config: Config) -> "MockBeaconNode":
+        return cls(config.slots_per_epoch, config.seconds_per_slot)
+
+    async def __aenter__(self) -> BeaconNodeAPI:
+        return self
+
+    async def __aexit__(
+        self,
+        exc_type: Optional[Type[BaseException]],
+        exc_value: Optional[BaseException],
+        traceback: Optional[TracebackType],
+    ) -> None:
+        pass
+
+    def _duty_filter(self, duty: Duty) -> bool:
+        some_validator = duty.validator_public_key
+        if duty.duty_type == DutyType.Attestation:
+            attestation_epochs = self._attestation_duty_tracker.get(
+                some_validator, set()
+            )
+            target_epoch = duty.tick_for_execution.epoch
+            if target_epoch in attestation_epochs:
+                return False
+            attestation_epochs.add(target_epoch)
+            self._attestation_duty_tracker[some_validator] = attestation_epochs
+            return True
+        else:
+            some_slot = duty.tick_for_execution.slot
+            if some_slot in self._block_duty_tracker:
+                return False
+            self._block_duty_tracker.add(some_slot)
+            return True
+
+    async def fetch_duties(
+        self,
+        current_tick: Tick,
+        public_keys: Collection[BLSPubkey],
+        target_epoch: Epoch,
+    ) -> Collection[Duty]:
+        some_duties = self._duty_fetcher(
+            current_tick,
+            public_keys,
+            target_epoch,
+            self._slots_per_epoch,
+            self._seconds_per_slot,
+        )
+        valid_duties = tuple(filter(self._duty_filter, some_duties))
+        self.logger.debug("%s: got duties %s", current_tick, valid_duties)
+        for duty in valid_duties:
+            # sanity check
+            assert duty not in self.given_duties
+            self.given_duties.add(duty)
+        return valid_duties
+
+    async def fetch_attestation(
+        self, public_key: BLSPubkey, slot: Slot, committee_index: CommitteeIndex
+    ) -> Attestation:
+        return Attestation.create(
+            data=AttestationData.create(slot=slot, index=committee_index)
+        )
+
+    async def fetch_block_proposal(
+        self, public_key: BLSPubkey, slot: Slot
+    ) -> BeaconBlock:
+        return BeaconBlock.create(slot=slot)
+
+    async def publish(self, duty: Duty, signature: BLSSignature) -> None:
+        self.logger.debug(
+            "publishing %s with signature %s to beacon node",
+            duty,
+            humanize_bytes(signature),
+        )
+        self.published_signatures[duty] = signature

--- a/eth2/validator_client/cli_parser.py
+++ b/eth2/validator_client/cli_parser.py
@@ -1,0 +1,67 @@
+import argparse
+import getpass
+import logging
+import signal
+
+import argcomplete
+from async_service.trio import background_trio_service
+import trio
+
+from eth2.validator_client.client import Client
+from eth2.validator_client.config import Config
+from eth2.validator_client.key_store import KeyStore
+
+CLI_PARSER_DESCRIPTION = "Trinity Eth2.0 Validator Client"
+DEMO_MODE_HELP_MSG = (
+    "set configuration suitable for demonstration purposes (like ignoring a password)."
+    " Do NOT use in production."
+)
+IMPORT_PARSER_HELP_MSG = (
+    "import a validator private key to the keystore discovered from the configuration"
+)
+IMPORT_PARSER_KEY_ARGUMENT_HELP_MSG = "private key, encoded as big-endian hex"
+
+
+async def _wait_for_interrupts() -> None:
+    with trio.open_signal_receiver(signal.SIGINT, signal.SIGTERM) as stream:
+        async for _ in stream:
+            return
+
+
+async def _main(
+    logger: logging.Logger, config: Config, arguments: argparse.Namespace
+) -> None:
+    client = Client.from_config(config)
+    async with background_trio_service(client):
+        await _wait_for_interrupts()
+        logger.info("received interrupt; shutting down...")
+
+
+async def _import_key(
+    logger: logging.Logger, config: Config, arguments: argparse.Namespace
+) -> None:
+    logger.info("importing private key...")
+    try:
+        key_store = KeyStore.from_config(config)
+        logger.warn(
+            "please enter a password to protect the key on-disk (can be empty):"
+        )
+        password = getpass.getpass().encode()
+        key_store.import_private_key(arguments.private_key, password)
+    except Exception:
+        logger.exception("error importing key")
+
+
+def parse_cli_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=CLI_PARSER_DESCRIPTION)
+    parser.add_argument("--demo-mode", action="store_true", help=DEMO_MODE_HELP_MSG)
+    parser.set_defaults(func=_main)
+    subparsers = parser.add_subparsers(title="subcommands", dest="subparser_name")
+    import_key_parser = subparsers.add_parser("import-key", help=IMPORT_PARSER_HELP_MSG)
+    import_key_parser.add_argument(
+        "private_key", type=str, help=IMPORT_PARSER_KEY_ARGUMENT_HELP_MSG
+    )
+    import_key_parser.set_defaults(func=_import_key)
+
+    argcomplete.autocomplete(parser)
+    return parser.parse_args()

--- a/eth2/validator_client/client.py
+++ b/eth2/validator_client/client.py
@@ -1,0 +1,179 @@
+import logging
+from typing import AsyncIterable, Collection
+
+from async_service.base import Service
+from eth_typing import BLSPubkey
+import trio
+from trio.abc import ReceiveChannel, SendChannel
+
+from eth2._utils.humanize import humanize_bytes
+from eth2.validator_client.abc import BeaconNodeAPI, KeyStoreAPI, SignatoryDatabaseAPI
+from eth2.validator_client.beacon_node import MockBeaconNode as BeaconNode
+from eth2.validator_client.clock import Clock
+from eth2.validator_client.config import Config
+from eth2.validator_client.duty import Duty
+from eth2.validator_client.duty_scheduler import (
+    resolve_duty,
+    schedule_and_dispatch_duties_at_tick,
+)
+from eth2.validator_client.duty_store import DutyStore
+from eth2.validator_client.signatory import sign_and_broadcast_operation_if_valid
+from eth2.validator_client.signatory_db import InMemorySignatoryDB
+from eth2.validator_client.tick import Tick
+from eth2.validator_client.typing import PrivateKeyProvider, ResolvedDuty
+
+# NOTE: ``MAX_INDIVIDUAL_DUTIES_PER_SLOT`` is the maximum number of duties
+# per slot we expect a single validator to have to be able to perform.
+MAX_INDIVIDUAL_DUTIES_PER_SLOT = 2
+
+
+def _estimate_max_duties_per_slot(number_of_validators: int) -> int:
+    """
+    Estimate the maximum number of duties a validator may have to perform.
+
+    This value is used to select an appropriate size of buffer for the communication
+    of duties between the scheduler and the signatory.
+    """
+    # TODO: cap this number so it is not much higher than the expected average
+    return MAX_INDIVIDUAL_DUTIES_PER_SLOT * number_of_validators
+
+
+class Client(Service):
+    logger = logging.getLogger("eth2.validator_client.client")
+
+    def __init__(
+        self,
+        key_store: KeyStoreAPI,
+        clock: AsyncIterable[Tick],
+        beacon_node: BeaconNodeAPI,
+    ) -> None:
+        self._key_store = key_store
+        self._clock = clock
+        self._beacon_node = beacon_node
+
+        self._duty_store = DutyStore()
+        self._signature_db = InMemorySignatoryDB()
+
+    @classmethod
+    def from_config(cls, config: Config) -> "Client":
+        clock = Clock.from_config(config)
+        beacon_node = BeaconNode.from_config(config)
+        return cls(config.key_store, clock, beacon_node)
+
+    async def _run_client(self) -> None:
+        # NOTE: all duties dispatched from the scheduler are expected to be
+        # completed in one slot. thus, the maximum expected size of the
+        # trio channels connecting the components downstream of the scheduler
+        # can be bounded by the maximum number of expected duties per slot,
+        # subject to memory constraints on the underlying hardware.
+        max_duties_per_slot = _estimate_max_duties_per_slot(
+            len(self._key_store.public_keys)
+        )
+
+        duty_dispatcher, duties_to_resolve = trio.open_memory_channel[Duty](
+            max_duties_per_slot
+        )
+
+        resolved_duties, resolved_duty_provider = trio.open_memory_channel[
+            ResolvedDuty
+        ](max_duties_per_slot)
+
+        self.manager.run_daemon_task(
+            self.duty_scheduler,
+            self._clock,
+            self._duty_store,
+            self._beacon_node,
+            self._key_store.public_keys,
+            duty_dispatcher,
+        )
+        self.manager.run_daemon_task(
+            self.duty_resolver, self._beacon_node, duties_to_resolve, resolved_duties
+        )
+        self.manager.run_daemon_task(
+            self.signatory,
+            resolved_duty_provider,
+            self._signature_db,
+            self._beacon_node,
+            self._key_store.private_key_for,
+        )
+
+        await self.manager.wait_finished()
+
+    async def _verify_client_state_at_boot(self) -> None:
+        """
+        Verify any state the client has against the state observable
+        from the beacon node as we are booting up.
+
+        There can be simple discrepancies (e.g. differing genesis times) that
+        suggest the client is connected to a bad beacon node.
+        """
+        # TODO: sanity check the validator key pairs we find are valid
+        # perhaps by fetching their indices in the state
+        pass
+
+    async def run(self) -> None:
+        self.logger.debug("booting client from the provided config...")
+
+        with self._key_store:
+            self.logger.info(
+                "found %d validator key pair(s) for public key(s) %s",
+                len(self._key_store.public_keys),
+                tuple(map(humanize_bytes, self._key_store.public_keys)),
+            )
+            async with self._beacon_node:
+                await self._verify_client_state_at_boot()
+                await self._run_client()
+
+    async def duty_scheduler(
+        self,
+        clock: AsyncIterable[Tick],
+        duty_store: DutyStore,
+        beacon_node: BeaconNodeAPI,
+        validator_public_keys: Collection[BLSPubkey],
+        duty_dispatcher: SendChannel[Duty],
+    ) -> None:
+        """
+        ``duty_scheduler`` manages the set of duties for the validator public keys in the key store.
+
+        This task involves polling the beacon node periodically to get the latest set of assignments
+        based on the beacon chain state. Duties are dispatched to consumers of the ``duty_channel``
+        at the appropriate point in time.
+        """
+        async with duty_dispatcher:
+            async for tick in clock:
+                self.manager.run_task(
+                    schedule_and_dispatch_duties_at_tick,
+                    tick,
+                    beacon_node,
+                    validator_public_keys,
+                    duty_store,
+                    duty_dispatcher,
+                )
+
+    async def duty_resolver(
+        self,
+        beacon_node: BeaconNodeAPI,
+        duties_to_resolve: ReceiveChannel[Duty],
+        resolved_duties: SendChannel[ResolvedDuty],
+    ) -> None:
+        async with duties_to_resolve:
+            async for duty in duties_to_resolve:
+                self.manager.run_task(resolve_duty, beacon_node, duty, resolved_duties)
+
+    async def signatory(
+        self,
+        duty_provider: ReceiveChannel[ResolvedDuty],
+        signature_store: SignatoryDatabaseAPI,
+        beacon_node: BeaconNodeAPI,
+        private_key_provider: PrivateKeyProvider,
+    ) -> None:
+        async with duty_provider:
+            async for duty, operation in duty_provider:
+                self.manager.run_task(
+                    sign_and_broadcast_operation_if_valid,
+                    duty,
+                    operation,
+                    signature_store,
+                    beacon_node,
+                    private_key_provider,
+                )

--- a/eth2/validator_client/clock.py
+++ b/eth2/validator_client/clock.py
@@ -1,0 +1,153 @@
+import logging
+import time
+from typing import AsyncIterable, AsyncIterator, Callable, Tuple
+
+import trio
+
+from eth2.beacon.typing import Epoch, Slot
+from eth2.validator_client.config import Config
+from eth2.validator_client.tick import Tick
+
+TICKS_PER_SLOT = 2
+DEFAULT_EPOCH_LOOKAHEAD = 1
+
+
+def _get_unix_time() -> float:
+    return time.time()
+
+
+TimeProvider = Callable[[], float]
+
+
+def _compute_tick_multiplier(interval: float) -> int:
+    """
+    The tick multiplier is the order of magnitude by which the ``interval`` has to
+    be multiplied such that the interval is a number >= 1.
+
+    The tick multiplier simplifies the math to determine the sub slot count
+    when the ``Clock``'s tick interval is fractional. The idea is to scale the
+    sub slot value such that we can just look at the integer part of this value.
+    """
+    multiplier = 0
+    while interval < 1:
+        multiplier += 1
+        interval *= 10
+    return 10 ** multiplier
+
+
+class Clock(AsyncIterable[Tick]):
+    logger = logging.getLogger("eth2.validator_client.clock")
+
+    def __init__(
+        self,
+        seconds_per_slot: int,
+        genesis_time: int,
+        slots_per_epoch: Slot,
+        seconds_per_epoch: int,
+        time_provider: TimeProvider = _get_unix_time,
+        ticks_per_slot: int = TICKS_PER_SLOT,
+    ) -> None:
+        self._time_provider = time_provider
+        self.logger.setLevel(logging.DEBUG)
+
+        self._ticks_per_slot = ticks_per_slot
+        # The validator client needs to take action with sub-slot granularity.
+        # Each period on this finer resolution is called a "tick".
+        self._tick_interval = seconds_per_slot / self._ticks_per_slot
+        self._tick_multiplier = _compute_tick_multiplier(self._tick_interval)
+        self._seconds_per_slot = seconds_per_slot
+        self._genesis_time = genesis_time
+        self._slots_per_epoch = slots_per_epoch
+        self._seconds_per_epoch = seconds_per_epoch
+
+    @classmethod
+    def from_config(
+        cls, config: Config, time_provider: TimeProvider = _get_unix_time
+    ) -> "Clock":
+        return cls(
+            config.seconds_per_slot,
+            config.genesis_time,
+            config.slots_per_epoch,
+            config.seconds_per_epoch,
+            time_provider=time_provider,
+        )
+
+    def _compute_slot_and_alignment(self, t: float) -> Tuple[Slot, bool]:
+        """
+        Compute the slot corresponding to a time ``t``.
+        Indicate if ``t`` corresponds to the first tick in the relevant slot
+        with a boolean return value.
+        """
+        time_since_genesis = t - self._genesis_time
+        slot, sub_slot = divmod(time_since_genesis, self._seconds_per_slot)
+        return (Slot(int(slot)), int(sub_slot * self._tick_multiplier) == 0)
+
+    def _compute_epoch(self, slot: Slot) -> Epoch:
+        return Epoch(slot // self._slots_per_epoch)
+
+    def _compute_current_tick(self) -> Tick:
+        t = self._time_provider()
+        slot, aligned = self._compute_slot_and_alignment(t)
+        epoch = self._compute_epoch(slot)
+        count = int(not aligned)
+        return Tick(t, slot, epoch, count)
+
+    async def _wait_until(self, target_t: float) -> None:
+        """
+        Block execution until ``target_t`` (a unix timestamp)
+        """
+        t = self._time_provider()
+        duration = max(target_t - t, 0)
+        await trio.sleep(duration)
+
+    async def _wait_for_genesis_with_lookahead(
+        self, with_epoch_lookahead: int = DEFAULT_EPOCH_LOOKAHEAD
+    ) -> None:
+        """
+        Sleep the clock until the time is ``with_epoch_lookahead`` epoch(s)
+        of slots ahead of the genesis time.
+
+        This is the earliest time the client can poll for duties and expect to receive anything
+        meaningful from a honest beacon node.
+        """
+        genesis_time = self._genesis_time
+        start_time = genesis_time - (with_epoch_lookahead * self._seconds_per_epoch)
+        self.logger.info(
+            "...blocking until unix time %s which is %d epochs before the genesis time %d",
+            start_time,
+            with_epoch_lookahead,
+            genesis_time,
+        )
+        await self._wait_until(start_time)
+
+    def _compute_time_of_next_tick(self, tick: Tick) -> float:
+        """
+        The first ``Tick`` in a slot is aligned to the nearest second in unix time.
+        We can use the ``tick``'s count to determine when the time of the next
+        tick should be, even if there was jitter in producing ``tick``.
+        """
+        next_tick_count = tick.count + 1
+        count_rolls_over = next_tick_count == self._ticks_per_slot
+        if count_rolls_over:
+            next_slot = tick.slot + 1
+        else:
+            next_slot = tick.slot
+        time_of_next_slot = self._genesis_time + self._seconds_per_slot * next_slot
+        return time_of_next_slot + self._tick_interval * (
+            next_tick_count % self._ticks_per_slot
+        )
+
+    async def _wait_until_next_tick(self, tick: Tick) -> None:
+        next_time = self._compute_time_of_next_tick(tick)
+        await self._wait_until(next_time)
+
+    async def __aiter__(self) -> AsyncIterator[Tick]:
+        await self._wait_for_genesis_with_lookahead()
+
+        while True:
+            tick = self._compute_current_tick()
+            self.logger.debug("%s", tick)
+            if tick.is_at_genesis(self._genesis_time):
+                self.logger.warning("Network genesis time is now!")
+            yield tick
+            await self._wait_until_next_tick(tick)

--- a/eth2/validator_client/config.py
+++ b/eth2/validator_client/config.py
@@ -1,0 +1,52 @@
+from pathlib import Path
+from typing import Callable
+
+from cached_property import cached_property
+
+from eth2.beacon.typing import Slot
+from eth2.validator_client.abc import KeyStoreAPI
+
+DEFAULT_BEACON_NODE_ENDPOINT = "https://127.0.0.1:30303"
+DEFAULT_VALIDATOR_DATA_DIR = Path("validator_client")
+DEFAULT_KEY_STORE_DIR_SUFFIX = Path("key_store")
+DEFAULT_SIGNATORY_DB_DIR_SUFFIX = Path("db") / "signatory"
+
+KeyStoreConstructor = Callable[["Config"], KeyStoreAPI]
+
+
+class Config:
+    """
+    Represents data specific to a particular instance of a ``Client``.
+    """
+
+    def __init__(
+        self,
+        *,
+        key_store_constructor: KeyStoreConstructor = None,
+        root_data_dir: Path = None,
+        beacon_node_endpoint: str = DEFAULT_BEACON_NODE_ENDPOINT,
+        key_store_dir_suffix: Path = DEFAULT_KEY_STORE_DIR_SUFFIX,
+        signatory_db_handle: Path = DEFAULT_SIGNATORY_DB_DIR_SUFFIX,
+        slots_per_epoch: Slot = None,
+        seconds_per_slot: int = None,
+        genesis_time: int = None,
+        demo_mode: bool = False,
+    ) -> None:
+        self._root_data_dir = root_data_dir
+        self.beacon_node_endpoint = beacon_node_endpoint
+        self.key_store_dir_suffix = key_store_dir_suffix
+        self.signatory_db_handle = signatory_db_handle
+        self.slots_per_epoch = slots_per_epoch
+        self.seconds_per_slot = seconds_per_slot
+        self.genesis_time = genesis_time
+        self.demo_mode = demo_mode
+
+        self.key_store = key_store_constructor(self)
+
+    @cached_property
+    def seconds_per_epoch(self) -> int:
+        return self.slots_per_epoch * self.seconds_per_slot
+
+    @cached_property
+    def key_store_dir(self) -> Path:
+        return self._root_data_dir / self.key_store_dir_suffix

--- a/eth2/validator_client/duty.py
+++ b/eth2/validator_client/duty.py
@@ -1,0 +1,64 @@
+from dataclasses import dataclass, field
+from enum import Enum, auto, unique
+
+from eth_typing import BLSPubkey
+
+from eth2._utils.humanize import humanize_bytes
+from eth2.beacon.signature_domain import SignatureDomain
+from eth2.beacon.typing import CommitteeIndex
+from eth2.validator_client.tick import Tick
+
+
+@unique
+class DutyType(Enum):
+    Attestation = auto()
+    BlockProposal = auto()
+
+
+@dataclass(eq=True, frozen=True)
+class Duty:
+    """
+    A ``Duty`` represents some work that needs to be performed on behalf of some
+    validator, like signing an ``Attestation``.
+    """
+
+    validator_public_key: BLSPubkey
+    # ``Tick`` when this ``Duty`` should be executed, resulting in a
+    # (slashable) signature to publish
+    tick_for_execution: Tick
+    # ``Tick`` when this ``Duty`` was discovered via a ``BeaconNode``
+    discovered_at_tick: Tick
+    duty_type: DutyType
+    signature_domain: SignatureDomain
+
+
+@dataclass(eq=True, frozen=True)
+class AttestationDuty(Duty):
+    duty_type: DutyType = field(init=False, default=DutyType.Attestation)
+    signature_domain: SignatureDomain = field(
+        init=False, default=SignatureDomain.DOMAIN_BEACON_ATTESTER
+    )
+    committee_index: CommitteeIndex
+
+    def __repr__(self) -> str:
+        return (
+            f"AttestationDuty(validator_public_key={humanize_bytes(self.validator_public_key)},"
+            f" tick_for_execution={self.tick_for_execution},"
+            f" discovered_at_tick={self.discovered_at_tick},"
+            f" committee_index={self.committee_index})"
+        )
+
+
+@dataclass(eq=True, frozen=True)
+class BlockProposalDuty(Duty):
+    duty_type: DutyType = field(init=False, default=DutyType.BlockProposal)
+    signature_domain: SignatureDomain = field(
+        init=False, default=SignatureDomain.DOMAIN_BEACON_PROPOSER
+    )
+
+    def __repr__(self) -> str:
+        return (
+            f"BlockProposalDuty(validator_public_key={humanize_bytes(self.validator_public_key)},"
+            f" tick_for_execution={self.tick_for_execution},"
+            f" discovered_at_tick={self.discovered_at_tick}"
+        )

--- a/eth2/validator_client/duty_scheduler.py
+++ b/eth2/validator_client/duty_scheduler.py
@@ -1,0 +1,90 @@
+import logging
+from typing import Collection, Tuple, cast
+
+from eth_typing import BLSPubkey
+from trio.abc import SendChannel
+
+from eth2.beacon.typing import Epoch
+from eth2.validator_client.abc import BeaconNodeAPI
+from eth2.validator_client.duty import AttestationDuty, Duty, DutyType
+from eth2.validator_client.duty_store import DutyStore
+from eth2.validator_client.tick import Tick
+from eth2.validator_client.typing import ResolvedDuty
+
+logger = logging.getLogger("eth2.validator_client.duty_scheduler")
+
+
+async def resolve_duty(
+    beacon_node: BeaconNodeAPI, duty: Duty, resolved_duties: SendChannel[ResolvedDuty]
+) -> None:
+    if duty.duty_type == DutyType.Attestation:
+        duty = cast(AttestationDuty, duty)
+        attestation = await beacon_node.fetch_attestation(
+            duty.validator_public_key,
+            duty.tick_for_execution.slot,
+            duty.committee_index,
+        )
+        await resolved_duties.send((duty, attestation))
+    elif duty.duty_type == DutyType.BlockProposal:
+        block_proposal = await beacon_node.fetch_block_proposal(
+            duty.validator_public_key, duty.tick_for_execution.slot
+        )
+        await resolved_duties.send((duty, block_proposal))
+    else:
+        raise NotImplementedError(
+            "request to resolve a non-supported type of duty: %s", duty
+        )
+
+
+async def _dispatch_duties_for(
+    tick: Tick,
+    duty_store: DutyStore,
+    beacon_node: BeaconNodeAPI,
+    duty_dispatcher: SendChannel[Duty],
+) -> None:
+    duties = await duty_store.duties_at_tick(tick)
+    if not duties:
+        logger.debug("%s: no duties found", tick)
+        return
+    logger.debug("%s: got duties %s to execute", tick, duties)
+    for duty in duties:
+        await duty_dispatcher.send(duty)
+
+
+async def _fetch_latest_duties(
+    tick: Tick,
+    beacon_node: BeaconNodeAPI,
+    validator_public_keys: Collection[BLSPubkey],
+    duty_store: DutyStore,
+) -> None:
+    current_epoch = tick.epoch
+    next_epoch = Epoch(current_epoch + 1)
+
+    current_duties = await beacon_node.fetch_duties(
+        tick, validator_public_keys, current_epoch
+    )
+    upcoming_duties = await beacon_node.fetch_duties(
+        tick, validator_public_keys, next_epoch
+    )
+    latest_duties = cast(Tuple[Duty, ...], current_duties) + cast(
+        Tuple[Duty, ...], upcoming_duties
+    )
+    if not latest_duties:
+        return
+
+    logger.debug("%s: found duties %s", tick, latest_duties)
+
+    # TODO manage duties correctly, accounting for re-orgs, etc.
+    # NOTE: the naive strategy is likely "last write wins"
+    await duty_store.add_duties(*latest_duties)
+
+
+async def schedule_and_dispatch_duties_at_tick(
+    tick: Tick,
+    beacon_node: BeaconNodeAPI,
+    validator_public_keys: Collection[BLSPubkey],
+    duty_store: DutyStore,
+    duty_dispatcher: SendChannel[Duty],
+) -> None:
+    await _fetch_latest_duties(tick, beacon_node, validator_public_keys, duty_store)
+    await _dispatch_duties_for(tick, duty_store, beacon_node, duty_dispatcher)

--- a/eth2/validator_client/duty_store.py
+++ b/eth2/validator_client/duty_store.py
@@ -1,0 +1,31 @@
+from collections import defaultdict
+from typing import Collection, Dict, Tuple
+
+import trio
+
+from eth2.beacon.typing import Slot
+from eth2.validator_client.duty import Duty
+from eth2.validator_client.tick import Tick
+
+
+class DutyStore:
+    def __init__(self) -> None:
+        self._store: Dict[Slot, Dict[int, Tuple[Duty, ...]]] = {}
+        self._store_lock = trio.Lock()
+
+    async def duties_at_tick(self, tick: Tick) -> Collection[Duty]:
+        async with self._store_lock:
+            if tick.slot in self._store:
+                duties_by_tick = self._store[tick.slot]
+                return duties_by_tick.get(tick.count, ())
+            else:
+                return ()
+
+    async def add_duties(self, *duties: Duty) -> None:
+        async with self._store_lock:
+            for duty in duties:
+                tick = duty.tick_for_execution
+                if tick.slot not in self._store:
+                    self._store[tick.slot] = defaultdict(tuple)
+
+                self._store[tick.slot][tick.count] += (duty,)

--- a/eth2/validator_client/key_store.py
+++ b/eth2/validator_client/key_store.py
@@ -1,0 +1,161 @@
+import getpass
+import json
+import logging
+from pathlib import Path
+from types import TracebackType
+from typing import Any, Collection, Dict, Optional, Type
+
+import eth_keyfile
+from eth_typing import BLSPubkey
+from eth_utils import decode_hex, encode_hex
+
+from eth2._utils.bls import bls
+from eth2._utils.humanize import humanize_bytes
+from eth2.validator_client.abc import KeyStoreAPI
+from eth2.validator_client.config import Config
+from eth2.validator_client.typing import BLSPrivateKey, KeyPair
+
+EMPTY_PASSWORD = b""
+
+
+def _compute_key_pair_from_private_key_bytes(private_key_bytes: bytes) -> KeyPair:
+    private_key = int.from_bytes(private_key_bytes, byteorder="big")
+    return (bls.privtopub(private_key), private_key)
+
+
+def _create_dir_if_missing(path: Path) -> bool:
+    if not path.exists():
+        path.mkdir(parents=True)
+        return True
+    return False
+
+
+class KeyStore(KeyStoreAPI):
+    """
+    A ``KeyStore`` instance is a read-only repository for the private and public keys
+    corresponding to the validators under the control of a client of this class.
+    """
+
+    logger = logging.getLogger("eth2.validator_client.key_store")
+
+    def __init__(self, key_store_dir: Path, demo_mode: bool) -> None:
+        self._location = key_store_dir
+        self._demo_mode = demo_mode
+        self._key_pairs: Dict[BLSPubkey, BLSPrivateKey] = {}
+        # NOTE: ``_key_files`` is a temporary cache
+        # so that there may be key pairs in ``_key_pairs``
+        # that do not have key files in ``_key_files``.
+        self._key_files: Dict[str, Dict[str, Any]] = {}
+
+        self._ensure_dirs()
+
+    @classmethod
+    def from_config(cls, config: Config) -> "KeyStore":
+        return cls(config.key_store_dir, config.demo_mode)
+
+    def __enter__(self) -> KeyStoreAPI:
+        self._load_validator_key_pairs()
+        return self
+
+    def __exit__(
+        self,
+        exc_type: Optional[Type[BaseException]],
+        exc_value: Optional[BaseException],
+        traceback: Optional[TracebackType],
+    ) -> None:
+        for key_file_id, key_file_json in self._key_files.items():
+            with open(self._location / (key_file_id + ".json"), "w") as key_file_handle:
+                json.dump(key_file_json, key_file_handle)
+
+    def _ensure_dirs(self) -> None:
+        did_create = _create_dir_if_missing(self._location)
+        if did_create:
+            self.logger.warning(
+                "the key store location provided (%s) was created because it was missing",
+                self._location,
+            )
+
+    def _load_validator_key_pairs(self) -> None:
+        """
+        Load all key pairs found in the key store directory.
+        """
+        for key_file in self._location.iterdir():
+            public_key, private_key = self._load_key_file(key_file)
+            self._key_pairs[public_key] = private_key
+
+        self.logger.info(
+            "loaded %d validator(s) from the key store", len(self._key_pairs)
+        )
+
+    def _load_key_file(self, key_file: Path) -> KeyPair:
+        with open(key_file) as key_file_handle:
+            keyfile_json = json.load(key_file_handle)
+            public_key = decode_hex(keyfile_json["public_key"])
+            if not self._demo_mode:
+                self.logger.warn(
+                    "please enter password for protected keyfile with public key %s:",
+                    humanize_bytes(public_key),
+                )
+                password = getpass.getpass().encode()
+            else:
+                password = EMPTY_PASSWORD
+            private_key = eth_keyfile.decode_keyfile_json(keyfile_json, password)
+            return _compute_key_pair_from_private_key_bytes(private_key)
+
+    @property
+    def public_keys(self) -> Collection[BLSPubkey]:
+        return tuple(self._key_pairs.keys())
+
+    def import_private_key(self, encoded_private_key: str, password: bytes) -> None:
+        """
+        Parse the ``private_key`` provided as a hex-encoded ``str`` and then stores the
+        private key and public key as a key pair in the key store on disk.
+        """
+        private_key_bytes = decode_hex(encoded_private_key)
+        public_key, private_key = _compute_key_pair_from_private_key_bytes(
+            private_key_bytes
+        )
+        key_file_json = eth_keyfile.create_keyfile_json(private_key_bytes, password)
+        key_file_json["public_key"] = encode_hex(public_key)
+
+        self._key_pairs[public_key] = private_key
+        self._key_files[key_file_json["id"]] = key_file_json
+
+    def private_key_for(self, public_key: BLSPubkey) -> BLSPrivateKey:
+        return self._key_pairs[public_key]
+
+
+class InMemoryKeyStore(KeyStoreAPI):
+    def __init__(self, key_pairs: Collection[KeyPair] = ()) -> None:
+        self._key_pairs = dict(key_pairs)
+
+    @classmethod
+    def from_config(
+        cls, config: Config, key_pairs: Collection[KeyPair] = ()
+    ) -> "InMemoryKeyStore":
+        return cls(key_pairs)
+
+    def __enter__(self) -> KeyStoreAPI:
+        return self
+
+    def __exit__(
+        self,
+        exc_type: Optional[Type[BaseException]],
+        exc_value: Optional[BaseException],
+        traceback: Optional[TracebackType],
+    ) -> None:
+        pass
+
+    @property
+    def public_keys(self) -> Collection[BLSPubkey]:
+        return tuple(self._key_pairs.keys())
+
+    def import_private_key(self, encoded_private_key: str, password: bytes) -> None:
+        private_key_bytes = decode_hex(encoded_private_key)
+        public_key, private_key = _compute_key_pair_from_private_key_bytes(
+            private_key_bytes
+        )
+        self._key_pairs[public_key] = private_key
+
+    def private_key_for(self, public_key: BLSPubkey) -> BLSPrivateKey:
+        return self._key_pairs[public_key]

--- a/eth2/validator_client/signatory.py
+++ b/eth2/validator_client/signatory.py
@@ -1,0 +1,68 @@
+import logging
+
+from eth_typing import BLSSignature
+from eth_utils import ValidationError
+from py_ecc.bls.typing import Domain
+
+from eth2._utils.bls import bls
+from eth2._utils.humanize import humanize_bytes
+from eth2.beacon.helpers import signature_domain_to_domain_type
+from eth2.beacon.typing import Operation
+from eth2.validator_client.abc import BeaconNodeAPI, SignatoryDatabaseAPI
+from eth2.validator_client.duty import Duty
+from eth2.validator_client.typing import PrivateKeyProvider
+
+logger = logging.getLogger("eth2.validator_client.signatory")
+
+
+async def _validate_duty(
+    duty: Duty, operation: Operation, db: SignatoryDatabaseAPI
+) -> None:
+    """
+    ``db`` contains a persistent record of all signatures with
+    enough information to prevent the triggering of any slashing conditions.
+    """
+    if await db.is_slashable(duty, operation):
+        raise ValidationError(
+            f"signing the duty {duty} would result in a slashable signature"
+        )
+
+
+def sign(
+    duty: Duty, operation: Operation, private_key_provider: PrivateKeyProvider
+) -> BLSSignature:
+    message = operation.hash_tree_root
+    private_key = private_key_provider(duty.validator_public_key)
+    # TODO use correct ``domain`` value
+    # NOTE currently only uses part of the domain value
+    # need to get fork from the state and compute the full domain value locally
+    domain = Domain(
+        b"\x00" * 4 + signature_domain_to_domain_type(duty.signature_domain)
+    )
+    return bls.sign(message, private_key, domain)
+
+
+async def sign_and_broadcast_operation_if_valid(
+    duty: Duty,
+    operation: Operation,
+    signature_store: SignatoryDatabaseAPI,
+    beacon_node: BeaconNodeAPI,
+    private_key_provider: PrivateKeyProvider,
+) -> None:
+    try:
+        await _validate_duty(duty, operation, signature_store)
+    except ValidationError as e:
+        logger.warn("a duty %s was not valid: %s", duty, e)
+        return
+    else:
+        logger.debug(
+            "received a valid duty %s for the operation with hash tree root %s; signing...",
+            duty,
+            humanize_bytes(operation.hash_tree_root),
+        )
+
+    await signature_store.record_signature_for(duty, operation)
+    signature = sign(duty, operation, private_key_provider)
+
+    logger.info("got signature %s for duty %s", humanize_bytes(signature), duty)
+    await beacon_node.publish(duty, signature)

--- a/eth2/validator_client/signatory_db.py
+++ b/eth2/validator_client/signatory_db.py
@@ -1,0 +1,105 @@
+from enum import Enum, unique
+import logging
+from typing import Dict
+
+import ssz
+
+from eth2.beacon.typing import Operation
+from eth2.validator_client.abc import SignatoryDatabaseAPI
+from eth2.validator_client.duty import Duty, DutyType
+
+
+@unique
+class OperationTag(Enum):
+    Attestation = b"\x00"
+    BlockProposal = b"\x01"
+
+
+def _key_for_attestation(duty: Duty) -> bytes:
+    return (
+        OperationTag.Attestation.value
+        + duty.validator_public_key
+        + ssz.encode(duty.tick_for_execution.slot, ssz.sedes.uint64)
+    )
+
+
+async def _record_attestation(
+    duty: Duty, operation: Operation, db: SignatoryDatabaseAPI
+) -> None:
+    # TODO temporary; will need more sophisticated logic to avoid slashing
+    db.insert(_key_for_attestation(duty), operation.hash_tree_root)
+
+
+async def _is_attestation_slashable(
+    duty: Duty, operation: Operation, db: SignatoryDatabaseAPI
+) -> bool:
+    # TODO temporary; will need more sophisticated logic to avoid slashing
+    return _key_for_attestation(duty) in db
+
+
+def _key_for_block_proposal(duty: Duty) -> bytes:
+    return (
+        OperationTag.BlockProposal.value
+        + duty.validator_public_key
+        + ssz.encode(duty.tick_for_execution.slot, ssz.sedes.uint64)
+    )
+
+
+async def _record_block_proposal(
+    duty: Duty, operation: Operation, db: SignatoryDatabaseAPI
+) -> None:
+    db.insert(_key_for_block_proposal(duty), operation.hash_tree_root)
+
+
+async def _is_block_proposal_slashable(
+    duty: Duty, operation: Operation, db: SignatoryDatabaseAPI
+) -> bool:
+    """
+    A block proposal is invalid if we already have produced a signature for the proposal's slot.
+    """
+    return _key_for_block_proposal(duty) in db
+
+
+SLASHING_VALIDATIONS = {
+    DutyType.Attestation: _is_attestation_slashable,
+    DutyType.BlockProposal: _is_block_proposal_slashable,
+}
+
+SLASHING_RECORDERS = {
+    DutyType.Attestation: _record_attestation,
+    DutyType.BlockProposal: _record_block_proposal,
+}
+
+
+class InMemorySignatoryDB(SignatoryDatabaseAPI):
+    logger = logging.getLogger("eth2.validator_client.signatory_db")
+
+    def __init__(self) -> None:
+        self._store: Dict[bytes, bytes] = {}
+
+    async def record_signature_for(self, duty: Duty, operation: Operation) -> None:
+        self.logger.debug("recording signature for duty %s", duty)
+        recorder = SLASHING_RECORDERS.get(duty.duty_type, None)
+        if not recorder:
+            raise NotImplementedError(
+                f"missing a signature recorder handler for the duty type {duty.duty_type}"
+            )
+
+        await recorder(duty, operation, self)
+
+    async def is_slashable(self, duty: Duty, operation: Operation) -> bool:
+        validation = SLASHING_VALIDATIONS.get(duty.duty_type, None)
+        if not validation:
+            raise NotImplementedError(
+                f"missing a slashing validation handler for the duty type {duty.duty_type}"
+            )
+
+        return await validation(duty, operation, self)
+
+    def insert(self, key: bytes, value: bytes) -> None:
+        self._store[key] = value
+
+    def __contains__(self, key: object) -> bool:
+        if not isinstance(key, bytes):
+            raise Exception("element type is ``bytes``")
+        return key in self._store

--- a/eth2/validator_client/tick.py
+++ b/eth2/validator_client/tick.py
@@ -1,0 +1,17 @@
+from dataclasses import dataclass
+
+from eth2.beacon.typing import Epoch, Slot
+
+
+@dataclass(eq=True, frozen=True)
+class Tick:
+    t: float
+    slot: Slot
+    epoch: Epoch
+    count: int  # non-negative counter for the tick w/in a slot
+
+    def __repr__(self) -> str:
+        return f"Tick({self.epoch},{self.slot},{self.count})"
+
+    def is_at_genesis(self, genesis_time: int) -> bool:
+        return int(self.t) == genesis_time and self.count == 0

--- a/eth2/validator_client/typing.py
+++ b/eth2/validator_client/typing.py
@@ -1,0 +1,14 @@
+from typing import Callable, Tuple
+
+from eth_typing import BLSPubkey
+
+from eth2.beacon.typing import Operation
+from eth2.validator_client.duty import Duty
+
+BLSPrivateKey = int
+
+KeyPair = Tuple[BLSPubkey, BLSPrivateKey]
+
+PrivateKeyProvider = Callable[[BLSPubkey], BLSPrivateKey]
+
+ResolvedDuty = Tuple[Duty, Operation]

--- a/setup.py
+++ b/setup.py
@@ -120,6 +120,8 @@ deps = {
         "rlp>=1.1.0,<2.0.0",
         PYEVM_DEPENDENCY,
         "ssz==0.2.3",
+        "asks>=2.3.6,<3",  # validator client
+        "eth-keyfile",  # validator client
     ],
     'eth2-extra': [
         "milagro-bls-binding==0.1.3",
@@ -206,7 +208,8 @@ setup(
     entry_points={
         'console_scripts': [
             'trinity=trinity:main',
-            'trinity-beacon=trinity:main_beacon'
+            'trinity-beacon=trinity:main_beacon',
+            'trinity-validator=trinity:main_validator'
         ],
     },
 )

--- a/tests-trio/eth2/validator_client/conftest.py
+++ b/tests-trio/eth2/validator_client/conftest.py
@@ -1,0 +1,36 @@
+import pytest
+
+from eth2._utils.bls import Eth2BLS, bls
+
+
+@pytest.fixture
+def sample_bls_private_key():
+    return 42
+
+
+@pytest.fixture
+def sample_bls_public_key(sample_bls_private_key):
+    return bls.privtopub(sample_bls_private_key)
+
+
+@pytest.fixture
+def sample_bls_key_pair(sample_bls_private_key, sample_bls_public_key):
+    return (sample_bls_public_key, sample_bls_private_key)
+
+
+@pytest.fixture
+def seconds_per_slot():
+    return 12
+
+
+@pytest.fixture
+def slots_per_epoch():
+    return 32
+
+
+@pytest.fixture
+def no_op_bls():
+    """
+    Disables BLS cryptography across the entire process.
+    """
+    Eth2BLS.use_noop_backend()

--- a/tests-trio/eth2/validator_client/test_client.py
+++ b/tests-trio/eth2/validator_client/test_client.py
@@ -1,0 +1,120 @@
+from async_service.exceptions import DaemonTaskExit
+from async_service.trio import background_trio_service
+import pytest
+import trio
+
+from eth2.beacon.typing import CommitteeIndex
+from eth2.validator_client.beacon_node import MockBeaconNode
+from eth2.validator_client.client import Client
+from eth2.validator_client.clock import Clock
+from eth2.validator_client.duty import AttestationDuty, BlockProposalDuty, DutyType
+from eth2.validator_client.key_store import InMemoryKeyStore
+from eth2.validator_client.signatory import sign
+from eth2.validator_client.tick import Tick
+
+
+def _mk_duty_fetcher(public_key, slots_per_epoch, seconds_per_slot):
+    """"
+    This ``duty_fetcher`` works by just returning a block proposal duty for the current slot
+    and an attestation duty for the same slot but one epoch ahead.
+
+    It is expected that another component will filter slashable duties.
+    """
+
+    def duty_fetcher(
+        current_tick, _public_keys, target_epoch, _slots_per_epoch, _seconds_per_slot
+    ):
+        duties = ()
+        if target_epoch < 0:
+            return duties
+
+        some_slot = current_tick.slot
+        if current_tick.epoch >= 0:
+            block_proposal_duty = BlockProposalDuty(
+                public_key, Tick(0, some_slot, target_epoch, 0), current_tick
+            )
+            duties += (block_proposal_duty,)
+        attestation_duty = AttestationDuty(
+            public_key,
+            Tick(0, some_slot + slots_per_epoch, target_epoch, 1),
+            current_tick,
+            CommitteeIndex(22),
+        )
+        duties += (attestation_duty,)
+        return duties
+
+    return duty_fetcher
+
+
+@pytest.mark.trio
+async def test_client_works(
+    autojump_clock, sample_bls_key_pair, seconds_per_slot, slots_per_epoch
+):
+    """
+    This test constructs a ``Client`` with enough known inputs to compute an expected set of
+    signatures after running for a given amount of time. The test fails if the expected signatures
+    are not observed as outputs of the client.
+    """
+    slots_per_epoch = 4
+    # NOTE: start 2 epochs ahead of genesis to emulate the client
+    # waiting to the time it can start polling the beacon node
+    # and the getting duties in the first epoch in the epoch prior to genesis
+    total_epochs_to_run = 4
+    epochs_before_genesis_to_start = 2
+    epochs_after_genesis_to_end = total_epochs_to_run - epochs_before_genesis_to_start
+    # Set genesis so that we aren't aligned with a slot, which could hide some
+    # bugs we will otherwise see...
+    non_aligned_time = trio.current_time() + seconds_per_slot / 3
+    seconds_per_epoch = seconds_per_slot * slots_per_epoch
+    genesis_time = int(
+        non_aligned_time + epochs_before_genesis_to_start * seconds_per_epoch
+    )
+
+    public_key, _ = sample_bls_key_pair
+    key_store = InMemoryKeyStore((sample_bls_key_pair,))
+    beacon_node = MockBeaconNode(
+        slots_per_epoch,
+        seconds_per_slot,
+        duty_fetcher=_mk_duty_fetcher(public_key, slots_per_epoch, seconds_per_slot),
+    )
+
+    clock = Clock(
+        seconds_per_slot,
+        genesis_time,
+        slots_per_epoch,
+        seconds_per_epoch,
+        trio.current_time,
+    )
+    client = Client(key_store, clock, beacon_node)
+
+    try:
+        async with background_trio_service(client):
+            await trio.sleep(total_epochs_to_run * seconds_per_epoch)
+    except DaemonTaskExit:
+        # NOTE: there is a race condition in ``async_service`` that will
+        # trigger ``DaemonTaskExit`` when the test would otherwise pass.
+        # See: https://github.com/ethereum/async-service/issues/54
+        pass
+
+    fulfilled_duties = tuple(
+        filter(
+            lambda duty: duty.tick_for_execution.epoch < epochs_after_genesis_to_end,
+            beacon_node.given_duties,
+        )
+    )
+    assert len(beacon_node.published_signatures) == len(fulfilled_duties)
+    for duty in fulfilled_duties:
+        if duty.duty_type == DutyType.Attestation:
+            operation = await beacon_node.fetch_attestation(
+                duty.validator_public_key,
+                duty.tick_for_execution.slot,
+                duty.committee_index,
+            )
+        else:
+            operation = await beacon_node.fetch_block_proposal(
+                duty.validator_public_key, duty.tick_for_execution.slot
+            )
+
+        observed_signature = beacon_node.published_signatures[duty]
+        expected_signature = sign(duty, operation, key_store.private_key_for)
+        assert observed_signature == expected_signature

--- a/tests-trio/eth2/validator_client/test_signatory_db.py
+++ b/tests-trio/eth2/validator_client/test_signatory_db.py
@@ -1,0 +1,79 @@
+import pytest
+
+from eth2.beacon.types.attestations import Attestation, AttestationData
+from eth2.beacon.types.blocks import BeaconBlock
+from eth2.validator_client.clock import Tick
+from eth2.validator_client.duty import AttestationDuty, BlockProposalDuty
+from eth2.validator_client.signatory_db import InMemorySignatoryDB
+
+
+def _mk_resolved_attestation_duty(slot, public_key):
+    return (
+        AttestationDuty(
+            public_key, Tick(0, slot, 0, 1), Tick(0, 0, 0, 1), committee_index=22
+        ),
+        Attestation.create(data=AttestationData.create(slot=slot)),
+    )
+
+
+@pytest.mark.trio
+@pytest.mark.parametrize(
+    ("slots_to_make_duties_at," "is_slashable,"), [((1, 2), False), ((2, 2), True)]
+)
+async def test_signatory_db_attestation_slashing_conditions(
+    slots_to_make_duties_at, is_slashable, sample_bls_public_key
+):
+    """
+    NOTE: these are not the actual attestation slashing conditions
+    DO _NOT_ USE IN PRODUCTION.
+
+    This test will be updated w/ the appropratie test cases once the attestation slashing conditions
+    are installed in the validator client.
+    """
+
+    first_resolved_duty, second_resolved_duty = tuple(
+        _mk_resolved_attestation_duty(slot, sample_bls_public_key)
+        for slot in slots_to_make_duties_at
+    )
+    db = InMemorySignatoryDB()
+
+    first_duty, first_operation = first_resolved_duty
+    assert not await db.is_slashable(first_duty, first_operation)
+    await db.record_signature_for(first_duty, first_operation)
+    # NOTE: once we have recorded the first duty, it is slashable wrt the db
+    assert await db.is_slashable(first_duty, first_operation)
+
+    second_duty, second_operation = second_resolved_duty
+    is_slashable_in_db = await db.is_slashable(second_duty, second_operation)
+    assert is_slashable_in_db == is_slashable
+
+
+def _mk_resolved_block_proposal_duty(slot, public_key):
+    return (
+        BlockProposalDuty(public_key, Tick(0, slot, 0, 0), Tick(0, 0, 0, 0)),
+        BeaconBlock.create(slot=slot),
+    )
+
+
+@pytest.mark.trio
+@pytest.mark.parametrize(
+    ("slots_to_make_duties_at," "is_slashable,"), [((1, 2), False), ((2, 2), True)]
+)
+async def test_signatory_db_block_proposal_slashing_conditions(
+    slots_to_make_duties_at, is_slashable, sample_bls_public_key
+):
+    first_resolved_duty, second_resolved_duty = tuple(
+        _mk_resolved_block_proposal_duty(slot, sample_bls_public_key)
+        for slot in slots_to_make_duties_at
+    )
+    db = InMemorySignatoryDB()
+
+    first_duty, first_operation = first_resolved_duty
+    assert not await db.is_slashable(first_duty, first_operation)
+    await db.record_signature_for(first_duty, first_operation)
+    # NOTE: once we have recorded the first duty, it is slashable wrt the db
+    assert await db.is_slashable(first_duty, first_operation)
+
+    second_duty, second_operation = second_resolved_duty
+    is_slashable_in_db = await db.is_slashable(second_duty, second_operation)
+    assert is_slashable_in_db == is_slashable

--- a/tests/eth2/core/validator_client/conftest.py
+++ b/tests/eth2/core/validator_client/conftest.py
@@ -1,0 +1,18 @@
+import pytest
+
+from eth2._utils.bls import bls
+
+
+@pytest.fixture
+def sample_bls_private_key():
+    return 42
+
+
+@pytest.fixture
+def sample_bls_public_key(sample_bls_private_key):
+    return bls.privtopub(sample_bls_private_key)
+
+
+@pytest.fixture
+def sample_bls_key_pair(sample_bls_private_key, sample_bls_public_key):
+    return (sample_bls_public_key, sample_bls_private_key)

--- a/tests/eth2/core/validator_client/test_key_store.py
+++ b/tests/eth2/core/validator_client/test_key_store.py
@@ -1,0 +1,51 @@
+import json
+
+import eth_keyfile
+from eth_utils import decode_hex
+import pytest
+
+from eth2.validator_client.config import Config
+from eth2.validator_client.key_store import InMemoryKeyStore, KeyStore
+
+
+@pytest.mark.parametrize("key_store_impl", (KeyStore, InMemoryKeyStore))
+def test_key_stores_can_import_private_key(
+    tmp_path, sample_bls_key_pair, key_store_impl
+):
+    config = Config(
+        key_store_constructor=lambda config: key_store_impl.from_config(config),
+        root_data_dir=tmp_path,
+    )
+    some_password = b"password"
+    public_key, private_key = sample_bls_key_pair
+    encoded_private_key = private_key.to_bytes(length=32, byteorder="big").hex()
+
+    with config.key_store as key_store:
+        key_store.import_private_key(encoded_private_key, some_password)
+        assert key_store.private_key_for(public_key) == private_key
+
+
+def test_key_store_can_persist_key_files(tmp_path, sample_bls_key_pair):
+    config = Config(
+        key_store_constructor=lambda config: KeyStore.from_config(config),
+        root_data_dir=tmp_path,
+    )
+    some_password = b"password"
+    public_key, private_key = sample_bls_key_pair
+    private_key_bytes = private_key.to_bytes(length=32, byteorder="big")
+    encoded_private_key = private_key_bytes.hex()
+
+    with config.key_store as key_store:
+        assert not tuple(key_store._location.iterdir())
+        key_store.import_private_key(encoded_private_key, some_password)
+
+    key_files = tuple(key_store._location.iterdir())
+    assert len(key_files) == 1
+
+    key_file = key_files[0]
+    with open(key_file) as key_file_handle:
+        key_file_json = json.load(key_file_handle)
+        assert decode_hex(key_file_json["public_key"]) == public_key
+        assert private_key_bytes == eth_keyfile.decode_keyfile_json(
+            key_file_json, some_password
+        )

--- a/tox.ini
+++ b/tox.ini
@@ -79,6 +79,14 @@ commands = pytest -n 4 {posargs:tests-trio/eth1-monitor}
 deps = .[p2p,trinity,test,test-trio]
 commands = pytest -n 4 {posargs:tests-trio/eth1-monitor}
 
+[testenv:py36-eth2-trio]
+deps = .[eth2,trinity,test,test-trio]
+commands = pytest -n 4 {posargs:tests-trio/eth2}
+
+[testenv:py37-eth2-trio]
+deps = .[eth2,trinity,test,test-trio]
+commands = pytest -n 4 {posargs:tests-trio/eth2}
+
 [testenv:py36-docs]
 whitelist_externals=
     make

--- a/trinity/__init__.py
+++ b/trinity/__init__.py
@@ -35,3 +35,7 @@ from .main import (  # noqa: F401
 from .main_beacon import (  # noqa: F401
     main_beacon,
 )
+
+from .main_validator import (  # noqa: F401
+    main_validator
+)

--- a/trinity/config.py
+++ b/trinity/config.py
@@ -71,6 +71,7 @@ from eth2.beacon.typing import (
 from eth2.configs import (
     Eth2GenesisConfig,
 )
+from eth2.validator_client.config import Config as ValidatorClientConfig
 from p2p.kademlia import (
     Node as KademliaNode,
 )
@@ -808,3 +809,8 @@ class BeaconAppConfig(BaseAppConfig):
             root_dir=self.trinity_config.trinity_root_dir,
             chain_name="SkeletonLakeChain",
         )
+
+
+class ValidatorClientAppConfig(BaseAppConfig):
+    def get_client_config(self) -> ValidatorClientConfig:
+        return ValidatorClientConfig()

--- a/trinity/main_validator.py
+++ b/trinity/main_validator.py
@@ -1,0 +1,93 @@
+import logging
+import os
+from pathlib import Path
+import time
+from typing import Callable, Collection
+
+import trio
+
+from eth2._utils.bls import bls
+from eth2.beacon.typing import Slot
+from eth2.validator_client.abc import KeyStoreAPI
+from eth2.validator_client.cli_parser import parse_cli_args
+from eth2.validator_client.config import Config
+from eth2.validator_client.key_store import InMemoryKeyStore
+from eth2.validator_client.typing import KeyPair
+from trinity._utils.logging import LOG_FORMATTER
+
+
+def _setup_logging() -> logging.Logger:
+    logger = logging.getLogger("eth2.validator_client")
+    logger.setLevel(logging.DEBUG)
+
+    stream_handler = logging.StreamHandler()
+    stream_handler.setLevel(logging.DEBUG)
+    stream_handler.setFormatter(LOG_FORMATTER)
+    logger.addHandler(stream_handler)
+
+    return logger
+
+
+def _random_private_key(index: int) -> int:
+    """
+    Using the algorithm from:
+    https://github.com/ethereum/eth2.0-pm/blob/master/interop/mocked_start/keygen.py
+    """
+    from py_ecc.optimized_bls12_381 import curve_order
+    from hashlib import sha256
+
+    return (
+        int.from_bytes(
+            sha256(index.to_bytes(length=32, byteorder="little")).digest(),
+            byteorder="little",
+        )
+        % curve_order
+    )
+
+
+def _mk_random_key_pair(index: int) -> KeyPair:
+    private_key = _random_private_key(index)
+    public_key = bls.privtopub(private_key)
+    return (public_key, private_key)
+
+
+def _mk_key_store_from_key_pairs(
+    key_pairs: Collection[KeyPair]
+) -> Callable[[Config], KeyStoreAPI]:
+    def _mk_key_store(config: Config) -> KeyStoreAPI:
+        return InMemoryKeyStore.from_config(config, key_pairs)
+
+    return _mk_key_store
+
+
+def main_validator() -> None:
+    # TODO:
+    # Merge into trinity platform
+    # 1. CLI parsing
+    # 2. Loading config from file and/or cmd line
+    # 3. Logging
+    logger = _setup_logging()
+    arguments = parse_cli_args()
+    root_data_dir = (
+        Path(os.environ["HOME"]) /
+        ".local" /
+        "share" /
+        "trinity" /
+        "eth2" /
+        "validator_client"
+    )
+    slots_per_epoch = Slot(4)
+    seconds_per_slot = 2
+    genesis_time = int(time.time()) + slots_per_epoch * seconds_per_slot + 3
+    num_validators = 16
+    key_pairs = tuple(_mk_random_key_pair(index) for index in range(num_validators))
+
+    config = Config(
+        key_store_constructor=_mk_key_store_from_key_pairs(key_pairs),
+        root_data_dir=root_data_dir,
+        slots_per_epoch=slots_per_epoch,
+        seconds_per_slot=seconds_per_slot,
+        genesis_time=genesis_time,
+        demo_mode=arguments.demo_mode,
+    )
+    trio.run(arguments.func, logger, config, arguments)


### PR DESCRIPTION
### What was wrong?

We want to pull our validator out of the beacon node into its own software package to encourage interoperability and security.

### How was it fixed?

This PR introduces a MVP of the validator client with some known outstanding issues listed below. For context, there was an earlier pass at the client in #1217. There are some todo items I want to finish before this is ready to merge (listed under `To-Do`). The following items should not block the merge and depend on things downstream of this PR.

To run the client, use `trinity-validator`.

To import a key, you can run `trinity-validator import $KEY` where `$KEY` is a hex-encoded private key. This will write a BLS key pair to the key store using `eth-keyfile` to encrypt the private key. If you leave the password blank then you will be able to use the key in `--demo-mode`.

To run the client in demo-mode (using a blank password for all keys in the keystore), run `trinity-validator --demo-mode`.

Known issues:

- The client should verify that the validator pubkeys it discovers are in the latest canonical state (based on what the beacon node provides)
- We should match how `trinity` handles loading and managing of configuration
- The current key mgmt story is very basic and may not even be what we want long term (e.g. the "block the client until we enter a password" flow is tedious); eventually we will want to support hardware wallets.. in general, the `KeyStore` could support a lot of features and nice-to-haves...
- The eth2.0 validator API is still in flux given recent changes to the spec. We will want to finalize this API and then implement it on the beacon node side and on the validator client side.
- There is the beginnings of a "demo mode" which we may want to remove sooner, rather than later. I'd elect to remove any code from the client that could in any way circumvent the security of a user's private keys.
- Validate the data we get back from the beacon node to the best of the client's ability. For example, if we request a BeaconBlock for a BlockProposalDuty, verify that the slots match across each instance.
- ~There is a tracking issue here for something in the client's construction: https://github.com/ethereum/async-service/issues/51~
- There has been some flux in the spec recently that may affect how we are organizing duties (by "tick") and if there are changes we need to make then that component may need to be updated.
- The `DutyScheduler` should be smarter about re-orgs, and if we stick to just having a read-only image of the chain, this amounts to just polling that state frequently enough to have an up-to-date view.
- The slashing protection should actually be solid for proposing blocks but the attestation slashing logic is not accurate. Needs to reflect the Casper FFG slashing conditions.
- Need to poll the beacon node for the latest `Fork` data from the state so we can make the accurate signature domain for any BLS signatures we produce.
- Need a persistent version of the `SignatureDB`, right now it only lives in-memory and this component is critical for determining slashability.
- Want to respect a user's weak subjectivity period and/or their view of the network while still applying some sanity checks against a beacon node that the client connects to: see this thread https://github.com/ethereum/trinity/pull/1482#discussion_r370111382
- Consider flow of data across client wrt backpressure -- what happens if the beacon node is slow or some processing takes longer than expected?
- Ensure we do not miss the handling of duties in the first epoch (looks like we do not process duties in the first slot because we are not checking before genesis in the demo.... do we check for any *prior* duties w/in a few epochs?)
- avoid unbounded memory growth in the case we are handling many validators, e.g. in the `DutyStore`, https://github.com/ethereum/trinity/pull/1482#discussion_r373046478
- (eventually) want to get notifications of new blocks from the beacon node, which implies the client should poll for the latest duties (regardless of where in the slot the client is)
- integrity of private key import, https://github.com/ethereum/trinity/pull/1482#discussion_r373049134
- also, integrity of writing to the slashing db
- Add more testing
- Add more docs


### To-Do

- [x] Typing
- [x] Set up linting for the project
- [ ] Add some high-level tests

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://i.pinimg.com/736x/0f/58/d2/0f58d20b2ab891d7b9ed710de55ddc67.jpg)
