### PR TITLE
Improve error handling on startup

### DIFF
--- a/newsfragments/1486.bugfix.rst
+++ b/newsfragments/1486.bugfix.rst
@@ -1,0 +1,2 @@
+Ensure validation errors in components are properly handled
+during bootstrap.

--- a/trinity/_utils/eip1085.py
+++ b/trinity/_utils/eip1085.py
@@ -1,5 +1,4 @@
 from enum import (
-    auto,
     Enum,
 )
 import json
@@ -102,9 +101,9 @@ class GenesisParams(NamedTuple):
 
 class MiningMethod(Enum):
 
-    NoProof = auto()
-    Ethash = auto()
-    Clique = auto()
+    NoProof = "noproof"
+    Ethash = "ethash"
+    Clique = "clique"
 
 
 class GenesisData(NamedTuple):
@@ -248,14 +247,10 @@ def extract_chain_id(genesis_config: RawEIP1085Dict) -> int:
 
 def extract_mining_method(genesis_config: RawEIP1085Dict) -> MiningMethod:
     miningMethod = genesis_config['params']['miningMethod']
-    if miningMethod.lower() == "clique":
-        return MiningMethod.Clique
-    elif miningMethod.lower() == "ethash":
-        return MiningMethod.Ethash
-    elif miningMethod.lower() == "noproof":
-        return MiningMethod.NoProof
-    else:
-        raise ValueError(f"Unsupported mining method: {miningMethod}")
+    try:
+        return MiningMethod(miningMethod.lower())
+    except TypeError:
+        raise ValidationError(f"Unsupported mining method: {miningMethod}")
 
 
 @to_dict

--- a/trinity/bootstrap.py
+++ b/trinity/bootstrap.py
@@ -15,6 +15,7 @@ from typing import (
 )
 
 from async_service import AsyncioManager
+from eth_utils import ValidationError
 
 from trinity.exceptions import (
     AmbigiousFileSystem,
@@ -205,7 +206,10 @@ def main_entry(trinity_boot: BootFn,
 
     # Let the components do runtime validation
     for component_cls in component_types:
-        component_cls.validate_cli(boot_info)
+        try:
+            component_cls.validate_cli(boot_info)
+        except ValidationError as exc:
+            parser.exit(message=str(exc))
 
     # Components can provide a subcommand with a `func` which does then control
     # the entire process from here.

--- a/trinity/components/builtin/syncer/component.py
+++ b/trinity/components/builtin/syncer/component.py
@@ -264,6 +264,10 @@ class SyncerComponent(AsyncioIsolatedComponent):
         # this will trigger a ValidationError if the specified strategy isn't known.
         cls.get_active_strategy(boot_info)
 
+        # This will trigger a ValidationError if the loaded EIP1085 file
+        # has errors such as an unsupported mining method
+        boot_info.trinity_config.get_app_config(Eth1AppConfig).get_chain_config()
+
     @classmethod
     @to_tuple
     def extract_modes(cls) -> Iterable[str]:


### PR DESCRIPTION
### What was wrong?

1. We didn't use a string enum for `MiningMethod` when we should be (cleans up case matching)

2. We didn't validate the EIP1085 file early at startup which means errors would escape until a later point which isn't optimal

3. We run `validate_cli` on every component but we don't catch the errors to present them to the user properly

### How was it fixed?

1. Turned `MiningMethod` into an enum with string values

2. Call `boot_info.trinity_config.get_app_config(Eth1AppConfig).get_chain_config()` early in the syncer component

3. Catch validation errors on bootstrap and call `ArgumentParser().exit(message=str(exc))`

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

[//]: # (See: https://trinity-client.readthedocs.io/en/latest/contributing.html#pull-requests)
- [x] Add entry to the [release notes](https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://www.sciencemag.org/sites/default/files/styles/inline__450w__no_aspect/public/mice_16x9_0.jpg?itok=02pIb90t)
