### PR TITLE
Remove signing_root api

### DIFF
--- a/eth2/beacon/chains/base.py
+++ b/eth2/beacon/chains/base.py
@@ -378,7 +378,7 @@ class BeaconChain(BaseBeaconChain):
 
         Raise ``BlockNotFound`` if there's no block with the given hash in the db.
         """
-        validate_word(block_root, title="Block Signing Root")
+        validate_word(block_root, title="Block Root")
 
         block_class = self.get_block_class(block_root)
         return self.chaindb.get_block_by_root(block_root, block_class)
@@ -439,9 +439,9 @@ class BeaconChain(BaseBeaconChain):
         - a tuple of blocks which were canonical and now are no longer canonical.
         """
         self.logger.debug(
-            "attempting import of block with slot %s and signing_root %s",
+            "attempting import of block with slot %s and root %s",
             block.slot,
-            humanize_hash(block.signing_root),
+            humanize_hash(block.message.hash_tree_root),
         )
 
         try:
@@ -451,7 +451,7 @@ class BeaconChain(BaseBeaconChain):
                 "Attempt to import block #{}.  Cannot import block {} before importing "
                 "its parent block at {}".format(
                     block.slot,
-                    humanize_hash(block.signing_root),
+                    humanize_hash(block.message.hash_tree_root),
                     humanize_hash(block.parent_root),
                 )
             )
@@ -483,9 +483,9 @@ class BeaconChain(BaseBeaconChain):
             self.chaindb.update_head_state(state.slot, state.hash_tree_root)
 
         self.logger.debug(
-            "successfully imported block at slot %s with signing root %s",
+            "successfully imported block at slot %s with root %s",
             imported_block.slot,
-            humanize_hash(imported_block.signing_root),
+            humanize_hash(imported_block.message.hash_tree_root),
         )
 
         return imported_block, new_canonical_blocks, old_canonical_blocks

--- a/eth2/beacon/fork_choice/lmd_ghost.py
+++ b/eth2/beacon/fork_choice/lmd_ghost.py
@@ -110,7 +110,7 @@ class Context:
         the chain at that point in time.
         """
         assert state.slot == block.slot
-        root = block.signing_root
+        root = block.message.hash_tree_root
         justified_checkpoint = state.current_justified_checkpoint
         finalized_checkpoint = state.finalized_checkpoint
         return Context(
@@ -310,7 +310,7 @@ class Store:
         )
         if not is_ancestor_of_finalized_block:
             raise ValidationError(
-                f"block with signing root {root.hex()} is not a descendant of the finalized"
+                f"block with root {root.hex()} is not a descendant of the finalized"
                 f" checkpoint with root {finalized_ancestor.hex()}"
             )
 
@@ -425,7 +425,7 @@ class Store:
         Return the score of the target ``block`` according to the LMD GHOST algorithm,
         using the lexicographic ordering of the block root to break ties.
         """
-        root = block.signing_root
+        root = block.message.hash_tree_root
 
         attestation_score = self.get_latest_attesting_balance(root)
         block_root_score = score_block_by_root(root)

--- a/eth2/beacon/state_machines/forks/serenity/block_validation.py
+++ b/eth2/beacon/state_machines/forks/serenity/block_validation.py
@@ -45,7 +45,7 @@ def validate_correct_number_of_deposits(
     if deposit_count_in_block != expected_deposit_count:
         raise ValidationError(
             f"Incorrect number of deposits ({deposit_count_in_block})"
-            f" in block {encode_hex(block.signing_root)};"
+            f" in block {encode_hex(block.hash_tree_root)};"
             f" expected {expected_deposit_count} based on"
             f" the state {encode_hex(state.hash_tree_root)}"
         )

--- a/eth2/beacon/tools/fixtures/test_types/ssz_static.py
+++ b/eth2/beacon/tools/fixtures/test_types/ssz_static.py
@@ -95,7 +95,7 @@ class SSZHandler(TestHandler[InputType, OutputType]):
             test_case_parts["value"], cls.object_type
         )
         roots_yaml = test_case_parts["roots"].load_yaml()
-        roots = (roots_yaml["root"], roots_yaml.get("signing_root", None))
+        roots = (roots_yaml["root"], roots_yaml.get("message.hash_tree_root", None))
         return (
             serialized_ssz_object,
             ssz_object_from_yaml,
@@ -115,7 +115,7 @@ class SSZHandler(TestHandler[InputType, OutputType]):
             ssz.encode(deserialized_object, cls.object_type),
             (
                 ssz.get_hash_tree_root(ssz_object_from_yaml),
-                ssz_object_from_yaml.signing_root
+                ssz_object_from_yaml.message.hash_tree_root
                 if isinstance(ssz_object_from_yaml, SignedHashableContainer)
                 else None,
             ),
@@ -128,7 +128,7 @@ class SSZHandler(TestHandler[InputType, OutputType]):
           parsing YAML and SSZ serializing == input serialization
           deserializing the input serialization yields the object given by YAML
           deserializing and serializing the input yields the input (roundtrip)
-          the root and signing root match the given values
+          the roots match
         """
         object_serialization, deserialized_object, roundtrip_bytes, roots = output
         (

--- a/eth2/beacon/types/blocks.py
+++ b/eth2/beacon/types/blocks.py
@@ -143,11 +143,6 @@ class BaseBeaconBlock(HashableContainer, Configurable, ABC):
     def __repr__(self) -> str:
         return f"<{self.__class__.__name__}: {str(self)}>"
 
-    @property
-    def signing_root(self) -> Root:
-        # Remove this soon
-        return self.hash_tree_root
-
 
 TBeaconBlock = TypeVar("TBeaconBlock", bound="BeaconBlock")
 
@@ -212,10 +207,6 @@ class BaseSignedBeaconBlock(HashableContainer):
     @property
     def parent_root(self) -> Root:
         return self.message.parent_root
-
-    @property
-    def signing_root(self) -> Root:
-        return self.message.hash_tree_root
 
     @property
     def is_genesis(self) -> bool:

--- a/tests/components/eth2/apis/test_http.py
+++ b/tests/components/eth2/apis/test_http.py
@@ -76,7 +76,7 @@ async def test_json_rpc_http_server(
             assert response_data['id'] == request_id
             result = response_data['result']
             assert result['slot'] == 0
-            assert decode_hex(result['block_root']) == genesis_block.signing_root
+            assert decode_hex(result['block_root']) == genesis_block.hash_tree_root
             assert decode_hex(result['state_root']) == genesis_state.hash_tree_root
         except KeyboardInterrupt:
             pass

--- a/tests/components/eth2/beacon/test_validator.py
+++ b/tests/components/eth2/beacon/test_validator.py
@@ -187,7 +187,7 @@ async def test_validator_propose_block_succeeds(event_loop, event_bus, monkeypat
     )
 
     # test: ensure the proposed block is saved to the chaindb
-    assert alice.chain.get_block_by_root(block.signing_root) == block
+    assert alice.chain.get_block_by_root(block.message.hash_tree_root) == block
 
     # test: ensure that the `canonical_head` changed after proposing
     new_head = alice.chain.get_canonical_head()
@@ -432,7 +432,7 @@ async def test_validator_attest(event_loop, event_bus, monkeypatch):
     assert len(attestations) >= 1
     attestation = attestations[0]
     assert attestation.data.slot == assignment.slot
-    assert attestation.data.beacon_block_root == head.signing_root
+    assert attestation.data.beacon_block_root == head.message.hash_tree_root
     assert attestation.data.index == assignment.committee_index
 
     # Advance the state and validate the attestation
@@ -479,7 +479,7 @@ async def test_validator_aggregate(event_loop, event_bus, monkeypatch):
     for aggregate_and_proof in aggregate_and_proofs:
         attestation = aggregate_and_proof.aggregate
         assert attestation.data.slot == assignment.slot
-        assert attestation.data.beacon_block_root == head.signing_root
+        assert attestation.data.beacon_block_root == head.message.hash_tree_root
         assert attestation.data.index == assignment.committee_index
 
         # Advance the state and validate the attestation

--- a/tests/eth2/core/beacon/state_machines/forks/test_serenity_operation_processing.py
+++ b/tests/eth2/core/beacon/state_machines/forks/test_serenity_operation_processing.py
@@ -176,7 +176,7 @@ def test_process_attestations(
         config=config,
         state_machine=fixture_sm_class(chaindb, genesis_fork_choice_context),
         attestation_slot=attestation_slot,
-        beacon_block_root=genesis_block.signing_root,
+        beacon_block_root=genesis_block.message.hash_tree_root,
         keymap=keymap,
         voted_attesters_ratio=1.0,
     )

--- a/tests/eth2/integration/test_demo.py
+++ b/tests/eth2/integration/test_demo.py
@@ -92,7 +92,7 @@ def test_demo(base_db, validator_count, keymap, pubkeys, fork_choice_scoring):
             config=config,
             state_machine=fixture_sm_class(chaindb),
             attestation_slot=attestation_slot,
-            beacon_block_root=block.signing_root,
+            beacon_block_root=block.message.hash_tree_root,
             keymap=keymap,
             voted_attesters_ratio=1.0,
         )

--- a/tests/libp2p/bcc/test_req_resp.py
+++ b/tests/libp2p/bcc/test_req_resp.py
@@ -190,7 +190,9 @@ async def test_request_beacon_blocks_by_root(monkeypatch):
     async with ConnectionPairFactory() as (alice, bob):
 
         blocks = SignedBeaconBlockFactory.create_branch(5)
-        mock_root_to_block_db = {block.signing_root: block for block in blocks}
+        mock_root_to_block_db = {
+            block.message.hash_tree_root: block for block in blocks
+        }
 
         def get_block_by_root(root):
             validate_word(root)
@@ -202,11 +204,11 @@ async def test_request_beacon_blocks_by_root(monkeypatch):
         monkeypatch.setattr(bob.chain, "get_block_by_root", get_block_by_root)
 
         requesting_block_roots = [
-            blocks[0].signing_root,
+            blocks[0].message.hash_tree_root,
             b"\x12" * 32,  # Unknown block root
-            blocks[1].signing_root,
+            blocks[1].message.hash_tree_root,
             b"\x23" * 32,  # Unknown block root
-            blocks[3].signing_root,
+            blocks[3].message.hash_tree_root,
         ]
         requested_blocks = await alice.request_beacon_blocks_by_root(
             peer_id=bob.peer_id, block_roots=requesting_block_roots

--- a/tests/libp2p/bcc/test_utils.py
+++ b/tests/libp2p/bcc/test_utils.py
@@ -205,7 +205,9 @@ async def test_get_blocks_from_fork_chain_by_root(
     fork_chain_blocks = SignedBeaconBlockFactory.create_branch_by_slots(
         fork_chain_block_slots
     )
-    mock_root_to_block_db = {block.signing_root: block for block in fork_chain_blocks}
+    mock_root_to_block_db = {
+        block.message.hash_tree_root: block for block in fork_chain_blocks
+    }
 
     class Chain:
         def get_block_by_root(self, root):

--- a/trinity/components/eth2/beacon/validator.py
+++ b/trinity/components/eth2/beacon/validator.py
@@ -606,7 +606,7 @@ class Validator(BaseService):
                 state_machine.config,
                 state_machine,
                 slot,
-                head.signing_root,
+                head.message.hash_tree_root,
                 attesting_validator_privkeys,
                 committee,
                 committee_index,

--- a/trinity/protocol/bcc_libp2p/topic_validators.py
+++ b/trinity/protocol/bcc_libp2p/topic_validators.py
@@ -202,7 +202,7 @@ def run_validate_block_proposer_signature(
         validate_proposer_signature(future_state, block, CommitteeConfig(state_machine.config))
     except ValidationError as error:
         raise InvalidGossipMessage(
-            f"Failed to validate block={encode_hex(block.signing_root)}",
+            f"Failed to validate block={encode_hex(block.message.hash_tree_root)}",
             error,
         )
 

--- a/trinity/protocol/bcc_libp2p/utils.py
+++ b/trinity/protocol/bcc_libp2p/utils.py
@@ -120,7 +120,7 @@ def get_my_status(chain: BaseBeaconChain) -> Status:
         head_fork_version=state.fork.current_version,
         finalized_root=finalized_checkpoint.root,
         finalized_epoch=finalized_checkpoint.epoch,
-        head_root=head.signing_root,
+        head_root=head.message.hash_tree_root,
         head_slot=head.slot,
     )
 

--- a/trinity/rpc/modules/beacon.py
+++ b/trinity/rpc/modules/beacon.py
@@ -26,7 +26,7 @@ class Beacon(BeaconChainRPCModule):
         block = await self.chain.coro_get_canonical_head(SignedBeaconBlock)
         return dict(
             slot=block.slot,
-            block_root=encode_hex(block.signing_root),
+            block_root=encode_hex(block.message.hash_tree_root),
             state_root=encode_hex(block.message.state_root),
         )
 

--- a/trinity/sync/beacon/chain.py
+++ b/trinity/sync/beacon/chain.py
@@ -129,7 +129,7 @@ class BeaconChainSyncer(BaseService):
                     self.logger.debug("Invalid first batch: %s", error)
                     return
             else:
-                if batch[0].parent_root != last_block.signing_root:
+                if batch[0].parent_root != last_block.message.hash_tree_root:
                     self.logger.info("Received batch is not linked to previous one")
                     break
             last_block = batch[-1]
@@ -202,7 +202,7 @@ class BeaconChainSyncer(BaseService):
         )
         finalized_head = await self.chain_db.coro_get_finalized_head(SignedBeaconBlock)
 
-        if parent.signing_root != finalized_head.signing_root:
+        if parent.message.hash_tree_root != finalized_head.message.hash_tree_root:
             message = f"Peer has different block finalized at slot #{parent.slot}"
             self.logger.info(message)
             self.logger.info(

--- a/trinity/tools/bcc_factories.py
+++ b/trinity/tools/bcc_factories.py
@@ -200,11 +200,11 @@ class SignedBeaconBlockFactory(factory.Factory):
             root = cls()
 
         parent = cls(
-            message__parent_root=root.signing_root, message__slot=slots[0], **kwargs
+            message__parent_root=root.message.hash_tree_root, message__slot=slots[0], **kwargs
         )
         yield parent
         for slot in slots[1:]:
-            child = cls(message__parent_root=parent.signing_root, message__slot=slot)
+            child = cls(message__parent_root=parent.message.hash_tree_root, message__slot=slot)
             yield child
             parent = child
 


### PR DESCRIPTION
### What was wrong?

This is part of #1480. We have only one true block root now! We need to get rid of the notion for the old `signing_root` since a new definition of signing root with a completely different meaning will be introduced in 0.10.0.

### How was it fixed?

- Replace `block.signing_root` with `block.message.hash_tree_root`
- Remove any wording that refers to signing_root

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

[//]: # (See: https://trinity-client.readthedocs.io/en/latest/contributing.html#pull-requests)
- [ ] Add entry to the [release notes](https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://i.imgur.com/hrg9BKK.jpg)
