### PR TITLE
Add partial support for admin_peers JSON-RPC API

### DIFF
--- a/newsfragments/1491.feature.rst
+++ b/newsfragments/1491.feature.rst
@@ -1,0 +1,1 @@
+Implement ``admin_peers`` JSON-RPC API

--- a/tests/core/p2p-proto/test_base_proxy_peer_pool.py
+++ b/tests/core/p2p-proto/test_base_proxy_peer_pool.py
@@ -8,14 +8,13 @@ from p2p.service import run_service
 from trinity.constants import TO_NETWORKING_BROADCAST_CONFIG
 from trinity.protocol.common.events import (
     GetConnectedPeersRequest,
-    GetConnectedPeersResponse,
     PeerJoinedEvent,
     PeerLeftEvent,
 )
 from trinity.tools.event_bus import mock_request_response
 
 from trinity.protocol.eth.peer import ETHProxyPeerPool
-
+from trinity.tools.factories.events import GetConnectedPeersResponseFactory
 
 TEST_NODES = tuple(SessionFactory.create_batch(4))
 
@@ -28,8 +27,8 @@ async def test_can_instantiate_proxy_pool(event_bus):
 @pytest.mark.parametrize(
     "response, expected_count",
     (
-        (GetConnectedPeersResponse(tuple()), 0),
-        (GetConnectedPeersResponse(TEST_NODES), 4),
+        (GetConnectedPeersResponseFactory.from_sessions(tuple()), 0),
+        (GetConnectedPeersResponseFactory.from_sessions(TEST_NODES), 4),
     ),
 )
 @pytest.mark.asyncio
@@ -47,8 +46,8 @@ async def test_fetch_initial_peers(event_bus, response, expected_count):
 @pytest.mark.parametrize(
     "response, expected_count",
     (
-        (GetConnectedPeersResponse(tuple()), 0),
-        (GetConnectedPeersResponse(TEST_NODES), 4),
+        (GetConnectedPeersResponseFactory.from_sessions(tuple()), 0),
+        (GetConnectedPeersResponseFactory.from_sessions(TEST_NODES), 4),
     ),
 )
 @pytest.mark.asyncio
@@ -67,7 +66,7 @@ async def test_adds_new_peers(event_bus):
 
     do_mock = mock_request_response(
         GetConnectedPeersRequest,
-        GetConnectedPeersResponse((TEST_NODES[0],)),
+        GetConnectedPeersResponseFactory.from_sessions((TEST_NODES[0],)),
         event_bus,
     )
     async with do_mock:
@@ -87,7 +86,7 @@ async def test_adds_new_peers(event_bus):
 async def test_removes_peers(event_bus):
     do_mock = mock_request_response(
         GetConnectedPeersRequest,
-        GetConnectedPeersResponse(TEST_NODES[:2]),
+        GetConnectedPeersResponseFactory.from_sessions(TEST_NODES[:2]),
         event_bus,
     )
 

--- a/tests/core/tx-pool/test_tx_pool.py
+++ b/tests/core/tx-pool/test_tx_pool.py
@@ -20,7 +20,6 @@ from trinity.components.builtin.tx_pool.validators import (
 )
 from trinity.protocol.common.events import (
     GetConnectedPeersRequest,
-    GetConnectedPeersResponse,
 )
 from trinity.protocol.eth.commands import (
     Transactions
@@ -30,6 +29,7 @@ from trinity.protocol.eth.events import (
     SendTransactionsEvent,
 )
 from trinity.tools.event_bus import mock_request_response
+from trinity.tools.factories.events import GetConnectedPeersResponseFactory
 
 from trinity.protocol.eth.peer import (
     ETHProxyPeerPool,
@@ -71,7 +71,7 @@ async def test_tx_propagation(event_bus,
     async with AsyncExitStack() as stack:
         await stack.enter_async_context(mock_request_response(
             GetConnectedPeersRequest,
-            GetConnectedPeersResponse(initial_two_peers),
+            GetConnectedPeersResponseFactory.from_sessions(initial_two_peers),
             event_bus,
         ))
 
@@ -155,7 +155,7 @@ async def test_does_not_propagate_invalid_tx(event_bus,
     async with AsyncExitStack() as stack:
         await stack.enter_async_context(mock_request_response(
             GetConnectedPeersRequest,
-            GetConnectedPeersResponse(initial_two_peers),
+            GetConnectedPeersResponseFactory.from_sessions(initial_two_peers),
             event_bus,
         ))
 

--- a/trinity/protocol/common/peer_pool_event_bus.py
+++ b/trinity/protocol/common/peer_pool_event_bus.py
@@ -45,7 +45,7 @@ from .events import (
     PeerCountResponse,
     PeerJoinedEvent,
     PeerLeftEvent,
-    ProtocolCapabilitiesResponse
+    ProtocolCapabilitiesResponse,
 )
 from .peer import BaseProxyPeer
 
@@ -157,7 +157,7 @@ class PeerPoolEventServer(Service, PeerSubscriber, Generic[TPeer]):
     async def handle_get_connected_peers_requests(self) -> None:
         async for req in self.event_bus.stream(GetConnectedPeersRequest):
             await self.event_bus.broadcast(
-                GetConnectedPeersResponse(tuple(self.peer_pool.connected_nodes.keys())),
+                GetConnectedPeersResponse.from_connected_nodes(self.peer_pool.connected_nodes),
                 req.broadcast_config()
             )
 
@@ -304,9 +304,9 @@ class BaseProxyPeerPool(BaseService, Generic[TProxyPeer]):
         )
 
         return tuple([
-            await self.ensure_proxy_peer(session)
-            for session
-            in response.sessions
+            await self.ensure_proxy_peer(peer_info.session)
+            for peer_info
+            in response.peers
         ])
 
     async def get_peers(self) -> Tuple[TProxyPeer, ...]:

--- a/trinity/rpc/typing.py
+++ b/trinity/rpc/typing.py
@@ -30,6 +30,20 @@ class RpcNodeInfoResponse(TypedDict):
     protocols: Dict[str, RpcProtocolResponse]
 
 
+class RpcPeerNetworkResponse(TypedDict):
+    localAddress: str
+    remoteAddress: str
+    inbound: bool
+
+
+class RpcPeerResponse(TypedDict):
+    enode: str
+    id: str
+    name: str
+    caps: Sequence[str]
+    network: RpcPeerNetworkResponse
+
+
 RpcTransactionResponse = TypedDict('RpcTransactionResponse', {
     'hash': HexStr,
     'nonce': str,

--- a/trinity/tools/factories/events.py
+++ b/trinity/tools/factories/events.py
@@ -1,0 +1,32 @@
+from typing import Sequence, Any
+
+from p2p.abc import SessionAPI
+
+try:
+    import factory
+except ImportError:
+    raise ImportError(
+        "The p2p.tools.factories module requires the `factory_boy` and `faker` libraries."
+    )
+
+
+from trinity.protocol.common.events import GetConnectedPeersResponse, PeerInfo
+
+
+class GetConnectedPeersResponseFactory(factory.Factory):
+    class Meta:
+        model = GetConnectedPeersResponse
+
+    @classmethod
+    def from_sessions(cls,
+                      sessions: Sequence[SessionAPI],
+                      *args: Any,
+                      **kwargs: Any) -> GetConnectedPeersResponse:
+        return GetConnectedPeersResponse(tuple(
+            PeerInfo(
+                session=session,
+                capabilities=(),
+                client_version_string='unknown',
+                inbound=False
+            ) for session in sessions
+        ))


### PR DESCRIPTION
### What was wrong?

As part of the things that we want to ship with our first beta, we want to support the [`admin_peers` RPC endpoint](https://github.com/ethereum/go-ethereum/wiki/Management-APIs#admin_peers).

The response looks something like this in Geth:

```
{
    "jsonrpc": "2.0",
    "id": 1,
    "result": [
        {
            "enode": "enode://2ea727082ae93766342646f8ac1c98a20a4d14b1c1ca043e1b3c99dfa5a36767692eec2baf7b66474f6bdaca516322fcb45db58173c08a936f6ebab8928d4562@3.1.27.148:30303",
            "id": "e8191234978143d641f1df9898fde0a7a080ef3feb0f6149d857b1fa7d8a4549",
            "name": "Geth/source/linux/go1.10.4",
            "caps": [
                "eth/62",
                "eth/63"
            ],
            "network": {
                "localAddress": "172.17.0.2:56092",
                "remoteAddress": "3.1.27.148:30303",
                "inbound": false,
                "trusted": false,
                "static": false
            },
            "protocols": {
                "eth": {
                    "version": 63,
                    "difficulty": 729514544367193473735,
                    "head": "0x66f682d761aaabe7a98a1bc1b35303ef9c21b1b6c0a35c61965bce13f5499d28"
                }
            }
        },
        {
            "enode": "enode://c25a1d915f9cc87705690bd59af1776cf0ccc3fb7e8dfd31f5f37ef4a8b6a758a743a379bad6f0793c1413b10cdc26aa9aacb5bc1581c4625e22bb414af5840e@139.199.66.86:20182",
            "id": "e81f6a84023ea00c66bfc87857d14080136e91412afe2421816cd4c3be96e686",
            "name": "Geth/qk_client 1.0.1.202 0x4C1a41639D5bf12b8F5D1A83B2aFcbB6100174Eb/v1.9.11-stable-6a62fe39/windows-amd64/go1.13.8",
            "caps": [
                "eth/63",
                "eth/64",
                "eth/65",
                "les/2",
                "les/3"
            ],
            "network": {
                "localAddress": "172.17.0.2:51214",
                "remoteAddress": "139.199.66.86:20182",
                "inbound": false,
                "trusted": false,
                "static": false
            },
            "protocols": {
                "eth": "handshake"
            }
        }
    ]
}
```


### How was it fixed?

Actual Trintiy API response:

```python
{
    "id": 1,
    "jsonrpc": "2.0",
    "result": [
        {
            "enode": "enode://c25a56161448824a805edda3de2ca2de1e5ff498fa0ff6d6bc05939a075805d7217ff791bc003b8fe7cf05d8f1338ac578e1e68dc8e3358f5d27ff78799bcbb8@47.94.236.241:30303",
            "id": "40d4dbe8-675c-48c2-867f-b6a0ea919a94",
            "name": "Geth/v1.9.9-stable-01744997/linux-amd64/go1.13.5",
            "caps": [
                "eth/63",
                "eth/64",
                "shh/6"
            ],
            "network": {
                "localAddress": "0.0.0.0:30303",
                "remoteAddress": "47.94.236.241:30303"
            }
        }
    ]
}
```

Eagle eyes might spot that this is missing the `protocols` part which I aim to add in a different PR. The current implementation is based only on the information that we can obtain from the `BasePeerPool`.

### To-Do

- [x] Add tests

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

[//]: # (See: https://trinity-client.readthedocs.io/en/latest/contributing.html#pull-requests)
- [x] Add entry to the [release notes](https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://i.ytimg.com/vi/vJ09jTqhI-4/maxresdefault.jpg)
