### PR TITLE
Create ENRs for all nodes we find during discovery and use them as the backing data structure of Nodes

### DIFF
--- a/p2p/abc.py
+++ b/p2p/abc.py
@@ -26,6 +26,7 @@ from eth_utils import ExtendedDebugLogger
 
 from eth_keys import keys
 
+from p2p.discv5.enr import ENR
 from p2p.typing import (
     Capabilities,
     Capability,
@@ -49,7 +50,7 @@ class AddressAPI(ABC):
     tcp_port: int
 
     @abstractmethod
-    def __init__(self, ip: str, udp_port: int, tcp_port: int = 0) -> None:
+    def __init__(self, ip: str, udp_port: int, tcp_port: int) -> None:
         ...
 
     @property
@@ -109,12 +110,28 @@ class NodeAPI(ABC):
     id_bytes: bytes
 
     @abstractmethod
-    def __init__(self, pubkey: keys.PublicKey, address: AddressAPI) -> None:
+    def __init__(self, enr: ENR) -> None:
+        ...
+
+    @classmethod
+    @abstractmethod
+    def from_pubkey_and_addr(
+            cls: Type[TNode], pubkey: keys.PublicKey, address: AddressAPI) -> TNode:
         ...
 
     @classmethod
     @abstractmethod
     def from_uri(cls: Type[TNode], uri: str) -> TNode:
+        ...
+
+    @classmethod
+    @abstractmethod
+    def from_enode_uri(cls: Type[TNode], uri: str) -> TNode:
+        ...
+
+    @classmethod
+    @abstractmethod
+    def from_enr_repr(cls: Type[TNode], uri: str) -> TNode:
         ...
 
     @abstractmethod

--- a/p2p/discv5/channel_services.py
+++ b/p2p/discv5/channel_services.py
@@ -153,7 +153,7 @@ async def PacketDecoder(manager: ManagerAPI,
                     f"Successfully decoded {packet.__class__.__name__} from {endpoint}"
                 )
             except ValidationError:
-                logger.warn(f"Failed to decode a packet from {endpoint}", exc_info=True)
+                logger.warning(f"Failed to decode a packet from {endpoint}", exc_info=True)
             else:
                 await incoming_packet_send_channel.send(IncomingPacket(packet, endpoint))
 

--- a/p2p/tools/factories/__init__.py
+++ b/p2p/tools/factories/__init__.py
@@ -9,9 +9,10 @@ from .discovery import (  # noqa: F401
     AuthHeaderPacketFactory,
     AuthTagPacketFactory,
     EndpointFactory,
+    ENRFactory,
     WhoAreYouPacketFactory,
 )
-from .kademlia import AddressFactory, NodeFactory  # noqa: F401
+from .kademlia import AddressFactory, IPAddressFactory, NodeFactory  # noqa: F401
 from .keys import (  # noqa: F401
     PrivateKeyFactory,
     PublicKeyFactory,

--- a/p2p/tools/factories/kademlia.py
+++ b/p2p/tools/factories/kademlia.py
@@ -9,13 +9,15 @@ from .keys import PublicKeyFactory
 from .socket import get_open_port
 
 
+IPAddressFactory = factory.Faker("ipv4")
+
+
 class AddressFactory(factory.Factory):
     class Meta:
         model = Address
 
-    ip = factory.Sequence(lambda n: f'10.{(n // 65536) % 256}.{(n // 256) % 256}.{n % 256}')
-    udp_port = factory.LazyFunction(get_open_port)
-    tcp_port = 0
+    ip = IPAddressFactory
+    udp_port = tcp_port = factory.LazyFunction(get_open_port)
 
     @classmethod
     def localhost(cls, *args: Any, **kwargs: Any) -> AddressAPI:
@@ -24,7 +26,7 @@ class AddressFactory(factory.Factory):
 
 class NodeFactory(factory.Factory):
     class Meta:
-        model = Node
+        model = Node.from_pubkey_and_addr
 
     pubkey = factory.LazyFunction(PublicKeyFactory)
     address = factory.SubFactory(AddressFactory)

--- a/p2p/transport.py
+++ b/p2p/transport.py
@@ -203,11 +203,11 @@ class Transport(TransportAPI):
             )
 
         ip, socket, *_ = peername
-        remote_address = Address(ip, socket)
+        remote_address = Address(ip, socket, socket)
 
         cls.logger.debug("Receiving auth handshake from %s", remote_address)
 
-        initiator_remote = Node(initiator_pubkey, remote_address)
+        initiator_remote = Node.from_pubkey_and_addr(initiator_pubkey, remote_address)
 
         responder = HandshakeResponder(initiator_remote, private_key, got_eip8, token)
 

--- a/scripts/discovery.py
+++ b/scripts/discovery.py
@@ -86,7 +86,6 @@ async def main() -> None:
     async with TrioEndpoint.serve(networking_connection_config) as endpoint:
         service = DiscoveryService(
             privkey, addr, bootstrap_nodes, endpoint, socket, enr_db, enr_field_providers)
-        service.logger.info("Enode: %s", service.this_node.uri())
         async with background_trio_service(service):
             await service.manager.wait_finished()
 

--- a/tests-trio/p2p-trio/test_discovery.py
+++ b/tests-trio/p2p-trio/test_discovery.py
@@ -124,9 +124,9 @@ async def test_get_local_enr(manually_driven_discovery):
 async def test_local_enr_on_startup(manually_driven_discovery):
     discovery = manually_driven_discovery
 
-    validate_node_enr(discovery.this_node, discovery._local_enr, sequence_number=1)
+    validate_node_enr(discovery.this_node, discovery.this_node.enr, sequence_number=1)
     # Our local ENR will also be stored in our DB.
-    assert discovery._local_enr == await discovery._enr_db.get(discovery.this_node.id_bytes)
+    assert discovery.this_node.enr == await discovery._enr_db.get(discovery.this_node.id_bytes)
 
 
 @pytest.mark.trio

--- a/tests/p2p/discv5/test_identity_schemes.py
+++ b/tests/p2p/discv5/test_identity_schemes.py
@@ -21,6 +21,7 @@ from p2p.discv5.identity_schemes import (
     default_identity_scheme_registry,
     IdentityScheme,
     V4IdentityScheme,
+    V4CompatIdentityScheme,
 )
 from p2p.discv5.enr import (
     UnsignedENR,
@@ -79,6 +80,34 @@ def test_enr_signature_validation():
     forged_enr = ENR(enr.sequence_number, dict(enr), b"\x00" * 64)
     with pytest.raises(ValidationError):
         V4IdentityScheme.validate_enr_signature(forged_enr)
+
+
+def test_enr_v4_compat_signature_validation():
+    private_key = PrivateKey(b"\x11" * 32)
+    enr = ENR(
+        0,
+        {
+            b"id": b"v4-compat",
+            b"secp256k1": private_key.public_key.to_compressed_bytes(),
+            b"key1": b"value1",
+        },
+        signature=b'')
+
+    V4CompatIdentityScheme.validate_enr_signature(enr)
+
+
+def test_enr_v4_compat_signing():
+    private_key = PrivateKey(b"\x11" * 32)
+    unsigned_enr = UnsignedENR(
+        0,
+        {
+            b"id": b"v4-compat",
+            b"secp256k1": private_key.public_key.to_compressed_bytes(),
+            b"key1": b"value1",
+        }
+    )
+    with pytest.raises(NotImplementedError):
+        V4CompatIdentityScheme.create_enr_signature(unsigned_enr, b'')
 
 
 def test_enr_public_key():

--- a/tests/p2p/test_auth.py
+++ b/tests/p2p/test_auth.py
@@ -44,7 +44,7 @@ async def test_handshake():
     # TODO: this test should be re-written to not depend on functionality in the `ETHPeer` class.
     cancel_token = CancelToken("test_handshake")
     use_eip8 = False
-    initiator_remote = kademlia.Node(
+    initiator_remote = kademlia.Node.from_pubkey_and_addr(
         keys.PrivateKey(test_values['receiver_private_key']).public_key,
         kademlia.Address('0.0.0.0', 0, 0))
     initiator = HandshakeInitiator(
@@ -54,7 +54,7 @@ async def test_handshake():
         cancel_token)
     initiator.ephemeral_privkey = keys.PrivateKey(test_values['initiator_ephemeral_private_key'])
 
-    responder_remote = kademlia.Node(
+    responder_remote = kademlia.Node.from_pubkey_and_addr(
         keys.PrivateKey(test_values['initiator_private_key']).public_key,
         kademlia.Address('0.0.0.0', 0, 0))
     responder = HandshakeResponder(
@@ -192,7 +192,7 @@ async def test_handshake():
 async def test_handshake_eip8():
     cancel_token = CancelToken("test_handshake_eip8")
     use_eip8 = True
-    initiator_remote = kademlia.Node(
+    initiator_remote = kademlia.Node.from_pubkey_and_addr(
         keys.PrivateKey(eip8_values['receiver_private_key']).public_key,
         kademlia.Address('0.0.0.0', 0, 0))
     initiator = HandshakeInitiator(
@@ -202,7 +202,7 @@ async def test_handshake_eip8():
         cancel_token)
     initiator.ephemeral_privkey = keys.PrivateKey(eip8_values['initiator_ephemeral_private_key'])
 
-    responder_remote = kademlia.Node(
+    responder_remote = kademlia.Node.from_pubkey_and_addr(
         keys.PrivateKey(eip8_values['initiator_private_key']).public_key,
         kademlia.Address('0.0.0.0', 0, 0))
     responder = HandshakeResponder(

--- a/trinity/constants.py
+++ b/trinity/constants.py
@@ -47,39 +47,39 @@ GOERLI_NETWORK_ID = 5
 # Default preferred enodes
 DEFAULT_PREFERRED_NODES: Dict[int, Tuple[Node, ...]] = {
     MAINNET_NETWORK_ID: (
-        Node(keys.PublicKey(decode_hex("1118980bf48b0a3640bdba04e0fe78b1add18e1cd99bf22d53daac1fd9972ad650df52176e7c7d89d1114cfef2bc23a2959aa54998a46afcf7d91809f0855082")),  # noqa: E501
+        Node.from_pubkey_and_addr(keys.PublicKey(decode_hex("1118980bf48b0a3640bdba04e0fe78b1add18e1cd99bf22d53daac1fd9972ad650df52176e7c7d89d1114cfef2bc23a2959aa54998a46afcf7d91809f0855082")),  # noqa: E501
              Address("52.74.57.123", 30303, 30303)),
-        Node(keys.PublicKey(decode_hex("78de8a0916848093c73790ead81d1928bec737d565119932b98c6b100d944b7a95e94f847f689fc723399d2e31129d182f7ef3863f2b4c820abbf3ab2722344d")),  # noqa: E501
+        Node.from_pubkey_and_addr(keys.PublicKey(decode_hex("78de8a0916848093c73790ead81d1928bec737d565119932b98c6b100d944b7a95e94f847f689fc723399d2e31129d182f7ef3863f2b4c820abbf3ab2722344d")),  # noqa: E501
              Address("191.235.84.50", 30303, 30303)),
-        Node(keys.PublicKey(decode_hex("ddd81193df80128880232fc1deb45f72746019839589eeb642d3d44efbb8b2dda2c1a46a348349964a6066f8afb016eb2a8c0f3c66f32fadf4370a236a4b5286")),  # noqa: E501
+        Node.from_pubkey_and_addr(keys.PublicKey(decode_hex("ddd81193df80128880232fc1deb45f72746019839589eeb642d3d44efbb8b2dda2c1a46a348349964a6066f8afb016eb2a8c0f3c66f32fadf4370a236a4b5286")),  # noqa: E501
              Address("52.231.202.145", 30303, 30303)),
-        Node(keys.PublicKey(decode_hex("3f1d12044546b76342d59d4a05532c14b85aa669704bfe1f864fe079415aa2c02d743e03218e57a33fb94523adb54032871a6c51b2cc5514cb7c7e35b3ed0a99")),  # noqa: E501
+        Node.from_pubkey_and_addr(keys.PublicKey(decode_hex("3f1d12044546b76342d59d4a05532c14b85aa669704bfe1f864fe079415aa2c02d743e03218e57a33fb94523adb54032871a6c51b2cc5514cb7c7e35b3ed0a99")),  # noqa: E501
              Address("13.93.211.84", 30303, 30303)),
     ),
     ROPSTEN_NETWORK_ID: (
-        Node(keys.PublicKey(decode_hex("053d2f57829e5785d10697fa6c5333e4d98cc564dbadd87805fd4fedeb09cbcb642306e3a73bd4191b27f821fb442fcf964317d6a520b29651e7dd09d1beb0ec")),  # noqa: E501
+        Node.from_pubkey_and_addr(keys.PublicKey(decode_hex("053d2f57829e5785d10697fa6c5333e4d98cc564dbadd87805fd4fedeb09cbcb642306e3a73bd4191b27f821fb442fcf964317d6a520b29651e7dd09d1beb0ec")),  # noqa: E501
              Address("79.98.29.154", 30303, 30303)),
-        Node(keys.PublicKey(decode_hex("94c15d1b9e2fe7ce56e458b9a3b672ef11894ddedd0c6f247e0f1d3487f52b66208fb4aeb8179fce6e3a749ea93ed147c37976d67af557508d199d9594c35f09")),  # noqa: E501
+        Node.from_pubkey_and_addr(keys.PublicKey(decode_hex("94c15d1b9e2fe7ce56e458b9a3b672ef11894ddedd0c6f247e0f1d3487f52b66208fb4aeb8179fce6e3a749ea93ed147c37976d67af557508d199d9594c35f09")),  # noqa: E501
              Address("192.81.208.223", 30303, 30303)),
-        Node(keys.PublicKey(decode_hex("a147a3adde1daddc0d86f44f1a76404914e44cee018c26d49248142d4dc8a9fb0e7dd14b5153df7e60f23b037922ae1f33b8f318844ef8d2b0453b9ab614d70d")),  # noqa: E501
+        Node.from_pubkey_and_addr(keys.PublicKey(decode_hex("a147a3adde1daddc0d86f44f1a76404914e44cee018c26d49248142d4dc8a9fb0e7dd14b5153df7e60f23b037922ae1f33b8f318844ef8d2b0453b9ab614d70d")),  # noqa: E501
              Address("72.36.89.11", 30303, 30303)),
-        Node(keys.PublicKey(decode_hex("d8714127db3c10560a2463c557bbe509c99969078159c69f9ce4f71c2cd1837bcd33db3b9c3c3e88c971b4604bbffa390a0a7f53fc37f122e2e6e0022c059dfd")),  # noqa: E501
+        Node.from_pubkey_and_addr(keys.PublicKey(decode_hex("d8714127db3c10560a2463c557bbe509c99969078159c69f9ce4f71c2cd1837bcd33db3b9c3c3e88c971b4604bbffa390a0a7f53fc37f122e2e6e0022c059dfd")),  # noqa: E501
              Address("51.15.217.106", 30303, 30303)),
-        Node(keys.PublicKey(decode_hex("efc75f109d91cdebc62f33be992ca86fce2637044d49a954a8bdceb439b1239afda32e642456e9dfd759af5b440ef4d8761b9bda887e2200001c5f3ab2614043")),  # noqa: E501
+        Node.from_pubkey_and_addr(keys.PublicKey(decode_hex("efc75f109d91cdebc62f33be992ca86fce2637044d49a954a8bdceb439b1239afda32e642456e9dfd759af5b440ef4d8761b9bda887e2200001c5f3ab2614043")),  # noqa: E501
              Address("34.228.166.142", 30303, 30303)),
-        Node(keys.PublicKey(decode_hex("c8b9ec645cd7fe570bc73740579064c528771338c31610f44d160d2ae63fd00699caa163f84359ab268d4a0aed8ead66d7295be5e9c08b0ec85b0198273bae1f")),  # noqa: E501
+        Node.from_pubkey_and_addr(keys.PublicKey(decode_hex("c8b9ec645cd7fe570bc73740579064c528771338c31610f44d160d2ae63fd00699caa163f84359ab268d4a0aed8ead66d7295be5e9c08b0ec85b0198273bae1f")),  # noqa: E501
              Address("178.62.246.6", 30303, 30303)),
-        Node(keys.PublicKey(decode_hex("7a34c02d5ef9de43475580cbb88fb492afb2858cfc45f58cf5c7088ceeded5f58e65be769b79c31c5ae1f012c99b3e9f2ea9ef11764d553544171237a691493b")),  # noqa: E501
+        Node.from_pubkey_and_addr(keys.PublicKey(decode_hex("7a34c02d5ef9de43475580cbb88fb492afb2858cfc45f58cf5c7088ceeded5f58e65be769b79c31c5ae1f012c99b3e9f2ea9ef11764d553544171237a691493b")),  # noqa: E501
              Address("35.227.38.243", 30303, 30303)),
-        Node(keys.PublicKey(decode_hex("bbb3ad8be9684fa1d67ac057d18f7357dd236dc01a806fef6977ac9a259b352c00169d092c50475b80aed9e28eff12d2038e97971e0be3b934b366e86b59a723")),  # noqa: E501
+        Node.from_pubkey_and_addr(keys.PublicKey(decode_hex("bbb3ad8be9684fa1d67ac057d18f7357dd236dc01a806fef6977ac9a259b352c00169d092c50475b80aed9e28eff12d2038e97971e0be3b934b366e86b59a723")),  # noqa: E501
              Address("81.169.153.213", 30303, 30303)),
-        Node(keys.PublicKey(decode_hex("30b7ab30a01c124a6cceca36863ece12c4f5fa68e3ba9b0b51407ccc002eeed3b3102d20a88f1c1d3c3154e2449317b8ef95090e77b312d5cc39354f86d5d606")),  # noqa: E501
+        Node.from_pubkey_and_addr(keys.PublicKey(decode_hex("30b7ab30a01c124a6cceca36863ece12c4f5fa68e3ba9b0b51407ccc002eeed3b3102d20a88f1c1d3c3154e2449317b8ef95090e77b312d5cc39354f86d5d606")),  # noqa: E501
              Address("52.176.7.10", 30303, 30303)),
-        Node(keys.PublicKey(decode_hex("02508da84b37a1b7f19f77268e5b69acc9e9ab6989f8e5f2f8440e025e633e4277019b91884e46821414724e790994a502892144fc1333487ceb5a6ce7866a46")),  # noqa: E501
+        Node.from_pubkey_and_addr(keys.PublicKey(decode_hex("02508da84b37a1b7f19f77268e5b69acc9e9ab6989f8e5f2f8440e025e633e4277019b91884e46821414724e790994a502892144fc1333487ceb5a6ce7866a46")),  # noqa: E501
              Address("54.175.255.230", 30303, 30303)),
-        Node(keys.PublicKey(decode_hex("0eec3472a46f0b637045e41f923ce1d4a585cd83c1c7418b183c46443a0df7405d020f0a61891b2deef9de35284a0ad7d609db6d30d487dbfef72f7728d09ca9")),  # noqa: E501
+        Node.from_pubkey_and_addr(keys.PublicKey(decode_hex("0eec3472a46f0b637045e41f923ce1d4a585cd83c1c7418b183c46443a0df7405d020f0a61891b2deef9de35284a0ad7d609db6d30d487dbfef72f7728d09ca9")),  # noqa: E501
              Address("181.168.193.197", 30303, 30303)),
-        Node(keys.PublicKey(decode_hex("643c31104d497e3d4cd2460ff0dbb1fb9a6140c8bb0fca66159bbf177d41aefd477091c866494efd3f1f59a0652c93ab2f7bb09034ed5ab9f2c5c6841aef8d94")),  # noqa: E501
+        Node.from_pubkey_and_addr(keys.PublicKey(decode_hex("643c31104d497e3d4cd2460ff0dbb1fb9a6140c8bb0fca66159bbf177d41aefd477091c866494efd3f1f59a0652c93ab2f7bb09034ed5ab9f2c5c6841aef8d94")),  # noqa: E501
              Address("34.198.237.7", 30303, 30303)),
     ),
 }


### PR DESCRIPTION
This will allow us to fix #1451, use a single DB for all nodes and by including an ENR in every Node instance, peer backends will have more info (e.g fork IDs) to decide which peers to connect to