### PR TITLE
initialize beacon database without BeaconBlock

### DIFF
--- a/trinity/initialization.py
+++ b/trinity/initialization.py
@@ -1,5 +1,4 @@
 import os
-from typing import Type
 
 from eth.abc import (
     AtomicDatabaseAPI,
@@ -15,10 +14,6 @@ from trinity.config import (
     Eth1AppConfig,
     Eth1ChainConfig,
     TrinityConfig,
-)
-
-from eth2.beacon.types.blocks import (
-    BaseBeaconBlock,
 )
 from eth2.beacon.db.chain import BaseBeaconChainDB
 from trinity.exceptions import (
@@ -74,10 +69,9 @@ def is_database_initialized(chaindb: ChainDatabaseAPI) -> bool:
         return True
 
 
-def is_beacon_database_initialized(chaindb: BaseBeaconChainDB,
-                                   block_class: Type[BaseBeaconBlock]) -> bool:
+def is_beacon_database_initialized(chaindb: BaseBeaconChainDB) -> bool:
     try:
-        chaindb.get_canonical_head(block_class)
+        chaindb.get_canonical_head_root()
     except CanonicalHeadNotFound:
         # empty chain database
         return False
@@ -147,10 +141,9 @@ def initialize_database(chain_config: Eth1ChainConfig,
 
 def initialize_beacon_database(chain_config: BeaconChainConfig,
                                chaindb: BaseBeaconChainDB,
-                               base_db: AtomicDatabaseAPI,
-                               block_class: Type[BaseBeaconBlock]) -> None:
+                               base_db: AtomicDatabaseAPI) -> None:
     try:
-        chaindb.get_canonical_head(block_class)
+        chaindb.get_canonical_head_root()
     except CanonicalHeadNotFound:
         chain_config.initialize_chain(base_db)
 

--- a/trinity/main_beacon.py
+++ b/trinity/main_beacon.py
@@ -13,7 +13,6 @@ from eth.db.backends.level import (
 )
 
 from eth2.beacon.db.chain import BeaconChainDB
-from eth2.beacon.types.blocks import BeaconBlock
 
 from trinity.bootstrap import (
     main_entry,
@@ -96,8 +95,8 @@ def run_database_process(boot_info: BootInfo, db_class: Type[LevelDB]) -> None:
             base_db = db_class(db_path=app_config.database_dir)
             chaindb = BeaconChainDB(base_db, chain_config.genesis_config)
 
-            if not is_beacon_database_initialized(chaindb, BeaconBlock):
-                initialize_beacon_database(chain_config, chaindb, base_db, BeaconBlock)
+            if not is_beacon_database_initialized(chaindb):
+                initialize_beacon_database(chain_config, chaindb, base_db)
 
             manager = DBManager(base_db)
             with manager.run(trinity_config.database_ipc_path):


### PR DESCRIPTION
### What was wrong?

`trinity-beacon` crashes if in `run_database_process` we pass the wrong block class to the `initialize_beacon_database` and `is_beacon_database_initialized`.

### How was it fixed?

It looks like the intention of `get_canonical_head` is to see if the chaindb is empty, so we can replace it by checking `get_canonical_head_root` to circumvent the need of passing block class.

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://preview.redd.it/ki86e81aahc41.jpg?width=640&crop=smart&auto=webp&s=9a303b8346924ea4d9d6a1f0b270a2003945fcd1)
