### PR TITLE
Avoid raising IndexError from operations

### DIFF
--- a/eth2/beacon/tools/fixtures/test_types/operations.py
+++ b/eth2/beacon/tools/fixtures/test_types/operations.py
@@ -103,7 +103,6 @@ class AttestationHandler(OperationHandler):
     name = "attestation"
     operation_type = Attestation
     processor = staticmethod(process_attestations)
-    expected_exceptions = (IndexError,)
 
 
 class AttesterSlashingHandler(OperationHandler):
@@ -136,14 +135,12 @@ class ProposerSlashingHandler(OperationHandler):
     name = "proposer_slashing"
     operation_type = ProposerSlashing
     processor = staticmethod(process_proposer_slashings)
-    expected_exceptions = (IndexError,)
 
 
 class VoluntaryExitHandler(OperationHandler):
     name = "voluntary_exit"
     operation_type = SignedVoluntaryExit
     processor = staticmethod(process_voluntary_exits)
-    expected_exceptions = (IndexError,)
 
 
 OperationsHandlerType = Tuple[


### PR DESCRIPTION
### What was wrong?

This is an attempt to fix #1497. We have block operation validations that raise IndexError, which was usually assumed unhandled throughout the codebase. This bug can be exploited to crash Trinity by sending a block contains an operation with an out of range validator index.

### How was it fixed?

Don't raise IndexError, raise ValidationError instead.

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://preview.redd.it/tqzn8771dic41.jpg?width=640&crop=smart&auto=webp&s=93f79bb8b4eef7a152f1b863e6d875e0d7f6e65a)
