### PR TITLE
Implement admin_nodeInfo RPC endpoint

### DIFF
--- a/newsfragments/1503.feature.rst
+++ b/newsfragments/1503.feature.rst
@@ -1,0 +1,1 @@
+Implement ``admin_nodeInfo`` JSON-RPC endpoint

--- a/p2p/peer_pool.py
+++ b/p2p/peer_pool.py
@@ -259,6 +259,12 @@ class BasePeerPool(BaseService, AsyncIterable[BasePeer]):
             token=self.cancel_token,
         )
 
+    async def get_protocol_capabilities(self) -> Tuple[Tuple[str, int], ...]:
+        return tuple(
+            (handshaker.protocol_class.name, handshaker.protocol_class.version)
+            for handshaker in await self.get_peer_factory().get_handshakers()
+        )
+
     @property
     def is_full(self) -> bool:
         return len(self) >= self.max_peers

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -279,8 +279,9 @@ async def ipc_server(
     This fixture runs a single RPC server over IPC over
     the course of all tests. It yields the IPC server only for monkeypatching purposes
     """
+    trinity_config = TrinityConfig(app_identifier="eth1", network_id=1)
     rpc = RPCServer(
-        initialize_eth1_modules(chain_with_block_validation, event_bus),
+        initialize_eth1_modules(chain_with_block_validation, event_bus, trinity_config),
         chain_with_block_validation,
         event_bus,
     )

--- a/tests/json-fixtures-over-rpc/test_rpc_fixtures.py
+++ b/tests/json-fixtures-over-rpc/test_rpc_fixtures.py
@@ -46,6 +46,7 @@ from eth._utils.padding import (
 from trinity.chains.full import (
     FullChain,
 )
+from trinity.config import TrinityConfig
 from trinity.rpc import RPCServer
 from trinity.rpc.format import (
     empty_to_0x,
@@ -508,7 +509,8 @@ class MainnetFullChain(FullChain):
 
 async def setup_rpc_server(event_bus, chain_fixture, fixture_path):
     chain = MainnetFullChain(None)
-    rpc = RPCServer(initialize_eth1_modules(chain, event_bus), chain, event_bus)
+    trinity_config = TrinityConfig(app_identifier="eth1", network_id=1)
+    rpc = RPCServer(initialize_eth1_modules(chain, event_bus, trinity_config), chain, event_bus)
 
     setup_result, setup_error = await call_rpc(rpc, 'evm_resetToGenesisFixture', [chain_fixture])
     # We need to advance the event loop for modules to be able to pickup the new chain

--- a/trinity/chains/base.py
+++ b/trinity/chains/base.py
@@ -70,6 +70,10 @@ class AsyncChainAPI(ChainAPI):
         ...
 
     @abstractmethod
+    async def coro_get_score(self, block_hash: Hash32) -> int:
+        ...
+
+    @abstractmethod
     async def coro_get_canonical_transaction_index(
             self,
             transaction_hash: Hash32) -> Tuple[BlockNumber, int]:

--- a/trinity/chains/coro.py
+++ b/trinity/chains/coro.py
@@ -24,6 +24,7 @@ class AsyncChainMixin(AsyncChainAPI):
     coro_get_canonical_transaction_index = async_method(Chain.get_canonical_transaction_index)
     coro_get_canonical_transaction = async_method(Chain.get_canonical_transaction)
     coro_get_canonical_transaction_by_index = async_method(Chain.get_canonical_transaction_by_index)
+    coro_get_score = async_method(Chain.get_score)
     coro_get_transaction_receipt = async_method(Chain.get_transaction_receipt)
     coro_get_transaction_receipt_by_index = async_method(Chain.get_transaction_receipt_by_index)
     coro_import_block = async_method(Chain.import_block)

--- a/trinity/chains/light.py
+++ b/trinity/chains/light.py
@@ -116,6 +116,8 @@ class LightDispatchChain(AsyncChainAPI, Chain):
     def get_score(self, block_hash: Hash32) -> int:
         return self._headerdb.get_score(block_hash)
 
+    coro_get_score = async_method(Chain.get_score)
+
     #
     # Block API
     #

--- a/trinity/components/builtin/json_rpc/component.py
+++ b/trinity/components/builtin/json_rpc/component.py
@@ -125,7 +125,7 @@ class JsonRpcServerComponent(AsyncioIsolatedComponent):
 
         with chain_for_config(trinity_config, event_bus) as chain:
             if trinity_config.has_app_config(Eth1AppConfig):
-                modules = initialize_eth1_modules(chain, event_bus)
+                modules = initialize_eth1_modules(chain, event_bus, trinity_config)
             elif trinity_config.has_app_config(BeaconAppConfig):
                 modules = initialize_beacon_modules(chain, event_bus)
             else:

--- a/trinity/protocol/common/events.py
+++ b/trinity/protocol/common/events.py
@@ -14,6 +14,7 @@ from lahja import (
 
 from p2p.abc import CommandAPI, NodeAPI, SessionAPI
 from p2p.disconnect import DisconnectReason
+from p2p.typing import Capabilities
 
 
 @dataclass
@@ -90,3 +91,16 @@ class PeerPoolMessageEvent(BaseEvent):
     """
     session: SessionAPI
     command: CommandAPI[Any]
+
+
+@dataclass
+class ProtocolCapabilitiesResponse(BaseEvent):
+
+    capabilities: Capabilities
+
+
+class GetProtocolCapabilitiesRequest(BaseRequestResponseEvent[ProtocolCapabilitiesResponse]):
+
+    @staticmethod
+    def expected_response_type() -> Type[ProtocolCapabilitiesResponse]:
+        return ProtocolCapabilitiesResponse

--- a/trinity/rpc/modules/__init__.py
+++ b/trinity/rpc/modules/__init__.py
@@ -10,6 +10,7 @@ from eth_utils import (
 )
 
 from trinity.chains.base import AsyncChainAPI
+from trinity.config import TrinityConfig
 
 from .main import (  # noqa: F401
     BaseRPCModule,
@@ -29,12 +30,13 @@ from .web3 import Web3  # noqa: F401
 
 @to_tuple
 def initialize_eth1_modules(chain: AsyncChainAPI,
-                            event_bus: EndpointAPI) -> Iterable[BaseRPCModule]:
+                            event_bus: EndpointAPI,
+                            trinity_config: TrinityConfig) -> Iterable[BaseRPCModule]:
     yield Eth(chain, event_bus)
     yield EVM(chain, event_bus)
     yield Net(event_bus)
     yield Web3()
-    yield Admin(event_bus)
+    yield Admin(chain, event_bus, trinity_config)
 
 
 @to_tuple

--- a/trinity/rpc/modules/admin.py
+++ b/trinity/rpc/modules/admin.py
@@ -1,17 +1,47 @@
+from typing import Tuple, Iterable, Dict
+
+from eth.constants import GENESIS_BLOCK_NUMBER
+from eth_typing import BlockNumber
+from eth_utils import encode_hex, to_dict
 from lahja import EndpointAPI
 
 from p2p.kademlia import Node
+from p2p.typing import Capabilities
 from p2p.validation import validate_enode_uri
 
+from trinity.chains.base import AsyncChainAPI
+from trinity.config import TrinityConfig, Eth1AppConfig, Eth1ChainConfig
 from trinity.constants import TO_NETWORKING_BROADCAST_CONFIG
-from trinity.protocol.common.events import ConnectToNodeCommand
-from trinity.rpc.modules import BaseRPCModule
+from trinity.protocol.common.events import (
+    ConnectToNodeCommand,
+    GetProtocolCapabilitiesRequest
+)
+from trinity.rpc.modules import Eth1ChainRPCModule
+from trinity.rpc.typing import RpcProtocolResponse, RpcNodeInfoResponse
+from trinity.server import BOUND_IP
+from trinity._utils.version import construct_trinity_client_identifier
 
 
-class Admin(BaseRPCModule):
+def format_enode(config: TrinityConfig) -> str:
+    return f"enode://{config.nodekey.public_key.to_hex()[2:]}@{BOUND_IP}:{config.port}"
 
-    def __init__(self, event_bus: EndpointAPI) -> None:
-        self.event_bus = event_bus
+
+@to_dict
+def generate_chain_config(chain_config: Eth1ChainConfig) -> Iterable[Tuple[str, int]]:
+    for fork_block, vm in chain_config.vm_configuration:
+        yield f"{vm.fork}Block", fork_block
+
+    yield 'chainId', chain_config.chain_id
+
+
+class Admin(Eth1ChainRPCModule):
+
+    def __init__(self,
+                 chain: AsyncChainAPI,
+                 event_bus: EndpointAPI,
+                 trinity_config: TrinityConfig) -> None:
+        super().__init__(chain, event_bus)
+        self.trinity_config = trinity_config
 
     async def addPeer(self, uri: str) -> None:
         validate_enode_uri(uri, require_ip=True)
@@ -20,3 +50,44 @@ class Admin(BaseRPCModule):
             ConnectToNodeCommand(Node.from_uri(uri)),
             TO_NETWORKING_BROADCAST_CONFIG
         )
+
+    async def nodeInfo(self) -> RpcNodeInfoResponse:
+        response = await self.event_bus.request(
+            GetProtocolCapabilitiesRequest(),
+            TO_NETWORKING_BROADCAST_CONFIG
+        )
+        return {
+            'enode': format_enode(self.trinity_config),
+            # TODO: get the external ip from the upnp service
+            'ip': "::",
+            'listenAddr': f"[::]:{self.trinity_config.port}",
+            'name': construct_trinity_client_identifier(),
+            'ports': {
+                'discovery': self.trinity_config.port,
+                'listener': self.trinity_config.port
+            },
+            'protocols': await self._generate_protocol_info(response.capabilities)
+        }
+
+    async def _generate_protocol_info(
+            self,
+            protocols: Capabilities) -> Dict[str, RpcProtocolResponse]:
+
+        head = await self.chain.coro_get_canonical_head()
+        total_difficulty = await self.chain.coro_get_score(head.hash)
+        genesis_header = await self.chain.coro_get_canonical_block_header_by_number(
+            BlockNumber(GENESIS_BLOCK_NUMBER)
+        )
+        chain_config = self.trinity_config.get_app_config(Eth1AppConfig).get_chain_config()
+
+        return {
+            protocol: {
+                'version': f'{protocol}/{version}',
+                'difficulty': total_difficulty,
+                'genesis': encode_hex(genesis_header.hash),
+                'head': encode_hex(head.hash),
+                'network': self.trinity_config.network_id,
+                'config': generate_chain_config(chain_config)
+            }
+            for protocol, version in protocols
+        }

--- a/trinity/rpc/typing.py
+++ b/trinity/rpc/typing.py
@@ -1,9 +1,33 @@
 from typing import (
     Sequence,
     Union,
+    Dict,
 )
 from eth_typing import HexStr
 from typing_extensions import TypedDict
+
+
+class RpcProtocolResponse(TypedDict):
+    version: str
+    difficulty: int
+    genesis: str
+    head: str
+    network: int
+    config: Dict[str, int]
+
+
+class RpcPortsResponse(TypedDict):
+    discovery: int
+    listener: int
+
+
+class RpcNodeInfoResponse(TypedDict):
+    enode: str
+    ip: str
+    listenAddr: str
+    name: str
+    ports: RpcPortsResponse
+    protocols: Dict[str, RpcProtocolResponse]
 
 
 RpcTransactionResponse = TypedDict('RpcTransactionResponse', {


### PR DESCRIPTION
### What was wrong?

Related to #1303, we should support the [`admin_nodeInfo` RPC endpoint](https://github.com/ethereum/go-ethereum/wiki/Management-APIs#admin_nodeInfo).

### How was it fixed?

1. Added a new `GetSupportedProtocolsRequest` / `SupportedProtocolsResponse` pair to query the supported protocols from the peer pool

2. Added a new `nodeInfo` method to the `Admin` RPC module

3. Collect all relevant data and return it

Tada :tada: 

```
{
    "id": 1,
    "jsonrpc": "2.0",
    "result": {
        "enode": "enode://5796ec189cad54c801a8dab9790c6d5dad4378a128f336ed121f2edbb242b6bd1b31cb0d58f3c842626d10e5653a75e9a31a1831b969d27f3bdb45941e637f0f@0.0.0.0:30303",
        "ip": "::",
        "listenAddr": "[::]:30303",
        "name": "Trinity/v0.1.0a34/linux/cpython3.7.3",
        "ports": {
            "discovery": 30303,
            "listener": 30303
        },
        "protocols": {
            "eth": {
                "version": "eth/63",
                "difficulty": 2425203,
                "genesis": "0xbf7e331f7f7c1dd2e05159666b3bf8bc7a8a3a9eb1d518969eab529dd9b88c1a",
                "head": "0xd0902d3ef345f083011d18642b80629ba30b750d2ac4abe1ffe0a1a018098c6b",
                "network": 5,
                "config": {
                    "petersburgBlock": 0,
                    "istanbulBlock": 1561651,
                    "chainId": 5
                }
            }
        }
    }
}
```

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

[//]: # (See: https://trinity-client.readthedocs.io/en/latest/contributing.html#pull-requests)
- [x] Add entry to the [release notes](https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)
- [x] Add tests


#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://www.itl.cat/pngfile/big/24-246494_standard-khao-yai-national-park-animals.jpg)
