### PR TITLE
Fix test_server fixture that was not waiting for the right thing

### DIFF
--- a/p2p/peer_pool.py
+++ b/p2p/peer_pool.py
@@ -429,7 +429,12 @@ class BasePeerPool(BaseService, AsyncIterable[BasePeer]):
         while connecting.
         """
         if self.is_full or not self.is_operational:
+            self.logger.warning("Asked to connect to node when either full or not operational")
             return
+
+        if self._handshake_locks.is_locked(node):
+            self.logger.info(
+                "Asked to connect to node when handshake lock is already locked, will wait")
 
         async with self.lock_node_for_handshake(node):
             if self.is_connected_to_node(node):

--- a/tests/core/p2p-proto/test_server.py
+++ b/tests/core/p2p-proto/test_server.py
@@ -88,11 +88,11 @@ def receiver_remote():
 async def server(event_bus, receiver_remote):
     server = get_server(RECEIVER_PRIVKEY, receiver_remote.address, event_bus)
     async with run_service(server):
-        # wait for the tcp server to be present
+        # wait for the tcp server to start listening
         for _ in range(50):
-            if hasattr(server, '_tcp_listener'):
+            if server._tcp_listener is not None and server._tcp_listener.is_serving():
                 break
-            await asyncio.sleep(0)
+            await asyncio.sleep(0.01)
         else:
             raise AssertionError("Never got listener")
         yield server


### PR DESCRIPTION
It could sometimes yield a server instance that was not yet listening,
causing random test failures.

The fixture was waiting for the `_tcp_listener` attr to exist, but that
is wrong because the attr is set on the class as None: https://github.com/ethereum/trinity/blob/master/trinity/server.py#L53

Closes: #1504