### PR TITLE
Add libp2p to autodoc_mock_imports

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -51,7 +51,7 @@ autodoc_default_options = {
 }
 
 autodoc_member_order = 'groupwise'
-autodoc_mock_imports = ["snappy"]
+autodoc_mock_imports = ["snappy", "libp2p"]
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']

--- a/newsfragments/1510.bugfix.rst
+++ b/newsfragments/1510.bugfix.rst
@@ -1,0 +1,1 @@
+Fix broken API docs on https://trinity-client.readthedocs.io/en/latest/api/


### PR DESCRIPTION
### What was wrong?

Our live API docs are currently broken.

### How was it fixed?

While we had excluded `libp2p` for RTD bugs since ages, we did not put it in the `autodoc_mock_imports`. My theory is that we initially didn't need it because we had no direct imports to `libp2p` but started to have these at some point.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

[//]: # (See: https://trinity-client.readthedocs.io/en/latest/contributing.html#pull-requests)
- [x] Add entry to the [release notes](https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://raisedvibrations.org/wp-content/uploads/2019/10/dog-first-aid.jpg)
