### PR TITLE
discv4: Use NodeID instead of int for Node.id

### DIFF
--- a/p2p/abc.py
+++ b/p2p/abc.py
@@ -27,6 +27,7 @@ from eth_utils import ExtendedDebugLogger
 from eth_keys import keys
 
 from p2p.discv5.enr import ENR
+from p2p.discv5.typing import NodeID
 from p2p.typing import (
     Capabilities,
     Capability,
@@ -104,10 +105,10 @@ TNode = TypeVar('TNode', bound='NodeAPI')
 
 
 class NodeAPI(ABC):
+    _id_int: int
     pubkey: keys.PublicKey
     address: AddressAPI
-    id: int
-    id_bytes: bytes
+    id: NodeID
     last_pong: float
 
     @abstractmethod

--- a/p2p/tools/factories/kademlia.py
+++ b/p2p/tools/factories/kademlia.py
@@ -2,6 +2,8 @@ from typing import Any
 
 import factory
 
+from eth_utils import int_to_big_endian
+
 from p2p.abc import AddressAPI, NodeAPI
 from p2p.kademlia import Node, Address
 
@@ -34,5 +36,6 @@ class NodeFactory(factory.Factory):
     @classmethod
     def with_nodeid(cls, nodeid: int, *args: Any, **kwargs: Any) -> NodeAPI:
         node = cls(*args, **kwargs)
-        node.id = nodeid
+        node._id_int = nodeid
+        node.id = int_to_big_endian(nodeid)
         return node

--- a/tests-trio/p2p-trio/test_discovery.py
+++ b/tests-trio/p2p-trio/test_discovery.py
@@ -114,7 +114,7 @@ async def test_get_local_enr(manually_driven_discovery):
     validate_node_enr(discovery.this_node, enr, sequence_number=2)
 
     # The new ENR will also be stored in our DB.
-    assert enr == await discovery._enr_db.get(discovery.this_node.id_bytes)
+    assert enr == await discovery._enr_db.get(discovery.this_node.id)
 
     # And the next refresh time will be updated.
     assert discovery._local_enr_next_refresh > time.monotonic()
@@ -126,7 +126,7 @@ async def test_local_enr_on_startup(manually_driven_discovery):
 
     validate_node_enr(discovery.this_node, discovery.this_node.enr, sequence_number=1)
     # Our local ENR will also be stored in our DB.
-    assert discovery.this_node.enr == await discovery._enr_db.get(discovery.this_node.id_bytes)
+    assert discovery.this_node.enr == await discovery._enr_db.get(discovery.this_node.id)
 
 
 @pytest.mark.trio
@@ -204,7 +204,7 @@ async def test_find_node_neighbours(nursery, manually_driven_discovery_pair):
     alice.this_node.last_pong = time.monotonic()
     bob.update_routing_table(alice.this_node)
 
-    alice.send_find_node_v4(bob.this_node, alice.this_node.id)
+    alice.send_find_node_v4(bob.this_node, alice.pubkey.to_bytes())
 
     with trio.fail_after(1):
         await bob.consume_datagram()
@@ -341,10 +341,10 @@ async def test_fetch_enrs(nursery, manually_driven_discovery_pair):
         # it in our DB.
         while True:
             await trio.sleep(0.1)
-            if await alice._enr_db.contains(bob.this_node.id_bytes):
+            if await alice._enr_db.contains(bob.this_node.id):
                 break
 
-    enr = await alice._enr_db.get(bob.this_node.id_bytes)
+    enr = await alice._enr_db.get(bob.this_node.id)
     assert enr is not None
     assert enr == await bob.get_local_enr()
 

--- a/tests/p2p/test_kademlia.py
+++ b/tests/p2p/test_kademlia.py
@@ -49,7 +49,7 @@ def test_node_from_enr_uri():
 
     node = Node.from_uri(repr(enr))
 
-    assert node.id_bytes == keccak(privkey.public_key.to_bytes())
+    assert node.id == keccak(privkey.public_key.to_bytes())
     assert node.address.ip_packed == ip
     assert node.address.tcp_port == tcp_port
     assert node.address.udp_port == udp_port
@@ -66,7 +66,7 @@ def test_node_enr_property():
 
     node = Node(enr)
 
-    assert node.id_bytes == keccak(privkey.public_key.to_bytes())
+    assert node.id == keccak(privkey.public_key.to_bytes())
     assert node.address.ip_packed == ip
     assert node.address.tcp_port == tcp_port
     assert node.address.udp_port == udp_port
@@ -81,7 +81,7 @@ def test_node_enr_property():
     # If we update our Node's enr, the node's attributes will be changed to reflect that.
     node.enr = enr2
 
-    assert node.id_bytes == keccak(privkey.public_key.to_bytes())
+    assert node.id == keccak(privkey.public_key.to_bytes())
     assert node.address.ip_packed == ip
     assert node.address.tcp_port == tcp_port
     assert node.address.udp_port == udp_port
@@ -134,12 +134,12 @@ def test_routingtable_neighbours():
 
     for _ in range(100):
         node = NodeFactory()
-        nearest_bucket = table.buckets_by_distance_to(node.id)[0]
+        nearest_bucket = table.buckets_by_distance_to(node._id_int)[0]
         if not nearest_bucket.nodes:
             continue
         # Change nodeid to something that is in this bucket's range.
         node_a = nearest_bucket.nodes[0]
-        node_b = NodeFactory.with_nodeid(node_a.id + 1)
+        node_b = NodeFactory.with_nodeid(node_a._id_int + 1)
         assert node_a == table.neighbours(node_b.id)[0]
 
 
@@ -245,9 +245,9 @@ def test_kbucket_split():
         # Set the IDs of half the nodes below the midpoint, so when we split we should end up with
         # two buckets containing k/2 nodes.
         if i % 2 == 0:
-            node.id = bucket.midpoint + i
+            node._id_int = bucket.midpoint + i
         else:
-            node.id = bucket.midpoint - i
+            node._id_int = bucket.midpoint - i
         bucket.add(node)
     assert bucket.is_full
     bucket1, bucket2 = bucket.split()
@@ -318,12 +318,12 @@ def test_compute_shared_prefix_bits():
     # Otherwise the depth is the number of leading bits (in the left-padded binary representation)
     # shared by all node IDs.
     nodes.append(NodeFactory())
-    nodes[0].id = int('0b1', 2)
-    nodes[1].id = int('0b0', 2)
+    nodes[0]._id_int = int('0b1', 2)
+    nodes[1]._id_int = int('0b0', 2)
     assert kademlia._compute_shared_prefix_bits(nodes) == KADEMLIA_ID_SIZE - 1
 
-    nodes[0].id = int('0b010', 2)
-    nodes[1].id = int('0b110', 2)
+    nodes[0]._id_int = int('0b010', 2)
+    nodes[1]._id_int = int('0b110', 2)
     assert kademlia._compute_shared_prefix_bits(nodes) == KADEMLIA_ID_SIZE - 3
 
 


### PR DESCRIPTION
We still use int IDs internally but this will make it easier for us to
share a single RoutingTable implementation between both discv5 and
discv4

Another step towards fixing #1451