### PR TITLE
PeerPool now uses a filter function when asking for connection candidates

### DIFF
--- a/p2p/abc.py
+++ b/p2p/abc.py
@@ -136,6 +136,18 @@ class NodeAPI(ABC):
     def from_enr_repr(cls: Type[TNode], uri: str) -> TNode:
         ...
 
+    @property
+    @abstractmethod
+    def enr(self) -> ENR:
+        ...
+
+    @enr.setter
+    def enr(self, enr: ENR) -> None:
+        # See: https://github.com/python/mypy/issues/4165
+        # Since we can't also decorate this with abstract method we want to be
+        # sure that the setter doesn't actually get used as a noop.
+        raise NotImplementedError()
+
     @abstractmethod
     def uri(self) -> str:
         ...

--- a/p2p/events.py
+++ b/p2p/events.py
@@ -2,6 +2,7 @@ from dataclasses import (
     dataclass,
 )
 from typing import (
+    Callable,
     Tuple,
     Type,
 )
@@ -24,10 +25,11 @@ class PeerCandidatesResponse(BaseDiscoveryServiceResponse):
     candidates: Tuple[NodeAPI, ...]
 
 
-@dataclass
 class PeerCandidatesRequest(BaseRequestResponseEvent[PeerCandidatesResponse]):
 
-    max_candidates: int
+    def __init__(self, max_candidates: int, should_skip_fn: Callable[[NodeAPI], bool]) -> None:
+        self.max_candidates = max_candidates
+        self.should_skip_fn = should_skip_fn
 
     @staticmethod
     def expected_response_type() -> Type[PeerCandidatesResponse]:

--- a/p2p/tracking/connection.py
+++ b/p2p/tracking/connection.py
@@ -2,10 +2,12 @@ from abc import ABC, abstractmethod
 import logging
 from typing import (
     Dict,
+    Tuple,
     Type,
 )
 
 from p2p.abc import NodeAPI
+from p2p.discv5.typing import NodeID
 from p2p.exceptions import (
     BaseP2PError,
     HandshakeFailure,
@@ -55,6 +57,10 @@ class BaseConnectionTracker(ABC):
     async def should_connect_to(self, remote: NodeAPI) -> bool:
         ...
 
+    @abstractmethod
+    async def get_blacklisted(self) -> Tuple[NodeID, ...]:
+        ...
+
 
 class NoopConnectionTracker(BaseConnectionTracker):
     def record_blacklist(self, remote: NodeAPI, timeout_seconds: int, reason: str) -> None:
@@ -62,3 +68,6 @@ class NoopConnectionTracker(BaseConnectionTracker):
 
     async def should_connect_to(self, remote: NodeAPI) -> bool:
         return True
+
+    async def get_blacklisted(self) -> Tuple[NodeID, ...]:
+        return tuple()

--- a/p2p/tracking/connection.py
+++ b/p2p/tracking/connection.py
@@ -54,10 +54,6 @@ class BaseConnectionTracker(ABC):
         ...
 
     @abstractmethod
-    async def should_connect_to(self, remote: NodeAPI) -> bool:
-        ...
-
-    @abstractmethod
     async def get_blacklisted(self) -> Tuple[NodeID, ...]:
         ...
 
@@ -65,9 +61,6 @@ class BaseConnectionTracker(ABC):
 class NoopConnectionTracker(BaseConnectionTracker):
     def record_blacklist(self, remote: NodeAPI, timeout_seconds: int, reason: str) -> None:
         pass
-
-    async def should_connect_to(self, remote: NodeAPI) -> bool:
-        return True
 
     async def get_blacklisted(self) -> Tuple[NodeID, ...]:
         return tuple()

--- a/tests/core/network-db/test_connection_tracker_server.py
+++ b/tests/core/network-db/test_connection_tracker_server.py
@@ -9,7 +9,7 @@ from p2p.tools.factories import NodeFactory
 from trinity.constants import (
     NETWORKING_EVENTBUS_ENDPOINT,
 )
-from trinity.components.builtin.network_db.connection.events import ShouldConnectToPeerRequest
+from trinity.components.builtin.network_db.connection.events import GetBlacklistedPeersRequest
 from trinity.components.builtin.network_db.connection.server import ConnectionTrackerServer
 from trinity.components.builtin.network_db.connection.tracker import (
     ConnectionTrackerClient,
@@ -23,7 +23,8 @@ async def test_connection_tracker_server_and_client(event_loop, event_bus):
     remote_a = NodeFactory()
     tracker.record_blacklist(remote_a, 60, "testing")
 
-    assert await tracker.should_connect_to(remote_a) is False
+    blacklisted_ids = await tracker.get_blacklisted()
+    assert remote_a.id in blacklisted_ids
 
     service = ConnectionTrackerServer(event_bus, tracker)
 
@@ -33,24 +34,20 @@ async def test_connection_tracker_server_and_client(event_loop, event_bus):
         bus_tracker = ConnectionTrackerClient(event_bus, config=config)
 
         # Give `bus_tracker` a moment to setup subscriptions
-        await event_bus.wait_until_any_endpoint_subscribed_to(ShouldConnectToPeerRequest)
+        await event_bus.wait_until_any_endpoint_subscribed_to(GetBlacklistedPeersRequest)
         # ensure we can read from the tracker over the event bus
-        assert await bus_tracker.should_connect_to(remote_a) is False
+        bus_blacklisted_ids = await bus_tracker.get_blacklisted()
+        assert remote_a.id in bus_blacklisted_ids
 
         # ensure we can write to the tracker over the event bus
         remote_b = NodeFactory()
-
-        assert await bus_tracker.should_connect_to(remote_b) is True
-
         bus_tracker.record_blacklist(remote_b, 60, "testing")
         # let the underlying broadcast_nowait execute
         await asyncio.sleep(0.01)
 
-        assert await bus_tracker.should_connect_to(remote_b) is False
-        assert await tracker.should_connect_to(remote_b) is False
-
         bus_blacklisted_ids = await bus_tracker.get_blacklisted()
         blacklisted_ids = await tracker.get_blacklisted()
+        assert remote_b.id in blacklisted_ids
         assert bus_blacklisted_ids == blacklisted_ids
 
         assert sorted(blacklisted_ids) == sorted([remote_a.id, remote_b.id])

--- a/tests/core/network-db/test_connection_tracker_server.py
+++ b/tests/core/network-db/test_connection_tracker_server.py
@@ -48,3 +48,9 @@ async def test_connection_tracker_server_and_client(event_loop, event_bus):
 
         assert await bus_tracker.should_connect_to(remote_b) is False
         assert await tracker.should_connect_to(remote_b) is False
+
+        bus_blacklisted_ids = await bus_tracker.get_blacklisted()
+        blacklisted_ids = await tracker.get_blacklisted()
+        assert bus_blacklisted_ids == blacklisted_ids
+
+        assert sorted(blacklisted_ids) == sorted([remote_a.id, remote_b.id])

--- a/trinity/components/builtin/network_db/connection/events.py
+++ b/trinity/components/builtin/network_db/connection/events.py
@@ -1,7 +1,7 @@
 from dataclasses import (
     dataclass,
 )
-from typing import Type
+from typing import Tuple, Type
 
 from lahja import (
     BaseEvent,
@@ -9,6 +9,7 @@ from lahja import (
 )
 
 from p2p.abc import NodeAPI
+from p2p.discv5.typing import NodeID
 
 
 class BaseConnectionTrackerEvent(BaseEvent):
@@ -37,3 +38,17 @@ class ShouldConnectToPeerRequest(BaseRequestResponseEvent[ShouldConnectToPeerRes
     @staticmethod
     def expected_response_type() -> Type[ShouldConnectToPeerResponse]:
         return ShouldConnectToPeerResponse
+
+
+@dataclass
+class GetBlacklistedPeersResponse(BaseConnectionTrackerEvent):
+
+    peers: Tuple[NodeID, ...]
+
+
+@dataclass
+class GetBlacklistedPeersRequest(BaseRequestResponseEvent[GetBlacklistedPeersResponse]):
+
+    @staticmethod
+    def expected_response_type() -> Type[GetBlacklistedPeersResponse]:
+        return GetBlacklistedPeersResponse

--- a/trinity/components/builtin/network_db/connection/events.py
+++ b/trinity/components/builtin/network_db/connection/events.py
@@ -25,22 +25,6 @@ class BlacklistEvent(BaseConnectionTrackerEvent):
 
 
 @dataclass
-class ShouldConnectToPeerResponse(BaseConnectionTrackerEvent):
-
-    should_connect: bool
-
-
-@dataclass
-class ShouldConnectToPeerRequest(BaseRequestResponseEvent[ShouldConnectToPeerResponse]):
-
-    remote: NodeAPI
-
-    @staticmethod
-    def expected_response_type() -> Type[ShouldConnectToPeerResponse]:
-        return ShouldConnectToPeerResponse
-
-
-@dataclass
 class GetBlacklistedPeersResponse(BaseConnectionTrackerEvent):
 
     peers: Tuple[NodeID, ...]

--- a/trinity/components/builtin/network_db/eth1_peer_db/events.py
+++ b/trinity/components/builtin/network_db/eth1_peer_db/events.py
@@ -2,11 +2,10 @@ from dataclasses import (
     dataclass,
 )
 import datetime
-from typing import Optional, Set, Type, Tuple
+from typing import Optional
 
 from lahja import (
     BaseEvent,
-    BaseRequestResponseEvent,
 )
 
 from eth_typing import Hash32
@@ -28,20 +27,3 @@ class TrackPeerEvent(BasePeerDBEvent):
     protocol: str
     protocol_version: int
     network_id: int
-
-
-@dataclass
-class GetPeerCandidatesResponse(BasePeerDBEvent):
-
-    candidates: Tuple[NodeAPI, ...]
-
-
-@dataclass
-class GetPeerCandidatesRequest(BaseRequestResponseEvent[GetPeerCandidatesResponse]):
-
-    num_requested: int
-    connected_remotes: Set[NodeAPI]
-
-    @staticmethod
-    def expected_response_type() -> Type[GetPeerCandidatesResponse]:
-        return GetPeerCandidatesResponse

--- a/trinity/components/builtin/network_db/eth1_peer_db/server.py
+++ b/trinity/components/builtin/network_db/eth1_peer_db/server.py
@@ -4,13 +4,13 @@ from lahja import EndpointAPI
 
 from async_service import Service
 
+from p2p.events import PeerCandidatesRequest, PeerCandidatesResponse
+
 from .tracker import (
     BaseEth1PeerTracker,
 )
 from .events import (
     TrackPeerEvent,
-    GetPeerCandidatesRequest,
-    GetPeerCandidatesResponse,
 )
 
 
@@ -39,13 +39,13 @@ class PeerDBServer(Service):
             )
 
     async def handle_get_peer_candidates_request(self) -> None:
-        async for req in self.event_bus.stream(GetPeerCandidatesRequest):
+        async for req in self.event_bus.stream(PeerCandidatesRequest):
             candidates = tuple(await self.tracker.get_peer_candidates(
-                req.num_requested,
-                req.connected_remotes,
+                req.max_candidates,
+                req.should_skip_fn,
             ))
             await self.event_bus.broadcast(
-                GetPeerCandidatesResponse(candidates),
+                PeerCandidatesResponse(candidates),
                 req.broadcast_config(),
             )
 

--- a/trinity/db/orm.py
+++ b/trinity/db/orm.py
@@ -27,7 +27,7 @@ from trinity.exceptions import (
 Base = declarative_base()
 
 
-SCHEMA_VERSION = '3'
+SCHEMA_VERSION = '4'
 
 
 class SchemaVersion(Base):


### PR DESCRIPTION
One of the issues I've found with our peer discovery implementation is that PeerPool keeps asking the Discovery backend for a batch of random peers, and it only skips the nodes we are
already connected to, so we are likely to get duplicates across requests and if we have a big routing table with few compatible peers we're very unlikely to ever get to them.

This changes our backends to instead take a filter function and only return candidates that pass it. This way we can use ENR info (e.g. fork-id) to first try and connect to peers that are known to be compatible, and resort to random ones (that don't support ENR) if we do not have enough compatible ones. This will come in a separate PR (#1523)

Also, this allows us to make DiscoveryService's strategy less eager (#1449) by only triggering random lookups when we don't have enough compatible peers in the routing table.

Closes: #1449