### PR TITLE
Update async-service library to 0.1.0a6

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ deps = {
     'p2p': [
         "async-exit-stack==1.0.1",
         "async-generator==1.10",
-        "async-service==0.1.0a4",
+        "async-service==0.1.0a6",
         "asyncio-cancel-token>=0.2,<0.3",
         "async_lru>=0.1.0,<1.0.0",
         "cached-property>=1.5.1,<2",


### PR DESCRIPTION
### What was wrong?

New version of `async-service` released today `v0.1.0-alpha.6`

Major change is removal of the `is_stopping/wait_stopping` APIs and a bugfix which ensures that we don't lose errors that occur in a child service when the parent service gets cancelled very close to the moment of the error.

### How was it fixed?

Bumped the version.

#### Cute Animal Picture

![dog-blue-chair](https://user-images.githubusercontent.com/824194/73402001-8d8dad00-42a9-11ea-9480-9507dcab07e1.jpeg)

