### PR TITLE
Fix implicit Any return types

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -1,14 +1,16 @@
 [mypy]
-warn_unused_ignores = True
-ignore_missing_imports = True
-strict_optional = False
 check_untyped_defs = True
-disallow_incomplete_defs = True
-disallow_untyped_defs = True
 disallow_any_generics = True
+disallow_incomplete_defs = True
 disallow_untyped_calls = True
-warn_redundant_casts = True
-warn_unused_configs = True
-strict_equality = True
+disallow_untyped_defs = True
+ignore_missing_imports = True
+mypy_path = ./stubs
 plugins = sqlmypy
+show_error_codes = True
+strict_equality = True
+strict_optional = False
+warn_redundant_casts = True
 warn_return_any = True
+warn_unused_configs = True
+warn_unused_ignores = True

--- a/mypy.ini
+++ b/mypy.ini
@@ -11,3 +11,4 @@ warn_redundant_casts = True
 warn_unused_configs = True
 strict_equality = True
 plugins = sqlmypy
+warn_return_any = True


### PR DESCRIPTION
originally discovered here: https://github.com/ethereum/trinity/pull/1460#discussion_r364753916

### What was wrong?

Currently `mypy` will not complain about the following.

```python
class Thing:
    def something(self) -> None:
        self._attribute_without_type_definition = some_implicit_Any_type()
    def foo(self) -> None:
        return self._attribute_without_type_definition  # mypy doesn't complain about this...
```

This is because the attribute gets set to an `Any` type *implicitely*.

### How was it fixed?

Enabled the `warn_return_any = True` option in our `mypy.conf` file which makes this into an error case.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

[//]: # (See: https://trinity-client.readthedocs.io/en/latest/contributing.html#pull-requests)
- [ ] Add entry to the [release notes](https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses]()
