### PR TITLE
Don't use closed channel

### DIFF
--- a/p2p/discv5/packer.py
+++ b/p2p/discv5/packer.py
@@ -511,7 +511,13 @@ class Packer(Service):
                         incoming_packet,
                         managed_peer_packer.peer_packer,
                     )
-                    await managed_peer_packer.incoming_packet_send_channel.send(incoming_packet)
+                    try:
+                        await managed_peer_packer.incoming_packet_send_channel.send(incoming_packet)
+                    except trio.BrokenResourceError:
+                        self.logger.warning(
+                            "Dropping packet as channel to %s is closed" %
+                            managed_peer_packer.peer_packer
+                        )
 
             elif isinstance(incoming_packet.packet, AuthTagPacket):
                 tag = incoming_packet.packet.tag
@@ -532,7 +538,13 @@ class Packer(Service):
                     incoming_packet,
                     encode_hex(remote_node_id),
                 )
-                await managed_peer_packer.incoming_packet_send_channel.send(incoming_packet)
+                try:
+                    await managed_peer_packer.incoming_packet_send_channel.send(incoming_packet)
+                except trio.BrokenResourceError:
+                    self.logger.warning(
+                        "Dropping packet as channel to %s is closed" %
+                        managed_peer_packer.peer_packer
+                    )
 
             else:
                 self.logger.warning("Dropping unprompted handshake packet %s", incoming_packet)

--- a/tests-trio/p2p-trio/test_packer.py
+++ b/tests-trio/p2p-trio/test_packer.py
@@ -219,14 +219,8 @@ async def packer(enr_db,
         outgoing_message_receive_channel=outgoing_message_channels[1],
         outgoing_packet_send_channel=outgoing_packet_channels[0],
     )
-    try:
-        async with background_trio_service(packer):
-            yield packer
-    except trio.BrokenResourceError:
-        # TODO: This hack fixes flakyness in some tests.  This try/except
-        # should be dropped once the main issue has been addressed.
-        # ISSUE LINK: https://github.com/ethereum/trinity/issues/1517
-        pass
+    async with background_trio_service(packer):
+        yield packer
 
 
 @pytest_trio.trio_fixture


### PR DESCRIPTION
### What was wrong?

#1517 

I could not reproduce the issue locally and I didn't fully understand why it was occurring. But apparently, there are cases in which a peer packer has stopped (i.e. the [context manager](https://github.com/ethereum/trinity/blob/25567f3da9027014908af3777a93f958038e9dd4/p2p/discv5/packer.py#L114) for its packet receive channel has exited), but it is [not deregistered yet](https://github.com/ethereum/trinity/blob/25567f3da9027014908af3777a93f958038e9dd4/p2p/discv5/packer.py#L635-L637). If in such a state a packet for the peer packer is received, the packer will still try to send it to the peer packer, but because the channel is closed already, a `BrokenResourceError` is thrown and the packer crashes.

### How was it fixed?

Catch the `BrokenResourceError` when sending the packet via the potentially closed channel and log a warning. This isn't ideal because the packet is dropped, but since this doesn't seem to happen very often and discv5 is a UDP protocol in which packet delivery isn't guaranteed anyways, this should be ok for now.

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://cdn2-www.dogtime.com/assets/uploads/2016/01/husky-stuck-in-vent-600x339.jpg)
