### PR TITLE
Catch PeerConnectionLost looking up high td peer

### DIFF
--- a/newsfragments/1524.bugfix.rst
+++ b/newsfragments/1524.bugfix.rst
@@ -1,0 +1,2 @@
+:cls:`~p2p.exceptions.PeerConnectionLost` was escaping during a ``highest_td_peer`` call, and
+crashing whatever called it. The exception is now caught.

--- a/trinity/protocol/common/peer.py
+++ b/trinity/protocol/common/peer.py
@@ -24,7 +24,7 @@ from p2p.abc import BehaviorAPI, NodeAPI, SessionAPI
 from p2p.disconnect import DisconnectReason
 from p2p.exceptions import (
     NoConnectedPeers,
-    UnknownAPI,
+    PeerConnectionLost,
 )
 from p2p.peer import (
     BasePeer,
@@ -157,7 +157,11 @@ class BaseChainPeerPool(BasePeerPool):
         if not peers:
             raise NoConnectedPeers("No connected peers")
 
-        td_getter = excepts(UnknownAPI, operator.attrgetter('head_info.head_td'), lambda _: 0)
+        td_getter = excepts(
+            PeerConnectionLost,
+            operator.attrgetter('head_info.head_td'),
+            lambda _: 0,
+        )
         peers_by_td = groupby(td_getter, peers)
         max_td = max(peers_by_td.keys())
         return random.choice(peers_by_td[max_td])


### PR DESCRIPTION
### What was wrong?

Fixes #1524 

### How was it fixed?

Catch a lost connection error, and treat it as a 0 total-difficulty peer. (as was done when it used to be a `UnknownAPI` exception)

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

[//]: # (See: https://trinity-client.readthedocs.io/en/latest/contributing.html#pull-requests)
- [x] Add entry to the [release notes](https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://img.huffingtonpost.com/asset/56e2cfc81e0000b300703ce5.jpeg?ops=scalefit_950_800_noupscale)
