### PR TITLE
Topic table fixes

### DIFF
--- a/p2p/discv5/topic_table.py
+++ b/p2p/discv5/topic_table.py
@@ -48,7 +48,6 @@ class TopicTable:
 
         The result will be ordered from newest to oldest entry.
         """
-        # reverse queue so that old entries come first
         return tuple(ad.enr for ad in self.topic_queues[topic])
 
     def get_wait_time(self, topic: Topic) -> float:

--- a/p2p/discv5/topic_table.py
+++ b/p2p/discv5/topic_table.py
@@ -37,7 +37,7 @@ class TopicTable:
         """Return the total number of ads in the table across all queues."""
         return self.total_size
 
-    def is_table_full(self) -> bool:
+    def is_full(self) -> bool:
         return len(self) >= self.max_total_size
 
     def is_queue_full(self, topic: Topic) -> bool:
@@ -53,7 +53,7 @@ class TopicTable:
 
     def get_wait_time(self, topic: Topic) -> float:
         """Return the time at which the next ad for a given topic can be added."""
-        if self.is_table_full():
+        if self.is_full():
             oldest_ads = [queue[-1] for queue in self.topic_queues.values()]
             oldest_ad_reg_time = max(ad.registration_time for ad in oldest_ads)
         elif self.is_queue_full(topic):

--- a/p2p/discv5/topic_table.py
+++ b/p2p/discv5/topic_table.py
@@ -39,6 +39,7 @@ class TopicTable:
         """Return the total number of ads in the table across all queues."""
         return self.total_size
 
+    @property
     def is_full(self) -> bool:
         return len(self) >= self.max_total_size
 
@@ -54,7 +55,7 @@ class TopicTable:
 
     def get_wait_time(self, topic: Topic, current_time: float) -> float:
         """Return the time at which the next ad for a given topic can be added."""
-        is_table_full = self.is_full()
+        is_table_full = self.is_full
         is_queue_full = self.is_queue_full(topic)
 
         if not is_queue_full and not is_table_full:
@@ -98,7 +99,7 @@ class TopicTable:
                 f"Topic queue already contains entry for node {encode_hex(enr.node_id)}"
             )
 
-        if self.is_full():
+        if self.is_full:
             queues = [queue for queue in self.topic_queues.values() if queue]
             queue_with_oldest_ad = min(
                 queues,

--- a/tests/p2p/discv5/test_topic_table.py
+++ b/tests/p2p/discv5/test_topic_table.py
@@ -1,5 +1,3 @@
-import math
-
 import pytest
 
 from p2p.discv5.topic_table import TopicTable
@@ -60,7 +58,7 @@ def test_wait_time_full_table(topic_table, target_ad_lifetime):
     # fill one queue
     reg_time = 0
     oldest_table_eol = reg_time + target_ad_lifetime
-    while not topic_table.is_full():
+    while not topic_table.is_full:
         assert topic_table.get_wait_time(TopicFactory(), 0) == 0
         topic_table.register(TopicFactory(), ENRFactory(), reg_time)
         reg_time += 1
@@ -100,7 +98,7 @@ def test_wait_time_full_queue_and_table(topic_table, max_queue_size, target_ad_l
 
     # fill the rest of the table
     oldest_table_eol = reg_time + target_ad_lifetime
-    while not topic_table.is_full():
+    while not topic_table.is_full:
         topic_table.register(TopicFactory(), ENRFactory(), reg_time)
         reg_time += 1
 
@@ -181,7 +179,7 @@ def test_registration_two_queues(topic_table, max_queue_size):
 def test_registration_full_table(topic_table, max_queue_size, max_total_size):
     for _ in range(max_total_size):
         topic_table.register(TopicFactory(), ENRFactory(), 0)
-    assert topic_table.is_full()
+    assert topic_table.is_full
 
     with pytest.raises(ValueError):
         topic_table.register(TopicFactory(), ENRFactory(), 0)

--- a/tests/p2p/discv5/test_topic_table.py
+++ b/tests/p2p/discv5/test_topic_table.py
@@ -56,33 +56,68 @@ def test_table_size(topic_table, max_queue_size, target_ad_lifetime):
     assert len(topic_table) == 3 + max_queue_size
 
 
-def test_wait_time(topic_table, max_queue_size, max_total_size, target_ad_lifetime):
+def test_wait_time_full_table(topic_table, target_ad_lifetime):
+    # fill one queue
+    reg_time = 0
+    oldest_table_eol = reg_time + target_ad_lifetime
+    while not topic_table.is_full():
+        assert topic_table.get_wait_time(TopicFactory()) == -math.inf
+        topic_table.register(TopicFactory(), ENRFactory(), reg_time)
+        reg_time += 1
+
+    assert topic_table.get_wait_time(TopicFactory()) == oldest_table_eol
+    topic_table.register(TopicFactory(), ENRFactory(), reg_time)
+    assert topic_table.get_wait_time(TopicFactory()) == oldest_table_eol + 1
+
+
+def test_wait_time_full_queue(topic_table, max_total_size, target_ad_lifetime):
     topic = TopicFactory()
     different_topic = TopicFactory()
 
-    assert topic_table.get_wait_time(topic) == -math.inf
-
-    start_time = 10
-    time_delta = 2
-    reg_times = tuple(start_time + index * time_delta for index in range(20))
-    for index, reg_time in enumerate(reg_times):
+    reg_time = 0
+    oldest_queue_eol = reg_time + target_ad_lifetime
+    while not topic_table.is_queue_full(topic):
+        assert topic_table.get_wait_time(topic) == -math.inf
+        assert topic_table.get_wait_time(different_topic) == -math.inf
         topic_table.register(topic, ENRFactory(), reg_time)
+        reg_time += 1
 
-        oldest_topic_reg_time = reg_times[max(0, index + 1 - max_queue_size)]
-        oldest_topic_eol = oldest_topic_reg_time + target_ad_lifetime
-
-        if not topic_table.is_queue_full(topic):
-            assert topic_table.get_wait_time(topic) == -math.inf
-        else:
-            assert topic_table.get_wait_time(topic) == oldest_topic_eol
-
-        if not topic_table.is_table_full():
-            assert topic_table.get_wait_time(different_topic) == -math.inf
-        else:
-            assert topic_table.get_wait_time(topic) == oldest_topic_eol
+    assert topic_table.get_wait_time(topic) == oldest_queue_eol
+    assert topic_table.get_wait_time(different_topic) == -math.inf
+    topic_table.register(topic, ENRFactory(), reg_time)
+    assert topic_table.get_wait_time(topic) == oldest_queue_eol + 1
+    assert topic_table.get_wait_time(different_topic) == -math.inf
 
 
-def test_registration(topic_table, max_queue_size, max_total_size, target_ad_lifetime):
+def test_wait_time_full_queue_and_table(topic_table, max_queue_size, target_ad_lifetime):
+    # fill one queue
+    topic = TopicFactory()
+    reg_time = 0
+    oldest_queue_eol = reg_time + target_ad_lifetime
+    while not topic_table.is_queue_full(topic):
+        topic_table.register(topic, ENRFactory(), reg_time)
+        reg_time += 1
+
+    # fill the rest of the table
+    oldest_table_eol = reg_time + target_ad_lifetime
+    while not topic_table.is_full():
+        topic_table.register(TopicFactory(), ENRFactory(), reg_time)
+        reg_time += 1
+
+    assert topic_table.get_wait_time(topic) == oldest_queue_eol
+    assert topic_table.get_wait_time(TopicFactory()) == oldest_queue_eol
+
+    # refill queue
+    oldest_queue_eol = reg_time + target_ad_lifetime
+    for _ in range(max_queue_size):
+        topic_table.register(topic, ENRFactory(), reg_time)
+        reg_time += 1
+
+    assert topic_table.get_wait_time(topic) == oldest_queue_eol
+    assert topic_table.get_wait_time(TopicFactory()) == oldest_table_eol
+
+
+def test_registration_single_queue(topic_table, max_queue_size):
     topic = TopicFactory()
     enr = ENRFactory()
     other_enr = ENRFactory()
@@ -98,13 +133,67 @@ def test_registration(topic_table, max_queue_size, max_total_size, target_ad_lif
 
     while not topic_table.is_queue_full(topic):
         topic_table.register(topic, ENRFactory(), 0)
+
     with pytest.raises(ValueError):
         topic_table.register(topic, ENRFactory(), 0)
-    topic_table.register(topic, enr, target_ad_lifetime)
-    assert len(topic_table.get_enrs_for_topic(topic)) == max_queue_size
-    assert topic_table.get_enrs_for_topic(topic)[0] == enr
 
-    while not topic_table.is_full():
+    enrs_before = topic_table.get_enrs_for_topic(topic)
+    new_enr = ENRFactory()
+    topic_table.register(topic, new_enr, topic_table.get_wait_time(topic))
+    enrs_after = topic_table.get_enrs_for_topic(topic)
+    assert enrs_after == (new_enr,) + enrs_before[:-1]
+
+
+def test_registration_two_queues(topic_table, max_queue_size):
+    topic1 = TopicFactory()
+    topic2 = TopicFactory()
+    enr = ENRFactory()
+
+    topic_table.register(topic1, enr, 0)
+    while not topic_table.is_queue_full(topic1):
+        topic_table.register(topic1, ENRFactory(), 0)
+
+    topic_table.register(topic2, enr, 1)
+    while not topic_table.is_queue_full(topic2):
+        topic_table.register(topic2, ENRFactory(), 1)
+
+    with pytest.raises(ValueError):
+        topic_table.register(topic1, ENRFactory(), 1)
+    with pytest.raises(ValueError):
+        topic_table.register(topic2, ENRFactory(), 1)
+    with pytest.raises(ValueError):
+        topic_table.register(topic2, ENRFactory(), topic_table.get_wait_time(topic1))
+
+    enrs_topic1_before = topic_table.get_enrs_for_topic(topic1)
+    enrs_topic2_before = topic_table.get_enrs_for_topic(topic2)
+    new_enr_topic1 = ENRFactory()
+    new_enr_topic2 = ENRFactory()
+
+    topic_table.register(topic1, new_enr_topic1, topic_table.get_wait_time(topic1))
+    topic_table.register(topic2, new_enr_topic2, topic_table.get_wait_time(topic2))
+
+    enrs_topic1_after = topic_table.get_enrs_for_topic(topic1)
+    enrs_topic2_after = topic_table.get_enrs_for_topic(topic1)
+    assert enrs_topic1_after == (new_enr_topic1,) + enrs_topic1_before[:-1]
+    assert enrs_topic2_after == (new_enr_topic2,) + enrs_topic2_before[:-1]
+
+
+def test_registration_full_table(topic_table, max_queue_size, max_total_size):
+    for _ in range(max_total_size):
         topic_table.register(TopicFactory(), ENRFactory(), 0)
+    assert topic_table.is_full()
+
     with pytest.raises(ValueError):
         topic_table.register(TopicFactory(), ENRFactory(), 0)
+    wait_time = topic_table.get_wait_time(TopicFactory())
+    topic_table.register(TopicFactory(), ENRFactory(), wait_time)
+
+    topic = TopicFactory()
+    assert not topic_table.is_queue_full(topic)
+    while not topic_table.is_queue_full(topic):
+        topic_table.register(topic, ENRFactory(), topic_table.get_wait_time(topic))
+
+    with pytest.raises(ValueError):
+        topic_table.register(TopicFactory(), ENRFactory(), 0)
+    wait_time = topic_table.get_wait_time(TopicFactory())
+    topic_table.register(TopicFactory(), ENRFactory(), wait_time)

--- a/tests/p2p/discv5/test_topic_table.py
+++ b/tests/p2p/discv5/test_topic_table.py
@@ -104,7 +104,7 @@ def test_registration(topic_table, max_queue_size, max_total_size, target_ad_lif
     assert len(topic_table.get_enrs_for_topic(topic)) == max_queue_size
     assert topic_table.get_enrs_for_topic(topic)[0] == enr
 
-    while not topic_table.is_table_full():
+    while not topic_table.is_full():
         topic_table.register(TopicFactory(), ENRFactory(), 0)
     with pytest.raises(ValueError):
         topic_table.register(TopicFactory(), ENRFactory(), 0)


### PR DESCRIPTION
### What was wrong?

As pointed out by @pipermerriam [here](https://github.com/ethereum/trinity/pull/1494), the topic table implementation was buggy:

- wait time was computed incorrectly if both queue and table are full
- registering ads in full tables wasn't possible

### How was it fixed?

- compute wait time properly (based on the registration time of the oldest ad in the queue or in the table, whatever was later
- if the table is full, remove the oldest ad in the table, no matter the queue
- rename `is_table_full` to `is_full`
- remove wrong comment on order of enrs in queue
- extend the tests so that the fixed issues are covered

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://user-images.githubusercontent.com/29854669/73735225-37a08580-473f-11ea-8eca-198449e1cda3.jpg)
