### PR TITLE
Convert main Node service to use async-service API

### DIFF
--- a/p2p/abc.py
+++ b/p2p/abc.py
@@ -20,6 +20,7 @@ from typing import (
 )
 import uuid
 
+from async_service import ServiceAPI
 from cancel_token import CancelToken
 
 from eth_utils import ExtendedDebugLogger
@@ -411,6 +412,10 @@ class AsyncioServiceAPI(ABC):
     events: ServiceEventsAPI
     cancel_token: CancelToken
 
+    @abstractmethod
+    def as_new_service(self) -> ServiceAPI:
+        ...
+
     @property
     @abstractmethod
     def logger(self) -> ExtendedDebugLogger:
@@ -443,6 +448,10 @@ class AsyncioServiceAPI(ABC):
 
     @abstractmethod
     async def cancel(self) -> None:
+        ...
+
+    @abstractmethod
+    async def cancellation(self) -> None:
         ...
 
     @abstractmethod

--- a/trinity/nodes/full.py
+++ b/trinity/nodes/full.py
@@ -37,7 +37,7 @@ class FullNode(Node[ETHPeer]):
         """
         if self._event_server is None:
             self._event_server = ETHPeerPoolEventServer(
-                self.event_bus, self.get_peer_pool(), self.cancel_token)
+                self.event_bus, self.get_peer_pool(), self.master_cancel_token)
         return self._event_server
 
     def get_p2p_server(self) -> FullServer:
@@ -51,7 +51,7 @@ class FullNode(Node[ETHPeer]):
                 base_db=self._base_db,
                 network_id=self._network_id,
                 max_peers=self._max_peers,
-                token=self.cancel_token,
+                token=self.master_cancel_token,
                 event_bus=self.event_bus,
             )
         return self._p2p_server

--- a/trinity/nodes/light.py
+++ b/trinity/nodes/light.py
@@ -50,16 +50,16 @@ class LightNode(Node[LESPeer]):
         self._peer_chain = LightPeerChain(
             self.headerdb,
             cast(LESPeerPool, self.get_peer_pool()),
-            token=self.cancel_token,
+            token=self.master_cancel_token,
         )
 
     @property
     def chain_class(self) -> Type[LightDispatchChain]:
         return self.chain_config.light_chain_class
 
-    async def _run(self) -> None:
-        self.run_daemon(self._peer_chain)
-        await super()._run()
+    async def run(self) -> None:
+        self.manager.run_daemon_child_service(self._peer_chain.as_new_service())
+        await super().run()
 
     def get_chain(self) -> LightDispatchChain:
         if self._chain is None:
@@ -77,7 +77,7 @@ class LightNode(Node[LESPeer]):
             self._event_server = LESPeerPoolEventServer(
                 self.event_bus,
                 self.get_peer_pool(),
-                self.cancel_token,
+                self.master_cancel_token,
                 self._peer_chain
             )
         return self._event_server
@@ -93,7 +93,7 @@ class LightNode(Node[LESPeer]):
                 base_db=self._base_db,
                 network_id=self._network_id,
                 max_peers=self._max_peers,
-                token=self.cancel_token,
+                token=self.master_cancel_token,
                 event_bus=self.event_bus,
             )
         return self._p2p_server


### PR DESCRIPTION
### What was wrong?

The `Node` concept in trinity is still using the legacy service API

### How was it fixed?

Updated it to use the new `async-service` API.  This includes a small patch to the old service API to easily wrap them in the new service API.


#### Cute Animal Picture

![funny-cats-dogs-stuck-furniture-19](https://user-images.githubusercontent.com/824194/73772366-3cfcd080-473d-11ea-89e5-bbb8f0043872.jpg)

