### PR TITLE
Convert trinity server to use async service

### DIFF
--- a/trinity/nodes/full.py
+++ b/trinity/nodes/full.py
@@ -51,7 +51,6 @@ class FullNode(Node[ETHPeer]):
                 base_db=self._base_db,
                 network_id=self._network_id,
                 max_peers=self._max_peers,
-                token=self.master_cancel_token,
                 event_bus=self.event_bus,
             )
         return self._p2p_server

--- a/trinity/nodes/light.py
+++ b/trinity/nodes/light.py
@@ -92,7 +92,6 @@ class LightNode(Node[LESPeer]):
                 base_db=self._base_db,
                 network_id=self._network_id,
                 max_peers=self._max_peers,
-                token=self.master_cancel_token,
                 event_bus=self.event_bus,
             )
         return self._p2p_server


### PR DESCRIPTION
builds on https://github.com/ethereum/trinity/pull/1537

### What was wrong?

The `trinity.server` constructs were not using the `async-service` API

### How was it fixed?

Converted them to use `async-service`.

#### Cute Animal Picture

![5845719280_02d8a774e5_z](https://user-images.githubusercontent.com/824194/73882078-b28c9d80-481e-11ea-8605-25485acbcdff.jpg)
