### PR TITLE
Helpers to run components in a standalone fashion

### DIFF
--- a/p2p/peer_pool.py
+++ b/p2p/peer_pool.py
@@ -33,7 +33,6 @@ from eth_utils.toolz import (
     take,
 )
 from lahja import (
-    BroadcastConfig,
     EndpointAPI,
 )
 
@@ -41,7 +40,6 @@ from p2p.abc import AsyncioServiceAPI, NodeAPI, SessionAPI
 from p2p.constants import (
     DEFAULT_MAX_PEERS,
     DEFAULT_PEER_BOOT_TIMEOUT,
-    DISCOVERY_EVENTBUS_ENDPOINT,
     HANDSHAKE_TIMEOUT,
     MAX_CONCURRENT_CONNECTION_ATTEMPTS,
     REQUEST_PEER_CANDIDATE_TIMEOUT,
@@ -82,9 +80,6 @@ from p2p.tracking.connection import (
     BaseConnectionTracker,
     NoopConnectionTracker,
 )
-
-
-TO_DISCOVERY_BROADCAST_CONFIG = BroadcastConfig(filter_endpoint=DISCOVERY_EVENTBUS_ENDPOINT)
 
 
 COMMON_PEER_CONNECTION_EXCEPTIONS = cast(Tuple[Type[BaseP2PError], ...], (

--- a/scripts/discovery.py
+++ b/scripts/discovery.py
@@ -1,135 +1,83 @@
 import argparse
 import functools
 import logging
-from pathlib import Path
 from typing import Set
 import uuid
 
 import trio
 
-from eth_keys import keys
-
-from eth_utils import DEBUG2_LEVEL_NUM
-
-from async_service import background_trio_service
-
 from lahja import ConnectionConfig, TrioEndpoint
 
-from eth.db.atomic import AtomicDB
-from eth.db.backends.memory import MemoryDB
-
-from p2p import kademlia
-from p2p.discovery import DiscoveryService
-from p2p.discv5.enr_db import FileNodeDB
-from p2p.discv5.identity_schemes import default_identity_scheme_registry
+from p2p.events import PeerCandidatesRequest
+from p2p.constants import DISCOVERY_EVENTBUS_ENDPOINT
 from p2p.discv5.typing import NodeID
-from p2p.forkid import extract_fork_blocks
 
-from trinity.components.builtin.peer_discovery.component import generate_eth_cap_enr_field
-from trinity.constants import (
-    MAINNET_NETWORK_ID,
-    NETWORKING_EVENTBUS_ENDPOINT,
-    ROPSTEN_NETWORK_ID
-)
-from trinity.db.eth1.header import TrioHeaderDB
 from trinity.network_configurations import PRECONFIGURED_NETWORKS
-from trinity.protocol.common.peer import extract_forkid, skip_candidate_if_on_list_or_fork_mismatch
+from trinity.protocol.eth.forkid import (
+    extract_fork_blocks,
+    extract_forkid,
+)
+from trinity.protocol.common.peer import skip_candidate_if_on_list_or_fork_mismatch
 
 
 async def main() -> None:
-    parser = argparse.ArgumentParser()
-    parser.add_argument('-bootnode', type=str, help="The enode to use as bootnode")
-    parser.add_argument(
-        '-networkid',
-        type=int,
-        choices=[ROPSTEN_NETWORK_ID, MAINNET_NETWORK_ID],
-        default=ROPSTEN_NETWORK_ID,
-        help="1 for mainnet, 3 for testnet"
-    )
-    parser.add_argument('-l', type=str, help="Log level", default="info")
-    parser.add_argument('-nodedb', type=str, help="Path to Node database")
-    args = parser.parse_args()
-
     logging.basicConfig(
         level=logging.INFO, format='%(asctime)s %(levelname)s: %(message)s', datefmt='%H:%M:%S')
+    logger = logging.getLogger()
 
-    if args.l == "debug2":  # noqa: E741
-        log_level = DEBUG2_LEVEL_NUM
+    parser = argparse.ArgumentParser()
+    parser.add_argument('-ipc', type=str, help="The path to DiscoveryService's IPC file")
+    args = parser.parse_args()
+
+    # XXX: This is an ugly hack, but it's the easiest way to ensure we use the same network as the
+    # DiscoveryService instance we connect to.
+    for n_id, network_cfg in PRECONFIGURED_NETWORKS.items():
+        if network_cfg.data_dir_name in args.ipc:
+            network_id = n_id
+            break
     else:
-        log_level = getattr(logging, args.l.upper())
-    logger = logging.getLogger('p2p')
-    logger.setLevel(log_level)
+        raise AssertionError("Failed to detect network_id")
 
-    node_db_path = Path(args.nodedb)
-    node_db_path.mkdir(exist_ok=True)
-
-    network_cfg = PRECONFIGURED_NETWORKS[args.networkid]
-    # Listen on a port other than 30303 so that we can test against a local geth instance
-    # running on that port.
-    listen_port = 30304
-    # Use a hard-coded privkey so that our enode is always the same.
-    privkey = keys.PrivateKey(
-        b'~\x054{4\r\xd64\x0f\x98\x1e\x85;\xcc\x08\x1eQ\x10t\x16\xc0\xb0\x7f)=\xc4\x1b\xb7/\x8b&\x83')  # noqa: E501
-    addr = kademlia.Address('127.0.0.1', listen_port, listen_port)
-    if args.bootnode:
-        bootstrap_nodes = tuple([kademlia.Node.from_uri(args.bootnode)])
-    else:
-        bootstrap_nodes = tuple(kademlia.Node.from_uri(enode) for enode in network_cfg.bootnodes)
-
-    ipc_path = Path(f"networking-{uuid.uuid4()}.ipc")
-    networking_connection_config = ConnectionConfig(
-        name=NETWORKING_EVENTBUS_ENDPOINT,
-        path=ipc_path
-    )
-
-    headerdb = TrioHeaderDB(AtomicDB(MemoryDB()))
-    headerdb.persist_header(network_cfg.genesis_header)
+    logger.info(f"Asking DiscoveryService for peers on {network_cfg.chain_name}")
+    connection_config = ConnectionConfig(DISCOVERY_EVENTBUS_ENDPOINT, args.ipc)
+    network_cfg = PRECONFIGURED_NETWORKS[network_id]
     vm_config = network_cfg.vm_configuration
     fork_blocks = extract_fork_blocks(vm_config)
-    enr_field_providers = (functools.partial(generate_eth_cap_enr_field, vm_config, headerdb),)
-    node_db = FileNodeDB(default_identity_scheme_registry, node_db_path)
-    socket = trio.socket.socket(family=trio.socket.AF_INET, type=trio.socket.SOCK_DGRAM)
-    await socket.bind(('0.0.0.0', listen_port))
     MAX_PEERS = 60
     skip_list: Set[NodeID] = set()
-    async with TrioEndpoint.serve(networking_connection_config) as endpoint:
-        service = DiscoveryService(
-            privkey, addr, bootstrap_nodes, endpoint, socket, node_db, enr_field_providers)
-        async with background_trio_service(service):
-            # Loop forever, querying DiscoveryService for connection candidates with a ForkID that
-            # matches our network_cfg parameters.
-            while True:
-                # Give DiscoveryService some time to bootstrap and get some entries in the RT
-                # before we start asking for candidates.
-                await trio.sleep(5)
-                if service._lookup_lock.locked():
-                    logger.info("Discovery lookup still in progress, waiting a bit more")
-                    continue
+    async with TrioEndpoint(f"discv4-driver-{uuid.uuid4()}").run() as client:
+        with trio.fail_after(2):
+            await client.connect_to_endpoints(connection_config)
+            await client.wait_until_any_endpoint_subscribed_to(PeerCandidatesRequest)
 
-                logger.info("Skip list has %d peers", len(skip_list))
-                should_skip = functools.partial(
-                    skip_candidate_if_on_list_or_fork_mismatch,
-                    network_cfg.genesis_header.hash,
-                    network_cfg.genesis_header.block_number,
-                    fork_blocks,
-                    skip_list,
-                )
-                candidates = service.get_peer_candidates(should_skip, MAX_PEERS)
-                missing_forkid = [
-                    candidate.id for candidate in candidates
-                    if extract_forkid(candidate.enr) is None
-                ]
-                logger.info(
-                    "Got %d connection candidates, %d of those with a matching ForkID",
-                    len(candidates),
-                    len(candidates) - len(missing_forkid),
-                )
+        while True:
+            logger.info("Skip list has %d peers", len(skip_list))
+            should_skip = functools.partial(
+                skip_candidate_if_on_list_or_fork_mismatch,
+                network_cfg.genesis_header.hash,
+                network_cfg.genesis_header.block_number,
+                fork_blocks,
+                skip_list,
+            )
+            with trio.fail_after(2):
+                response = await client.request(PeerCandidatesRequest(MAX_PEERS, should_skip))
+            candidates = response.candidates
+            missing_forkid = [
+                candidate.id for candidate in candidates
+                if extract_forkid(candidate.enr) is None
+            ]
+            logger.info(
+                "Got %d connection candidates, %d of those with a matching ForkID",
+                len(candidates),
+                len(candidates) - len(missing_forkid),
+            )
 
-                # Add candidates with no forkid to the skip list, just so that we keep triggering
-                # random discovery lookups and hopefully come across more candidates with
-                # compatible forkids
-                logger.info("Adding %d candidates with no ForkID to skip list", len(missing_forkid))
-                skip_list.update(missing_forkid)
+            # Add candidates with no forkid to the skip list, just so that we keep triggering
+            # random discovery lookups and hopefully come across more candidates with
+            # compatible forkids
+            logger.info("Adding %d candidates with no ForkID to skip list", len(missing_forkid))
+            skip_list.update(missing_forkid)
+            await trio.sleep(10)
 
 
 if __name__ == "__main__":

--- a/trinity/_utils/socket.py
+++ b/trinity/_utils/socket.py
@@ -104,7 +104,7 @@ class IPCSocketServer(ABC):
                 ipc_path.unlink()
 
     def serve(self, ipc_path: pathlib.Path) -> None:
-        self.logger.debug("Starting %s server over IPC socket: %s", self, ipc_path)
+        self.logger.info("Starting %s server over IPC socket: %s", self, ipc_path)
 
         with socket.socket(socket.AF_UNIX, socket.SOCK_STREAM) as sock:
             # background task to close the socket.

--- a/trinity/components/builtin/peer_discovery/component.py
+++ b/trinity/components/builtin/peer_discovery/component.py
@@ -116,3 +116,12 @@ async def generate_eth_cap_enr_field(
     fork_blocks = forkid.extract_fork_blocks(vm_config)
     our_forkid = forkid.make_forkid(genesis_hash, head.block_number, fork_blocks)
     return (b'eth', sedes.List([forkid.ForkID]).serialize([our_forkid]))
+
+
+async def main() -> None:
+    from trinity.extensibility.component import run_standalone_eth1_component
+    await run_standalone_eth1_component(PeerDiscoveryComponent)
+
+
+if __name__ == "__main__":
+    trio.run(main)

--- a/trinity/extensibility/__init__.py
+++ b/trinity/extensibility/__init__.py
@@ -4,6 +4,7 @@ from trinity.extensibility.asyncio import (  # noqa: F401
 from trinity.extensibility.component import (  # noqa: F401
     Application,
     BaseComponentAPI,
+    BaseIsolatedComponent,
     ComponentAPI,
     run_component,
 )

--- a/trinity/extensibility/asyncio.py
+++ b/trinity/extensibility/asyncio.py
@@ -54,7 +54,7 @@ class AsyncioIsolatedComponent(BaseIsolatedComponent):
     @classmethod
     async def _do_run(cls, boot_info: BootInfo) -> None:
         with child_process_logging(boot_info):
-            endpoint_name = cls._get_endpoint_name()
+            endpoint_name = cls.get_endpoint_name()
             event_bus_service = AsyncioEventBusService(
                 boot_info.trinity_config,
                 endpoint_name,
@@ -64,7 +64,7 @@ class AsyncioIsolatedComponent(BaseIsolatedComponent):
 
                 try:
                     if boot_info.profile:
-                        with profiler(f'profile_{cls._get_endpoint_name}'):
+                        with profiler(f'profile_{cls.get_endpoint_name()}'):
                             await cls.do_run(boot_info, event_bus)
                     else:
                         await cls.do_run(boot_info, event_bus)


### PR DESCRIPTION
So, these changes allow us to run a DBManager in one terminal and then easily run standalone components, connecting to that DB. My goal here was to be able to run the Discovery component and then use an event-bus client to request peer candidates to it. To do that one simply has to 

```
$ python trinity/db/manager.py -l debug --trinity-root-dir /tmp/discv4-driver
$ python trinity/components/builtin/peer_discovery/component.py -l p2p=debug --trinity-root-dir /tmp/discv4-driver
$ python scripts/discovery.py -ipc /tmp/discv4-driver/mainnet/ipcs-eth1/discovery.ipc
```

This doesn't have an event-bus service like when we run trinity, so all connections between components would have to be established manually. 