### PR TITLE
Reproducing issue from 1526

### DIFF
--- a/p2p/multiplexer.py
+++ b/p2p/multiplexer.py
@@ -101,7 +101,7 @@ class Multiplexer(CancellableMixin, MultiplexerAPI):
     _transport: TransportAPI
     _msg_counts: DefaultDict[Type[CommandAPI[Any]], int]
 
-    _protocol_locks: ResourceLock
+    _protocol_locks: ResourceLock[Type[ProtocolAPI]]
     _protocol_queues: Dict[Type[ProtocolAPI], 'asyncio.Queue[CommandAPI[Any]]']
 
     def __init__(self,

--- a/p2p/peer_pool.py
+++ b/p2p/peer_pool.py
@@ -3,6 +3,7 @@ import asyncio
 import functools
 import operator
 from typing import (
+    AsyncContextManager,
     AsyncIterator,
     AsyncIterable,
     Callable,
@@ -114,6 +115,8 @@ class BasePeerPool(BaseService, AsyncIterable[BasePeer]):
     _report_interval = 60
     _peer_boot_timeout = DEFAULT_PEER_BOOT_TIMEOUT
     _event_bus: EndpointAPI = None
+
+    _handshake_locks: ResourceLock[NodeAPI]
 
     def __init__(self,
                  privkey: datatypes.PrivateKey,
@@ -425,7 +428,7 @@ class BasePeerPool(BaseService, AsyncIterable[BasePeer]):
                 loop=self.get_event_loop(),
             )
 
-    def lock_node_for_handshake(self, node: NodeAPI) -> asyncio.Lock:
+    def lock_node_for_handshake(self, node: NodeAPI) -> AsyncContextManager[None]:
         return self._handshake_locks.lock(node)
 
     def is_connected_to_node(self, node: NodeAPI) -> bool:

--- a/p2p/resource_lock.py
+++ b/p2p/resource_lock.py
@@ -1,24 +1,41 @@
 import asyncio
+from collections import defaultdict
 from collections.abc import Hashable
-import weakref
+from typing import AsyncIterator, DefaultDict, Dict, Generic, TypeVar
+
+from async_generator import asynccontextmanager
 
 
-class ResourceLock:
+TResource = TypeVar('TResource', bound=Hashable)
+
+
+class ResourceLock(Generic[TResource]):
     """
     Manage a set of locks for some set of hashable resources.
     """
-    _locks: 'weakref.WeakKeyDictionary[Hashable, asyncio.Lock]'
+    _locks: Dict[TResource, asyncio.Lock]
+    _reference_counts: DefaultDict[TResource, int]
 
     def __init__(self) -> None:
-        self._locks = weakref.WeakKeyDictionary()
+        self._locks = {}
+        self._reference_counts = defaultdict(int)
 
-    def lock(self, resource: Hashable) -> asyncio.Lock:
+    @asynccontextmanager
+    async def lock(self, resource: TResource) -> AsyncIterator[None]:
         if resource not in self._locks:
             self._locks[resource] = asyncio.Lock()
-        lock = self._locks[resource]
-        return lock
 
-    def is_locked(self, resource: Hashable) -> bool:
+        try:
+            self._reference_counts[resource] += 1
+            async with self._locks[resource]:
+                yield
+        finally:
+            self._reference_counts[resource] -= 1
+            if self._reference_counts[resource] <= 0:
+                del self._reference_counts[resource]
+                del self._locks[resource]
+
+    def is_locked(self, resource: TResource) -> bool:
         if resource not in self._locks:
             return False
         else:

--- a/p2p/resource_lock.py
+++ b/p2p/resource_lock.py
@@ -3,7 +3,10 @@ from collections import defaultdict
 from collections.abc import Hashable
 from typing import AsyncIterator, DefaultDict, Dict, Generic, TypeVar
 
-from async_generator import asynccontextmanager
+try:
+    from contextlib import asynccontextmanager
+except ImportError:
+    from async_generator import asynccontextmanager
 
 
 TResource = TypeVar('TResource', bound=Hashable)

--- a/tests/p2p/test_resource_lock.py
+++ b/tests/p2p/test_resource_lock.py
@@ -1,0 +1,58 @@
+import asyncio
+import random
+
+from hypothesis import (
+    given,
+    strategies as st,
+)
+import pytest
+
+from p2p.resource_lock import ResourceLock
+
+
+async def _yield_to_loop_some():
+    for _ in range(random.randint(0, 5)):
+        await asyncio.sleep(0)
+
+
+class Resource:
+    is_available = True
+
+    async def consume(self):
+        assert self.is_available
+        self.is_available = False
+        try:
+            await _yield_to_loop_some()
+        finally:
+            self.is_available = True
+
+
+@given(
+    num_consumers=st.integers(min_value=0, max_value=100),
+)
+@pytest.mark.asyncio
+async def test_resource_lock(num_consumers):
+    """
+    The lock is tested by fuzzing it against multiple consumers that all try to
+    acquire the same resource.  Each consumer randomly yields to the event loop
+    a few times between each context switch to better guarantee that different
+    race conditions are covered.
+    """
+    resource_lock = ResourceLock()
+    resource = Resource()
+
+    async def consume_resource():
+        await _yield_to_loop_some()
+
+        async with resource_lock.lock(resource):
+            await _yield_to_loop_some()
+            await resource.consume()
+            await _yield_to_loop_some()
+
+    await asyncio.gather(*(
+        consume_resource()
+        for i in range(num_consumers)
+    ))
+
+    assert resource not in resource_lock._locks
+    assert resource not in resource_lock._reference_counts


### PR DESCRIPTION
### What was wrong?

#1526 has an issue. Buried in the latest fix is a bug that will be even harder to track it down and see what's going on.  I want to see if we can find a different solution.

### How was it fixed?

Checking to see if the builtin `asynccontextmanager` will solve it.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

[//]: # (See: https://trinity-client.readthedocs.io/en/latest/contributing.html#pull-requests)
- [ ] Add entry to the [release notes](https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses]()
