### PR TITLE
Catch UnknownAPI error & log fixup

### DIFF
--- a/p2p/discovery.py
+++ b/p2p/discovery.py
@@ -550,7 +550,7 @@ class DiscoveryService(Service):
                 eth_utils.toolz.unique(closest), target_id)[:constants.KADEMLIA_BUCKET_SIZE]
             nodes_to_ask = _exclude_if_asked(closest)
 
-        self.logger.info(
+        self.logger.debug(
             "lookup finished for target %s; closest neighbours: %s", to_hex(target_id), closest
         )
         return tuple(closest)

--- a/trinity/protocol/common/peer.py
+++ b/trinity/protocol/common/peer.py
@@ -25,6 +25,7 @@ from p2p.disconnect import DisconnectReason
 from p2p.exceptions import (
     NoConnectedPeers,
     PeerConnectionLost,
+    UnknownAPI,
 )
 from p2p.peer import (
     BasePeer,
@@ -158,7 +159,7 @@ class BaseChainPeerPool(BasePeerPool):
             raise NoConnectedPeers("No connected peers")
 
         td_getter = excepts(
-            PeerConnectionLost,
+            (PeerConnectionLost, UnknownAPI),
             operator.attrgetter('head_info.head_td'),
             lambda _: 0,
         )


### PR DESCRIPTION
### What was wrong?

A bug in #1525 -- Not all `UnknownAPI` exceptions were replaced by `PeerConnectionLost`.

### How was it fixed?

We need to catch both exceptions.

Bonus change: the "lookup finished for target" log was moved to `debug`.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

[//]: # (See: https://trinity-client.readthedocs.io/en/latest/contributing.html#pull-requests)
- [x] Add entry to the [release notes](https://github.com/ethereum/trinity/blob/master/newsfragments/README.md) (nothing to add)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://dnl7t01l0fo05.cloudfront.net/wp-content/uploads/2017/06/animals-hugging-lifestyle-12.jpg)
