### PR TITLE
Move the forkid package under trinity/protocol/eth

### DIFF
--- a/p2p/discovery.py
+++ b/p2p/discovery.py
@@ -24,11 +24,8 @@ from typing import (
     Sequence,
     Set,
     Tuple,
-    Type,
     TypeVar,
-    TYPE_CHECKING,
 )
-from typing_extensions import Literal
 
 from async_generator import aclosing
 
@@ -47,7 +44,7 @@ from lahja import (
 import rlp
 from rlp.exceptions import DeserializationError
 
-from eth_typing import BlockNumber, Hash32
+from eth_typing import Hash32
 
 from eth_utils import (
     encode_hex,
@@ -67,9 +64,6 @@ from eth_hash.auto import keccak
 
 from async_service import Service
 
-from eth.abc import VirtualMachineAPI
-from eth.constants import GENESIS_BLOCK_NUMBER
-
 from p2p import constants
 from p2p.abc import AddressAPI, ENR_FieldProvider, NodeAPI
 from p2p.discv5.abc import EnrDbApi
@@ -88,12 +82,8 @@ from p2p.events import (
     PeerCandidatesResponse,
 )
 from p2p.exceptions import AlreadyWaitingDiscoveryResponse, CouldNotRetrieveENR, NoEligibleNodes
-from p2p import forkid
 from p2p.kademlia import Address, Node, RoutingTable, check_relayed_addr, sort_by_distance
 from p2p import trio_utils
-
-if TYPE_CHECKING:
-    from trinity.db.eth1.header import BaseAsyncHeaderDB
 
 
 # V4 handler are async methods that take a Node, payload and msg_hash as arguments.
@@ -1212,17 +1202,6 @@ class ExpectedResponseChannels(Generic[TMsg]):
                     yield await recv_chan.receive()
         finally:
             self._channels.pop(remote, None)
-
-
-async def generate_eth_cap_enr_field(
-        vm_config: Tuple[Tuple[BlockNumber, Type[VirtualMachineAPI]], ...],
-        headerdb: 'BaseAsyncHeaderDB',
-) -> Tuple[Literal[b'eth'], Tuple[forkid.ForkID]]:
-    head = await headerdb.coro_get_canonical_head()
-    genesis_hash = await headerdb.coro_get_canonical_block_hash(GENESIS_BLOCK_NUMBER)
-    fork_blocks = forkid.extract_fork_blocks(vm_config)
-    our_forkid = forkid.make_forkid(genesis_hash, head.block_number, fork_blocks)
-    return (b'eth', (our_forkid,))
 
 
 def node_id_from_pubkey(pubkey: keys.PublicKey) -> NodeID:

--- a/p2p/discv5/enr.py
+++ b/p2p/discv5/enr.py
@@ -25,7 +25,6 @@ from rlp.sedes import (
     big_endian_int,
     binary,
     Binary,
-    List,
     raw,
 )
 
@@ -52,7 +51,6 @@ from p2p.discv5.constants import (
     IP_V4_SIZE,
     IP_V6_SIZE,
 )
-from p2p.forkid import ForkID
 
 
 class ENRContentSedes:
@@ -369,13 +367,6 @@ class ENR(BaseENR, ENRSedes):
             unpadded_base64_rlp.decode("ASCII"),
         ))
 
-    @property
-    def fork_id(self) -> ForkID:
-        eth_cap = self._kv_pairs.get(b'eth', None)
-        if eth_cap is not None:
-            return eth_cap[0]
-        return None
-
 
 IDENTITY_SCHEME_ENR_KEY = b"id"
 
@@ -388,9 +379,6 @@ ENR_KEY_SEDES_MAPPING = {
     b"ip6": Binary.fixed_length(IP_V6_SIZE),
     b"tcp6": big_endian_int,
     b"udp6": big_endian_int,
-    # For now this key is used only for ForkIDs (https://eips.ethereum.org/EIPS/eip-2124) but it
-    # is represented as a List because more stuff (e.g. network-id) may be added in the future.
-    b"eth": List([ForkID]),
 }
 
 # Must use raw for values with an unknown key as they may be lists or individual values.

--- a/p2p/exceptions.py
+++ b/p2p/exceptions.py
@@ -206,30 +206,6 @@ class UnknownAPI(BaseP2PError):
     pass
 
 
-class BaseForkIDValidationError(BaseP2PError):
-    """
-    Base class for all ForkID validation errors.
-
-    """
-    pass
-
-
-class RemoteChainIsStale(BaseForkIDValidationError):
-    """
-    Raised when a remote fork ID is a subset of our already applied forks, but the announced next
-    fork block is not on our already passed chain.
-    """
-    pass
-
-
-class LocalChainIncompatibleOrStale(BaseForkIDValidationError):
-    """
-    Raised when a remote fork ID does not match any local checksum variation, signalling that the
-    two chains have diverged in the past at some point (possibly at genesis).
-    """
-    pass
-
-
 class CouldNotRetrieveENR(BaseP2PError):
     """
     Raised when we cannot get an ENR from a remote node.

--- a/scripts/discovery.py
+++ b/scripts/discovery.py
@@ -19,12 +19,13 @@ from eth.db.atomic import AtomicDB
 from eth.db.backends.memory import MemoryDB
 
 from p2p import kademlia
-from p2p.discovery import DiscoveryService, generate_eth_cap_enr_field
+from p2p.discovery import DiscoveryService
 from p2p.discv5.enr_db import FileEnrDb
 from p2p.discv5.identity_schemes import default_identity_scheme_registry
 from p2p.discv5.typing import NodeID
 from p2p.forkid import extract_fork_blocks
 
+from trinity.components.builtin.peer_discovery.component import generate_eth_cap_enr_field
 from trinity.constants import (
     MAINNET_NETWORK_ID,
     NETWORKING_EVENTBUS_ENDPOINT,
@@ -32,7 +33,7 @@ from trinity.constants import (
 )
 from trinity.db.eth1.header import TrioHeaderDB
 from trinity.network_configurations import PRECONFIGURED_NETWORKS
-from trinity.protocol.common.peer import skip_candidate_if_on_list_or_fork_mismatch
+from trinity.protocol.common.peer import extract_forkid, skip_candidate_if_on_list_or_fork_mismatch
 
 
 async def main() -> None:
@@ -116,7 +117,7 @@ async def main() -> None:
                 candidates = service.get_peer_candidates(should_skip, MAX_PEERS)
                 missing_forkid = [
                     candidate.id for candidate in candidates
-                    if candidate.enr.fork_id is None
+                    if extract_forkid(candidate.enr) is None
                 ]
                 logger.info(
                     "Got %d connection candidates, %d of those with a matching ForkID",

--- a/tests/core/p2p-proto/test_forkid.py
+++ b/tests/core/p2p-proto/test_forkid.py
@@ -9,8 +9,17 @@ from eth_utils import to_bytes
 from eth.chains.mainnet import MAINNET_VM_CONFIGURATION
 from eth.chains.ropsten import ROPSTEN_VM_CONFIGURATION
 
-from p2p.exceptions import RemoteChainIsStale, LocalChainIncompatibleOrStale
-from p2p.forkid import extract_fork_blocks, ForkID, make_forkid, validate_forkid
+from p2p.discv5.enr import ENR
+
+from trinity.exceptions import RemoteChainIsStale, LocalChainIncompatibleOrStale
+from trinity.protocol.eth.forkid import (
+    extract_fork_blocks,
+    extract_forkid,
+    ForkID,
+    make_forkid,
+    validate_forkid,
+)
+
 
 MAINNET_GENESIS_HASH = to_bytes(
     hexstr='0xd4e56740f876aef8c010b86a40d5f56745a118d0906a34e69aec8c0db1cb8fa3')
@@ -195,3 +204,11 @@ def test_forkid_validation(local_head, remote_forkid, expected_error):
 def test_rlp_encoding(forkid, expected_rlp):
     assert rlp.encode(forkid) == expected_rlp
     assert rlp.decode(expected_rlp, sedes=ForkID) == forkid
+
+
+def test_extract_forkid():
+    enr = ENR.from_repr(
+        "enr:-Jq4QO5zEyIBU5lSa9iaen0A2xUB5_IVrCi1DbyASTTnLV5RJan6aGPr8kU0p0MYKU5YezZgdSUE"
+        "-GOBEio6Ultyf1Aog2V0aMrJhGN2AZCDGfCggmlkgnY0gmlwhF4_wLuJc2VjcDI1NmsxoQOt7cA_B_Kg"
+        "nQ5RmwyA6ji8M1Y0jfINItRGbOOwy7XgbIN0Y3CCdl-DdWRwgnZf")
+    assert extract_forkid(enr) == ForkID(hash=to_bytes(hexstr='0x63760190'), next=1700000)

--- a/tests/core/p2p-proto/test_peer_discovery.py
+++ b/tests/core/p2p-proto/test_peer_discovery.py
@@ -1,0 +1,24 @@
+import pytest
+
+from eth_utils import to_bytes
+
+from eth.chains.ropsten import ROPSTEN_GENESIS_HEADER, ROPSTEN_VM_CONFIGURATION
+from eth.db.atomic import AtomicDB
+from eth.db.chain import ChainDB
+
+from p2p.tools.factories.discovery import ENRFactory
+
+from trinity.components.builtin.peer_discovery.component import generate_eth_cap_enr_field
+from trinity.db.eth1.header import AsyncHeaderDB
+from trinity.protocol.eth.forkid import extract_forkid, ForkID
+
+
+@pytest.mark.asyncio
+async def test_generate_eth_cap_enr_field():
+    base_db = AtomicDB()
+    ChainDB(base_db).persist_header(ROPSTEN_GENESIS_HEADER)
+
+    enr_field = await generate_eth_cap_enr_field(ROPSTEN_VM_CONFIGURATION, AsyncHeaderDB(base_db))
+
+    enr = ENRFactory(custom_kv_pairs={enr_field[0]: enr_field[1]})
+    assert extract_forkid(enr) == ForkID(hash=to_bytes(hexstr='0x30c7ddbc'), next=10)

--- a/tests/p2p/discv5/test_enr.py
+++ b/tests/p2p/discv5/test_enr.py
@@ -6,7 +6,6 @@ import rlp
 
 from eth_utils import (
     decode_hex,
-    to_bytes,
     ValidationError,
 )
 from eth_utils.toolz import (
@@ -24,7 +23,6 @@ from p2p.discv5.identity_schemes import (
     V4IdentityScheme,
     IdentitySchemeRegistry,
 )
-from p2p.forkid import ForkID
 
 
 # Source: https://github.com/fjl/EIPs/blob/0acb5939555cbd0efcdd04da0d3acb0cc81d049a/EIPS/eip-778.md
@@ -62,7 +60,7 @@ REAL_LIFE_TEST_DATA = {
     "identity_scheme": V4IdentityScheme,
     "sequence_number": 40,
     "kv_pairs": {
-        b"eth": (ForkID(hash=to_bytes(hexstr='0x63760190'), next=1700000), ),
+        b"eth": [[b'cv\x01\x90', b'\x19\xf0\xa0']],
         b"id": b"v4",
         b"ip": decode_hex("5e3fc0bb"),
         b"secp256k1": decode_hex(
@@ -395,7 +393,6 @@ def test_official_test_vector():
     assert enr.node_id == OFFICIAL_TEST_DATA["node_id"]
     assert enr.identity_scheme is OFFICIAL_TEST_DATA["identity_scheme"]
     assert repr(enr) == OFFICIAL_TEST_DATA["repr"]
-    assert enr.fork_id is None
 
     unsigned_enr = UnsignedENR(enr.sequence_number, dict(enr))
     reconstructed_enr = unsigned_enr.to_signed_enr(OFFICIAL_TEST_DATA["private_key"])
@@ -411,4 +408,3 @@ def test_real_life_test_vector():
     assert enr.identity_scheme is REAL_LIFE_TEST_DATA["identity_scheme"]
     assert dict(enr) == REAL_LIFE_TEST_DATA["kv_pairs"]
     assert repr(enr) == REAL_LIFE_TEST_DATA["repr"]
-    assert enr.fork_id == ForkID(hash=to_bytes(hexstr='0x63760190'), next=1700000)

--- a/trinity/exceptions.py
+++ b/trinity/exceptions.py
@@ -92,3 +92,27 @@ class RpcError(BaseTrinityError):
     Raised when a JSON-RPC API request can not be fulfilled.
     """
     pass
+
+
+class BaseForkIDValidationError(BaseTrinityError):
+    """
+    Base class for all ForkID validation errors.
+
+    """
+    pass
+
+
+class RemoteChainIsStale(BaseForkIDValidationError):
+    """
+    Raised when a remote fork ID is a subset of our already applied forks, but the announced next
+    fork block is not on our already passed chain.
+    """
+    pass
+
+
+class LocalChainIncompatibleOrStale(BaseForkIDValidationError):
+    """
+    Raised when a remote fork ID does not match any local checksum variation, signalling that the
+    two chains have diverged in the past at some point (possibly at genesis).
+    """
+    pass

--- a/trinity/protocol/eth/forkid.py
+++ b/trinity/protocol/eth/forkid.py
@@ -13,7 +13,9 @@ from eth_typing import BlockNumber, Hash32
 
 from eth_utils import encode_hex, to_tuple
 
-from p2p.exceptions import RemoteChainIsStale, LocalChainIncompatibleOrStale
+from p2p.discv5.enr import ENR
+
+from trinity.exceptions import RemoteChainIsStale, LocalChainIncompatibleOrStale
 
 
 class ForkID(rlp.Serializable):
@@ -117,6 +119,14 @@ def validate_forkid(
 
     # Something is very wrong if we get here, but better to accept than reject.
     logging.getLogger('p2p').error("Impossible forkid validation for %s", forkid)
+
+
+def extract_forkid(enr: ENR) -> ForkID:
+    eth_cap = enr.get(b'eth', None)
+    if eth_cap is not None:
+        [forkid] = rlp.sedes.List([ForkID]).deserialize(eth_cap)
+        return forkid
+    return None
 
 
 def _crc_to_bytes(crc: int) -> bytes:


### PR DESCRIPTION
This created circular dependencies so I've moved some globals into a classmethod
in ENRContentSedes and used a local import there to workaround it.

I was thinking that going forward we'd want to refactor the ENR class (and its parents)
into a base ENR and then extend that in trinity, but that's going to be annoying
because the current NodeAPI has an ENR instance attribute. Maybe the right way forward
is to have ENR expose any extra key/value pairs (like the 'eth' one) as raw values
and let callsites decode them? I think that's probably the most future-proof solution