### PR TITLE
Implement eth/64 protocol

### DIFF
--- a/newsfragments/1543.feature.rst
+++ b/newsfragments/1543.feature.rst
@@ -1,0 +1,2 @@
+Implement the ``eth/64`` networking protocol according to
+`EIP 2124 <https://eips.ethereum.org/EIPS/eip-2124>`_

--- a/p2p/abc.py
+++ b/p2p/abc.py
@@ -483,15 +483,15 @@ class HandshakeReceiptAPI(ABC):
 THandshakeReceipt = TypeVar('THandshakeReceipt', bound=HandshakeReceiptAPI)
 
 
-class HandshakerAPI(ABC):
+class HandshakerAPI(ABC, Generic[TProtocol]):
     logger: ExtendedDebugLogger
 
-    protocol_class: Type[ProtocolAPI]
+    protocol_class: Type[TProtocol]
 
     @abstractmethod
     async def do_handshake(self,
                            multiplexer: MultiplexerAPI,
-                           protocol: ProtocolAPI) -> HandshakeReceiptAPI:
+                           protocol: TProtocol) -> HandshakeReceiptAPI:
         """
         Perform the actual handshake for the protocol.
         """

--- a/p2p/handshake.py
+++ b/p2p/handshake.py
@@ -28,6 +28,8 @@ from p2p.abc import (
     MultiplexerAPI,
     NodeAPI,
     TransportAPI,
+    TProtocol,
+    ProtocolAPI,
 )
 from p2p.connection import Connection
 from p2p.constants import DEVP2P_V5
@@ -58,7 +60,7 @@ from p2p.typing import (
 )
 
 
-class Handshaker(HandshakerAPI):
+class Handshaker(HandshakerAPI[TProtocol]):
     """
     Base class that handles the handshake for a given protocol.  The primary
     justification for this class's existence is to house parameters that are
@@ -179,7 +181,7 @@ async def _do_p2p_handshake(transport: TransportAPI,
 
 async def negotiate_protocol_handshakes(transport: TransportAPI,
                                         p2p_handshake_params: DevP2PHandshakeParams,
-                                        protocol_handshakers: Sequence[HandshakerAPI],
+                                        protocol_handshakers: Sequence[HandshakerAPI[ProtocolAPI]],
                                         token: CancelToken,
                                         ) -> Tuple[MultiplexerAPI, DevP2PReceipt, Tuple[HandshakeReceiptAPI, ...]]:  # noqa: E501
     """
@@ -294,7 +296,7 @@ async def negotiate_protocol_handshakes(transport: TransportAPI,
 async def dial_out(remote: NodeAPI,
                    private_key: keys.PrivateKey,
                    p2p_handshake_params: DevP2PHandshakeParams,
-                   protocol_handshakers: Sequence[HandshakerAPI],
+                   protocol_handshakers: Sequence[HandshakerAPI[ProtocolAPI]],
                    token: CancelToken) -> ConnectionAPI:
     """
     Perform the auth and P2P handshakes with the given remote.
@@ -345,7 +347,7 @@ async def receive_dial_in(reader: asyncio.StreamReader,
                           writer: asyncio.StreamWriter,
                           private_key: keys.PrivateKey,
                           p2p_handshake_params: DevP2PHandshakeParams,
-                          protocol_handshakers: Sequence[HandshakerAPI],
+                          protocol_handshakers: Sequence[HandshakerAPI[ProtocolAPI]],
                           token: CancelToken) -> Connection:
     transport = await Transport.receive_connection(
         reader=reader,

--- a/p2p/peer.py
+++ b/p2p/peer.py
@@ -474,7 +474,7 @@ class BasePeerFactory(ABC):
         self.event_bus = event_bus
 
     @abstractmethod
-    async def get_handshakers(self) -> Tuple[HandshakerAPI, ...]:
+    async def get_handshakers(self) -> Tuple[HandshakerAPI[ProtocolAPI], ...]:
         ...
 
     async def handshake(self, remote: NodeAPI) -> BasePeer:

--- a/p2p/peer.py
+++ b/p2p/peer.py
@@ -179,10 +179,10 @@ class BasePeer(BaseService):
         return NoopConnectionTracker()
 
     def __str__(self) -> str:
-        return f"{self.__class__.__name__} {self.session}"
+        return f"{self.__class__.__name__} {self.sub_proto} {self.session}"
 
     def __repr__(self) -> str:
-        return f"{self.__class__.__name__} {self.session!r}"
+        return f"{self.__class__.__name__} {self.sub_proto!r} {self.session!r}"
 
     #
     # Proxy Transport attributes

--- a/p2p/tools/factories/connection.py
+++ b/p2p/tools/factories/connection.py
@@ -7,7 +7,7 @@ from cancel_token import CancelToken
 
 from eth_keys import keys
 
-from p2p.abc import ConnectionAPI, HandshakerAPI, NodeAPI
+from p2p.abc import ConnectionAPI, HandshakerAPI, NodeAPI, ProtocolAPI
 from p2p.connection import Connection
 from p2p.constants import DEVP2P_V5
 from p2p.handshake import (
@@ -24,8 +24,8 @@ from .transport import MemoryTransportPairFactory
 
 @asynccontextmanager
 async def ConnectionPairFactory(*,
-                                alice_handshakers: Tuple[HandshakerAPI, ...] = (),
-                                bob_handshakers: Tuple[HandshakerAPI, ...] = (),
+                                alice_handshakers: Tuple[HandshakerAPI[ProtocolAPI], ...] = (),
+                                bob_handshakers: Tuple[HandshakerAPI[ProtocolAPI], ...] = (),
                                 alice_remote: NodeAPI = None,
                                 alice_private_key: keys.PrivateKey = None,
                                 alice_client_version: str = 'alice',

--- a/p2p/tools/handshake.py
+++ b/p2p/tools/handshake.py
@@ -5,7 +5,7 @@ from p2p.handshake import Handshaker
 from p2p.receipt import HandshakeReceipt
 
 
-class NoopHandshaker(Handshaker):
+class NoopHandshaker(Handshaker[ProtocolAPI]):
     def __init__(self, protocol_class: Type[ProtocolAPI]) -> None:
         self.protocol_class = protocol_class
 

--- a/p2p/tools/paragon/peer.py
+++ b/p2p/tools/paragon/peer.py
@@ -1,6 +1,7 @@
 from typing import (
     Iterable,
     Tuple,
+    Any,
 )
 
 from cached_property import cached_property
@@ -46,12 +47,12 @@ class ParagonContext(BasePeerContext):
         super().__init__(client_version_string, listen_port, p2p_version)
 
 
-class ParagonHandshaker(Handshaker):
+class ParagonHandshaker(Handshaker[ParagonProtocol]):
     protocol_class = ParagonProtocol
 
     async def do_handshake(self,
                            multiplexer: MultiplexerAPI,
-                           protocol: ProtocolAPI) -> HandshakeReceipt:
+                           protocol: ParagonProtocol) -> HandshakeReceipt:
         return HandshakeReceipt(protocol)
 
 
@@ -59,7 +60,7 @@ class ParagonPeerFactory(BasePeerFactory):
     peer_class = ParagonPeer
     context: ParagonContext
 
-    async def get_handshakers(self) -> Tuple[HandshakerAPI, ...]:
+    async def get_handshakers(self) -> Tuple[HandshakerAPI[Any], ...]:
         return (ParagonHandshaker(),)
 
 

--- a/p2p/tools/paragon/peer.py
+++ b/p2p/tools/paragon/peer.py
@@ -10,7 +10,7 @@ from p2p.abc import HandshakerAPI, MultiplexerAPI
 from p2p.handshake import Handshaker
 from p2p.receipt import HandshakeReceipt
 
-from p2p.abc import BehaviorAPI, ProtocolAPI
+from p2p.abc import BehaviorAPI
 from p2p.constants import DEVP2P_V5
 from p2p.peer import (
     BasePeer,

--- a/tests/core/p2p-proto/test_eth_proto.py
+++ b/tests/core/p2p-proto/test_eth_proto.py
@@ -16,6 +16,7 @@ from trinity.protocol.eth.commands import (
     Receipts,
     Status,
     Transactions,
+    StatusV63,
 )
 
 from trinity.tools.factories import (
@@ -32,12 +33,14 @@ from trinity.tools.factories.eth import (
     NewBlockHashFactory,
     NewBlockPayloadFactory,
     StatusPayloadFactory,
+    StatusV63PayloadFactory,
 )
 
 
 @pytest.mark.parametrize(
     'command_type,payload',
     (
+        (StatusV63, StatusV63PayloadFactory()),
         (Status, StatusPayloadFactory()),
         (NewBlockHashes, tuple(NewBlockHashFactory.create_batch(2))),
         (Transactions, tuple(BaseTransactionFieldsFactory.create_batch(2))),

--- a/tests/core/p2p-proto/test_peer.py
+++ b/tests/core/p2p-proto/test_peer.py
@@ -5,7 +5,7 @@ import pytest
 from p2p.disconnect import DisconnectReason
 
 from trinity.protocol.eth.peer import ETHPeer
-from trinity.protocol.eth.proto import ETHProtocolV63
+from trinity.protocol.eth.proto import ETHProtocol, ETHProtocolV63
 from trinity.protocol.les.peer import LESPeer
 from trinity.protocol.les.proto import (
     LESProtocolV1,
@@ -21,6 +21,7 @@ from trinity.tools.factories import (
 from tests.core.peer_helpers import (
     MockPeerPoolWithConnectedPeers,
 )
+from trinity.tools.factories.eth.proto import ETHV63PeerPairFactory
 
 
 @pytest.mark.asyncio
@@ -44,13 +45,23 @@ async def test_LES_v2_peers():
 
 
 @pytest.mark.asyncio
-async def test_ETH_peers():
-    async with ETHPeerPairFactory() as (alice, bob):
+async def test_ETH_v63_peers():
+    async with ETHV63PeerPairFactory() as (alice, bob):
         assert isinstance(alice, ETHPeer)
         assert isinstance(bob, ETHPeer)
 
         assert isinstance(alice.sub_proto, ETHProtocolV63)
         assert isinstance(bob.sub_proto, ETHProtocolV63)
+
+
+@pytest.mark.asyncio
+async def test_ETH_peers():
+    async with ETHPeerPairFactory() as (alice, bob):
+        assert isinstance(alice, ETHPeer)
+        assert isinstance(bob, ETHPeer)
+
+        assert isinstance(alice.sub_proto, ETHProtocol)
+        assert isinstance(bob.sub_proto, ETHProtocol)
 
 
 @pytest.mark.asyncio

--- a/tests/core/p2p-proto/test_peer.py
+++ b/tests/core/p2p-proto/test_peer.py
@@ -5,7 +5,7 @@ import pytest
 from p2p.disconnect import DisconnectReason
 
 from trinity.protocol.eth.peer import ETHPeer
-from trinity.protocol.eth.proto import ETHProtocol
+from trinity.protocol.eth.proto import ETHProtocolV63
 from trinity.protocol.les.peer import LESPeer
 from trinity.protocol.les.proto import (
     LESProtocolV1,
@@ -49,8 +49,8 @@ async def test_ETH_peers():
         assert isinstance(alice, ETHPeer)
         assert isinstance(bob, ETHPeer)
 
-        assert isinstance(alice.sub_proto, ETHProtocol)
-        assert isinstance(bob.sub_proto, ETHProtocol)
+        assert isinstance(alice.sub_proto, ETHProtocolV63)
+        assert isinstance(bob.sub_proto, ETHProtocolV63)
 
 
 @pytest.mark.asyncio

--- a/tests/integration/test_trinity_cli.py
+++ b/tests/integration/test_trinity_cli.py
@@ -202,7 +202,7 @@ async def test_web3_commands_via_attached_console(command,
             attached_trinity.expect_exact("'listenAddr': '[::]")
             attached_trinity.expect_exact("'name': 'Trinity/")
             attached_trinity.expect_exact("'ports': AttributeDict({")
-            attached_trinity.expect_exact("'protocols': AttributeDict({'eth': AttributeDict({'version': 'eth/63'")  # noqa: E501
+            attached_trinity.expect_exact("'protocols': AttributeDict({'eth': AttributeDict({'version': 'eth/64'")  # noqa: E501
             attached_trinity.expect_exact("'difficulty': ")
             attached_trinity.expect_exact(f"'genesis': '{expected_genesis_hash}'")
             attached_trinity.expect_exact("'head': '0x")

--- a/trinity/exceptions.py
+++ b/trinity/exceptions.py
@@ -77,6 +77,16 @@ class WrongNetworkFailure(HandshakeFailure):
 register_error(WrongNetworkFailure, BLACKLIST_SECONDS_WRONG_NETWORK_OR_GENESIS)
 
 
+class WrongForkIDFailure(HandshakeFailure):
+    """
+    Disconnected from the peer because it has an incompatible ForkID
+    """
+    pass
+
+
+register_error(WrongForkIDFailure, BLACKLIST_SECONDS_WRONG_NETWORK_OR_GENESIS)
+
+
 class WrongGenesisFailure(HandshakeFailure):
     """
     Disconnected from the peer because it has a different genesis than we do

--- a/trinity/protocol/common/api.py
+++ b/trinity/protocol/common/api.py
@@ -7,13 +7,13 @@ from p2p.logic import Application
 from p2p.qualifiers import HasProtocol
 
 from trinity.protocol.eth.api import ETHAPI
-from trinity.protocol.eth.proto import ETHProtocol
+from trinity.protocol.eth.proto import ETHProtocolV63
 from trinity.protocol.les.api import LESV1API, LESV2API
 from trinity.protocol.les.proto import LESProtocolV1, LESProtocolV2
 
 from .abc import ChainInfoAPI, HeadInfoAPI
 
-AnyETHLES = HasProtocol(ETHProtocol) | HasProtocol(LESProtocolV2) | HasProtocol(LESProtocolV1)
+AnyETHLES = HasProtocol(ETHProtocolV63) | HasProtocol(LESProtocolV2) | HasProtocol(LESProtocolV1)
 
 
 class ChainInfo(Application, ChainInfoAPI):
@@ -30,7 +30,7 @@ class ChainInfo(Application, ChainInfoAPI):
         return self._get_logic().genesis_hash
 
     def _get_logic(self) -> Union[ETHAPI, LESV1API, LESV2API]:
-        if self.connection.has_protocol(ETHProtocol):
+        if self.connection.has_protocol(ETHProtocolV63):
             return self.connection.get_logic(ETHAPI.name, ETHAPI)
         elif self.connection.has_protocol(LESProtocolV2):
             return self.connection.get_logic(LESV2API.name, LESV2API)
@@ -47,7 +47,7 @@ class HeadInfo(Application, HeadInfoAPI):
 
     @cached_property
     def _tracker(self) -> HeadInfoAPI:
-        if self.connection.has_protocol(ETHProtocol):
+        if self.connection.has_protocol(ETHProtocolV63):
             eth_logic = self.connection.get_logic(ETHAPI.name, ETHAPI)
             return eth_logic.head_info
         elif self.connection.has_protocol(LESProtocolV2):

--- a/trinity/protocol/common/api.py
+++ b/trinity/protocol/common/api.py
@@ -6,14 +6,15 @@ from eth_typing import BlockNumber, Hash32
 from p2p.logic import Application
 from p2p.qualifiers import HasProtocol
 
-from trinity.protocol.eth.api import ETHAPI
-from trinity.protocol.eth.proto import ETHProtocolV63
+from trinity.protocol.eth.api import ETHV63API, ETHAPI
+from trinity.protocol.eth.proto import ETHProtocolV63, ETHProtocol
 from trinity.protocol.les.api import LESV1API, LESV2API
 from trinity.protocol.les.proto import LESProtocolV1, LESProtocolV2
 
 from .abc import ChainInfoAPI, HeadInfoAPI
 
-AnyETHLES = HasProtocol(ETHProtocolV63) | HasProtocol(LESProtocolV2) | HasProtocol(LESProtocolV1)
+AnyETHLES = HasProtocol(ETHProtocol) | HasProtocol(ETHProtocolV63) | HasProtocol(
+    LESProtocolV2) | HasProtocol(LESProtocolV1)
 
 
 class ChainInfo(Application, ChainInfoAPI):
@@ -29,9 +30,11 @@ class ChainInfo(Application, ChainInfoAPI):
     def genesis_hash(self) -> Hash32:
         return self._get_logic().genesis_hash
 
-    def _get_logic(self) -> Union[ETHAPI, LESV1API, LESV2API]:
-        if self.connection.has_protocol(ETHProtocolV63):
+    def _get_logic(self) -> Union[ETHAPI, ETHV63API, LESV1API, LESV2API]:
+        if self.connection.has_protocol(ETHProtocol):
             return self.connection.get_logic(ETHAPI.name, ETHAPI)
+        elif self.connection.has_protocol(ETHProtocolV63):
+            return self.connection.get_logic(ETHV63API.name, ETHV63API)
         elif self.connection.has_protocol(LESProtocolV2):
             return self.connection.get_logic(LESV2API.name, LESV2API)
         elif self.connection.has_protocol(LESProtocolV1):
@@ -47,9 +50,12 @@ class HeadInfo(Application, HeadInfoAPI):
 
     @cached_property
     def _tracker(self) -> HeadInfoAPI:
-        if self.connection.has_protocol(ETHProtocolV63):
+        if self.connection.has_protocol(ETHProtocol):
             eth_logic = self.connection.get_logic(ETHAPI.name, ETHAPI)
             return eth_logic.head_info
+        elif self.connection.has_protocol(ETHProtocolV63):
+            eth_v63_logic = self.connection.get_logic(ETHV63API.name, ETHV63API)
+            return eth_v63_logic.head_info
         elif self.connection.has_protocol(LESProtocolV2):
             les_v2_logic = self.connection.get_logic(LESV2API.name, LESV2API)
             return les_v2_logic.head_info

--- a/trinity/protocol/common/peer.py
+++ b/trinity/protocol/common/peer.py
@@ -63,12 +63,13 @@ from trinity.constants import TO_NETWORKING_BROADCAST_CONFIG
 from trinity.exceptions import BaseForkIDValidationError
 from trinity.protocol.common.abc import ChainInfoAPI, HeadInfoAPI
 from trinity.protocol.common.api import ChainInfo, HeadInfo
-from trinity.protocol.eth.api import ETHAPI
+from trinity.protocol.eth.api import ETHV63API, ETHAPI
 from trinity.protocol.eth.forkid import (
     extract_fork_blocks,
     extract_forkid,
     validate_forkid,
 )
+from trinity.protocol.eth.proto import ETHProtocol, ETHProtocolV63
 from trinity.protocol.les.api import LESV1API, LESV2API
 from trinity.protocol.les.proto import LESProtocolV1, LESProtocolV2
 
@@ -94,9 +95,14 @@ class BaseChainPeer(BasePeer):
     context: ChainContext
 
     @cached_property
-    def chain_api(self) -> Union[ETHAPI, LESV1API, LESV2API]:
+    def chain_api(self) -> Union[ETHAPI, ETHV63API, LESV1API, LESV2API]:
         if self.connection.has_logic(ETHAPI.name):
-            return self.connection.get_logic(ETHAPI.name, ETHAPI)
+            if self.connection.has_protocol(ETHProtocol):
+                return self.connection.get_logic(ETHAPI.name, ETHAPI)
+            elif self.connection.has_protocol(ETHProtocolV63):
+                return self.connection.get_logic(ETHV63API.name, ETHV63API)
+            else:
+                raise Exception("Should be unreachable")
         elif self.connection.has_logic(LESV1API.name):
             if self.connection.has_protocol(LESProtocolV2):
                 return self.connection.get_logic(LESV2API.name, LESV2API)

--- a/trinity/protocol/eth/api.py
+++ b/trinity/protocol/eth/api.py
@@ -47,7 +47,7 @@ from .payloads import (
     NewBlockPayload,
     StatusPayload,
 )
-from .proto import ETHProtocol
+from .proto import ETHProtocolV63
 
 
 class HeadInfoTracker(CommandHandler[NewBlock], HeadInfoAPI):
@@ -95,7 +95,7 @@ class HeadInfoTracker(CommandHandler[NewBlock], HeadInfoAPI):
 
 class ETHAPI(Application):
     name = 'eth'
-    qualifier = HasProtocol(ETHProtocol)
+    qualifier = HasProtocol(ETHProtocolV63)
 
     head_info: HeadInfoTracker
 
@@ -135,8 +135,8 @@ class ETHAPI(Application):
         )
 
     @cached_property
-    def protocol(self) -> ETHProtocol:
-        return self.connection.get_protocol_by_type(ETHProtocol)
+    def protocol(self) -> ETHProtocolV63:
+        return self.connection.get_protocol_by_type(ETHProtocolV63)
 
     @cached_property
     def receipt(self) -> ETHHandshakeReceipt:

--- a/trinity/protocol/eth/commands.py
+++ b/trinity/protocol/eth/commands.py
@@ -18,13 +18,34 @@ from p2p.commands import BaseCommand, RLPCodec
 from trinity.protocol.common.payloads import BlockHeadersQuery
 from trinity.rlp.block_body import BlockBody
 from trinity.rlp.sedes import HashOrNumber, hash_sedes
+from .forkid import ForkID
 
 from .payloads import (
-    StatusPayload,
+    StatusV63Payload,
     NewBlockHash,
     BlockFields,
     NewBlockPayload,
+    StatusPayload,
 )
+
+
+STATUS_V63_STRUCTURE = sedes.List((
+    sedes.big_endian_int,
+    sedes.big_endian_int,
+    sedes.big_endian_int,
+    hash_sedes,
+    hash_sedes,
+))
+
+
+class StatusV63(BaseCommand[StatusV63Payload]):
+    protocol_command_id = 0
+    serialization_codec: RLPCodec[StatusV63Payload] = RLPCodec(
+        sedes=STATUS_V63_STRUCTURE,
+        process_inbound_payload_fn=compose(
+            lambda args: StatusV63Payload(*args),
+        ),
+    )
 
 
 STATUS_STRUCTURE = sedes.List((
@@ -33,6 +54,7 @@ STATUS_STRUCTURE = sedes.List((
     sedes.big_endian_int,
     hash_sedes,
     hash_sedes,
+    ForkID
 ))
 
 

--- a/trinity/protocol/eth/handshaker.py
+++ b/trinity/protocol/eth/handshaker.py
@@ -1,11 +1,9 @@
-from typing import cast
-
 from cached_property import cached_property
 
 from eth_typing import Hash32
 from eth_utils import encode_hex
 
-from p2p.abc import MultiplexerAPI, ProtocolAPI
+from p2p.abc import MultiplexerAPI
 from p2p.exceptions import (
     HandshakeFailure,
 )
@@ -47,7 +45,7 @@ class ETHHandshakeReceipt(HandshakeReceipt):
         return self.handshake_params.version
 
 
-class ETHHandshaker(Handshaker):
+class ETHHandshaker(Handshaker[ETHProtocol]):
     protocol_class = ETHProtocol
     handshake_params: StatusPayload
 
@@ -56,12 +54,11 @@ class ETHHandshaker(Handshaker):
 
     async def do_handshake(self,
                            multiplexer: MultiplexerAPI,
-                           protocol: ProtocolAPI) -> ETHHandshakeReceipt:
+                           protocol: ETHProtocol) -> ETHHandshakeReceipt:
         """Perform the handshake for the sub-protocol agreed with the remote peer.
 
         Raises HandshakeFailure if the handshake is not successful.
         """
-        protocol = cast(ETHProtocol, protocol)
         protocol.send(Status(self.handshake_params))
 
         async for cmd in multiplexer.stream_protocol_messages(protocol):

--- a/trinity/protocol/eth/handshaker.py
+++ b/trinity/protocol/eth/handshaker.py
@@ -14,13 +14,13 @@ from trinity.exceptions import WrongGenesisFailure, WrongNetworkFailure
 
 from .commands import Status
 from .payloads import StatusPayload
-from .proto import ETHProtocol
+from .proto import ETHProtocolV63
 
 
 class ETHHandshakeReceipt(HandshakeReceipt):
     handshake_params: StatusPayload
 
-    def __init__(self, protocol: ETHProtocol, handshake_params: StatusPayload) -> None:
+    def __init__(self, protocol: ETHProtocolV63, handshake_params: StatusPayload) -> None:
         super().__init__(protocol)
         self.handshake_params = handshake_params
 
@@ -46,7 +46,7 @@ class ETHHandshakeReceipt(HandshakeReceipt):
 
 
 class ETHHandshaker(Handshaker[ETHProtocol]):
-    protocol_class = ETHProtocol
+    protocol_class = ETHProtocolV63
     handshake_params: StatusPayload
 
     def __init__(self, handshake_params: StatusPayload) -> None:

--- a/trinity/protocol/eth/payloads.py
+++ b/trinity/protocol/eth/payloads.py
@@ -4,6 +4,16 @@ from eth_typing import BlockNumber, Hash32
 
 from eth.abc import BlockHeaderAPI, TransactionFieldsAPI
 
+from trinity.protocol.eth.forkid import ForkID
+
+
+class StatusV63Payload(NamedTuple):
+    version: int
+    network_id: int
+    total_difficulty: int
+    head_hash: Hash32
+    genesis_hash: Hash32
+
 
 class StatusPayload(NamedTuple):
     version: int
@@ -11,6 +21,7 @@ class StatusPayload(NamedTuple):
     total_difficulty: int
     head_hash: Hash32
     genesis_hash: Hash32
+    fork_id: ForkID
 
 
 class NewBlockHash(NamedTuple):

--- a/trinity/protocol/eth/peer.py
+++ b/trinity/protocol/eth/peer.py
@@ -121,7 +121,7 @@ class ETHProxyPeer(BaseProxyPeer):
 class ETHPeerFactory(BaseChainPeerFactory):
     peer_class = ETHPeer
 
-    async def get_handshakers(self) -> Tuple[HandshakerAPI, ...]:
+    async def get_handshakers(self) -> Tuple[HandshakerAPI[Any], ...]:
         headerdb = self.context.headerdb
         wait = self.cancel_token.cancellable_wait
 

--- a/trinity/protocol/eth/peer.py
+++ b/trinity/protocol/eth/peer.py
@@ -67,7 +67,7 @@ from .events import (
     TransactionsEvent,
 )
 from .payloads import StatusPayload
-from .proto import ETHProtocol
+from .proto import ETHProtocolV63
 from .proxy import ProxyETHAPI
 from .handshaker import ETHHandshaker
 
@@ -75,8 +75,8 @@ from .handshaker import ETHHandshaker
 class ETHPeer(BaseChainPeer):
     max_headers_fetch = MAX_HEADERS_FETCH
 
-    supported_sub_protocols = (ETHProtocol,)
-    sub_proto: ETHProtocol = None
+    supported_sub_protocols = (ETHProtocolV63,)
+    sub_proto: ETHProtocolV63 = None
 
     def get_behaviors(self) -> Tuple[BehaviorAPI, ...]:
         return super().get_behaviors() + (ETHAPI().as_behavior(),)
@@ -136,7 +136,7 @@ class ETHPeerFactory(BaseChainPeerFactory):
             total_difficulty=total_difficulty,
             genesis_hash=genesis_hash,
             network_id=self.context.network_id,
-            version=ETHProtocol.version,
+            version=ETHProtocolV63.version,
         )
         return (
             ETHHandshaker(handshake_params),

--- a/trinity/protocol/eth/proto.py
+++ b/trinity/protocol/eth/proto.py
@@ -27,7 +27,7 @@ if TYPE_CHECKING:
     from .peer import ETHPeer  # noqa: F401
 
 
-class ETHProtocol(BaseProtocol):
+class ETHProtocolV63(BaseProtocol):
     name = 'eth'
     version = 63
     commands = (

--- a/trinity/protocol/eth/proto.py
+++ b/trinity/protocol/eth/proto.py
@@ -1,5 +1,7 @@
 from typing import (
     TYPE_CHECKING,
+    Union,
+    Type,
 )
 
 from eth_utils import (
@@ -7,7 +9,6 @@ from eth_utils import (
 )
 
 from p2p.protocol import BaseProtocol
-
 from .commands import (
     BlockBodies,
     BlockHeaders,
@@ -19,17 +20,40 @@ from .commands import (
     NewBlockHashes,
     NodeData,
     Receipts,
-    Status,
     Transactions,
+    StatusV63,
+    Status,
 )
 
 if TYPE_CHECKING:
     from .peer import ETHPeer  # noqa: F401
 
 
-class ETHProtocolV63(BaseProtocol):
+class BaseETHProtocol(BaseProtocol):
     name = 'eth'
+    status_command_type: Union[Type[StatusV63], Type[Status]]
+
+
+class ETHProtocolV63(BaseETHProtocol):
     version = 63
+    commands = (
+        StatusV63,
+        NewBlockHashes,
+        Transactions,
+        GetBlockHeaders, BlockHeaders,
+        GetBlockBodies, BlockBodies,
+        NewBlock,
+        GetNodeData, NodeData,
+        GetReceipts, Receipts,
+    )
+    command_length = 17
+
+    logger = get_extended_debug_logger('trinity.protocol.eth.proto.ETHProtocolV63')
+    status_command_type = StatusV63
+
+
+class ETHProtocol(BaseETHProtocol):
+    version = 64
     commands = (
         Status,
         NewBlockHashes,
@@ -43,3 +67,4 @@ class ETHProtocolV63(BaseProtocol):
     command_length = 17
 
     logger = get_extended_debug_logger('trinity.protocol.eth.proto.ETHProtocol')
+    status_command_type = Status

--- a/trinity/protocol/les/handshaker.py
+++ b/trinity/protocol/les/handshaker.py
@@ -1,5 +1,4 @@
 from typing import (
-    cast,
     Type,
     Union,
 )
@@ -9,7 +8,7 @@ from cached_property import cached_property
 from eth_typing import BlockNumber, Hash32
 from eth_utils import encode_hex
 
-from p2p.abc import MultiplexerAPI, ProtocolAPI
+from p2p.abc import MultiplexerAPI
 from p2p.exceptions import (
     HandshakeFailure,
 )
@@ -57,7 +56,7 @@ class LESHandshakeReceipt(HandshakeReceipt):
         return self.handshake_params.genesis_hash
 
 
-class BaseLESHandshaker(Handshaker):
+class BaseLESHandshaker(Handshaker[Union[LESProtocolV1, LESProtocolV2]]):
     handshake_params: StatusPayload
 
     def __init__(self, handshake_params: StatusPayload) -> None:
@@ -67,12 +66,12 @@ class BaseLESHandshaker(Handshaker):
 
     async def do_handshake(self,
                            multiplexer: MultiplexerAPI,
-                           protocol: ProtocolAPI) -> LESHandshakeReceipt:
+                           protocol: Union[LESProtocolV1, LESProtocolV2]) -> LESHandshakeReceipt:
         """Perform the handshake for the sub-protocol agreed with the remote peer.
 
         Raises HandshakeFailure if the handshake is not successful.
         """
-        protocol = cast(AnyLESProtocol, protocol)
+
         protocol.send(protocol.status_command_type(self.handshake_params))
 
         async for cmd in multiplexer.stream_protocol_messages(protocol):

--- a/trinity/protocol/les/peer.py
+++ b/trinity/protocol/les/peer.py
@@ -114,7 +114,7 @@ class LESProxyPeer(BaseProxyPeer):
 class LESPeerFactory(BaseChainPeerFactory):
     peer_class = LESPeer
 
-    async def get_handshakers(self) -> Tuple[HandshakerAPI, ...]:
+    async def get_handshakers(self) -> Tuple[HandshakerAPI[Any], ...]:
         headerdb = self.context.headerdb
         wait = self.cancel_token.cancellable_wait
 

--- a/trinity/tools/factories/__init__.py
+++ b/trinity/tools/factories/__init__.py
@@ -16,6 +16,7 @@ from .les.proto import (  # noqa: F401
 from .eth.proto import (  # noqa: F401
     ETHHandshakerFactory,
     ETHPeerPairFactory,
+    ETHV63PeerPairFactory,
 )
 from .headers import BlockHeaderFactory  # noqa: F401
 from .receipts import ReceiptFactory  # noqa: F401

--- a/trinity/tools/factories/eth/__init__.py
+++ b/trinity/tools/factories/eth/__init__.py
@@ -1,4 +1,5 @@
 from .payloads import (  # noqa: F401
+    StatusV63PayloadFactory,
     StatusPayloadFactory,
     NewBlockHashFactory,
     NewBlockPayloadFactory,

--- a/trinity/tools/factories/eth/payloads.py
+++ b/trinity/tools/factories/eth/payloads.py
@@ -18,7 +18,7 @@ from trinity.protocol.eth.payloads import (
     NewBlockPayload,
     BlockFields,
 )
-from trinity.protocol.eth.proto import ETHProtocol
+from trinity.protocol.eth.proto import ETHProtocolV63
 
 from trinity.tools.factories.block_hash import BlockHashFactory
 from trinity.tools.factories.headers import BlockHeaderFactory
@@ -29,7 +29,7 @@ class StatusPayloadFactory(factory.Factory):
     class Meta:
         model = StatusPayload
 
-    version = ETHProtocol.version
+    version = ETHProtocolV63.version
     network_id = MAINNET_NETWORK_ID
     total_difficulty = 1
     head_hash = factory.SubFactory(BlockHashFactory)

--- a/trinity/tools/factories/eth/payloads.py
+++ b/trinity/tools/factories/eth/payloads.py
@@ -1,3 +1,7 @@
+from eth_typing import BlockNumber
+from eth_utils import to_bytes
+
+from trinity.protocol.eth.forkid import ForkID
 
 try:
     import factory
@@ -13,27 +17,52 @@ from eth.constants import GENESIS_BLOCK_NUMBER
 
 from trinity.constants import MAINNET_NETWORK_ID
 from trinity.protocol.eth.payloads import (
-    StatusPayload,
+    StatusV63Payload,
     NewBlockHash,
     NewBlockPayload,
     BlockFields,
+    StatusPayload,
 )
-from trinity.protocol.eth.proto import ETHProtocolV63
+from trinity.protocol.eth.proto import ETHProtocolV63, ETHProtocol
 
 from trinity.tools.factories.block_hash import BlockHashFactory
 from trinity.tools.factories.headers import BlockHeaderFactory
 from trinity.tools.factories.transactions import BaseTransactionFieldsFactory
 
 
-class StatusPayloadFactory(factory.Factory):
+class StatusV63PayloadFactory(factory.Factory):
     class Meta:
-        model = StatusPayload
+        model = StatusV63Payload
 
     version = ETHProtocolV63.version
     network_id = MAINNET_NETWORK_ID
     total_difficulty = 1
     head_hash = factory.SubFactory(BlockHashFactory)
     genesis_hash = factory.SubFactory(BlockHashFactory)
+
+    @classmethod
+    def from_headerdb(cls, headerdb: HeaderDatabaseAPI, **kwargs: Any) -> StatusV63Payload:
+        head = headerdb.get_canonical_head()
+        head_score = headerdb.get_score(head.hash)
+        genesis = headerdb.get_canonical_block_header_by_number(GENESIS_BLOCK_NUMBER)
+        return cls(
+            head_hash=head.hash,
+            genesis_hash=genesis.hash,
+            total_difficulty=head_score,
+            **kwargs
+        )
+
+
+class StatusPayloadFactory(factory.Factory):
+    class Meta:
+        model = StatusPayload
+
+    version = ETHProtocol.version
+    network_id = MAINNET_NETWORK_ID
+    total_difficulty = 1
+    head_hash = factory.SubFactory(BlockHashFactory)
+    genesis_hash = factory.SubFactory(BlockHashFactory)
+    fork_id = ForkID(to_bytes(hexstr='0xfc64ec04'), BlockNumber(1150000))  # unsynced
 
     @classmethod
     def from_headerdb(cls, headerdb: HeaderDatabaseAPI, **kwargs: Any) -> StatusPayload:
@@ -44,6 +73,7 @@ class StatusPayloadFactory(factory.Factory):
             head_hash=head.hash,
             genesis_hash=genesis.hash,
             total_difficulty=head_score,
+            fork_id=cls.fork_id,
             **kwargs
         )
 

--- a/trinity/tools/factories/eth/proto.py
+++ b/trinity/tools/factories/eth/proto.py
@@ -1,3 +1,6 @@
+from p2p.abc import HandshakerAPI
+from trinity.protocol.eth.proto import ETHProtocolV63
+
 try:
     import factory
 except ImportError:
@@ -7,6 +10,7 @@ from typing import (
     cast,
     AsyncContextManager,
     Tuple,
+    Any,
 )
 
 from lahja import EndpointAPI
@@ -38,11 +42,65 @@ class ETHHandshakerFactory(factory.Factory):
     handshake_params = factory.SubFactory(StatusPayloadFactory)
 
 
+class ETHV63Peer(ETHPeer):
+    supported_sub_protocols = (ETHProtocolV63,)  # type: ignore
+
+
+class ETHV63PeerFactory(ETHPeerFactory):
+    peer_class = ETHV63Peer
+
+    async def get_handshakers(self) -> Tuple[HandshakerAPI[Any], ...]:
+        return tuple(
+            shaker for shaker in await super().get_handshakers()
+            # mypy doesn't know these have a `handshake_params` property
+            if shaker.handshake_params.version == ETHProtocolV63.version  # type: ignore
+        )
+
+
+def ETHV63PeerPairFactory(*,
+                          alice_peer_context: ChainContext = None,
+                          alice_remote: kademlia.Node = None,
+                          alice_private_key: keys.PrivateKey = None,
+                          alice_client_version: str = 'alice',
+                          bob_peer_context: ChainContext = None,
+                          bob_remote: kademlia.Node = None,
+                          bob_private_key: keys.PrivateKey = None,
+                          bob_client_version: str = 'bob',
+                          cancel_token: CancelToken = None,
+                          event_bus: EndpointAPI = None,
+                          ) -> AsyncContextManager[Tuple[ETHPeer, ETHPeer]]:
+    if alice_peer_context is None:
+        alice_peer_context = ChainContextFactory()
+
+    if bob_peer_context is None:
+        alice_genesis = alice_peer_context.headerdb.get_canonical_block_header_by_number(
+            BlockNumber(GENESIS_BLOCK_NUMBER),
+        )
+        bob_peer_context = ChainContextFactory(
+            headerdb__genesis_params={'timestamp': alice_genesis.timestamp},
+        )
+
+    return cast(AsyncContextManager[Tuple[ETHPeer, ETHPeer]], PeerPairFactory(
+        alice_peer_context=alice_peer_context,
+        alice_peer_factory_class=ETHV63PeerFactory,
+        bob_peer_context=bob_peer_context,
+        bob_peer_factory_class=ETHV63PeerFactory,
+        alice_remote=alice_remote,
+        alice_private_key=alice_private_key,
+        alice_client_version=alice_client_version,
+        bob_remote=bob_remote,
+        bob_private_key=bob_private_key,
+        bob_client_version=bob_client_version,
+        cancel_token=cancel_token,
+        event_bus=event_bus,
+    ))
+
+
 def ETHPeerPairFactory(*,
                        alice_peer_context: ChainContext = None,
                        alice_remote: kademlia.Node = None,
                        alice_private_key: keys.PrivateKey = None,
-                       alice_client_version: str = 'bob',
+                       alice_client_version: str = 'alice',
                        bob_peer_context: ChainContext = None,
                        bob_remote: kademlia.Node = None,
                        bob_private_key: keys.PrivateKey = None,

--- a/trinity/tools/factories/les/proto.py
+++ b/trinity/tools/factories/les/proto.py
@@ -7,6 +7,7 @@ from typing import (
     cast,
     AsyncContextManager,
     Tuple,
+    Any,
 )
 
 from lahja import EndpointAPI
@@ -54,7 +55,7 @@ class LESV1Peer(LESPeer):
 class LESV1PeerFactory(LESPeerFactory):
     peer_class = LESV1Peer
 
-    async def get_handshakers(self) -> Tuple[HandshakerAPI, ...]:
+    async def get_handshakers(self) -> Tuple[HandshakerAPI[Any], ...]:
         return tuple(filter(
             # mypy doesn't know these have a `handshake_params` property
             lambda handshaker: handshaker.handshake_params.version == 1,  # type: ignore


### PR DESCRIPTION
### What was wrong?

Trinity is currently on `eth/63` whereas Geth has implemented `eth/64` and `eth/65` already. We are [pushing for the inclusion of request ids as `eth/66`](https://github.com/ethereum/EIPs/pull/2481).

Before we add an implementation for the proposed `eth/66` protocol, we should first implement `eth/64` and `eth/65`.

### How was it fixed?

This implements the `eth/64` protocol according to [EIP 2124](https://eips.ethereum.org/EIPS/eip-2124). The implementation follows the general principle of how LESV1, LESV2 are implemented side by side.

This also adds a tiny cleanup to combine three different places with the same `if/else` construct to choose the concrete API version into a single helper function.

Real life testing also demonstrates we are having `eth/64` peers alongside `eth/63` peers in the pool.

```
Adding ETHPeer (eth, 64) <Session <Node(0x089581@45.40.132.135)> 1da28744-11a1-4ce4-82e3-c84449cd41df> to pool
Adding ETHPeer (eth, 63) <Session <Node(0x5629f4@54.39.133.125)> 656b4238-5afd-4df8-8f29-515022183c0b> to pool
```

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history
- [x] Update tests
- [x] Fill in PR description
- [x] Cleanup code
- [x] Do the actual ForkID check and disconnect

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

[//]: # (See: https://trinity-client.readthedocs.io/en/latest/contributing.html#pull-requests)
- [x] Add entry to the [release notes](https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://www.traveller.com.au/content/dam/images/3/4/9/p/r/image.related.articleLeadwide.520x294.346k5.png/1406874443880.jpg)
