### PR TITLE
Catch more sync errors

### DIFF
--- a/p2p/exceptions.py
+++ b/p2p/exceptions.py
@@ -211,3 +211,12 @@ class CouldNotRetrieveENR(BaseP2PError):
     Raised when we cannot get an ENR from a remote node.
     """
     pass
+
+
+class CorruptTransport(BaseP2PError):
+    """
+    We lost our place in the stream due to a read operation being interrupted at some point.
+    This isn't recoverable at the moment, so typically this means we should close the transport
+    and terminate the peer connection, when this exception is raised.
+    """
+    pass

--- a/p2p/kademlia.py
+++ b/p2p/kademlia.py
@@ -196,13 +196,33 @@ class Node(NodeAPI):
     def uri(self) -> str:
         hexstring = self.pubkey.to_hex()
         hexstring = remove_0x_prefix(hexstring)
-        return f'enode://{hexstring}@{self.address.ip}:{self.address.tcp_port}'
+
+        if self.address is not None:
+            ip = self.address.ip
+            tcp_port = self.address.tcp_port
+        else:
+            ip = None
+            tcp_port = None
+
+        return f'enode://{hexstring}@{ip}:{tcp_port}'
 
     def __str__(self) -> str:
-        return f"<Node({self.pubkey.to_hex()[:8]}@{self.address.ip})>"
+        if self.address is not None:
+            ip = self.address.ip
+        else:
+            ip = None
+
+        return f"<Node({self.pubkey.to_hex()[:8]}@{ip})>"
 
     def __repr__(self) -> str:
-        return f"<Node({self.pubkey.to_hex()}@{self.address.ip}:{self.address.tcp_port})>"
+        if self.address is not None:
+            ip = self.address.ip
+            tcp_port = self.address.tcp_port
+        else:
+            ip = None
+            tcp_port = None
+
+        return f"<Node({self.pubkey.to_hex()}@{ip}:{tcp_port})>"
 
     def distance_to(self, id: int) -> int:
         return self._id_int ^ id

--- a/p2p/multiplexer.py
+++ b/p2p/multiplexer.py
@@ -396,6 +396,21 @@ class Multiplexer(CancellableMixin, MultiplexerAPI):
             *self._protocols,
             token=token,
         ), token=token)
+        try:
+            await self._handle_commands(msg_stream, stop)
+        except asyncio.TimeoutError as exc:
+            self.logger.warning(
+                "Timed out waiting for command from %s, Stop: %r, exiting...",
+                self,
+                stop.is_set(),
+            )
+            self.logger.debug("Timeout %r: %s", self, exc, exc_info=True)
+
+    async def _handle_commands(
+            self,
+            msg_stream: AsyncIterator[Tuple[ProtocolAPI, CommandAPI[Any]]],
+            stop: asyncio.Event) -> None:
+
         async for protocol, cmd in msg_stream:
             # track total number of messages received for each command type.
             self._msg_counts[type(cmd)] += 1

--- a/p2p/multiplexer.py
+++ b/p2p/multiplexer.py
@@ -33,6 +33,7 @@ from p2p.abc import (
 )
 from p2p.cancellable import CancellableMixin
 from p2p.exceptions import (
+    CorruptTransport,
     UnknownProtocol,
     UnknownProtocolCommand,
 )
@@ -365,6 +366,9 @@ class Multiplexer(CancellableMixin, MultiplexerAPI):
                         await asyncio.wait_for(fut, timeout=1)
                     except asyncio.TimeoutError:
                         pass
+                    except CorruptTransport as exc:
+                        self.logger.error("Corrupted transport found in %s: %r", self, exc)
+                        self.logger.debug("Corrupted transport trace in %s", self, exc_info=True)
 
                 # After giving the transport an opportunity to shutdown
                 # cleanly, we issue a hard shutdown, first via cancellation and

--- a/p2p/peer_pool.py
+++ b/p2p/peer_pool.py
@@ -520,8 +520,6 @@ class BasePeerPool(BaseService, AsyncIterable[BasePeer]):
                     "client_version_string='%s'",
                     peer.p2p_api.safe_client_version_string,
                 )
-                if not hasattr(peer, "eth_api"):
-                    self.logger.warning("Huh? %s doesn't have an eth API", peer)
                 for line in peer.get_extra_stats():
                     self.logger.debug("    %s", line)
             self.logger.debug("== End peer details == ")

--- a/p2p/peer_pool.py
+++ b/p2p/peer_pool.py
@@ -53,6 +53,7 @@ from p2p.exceptions import (
     MalformedMessage,
     NoMatchingPeerCapabilities,
     PeerConnectionLost,
+    UnknownAPI,
     UnreachablePeer,
 )
 from p2p.peer import (
@@ -520,7 +521,11 @@ class BasePeerPool(BaseService, AsyncIterable[BasePeer]):
                     "client_version_string='%s'",
                     peer.p2p_api.safe_client_version_string,
                 )
-                for line in peer.get_extra_stats():
-                    self.logger.debug("    %s", line)
+                try:
+                    for line in peer.get_extra_stats():
+                        self.logger.debug("    %s", line)
+                except (UnknownAPI, PeerConnectionLost) as exc:
+                    self.logger.debug("    Failure during stats lookup: %r", exc)
+
             self.logger.debug("== End peer details == ")
             await self.sleep(self._report_interval)

--- a/p2p/transport.py
+++ b/p2p/transport.py
@@ -46,6 +46,7 @@ from p2p.exceptions import (
     DecryptionError,
     MalformedMessage,
     PeerConnectionLost,
+    CorruptTransport,
     UnreachablePeer,
 )
 from p2p.kademlia import Address, Node
@@ -272,7 +273,7 @@ class Transport(TransportAPI):
                 self,
                 self.read_state.name,
             )
-            raise Exception(f"Corrupted transport: {self} - state={self.read_state.name}")
+            raise CorruptTransport(f"Corrupted transport: {self} - state={self.read_state.name}")
 
         # Set status to indicate we are waiting to read the message header
         self.read_state = TransportState.HEADER

--- a/trinity/sync/beam/chain.py
+++ b/trinity/sync/beam/chain.py
@@ -734,15 +734,15 @@ class MissingDataEventHandler(BaseService):
 
     async def _provide_missing_account_tries(self) -> None:
         async for event in self.wait_iter(self._event_bus.stream(CollectMissingAccount)):
-            self.run_task(self._serve_account(event))
+            self.run_task(self.wait(self._serve_account(event)))
 
     async def _provide_missing_bytecode(self) -> None:
         async for event in self.wait_iter(self._event_bus.stream(CollectMissingBytecode)):
-            self.run_task(self._serve_bytecode(event))
+            self.run_task(self.wait(self._serve_bytecode(event)))
 
     async def _provide_missing_storage(self) -> None:
         async for event in self.wait_iter(self._event_bus.stream(CollectMissingStorage)):
-            self.run_task(self._serve_storage(event))
+            self.run_task(self.wait(self._serve_storage(event)))
 
     async def _serve_account(self, event: CollectMissingAccount) -> None:
         _, num_nodes_collected = await self._state_downloader.download_account(

--- a/trinity/sync/full/chain.py
+++ b/trinity/sync/full/chain.py
@@ -51,7 +51,7 @@ from eth.exceptions import HeaderNotFound
 
 from p2p.abc import CommandAPI
 from p2p.disconnect import DisconnectReason
-from p2p.exceptions import BaseP2PError, PeerConnectionLost
+from p2p.exceptions import BaseP2PError, PeerConnectionLost, UnknownAPI
 from p2p.peer import BasePeer, PeerSubscriber
 from p2p.service import BaseService
 from p2p.stats.ema import EMA
@@ -410,6 +410,12 @@ class BaseBodyChainSyncer(BaseService, PeerSubscriber):
             return tuple()
         except PeerConnectionLost:
             self.logger.debug("Peer went away, cancelling the block body request and moving on...")
+            return tuple()
+        except UnknownAPI as exc:
+            self.logger.debug(
+                "Peer was missing API, cancelling the block body request and moving on... %r",
+                exc,
+            )
             return tuple()
         except Exception:
             self.logger.exception("Unknown error when getting block bodies from %s", peer)


### PR DESCRIPTION
### What was wrong?

A variety of errors pop up sporadically. Occasionally, they event stop sync dead.

There is also an issue that causes the `BeamSyncer` to hang on shutdown. This was preventing pivot from working correctly, so is a blocker for #908 

### How was it fixed?

Mostly, just catch exceptions that were bubbling up too far.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

[//]: # (See: https://trinity-client.readthedocs.io/en/latest/contributing.html#pull-requests)
- [ ] Add entry to the [release notes](https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://iso.500px.com/wp-content/uploads/2015/04/cuddles_cover.jpeg)
