### PR TITLE
discv4: Address a few XXXs and FIXMEs I'd left behind

### DIFF
--- a/p2p/abc.py
+++ b/p2p/abc.py
@@ -114,10 +114,6 @@ class NodeAPI(ABC):
 
     When we get a new ENR version for a given NodeID, a new NodeAPI instance must be created.
     """
-    # FIXME: For now this is a writable property, which is not a big deal as it is not persisted,
-    # but once we start persisting that info we should probably remove the property and always
-    # look it up from the DB.
-    last_pong: float
 
     @abstractmethod
     def __init__(self, enr: ENR) -> None:
@@ -170,11 +166,6 @@ class NodeAPI(ABC):
 
     @abstractmethod
     def distance_to(self, id: int) -> int:
-        ...
-
-    @property
-    @abstractmethod
-    def is_bond_valid(self) -> bool:
         ...
 
     # mypy doesn't have support for @total_ordering

--- a/p2p/discv5/enr_db.py
+++ b/p2p/discv5/enr_db.py
@@ -1,6 +1,5 @@
 import binascii
 from collections import defaultdict
-import logging
 import operator
 import pathlib
 import re
@@ -16,7 +15,10 @@ import rlp
 
 import trio
 
-from eth_utils import encode_hex
+from eth_utils import (
+    encode_hex,
+    get_extended_debug_logger,
+)
 
 from p2p.abc import NodeAPI
 from p2p.discv5.abc import NodeDBAPI
@@ -32,7 +34,7 @@ ACCEPTABLE_LOAD_TIME = 1.0
 class BaseNodeDB(NodeDBAPI):
 
     def __init__(self, identity_scheme_registry: IdentitySchemeRegistry):
-        self.logger = logging.getLogger(".".join((
+        self.logger = get_extended_debug_logger(".".join((
             self.__module__,
             self.__class__.__name__,
         )))
@@ -149,7 +151,7 @@ class FileNodeDB(BaseNodeDB):
         if await self.contains(node.id):
             raise ValueError("Node with node id %s already exists", encode_hex(node.id))
         else:
-            self.logger.debug(
+            self.logger.debug2(
                 "Inserting new Node of %s with sequence number %d",
                 encode_hex(node.id),
                 node.enr.sequence_number,
@@ -162,7 +164,7 @@ class FileNodeDB(BaseNodeDB):
 
         existing_node = await self.get(node.id)
         if existing_node.enr.sequence_number < node.enr.sequence_number:
-            self.logger.debug(
+            self.logger.debug2(
                 "Updating Node of %s from sequence number %d to %d",
                 encode_hex(node.id),
                 existing_node.enr.sequence_number,

--- a/p2p/kademlia.py
+++ b/p2p/kademlia.py
@@ -134,7 +134,6 @@ class Node(NodeAPI):
         self._id = NodeID(keccak(self.pubkey.to_bytes()))
         self._id_int = big_endian_to_int(self.id)
         self._enr = enr
-        self.last_pong = None
 
     @property
     def id(self) -> NodeID:
@@ -185,13 +184,6 @@ class Node(NodeAPI):
     @property
     def enr(self) -> ENR:
         return self._enr
-
-    @property
-    def is_bond_valid(self) -> bool:
-        return (
-            self.last_pong is not None and
-            self.last_pong > time.monotonic() - constants.KADEMLIA_BOND_EXPIRATION
-        )
 
     def uri(self) -> str:
         hexstring = self.pubkey.to_hex()


### PR DESCRIPTION
- Drop Node.last_pong and instead keep track of valid bonds in
  DiscoveryService. This is how it should've been implemented in
  the first place because Nodes are not singletons and multiple
  coroutines may create separate instances during the initial bonding
  process, which can lead to some not realizing when the bonding
  completes and thus treating the remote as one without a valid bond

- Combined addition of nodes to DB and routing table in a single method,
  to ensure they're kept in sync

- Changed APIs for scheduling ENR retrieval to take NodeIDs instead of
  Nodes

- Got rid of _lookup_node_from_db(), which was meant to be temporary

- When receiving a NEIGHBOURS response we no longer need to load
  existing Node entries from the DB just to see if we've bonded with them
  already

- When we receive a ping from a Node for which we don't have a valid
  bond, we now will also trigger a bond in the background. This was
  is the behaviour defined in the spec, but we were not doing it