### PR TITLE
discv4: Fix the way we randomly iterate over peer candidates

### DIFF
--- a/p2p/discovery.py
+++ b/p2p/discovery.py
@@ -206,9 +206,8 @@ class DiscoveryService(Service):
     def get_peer_candidates(
         self, should_skip_fn: Callable[[NodeAPI], bool], max_candidates: int,
     ) -> Tuple[NodeAPI, ...]:
-        total_nodes = len(self.routing)
         candidates = []
-        for candidate in self.get_nodes_to_connect(total_nodes):
+        for candidate in self.iter_nodes():
             if should_skip_fn(candidate):
                 continue
             candidates.append(candidate)
@@ -575,8 +574,8 @@ class DiscoveryService(Service):
         else:
             self.logger.warning('No bootnodes available')
 
-    def get_nodes_to_connect(self, count: int) -> Iterator[NodeAPI]:
-        return self.routing.get_random_nodes(count)
+    def iter_nodes(self) -> Iterator[NodeAPI]:
+        return self.routing.iter_random()
 
     @property
     def pubkey(self) -> datatypes.PublicKey:
@@ -975,17 +974,15 @@ class PreferredNodeDiscoveryService(DiscoveryService):
         except NoEligibleNodes:
             yield from super().get_random_bootnode()
 
-    def get_nodes_to_connect(self, count: int) -> Iterator[NodeAPI]:
+    def iter_nodes(self) -> Iterator[NodeAPI]:
         """
-        Return up to `count` nodes, preferring nodes from the preferred list.
+        Iterate over available nodes, preferring nodes from the preferred list.
         """
-        preferred_nodes = self._get_eligible_preferred_nodes()[:count]
-        for node in preferred_nodes:
+        for node in self._get_eligible_preferred_nodes():
             self._preferred_node_tracker[node] = time.time()
             yield node
 
-        num_nodes_needed = max(0, count - len(preferred_nodes))
-        yield from super().get_nodes_to_connect(num_nodes_needed)
+        yield from super().iter_nodes()
 
 
 class StaticDiscoveryService(Service):

--- a/scripts/discovery.py
+++ b/scripts/discovery.py
@@ -59,7 +59,7 @@ async def main() -> None:
                 fork_blocks,
                 skip_list,
             )
-            with trio.fail_after(2):
+            with trio.fail_after(1):
                 response = await client.request(PeerCandidatesRequest(MAX_PEERS, should_skip))
             candidates = response.candidates
             missing_forkid = [

--- a/tests/p2p/test_kademlia.py
+++ b/tests/p2p/test_kademlia.py
@@ -127,20 +127,30 @@ def test_routingtable_neighbours():
         assert node_a == table.neighbours(node_b.id)[0]
 
 
-def test_routingtable_get_random_nodes():
+def test_routingtable_iter_random():
     table = RoutingTable(NodeFactory().id)
+    nodes_in_insertion_order = []
+    # Use a relatively high number of nodes here otherwise we could have two consecutive calls
+    # yielding nodes in the same order.
     for _ in range(100):
-        assert table.add_node(NodeFactory()) is None
+        node = NodeFactory()
+        assert table.add_node(node) is None
+        nodes_in_insertion_order.append(node)
 
-    nodes = list(table.get_random_nodes(50))
-    assert len(nodes) == 50
-    assert len(set(nodes)) == 50
+    nodes_in_iteration_order = [node for node in table.iter_random()]
 
-    # If we ask for more nodes than what the routing table contains, we'll get only what the
-    # routing table contains, without duplicates.
-    nodes = list(table.get_random_nodes(200))
-    assert len(nodes) == 100
-    assert len(set(nodes)) == 100
+    # We iterate over all nodes
+    assert len(nodes_in_iteration_order) == len(table) == len(nodes_in_insertion_order)
+    # No repeated nodes are returned
+    assert len(set(nodes_in_iteration_order)) == len(nodes_in_iteration_order)
+    # The order in which we iterate is not the same as the one in which nodes were inserted.
+    assert nodes_in_iteration_order != nodes_in_insertion_order
+
+    second_iteration_order = [node for node in table.iter_random()]
+
+    # Multiple calls should yield the same nodes, but in a different order.
+    assert set(nodes_in_iteration_order) == set(second_iteration_order)
+    assert nodes_in_iteration_order != second_iteration_order
 
 
 def test_kbucket_add():


### PR DESCRIPTION
We recently changed DiscoveryService to iterate over the nodes in the
routing table, applying a caller-provided function to skip undersirable
ones, instead of simply blindly asking for a batch of random peers from
the RT. However, we were still using the get_random_nodes(count) API to
iterate over all nodes, which was insanely inneficient when iterating
over all the nodes, but also buggy because the RT's buckets can mutate
during iteration, leading to various sorts of issues.

This fixes that by creating a new API (iter_randmo()), which copies the
RT's buckets, shuffling all available nodes and then iterating over
them.