### PR TITLE
Proper Endpoint Voting

### DIFF
--- a/p2p/discv5/constants.py
+++ b/p2p/discv5/constants.py
@@ -45,6 +45,10 @@ ROUTING_TABLE_LOOKUP_INTERVAL = 60  # intervals between lookups
 LOOKUP_RETRY_THRESHOLD = 5  # minimum number of ENRs desired in responses to FindNode requests
 LOOKUP_PARALLELIZATION_FACTOR = 3  # number of parallel lookup requests (aka alpha)
 
+ENDPOINT_VOTE_EXPIRY_TIME = 3 * 60 * 60  # votes older than this are disregarded
+ENDPOINT_VOTE_QUORUM = 10  # total number of votes needed for an endpoint change
+ENDPOINT_VOTE_MAJORITY_FRACTION = 0.5  # required fraction of votes needed for an endpoint change
+
 NUM_ROUTING_TABLE_BUCKETS = 256  # number of buckets in the routing table
 
 MAX_NODES_MESSAGE_TOTAL = 8  # max allowed total value for nodes messages

--- a/tests/p2p/discv5/test_endpoint_vote_ballot_box.py
+++ b/tests/p2p/discv5/test_endpoint_vote_ballot_box.py
@@ -1,0 +1,88 @@
+import pytest
+
+from p2p.discv5.endpoint_tracker import (
+    EndpointVoteBallotBox,
+)
+from p2p.tools.factories.discovery import (
+    EndpointFactory,
+    EndpointVoteFactory,
+)
+
+
+@pytest.fixture
+def box():
+    return EndpointVoteBallotBox(quorum=8, majority_fraction=0.65, expiry_time=3)
+
+
+def test_add_vote(box):
+    endpoint_vote = EndpointVoteFactory()
+    box.add_vote(endpoint_vote)
+    assert box.votes_by_sender[endpoint_vote.node_id] == endpoint_vote
+    assert box.num_votes_by_endpoint[endpoint_vote.endpoint] == 1
+
+    box.add_vote(endpoint_vote)
+    assert box.votes_by_sender[endpoint_vote.node_id] == endpoint_vote
+    assert box.num_votes_by_endpoint[endpoint_vote.endpoint] == 1
+
+    another_endpoint_vote = EndpointVoteFactory()
+    assert another_endpoint_vote.endpoint != endpoint_vote.endpoint
+    box.add_vote(another_endpoint_vote)
+    assert box.votes_by_sender[another_endpoint_vote.node_id] == another_endpoint_vote
+    assert box.num_votes_by_endpoint[another_endpoint_vote.endpoint] == 1
+
+    vote_for_same_endpoint = EndpointVoteFactory(endpoint=another_endpoint_vote.endpoint)
+    box.add_vote(vote_for_same_endpoint)
+    assert box.votes_by_sender[vote_for_same_endpoint.node_id] == vote_for_same_endpoint
+    assert box.num_votes_by_endpoint[vote_for_same_endpoint.endpoint] == 2
+
+
+def test_remove_vote(box):
+    endpoint_vote = EndpointVoteFactory()
+    with pytest.raises(KeyError):
+        box.remove_vote_by_node_id(endpoint_vote.node_id)
+    box.add_vote(endpoint_vote)
+    box.remove_vote_by_node_id(endpoint_vote.node_id)
+    assert endpoint_vote.node_id not in box.votes_by_sender
+    assert box.num_votes_by_endpoint[endpoint_vote.endpoint] == 0
+
+
+def test_remove_expired_votes(box):
+    v1 = EndpointVoteFactory(timestamp=0)
+    v2 = EndpointVoteFactory(timestamp=2)
+    v3 = EndpointVoteFactory(timestamp=4)
+    box.add_vote(v1)
+    box.add_vote(v2)
+    box.add_vote(v3)
+    box.remove_expired_votes(6)
+    assert v1.node_id not in box.votes_by_sender
+    assert v2.node_id not in box.votes_by_sender
+    assert v3.node_id in box.votes_by_sender
+
+
+def test_majority():
+    box = EndpointVoteBallotBox(quorum=8, majority_fraction=0.65, expiry_time=3)
+    e1 = EndpointFactory()
+    e2 = EndpointFactory()
+
+    # vote for e1 without reaching quorum
+    for _ in range(7):
+        box.add_vote(EndpointVoteFactory(endpoint=e1))
+        assert box.result is None
+
+    # vote for e1, exceeding quorum, with no votes against
+    for _ in range(3):
+        box.add_vote(EndpointVoteFactory(endpoint=e1))
+        assert box.result == e1
+
+    # vote for e2, without e1 losing required majority
+    for _ in range(5):
+        box.add_vote(EndpointVoteFactory(endpoint=e2))
+        assert box.result == e1
+
+    # vote for e2, reaching simple majority, but not required fraction
+    for _ in range(13):
+        box.add_vote(EndpointVoteFactory(endpoint=e2))
+        assert box.result is None
+
+    box.add_vote(EndpointVoteFactory(endpoint=e2))
+    assert box.result == e2

--- a/trinity/components/eth2/discv5/component.py
+++ b/trinity/components/eth2/discv5/component.py
@@ -22,6 +22,9 @@ from eth_utils.toolz import (
 from lahja import EndpointAPI
 
 from p2p.discv5.constants import (
+    ENDPOINT_VOTE_EXPIRY_TIME,
+    ENDPOINT_VOTE_MAJORITY_FRACTION,
+    ENDPOINT_VOTE_QUORUM,
     NUM_ROUTING_TABLE_BUCKETS,
 )
 from p2p.discv5.abc import (
@@ -232,6 +235,9 @@ class DiscV5Component(TrioIsolatedComponent):
             node_db=node_db,
             identity_scheme_registry=identity_scheme_registry,
             vote_receive_channel=endpoint_vote_channels[1],
+            quorum=ENDPOINT_VOTE_QUORUM,
+            majority_fraction=ENDPOINT_VOTE_MAJORITY_FRACTION,
+            expiry_time=ENDPOINT_VOTE_EXPIRY_TIME,
         )
 
         routing_table_manager = RoutingTableManager(


### PR DESCRIPTION
### What was wrong?

We treated the endpoint received in any pong message as correct.

### How was it fixed?

Gather endpoints received via pongs by multiple senders and have a vote. Change the endpoint to the winner of the vote if a quorum and a suitable majority is reached.

#### Cute Animal Picture

![black-tortoise-standing-162307](https://user-images.githubusercontent.com/29854669/74463973-ffade680-4e92-11ea-9a31-39cd430d665b.jpg)

![put a cute animal picture link inside the parentheses]()
