### PR TITLE
Add support for Etherscan API keys

### DIFF
--- a/newsfragments/1565.feature.rst
+++ b/newsfragments/1565.feature.rst
@@ -1,0 +1,6 @@
+Add support for Etherscan API keys to continue support for the
+``--beam-from-checkpoint eth://block/byetherscan/latest`` flag now that
+Etherscan `has made API keys mandatory <https://medium.com/etherscan-blog/psa-for-developers-implementation-of-api-key-requirements-starting-from-february-15th-2020-b616870f3746>`_
+
+API keys need to be exposed via the ``TRINITY_ETHERSCAN_API_KEY``
+environment variable.

--- a/newsfragments/1565.feature.rst
+++ b/newsfragments/1565.feature.rst
@@ -1,6 +1,5 @@
 Add support for Etherscan API keys to continue support for the
 ``--beam-from-checkpoint eth://block/byetherscan/latest`` flag now that
-Etherscan `has made API keys mandatory <https://medium.com/etherscan-blog/psa-for-developers-implementation-of-api-key-requirements-starting-from-february-15th-2020-b616870f3746>`_
-
+Etherscan `has made API keys mandatory <https://medium.com/etherscan-blog/psa-for-developers-implementation-of-api-key-requirements-starting-from-february-15th-2020-b616870f3746>`_.
 API keys need to be exposed via the ``TRINITY_ETHERSCAN_API_KEY``
 environment variable.

--- a/setup.py
+++ b/setup.py
@@ -37,6 +37,11 @@ deps = {
         "coincurve>=10.0.0,<11.0.0",
         "dataclasses>=0.6, <1;python_version<'3.7'",
         "eth-utils>=1.8.4,<2",
+        # Fixing this dependency due to: requests 2.20.1 has requirement
+        # idna<2.8,>=2.5, but you'll have idna 2.8 which is incompatible.
+        "idna==2.7",
+        # idna 2.7 is not supported by requests 2.18
+        "requests>=2.20,<3",
         "ipython>=7.8.0,<7.10.0",  # attach fails with v7.10.{0,1}
         "plyvel==1.1.0",
         PYEVM_DEPENDENCY,
@@ -104,11 +109,6 @@ deps = {
         "bumpversion>=0.5.3,<1",
         "wheel",
         "setuptools>=36.2.0",
-        # Fixing this dependency due to: requests 2.20.1 has requirement
-        # idna<2.8,>=2.5, but you'll have idna 2.8 which is incompatible.
-        "idna==2.7",
-        # idna 2.7 is not supported by requests 2.18
-        "requests>=2.20,<3",
         "tox==2.7.0",
         "twine",
     ],

--- a/tests/integration/test_etherscan_checkpoint_resolver.py
+++ b/tests/integration/test_etherscan_checkpoint_resolver.py
@@ -13,7 +13,6 @@ from trinity.constants import MAINNET_NETWORK_ID
 MIN_EXPECTED_SCORE = 11631608640717612820968
 
 
-@pytest.mark.skip("Need support for API keys (https://github.com/ethereum/trinity/issues/1561)")
 @pytest.mark.parametrize(
     'uri',
     (

--- a/tox.ini
+++ b/tox.ini
@@ -130,6 +130,7 @@ usedevelop=false
 deps = .[p2p,trinity,eth2,test,test-asyncio]
 passenv =
     TRAVIS_EVENT_TYPE
+    TRINITY_ETHERSCAN_API_KEY
 commands=
     pip install -e {toxinidir}/trinity-external-components/examples/peer_count_reporter
     # We don't want to run these tests concurrently to avoid running into errors


### PR DESCRIPTION
### What was wrong?

From February 15th, Etherscan [has made API keys mandatory for all API access](https://medium.com/etherscan-blog/psa-for-developers-implementation-of-api-key-requirements-starting-from-february-15th-2020-b616870f3746) (See #1561).

Hence we need to support API keys for `--beam-from-checkpoint eth://block/byetherscan/latest` to continue to work.

### How was it fixed?

1. Read the API key from the `XDG_TRINITY_ETHERSCAN_API_KEY` (wasn't sure about the `XDG` prefix or even about the Trinity prefix. Should this be just `ETHERSCAN_API_KEY` instead?)

2. Refactor the loose etherscan api functions into a `Etherscan` class that cashes the API key.

This also moves the `request` and `idna` dependency from `dev` to `trinity`. The `request` library is directly used by Trinity and so having it only in `dev` breaks Trinity if it isn't installed with the `dev` extras (read, for the regular user). This issue was exposed just now because the `idna` library that `requests` depends on had a new [release](https://pypi.org/project/idna/#history) yesterday which now caused the integration tests to fail because the `idna` resolution was only specified in `dev`.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

[//]: # (See: https://trinity-client.readthedocs.io/en/latest/contributing.html#pull-requests)
- [x] Add entry to the [release notes](https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://encrypted-tbn0.gstatic.com/images?q=tbn%3AANd9GcTWtwvCcygPqCPa7xIVEWJ6uGdmZFZwLrBCOhTyy1scaetrc-lQ)
