### PR TITLE
Use CouldNotRetrieveENR instead of AttributeError

### DIFF
--- a/newsfragments/1566.bugfix.rst
+++ b/newsfragments/1566.bugfix.rst
@@ -1,0 +1,2 @@
+Handle uncaught AttributeError and UnknownAPI exceptions. One happens during ENR retrieval,
+UnknownAPI happens when getting receipts for sync.

--- a/p2p/discovery.py
+++ b/p2p/discovery.py
@@ -842,6 +842,9 @@ class DiscoveryService(Service):
             pass
 
     def send_enr_request(self, node: NodeAPI) -> Hash32:
+        if node.address is None:
+            raise CouldNotRetrieveENR(f"Cannot ask for ENR from {node} with no address")
+
         message = self.send(node, CMD_ENR_REQUEST, [_get_msg_expiration()])
         token = Hash32(message[:MAC_SIZE])
         self.logger.debug("Sending ENR request with token: %s", encode_hex(token))

--- a/trinity/sync/full/chain.py
+++ b/trinity/sync/full/chain.py
@@ -942,6 +942,12 @@ class FastChainBodySyncer(BaseBodyChainSyncer):
         except PeerConnectionLost:
             self.logger.debug("Peer went away, cancelling the receipts request and moving on...")
             return tuple()
+        except UnknownAPI as exc:
+            self.logger.debug(
+                "Peer was missing API, cancelling the receipts request and moving on... %r",
+                exc,
+            )
+            return tuple()
         except Exception:
             self.logger.exception("Unknown error when getting receipts")
             raise


### PR DESCRIPTION

### What was wrong?

When the address of a node is None, it was raising an AttributeError, because it tried to get node.address.ip. The AttributeError isn't caught, and crashes all of trinity.

### How was it fixed?

Raise a CouldNotRetrieveENR, which is handled much more gracefully, with a debug log.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

[//]: # (See: https://trinity-client.readthedocs.io/en/latest/contributing.html#pull-requests)
- [x] Add entry to the [release notes](https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://66.media.tumblr.com/62b755de10f3567d5642ae236a7752e9/tumblr_mquegp8Fbs1rbybp4o3_500.jpg)
