### PR TITLE
Only log new peers when fewer than 5

### DIFF
--- a/newsfragments/1567.internal.rst
+++ b/newsfragments/1567.internal.rst
@@ -1,0 +1,1 @@
+Less noisy logs when adding peers. Only show INFO logs when you have fewer than 5 peers.

--- a/p2p/constants.py
+++ b/p2p/constants.py
@@ -153,6 +153,11 @@ BLACKLIST_SECONDS_TOO_MANY_TIMEOUTS = 60 * 5  # 5 minutes
 # so.
 BLACKLIST_SECONDS_QUICK_DISCONNECT = 60
 
+# Some logs are noisy, but we're very interested in them when the peer pool is small.
+# Like we're eager to know about newly added peers. This constant defines the
+# minimum pool size that we start quieting the logs.
+QUIET_PEER_POOL_SIZE = 5
+
 #
 # Kademlia Constants
 #

--- a/p2p/peer_pool.py
+++ b/p2p/peer_pool.py
@@ -42,6 +42,7 @@ from p2p.constants import (
     DEFAULT_PEER_BOOT_TIMEOUT,
     HANDSHAKE_TIMEOUT,
     MAX_CONCURRENT_CONNECTION_ATTEMPTS,
+    QUIET_PEER_POOL_SIZE,
     REQUEST_PEER_CANDIDATE_TIMEOUT,
 )
 from p2p.discv5.typing import NodeID
@@ -292,7 +293,11 @@ class BasePeerPool(BaseService, AsyncIterable[BasePeer]):
         Appart from adding it to our list of connected nodes and adding each of our subscriber's
         to the peer, we also add the given messages to our subscriber's queues.
         """
-        self.logger.info('Adding %s to pool', peer)
+        if len(self) < QUIET_PEER_POOL_SIZE:
+            logger = self.logger.info
+        else:
+            logger = self.logger.debug
+        logger("Adding %s to pool", peer)
         self.connected_nodes[peer.session] = peer
         peer.add_finished_callback(self._peer_finished)
         for subscriber in self._subscribers:


### PR DESCRIPTION
### What was wrong?

Especially when getting started, it's nice to have feedback when new peers finally join. But by the time sync is well underway, the logs are mostly noise.

### How was it fixed?

Only log when a peer is added if you have fewer than 5 peers.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Move 5 to constant somewhere
- [x] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

[//]: # (See: https://trinity-client.readthedocs.io/en/latest/contributing.html#pull-requests)
- [x] Add entry to the [release notes](https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://hips.hearstapps.com/ame-prod-goodhousekeeping-assets.s3.amazonaws.com/main/galleries/22257/International_hug_day_-_cute_animals_hugging_-_baby_lion_leopard_cub_and_monkey_-_unlikely_friendship_instagram_-_good_housekeeping_uk.jpg?resize=480:*)
