### PR TITLE
Collect runtime metrics and push them into InfluxDB to be used by Grafana

### DIFF
--- a/newsfragments/1569.feature.rst
+++ b/newsfragments/1569.feature.rst
@@ -1,0 +1,9 @@
+Implement basic metrics tracking. With this change Trinity supports collecting
+and writing metrics to InfluxDB to be further processed and visualized
+by Grafana.
+
+Run Trinity with ``--metrics --metrics-host "mymachine"`` and provide the
+Influx server and password via the following two environment variables:
+
+- ``TRINITY_METRICS_INFLUX_DB_SERVER``
+- ``TRINITY_METRICS_INFLUX_DB_PW``

--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,9 @@ deps = {
         "argcomplete>=1.10.0,<2",
         "multiaddr>=0.0.8,<0.1.0",
         "prometheus-client==0.7.1",
+        "pyformance==0.4",
         "pymultihash>=0.8.2",
+        "psutil>=5.7.0, <6",
         "libp2p==0.1.4",
         # The direct dependency resolves a version conflict between multiaddr and libp2p
         "base58>=1.0.3,<2.0.0",

--- a/trinity/components/builtin/metrics/component.py
+++ b/trinity/components/builtin/metrics/component.py
@@ -1,0 +1,112 @@
+import os
+from argparse import (
+    ArgumentParser,
+    _SubParsersAction,
+)
+
+
+from async_exit_stack import AsyncExitStack
+from async_service import background_trio_service
+from eth_utils import ValidationError
+
+from lahja import EndpointAPI
+
+from trinity.boot_info import BootInfo
+from trinity.components.builtin.metrics.metrics_service import MetricsService
+from trinity.components.builtin.metrics.system_metrics_collector import collect_process_metrics
+
+from trinity.extensibility import (
+    TrioIsolatedComponent,
+)
+
+
+class MetricsComponent(TrioIsolatedComponent):
+    """
+    A component to continuously collect and report system wide metrics.
+    """
+    name = "Metrics"
+
+    @property
+    def is_enabled(self) -> bool:
+        return bool(self._boot_info.args.metrics)
+
+    @classmethod
+    def configure_parser(cls,
+                         arg_parser: ArgumentParser,
+                         subparser: _SubParsersAction) -> None:
+
+        metrics_parser = arg_parser.add_argument_group('metrics')
+
+        metrics_parser.add_argument(
+            "--metrics",
+            action="store_true",
+            help="Enable metrics component",
+        )
+
+        metrics_parser.add_argument(
+            '--metrics-host',
+            help='Host name to tag the metrics data (e.g. trinity-bootnode-europe-pt',
+            default=os.environ.get('TRINITY_METRICS_HOST'),
+        )
+
+        metrics_parser.add_argument(
+            '--metrics-influx-password',
+            help='Influx DB password. Defaults to ENV var TRINITY_METRICS_INFLUX_DB_PW',
+            default=os.environ.get('TRINITY_METRICS_INFLUX_DB_PW'),
+        )
+
+        metrics_parser.add_argument(
+            '--metrics-influx-server',
+            help='Influx DB server. Defaults to ENV var TRINITY_METRICS_INFLUX_DB_SERVER',
+            default=os.environ.get('TRINITY_METRICS_INFLUX_DB_SERVER'),
+        )
+
+        metrics_parser.add_argument(
+            '--metrics-reporting-frequency',
+            help='The frequency in seconds at which metrics are reported',
+            default=10,
+        )
+
+        metrics_parser.add_argument(
+            '--metrics-system-collector-frequency',
+            help='The frequency in seconds at which system metrics are collected',
+            default=3,
+        )
+
+    @classmethod
+    def validate_cli(cls, boot_info: BootInfo) -> None:
+        args = boot_info.args
+
+        if not args.metrics:
+            return
+
+        if not args.metrics_host:
+            raise ValidationError(
+                'You must provide the metrics host that is used '
+                'to tag the data via `--metrics-host`'
+            )
+
+    @classmethod
+    async def do_run(cls, boot_info: BootInfo, event_bus: EndpointAPI) -> None:
+
+        metrics_service = MetricsService(
+            influx_server=boot_info.args.metrics_influx_server,
+            influx_password=boot_info.args.metrics_influx_password,
+            host=boot_info.args.metrics_host,
+            reporting_frequency=boot_info.args.metrics_reporting_frequency,
+        )
+
+        # types ignored due to https://github.com/ethereum/async-service/issues/5
+        system_metrics_collector = collect_process_metrics(  # type: ignore
+            metrics_service.registry,
+            frequency_seconds=boot_info.args.metrics_system_collector_frequency
+        )
+
+        services_to_exit = (metrics_service, system_metrics_collector,)
+
+        async with AsyncExitStack() as stack:
+            managers = tuple([
+                await stack.enter_async_context(background_trio_service(service))
+                for service in services_to_exit
+            ])
+            await managers[0].wait_finished()

--- a/trinity/components/builtin/metrics/metrics_service.py
+++ b/trinity/components/builtin/metrics/metrics_service.py
@@ -1,0 +1,51 @@
+from async_service import Service
+from eth_utils import get_extended_debug_logger
+from p2p import trio_utils
+from pyformance.reporters import InfluxReporter
+
+from trinity.components.builtin.metrics.registry import HostMetricsRegistry
+
+
+class MetricsService(Service):
+    """
+    A service to provide a registry where metrics instruments can be registered and retrieved from.
+    It continuously reports metrics to the specified InfluxDB instance.
+    """
+
+    def __init__(self,
+                 influx_server: str,
+                 influx_password: str,
+                 host: str,
+                 reporting_frequency: int = 10):
+
+        self._influx_server = influx_server
+        self._reporting_frequency = reporting_frequency
+        self._registry = HostMetricsRegistry(host)
+        self._reporter = InfluxReporter(
+            registry=self._registry,
+            protocol='https',
+            port=443,
+            database='trinity',
+            username='trinity',
+            password=influx_password,
+            server=influx_server
+        )
+
+    logger = get_extended_debug_logger('trinity.components.builtin.metrics.MetricsService')
+
+    @property
+    def registry(self) -> HostMetricsRegistry:
+        """
+        Return the :class:`trinity.components.builtin.metrics.registry.HostMetricsRegistry` at which
+        metrics instruments can be registered and retrieved.
+        """
+        return self._registry
+
+    async def run(self) -> None:
+        self.logger.info("Reporting metrics to %s", self._influx_server)
+        self.manager.run_daemon_task(self._continuously_report)
+        await self.manager.wait_finished()
+
+    async def _continuously_report(self) -> None:
+        async for _ in trio_utils.every(self._reporting_frequency):
+            self._reporter.report_now()

--- a/trinity/components/builtin/metrics/registry.py
+++ b/trinity/components/builtin/metrics/registry.py
@@ -1,0 +1,21 @@
+import time
+from types import ModuleType
+from typing import Dict, Any
+
+from pyformance import MetricsRegistry
+
+
+class HostMetricsRegistry(MetricsRegistry):
+
+    def __init__(self, host: str, clock: ModuleType = time) -> None:
+        super().__init__(clock)
+        self.host = host
+
+    def dump_metrics(self) -> Dict[str, Dict[str, Any]]:
+        metrics = super().dump_metrics()
+
+        for key in metrics:
+            # We want every metric to include a 'host' identifier to be able to filter accordingly
+            metrics[key]['host'] = self.host
+
+        return metrics

--- a/trinity/components/builtin/metrics/system_metrics_collector.py
+++ b/trinity/components/builtin/metrics/system_metrics_collector.py
@@ -1,0 +1,84 @@
+from typing import (
+    NamedTuple,
+    Tuple,
+)
+
+from async_service import (
+    as_service,
+    ManagerAPI,
+)
+
+import psutil
+from p2p import trio_utils
+from trinity.components.builtin.metrics.registry import HostMetricsRegistry
+
+
+class CpuStats(NamedTuple):
+
+    # Time spent on all processes
+    global_time: int
+    # Time spent waiting on IO
+    global_wait_io: int
+
+
+class DiskStats(NamedTuple):
+
+    # Number of read operations executed
+    read_count: int
+    # Number of bytes read
+    read_bytes: int
+    # Number of write operations executed
+    write_count: int
+    # Number of bytes written
+    write_bytes: int
+
+
+def read_cpu_stats() -> CpuStats:
+    stats = psutil.cpu_times()
+    return CpuStats(
+        global_time=int(stats.user + stats.nice + stats.system),
+        global_wait_io=int(stats.iowait),
+    )
+
+
+def read_disk_stats() -> DiskStats:
+    stats = psutil.disk_io_counters()
+    return DiskStats(
+        read_count=stats.read_count,
+        read_bytes=stats.read_bytes,
+        write_count=stats.write_count,
+        write_bytes=stats.write_bytes,
+    )
+
+
+@as_service
+async def collect_process_metrics(manager: ManagerAPI,
+                                  registry: HostMetricsRegistry,
+                                  frequency_seconds: int) -> None:
+
+    previous: Tuple[CpuStats, DiskStats] = None
+
+    cpu_sysload_gauge = registry.gauge('trinity.system/cpu/sysload.gauge')
+    cpu_syswait_gauge = registry.gauge('trinity.system/cpu/syswait.gauge')
+
+    disk_readdata_meter = registry.meter('trinity.system/disk/readdata.meter')
+    disk_writedata_meter = registry.meter('trinity.system/disk/writedata.meter')
+
+    async for _ in trio_utils.every(frequency_seconds):
+        current = (read_cpu_stats(), read_disk_stats())
+
+        if previous is not None:
+            current_cpu_stats, current_disk_stats = current
+            previous_cpu_stats, previous_disk_stats = previous
+            global_time = current_cpu_stats.global_time - previous_cpu_stats.global_time
+            cpu_sysload_gauge.set_value(global_time / frequency_seconds)
+            global_wait = current_cpu_stats.global_wait_io - previous_cpu_stats.global_wait_io
+            cpu_syswait_gauge.set_value(global_wait / frequency_seconds)
+
+            read_bytes = current_disk_stats.read_bytes - previous_disk_stats.read_bytes
+            disk_readdata_meter.mark(read_bytes)
+
+            write_bytes = current_disk_stats.write_bytes - previous_disk_stats.write_bytes
+            disk_writedata_meter.mark(write_bytes)
+
+        previous = current

--- a/trinity/components/registry.py
+++ b/trinity/components/registry.py
@@ -4,6 +4,7 @@ from typing import (
     Type,
 )
 
+from trinity.components.builtin.metrics.component import MetricsComponent
 from trinity.extensibility import (
     BaseComponentAPI,
 )
@@ -63,6 +64,7 @@ BASE_COMPONENTS: Tuple[Type[BaseComponentAPI], ...] = (
     FixUncleanShutdownComponent,
     JsonRpcServerComponent,
     NetworkDBComponent,
+    MetricsComponent,
     PeerDiscoveryComponent,
     UpnpComponent,
 )


### PR DESCRIPTION
### What was wrong?

We don't have infrastructure in place to collect runtime metrics. Collecting various metrics helps tremendously to better understand the impact of changes ("Oh turns out our 2x improvement here causes a 4x regression there")

As an example, here's a [Geth PR with tons of shiny charts](https://github.com/karalabe/go-ethereum/pull/27) that demonstrate the impact of the PR.

I recently had a very constructive discussion with the Geth team and they have invited us to use their existing influxdb/grafana infrastructure to collect metrics for Trinity.

They went ahead and setup a DB and Grafana user for us and I decided to shift my attention there to get something off the ground.

### How was it fixed?

1. The general guideline for the implementation was "copy whatever geth does". This is based on the fact that they've already build up tons of knowledge in this area, invested many hours in the system including creating many different charts etc. and we can stand on the shoulders of giants if we just start copying what they do.

2. The implementation uses [pyformance](https://pyformance.readthedocs.io/en/latest/usage.html) which is the closest to [go-metrics](https://pkg.go.dev/github.com/rcrowley/go-metrics) that Geth uses. It provides Gauges, Counters, Meters etc as well as different reporters including one that reports straight to InfluxDB.

3. This adds a Metrics component that runs in its own process to collect system metrics similar to [this in Geth](https://github.com/ethereum/go-ethereum/blob/556888c4a971d4fd02be15f09cba7a65c5c0d930/metrics/metrics.go#L76-L126)

This does not yet add metrics that are concerned with more Trinity specific things such as peer connections etc. However, I think I have an idea about how that would work out. It's a little different for us compared to Geth because Trinity uses many different processes. I think that the `MetricsComponent` should be used to collect all *system wide*  metrics but that other metrics should just be collected and reported via additional `MetricService` instances in those other component processes. The alternative would be to send metrics cross processes via the eventbus to push them all at once but I see no benefit in that. I think that would just introduce lots of complexity and load in the form of inter process communication with the only benefit being a little better batching of data towards influxdb.

The following dashboard is a straight clone from one of the  Geth dashboards and it shows two connected charts with the rest of the charts just being a stub of metrics that we probably want to add in the future.

![image](https://user-images.githubusercontent.com/521109/75991243-79ffe280-5ef6-11ea-991b-41375e4c5bd9.png)

Also node that due to the nature of Trinitys multi process architecture there are quite a few interesting Trinity specific charts that we could also add in the future.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

[//]: # (See: https://trinity-client.readthedocs.io/en/latest/contributing.html#pull-requests)
- [x] Add entry to the [release notes](https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://i.pinimg.com/originals/41/7d/29/417d2985a8fe479185e82519a0f419f7.jpg)
