### PR TITLE
UPnPService now broadcasts an event when it creates a portmap

### DIFF
--- a/scripts/upnp.py
+++ b/scripts/upnp.py
@@ -1,0 +1,29 @@
+import argparse
+import uuid
+
+import trio
+
+from lahja import ConnectionConfig, TrioEndpoint
+
+from trinity.components.builtin.upnp.events import NewUPnPMapping
+from trinity.constants import UPNP_EVENTBUS_ENDPOINT
+
+
+async def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--ipc', type=str, help="The path to UPnPService's IPC file")
+    args = parser.parse_args()
+
+    connection_config = ConnectionConfig(UPNP_EVENTBUS_ENDPOINT, args.ipc)
+    async with TrioEndpoint(f"upnp-watcher-{uuid.uuid4()}").run() as client:
+        with trio.fail_after(1):
+            await client.connect_to_endpoints(connection_config)
+
+        async for event in client.stream(NewUPnPMapping):
+            external_ip = event.ip
+            print("Got new UPnP mapping:", external_ip)
+
+
+if __name__ == "__main__":
+    # Connect to a running UPnPService and prints any NewUPnPMapping it broadcasts.
+    trio.run(main)

--- a/trinity/components/builtin/upnp/component.py
+++ b/trinity/components/builtin/upnp/component.py
@@ -10,9 +10,8 @@ from trinity.boot_info import BootInfo
 from trinity.extensibility import (
     AsyncioIsolatedComponent,
 )
-from .nat import (
-    UPnPService
-)
+from trinity.components.builtin.upnp.nat import UPnPService
+from trinity.constants import UPNP_EVENTBUS_ENDPOINT
 
 
 class UpnpComponent(AsyncioIsolatedComponent):
@@ -21,6 +20,7 @@ class UpnpComponent(AsyncioIsolatedComponent):
     Universal Plug 'n' Play (upnp) standard.
     """
     name = "Upnp"
+    endpoint_name = UPNP_EVENTBUS_ENDPOINT
 
     @property
     def is_enabled(self) -> bool:
@@ -39,6 +39,13 @@ class UpnpComponent(AsyncioIsolatedComponent):
     @classmethod
     async def do_run(cls, boot_info: BootInfo, event_bus: EndpointAPI) -> None:
         port = boot_info.trinity_config.port
-        upnp_service = UPnPService(port)
+        upnp_service = UPnPService(port, event_bus)
 
         await run_asyncio_service(upnp_service)
+
+
+if __name__ == "__main__":
+    import asyncio
+    from trinity.extensibility.component import run_standalone_eth1_component
+    loop = asyncio.get_event_loop()
+    loop.run_until_complete(run_standalone_eth1_component(UpnpComponent))

--- a/trinity/components/builtin/upnp/events.py
+++ b/trinity/components/builtin/upnp/events.py
@@ -1,0 +1,8 @@
+from dataclasses import dataclass
+
+from lahja import BaseEvent
+
+
+@dataclass
+class NewUPnPMapping(BaseEvent):
+    ip: str

--- a/trinity/constants.py
+++ b/trinity/constants.py
@@ -37,6 +37,7 @@ SYNC_BEAM = 'beam'
 MAIN_EVENTBUS_ENDPOINT = 'main'
 NETWORKDB_EVENTBUS_ENDPOINT = 'network-db'
 NETWORKING_EVENTBUS_ENDPOINT = 'networking'
+UPNP_EVENTBUS_ENDPOINT = 'upnp'
 TO_NETWORKING_BROADCAST_CONFIG = BroadcastConfig(filter_endpoint=NETWORKING_EVENTBUS_ENDPOINT)
 
 # Network IDs: https://ethereum.stackexchange.com/questions/17051/how-to-select-a-network-id-or-is-there-a-list-of-network-ids/17101#17101  # noqa: E501

--- a/trinity/extensibility/component.py
+++ b/trinity/extensibility/component.py
@@ -150,8 +150,9 @@ async def run_standalone_component(
 
     logging.basicConfig(
         level=logging.INFO, format='%(asctime)s %(levelname)s: %(message)s', datefmt='%H:%M:%S')
-    for name, level in args.log_levels.items():
-        logging.getLogger(name).setLevel(level)
+    if args.log_levels is not None:
+        for name, level in args.log_levels.items():
+            logging.getLogger(name).setLevel(level)
 
     trinity_config = TrinityConfig.from_parser_args(args, app_identifier, app_config_types)
     trinity_config.trinity_root_dir.mkdir(exist_ok=True)


### PR DESCRIPTION
Also adds the boilerplate necessary to launch the UPnP component by
itself, as well as a helper script that listens for NewUPnPMapping
events and prints them to stdout.

We have no tests for UPnPService as that would probably require mocking
a ton of stuff, so there's no straightforward way to test that it emits
the events either, but at least now we can launch the component by
itself and there's a script to print the events it emits.