### PR TITLE
Use internet-facing address in our local ENR

### DIFF
--- a/tests-trio/conftest.py
+++ b/tests-trio/conftest.py
@@ -1,0 +1,43 @@
+import tempfile
+from pathlib import Path
+import uuid
+
+import pytest
+import trio
+
+from lahja.trio.endpoint import TrioEndpoint
+from lahja import ConnectionConfig
+
+# Fixtures below are copied from https://github.com/ethereum/lahja/blob/f0b7ead13298de82c02ed92cfb2d32a8bc00b42a/tests/core/trio/conftest.py  # noqa: E501
+
+
+@pytest.fixture
+def ipc_base_path():
+    with tempfile.TemporaryDirectory() as temp_dir:
+        yield Path(temp_dir)
+
+
+def generate_unique_name() -> str:
+    # We use unique names to avoid clashing of IPC pipes
+    return str(uuid.uuid4())
+
+
+@pytest.fixture
+def endpoint_server_config(ipc_base_path):
+    config = ConnectionConfig.from_name(generate_unique_name(), base_path=ipc_base_path)
+    return config
+
+
+@pytest.fixture
+async def endpoint_server(endpoint_server_config):
+    async with TrioEndpoint.serve(endpoint_server_config) as endpoint:
+        yield endpoint
+
+
+@pytest.fixture
+async def endpoint_client(endpoint_server_config, endpoint_server):
+    async with TrioEndpoint("client-for-testing").run() as client:
+        await client.connect_to_endpoints(endpoint_server_config)
+        while not endpoint_server.is_connected_to("client-for-testing"):
+            await trio.sleep(0)
+        yield client

--- a/tests-trio/eth1-monitor/conftest.py
+++ b/tests-trio/eth1-monitor/conftest.py
@@ -1,12 +1,7 @@
 import functools
 import json
-import tempfile
-from pathlib import Path
-import uuid
-
 
 import pytest
-import trio
 import ssz
 import eth_utils
 
@@ -15,8 +10,6 @@ from eth_tester import EthereumTester, PyEVMBackend
 from async_service import background_trio_service
 from web3 import Web3
 from web3.providers.eth_tester import EthereumTesterProvider
-from lahja.trio.endpoint import TrioEndpoint
-from lahja import ConnectionConfig
 
 from trinity.components.eth2.eth1_monitor.configs import deposit_contract_json
 from trinity.components.eth2.eth1_monitor.eth1_monitor import Eth1Monitor
@@ -126,38 +119,3 @@ def deposit(w3, deposit_contract) -> int:
     tx_receipt = w3.eth.waitForTransactionReceipt(tx_hash)
     assert tx_receipt["status"]
     return deposit_data.amount
-
-
-# Fixtures below are copied from https://github.com/ethereum/lahja/blob/f0b7ead13298de82c02ed92cfb2d32a8bc00b42a/tests/core/trio/conftest.py  # noqa: E501
-
-
-@pytest.fixture
-def ipc_base_path():
-    with tempfile.TemporaryDirectory() as temp_dir:
-        yield Path(temp_dir)
-
-
-def generate_unique_name() -> str:
-    # We use unique names to avoid clashing of IPC pipes
-    return str(uuid.uuid4())
-
-
-@pytest.fixture
-def endpoint_server_config(ipc_base_path):
-    config = ConnectionConfig.from_name(generate_unique_name(), base_path=ipc_base_path)
-    return config
-
-
-@pytest.fixture
-async def endpoint_server(endpoint_server_config):
-    async with TrioEndpoint.serve(endpoint_server_config) as endpoint:
-        yield endpoint
-
-
-@pytest.fixture
-async def endpoint_client(endpoint_server_config, endpoint_server):
-    async with TrioEndpoint("client-for-testing").run() as client:
-        await client.connect_to_endpoints(endpoint_server_config)
-        while not endpoint_server.is_connected_to("client-for-testing"):
-            await trio.sleep(0)
-        yield client

--- a/tests-trio/p2p-trio/conftest.py
+++ b/tests-trio/p2p-trio/conftest.py
@@ -16,7 +16,6 @@ from eth.db.backends.memory import MemoryDB
 from p2p.discovery import DiscoveryService
 from p2p.discv5.enr_db import NodeDB
 from p2p.discv5.identity_schemes import default_identity_scheme_registry
-from p2p.kademlia import Address
 
 
 # Silence factory-boy logs; we're not interested in them.
@@ -41,10 +40,11 @@ async def socket_pair():
 
 @asynccontextmanager
 async def _manually_driven_discovery(seed, socket, nursery):
-    ip, port = socket.getsockname()
+    _, port = socket.getsockname()
     discovery = ManuallyDrivenDiscoveryService(
         keys.PrivateKey(keccak(seed)),
-        Address(ip, port, port),
+        port,
+        port,
         bootstrap_nodes=[],
         event_bus=None,
         socket=socket,

--- a/trinity/components/builtin/peer_discovery/component.py
+++ b/trinity/components/builtin/peer_discovery/component.py
@@ -32,9 +32,6 @@ from p2p.discovery import (
 )
 from p2p.discv5.enr_db import NodeDB
 from p2p.discv5.identity_schemes import default_identity_scheme_registry
-from p2p.kademlia import (
-    Address,
-)
 
 from trinity.boot_info import BootInfo
 from trinity.config import Eth1AppConfig
@@ -73,8 +70,6 @@ class PeerDiscoveryComponent(TrioIsolatedComponent):
     async def do_run(cls, boot_info: BootInfo, event_bus: EndpointAPI) -> None:
         config = boot_info.trinity_config
         db = DBClient.connect(config.database_ipc_path)
-        external_ip = "0.0.0.0"
-        address = Address(external_ip, config.port, config.port)
 
         if boot_info.args.disable_discovery:
             discovery_service: async_service.Service = StaticDiscoveryService(
@@ -85,14 +80,14 @@ class PeerDiscoveryComponent(TrioIsolatedComponent):
             vm_config = config.get_app_config(Eth1AppConfig).get_chain_config().vm_configuration
             headerdb = TrioHeaderDB(db)
             eth_cap_provider = functools.partial(generate_eth_cap_enr_field, vm_config, headerdb)
-            external_ip = "0.0.0.0"
             socket = trio.socket.socket(family=trio.socket.AF_INET, type=trio.socket.SOCK_DGRAM)
+            await socket.bind(("0.0.0.0", config.port))
             base_db = LevelDB(config.node_db_dir)
             node_db = NodeDB(default_identity_scheme_registry, base_db)
-            await socket.bind((external_ip, config.port))
             discovery_service = PreferredNodeDiscoveryService(
                 config.nodekey,
-                address,
+                config.port,
+                config.port,
                 config.bootstrap_nodes,
                 config.preferred_nodes,
                 event_bus,


### PR DESCRIPTION
Upon startup, DiscoveryService will now use the first internet-facing
address it finds on any network interfaces, falling back to the loopback
address if none is found.

It will also watch for any NewUPnPMapping and use that to update our
local ENR.

Closes: #1571