### PR TITLE
Fork choice updates addressing spec PRs 1508, 1509

### DIFF
--- a/eth2/beacon/fork_choice/lmd_ghost.py
+++ b/eth2/beacon/fork_choice/lmd_ghost.py
@@ -330,9 +330,13 @@ class Store:
             post_state.current_justified_checkpoint.epoch
             > self._context.justified_checkpoint.epoch
         ):
-            self._context.best_justified_checkpoint = (
-                post_state.current_justified_checkpoint
-            )
+            if (
+                post_state.current_justified_checkpoint.epoch
+                > self._context.best_justified_checkpoint.epoch
+            ):
+                self._context.best_justified_checkpoint = (
+                    post_state.current_justified_checkpoint
+                )
             if self._should_update_justified_checkpoint(
                 post_state.current_justified_checkpoint
             ):
@@ -361,6 +365,13 @@ class Store:
         if target.epoch not in (current_epoch, previous_epoch):
             raise ValidationError(
                 "Attestations must be from the current or previous epoch"
+            )
+
+        if target.epoch != compute_epoch_at_slot(
+            attestation.data.slot, self._config.SLOTS_PER_EPOCH
+        ):
+            raise ValidationError(
+                "Attestation's slot is not for the epoch given in the target"
             )
 
         if target.root not in self._context.blocks:


### PR DESCRIPTION
### What was wrong?

Two small fork choice updates we did not implement from v0.9.3 of the spec.

https://github.com/ethereum/eth2.0-specs/pull/1508
https://github.com/ethereum/eth2.0-specs/pull/1509

### How was it fixed?

Implemented the spec.

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://i.pinimg.com/236x/a6/91/c5/a691c5fbef821a8b61810a545f5e8f32--bowties-persian-cats.jpg)
