### PR TITLE
discv4: Catch ValueError from set_enr() and log

### DIFF
--- a/p2p/discv5/enr_db.py
+++ b/p2p/discv5/enr_db.py
@@ -50,10 +50,8 @@ class NodeDB(NodeDBAPI):
             existing_enr = None
         if existing_enr and existing_enr.sequence_number > enr.sequence_number:
             raise ValueError(
-                "Cannot overwrite existing ENR (%d) with old one (%d)",
-                existing_enr.sequence_number,
-                enr.sequence_number
-            )
+                f"Cannot overwrite existing ENR ({existing_enr.sequence_number}) with old one "
+                f"({enr.sequence_number})")
         self.db.set(self._get_enr_key(enr.node_id), rlp.encode(enr))
 
     def get_enr(self, node_id: NodeID) -> ENR:

--- a/scripts/discovery.py
+++ b/scripts/discovery.py
@@ -26,7 +26,7 @@ async def main() -> None:
     logger = logging.getLogger()
 
     parser = argparse.ArgumentParser()
-    parser.add_argument('-ipc', type=str, help="The path to DiscoveryService's IPC file")
+    parser.add_argument('--ipc', type=str, help="The path to DiscoveryService's IPC file")
     args = parser.parse_args()
 
     # XXX: This is an ugly hack, but it's the easiest way to ensure we use the same network as the


### PR DESCRIPTION
As seen in #1570, we seem to have some race conditions causing us to attempt to overwrite an ENR
in our DB with the stub version we generate the first time we hear about a node. This should help
us figure out the cause of the race