### PR TITLE
discv4: Force new bonds with bootnodes when bootstrapping

### DIFF
--- a/p2p/kademlia.py
+++ b/p2p/kademlia.py
@@ -399,12 +399,17 @@ class RoutingTable:
         return None  # successfully added to not full bucket
 
     def get_node(self, node_id: NodeID) -> NodeAPI:
+        """
+        Return the Node with the given ID if it is in the routing table or the replacement cache.
+
+        Raises a KeyError otherwise.
+        """
         id_int = big_endian_to_int(node_id)
         bucket = binary_get_bucket_for_node(self.buckets, id_int)
         for node in itertools.chain(bucket.nodes, bucket.replacement_cache):
             if node.id == node_id:
                 return node
-        raise KeyError("Node {node_id} is not in routing table")
+        raise KeyError("Node {node_id} is not in routing table nor replacement cache")
 
     def get_bucket_for_node(self, node_id: int) -> KBucket:
         return binary_get_bucket_for_node(self.buckets, node_id)


### PR DESCRIPTION
Before we started persisting bond information in our NodeDB we'd always
perform a new bond with our bootnodes during bootstrap, ensuring they
get added to our RT so that we can query them but also ensuring they
have our latest ENR. This change restores that behaviour by having
bootstrap() pass force_new_bond=True when bonding with bootnodes

Also turns DiscoveryService.bootstrap_nodes into an `@property` that
always loads the last version of our bootnodes from the DB instead
of the ones passed at instantiation time, which might get outdated.