### PR TITLE
New get_logger() helper that ensures logger hierarchy

### DIFF
--- a/p2p/_utils.py
+++ b/p2p/_utils.py
@@ -3,6 +3,15 @@ from typing import Hashable, Sequence, Tuple, TypeVar
 
 import rlp
 
+import eth_utils
+
+
+def get_logger(name: str) -> eth_utils.ExtendedDebugLogger:
+    # Just a local wrapper around trinity's get_logger() as we need to delay the import to avoid
+    # cyclical imports ar parse time.
+    from trinity._utils.logging import get_logger as trinity_get_logger
+    return trinity_get_logger(name)
+
 
 def sxor(s1: bytes, s2: bytes) -> bytes:
     if len(s1) != len(s2):

--- a/p2p/abc.py
+++ b/p2p/abc.py
@@ -498,9 +498,13 @@ THandshakeReceipt = TypeVar('THandshakeReceipt', bound=HandshakeReceiptAPI)
 
 
 class HandshakerAPI(ABC, Generic[TProtocol]):
-    logger: ExtendedDebugLogger
 
     protocol_class: Type[TProtocol]
+
+    @property
+    @abstractmethod
+    def logger(self) -> ExtendedDebugLogger:
+        ...
 
     @abstractmethod
     async def do_handshake(self,

--- a/p2p/auth.py
+++ b/p2p/auth.py
@@ -1,5 +1,4 @@
 import asyncio
-import logging
 import os
 import random
 import struct
@@ -29,6 +28,7 @@ from p2p.exceptions import (
     HandshakeFailure,
 )
 from p2p._utils import (
+    get_logger,
     sxor,
 )
 
@@ -114,7 +114,6 @@ async def _handshake(initiator: 'HandshakeInitiator', reader: asyncio.StreamRead
 
 
 class HandshakeBase:
-    logger = logging.getLogger("p2p.peer.Handshake")
     _is_initiator = False
 
     def __init__(
@@ -125,6 +124,7 @@ class HandshakeBase:
         elif remote.address is None:
             raise ValidationError("Cannot create handshake with remote address=None")
 
+        self.logger = get_logger("p2p.peer.Handshake")
         self.remote = remote
         self.privkey = privkey
         self.ephemeral_privkey = ecies.generate_privkey()

--- a/p2p/discovery.py
+++ b/p2p/discovery.py
@@ -34,10 +34,7 @@ from async_generator import aclosing
 import trio
 
 import eth_utils.toolz
-from eth_utils import (
-    ExtendedDebugLogger,
-    get_extended_debug_logger,
-)
+from eth_utils import ExtendedDebugLogger
 
 from lahja import (
     EndpointAPI,
@@ -85,6 +82,7 @@ from p2p.exceptions import (
 )
 from p2p.kademlia import (
     Address, Node, check_relayed_addr, create_stub_enr, sort_by_distance, KademliaRoutingTable)
+from p2p._utils import get_logger
 from p2p import trio_utils
 
 # V4 handler are async methods that take a Node, payload and msg_hash as arguments.
@@ -145,7 +143,7 @@ class DiscoveryService(Service):
                  node_db: NodeDBAPI,
                  enr_field_providers: Sequence[ENR_FieldProvider] = tuple(),
                  ) -> None:
-        self.logger = get_extended_debug_logger('p2p.discovery.DiscoveryService')
+        self.logger = get_logger('p2p.discovery.DiscoveryService')
         self.privkey = privkey
         self._event_bus = event_bus
         self.enr_response_channels = ExpectedResponseChannels[Tuple[ENR, Hash32]]()
@@ -1172,7 +1170,7 @@ class StaticDiscoveryService(Service):
             self,
             event_bus: EndpointAPI,
             static_peers: Sequence[NodeAPI]) -> None:
-        self.logger = get_extended_debug_logger('p2p.discovery.StaticDiscoveryService')
+        self.logger = get_logger('p2p.discovery.StaticDiscoveryService')
         self._event_bus = event_bus
         self._static_peers = tuple(static_peers)
 
@@ -1215,7 +1213,7 @@ class NoopDiscoveryService(Service):
     'A stub "discovery service" which does nothing'
 
     def __init__(self, event_bus: EndpointAPI) -> None:
-        self.logger = get_extended_debug_logger('p2p.discovery.NoopDiscoveryService')
+        self.logger = get_logger('p2p.discovery.NoopDiscoveryService')
         self._event_bus = event_bus
 
     async def handle_get_peer_candidates_requests(self) -> None:

--- a/p2p/exchange/tracker.py
+++ b/p2p/exchange/tracker.py
@@ -1,11 +1,10 @@
 from abc import abstractmethod
 from typing import Optional
 
-from eth_utils import get_extended_debug_logger
-
 from p2p.stats.ema import EMA
 from p2p.stats.percentile import Percentile
 from p2p.stats.stddev import StandardDeviation
+from p2p._utils import get_logger
 
 from .abc import PerformanceTrackerAPI
 from .constants import ROUND_TRIP_TIMEOUT
@@ -13,9 +12,9 @@ from .typing import TRequestCommand, TResult
 
 
 class BasePerformanceTracker(PerformanceTrackerAPI[TRequestCommand, TResult]):
-    logger = get_extended_debug_logger('trinity.protocol.common.trackers.PerformanceTracker')
 
     def __init__(self) -> None:
+        self.logger = get_logger('trinity.protocol.common.trackers.PerformanceTracker')
         self.total_msgs = 0
         self.total_items = 0
         self.total_timeouts = 0

--- a/p2p/handshake.py
+++ b/p2p/handshake.py
@@ -10,17 +10,19 @@ from typing import (
     Tuple,
 )
 
+from cached_property import cached_property
+
 from cancel_token import CancelToken
 
 from eth_utils import (
-    get_extended_debug_logger,
+    ExtendedDebugLogger,
     to_tuple,
 )
 from eth_utils.toolz import groupby, valmap
 
 from eth_keys import keys
 
-from p2p._utils import duplicates
+from p2p._utils import duplicates, get_logger
 from p2p.abc import (
     ConnectionAPI,
     HandshakerAPI,
@@ -66,7 +68,10 @@ class Handshaker(HandshakerAPI[TProtocol]):
     justification for this class's existence is to house parameters that are
     needed for the protocol handshake.
     """
-    logger = get_extended_debug_logger('p2p.handshake.Handshaker')
+
+    @cached_property
+    def logger(self) -> ExtendedDebugLogger:
+        return get_logger('p2p.handshake.Handshaker')
 
 
 class DevP2PHandshakeParams(NamedTuple):

--- a/p2p/kademlia.py
+++ b/p2p/kademlia.py
@@ -2,7 +2,6 @@ import collections
 import functools
 import ipaddress
 import itertools
-import logging
 import operator
 import random
 import struct
@@ -37,6 +36,7 @@ from p2p.constants import (
     IP_V4_ADDRESS_ENR_KEY, UDP_PORT_ENR_KEY, TCP_PORT_ENR_KEY, NUM_ROUTING_TABLE_BUCKETS)
 from p2p.identity_schemes import V4CompatIdentityScheme
 from p2p.typing import NodeID
+from p2p._utils import get_logger
 from p2p.validation import validate_enode_uri
 
 
@@ -275,7 +275,7 @@ def compute_log_distance(left_node_id: NodeID, right_node_id: NodeID) -> int:
 class KademliaRoutingTable:
 
     def __init__(self, center_node_id: NodeID, bucket_size: int) -> None:
-        self.logger = logging.getLogger("p2p.discv5.routing_table.KademliaRoutingTable")
+        self.logger = get_logger("p2p.kademlia.KademliaRoutingTable")
         self.center_node_id = center_node_id
         self.bucket_size = bucket_size
 

--- a/p2p/multiplexer.py
+++ b/p2p/multiplexer.py
@@ -1,5 +1,4 @@
 import asyncio
-import logging
 import collections
 from typing import (
     Any,
@@ -20,7 +19,7 @@ from async_generator import asynccontextmanager
 
 from cancel_token import CancelToken
 
-from eth_utils import get_extended_debug_logger, ValidationError
+from eth_utils import ValidationError
 from eth_utils.toolz import cons
 import rlp
 
@@ -42,9 +41,7 @@ from p2p.exceptions import (
 )
 from p2p.p2p_proto import BaseP2PProtocol
 from p2p.transport_state import TransportState
-
-
-logger = logging.getLogger('p2p.multiplexer')
+from p2p._utils import get_logger
 
 
 async def stream_transport_messages(transport: TransportAPI,
@@ -101,7 +98,6 @@ async def stream_transport_messages(transport: TransportAPI,
 
 
 class Multiplexer(CancellableMixin, MultiplexerAPI):
-    logger = get_extended_debug_logger('p2p.multiplexer.Multiplexer')
 
     _multiplex_token: CancelToken
 
@@ -117,6 +113,7 @@ class Multiplexer(CancellableMixin, MultiplexerAPI):
                  protocols: Sequence[ProtocolAPI],
                  token: CancelToken = None,
                  max_queue_size: int = 4096) -> None:
+        self.logger = get_logger('p2p.multiplexer.Multiplexer')
         if token is None:
             loop = None
         else:

--- a/p2p/node_db.py
+++ b/p2p/node_db.py
@@ -7,22 +7,18 @@ from eth.abc import DatabaseAPI
 
 import rlp
 
-from eth_utils import get_extended_debug_logger
-
 from p2p.abc import NodeDBAPI
 from p2p.enr import ENR
 from p2p.identity_schemes import IdentitySchemeRegistry
 from p2p.typing import NodeID
+from p2p._utils import get_logger
 
 
 class NodeDB(NodeDBAPI):
 
     def __init__(self, identity_scheme_registry: IdentitySchemeRegistry, db: DatabaseAPI) -> None:
         self.db = db
-        self.logger = get_extended_debug_logger(".".join((
-            self.__module__,
-            self.__class__.__name__,
-        )))
+        self.logger = get_logger(".".join((self.__module__, self.__class__.__name__,)))
         self._identity_scheme_registry = identity_scheme_registry
 
     @property

--- a/p2p/p2p_api.py
+++ b/p2p/p2p_api.py
@@ -1,5 +1,3 @@
-import logging
-
 from cached_property import cached_property
 
 from p2p.abc import ConnectionAPI
@@ -7,6 +5,7 @@ from p2p.logic import Application, CommandHandler
 from p2p.disconnect import DisconnectReason
 from p2p.p2p_proto import Disconnect, Ping, Pong
 from p2p.qualifiers import always
+from p2p._utils import get_logger
 
 
 class PongWhenPinged(CommandHandler[Ping]):
@@ -23,12 +22,11 @@ class P2PAPI(Application):
     name = 'p2p'
     qualifier = always  # always valid for all connections.
 
-    logger = logging.getLogger('p2p.p2p_api.P2PAPI')
-
     local_disconnect_reason: DisconnectReason = None
     remote_disconnect_reason: DisconnectReason = None
 
     def __init__(self) -> None:
+        self.logger = get_logger('p2p.p2p_api.P2PAPI')
         self.add_child_behavior(PongWhenPinged().as_behavior())
 
     #

--- a/p2p/peer.py
+++ b/p2p/peer.py
@@ -23,8 +23,8 @@ from lahja import EndpointAPI
 from cached_property import cached_property
 
 from eth_utils import (
-    get_extended_debug_logger,
     to_tuple,
+    ExtendedDebugLogger,
     ValidationError,
 )
 
@@ -60,6 +60,7 @@ from p2p.tracking.connection import (
     BaseConnectionTracker,
     NoopConnectionTracker,
 )
+from p2p._utils import get_logger
 
 if TYPE_CHECKING:
     from p2p.peer_pool import BasePeerPool  # noqa: F401
@@ -464,9 +465,12 @@ class PeerSubscriber(ABC):
 
 
 class MsgBuffer(PeerSubscriber):
-    logger = get_extended_debug_logger('p2p.peer.MsgBuffer')
     msg_queue_maxsize = 500
     subscription_msg_types = frozenset({BaseCommand})
+
+    @cached_property
+    def logger(self) -> ExtendedDebugLogger:
+        return get_logger('p2p.peer.MsgBuffer')
 
     @to_tuple
     def get_messages(self) -> Iterator[PeerMessage]:

--- a/p2p/protocol.py
+++ b/p2p/protocol.py
@@ -1,4 +1,3 @@
-import logging
 from typing import (
     Any,
     Sequence,
@@ -15,15 +14,16 @@ from p2p.abc import (
 )
 from p2p.constants import P2P_PROTOCOL_COMMAND_LENGTH
 from p2p.typing import Capability
+from p2p._utils import get_logger
 
 
 class BaseProtocol(ProtocolAPI):
-    logger = logging.getLogger('p2p.protocol.Protocol')
 
     def __init__(self,
                  transport: TransportAPI,
                  command_id_offset: int,
                  snappy_support: bool) -> None:
+        self.logger = get_logger('p2p.protocol.Protocol')
         self.transport = transport
         self.command_id_offset = command_id_offset
         self.snappy_support = snappy_support

--- a/p2p/service.py
+++ b/p2p/service.py
@@ -21,11 +21,11 @@ from cancel_token import CancelToken, OperationCancelled
 from eth_utils import (
     ExtendedDebugLogger,
     ValidationError,
-    get_extended_debug_logger,
 )
 
 from p2p.abc import ServiceEventsAPI, AsyncioServiceAPI
 from p2p.cancellable import CancellableMixin
+from p2p._utils import get_logger
 
 
 class ServiceEvents(ServiceEventsAPI):
@@ -73,7 +73,7 @@ class BaseService(CancellableMixin, AsyncioServiceAPI):
     @property
     def logger(self) -> ExtendedDebugLogger:
         if self._logger is None:
-            self._logger = get_extended_debug_logger(
+            self._logger = get_logger(
                 self.__module__ + '.' + self.__class__.__name__
             )
         return self._logger

--- a/p2p/tools/memory_transport.py
+++ b/p2p/tools/memory_transport.py
@@ -5,9 +5,6 @@ from typing import Tuple
 from cached_property import cached_property
 from cancel_token import CancelToken
 from eth_keys import datatypes
-from eth_utils import (
-    get_extended_debug_logger,
-)
 
 from p2p.abc import MessageAPI, NodeAPI, TransportAPI
 from p2p.exceptions import PeerConnectionLost
@@ -15,6 +12,7 @@ from p2p.message import Message
 from p2p.session import Session
 from p2p.tools.asyncio_streams import get_directly_connected_streams
 from p2p.transport_state import TransportState
+from p2p._utils import get_logger
 
 
 CONNECTION_LOST_ERRORS = (
@@ -25,7 +23,6 @@ CONNECTION_LOST_ERRORS = (
 
 
 class MemoryTransport(TransportAPI):
-    logger = get_extended_debug_logger('p2p.tools.memory_transport.MemoryTransport')
     read_state = TransportState.IDLE
 
     def __init__(self,
@@ -33,6 +30,7 @@ class MemoryTransport(TransportAPI):
                  private_key: datatypes.PrivateKey,
                  reader: asyncio.StreamReader,
                  writer: asyncio.StreamWriter) -> None:
+        self.logger = get_logger('p2p.tools.memory_transport.MemoryTransport')
         self.remote = remote
         self.session = Session(remote)
         self._private_key = private_key

--- a/p2p/tools/paragon/proto.py
+++ b/p2p/tools/paragon/proto.py
@@ -1,6 +1,5 @@
-import logging
-
 from p2p.protocol import BaseProtocol
+from p2p._utils import get_logger
 
 from .commands import (
     BroadcastData,
@@ -17,4 +16,4 @@ class ParagonProtocol(BaseProtocol):
         GetSum, Sum,
     )
     command_length = 3
-    logger = logging.getLogger("p2p.tools.paragon.proto.ParagonProtocol")
+    logger = get_logger("p2p.tools.paragon.proto.ParagonProtocol")

--- a/p2p/tracking/connection.py
+++ b/p2p/tracking/connection.py
@@ -1,18 +1,19 @@
 from abc import ABC, abstractmethod
-import logging
 from typing import (
     Dict,
     Tuple,
     Type,
 )
 
+from eth_utils.logging import get_extended_debug_logger
+
 from p2p.abc import NodeAPI
-from p2p.typing import NodeID
 from p2p.exceptions import (
     BaseP2PError,
     HandshakeFailure,
     HandshakeFailureTooManyPeers,
 )
+from p2p.typing import NodeID
 
 
 FAILURE_TIMEOUTS: Dict[Type[Exception], int] = {}
@@ -41,7 +42,7 @@ class BaseConnectionTracker(ABC):
     Base API which defines the interface that the peer pool uses to record
     information about connection failures when attempting to connect to peers
     """
-    logger = logging.getLogger('p2p.tracking.connection.ConnectionTracker')
+    logger = get_extended_debug_logger('p2p.tracking.connection.ConnectionTracker')
 
     def record_failure(self, remote: NodeAPI, failure: BaseP2PError) -> None:
         timeout_seconds = get_timeout_for_failure(failure)

--- a/tests/core/test_logging.py
+++ b/tests/core/test_logging.py
@@ -1,0 +1,20 @@
+import eth_utils
+
+from trinity._utils.logging import get_logger
+
+
+def test_get_logger():
+    logger = get_logger("foo.bar.baz")
+    assert isinstance(logger, eth_utils.ExtendedDebugLogger)
+    assert logger.parent.name == "foo.bar"
+    assert isinstance(logger.parent, eth_utils.ExtendedDebugLogger)
+    assert logger.parent.parent.name == "foo"
+    assert isinstance(logger.parent.parent, eth_utils.ExtendedDebugLogger)
+
+
+def test_get_logger_with_existing_ancestors():
+    foo_logger = get_logger("foo")
+    bar_logger = get_logger("foo.bar")
+    assert bar_logger.parent == foo_logger
+    baz_logger = get_logger("foo.bar.baz")
+    assert baz_logger.parent == bar_logger

--- a/trinity/components/builtin/ethstats/ethstats_client.py
+++ b/trinity/components/builtin/ethstats/ethstats_client.py
@@ -9,8 +9,10 @@ from typing import (
 )
 
 from async_service import Service
-from eth_utils import get_extended_debug_logger
+
 import websockets
+
+from trinity._utils.logging import get_logger
 
 
 # Returns UTC timestamp in ms, used for latency calculation
@@ -31,7 +33,7 @@ class EthstatsException(Exception):
 
 
 class EthstatsClient(Service):
-    logger = get_extended_debug_logger('trinity.components.ethstats.Client')
+    logger = get_logger('trinity.components.ethstats.Client')
 
     def __init__(
         self,

--- a/trinity/components/builtin/metrics/service/base.py
+++ b/trinity/components/builtin/metrics/service/base.py
@@ -1,11 +1,11 @@
 from abc import abstractmethod
 
 from async_service import Service
-from eth_utils import get_extended_debug_logger
 from pyformance.reporters import InfluxReporter
 
 from trinity.components.builtin.metrics.abc import MetricsServiceAPI
 from trinity.components.builtin.metrics.registry import HostMetricsRegistry
+from trinity._utils.logging import get_logger
 
 
 class BaseMetricsService(Service, MetricsServiceAPI):
@@ -34,7 +34,7 @@ class BaseMetricsService(Service, MetricsServiceAPI):
             server=influx_server
         )
 
-    logger = get_extended_debug_logger('trinity.components.builtin.metrics.MetricsService')
+    logger = get_logger('trinity.components.builtin.metrics.MetricsService')
 
     @property
     def registry(self) -> HostMetricsRegistry:

--- a/trinity/components/builtin/metrics/service/noop.py
+++ b/trinity/components/builtin/metrics/service/noop.py
@@ -1,8 +1,8 @@
 from async_service import Service
-from eth_utils import get_extended_debug_logger
 
 from trinity.components.builtin.metrics.abc import MetricsServiceAPI
 from trinity.components.builtin.metrics.registry import NoopMetricsRegistry
+from trinity._utils.logging import get_logger
 
 
 class NoopMetricsService(Service, MetricsServiceAPI):
@@ -12,7 +12,7 @@ class NoopMetricsService(Service, MetricsServiceAPI):
     will only incur the cost of a noop.
     """
 
-    logger = get_extended_debug_logger('trinity.components.builtin.metrics.NoopMetricsService')
+    logger = get_logger('trinity.components.builtin.metrics.NoopMetricsService')
 
     def __init__(self,
                  influx_server: str = '',

--- a/trinity/components/builtin/network_db/connection/server.py
+++ b/trinity/components/builtin/network_db/connection/server.py
@@ -1,10 +1,11 @@
 from lahja import EndpointAPI
 
 from async_service import Service
-from eth_utils import get_extended_debug_logger, humanize_seconds
+from eth_utils import humanize_seconds
 
 from p2p.tracking.connection import BaseConnectionTracker
 
+from trinity._utils.logging import get_logger
 from .events import (
     BlacklistEvent,
     GetBlacklistedPeersRequest,
@@ -17,7 +18,7 @@ class ConnectionTrackerServer(Service):
     Server to handle the event bus communication for BlacklistEvent and
     GetBlacklistedPeersRequest/Response events
     """
-    logger = get_extended_debug_logger('trinity.components.network_db.ConnectionTrackerServer')
+    logger = get_logger('trinity.components.network_db.ConnectionTrackerServer')
 
     def __init__(self,
                  event_bus: EndpointAPI,

--- a/trinity/components/builtin/network_db/eth1_peer_db/tracker.py
+++ b/trinity/components/builtin/network_db/eth1_peer_db/tracker.py
@@ -34,7 +34,6 @@ from eth_typing import Hash32
 
 from eth_utils import (
     humanize_seconds,
-    get_extended_debug_logger,
     to_hex,
     to_tuple,
 )
@@ -59,6 +58,7 @@ from trinity.db.orm import (
 from trinity.components.builtin.network_db.connection.tracker import (
     BlacklistRecord,
 )
+from trinity._utils.logging import get_logger
 
 from .events import (
     TrackPeerEvent,
@@ -93,7 +93,7 @@ class Remote(Base):
 
 
 class BaseEth1PeerTracker(BasePeerBackend, PeerSubscriber):
-    logger = get_extended_debug_logger('trinity.protocol.common.connection.PeerTracker')
+    logger = get_logger('trinity.protocol.common.connection.PeerTracker')
 
     msg_queue_maxsize = 100
     subscription_msg_types: FrozenSet[Type[CommandAPI[Any]]] = frozenset()

--- a/trinity/components/builtin/tx_pool/pool.py
+++ b/trinity/components/builtin/tx_pool/pool.py
@@ -11,13 +11,13 @@ import uuid
 from async_service import Service
 from lahja import EndpointAPI
 
-from eth_utils import get_extended_debug_logger
 from eth_utils.toolz import partition_all
 from eth.abc import SignedTransactionAPI
 
 from p2p.abc import SessionAPI
 
 from trinity._utils.bloom import RollingBloom
+from trinity._utils.logging import get_logger
 from trinity.protocol.eth.events import (
     TransactionsEvent,
 )
@@ -51,7 +51,7 @@ class TxPool(Service):
         This is a minimal viable implementation that only relays transactions but doesn't actually
         hold on to them yet. It's still missing many features of a grown up transaction pool.
     """
-    logger = get_extended_debug_logger('trinity.components.txpool.TxPool')
+    logger = get_logger('trinity.components.txpool.TxPool')
 
     def __init__(self,
                  event_bus: EndpointAPI,

--- a/trinity/components/builtin/upnp/nat.py
+++ b/trinity/components/builtin/upnp/nat.py
@@ -13,13 +13,12 @@ from lahja import EndpointAPI
 
 from async_service import Service
 
-from eth_utils import get_extended_debug_logger
-
 from p2p.exceptions import (
     NoInternalAddressMatchesDevice,
 )
 
 from trinity.components.builtin.upnp.events import NewUPnPMapping
+from trinity._utils.logging import get_logger
 
 
 # UPnP discovery can take a long time, so use a loooong timeout here.
@@ -50,7 +49,7 @@ class UPnPService(Service):
     Generate a mapping of external network IP address/port to internal IP address/port,
     using the Universal Plug 'n' Play standard.
     """
-    logger = get_extended_debug_logger('trinity.components.upnp.UPnPService')
+    logger = get_logger('trinity.components.upnp.UPnPService')
 
     _nat_portmap_lifetime = 30 * 60
 

--- a/trinity/extensibility/asyncio.py
+++ b/trinity/extensibility/asyncio.py
@@ -1,6 +1,5 @@
 from abc import abstractmethod
 import asyncio
-import logging
 import signal
 from typing import Optional
 
@@ -10,7 +9,7 @@ from async_service import background_asyncio_service
 from lahja import EndpointAPI
 
 
-from trinity._utils.logging import child_process_logging
+from trinity._utils.logging import child_process_logging, get_logger
 from trinity._utils.profiling import profiler
 from trinity.boot_info import BootInfo
 
@@ -18,7 +17,7 @@ from .component import BaseIsolatedComponent
 from .event_bus import AsyncioEventBusService
 
 
-logger = logging.getLogger('trinity.extensibility.asyncio.AsyncioIsolatedComponent')
+logger = get_logger('trinity.extensibility.asyncio.AsyncioIsolatedComponent')
 
 
 class AsyncioIsolatedComponent(BaseIsolatedComponent):

--- a/trinity/extensibility/component.py
+++ b/trinity/extensibility/component.py
@@ -16,6 +16,7 @@ from async_generator import asynccontextmanager
 from lahja import AsyncioEndpoint, ConnectionConfig, TrioEndpoint
 
 from trinity._utils.os import friendly_filename_or_url
+from trinity._utils.logging import get_logger
 from trinity.boot_info import BootInfo
 from trinity.cli_parser import parser, subparser
 from trinity.config import BaseAppConfig, BeaconAppConfig, Eth1AppConfig, TrinityConfig
@@ -172,7 +173,7 @@ async def run_standalone_component(
         level=logging.INFO, format='%(asctime)s %(levelname)s: %(message)s', datefmt='%H:%M:%S')
     if args.log_levels is not None:
         for name, level in args.log_levels.items():
-            logging.getLogger(name).setLevel(level)
+            get_logger(name).setLevel(level)
 
     trinity_config = TrinityConfig.from_parser_args(args, app_identifier, (app_cfg,))
     trinity_config.trinity_root_dir.mkdir(exist_ok=True)

--- a/trinity/extensibility/trio.py
+++ b/trinity/extensibility/trio.py
@@ -1,6 +1,5 @@
 from abc import abstractmethod
 import asyncio
-import logging
 import signal
 
 import trio
@@ -9,7 +8,7 @@ from async_service import background_trio_service
 from lahja import EndpointAPI
 
 from trinity._utils.ipc import kill_process_gracefully
-from trinity._utils.logging import child_process_logging
+from trinity._utils.logging import child_process_logging, get_logger
 from trinity._utils.mp import ctx
 from trinity._utils.profiling import profiler
 from trinity.boot_info import BootInfo
@@ -43,7 +42,7 @@ class TrioIsolatedComponent(BaseIsolatedComponent):
         finally:
             kill_process_gracefully(
                 process,
-                logging.getLogger('trinity.extensibility.TrioIsolatedComponent'),
+                get_logger('trinity.extensibility.TrioIsolatedComponent'),
             )
 
     @classmethod

--- a/trinity/protocol/bcc_libp2p/utils.py
+++ b/trinity/protocol/bcc_libp2p/utils.py
@@ -37,7 +37,6 @@ from eth_keys import (
 )
 from eth_utils import (
     ValidationError,
-    get_extended_debug_logger,
     to_tuple,
 )
 from libp2p.network.stream.exceptions import (
@@ -65,6 +64,8 @@ from ssz.hashable_container import (
 from ssz.tools import (
     to_formatted_dict,
 )
+
+from trinity._utils.logging import get_logger
 
 from .configs import (
     REQ_RESP_ENCODE_POSTFIX,
@@ -340,7 +341,7 @@ def get_beacon_blocks_by_root(
 
 class Interaction:
     stream: INetStream
-    logger = get_extended_debug_logger("trinity.protocol.bcc_libp2p.Interaction")
+    logger = get_logger("trinity.protocol.bcc_libp2p.Interaction")
 
     def __init__(self, stream: INetStream):
         self.stream = stream

--- a/trinity/protocol/common/peer.py
+++ b/trinity/protocol/common/peer.py
@@ -18,7 +18,6 @@ from lahja import EndpointAPI
 
 from cancel_token import CancelToken, OperationCancelled
 
-from eth_utils.logging import get_extended_debug_logger
 from eth_utils.toolz import (
     excepts,
     groupby,
@@ -78,6 +77,7 @@ from trinity.components.builtin.network_db.eth1_peer_db.tracker import (
     EventBusEth1PeerTracker,
     NoopEth1PeerTracker,
 )
+from trinity._utils.logging import get_logger
 
 from .boot import DAOCheckBootManager
 from .context import ChainContext
@@ -86,7 +86,7 @@ from .events import (
 )
 
 
-p2p_logger = get_extended_debug_logger('p2p')
+p2p_logger = get_logger('p2p')
 
 
 class BaseChainPeer(BasePeer):

--- a/trinity/protocol/common/peer_pool_event_bus.py
+++ b/trinity/protocol/common/peer_pool_event_bus.py
@@ -17,7 +17,6 @@ from typing import (
 
 from async_service import Service
 from cancel_token import CancelToken
-from eth_utils import get_extended_debug_logger
 
 from lahja import (
     BaseEvent,
@@ -34,6 +33,8 @@ from p2p.peer import (
 )
 from p2p.peer_pool import BasePeerPool
 from p2p.service import BaseService
+
+from trinity._utils.logging import get_logger
 
 from .events import (
     ConnectToNodeCommand,
@@ -65,7 +66,7 @@ class PeerPoolEventServer(Service, PeerSubscriber, Generic[TPeer]):
     This class bridges all common APIs but protocol specific communication can be enabled through
     subclasses that add more handlers.
     """
-    logger = get_extended_debug_logger('trinity.protocol.common.PeerPoolEventServer')
+    logger = get_logger('trinity.protocol.common.PeerPoolEventServer')
 
     msg_queue_maxsize: int = 2000
 

--- a/trinity/protocol/common/servers.py
+++ b/trinity/protocol/common/servers.py
@@ -13,7 +13,6 @@ from async_service import Service
 from lahja import EndpointAPI
 
 from eth_typing import Hash32
-from eth_utils import get_extended_debug_logger
 
 from eth.exceptions import (
     HeaderNotFound,
@@ -36,6 +35,7 @@ from trinity._utils.headers import sequence_builder
 from trinity.db.eth1.header import BaseAsyncHeaderDB
 from trinity.protocol.common.peer import BasePeerPool
 from trinity.protocol.common.payloads import BlockHeadersQuery
+from trinity._utils.logging import get_logger
 
 from .events import PeerPoolMessageEvent
 
@@ -91,7 +91,7 @@ class BaseIsolatedRequestServer(Service):
     Monitor commands from peers, to identify inbound requests that should receive a response.
     Handle those inbound requests by querying our local database and replying.
     """
-    logger = get_extended_debug_logger('trinity.protocol.common.servers.IsolatedRequestServer')
+    logger = get_logger('trinity.protocol.common.servers.IsolatedRequestServer')
 
     def __init__(
             self,
@@ -134,7 +134,7 @@ class BaseIsolatedRequestServer(Service):
 
 
 class BasePeerRequestHandler:
-    logger = get_extended_debug_logger('trinity.protocol.common.servers.PeerRequestHandler')
+    logger = get_logger('trinity.protocol.common.servers.PeerRequestHandler')
 
     def __init__(self, db: BaseAsyncHeaderDB) -> None:
         self.db = db

--- a/trinity/protocol/eth/proto.py
+++ b/trinity/protocol/eth/proto.py
@@ -4,11 +4,10 @@ from typing import (
     Type,
 )
 
-from eth_utils import (
-    get_extended_debug_logger,
-)
-
 from p2p.protocol import BaseProtocol
+
+from trinity._utils.logging import get_logger
+
 from .commands import (
     BlockBodies,
     BlockHeaders,
@@ -48,7 +47,7 @@ class ETHProtocolV63(BaseETHProtocol):
     )
     command_length = 17
 
-    logger = get_extended_debug_logger('trinity.protocol.eth.proto.ETHProtocolV63')
+    logger = get_logger('trinity.protocol.eth.proto.ETHProtocolV63')
     status_command_type = StatusV63
 
 
@@ -66,5 +65,5 @@ class ETHProtocol(BaseETHProtocol):
     )
     command_length = 17
 
-    logger = get_extended_debug_logger('trinity.protocol.eth.proto.ETHProtocol')
+    logger = get_logger('trinity.protocol.eth.proto.ETHProtocol')
     status_command_type = Status

--- a/trinity/protocol/eth/proxy.py
+++ b/trinity/protocol/eth/proxy.py
@@ -13,7 +13,6 @@ from eth_typing import (
     BlockIdentifier,
     Hash32,
 )
-from eth_utils import get_extended_debug_logger
 from lahja import (
     BroadcastConfig,
     EndpointAPI,
@@ -22,6 +21,7 @@ from lahja import (
 from p2p.abc import SessionAPI
 
 from trinity._utils.errors import SupportsError
+from trinity._utils.logging import get_logger
 from trinity.protocol.common.typing import (
     BlockBodyBundles,
     NodeDataBundles,
@@ -54,7 +54,7 @@ class ProxyETHAPI:
     An ``ETHAPI`` that can be used outside of the process that runs the peer pool. Any
     action performed on this class is delegated to the process that runs the peer pool.
     """
-    logger = get_extended_debug_logger('trinity.protocol.eth.proxy.ProxyETHAPI')
+    logger = get_logger('trinity.protocol.eth.proxy.ProxyETHAPI')
 
     def __init__(self,
                  session: SessionAPI,

--- a/trinity/protocol/les/proxy.py
+++ b/trinity/protocol/les/proxy.py
@@ -3,7 +3,6 @@ from typing import (
 )
 
 from eth.abc import BlockHeaderAPI
-from eth_utils import get_extended_debug_logger
 from lahja import (
     BroadcastConfig,
     EndpointAPI,
@@ -17,6 +16,7 @@ from trinity._utils.les import (
 from trinity._utils.errors import (
     SupportsError,
 )
+from trinity._utils.logging import get_logger
 
 from .commands import (
     BlockHeaders,
@@ -34,7 +34,7 @@ class ProxyLESAPI:
     An ``LESAPI`` that can be used outside of the process that runs the peer pool. Any
     action performed on this class is delegated to the process that runs the peer pool.
     """
-    logger = get_extended_debug_logger('trinity.protocol.les.proxy.ProxyLESAPI')
+    logger = get_logger('trinity.protocol.les.proxy.ProxyLESAPI')
 
     def __init__(self,
                  session: SessionAPI,

--- a/trinity/sync/beam/chain.py
+++ b/trinity/sync/beam/chain.py
@@ -26,7 +26,6 @@ from eth_typing import (
 )
 from eth_utils import (
     ValidationError,
-    get_extended_debug_logger,
 )
 import rlp
 
@@ -78,6 +77,7 @@ from trinity.sync.beam.state import (
     BeamDownloader,
 )
 from trinity._utils.timer import Timer
+from trinity._utils.logging import get_logger
 
 from .backfill import BeamStateBackfill
 
@@ -369,7 +369,7 @@ class HeaderCheckpointSyncer(HeaderSyncerAPI):
 
     Can be used by a body syncer to pause syncing until a header checkpoint is reached.
     """
-    logger = get_extended_debug_logger('trinity.sync.beam.chain.HeaderCheckpointSyncer')
+    logger = get_logger('trinity.sync.beam.chain.HeaderCheckpointSyncer')
 
     def __init__(self, passthrough: HeaderSyncerAPI) -> None:
         self._real_syncer = passthrough

--- a/trinity/sync/beam/importer.py
+++ b/trinity/sync/beam/importer.py
@@ -37,7 +37,6 @@ from eth_typing import (
 from eth_utils import (
     ExtendedDebugLogger,
     ValidationError,
-    get_extended_debug_logger,
     humanize_seconds,
 )
 from eth_utils.toolz import (
@@ -65,6 +64,7 @@ from trinity.sync.common.events import (
     MissingStorageResult,
     StatelessBlockImportDone,
 )
+from trinity._utils.logging import get_logger
 
 ImportBlockType = Tuple[BlockAPI, Tuple[BlockAPI, ...], Tuple[BlockAPI, ...]]
 
@@ -381,7 +381,7 @@ def pausing_vm_decorator(
             return self._pause_on_missing_data(super().make_state_root)
 
     class PausingVM(original_vm_class):  # type: ignore
-        logger = get_extended_debug_logger(f'eth.vm.base.VM.{original_vm_class.__name__}')
+        logger = get_logger(f'eth.vm.base.VM.{original_vm_class.__name__}')
 
         @classmethod
         def get_state_class(cls) -> Type[StateAPI]:
@@ -455,7 +455,7 @@ def partial_import_block(beam_chain: BeamChain,
 
 
 class BlockImportServer(Service):
-    logger = get_extended_debug_logger('trinity.sync.beam.BlockImportServer')
+    logger = get_logger('trinity.sync.beam.BlockImportServer')
 
     def __init__(
             self,
@@ -633,7 +633,7 @@ def partial_speculative_execute(
 
 
 class BlockPreviewServer(Service):
-    logger = get_extended_debug_logger('trinity.sync.beam.BlockPreviewServer')
+    logger = get_logger('trinity.sync.beam.BlockPreviewServer')
 
     def __init__(
             self,


### PR DESCRIPTION
One annoying thing here is that even with the extra wrapper in `p2p._utils` (to avoid the module-level cyclic import), we still need to ensure all `get_logger()` calls in the `p2p` package only happen at runtime. Not a big deal as any calls made at the module level will cause test failures anyway

If you're happy with this approach I'll go ahead and update all callsites and add a test for the new wrapper

Closes: #1560