### PR TITLE
discv4: Replace ENR in our DB when we detect an address change

### DIFF
--- a/p2p/kademlia.py
+++ b/p2p/kademlia.py
@@ -150,18 +150,7 @@ class Node(NodeAPI):
     @classmethod
     def from_pubkey_and_addr(
             cls: Type[TNode], pubkey: datatypes.PublicKey, address: AddressAPI) -> TNode:
-        enr = ENR(
-            0,
-            {
-                IDENTITY_SCHEME_ENR_KEY: V4CompatIdentityScheme.id,
-                V4CompatIdentityScheme.public_key_enr_key: pubkey.to_compressed_bytes(),
-                IP_V4_ADDRESS_ENR_KEY: address.ip_packed,
-                UDP_PORT_ENR_KEY: address.udp_port,
-                TCP_PORT_ENR_KEY: address.tcp_port,
-            },
-            signature=b''
-        )
-        return cls(enr)
+        return cls(create_stub_enr(pubkey, address))
 
     @classmethod
     def from_uri(cls: Type[TNode], uri: str) -> TNode:
@@ -493,3 +482,17 @@ def _compute_shared_prefix_bits(nodes: List[NodeAPI]) -> int:
 def sort_by_distance(nodes: Iterable[NodeAPI], target_id: NodeID) -> List[NodeAPI]:
     target_id_int = big_endian_to_int(target_id)
     return sorted(nodes, key=operator.methodcaller('distance_to', target_id_int))
+
+
+def create_stub_enr(pubkey: datatypes.PublicKey, address: AddressAPI) -> ENR:
+    return ENR(
+        0,
+        {
+            IDENTITY_SCHEME_ENR_KEY: V4CompatIdentityScheme.id,
+            V4CompatIdentityScheme.public_key_enr_key: pubkey.to_compressed_bytes(),
+            IP_V4_ADDRESS_ENR_KEY: address.ip_packed,
+            UDP_PORT_ENR_KEY: address.udp_port,
+            TCP_PORT_ENR_KEY: address.tcp_port,
+        },
+        signature=b''
+    )

--- a/p2p/tools/factories/discovery.py
+++ b/p2p/tools/factories/discovery.py
@@ -63,6 +63,8 @@ from p2p.discv5.typing import (
     Topic,
 )
 
+from .kademlia import AddressFactory
+
 
 class AuthTagPacketFactory(factory.Factory):
     class Meta:
@@ -196,6 +198,9 @@ class ENRFactory(factory.Factory):
     kv_pairs = factory.LazyAttribute(lambda o: merge({
         b"id": b"v4",
         b"secp256k1": keys.PrivateKey(o.private_key).public_key.to_compressed_bytes(),
+        b"ip": o.address.ip_packed,
+        b"udp": o.address.udp_port,
+        b"tcp": o.address.tcp_port,
     }, o.custom_kv_pairs))
     signature = factory.LazyAttribute(
         lambda o: UnsignedENR(
@@ -206,6 +211,7 @@ class ENRFactory(factory.Factory):
 
     class Params:
         private_key = factory.Faker("binary", length=V4IdentityScheme.private_key_size)
+        address = factory.SubFactory(AddressFactory)
         custom_kv_pairs: Dict[bytes, Any] = {}
 
 

--- a/tests/p2p/test_kademlia.py
+++ b/tests/p2p/test_kademlia.py
@@ -1,16 +1,9 @@
-import socket
-
 import pytest
 
 from eth_hash.auto import keccak
 
 from p2p import kademlia
 from p2p.constants import KADEMLIA_ID_SIZE, KADEMLIA_MAX_NODE_ID
-from p2p.discv5.constants import (
-    IP_V4_ADDRESS_ENR_KEY,
-    TCP_PORT_ENR_KEY,
-    UDP_PORT_ENR_KEY,
-)
 from p2p.kademlia import (
     Address,
     KBucket,
@@ -20,8 +13,8 @@ from p2p.kademlia import (
     check_relayed_addr,
 )
 from p2p.tools.factories import (
+    AddressFactory,
     ENRFactory,
-    IPAddressFactory,
     NodeFactory,
     PrivateKeyFactory,
 )
@@ -40,35 +33,24 @@ def test_node_from_enode_uri():
 
 def test_node_from_enr_uri():
     privkey = PrivateKeyFactory()
-    ip = socket.inet_aton(IPAddressFactory.generate())
-    udp_port = tcp_port = 30303
-    enr = ENRFactory(
-        private_key=privkey.to_bytes(),
-        custom_kv_pairs={
-            IP_V4_ADDRESS_ENR_KEY: ip, UDP_PORT_ENR_KEY: udp_port, TCP_PORT_ENR_KEY: tcp_port})
+    address = AddressFactory()
+    enr = ENRFactory(private_key=privkey.to_bytes(), address=address)
 
     node = Node.from_uri(repr(enr))
 
     assert node.id == keccak(privkey.public_key.to_bytes())
-    assert node.address.ip_packed == ip
-    assert node.address.tcp_port == tcp_port
-    assert node.address.udp_port == udp_port
+    assert node.address == address
 
 
 def test_node_constructor():
     privkey = PrivateKeyFactory()
-    ip = socket.inet_aton(IPAddressFactory.generate())
-    udp_port = tcp_port = 30303
-    enr = ENRFactory(
-        private_key=privkey.to_bytes(),
-        custom_kv_pairs={IP_V4_ADDRESS_ENR_KEY: ip, UDP_PORT_ENR_KEY: udp_port})
+    address = AddressFactory()
+    enr = ENRFactory(private_key=privkey.to_bytes(), address=address)
 
     node = Node(enr)
 
     assert node.id == keccak(privkey.public_key.to_bytes())
-    assert node.address.ip_packed == ip
-    assert node.address.tcp_port == tcp_port
-    assert node.address.udp_port == udp_port
+    assert node.address == address
 
 
 def test_routingtable_split_bucket():


### PR DESCRIPTION
If a node sends us a message from an address different than what is
in their last ENR, we replace that with a stub ENR using the new
address.

Closes: #1586