### PR TITLE
Skip flaky shutdown test

### DIFF
--- a/tests/integration/test_trinity_cli.py
+++ b/tests/integration/test_trinity_cli.py
@@ -353,9 +353,11 @@ async def test_logger_configuration(command,
     )
 )
 @pytest.mark.asyncio
-# Once we get Trinity to shutdown cleanly, we should remove the xfail so that the test ensures
-# ongoing clean exits.
-@pytest.mark.xfail
+# The test ensures Trinity shuts down without reporting any errors. It is currently skipped because
+# Trinity shuts down with errors *most* of the time but often enough shuts down cleanly. This leaves
+# us in a state where we can neither activate the test nor mark it as xfail.
+# See: https://github.com/ethereum/trinity/issues/1307
+@pytest.mark.skip("Currently unreliable")
 async def test_shutdown_does_not_throw_errors(command, unused_tcp_port):
 
     command = amend_command_for_unused_port(command, unused_tcp_port)


### PR DESCRIPTION
### What was wrong?

We are currently in this weird phase where our shutdowns are most of th. e time full of errors but sometimes are clean as Christmas snow. This makes the test that should ensure clean shutdowns very flaky. To be clear, the test is currently marked as `xfail` and when it gets flaky it means that shutdowns are getting cleaner (a good thing!). In the past, we have found ways to be more picky such as counting `ResourceWarning` as errors. But now, we have reached a point where it is still terrible 80 % of the time but perfect 20 % of the time. Not sure if that is progress :sweat_smile: 

### How was it fixed?

Skipping the test for now and added reactivation as a todo in #1307 

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

[//]: # (See: https://trinity-client.readthedocs.io/en/latest/contributing.html#pull-requests)
- [ ] Add entry to the [release notes](https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://static.boredpanda.com/blog/wp-content/uuuploads/cute-baby-animals/cute-baby-animals-2.jpg)
