### PR TITLE
Skip DAO fork block check on eth/64

### DIFF
--- a/p2p/abc.py
+++ b/p2p/abc.py
@@ -477,8 +477,20 @@ class AsyncioServiceAPI(ABC):
         ...
 
 
+class HandshakeCheckAPI(ABC):
+    """
+    A certain type of check performed during a handshake with another peer.
+
+    e.g. Checking that we're on the same network, ForkID validation, etc.
+    """
+
+
 class HandshakeReceiptAPI(ABC):
     protocol: ProtocolAPI
+
+    @abstractmethod
+    def was_check_performed(self, check_type: Type[HandshakeCheckAPI]) -> bool:
+        ...
 
 
 THandshakeReceipt = TypeVar('THandshakeReceipt', bound=HandshakeReceiptAPI)

--- a/p2p/receipt.py
+++ b/p2p/receipt.py
@@ -1,4 +1,7 @@
+from typing import Type
+
 from p2p.abc import (
+    HandshakeCheckAPI,
     HandshakeReceiptAPI,
     ProtocolAPI,
 )
@@ -13,3 +16,6 @@ class HandshakeReceipt(HandshakeReceiptAPI):
 
     def __init__(self, protocol: ProtocolAPI) -> None:
         self.protocol = protocol
+
+    def was_check_performed(self, check_type: Type[HandshakeCheckAPI]) -> bool:
+        return False

--- a/tests/core/p2p-proto/test_peer.py
+++ b/tests/core/p2p-proto/test_peer.py
@@ -65,7 +65,7 @@ async def test_ETH_peers():
 
 
 @pytest.mark.asyncio
-async def test_peer_pool_iter(request, event_loop):
+async def test_peer_pool_iter(event_loop):
     factory_a = ETHPeerPairFactory()
     factory_b = ETHPeerPairFactory()
     factory_c = ETHPeerPairFactory()
@@ -87,3 +87,35 @@ async def test_peer_pool_iter(request, event_loop):
         assert peer1 in peers
         assert peer2 not in peers
         assert peer3 in peers
+
+
+@pytest.mark.asyncio
+async def test_remote_dao_fork_validation_skipped_on_eth64(monkeypatch):
+    dao_fork_validator_called = False
+
+    async def validate_remote_dao_fork_block():
+        nonlocal dao_fork_validator_called
+        dao_fork_validator_called = True
+
+    async with ETHPeerPairFactory() as (alice, _):
+        boot_manager = alice.get_boot_manager()
+        monkeypatch.setattr(
+            boot_manager, 'validate_remote_dao_fork_block', validate_remote_dao_fork_block)
+        await boot_manager.run()
+        assert not dao_fork_validator_called
+
+
+@pytest.mark.asyncio
+async def test_remote_dao_fork_validation_on_eth63(monkeypatch):
+    dao_fork_validator_called = False
+
+    async def validate_remote_dao_fork_block():
+        nonlocal dao_fork_validator_called
+        dao_fork_validator_called = True
+
+    async with ETHV63PeerPairFactory() as (alice, _):
+        boot_manager = alice.get_boot_manager()
+        monkeypatch.setattr(
+            boot_manager, 'validate_remote_dao_fork_block', validate_remote_dao_fork_block)
+        await boot_manager.run()
+        assert dao_fork_validator_called

--- a/trinity/protocol/eth/forkid.py
+++ b/trinity/protocol/eth/forkid.py
@@ -13,6 +13,7 @@ from eth_typing import BlockNumber, Hash32
 
 from eth_utils import encode_hex, to_tuple
 
+from p2p.abc import HandshakeCheckAPI
 from p2p.enr import ENR
 from p2p.exceptions import MalformedMessage
 
@@ -31,6 +32,10 @@ class ForkID(rlp.Serializable):
 
     def __repr__(self) -> str:
         return f"ForkID(hash={encode_hex(self.hash)}, next={self.next})"
+
+
+class ForkIDHandshakeCheck(HandshakeCheckAPI):
+    pass
 
 
 @to_tuple

--- a/trinity/protocol/eth/handshaker.py
+++ b/trinity/protocol/eth/handshaker.py
@@ -1,11 +1,11 @@
-from typing import Union, TypeVar, Generic, Tuple
+from typing import Union, Type, TypeVar, Generic, Tuple
 
 from cached_property import cached_property
 
 from eth_typing import Hash32, BlockNumber
 from eth_utils import encode_hex
 
-from p2p.abc import MultiplexerAPI, ProtocolAPI, NodeAPI
+from p2p.abc import HandshakeCheckAPI, MultiplexerAPI, ProtocolAPI, NodeAPI
 from p2p.exceptions import (
     HandshakeFailure,
 )
@@ -21,7 +21,7 @@ from trinity.exceptions import (
 
 
 from .commands import StatusV63, Status
-from .forkid import ForkID, validate_forkid
+from .forkid import ForkID, ForkIDHandshakeCheck, validate_forkid
 from .payloads import StatusV63Payload, StatusPayload
 from .proto import ETHProtocolV63, ETHProtocol
 
@@ -66,6 +66,11 @@ class ETHHandshakeReceipt(BaseETHHandshakeReceipt[StatusPayload]):
     @cached_property
     def fork_id(self) -> ForkID:
         return self.handshake_params.fork_id
+
+    def was_check_performed(self, check_type: Type[HandshakeCheckAPI]) -> bool:
+        if check_type == ForkIDHandshakeCheck:
+            return True
+        return False
 
 
 def validate_base_receipt(remote: NodeAPI,


### PR DESCRIPTION
As of eth/64, the handshake also ensures the remote's ForkID
is compatible with the local one, so there's no need to perform
the DAO fork block check.

I did consider a more generic API on `Protocol` that would allow us to specify multiple types of checks/validations performed during handshake, but ultimately decided to go with a simpler alternative until we have an actual use case for different types of checks.