### PR TITLE
Discv5Component can now be ran standalone

### DIFF
--- a/trinity/components/eth2/beacon/component.py
+++ b/trinity/components/eth2/beacon/component.py
@@ -61,14 +61,6 @@ class BeaconNodeComponent(AsyncioIsolatedComponent):
     @classmethod
     def configure_parser(cls, arg_parser: ArgumentParser, subparser: _SubParsersAction) -> None:
         arg_parser.add_argument(
-            "--bootstrap_nodes",
-            help="/ip4/127.0.0.1/tcp/1234/p2p/node1_peer_id,/ip4/127.0.0.1/tcp/5678/p2p/node2_peer_id",  # noqa: E501
-        )
-        arg_parser.add_argument(
-            "--preferred_nodes",
-            help="/ip4/127.0.0.1/tcp/1234/p2p/node1_peer_id,/ip4/127.0.0.1/tcp/5678/p2p/node2_peer_id",  # noqa: E501
-        )
-        arg_parser.add_argument(
             "--beacon-nodekey",
             help="0xabcd",
         )

--- a/trinity/components/eth2/discv5/component.py
+++ b/trinity/components/eth2/discv5/component.py
@@ -125,8 +125,16 @@ class DiscV5Component(TrioIsolatedComponent):
         discovery_parser = arg_parser.add_argument_group("discovery")
 
         discovery_parser.add_argument(
-            "--enr-dir",
-            help="Path to the directory in which ENRs are stored",
+            "--nodedb-dir",
+            help="Path to the directory in which our NodeDB is stored",
+        )
+        arg_parser.add_argument(
+            "--bootstrap_nodes",
+            help="/ip4/127.0.0.1/tcp/1234/p2p/node1_peer_id,/ip4/127.0.0.1/tcp/5678/p2p/node2_peer_id",  # noqa: E501
+        )
+        arg_parser.add_argument(
+            "--preferred_nodes",
+            help="/ip4/127.0.0.1/tcp/1234/p2p/node1_peer_id,/ip4/127.0.0.1/tcp/5678/p2p/node2_peer_id",  # noqa: E501
         )
         discovery_parser.add_argument(
             "--discovery-boot-enrs",
@@ -254,3 +262,12 @@ class DiscV5Component(TrioIsolatedComponent):
         async with trio.open_nursery() as nursery:
             for service in services:
                 nursery.start_soon(async_service.TrioManager.run_service, service)
+
+
+async def main() -> None:
+    from trinity.extensibility.component import run_standalone_eth2_component
+    await run_standalone_eth2_component(DiscV5Component)
+
+
+if __name__ == "__main__":
+    trio.run(main)


### PR DESCRIPTION
This allows us to run the discv5 component with the following:

  `python trinity/components/eth2/discv5/component.py --trinity-root-dir /tmp/discv5 --discovery-boot-enrs <some-enrs>`