### PR TITLE
Update quickstart.rst

### DIFF
--- a/docs/guides/quickstart.rst
+++ b/docs/guides/quickstart.rst
@@ -126,10 +126,7 @@ Running Trinity
 
 .. note::
 
-    Execution of the following comand will result in the downloading of a considerable amount of data. We need to make sure to have enough disk space available as well as a data plan that allows such traffic. 
-    
-    If you want to run Trinity as a light node, check out :ref:`Run Trinity as a light client<cookbook_recipe_running_as_a_light_client>`
-    or use the ``--sync-mode=light`` flag. 
+    Execution of the following comand will cause downloading of a considerable amount of data. We need to make sure to have enough disk space available as well as a data plan that allows such traffic.
 
 After Trinity is installed we should have the ``trinity`` command available to start it.
 

--- a/docs/guides/quickstart.rst
+++ b/docs/guides/quickstart.rst
@@ -124,6 +124,15 @@ the package and it will immediately start syncing. Head over to the
 Running Trinity
 ~~~~~~~~~~~~~~~
 
+.. warning::
+
+    Executing the following command will download the entire ethereum mainnet chain. Please be sure that
+    this is what you want to do. It will probably take a long time, as well as a good internet connection and 
+    enough disk space on your machine to store the whole blockchain. 
+    
+    If you want to run Trinity as a light node, check out :ref:`Run Trinity as a light client<cookbook_recipe_running_as_a_light_client>`
+    or use the ``--sync-mode=light`` flag. 
+
 After Trinity is installed we should have the ``trinity`` command available to start it.
 
 .. code:: sh

--- a/docs/guides/quickstart.rst
+++ b/docs/guides/quickstart.rst
@@ -124,11 +124,9 @@ the package and it will immediately start syncing. Head over to the
 Running Trinity
 ~~~~~~~~~~~~~~~
 
-.. warning::
+.. note::
 
-    Executing the following command will download the entire ethereum mainnet chain. Please be sure that
-    this is what you want to do. It will probably take a long time, as well as a good internet connection and 
-    enough disk space on your machine to store the whole blockchain. 
+    Execution of the following comand will result in the downloading of a considerable amount of data. We need to make sure to have enough disk space available as well as a data plan that allows such traffic. 
     
     If you want to run Trinity as a light node, check out :ref:`Run Trinity as a light client<cookbook_recipe_running_as_a_light_client>`
     or use the ``--sync-mode=light`` flag. 


### PR DESCRIPTION
### What was wrong?
There was no warning that starting trinity will lead to syncing (==downloading) the whole mainnet chain. 


### How was it fixed?
Added a warning in the docs that this will take time, a good internet connection + enough disk space to store the chain, as well as flags + reference to the guide on how to run a light node. 
