### PR TITLE
Add metrics on peer connections

### DIFF
--- a/newsfragments/1599.feature.rst
+++ b/newsfragments/1599.feature.rst
@@ -1,0 +1,1 @@
+Monitor the number of peers in Grafana

--- a/trinity/components/builtin/metrics/abc.py
+++ b/trinity/components/builtin/metrics/abc.py
@@ -1,0 +1,22 @@
+from abc import abstractmethod
+
+from async_service import ServiceAPI
+from pyformance import MetricsRegistry
+
+
+class MetricsServiceAPI(ServiceAPI):
+
+    @abstractmethod
+    def __init__(self,
+                 influx_server: str,
+                 influx_user: str,
+                 influx_password: str,
+                 influx_database: str,
+                 host: str,
+                 reporting_frequency: int) -> None:
+        ...
+
+    @property
+    @abstractmethod
+    def registry(self) -> MetricsRegistry:
+        ...

--- a/trinity/components/builtin/metrics/instruments.py
+++ b/trinity/components/builtin/metrics/instruments.py
@@ -75,12 +75,6 @@ class NoopMeter(Meter):
 
 class NoopTimer(Timer):
 
-    """
-    A timer metric which aggregates timing durations and provides duration statistics, plus
-    throughput statistics via Meter and Histogram.
-
-    """
-
     def __init__(self) -> None:
         pass
 

--- a/trinity/components/builtin/metrics/instruments.py
+++ b/trinity/components/builtin/metrics/instruments.py
@@ -1,0 +1,127 @@
+from typing import Any
+
+from pyformance.meters import (
+    Histogram,
+    Meter,
+    Timer,
+)
+
+
+class NoopHistogram(Histogram):
+
+    def __init__(self) -> None:
+        pass
+
+    def add(self, value: float) -> None:
+        pass
+
+    def clear(self) -> None:
+        pass
+
+    def get_count(self) -> float:
+        return 0.0
+
+    def get_sum(self) -> float:
+        return 0.0
+
+    def get_max(self) -> float:
+        return 0.0
+
+    def get_min(self) -> float:
+        return 0.0
+
+    def get_mean(self) -> int:
+        return 0
+
+    def get_stddev(self) -> int:
+        return 0
+
+    def get_var(self) -> int:
+        return 0
+
+    def get_snapshot(self) -> None:
+        raise NotImplementedError("`get_snapshot` on NoopHistogram isn't implemented")
+
+
+class NoopMeter(Meter):
+
+    def __init__(self) -> None:
+        pass
+
+    def clear(self) -> None:
+        pass
+
+    def get_one_minute_rate(self) -> int:
+        return 0
+
+    def get_five_minute_rate(self) -> int:
+        return 0
+
+    def get_fifteen_minute_rate(self) -> int:
+        return 0
+
+    def tick(self) -> None:
+        pass
+
+    def mark(self, value: int = 1) -> None:
+        pass
+
+    def get_count(self) -> float:
+        return 0.0
+
+    def get_mean_rate(self) -> int:
+        return 0
+
+
+class NoopTimer(Timer):
+
+    """
+    A timer metric which aggregates timing durations and provides duration statistics, plus
+    throughput statistics via Meter and Histogram.
+
+    """
+
+    def __init__(self) -> None:
+        pass
+
+    def get_count(self) -> float:
+        return 0.0
+
+    def get_sum(self) -> float:
+        return 0.0
+
+    def get_max(self) -> float:
+        return 0.0
+
+    def get_min(self) -> float:
+        return 0.0
+
+    def get_mean(self) -> float:
+        return 0.0
+
+    def get_stddev(self) -> float:
+        return 0.0
+
+    def get_var(self) -> float:
+        return 0.0
+
+    def get_snapshot(self) -> float:
+        return 0.0
+
+    def get_mean_rate(self) -> float:
+        return 0.0
+
+    def get_one_minute_rate(self) -> int:
+        return 0
+
+    def get_five_minute_rate(self) -> int:
+        return 0
+
+    def get_fifteen_minute_rate(self) -> int:
+        return 0
+
+    def time(self, *args: Any, **kwargs: Any) -> None:
+        raise NotImplementedError("time() isn't implemented on NoopTimer")
+
+    def clear(self) -> None:
+        pass

--- a/trinity/components/builtin/metrics/registry.py
+++ b/trinity/components/builtin/metrics/registry.py
@@ -1,8 +1,18 @@
 import time
 from types import ModuleType
-from typing import Dict, Any
+from typing import Dict, Any, Union
 
 from pyformance import MetricsRegistry
+from pyformance.meters import (
+    SimpleGauge,
+    Counter,
+)
+
+from trinity.components.builtin.metrics.instruments import (
+    NoopHistogram,
+    NoopMeter,
+    NoopTimer,
+)
 
 
 class HostMetricsRegistry(MetricsRegistry):
@@ -19,3 +29,45 @@ class HostMetricsRegistry(MetricsRegistry):
             metrics[key]['host'] = self.host
 
         return metrics
+
+
+NOOP_COUNTER = Counter()
+NOOP_TIMER = NoopTimer()
+NOOP_METER = NoopMeter()
+NOOP_GAUGE = SimpleGauge()
+NOOP_HISTOGRAM = NoopHistogram()
+
+Instrument = Union[Counter, NoopTimer, NoopMeter, SimpleGauge, NoopHistogram]
+
+
+class NoopMetricsRegistry(HostMetricsRegistry):
+    """
+    A ``MetricsRegistry`` where every action will result in a noop. Used when metrics are disabled.
+    """
+
+    def __init__(self) -> None:
+        pass
+
+    def dump_metrics(self) -> Dict[str, Dict[str, Any]]:
+        pass
+
+    def add(self, key: str, metric: Instrument) -> None:
+        pass
+
+    def counter(self, key: str) -> Counter:
+        return NOOP_COUNTER
+
+    def histogram(self, key: str) -> NoopHistogram:
+        return NOOP_HISTOGRAM
+
+    def gauge(self,
+              key: str,
+              gauge: SimpleGauge = None,
+              default: SimpleGauge = None) -> SimpleGauge:
+        return NOOP_GAUGE
+
+    def meter(self, key: str) -> NoopMeter:
+        return NOOP_METER
+
+    def timer(self, key: str) -> NoopTimer:
+        return NOOP_TIMER

--- a/trinity/components/builtin/metrics/service/asyncio.py
+++ b/trinity/components/builtin/metrics/service/asyncio.py
@@ -1,0 +1,11 @@
+import asyncio
+
+from trinity.components.builtin.metrics.service.base import BaseMetricsService
+
+
+class AsyncioMetricsService(BaseMetricsService):
+
+    async def continuously_report(self) -> None:
+        while self.manager.is_running:
+            self._reporter.report_now()
+            await asyncio.sleep(self._reporting_frequency)

--- a/trinity/components/builtin/metrics/service/base.py
+++ b/trinity/components/builtin/metrics/service/base.py
@@ -1,13 +1,14 @@
+from abc import abstractmethod
+
 from async_service import Service
 from eth_utils import get_extended_debug_logger
 from pyformance.reporters import InfluxReporter
 
-from p2p import trio_utils
-
+from trinity.components.builtin.metrics.abc import MetricsServiceAPI
 from trinity.components.builtin.metrics.registry import HostMetricsRegistry
 
 
-class MetricsService(Service):
+class BaseMetricsService(Service, MetricsServiceAPI):
     """
     A service to provide a registry where metrics instruments can be registered and retrieved from.
     It continuously reports metrics to the specified InfluxDB instance.
@@ -20,7 +21,6 @@ class MetricsService(Service):
                  influx_database: str,
                  host: str,
                  reporting_frequency: int = 10):
-
         self._influx_server = influx_server
         self._reporting_frequency = reporting_frequency
         self._registry = HostMetricsRegistry(host)
@@ -46,9 +46,9 @@ class MetricsService(Service):
 
     async def run(self) -> None:
         self.logger.info("Reporting metrics to %s", self._influx_server)
-        self.manager.run_daemon_task(self._continuously_report)
+        self.manager.run_daemon_task(self.continuously_report)
         await self.manager.wait_finished()
 
-    async def _continuously_report(self) -> None:
-        async for _ in trio_utils.every(self._reporting_frequency):
-            self._reporter.report_now()
+    @abstractmethod
+    async def continuously_report(self) -> None:
+        ...

--- a/trinity/components/builtin/metrics/service/noop.py
+++ b/trinity/components/builtin/metrics/service/noop.py
@@ -1,0 +1,43 @@
+from async_service import Service
+from eth_utils import get_extended_debug_logger
+
+from trinity.components.builtin.metrics.abc import MetricsServiceAPI
+from trinity.components.builtin.metrics.registry import NoopMetricsRegistry
+
+
+class NoopMetricsService(Service, MetricsServiceAPI):
+    """
+    A ``MetricsServiceAPI`` implementation that provides a stub registry where every action results
+    in a noop. Intended to be used when collecting of metrics is disabled. Every collected metric
+    will only incur the cost of a noop.
+    """
+
+    logger = get_extended_debug_logger('trinity.components.builtin.metrics.NoopMetricsService')
+
+    def __init__(self,
+                 influx_server: str = '',
+                 influx_user: str = '',
+                 influx_password: str = '',
+                 influx_database: str = '',
+                 host: str = '',
+                 reporting_frequency: int = 10):
+
+        self._registry = NoopMetricsRegistry()
+
+    @property
+    def registry(self) -> NoopMetricsRegistry:
+        """
+        Return the :class:`trinity.components.builtin.metrics.registry.NoopMetricsRegistry` at which
+        metrics instruments can be registered and retrieved.
+        """
+        return self._registry
+
+    async def run(self) -> None:
+        self.logger.info("Running NoopMetricsService")
+        await self.manager.wait_finished()
+
+    async def continuously_report(self) -> None:
+        pass
+
+
+NOOP_METRICS_SERVICE = NoopMetricsService()

--- a/trinity/components/builtin/metrics/service/trio.py
+++ b/trinity/components/builtin/metrics/service/trio.py
@@ -1,0 +1,10 @@
+from p2p import trio_utils
+
+from trinity.components.builtin.metrics.service.base import BaseMetricsService
+
+
+class TrioMetricsService(BaseMetricsService):
+
+    async def continuously_report(self) -> None:
+        async for _ in trio_utils.every(self._reporting_frequency):
+            self._reporter.report_now()

--- a/trinity/nodes/full.py
+++ b/trinity/nodes/full.py
@@ -5,6 +5,7 @@ from lahja import EndpointAPI
 from p2p.peer_pool import BasePeerPool
 
 from trinity.chains.full import FullChain
+from trinity.components.builtin.metrics.abc import MetricsServiceAPI
 from trinity.config import TrinityConfig
 from trinity.db.eth1.chain import AsyncChainDB
 from trinity.protocol.common.peer_pool_event_bus import PeerPoolEventServer
@@ -18,8 +19,11 @@ class FullNode(Node[ETHPeer]):
     _chain: FullChain = None
     _p2p_server: FullServer = None
 
-    def __init__(self, event_bus: EndpointAPI, trinity_config: TrinityConfig) -> None:
-        super().__init__(event_bus, trinity_config)
+    def __init__(self,
+                 event_bus: EndpointAPI,
+                 metrics_service: MetricsServiceAPI,
+                 trinity_config: TrinityConfig) -> None:
+        super().__init__(event_bus, metrics_service, trinity_config)
         self._node_key = trinity_config.nodekey
         self._node_port = trinity_config.port
         self._max_peers = trinity_config.max_peers
@@ -53,6 +57,7 @@ class FullNode(Node[ETHPeer]):
                 max_peers=self._max_peers,
                 token=self.master_cancel_token,
                 event_bus=self.event_bus,
+                metrics_registry=self.metrics_service.registry,
             )
         return self._p2p_server
 

--- a/trinity/nodes/light.py
+++ b/trinity/nodes/light.py
@@ -15,6 +15,7 @@ from p2p.peer_pool import BasePeerPool
 from trinity.chains.light import (
     LightDispatchChain,
 )
+from trinity.components.builtin.metrics.abc import MetricsServiceAPI
 from trinity.config import (
     TrinityConfig,
 )
@@ -40,8 +41,11 @@ class LightNode(Node[LESPeer]):
     network_id: int = None
     nodekey: PrivateKey = None
 
-    def __init__(self, event_bus: EndpointAPI, trinity_config: TrinityConfig) -> None:
-        super().__init__(event_bus, trinity_config)
+    def __init__(self,
+                 event_bus: EndpointAPI,
+                 metrics_service: MetricsServiceAPI,
+                 trinity_config: TrinityConfig) -> None:
+        super().__init__(event_bus, metrics_service, trinity_config)
 
         self._nodekey = trinity_config.nodekey
         self._port = trinity_config.port
@@ -94,6 +98,7 @@ class LightNode(Node[LESPeer]):
                 max_peers=self._max_peers,
                 token=self.master_cancel_token,
                 event_bus=self.event_bus,
+                metrics_registry=self.metrics_service.registry,
             )
         return self._p2p_server
 

--- a/trinity/server.py
+++ b/trinity/server.py
@@ -13,6 +13,7 @@ from cancel_token import CancelToken, OperationCancelled
 from eth_typing import BlockNumber
 
 from eth.abc import AtomicDatabaseAPI, VirtualMachineAPI
+from pyformance import MetricsRegistry
 
 from p2p.constants import DEFAULT_MAX_PEERS, DEVP2P_V5
 from p2p.disconnect import DisconnectReason
@@ -63,11 +64,13 @@ class BaseServer(BaseService, Generic[TPeerPool]):
                  network_id: int,
                  max_peers: int = DEFAULT_MAX_PEERS,
                  event_bus: EndpointAPI = None,
+                 metrics_registry: MetricsRegistry = None,
                  token: CancelToken = None,
                  ) -> None:
         super().__init__(token)
         # cross process event bus
         self.event_bus = event_bus
+        self.metrics_registry = metrics_registry
 
         # setup parameters for the base devp2p handshake.
         self.p2p_handshake_params = DevP2PHandshakeParams(
@@ -213,7 +216,8 @@ class FullServer(BaseServer[ETHPeerPool]):
             max_peers=self.max_peers,
             context=context,
             token=self.cancel_token,
-            event_bus=self.event_bus
+            event_bus=self.event_bus,
+            metrics_registry=self.metrics_registry,
         )
 
 
@@ -233,5 +237,6 @@ class LightServer(BaseServer[LESPeerPool]):
             max_peers=self.max_peers,
             context=context,
             token=self.cancel_token,
-            event_bus=self.event_bus
+            event_bus=self.event_bus,
+            metrics_registry=self.metrics_registry,
         )


### PR DESCRIPTION
### What was wrong?

The previous open PRs #1569 and #1595 only add simple system metrics that can be collected from within one specialized process. We also need a way to track things that happen in existing other processes such as the number of peers.

### How was it fixed?

- define a `MetricsServiceAPI` with different implementations:
   - This is to allow reuse of the service in trio components as well as in asyncio components
   - implementations are:
      - `BaseMetricsService` (abstract)
      - `TrioMetricsService`
      - `AsyncioMetricsService`
      - `NoopMetricsService` (used when metrics are disabled, to avoid branching logic)
- run the `AsyncioMetricsService` in the sync component and pass a registry down to the peer pool
   - track peer connections
  

![image](https://user-images.githubusercontent.com/521109/76514206-d9f70b80-6457-11ea-9a26-754a5d260496.png)


### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

[//]: # (See: https://trinity-client.readthedocs.io/en/latest/contributing.html#pull-requests)
- [ ] Add entry to the [release notes](https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses]()
