### PR TITLE
Make it possible to connect standalone components to one another

### DIFF
--- a/p2p/peer_pool.py
+++ b/p2p/peer_pool.py
@@ -184,7 +184,9 @@ class BasePeerPool(BaseService, AsyncIterable[BasePeer]):
                 self.connection_tracker.get_blacklisted(),
                 timeout=1)
         except asyncio.TimeoutError:
-            self.logger.warning("ConnectionTracker.get_blacklisted() request timed out.")
+            self.logger.warning(
+                "Timed out getting blacklisted peers from connection tracker, pausing peer "
+                "addition until we can get that.")
             return 0
 
         skip_list = connected_node_ids.union(blacklisted_node_ids)

--- a/scripts/discovery.py
+++ b/scripts/discovery.py
@@ -1,6 +1,7 @@
 import argparse
 import functools
 import logging
+import pathlib
 from typing import Set
 import uuid
 
@@ -9,7 +10,6 @@ import trio
 from lahja import ConnectionConfig, TrioEndpoint
 
 from p2p.events import PeerCandidatesRequest
-from p2p.constants import DISCOVERY_EVENTBUS_ENDPOINT
 from p2p.typing import NodeID
 
 from trinity.exceptions import ENRMissingForkID
@@ -40,7 +40,8 @@ async def main() -> None:
         raise AssertionError("Failed to detect network_id")
 
     logger.info(f"Asking DiscoveryService for peers on {network_cfg.chain_name}")
-    connection_config = ConnectionConfig(DISCOVERY_EVENTBUS_ENDPOINT, args.ipc)
+    ipc_path = pathlib.Path(args.ipc)
+    connection_config = ConnectionConfig(name=ipc_path.stem, path=ipc_path)
     network_cfg = PRECONFIGURED_NETWORKS[network_id]
     vm_config = network_cfg.vm_configuration
     fork_blocks = extract_fork_blocks(vm_config)

--- a/trinity/components/builtin/network_db/component.py
+++ b/trinity/components/builtin/network_db/component.py
@@ -29,17 +29,17 @@ from trinity.db.network import (
 )
 from trinity.exceptions import BadDatabaseError
 
-from .connection.server import ConnectionTrackerServer
-from .connection.tracker import (
+from trinity.components.builtin.network_db.connection.server import ConnectionTrackerServer
+from trinity.components.builtin.network_db.connection.tracker import (
     SQLiteConnectionTracker,
     MemoryConnectionTracker,
 )
-from .cli import (
+from trinity.components.builtin.network_db.cli import (
     TrackingBackend,
     NormalizeTrackingBackend,
 )
-from .eth1_peer_db.server import PeerDBServer
-from .eth1_peer_db.tracker import (
+from trinity.components.builtin.network_db.eth1_peer_db.server import PeerDBServer
+from trinity.components.builtin.network_db.eth1_peer_db.tracker import (
     BaseEth1PeerTracker,
     NoopEth1PeerTracker,
     SQLiteEth1PeerTracker,
@@ -249,3 +249,9 @@ class NetworkDBComponent(AsyncioIsolatedComponent):
                 manager.wait_finished()
                 for manager in tracker_managers
             ))
+
+
+if __name__ == "__main__":
+    from trinity.extensibility.component import run_standalone_eth1_component
+    loop = asyncio.get_event_loop()
+    loop.run_until_complete(run_standalone_eth1_component(NetworkDBComponent))

--- a/trinity/components/builtin/peer_discovery/component.py
+++ b/trinity/components/builtin/peer_discovery/component.py
@@ -115,10 +115,6 @@ async def generate_eth_cap_enr_field(
     return (b'eth', sedes.List([forkid.ForkID]).serialize([our_forkid]))
 
 
-async def main() -> None:
-    from trinity.extensibility.component import run_standalone_eth1_component
-    await run_standalone_eth1_component(PeerDiscoveryComponent)
-
-
 if __name__ == "__main__":
-    trio.run(main)
+    from trinity.extensibility.component import run_standalone_eth1_component
+    trio.run(run_standalone_eth1_component, PeerDiscoveryComponent)

--- a/trinity/components/builtin/syncer/component.py
+++ b/trinity/components/builtin/syncer/component.py
@@ -64,7 +64,7 @@ from trinity.sync.beam.service import (
 from trinity.sync.light.chain import (
     LightChainSyncer,
 )
-from .cli import NormalizeCheckpointURI
+from trinity.components.builtin.syncer.cli import NormalizeCheckpointURI
 
 
 class BaseSyncStrategy(ABC):
@@ -331,3 +331,14 @@ class SyncerComponent(AsyncioIsolatedComponent):
         if strategy.shutdown_node_on_halt:
             cls.logger.error("Sync ended unexpectedly. Shutting down trinity")
             await event_bus.broadcast(ShutdownRequest("Sync ended unexpectedly"))
+
+
+if __name__ == "__main__":
+    # SyncerComponent depends on a separate component to get peer candidates, so when running it
+    # you must pass the path to the discovery component's IPC file, like:
+    # $ python .../syncer/component.py --trinity-root-dir /tmp/syncer \
+    #        --connect-to-endpoints /tmp/syncer/mainnet/ipcs-eth1/discovery.ipc
+    import asyncio
+    from trinity.extensibility.component import run_standalone_eth1_component
+    loop = asyncio.get_event_loop()
+    loop.run_until_complete(run_standalone_eth1_component(SyncerComponent))

--- a/trinity/components/eth2/discv5/component.py
+++ b/trinity/components/eth2/discv5/component.py
@@ -264,10 +264,6 @@ class DiscV5Component(TrioIsolatedComponent):
                 nursery.start_soon(async_service.TrioManager.run_service, service)
 
 
-async def main() -> None:
-    from trinity.extensibility.component import run_standalone_eth2_component
-    await run_standalone_eth2_component(DiscV5Component)
-
-
 if __name__ == "__main__":
-    trio.run(main)
+    from trinity.extensibility.component import run_standalone_eth2_component
+    trio.run(run_standalone_eth2_component, DiscV5Component)

--- a/trinity/sync/beam/backfill.py
+++ b/trinity/sync/beam/backfill.py
@@ -66,7 +66,6 @@ class BeamStateBackfill(BaseService, QueenTrackerAPI):
         self._node_hashes: List[Hash32] = []
 
         self._peer_pool = peer_pool
-        self._available_peers = asyncio.Event()
 
         self._is_missing: Set[Hash32] = set()
 


### PR DESCRIPTION
When running standalone components one can now specify a list of IPC
files the component should connect to.

Also add the boilerplate code needed to run the chain syncer standalone.