### PR TITLE
Rename --ethstats to --enable-ethstats

### DIFF
--- a/docs/api/api.cli.rst
+++ b/docs/api/api.cli.rst
@@ -19,7 +19,7 @@ We can also generate an always up-to-date version of them by running ``trinity -
                   [--disable-networkdb-component] [--disable-blacklistdb]
                   [--disable-eth1-peer-db]
                   [--enable-experimental-eth1-peer-tracking]
-                  [--disable-discovery] [--disable-upnp] [--ethstats]
+                  [--disable-discovery] [--disable-upnp] [--enable-ethstats]
                   [--ethstats-server-url ETHSTATS_SERVER_URL]
                   [--ethstats-server-secret ETHSTATS_SERVER_SECRET]
                   [--ethstats-node-id ETHSTATS_NODE_ID]
@@ -140,7 +140,7 @@ We can also generate an always up-to-date version of them by running ``trinity -
                             successful connections to Eth1 peers.
 
     ethstats (experimental):
-      --ethstats            Enable node stats reporting service
+      --enable-ethstats     Enable node stats reporting service
       --ethstats-server-url ETHSTATS_SERVER_URL
                             Node stats server URL (e. g. wss://example.com/api)
       --ethstats-server-secret ETHSTATS_SERVER_SECRET

--- a/newsfragments/1604.feature.rst
+++ b/newsfragments/1604.feature.rst
@@ -1,0 +1,1 @@
+The `--ethstats` flag is now named `--enable-ethstats` to improve consistency.

--- a/trinity/components/builtin/ethstats/component.py
+++ b/trinity/components/builtin/ethstats/component.py
@@ -48,7 +48,7 @@ class EthstatsComponent(AsyncioIsolatedComponent):
         ethstats_parser = arg_parser.add_argument_group('ethstats (experimental)')
 
         ethstats_parser.add_argument(
-            '--ethstats',
+            '--enable-ethstats',
             action='store_true',
             help='Enable node stats reporting service',
         )
@@ -83,7 +83,7 @@ class EthstatsComponent(AsyncioIsolatedComponent):
     def validate_cli(cls, boot_info: BootInfo) -> None:
         args = boot_info.args
 
-        if not args.ethstats:
+        if not args.enable_ethstats:
             return
 
         network_id = boot_info.trinity_config.network_id
@@ -100,7 +100,7 @@ class EthstatsComponent(AsyncioIsolatedComponent):
 
     @property
     def is_enabled(self) -> bool:
-        return bool(self._boot_info.args.ethstats)
+        return bool(self._boot_info.args.enable_ethstats)
 
     @classmethod
     async def do_run(cls, boot_info: BootInfo, event_bus: EndpointAPI) -> None:


### PR DESCRIPTION
### What could be improved

Renaming `--ethstats` to `--enable-ethstats` improves consistency among the CLI flags. Sparked by https://github.com/ethereum/trinity/pull/1595#discussion_r392046451

### How was it fixed?

Renamed it everywhere.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

[//]: # (See: https://trinity-client.readthedocs.io/en/latest/contributing.html#pull-requests)
- [x] Add entry to the [release notes](https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://i.pinimg.com/736x/67/6a/54/676a54447ba3007b339f5b1cbbf629fd.jpg)
