### PR TITLE
Fix escaping CompressedLengthError

### DIFF
--- a/newsfragments/1606.feature.rst
+++ b/newsfragments/1606.feature.rst
@@ -1,0 +1,1 @@
+Don't let `CompressedLengthError` escape and be written to the console.

--- a/p2p/multiplexer.py
+++ b/p2p/multiplexer.py
@@ -13,6 +13,7 @@ from typing import (
     Union,
 )
 
+import snappy
 from cached_property import cached_property
 
 from async_generator import asynccontextmanager
@@ -89,7 +90,7 @@ async def stream_transport_messages(transport: TransportAPI,
 
         try:
             cmd = command_type.decode(msg, msg_proto.snappy_support)
-        except rlp.exceptions.DeserializationError as err:
+        except (rlp.exceptions.DeserializationError, snappy.CompressedLengthError) as err:
             raise MalformedMessage(f"Failed to decode {msg} for {command_type}") from err
 
         yield msg_proto, cmd


### PR DESCRIPTION
### What was wrong?

Fixes #1582,  escaping `CompressedLengthError`

### How was it fixed?

Catch and raise `MalformedMessage` error

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

[//]: # (See: https://trinity-client.readthedocs.io/en/latest/contributing.html#pull-requests)
- [x] Add entry to the [release notes](https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://i1.wp.com/metro.co.uk/wp-content/uploads/2019/08/PRI_76452395.jpg?quality=90&strip=all&zoom=1&resize=620%2C413&ssl=1)
