### PR TITLE
RFC: Peer now sends a disconnect msg when terminating

### DIFF
--- a/p2p/peer_pool.py
+++ b/p2p/peer_pool.py
@@ -260,9 +260,6 @@ class BasePeerPool(BaseService, AsyncIterable[BasePeer]):
             peer.remove_subscriber(subscriber)
 
     async def start_peer(self, peer: BasePeer) -> None:
-        self.run_child_service(peer.connection)
-        await self.wait(peer.connection.events.started.wait(), timeout=1)
-
         self.run_child_service(peer)
         await self.wait(peer.events.started.wait(), timeout=1)
         await self.wait(peer.ready.wait(), timeout=1)
@@ -320,19 +317,6 @@ class BasePeerPool(BaseService, AsyncIterable[BasePeer]):
 
         self.run_daemon_task(self._periodically_report_stats())
         await self.cancel_token.wait()
-
-    async def stop_all_peers(self) -> None:
-        self.logger.info("Stopping all peers ...")
-        peers = self.connected_nodes.values()
-        disconnections = (
-            peer.disconnect(DisconnectReason.CLIENT_QUITTING)
-            for peer in peers
-            if peer.is_running
-        )
-        await asyncio.gather(*disconnections)
-
-    async def _cleanup(self) -> None:
-        await self.stop_all_peers()
 
     async def connect(self, remote: NodeAPI) -> BasePeer:
         """

--- a/tests/p2p/test_p2p_api.py
+++ b/tests/p2p/test_p2p_api.py
@@ -70,24 +70,7 @@ async def test_p2p_api_disconnect_fn(bob, alice):
             alice_p2p_api = alice.get_logic('p2p', P2PAPI)
             bob_p2p_api = bob.get_logic('p2p', P2PAPI)
 
-            await alice_p2p_api.disconnect(DisconnectReason.CLIENT_QUITTING)
-            await asyncio.wait_for(bob.events.cancelled.wait(), timeout=1)
-
-            assert alice_p2p_api.remote_disconnect_reason is None
-            assert alice_p2p_api.local_disconnect_reason is DisconnectReason.CLIENT_QUITTING
-
-            assert bob_p2p_api.remote_disconnect_reason is DisconnectReason.CLIENT_QUITTING
-            assert bob_p2p_api.local_disconnect_reason is None
-
-
-@pytest.mark.asyncio
-async def test_p2p_api_disconnect_fn_nowait(bob, alice):
-    async with P2PAPI().as_behavior().apply(alice):
-        async with P2PAPI().as_behavior().apply(bob):
-            alice_p2p_api = alice.get_logic('p2p', P2PAPI)
-            bob_p2p_api = bob.get_logic('p2p', P2PAPI)
-
-            alice_p2p_api.disconnect_nowait(DisconnectReason.CLIENT_QUITTING)
+            alice_p2p_api.disconnect(DisconnectReason.CLIENT_QUITTING)
             await asyncio.wait_for(bob.events.cancelled.wait(), timeout=1)
 
             assert alice_p2p_api.remote_disconnect_reason is None

--- a/tests/p2p/test_peer_pair_factory.py
+++ b/tests/p2p/test_peer_pair_factory.py
@@ -4,6 +4,7 @@ import pytest
 
 from p2p.tools.factories import ParagonPeerPairFactory
 from p2p.p2p_proto import Ping, Pong
+from p2p import p2p_api
 
 
 @pytest.mark.asyncio
@@ -26,3 +27,22 @@ async def test_connection_factory_with_ParagonPeer():
 
         await asyncio.wait_for(got_ping.wait(), timeout=1)
         await asyncio.wait_for(got_pong.wait(), timeout=1)
+
+
+@pytest.mark.asyncio
+async def test_disconnect_on_cancellation(monkeypatch):
+    disconnects_received = []
+
+    orig_handle = p2p_api.CancelOnDisconnect.handle
+
+    async def handle(self, connection, cmd) -> None:
+        disconnects_received.append(connection)
+        await orig_handle(self, connection, cmd)
+
+    monkeypatch.setattr(p2p_api.CancelOnDisconnect, 'handle', handle)
+    async with ParagonPeerPairFactory() as (alice, bob):
+        await alice.cancel()
+        await alice.events.cleaned_up.wait()
+        await asyncio.sleep(0.1)
+        assert len(disconnects_received) == 1
+        assert disconnects_received[0] == bob.connection


### PR DESCRIPTION
In order to do so it has to ensure the connection stays open until its
cleanup() method is called, and it does that by running the connection with
an unchained cancel token, and then manually cancels the connection once it
has used it to send the disconnect msg

Before this change, the connection would run with the PeerPool's cancel token (and
as a child service of the PeerPool), so almost always it'd be closed before the Peer
had a chance to run its _cleanup()