### PR TITLE
Peer now sends a disconnect msg when terminating

### DIFF
--- a/p2p/abc.py
+++ b/p2p/abc.py
@@ -39,6 +39,7 @@ from p2p.transport_state import TransportState
 
 if TYPE_CHECKING:
     from p2p.handshake import DevP2PReceipt  # noqa: F401
+    from p2p.peer import BasePeer  # noqa: F401
     from p2p.p2p_proto import (  # noqa: F401
         BaseP2PProtocol,
     )
@@ -583,6 +584,10 @@ class ConnectionAPI(AsyncioServiceAPI):
     @property
     @abstractmethod
     def is_closing(self) -> bool:
+        ...
+
+    @abstractmethod
+    async def run_peer(self, peer: 'BasePeer') -> None:
         ...
 
     #

--- a/p2p/constants.py
+++ b/p2p/constants.py
@@ -126,6 +126,9 @@ SEAL_CHECK_RANDOM_SAMPLE_RATE = 48
 # aborting the connection attempt.
 DEFAULT_PEER_BOOT_TIMEOUT = 20
 
+# How long before we timeout when waiting for a peer to be ready.
+PEER_READY_TIMEOUT = 1
+
 # Name of the endpoint that the discovery uses to connect to the eventbus
 DISCOVERY_EVENTBUS_ENDPOINT = 'discovery'
 # Interval at which peer pool requests new connection candidates

--- a/p2p/peer_pool.py
+++ b/p2p/peer_pool.py
@@ -42,6 +42,7 @@ from p2p.constants import (
     DEFAULT_PEER_BOOT_TIMEOUT,
     HANDSHAKE_TIMEOUT,
     MAX_CONCURRENT_CONNECTION_ATTEMPTS,
+    PEER_READY_TIMEOUT,
     QUIET_PEER_POOL_SIZE,
     REQUEST_PEER_CANDIDATE_TIMEOUT,
 )
@@ -261,11 +262,9 @@ class BasePeerPool(BaseService, AsyncIterable[BasePeer]):
 
     async def start_peer(self, peer: BasePeer) -> None:
         self.run_child_service(peer.connection)
-        await self.wait(peer.connection.events.started.wait(), timeout=1)
+        await self.wait(peer.connection.events.started.wait(), timeout=PEER_READY_TIMEOUT)
 
-        self.run_child_service(peer)
-        await self.wait(peer.events.started.wait(), timeout=1)
-        await self.wait(peer.ready.wait(), timeout=1)
+        await peer.connection.run_peer(peer)
         if peer.is_operational:
             self._add_peer(peer, ())
         else:
@@ -320,19 +319,6 @@ class BasePeerPool(BaseService, AsyncIterable[BasePeer]):
 
         self.run_daemon_task(self._periodically_report_stats())
         await self.cancel_token.wait()
-
-    async def stop_all_peers(self) -> None:
-        self.logger.info("Stopping all peers ...")
-        peers = self.connected_nodes.values()
-        disconnections = (
-            peer.disconnect(DisconnectReason.CLIENT_QUITTING)
-            for peer in peers
-            if peer.is_running
-        )
-        await asyncio.gather(*disconnections)
-
-    async def _cleanup(self) -> None:
-        await self.stop_all_peers()
 
     async def connect(self, remote: NodeAPI) -> BasePeer:
         """

--- a/p2p/tools/factories/peer.py
+++ b/p2p/tools/factories/peer.py
@@ -11,7 +11,6 @@ from eth_keys import keys
 
 from p2p.abc import NodeAPI
 from p2p.peer import BasePeer, BasePeerContext, BasePeerFactory
-from p2p.service import run_service
 
 from p2p.tools.paragon import ParagonPeer, ParagonContext, ParagonPeerFactory
 
@@ -70,14 +69,16 @@ async def PeerPairFactory(*,
         bob_p2p_version=bob_p2p_version,
         cancel_token=cancel_token,
     )
+
     async with connection_pair as (alice_connection, bob_connection):
         alice = alice_factory.create_peer(connection=alice_connection)
         bob = bob_factory.create_peer(connection=bob_connection)
 
-        async with run_service(alice), run_service(bob):
-            await asyncio.wait_for(alice.ready.wait(), timeout=1)
-            await asyncio.wait_for(bob.ready.wait(), timeout=1)
-            yield alice, bob
+        await alice_connection.run_peer(alice)
+        await bob_connection.run_peer(bob)
+        await asyncio.wait_for(alice.ready.wait(), timeout=1)
+        await asyncio.wait_for(bob.ready.wait(), timeout=1)
+        yield alice, bob
 
 
 def ParagonPeerPairFactory(*,

--- a/tests/p2p/test_peer.py
+++ b/tests/p2p/test_peer.py
@@ -1,0 +1,43 @@
+import asyncio
+
+import pytest
+
+from p2p.disconnect import DisconnectReason
+from p2p.tools.factories import ParagonPeerPairFactory
+from p2p.p2p_proto import Disconnect
+
+
+@pytest.mark.asyncio
+async def test_disconnect_on_cancellation():
+    got_disconnect = asyncio.Event()
+
+    async def _handle_disconnect(conn, cmd):
+        got_disconnect.set()
+
+    async with ParagonPeerPairFactory() as (alice, bob):
+        bob.connection.add_command_handler(Disconnect, _handle_disconnect)
+        await alice.cancel()
+        await alice.events.cleaned_up.wait()
+        await asyncio.wait_for(got_disconnect.wait(), timeout=1)
+        assert bob.p2p_api.remote_disconnect_reason == DisconnectReason.CLIENT_QUITTING
+
+
+@pytest.mark.asyncio
+async def test_closes_connection_on_cancellation():
+    async with ParagonPeerPairFactory() as (alice, _):
+        await alice.cancel()
+        await asyncio.wait_for(alice.connection.events.cleaned_up.wait(), timeout=1)
+        assert alice.connection.is_closing
+
+
+@pytest.mark.asyncio
+async def test_cancels_on_received_disconnect():
+    async with ParagonPeerPairFactory() as (alice, bob):
+        # Here we send only a Disconnect msg because we want to ensure that will cause bob to
+        # cancel itself even if alice accidentally leaves her connection open. If we used
+        # alice.cancel() to send the Disconnect msg, alice would also close its connection,
+        # causing bob to detect it, close its own and cause the peer to be cancelled.
+        alice.p2p_api.disconnect(DisconnectReason.CLIENT_QUITTING)
+        await asyncio.wait_for(bob.connection.events.cleaned_up.wait(), timeout=1)
+        assert bob.connection.is_closing
+        assert bob.p2p_api.remote_disconnect_reason == DisconnectReason.CLIENT_QUITTING


### PR DESCRIPTION
In order to do so we need to ensure the connection stays open until the peer's cleanup() method is called, and we do that by running the peer as a child service of the connection.

Also moves the logic to cancel the peer/connection from P2PAPI to BasePeer
