### PR TITLE
Hunting CI failures

### DIFF
--- a/newsfragments/1611.internal.rst
+++ b/newsfragments/1611.internal.rst
@@ -1,0 +1,2 @@
+Remove test that scans for unhandled errors when the transaction pool is disabled.
+Disabling the transaction pool is unlikely to increase the chance of error.

--- a/tests/integration/test_trinity_cli.py
+++ b/tests/integration/test_trinity_cli.py
@@ -221,11 +221,9 @@ async def test_web3_commands_via_attached_console(command,
     (
         # mainnet
         ('trinity',),
-        ('trinity', '--disable-tx-pool',),
         ('trinity', '--sync-mode=light',),
         # ropsten
         ('trinity', '--ropsten',),
-        ('trinity', '--ropsten', '--disable-tx-pool',),
         ('trinity', '--sync-mode=light', '--ropsten',),
     )
 )


### PR DESCRIPTION
### What was wrong?

CI is a hellhole right now.

### How was it fixed?

Not fixed but here's a tiny improvement.

The `test_does_not_throw_error...` tests are meant to catch unhandled errors in Trinity by running it and scanning the console for suspected output. It is very effective at it as [the pesty EOFError](https://github.com/ethereum/trinity/issues/1435) demonstrates on a daily basis.

However, there's not much sense in running this test with the transaction pool disabled I believe. Originally, when the transaction pool wasn't enabled by default, this was added to ensure to additionally run Trinity with the tx pool enabled. But when it later was enabled by default this was traded for `--disable-tx-pool` but I believe there isn't a high likelihood that disabling the transaction pool will yield any extra errors.

This PR removes these extra tests to cut CI times and coincidentally stability by exposing us less to the pesky EOFError.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

[//]: # (See: https://trinity-client.readthedocs.io/en/latest/contributing.html#pull-requests)
- [x] Add entry to the [release notes](https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://i.pinimg.com/originals/49/16/50/4916509ba62f8a9b30535aab088ccd3b.jpg)
