### PR TITLE
Use threadsafe cancel to prevent hanging cleanup on ctrl-c

### DIFF
--- a/trinity/components/eth2/beacon/component.py
+++ b/trinity/components/eth2/beacon/component.py
@@ -261,6 +261,6 @@ class BeaconNodeComponent(AsyncioIsolatedComponent):
                     await stack.enter_async_context(run_service(service))
 
                 await asyncio.gather(*(
-                    service.cancellation()
+                    service.threadsafe_cancel()
                     for service in services
                 ))


### PR DESCRIPTION
### What was wrong?
Issue: #1507  
Suggested solution: https://github.com/ethereum/asyncio-run-in-process/issues/11
> I don't think this issue addresses the solution, I was not able to reproduce the failing tests locally. 

Problem:
- `trinity-beacon` command hangs when terminated with `ctrl-c`. 
- After process is killed manually - launching `trinity-beacon` again results in an `Address already in use` error - caused by dangling ipc files in the xdg directory. These ipc files need to be deleted manually.

### How was it fixed?
I'm new to this library - so this might not be the best way to solve this problem. But, the solution in this pr works locally. When sending a `SIGKILL` the `trinity-beacon` process (via `ctrl-c`), it successfully kills all processes, and removes all dangling ipc files from the xdg: (`ipcs-beacon`) directory.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

[//]: # (See: https://trinity-client.readthedocs.io/en/latest/contributing.html#pull-requests)
- [ ] Add entry to the [release notes](https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![image](https://user-images.githubusercontent.com/9753150/76818812-2af65f00-67cc-11ea-9de5-3c123b235b82.png)

