### PR TITLE
Implement beacon node API for the validator client

### DIFF
--- a/eth2/beacon/typing.py
+++ b/eth2/beacon/typing.py
@@ -1,6 +1,6 @@
 from typing import Any, NamedTuple, NewType, Sequence, Tuple
 
-from eth_typing import Hash32
+from eth_typing import BLSSignature, Hash32
 from typing_extensions import Protocol
 
 Slot = NewType("Slot", int)  # uint64
@@ -68,3 +68,7 @@ default_version = Version(b"\x00" * 4)
 
 class Operation(Protocol):
     hash_tree_root: Root
+
+
+class SignedOperation(Operation):
+    signature: BLSSignature

--- a/eth2/validator_client/abc.py
+++ b/eth2/validator_client/abc.py
@@ -5,7 +5,7 @@ from eth_typing import BLSPubkey, BLSSignature
 
 from eth2.beacon.types.attestations import Attestation
 from eth2.beacon.types.blocks import BeaconBlock
-from eth2.beacon.typing import CommitteeIndex, Epoch, Operation, Slot
+from eth2.beacon.typing import CommitteeIndex, Epoch, Operation, SignedOperation, Slot
 from eth2.validator_client.duty import Duty
 from eth2.validator_client.tick import Tick
 from eth2.validator_client.typing import BLSPrivateKey
@@ -35,12 +35,12 @@ class BeaconNodeAPI(AsyncContextManager["BeaconNodeAPI"]):
 
     @abstractmethod
     async def fetch_block_proposal(
-        self, public_key: BLSPubkey, slot: Slot
+        self, slot: Slot, randao_reveal: BLSSignature
     ) -> BeaconBlock:
         ...
 
     @abstractmethod
-    async def publish(self, duty: Duty, signature: BLSSignature) -> None:
+    async def publish(self, duty: Duty, signed_operation: SignedOperation) -> None:
         ...
 
 

--- a/eth2/validator_client/duty.py
+++ b/eth2/validator_client/duty.py
@@ -28,16 +28,21 @@ class Duty:
     tick_for_execution: Tick
     # ``Tick`` when this ``Duty`` was discovered via a ``BeaconNode``
     discovered_at_tick: Tick
+
+    # which ``Tick`` within a ``Slot`` should this ``Duty`` be performed
+    tick_count: int
     duty_type: DutyType
     signature_domain: SignatureDomain
 
 
 @dataclass(eq=True, frozen=True)
 class AttestationDuty(Duty):
+    tick_count: int = field(init=False, default=1)
     duty_type: DutyType = field(init=False, default=DutyType.Attestation)
     signature_domain: SignatureDomain = field(
         init=False, default=SignatureDomain.DOMAIN_BEACON_ATTESTER
     )
+
     committee_index: CommitteeIndex
 
     def __repr__(self) -> str:
@@ -51,6 +56,7 @@ class AttestationDuty(Duty):
 
 @dataclass(eq=True, frozen=True)
 class BlockProposalDuty(Duty):
+    tick_count: int = field(init=False, default=0)
     duty_type: DutyType = field(init=False, default=DutyType.BlockProposal)
     signature_domain: SignatureDomain = field(
         init=False, default=SignatureDomain.DOMAIN_BEACON_PROPOSER

--- a/eth2/validator_client/randao.py
+++ b/eth2/validator_client/randao.py
@@ -1,0 +1,24 @@
+from eth_typing import BLSPubkey, BLSSignature, Hash32
+from py_ecc.bls.typing import Domain
+
+from eth2._utils.bls import bls
+from eth2.beacon.helpers import signature_domain_to_domain_type
+from eth2.beacon.signature_domain import SignatureDomain
+from eth2.beacon.typing import Epoch
+from eth2.validator_client.typing import PrivateKeyProvider, RandaoProvider
+
+
+def mk_randao_provider(private_key_provider: PrivateKeyProvider) -> RandaoProvider:
+    def _randao_provider_of_epoch_signature(
+        public_key: BLSPubkey, epoch: Epoch
+    ) -> BLSSignature:
+        private_key = private_key_provider(public_key)
+        # TODO: fix how we get the signing root
+        message = Hash32(epoch.to_bytes(32, byteorder="big"))
+        domain = Domain(
+            b"\x00" * 4 + signature_domain_to_domain_type(SignatureDomain.DOMAIN_RANDAO)
+        )
+        sig = bls.sign(message, private_key, domain)
+        return sig
+
+    return _randao_provider_of_epoch_signature

--- a/eth2/validator_client/tick.py
+++ b/eth2/validator_client/tick.py
@@ -13,5 +13,18 @@ class Tick:
     def __repr__(self) -> str:
         return f"Tick({self.epoch},{self.slot},{self.count})"
 
+    @classmethod
+    def computing_t_from(
+        cls,
+        slot: Slot,
+        epoch: Epoch,
+        count: int,
+        genesis_time: int,
+        seconds_per_slot: int,
+        ticks_per_slot: int,
+    ) -> "Tick":
+        t = genesis_time + seconds_per_slot * slot + seconds_per_slot / ticks_per_slot
+        return cls(t, slot, epoch, count)
+
     def is_at_genesis(self, genesis_time: int) -> bool:
         return int(self.t) == genesis_time and self.count == 0

--- a/eth2/validator_client/typing.py
+++ b/eth2/validator_client/typing.py
@@ -1,8 +1,8 @@
 from typing import Callable, Tuple
 
-from eth_typing import BLSPubkey
+from eth_typing import BLSPubkey, BLSSignature
 
-from eth2.beacon.typing import Operation
+from eth2.beacon.typing import Epoch, Operation
 from eth2.validator_client.duty import Duty
 
 BLSPrivateKey = int
@@ -10,5 +10,7 @@ BLSPrivateKey = int
 KeyPair = Tuple[BLSPubkey, BLSPrivateKey]
 
 PrivateKeyProvider = Callable[[BLSPubkey], BLSPrivateKey]
+
+RandaoProvider = Callable[[BLSPubkey, Epoch], BLSSignature]
 
 ResolvedDuty = Tuple[Duty, Operation]


### PR DESCRIPTION
### What was wrong?

The eth2 validator client was missing its half of the API to interact with the beacon node.

### How was it fixed?

This PR adds a first pass at adding this API, noting that some details are likely to change as the rest of the repo is updated to later spec versions.

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://i0.wp.com/metro.co.uk/wp-content/uploads/2020/02/PRC_136966015.jpg?quality=90&strip=all&zoom=1&resize=644%2C338&ssl=1)
