### PR TITLE
Introduce utility to generate network genesis data

### DIFF
--- a/eth2/beacon/tools/builder/initializer.py
+++ b/eth2/beacon/tools/builder/initializer.py
@@ -1,23 +1,29 @@
-from typing import Any, Dict, Sequence, Tuple, Type
+from typing import Any, Callable, Dict, Sequence, Tuple, Type
 
 from eth.constants import ZERO_HASH32
 from eth_typing import BLSPubkey, Hash32
 from eth_utils import decode_hex
+from eth_utils.toolz import curry
 from py_ecc.optimized_bls12_381.optimized_curve import (
     curve_order as BLS12_381_CURVE_ORDER,
 )
 
+from eth2._utils.bls import bls
 from eth2._utils.hash import hash_eth2
+from eth2._utils.merkle.common import MerkleTree, get_merkle_proof
 from eth2.beacon.constants import ZERO_TIMESTAMP
 from eth2.beacon.genesis import get_genesis_block, initialize_beacon_state_from_eth1
-from eth2.beacon.tools.builder.validator import create_mock_deposit_data
+from eth2.beacon.tools.builder.validator import (
+    create_deposit_data,
+    create_mock_deposit_data,
+)
 from eth2.beacon.types.blocks import BaseBeaconBlock
 from eth2.beacon.types.deposit_data import DepositData  # noqa: F401
 from eth2.beacon.types.deposits import Deposit
 from eth2.beacon.types.eth1_data import Eth1Data
 from eth2.beacon.types.states import BeaconState
 from eth2.beacon.types.validators import Validator
-from eth2.beacon.typing import Timestamp
+from eth2.beacon.typing import Gwei, Timestamp
 from eth2.beacon.validator_status_helpers import activate_validator
 from eth2.configs import Eth2Config
 
@@ -36,6 +42,10 @@ def generate_privkey_from_index(index: int) -> int:
 def create_keypair_and_mock_withdraw_credentials(
     config: Eth2Config, key_set: Sequence[Dict[str, Any]]
 ) -> Tuple[Tuple[BLSPubkey, ...], Tuple[int, ...], Tuple[Hash32, ...]]:
+    """
+    NOTE: this function mixes the parsing of keying material with the generation of derived values.
+    Prefer other functions in this module that do the derivation directly.
+    """
     pubkeys: Tuple[BLSPubkey, ...] = ()
     privkeys: Tuple[int, ...] = ()
     withdrawal_credentials: Tuple[Hash32, ...] = ()
@@ -52,6 +62,64 @@ def create_keypair_and_mock_withdraw_credentials(
         withdrawal_credentials += (withdrawal_credential,)
 
     return (pubkeys, privkeys, withdrawal_credentials)
+
+
+def create_key_pairs_for(validator_count: int) -> Dict[BLSPubkey, int]:
+    """
+    Generates ``validator_count`` key pairs derived in a deterministic manner based
+    on the validator index in the ``range(validator_count)``.
+
+    Returns a second map associating a public key with the validator's index in the set.
+    """
+    key_pairs = {}
+    for i in range(validator_count):
+        private_key = generate_privkey_from_index(i)
+        public_key = bls.privtopub(private_key)
+        key_pairs[public_key] = private_key
+    return key_pairs
+
+
+@curry
+def mk_withdrawal_credentials_from(prefix: bytes, public_key: BLSPubkey) -> Hash32:
+    return Hash32(prefix + hash_eth2(public_key)[1:])
+
+
+def create_deposit_proof(
+    tree: MerkleTree, index: int, leaf_count: int
+) -> Tuple[Hash32, ...]:
+    length_mix_in = Hash32(leaf_count.to_bytes(32, byteorder="little"))
+    proof = get_merkle_proof(tree, index)
+    return proof + (length_mix_in,)
+
+
+def create_deposit(
+    deposit_data: DepositData, tree: MerkleTree, index: int, leaf_count: int
+) -> Deposit:
+    proof = create_deposit_proof(tree, index, leaf_count)
+    return Deposit.create(proof=proof, data=deposit_data)
+
+
+def create_genesis_deposits_from(
+    key_pairs: Dict[BLSPubkey, int],
+    withdrawal_credentials_provider: Callable[[BLSPubkey], Hash32],
+    amount_provider: Callable[[BLSPubkey], Gwei],
+) -> Tuple[Deposit, ...]:
+    deposit_data = tuple(
+        create_deposit_data(
+            public_key,
+            private_key,
+            withdrawal_credentials_provider(public_key),
+            amount_provider(public_key),
+        )
+        for public_key, private_key in key_pairs.items()
+    )
+
+    deposits: Tuple[Deposit, ...] = tuple()
+    for index, data in enumerate(deposit_data):
+        data_to_index = deposit_data[: index + 1]
+        tree, _ = make_deposit_tree_and_root(data_to_index)
+        deposits += (create_deposit(data, tree, index, len(data_to_index)),)
+    return deposits
 
 
 def create_mock_deposits_and_root(

--- a/eth2/beacon/tools/builder/validator.py
+++ b/eth2/beacon/tools/builder/validator.py
@@ -727,6 +727,24 @@ def create_mock_voluntary_exit(
 #
 # Deposit
 #
+def create_deposit_data(
+    public_key: BLSPubkey,
+    private_key: int,
+    withdrawal_credentials: Hash32,
+    amount: Gwei,
+) -> DepositData:
+    message = DepositMessage.create(
+        pubkey=public_key, withdrawal_credentials=withdrawal_credentials, amount=amount
+    )
+    signature = sign_proof_of_possession(deposit_message=message, privkey=private_key)
+    return DepositData.create(
+        pubkey=public_key,
+        withdrawal_credentials=withdrawal_credentials,
+        amount=amount,
+        signature=signature,
+    )
+
+
 def create_mock_deposit_data(
     *,
     config: Eth2Config,

--- a/eth2/configs.py
+++ b/eth2/configs.py
@@ -1,4 +1,6 @@
-from typing import NamedTuple
+from typing import Any, NamedTuple, Tuple, Union
+
+from eth_utils import encode_hex
 
 from eth2.beacon.typing import Epoch, Gwei, Second, Slot
 
@@ -58,6 +60,17 @@ Eth2Config = NamedTuple(
         ("DEPOSIT_CONTRACT_ADDRESS", bytes),
     ),
 )
+
+
+def _serialize(item: Any) -> Union[int, str]:
+    if isinstance(item, bytes):
+        return encode_hex(item)
+    else:
+        return item
+
+
+def serialize(config: Eth2Config) -> Tuple[Union[int, str], ...]:
+    return tuple(_serialize(item) for item in config)
 
 
 class CommitteeConfig:

--- a/eth2/configs.py
+++ b/eth2/configs.py
@@ -1,6 +1,6 @@
-from typing import Any, NamedTuple, Tuple, Union
+from typing import Any, NamedTuple, Tuple, Union, cast
 
-from eth_utils import encode_hex
+from eth_utils import decode_hex, encode_hex
 
 from eth2.beacon.typing import Epoch, Gwei, Second, Slot
 
@@ -66,11 +66,25 @@ def _serialize(item: Any) -> Union[int, str]:
     if isinstance(item, bytes):
         return encode_hex(item)
     else:
-        return item
+        return int(item)
 
 
 def serialize(config: Eth2Config) -> Tuple[Union[int, str], ...]:
     return tuple(_serialize(item) for item in config)
+
+
+def _deserialize(item: Union[int, str], typ: Any) -> Any:
+    if typ is bytes:
+        return decode_hex(cast(str, item))
+    else:
+        return typ(item)
+
+
+def deserialize(config: Tuple[Union[int, str], ...]) -> Eth2Config:
+    values: Tuple[Any, ...] = ()
+    for index, (_, typ) in enumerate(Eth2Config._field_types.items()):
+        values += (_deserialize(config[index], typ),)
+    return Eth2Config(*values)
 
 
 class CommitteeConfig:

--- a/trinity/components/eth2/constants.py
+++ b/trinity/components/eth2/constants.py
@@ -1,2 +1,0 @@
-VALIDATOR_KEY_DIR = "keys"
-GENESIS_FILE = "genesis_state.yaml"

--- a/trinity/components/eth2/discv5/component.py
+++ b/trinity/components/eth2/discv5/component.py
@@ -1,6 +1,7 @@
 from argparse import ArgumentParser, _SubParsersAction
 import logging
 import pathlib
+import re
 import secrets
 
 import async_service
@@ -39,8 +40,9 @@ from trinity.extensibility import TrioIsolatedComponent
 
 DEFAULT_NODEDB_DIR_NAME = "nodes"
 
-
-logger = logging.getLogger(__name__)
+logger = logging.getLogger(
+    re.sub(re.escape("component") + "$", "DiscV5Component", __name__)
+)
 
 
 def get_nodedb_dir(boot_info: BootInfo) -> pathlib.Path:

--- a/trinity/components/eth2/eth1_monitor/component.py
+++ b/trinity/components/eth2/eth1_monitor/component.py
@@ -94,8 +94,7 @@ class Eth1MonitorComponent(TrioIsolatedComponent):
         # Set the timestamp of start block earlier enough so that eth1 monitor
         # can query up to 2 * `ETH1_FOLLOW_DISTANCE` of blocks in the beginning.
         start_block_timestamp = (
-            chain_config.genesis_data.genesis_time
-            - 3 * ETH1_FOLLOW_DISTANCE * AVERAGE_BLOCK_TIME
+            chain_config.genesis_time - 3 * ETH1_FOLLOW_DISTANCE * AVERAGE_BLOCK_TIME
         )
         with base_db:
             fake_eth1_data_provider = FakeEth1DataProvider(

--- a/trinity/components/eth2/interop/component.py
+++ b/trinity/components/eth2/interop/component.py
@@ -15,7 +15,6 @@ from eth2.beacon.state_machines.forks.skeleton_lake import MINIMAL_SERENITY_CONF
 from eth2.beacon.tools.misc.ssz_vector import override_lengths
 from eth2.beacon.types.states import BeaconState
 from trinity.components.builtin.network_db.component import TrackingBackend
-from trinity.components.eth2.constants import GENESIS_FILE, VALIDATOR_KEY_DIR
 from trinity.config import BeaconAppConfig, TrinityConfig
 from trinity.extensibility import Application
 
@@ -139,11 +138,11 @@ class InteropComponent(Application):
 
         # Save the genesis state to the data dir!
         yaml = YAML(typ="unsafe")
-        with open(trinity_config.trinity_root_dir / GENESIS_FILE, "w") as f:
+        with open(trinity_config.trinity_root_dir / "genesis", "w") as f:
             yaml.dump(to_formatted_dict(state), f)
 
         # Save the validator keys to the data dir
-        keys_dir = trinity_config.trinity_root_dir / VALIDATOR_KEY_DIR
+        keys_dir = trinity_config.trinity_root_dir / "keys"
         try:
             shutil.rmtree(keys_dir)
         except FileNotFoundError:

--- a/trinity/components/eth2/network_generator/component.py
+++ b/trinity/components/eth2/network_generator/component.py
@@ -1,0 +1,126 @@
+from argparse import ArgumentParser, Namespace, _SubParsersAction
+import json
+import logging
+import pathlib
+import time
+from typing import Any, Callable, Dict, Tuple
+
+from eth.constants import ZERO_HASH32
+from eth_typing import BLSPubkey
+from eth_utils import encode_hex
+from ssz.tools.dump import to_formatted_dict
+
+from eth2.beacon.genesis import initialize_beacon_state_from_eth1
+from eth2.beacon.state_machines.forks.serenity.configs import SERENITY_CONFIG
+from eth2.beacon.state_machines.forks.skeleton_lake.config import (
+    MINIMAL_SERENITY_CONFIG,
+)
+from eth2.beacon.tools.builder.initializer import (
+    create_genesis_deposits_from,
+    create_key_pairs_for,
+    mk_withdrawal_credentials_from,
+)
+from eth2.beacon.types.states import BeaconState
+from eth2.configs import Eth2Config, serialize
+from trinity.config import TrinityConfig
+from trinity.extensibility import Application
+
+CONFIG_PROFILE_HELP = """
+Use this profile of configuration to determine minimal parameters in the system.
+"""
+
+
+def _get_eth2_config(profile: str) -> Eth2Config:
+    return {"minimal": MINIMAL_SERENITY_CONFIG, "mainnet": SERENITY_CONFIG}[profile]
+
+
+def _identity(x: Any) -> Any:
+    return x
+
+
+def _mk_genesis_key_map(
+    key_pairs: Dict[BLSPubkey, int],
+    genesis_state: BeaconState,
+    public_key_codec: Callable[[BLSPubkey], str] = _identity,
+    private_key_codec: Callable[[int], str] = _identity,
+) -> Tuple[Dict[str, Any]]:
+    key_map = ()
+    for _, validator in enumerate(genesis_state.validators):
+        public_key = validator.pubkey
+        private_key = key_pairs[public_key]
+        key_map += (
+            {
+                "public_key": public_key_codec(public_key),
+                "private_key": private_key_codec(private_key),
+            },
+        )
+    return key_map
+
+
+def _encode_private_key_as_hex(private_key: int) -> str:
+    return encode_hex(private_key.to_bytes(32, byteorder="little"))
+
+
+class NetworkGeneratorComponent(Application):
+    """
+    This component accepts some initial configuration and produces a genesis state and a set
+    of private keys for validators in the genesis state.
+    """
+
+    logger = logging.getLogger("trinity.components.eth2.network_generator")
+
+    @classmethod
+    def configure_parser(
+        cls, arg_parser: ArgumentParser, subparser: _SubParsersAction
+    ) -> None:
+        network_generator_parser = subparser.add_parser(
+            "create-network",
+            help="Produces a genesis state and a set of private keys for validators in the genesis state",
+        )
+        network_generator_parser.add_argument(
+            "--config-profile", help=CONFIG_PROFILE_HELP, choices=("minimal", "mainnet")
+        )
+        network_generator_parser.add_argument(
+            "--output", type=pathlib.Path, help="where to save the output configuration"
+        )
+        network_generator_parser.set_defaults(func=cls._generate_network_as_json)
+
+    @classmethod
+    def _generate_network_as_json(
+        cls, args: Namespace, trinity_config: TrinityConfig
+    ) -> None:
+        config = _get_eth2_config(args.config_profile)
+        validator_count = config.MIN_GENESIS_ACTIVE_VALIDATOR_COUNT
+        cls.logger.info(
+            "generating a configuration file at '%s' for %d validators and the genesis state containing them...",
+            args.output,
+            validator_count,
+        )
+        validator_key_pairs = create_key_pairs_for(validator_count)
+        deposits = create_genesis_deposits_from(
+            validator_key_pairs,
+            withdrawal_credentials_provider=mk_withdrawal_credentials_from(
+                config.BLS_WITHDRAWAL_PREFIX.to_bytes(1, byteorder="little")
+            ),
+            amount_provider=lambda _public_key: config.MAX_EFFECTIVE_BALANCE,
+        )
+        eth1_block_hash = ZERO_HASH32
+        eth1_timestamp = int(time.time())
+        genesis_state = initialize_beacon_state_from_eth1(
+            eth1_block_hash=eth1_block_hash,
+            eth1_timestamp=eth1_timestamp,
+            deposits=deposits,
+            config=config,
+        )
+        output = {
+            "eth2_config": serialize(config),
+            "genesis_validator_key_pairs": _mk_genesis_key_map(
+                validator_key_pairs,
+                genesis_state,
+                public_key_codec=encode_hex,
+                private_key_codec=_encode_private_key_as_hex,
+            ),
+            "genesis_state": to_formatted_dict(genesis_state),
+        }
+        with open(args.output, "w") as output_file:
+            output_file.write(json.dumps(output))

--- a/trinity/components/eth2/network_generator/component.py
+++ b/trinity/components/eth2/network_generator/component.py
@@ -2,12 +2,9 @@ from argparse import ArgumentParser, Namespace, _SubParsersAction
 import json
 import logging
 import pathlib
-import time
-from typing import Any, Callable, Dict, Tuple
 
 from eth.constants import ZERO_HASH32
-from eth_typing import BLSPubkey
-from eth_utils import encode_hex
+from eth_utils import humanize_hash
 from ssz.tools.dump import to_formatted_dict
 
 from eth2.beacon.genesis import initialize_beacon_state_from_eth1
@@ -18,13 +15,17 @@ from eth2.beacon.state_machines.forks.skeleton_lake.config import (
 from eth2.beacon.tools.builder.initializer import (
     create_genesis_deposits_from,
     create_key_pairs_for,
+    mk_genesis_key_map,
     mk_withdrawal_credentials_from,
 )
-from eth2.beacon.types.states import BeaconState
+from eth2.beacon.typing import Timestamp
 from eth2.configs import Eth2Config, serialize
-from trinity.config import TrinityConfig
+from trinity.config import BeaconChainConfig, TrinityConfig
 from trinity.extensibility import Application
 
+CREATE_NETWORK_HELP = """
+Produces a genesis state and a set of private keys for validators in the genesis state
+"""
 CONFIG_PROFILE_HELP = """
 Use this profile of configuration to determine minimal parameters in the system.
 """
@@ -34,31 +35,8 @@ def _get_eth2_config(profile: str) -> Eth2Config:
     return {"minimal": MINIMAL_SERENITY_CONFIG, "mainnet": SERENITY_CONFIG}[profile]
 
 
-def _identity(x: Any) -> Any:
-    return x
-
-
-def _mk_genesis_key_map(
-    key_pairs: Dict[BLSPubkey, int],
-    genesis_state: BeaconState,
-    public_key_codec: Callable[[BLSPubkey], str] = _identity,
-    private_key_codec: Callable[[int], str] = _identity,
-) -> Tuple[Dict[str, Any]]:
-    key_map = ()
-    for _, validator in enumerate(genesis_state.validators):
-        public_key = validator.pubkey
-        private_key = key_pairs[public_key]
-        key_map += (
-            {
-                "public_key": public_key_codec(public_key),
-                "private_key": private_key_codec(private_key),
-            },
-        )
-    return key_map
-
-
-def _encode_private_key_as_hex(private_key: int) -> str:
-    return encode_hex(private_key.to_bytes(32, byteorder="little"))
+def _get_network_config_path_from() -> pathlib.Path:
+    return BeaconChainConfig.get_genesis_config_file_path()
 
 
 class NetworkGeneratorComponent(Application):
@@ -74,14 +52,16 @@ class NetworkGeneratorComponent(Application):
         cls, arg_parser: ArgumentParser, subparser: _SubParsersAction
     ) -> None:
         network_generator_parser = subparser.add_parser(
-            "create-network",
-            help="Produces a genesis state and a set of private keys for validators in the genesis state",
+            "create-network", help=CREATE_NETWORK_HELP
         )
         network_generator_parser.add_argument(
             "--config-profile", help=CONFIG_PROFILE_HELP, choices=("minimal", "mainnet")
         )
         network_generator_parser.add_argument(
-            "--output", type=pathlib.Path, help="where to save the output configuration"
+            "--output",
+            required=False,
+            type=pathlib.Path,
+            help="where to save the output configuration",
         )
         network_generator_parser.set_defaults(func=cls._generate_network_as_json)
 
@@ -91,9 +71,14 @@ class NetworkGeneratorComponent(Application):
     ) -> None:
         config = _get_eth2_config(args.config_profile)
         validator_count = config.MIN_GENESIS_ACTIVE_VALIDATOR_COUNT
+        output_file_path = (
+            args.output if args.output else _get_network_config_path_from()
+        )
+
         cls.logger.info(
-            "generating a configuration file at '%s' for %d validators and the genesis state containing them...",
-            args.output,
+            "generating a configuration file at '%s'"
+            " for %d validators and the genesis state containing them...",
+            output_file_path,
             validator_count,
         )
         validator_key_pairs = create_key_pairs_for(validator_count)
@@ -105,22 +90,24 @@ class NetworkGeneratorComponent(Application):
             amount_provider=lambda _public_key: config.MAX_EFFECTIVE_BALANCE,
         )
         eth1_block_hash = ZERO_HASH32
-        eth1_timestamp = int(time.time())
+        eth1_timestamp = config.MIN_GENESIS_TIME
         genesis_state = initialize_beacon_state_from_eth1(
             eth1_block_hash=eth1_block_hash,
-            eth1_timestamp=eth1_timestamp,
+            eth1_timestamp=Timestamp(eth1_timestamp),
             deposits=deposits,
             config=config,
         )
         output = {
             "eth2_config": serialize(config),
-            "genesis_validator_key_pairs": _mk_genesis_key_map(
-                validator_key_pairs,
-                genesis_state,
-                public_key_codec=encode_hex,
-                private_key_codec=_encode_private_key_as_hex,
+            "genesis_validator_key_pairs": mk_genesis_key_map(
+                validator_key_pairs, genesis_state
             ),
             "genesis_state": to_formatted_dict(genesis_state),
         }
-        with open(args.output, "w") as output_file:
+        cls.logger.info(
+            "configuration generated; genesis state has root %s",
+            humanize_hash(genesis_state.hash_tree_root),
+        )
+        output_file_path.parent.mkdir(parents=True, exist_ok=True)
+        with open(output_file_path, "w") as output_file:
             output_file.write(json.dumps(output))

--- a/trinity/components/registry.py
+++ b/trinity/components/registry.py
@@ -53,6 +53,7 @@ from trinity.components.eth2.beacon.component import BeaconNodeComponent
 from trinity.components.eth2.discv5.component import DiscV5Component
 from trinity.components.eth2.eth1_monitor.component import Eth1MonitorComponent
 from trinity.components.eth2.interop.component import InteropComponent
+from trinity.components.eth2.network_generator.component import NetworkGeneratorComponent
 from trinity.components.builtin.tx_pool.component import (
     TxComponent,
 )
@@ -71,6 +72,7 @@ BASE_COMPONENTS: Tuple[Type[BaseComponentAPI], ...] = (
 BEACON_NODE_COMPONENTS: Tuple[Type[BaseComponentAPI], ...] = (
     BeaconNodeComponent,
     InteropComponent,
+    NetworkGeneratorComponent,
     Eth1MonitorComponent,
     DiscV5Component,
 )

--- a/trinity/components/registry.py
+++ b/trinity/components/registry.py
@@ -51,7 +51,6 @@ from trinity.components.builtin.upnp.component import (
 )
 from trinity.components.eth2.beacon.component import BeaconNodeComponent
 from trinity.components.eth2.discv5.component import DiscV5Component
-from trinity.components.eth2.eth1_monitor.component import Eth1MonitorComponent
 from trinity.components.eth2.interop.component import InteropComponent
 from trinity.components.eth2.network_generator.component import NetworkGeneratorComponent
 from trinity.components.builtin.tx_pool.component import (
@@ -73,7 +72,6 @@ BEACON_NODE_COMPONENTS: Tuple[Type[BaseComponentAPI], ...] = (
     BeaconNodeComponent,
     InteropComponent,
     NetworkGeneratorComponent,
-    Eth1MonitorComponent,
     DiscV5Component,
 )
 
@@ -113,4 +111,4 @@ def get_components_for_eth1_client() -> Tuple[Type[BaseComponentAPI], ...]:
 
 
 def get_components_for_beacon_client() -> Tuple[Type[BaseComponentAPI], ...]:
-    return get_all_components(*BEACON_NODE_COMPONENTS)
+    return BEACON_NODE_COMPONENTS


### PR DESCRIPTION
### What was wrong?

We need a single point of entry to generate a (self-contained) piece of data that describes a network genesis for both the beacon node and the validator client.

### How was it fixed?

Introduce an `Application` to accomplish this task; will deprecate the `Interop` component in a subsequent PR. NOTE: The genesis data is written in a custom JSON format that only Trinity nodes will know how to handle.

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://api.time.com/wp-content/uploads/2020/03/coronavirus-dog.jpg?quality=85&w=1024&h=628&crop=1)
