### PR TITLE
Fix an API issue with KeyStore creation

### DIFF
--- a/eth2/validator_client/cli_parser.py
+++ b/eth2/validator_client/cli_parser.py
@@ -2,17 +2,14 @@ import argparse
 import getpass
 import logging
 import signal
-from typing import Dict
 
 import argcomplete
 from async_service.trio import background_trio_service
-from eth_typing import BLSPubkey
 import trio
 
 from eth2.validator_client.client import Client
 from eth2.validator_client.config import Config
 from eth2.validator_client.key_store import KeyStore
-from eth2.validator_client.typing import BLSPrivateKey
 from trinity.cli_parser import parser, subparser
 
 DEMO_MODE_HELP_MSG = (
@@ -45,8 +42,7 @@ async def _import_key(
 ) -> None:
     logger.info("importing private key...")
     try:
-        key_pairs: Dict[BLSPubkey, BLSPrivateKey] = {}
-        key_store = KeyStore.from_config(config, key_pairs)
+        key_store = KeyStore.from_config(config)
         logger.warn(
             "please enter a password to protect the key on-disk (can be empty):"
         )

--- a/eth2/validator_client/client.py
+++ b/eth2/validator_client/client.py
@@ -17,6 +17,7 @@ from eth2.validator_client.duty_scheduler import (
     schedule_and_dispatch_duties_at_tick,
 )
 from eth2.validator_client.duty_store import DutyStore
+from eth2.validator_client.key_store import InMemoryKeyStore as KeyStore
 from eth2.validator_client.randao import mk_randao_provider
 from eth2.validator_client.signatory import sign_and_broadcast_operation_if_valid
 from eth2.validator_client.signatory_db import InMemorySignatoryDB
@@ -63,7 +64,8 @@ class Client(Service):
     def from_config(cls, config: Config) -> "Client":
         clock = Clock.from_config(config)
         beacon_node = BeaconNode.from_config(config)
-        return cls(config.key_store, clock, beacon_node)
+        key_store = KeyStore.from_config(config)
+        return cls(key_store, clock, beacon_node)
 
     async def _run_client(self) -> None:
         # NOTE: all duties dispatched from the scheduler are expected to be

--- a/eth2/validator_client/config.py
+++ b/eth2/validator_client/config.py
@@ -1,17 +1,16 @@
 from pathlib import Path
-from typing import Callable
+from typing import Dict
 
 from cached_property import cached_property
+from eth_typing import BLSPubkey
 
 from eth2.beacon.typing import Slot
-from eth2.validator_client.abc import KeyStoreAPI
+from eth2.validator_client.typing import BLSPrivateKey
 
 DEFAULT_BEACON_NODE_ENDPOINT = "https://127.0.0.1:30303"
 DEFAULT_VALIDATOR_DATA_DIR = Path("validator_client")
 DEFAULT_KEY_STORE_DIR_SUFFIX = Path("key_store")
 DEFAULT_SIGNATORY_DB_DIR_SUFFIX = Path("db") / "signatory"
-
-KeyStoreConstructor = Callable[["Config"], KeyStoreAPI]
 
 
 class Config:
@@ -22,7 +21,7 @@ class Config:
     def __init__(
         self,
         *,
-        key_store_constructor: KeyStoreConstructor = None,
+        key_pairs: Dict[BLSPubkey, BLSPrivateKey] = None,
         root_data_dir: Path = None,
         beacon_node_endpoint: str = DEFAULT_BEACON_NODE_ENDPOINT,
         key_store_dir_suffix: Path = DEFAULT_KEY_STORE_DIR_SUFFIX,
@@ -32,6 +31,7 @@ class Config:
         genesis_time: int = None,
         demo_mode: bool = False,
     ) -> None:
+        self.key_pairs = key_pairs
         self._root_data_dir = root_data_dir
         self.beacon_node_endpoint = beacon_node_endpoint
         self.key_store_dir_suffix = key_store_dir_suffix
@@ -40,8 +40,6 @@ class Config:
         self.seconds_per_slot = seconds_per_slot
         self.genesis_time = genesis_time
         self.demo_mode = demo_mode
-
-        self.key_store = key_store_constructor(self)
 
     @cached_property
     def seconds_per_epoch(self) -> int:

--- a/eth2/validator_client/key_store.py
+++ b/eth2/validator_client/key_store.py
@@ -40,6 +40,8 @@ class KeyStore(KeyStoreAPI):
     ) -> None:
         self._location = key_store_dir
         self._demo_mode = demo_mode
+        # TODO(ralexstokes) reconcile ``key_pairs`` provided to this class
+        # with those serialized on disk
         self._key_pairs = key_pairs
         # NOTE: ``_key_files`` is a temporary cache
         # so that there may be key pairs in ``_key_pairs``
@@ -49,10 +51,8 @@ class KeyStore(KeyStoreAPI):
         self._ensure_dirs()
 
     @classmethod
-    def from_config(
-        cls, config: Config, key_pairs: Dict[BLSPubkey, BLSPrivateKey]
-    ) -> "KeyStore":
-        return cls(config.key_store_dir, key_pairs, config.demo_mode)
+    def from_config(cls, config: Config) -> "KeyStore":
+        return cls(config.key_store_dir, config.key_pairs, config.demo_mode)
 
     def __enter__(self) -> KeyStoreAPI:
         self._load_validator_key_pairs()
@@ -131,10 +131,8 @@ class InMemoryKeyStore(KeyStoreAPI):
         self._key_pairs = key_pairs
 
     @classmethod
-    def from_config(
-        cls, config: Config, key_pairs: Dict[BLSPubkey, BLSPrivateKey]
-    ) -> "InMemoryKeyStore":
-        return cls(key_pairs)
+    def from_config(cls, config: Config) -> "InMemoryKeyStore":
+        return cls(config.key_pairs)
 
     def __enter__(self) -> KeyStoreAPI:
         return self

--- a/tests/eth2/core/validator_client/test_key_store.py
+++ b/tests/eth2/core/validator_client/test_key_store.py
@@ -12,34 +12,24 @@ from eth2.validator_client.key_store import InMemoryKeyStore, KeyStore
 def test_key_stores_can_import_private_key(
     tmp_path, sample_bls_key_pairs, key_store_impl
 ):
-    config = Config(
-        key_store_constructor=lambda config: key_store_impl.from_config(
-            config, sample_bls_key_pairs
-        ),
-        root_data_dir=tmp_path,
-    )
+    config = Config(key_pairs=sample_bls_key_pairs, root_data_dir=tmp_path)
     some_password = b"password"
     public_key, private_key = tuple(sample_bls_key_pairs.items())[0]
     encoded_private_key = private_key.to_bytes(length=32, byteorder="big").hex()
 
-    with config.key_store as key_store:
+    with key_store_impl.from_config(config) as key_store:
         key_store.import_private_key(encoded_private_key, some_password)
         assert key_store.private_key_for(public_key) == private_key
 
 
 def test_key_store_can_persist_key_files(tmp_path, sample_bls_key_pairs):
-    config = Config(
-        key_store_constructor=lambda config: KeyStore.from_config(
-            config, sample_bls_key_pairs
-        ),
-        root_data_dir=tmp_path,
-    )
+    config = Config(key_pairs=sample_bls_key_pairs, root_data_dir=tmp_path)
     some_password = b"password"
     public_key, private_key = tuple(sample_bls_key_pairs.items())[0]
     private_key_bytes = private_key.to_bytes(length=32, byteorder="big")
     encoded_private_key = private_key_bytes.hex()
 
-    with config.key_store as key_store:
+    with KeyStore.from_config(config) as key_store:
         assert not tuple(key_store._location.iterdir())
         key_store.import_private_key(encoded_private_key, some_password)
 

--- a/trinity/main_validator.py
+++ b/trinity/main_validator.py
@@ -1,9 +1,8 @@
 import json
 import logging
 from pathlib import Path
-from typing import Any, Callable, Dict
+from typing import Any, Dict
 
-from eth_typing import BLSPubkey
 from ssz.tools.parse import from_formatted_dict
 import trio
 
@@ -12,12 +11,9 @@ from eth2.beacon.tools.misc.ssz_vector import override_lengths
 from eth2.beacon.types.states import BeaconState
 from eth2.beacon.typing import Slot
 from eth2.configs import deserialize
-from eth2.validator_client.abc import KeyStoreAPI
 from eth2.validator_client.cli_parser import parse_cli_args
 from eth2.validator_client.config import Config
-from eth2.validator_client.key_store import InMemoryKeyStore
 from eth2.validator_client.tools.directory import create_dir_if_missing
-from eth2.validator_client.typing import BLSPrivateKey
 from trinity._utils.logging import LOG_FORMATTER
 from trinity.bootstrap import load_trinity_config_from_parser_args
 from trinity.config import ValidatorClientAppConfig
@@ -39,15 +35,6 @@ def _setup_logging() -> logging.Logger:
 def _load_genesis_config_at(genesis_config_path: Path) -> Dict[str, Any]:
     with open(genesis_config_path) as genesis_config_file:
         return json.load(genesis_config_file)
-
-
-def _mk_key_store_from_key_pairs(
-    key_pairs: Dict[BLSPubkey, BLSPrivateKey]
-) -> Callable[[Config], KeyStoreAPI]:
-    def _mk_key_store(config: Config) -> KeyStoreAPI:
-        return InMemoryKeyStore.from_config(config, key_pairs)
-
-    return _mk_key_store
 
 
 def main_validator() -> None:
@@ -81,7 +68,7 @@ def main_validator() -> None:
     genesis_time = genesis_state.genesis_time
 
     config = Config(
-        key_store_constructor=_mk_key_store_from_key_pairs(key_pairs),
+        key_pairs=key_pairs,
         root_data_dir=root_dir,
         slots_per_epoch=slots_per_epoch,
         seconds_per_slot=seconds_per_slot,


### PR DESCRIPTION
### What was wrong?

A `KeyStore` was (awkwardly) a property of a `Config` as the `Config` kept a record of any `KeyPair`s the user supplied to the validator client.

NOTE: this is mostly a quick fix intended to patch up an API deficiency from an earlier PR :)

### How was it fixed?

By separating the `key_pairs` away from the `KeyStore` construction we gain the flexibility to make `KeyStore`s as required independently of the collection of key pairs.

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://i.redd.it/h2m8hgknzff31.jpg)
