### PR TITLE
Convert DBClient.connect() to be a context manager

### DIFF
--- a/scripts/benchmark/db_managers/bench_db_client.py
+++ b/scripts/benchmark/db_managers/bench_db_client.py
@@ -49,13 +49,13 @@ def run_client(ipc_path, client_id, num_operations):
         for i in range(num_operations)
     }
 
-    db_client = DBClient.connect(ipc_path)
+    with DBClient.connect(ipc_path) as db_client:
+        start = time.perf_counter()
+        for key, value in key_values.items():
+            db_client.set(key, value)
+            db_client.get(key)
+        end = time.perf_counter()
 
-    start = time.perf_counter()
-    for key, value in key_values.items():
-        db_client.set(key, value)
-        db_client.get(key)
-    end = time.perf_counter()
     duration = end - start
 
     logger.info(

--- a/tests/components/eth2/apis/test_http.py
+++ b/tests/components/eth2/apis/test_http.py
@@ -1,8 +1,4 @@
-import pathlib
-import tempfile
-
 from eth_utils import decode_hex
-import pytest
 
 from eth2.beacon.fork_choice.higher_slot import HigherSlotScoring
 from eth2.beacon.state_machines.forks.serenity.configs import SERENITY_CONFIG
@@ -11,69 +7,56 @@ from eth2.beacon.tools.misc.ssz_vector import override_lengths
 from eth2.beacon.types.blocks import BeaconBlock, SignedBeaconBlock
 from eth2.configs import Eth2GenesisConfig
 from trinity.db.beacon.chain import AsyncBeaconChainDB
-from trinity.db.manager import DBClient, DBManager
 from trinity.http.handlers.rpc_handler import RPCHandler
 from trinity.rpc.main import RPCServer
 from trinity.rpc.modules import initialize_beacon_modules
 
 
-@pytest.fixture
-def ipc_path():
-    with tempfile.TemporaryDirectory() as dir:
-        yield pathlib.Path(dir) / "db_manager.ipc"
+async def test_json_rpc_http_server(aiohttp_raw_server, aiohttp_client, event_bus, db):
+    # Set chaindb
+    override_lengths(SERENITY_CONFIG)
+    genesis_config = Eth2GenesisConfig(SERENITY_CONFIG)
+    chaindb = AsyncBeaconChainDB(db, genesis_config)
 
+    fork_choice_scoring = HigherSlotScoring()
+    genesis_state, genesis_block = create_mock_genesis(
+        pubkeys=(),
+        config=SERENITY_CONFIG,
+        keymap=dict(),
+        genesis_block_class=BeaconBlock,
+        genesis_time=0,
+    )
 
-async def test_json_rpc_http_server(
-    aiohttp_raw_server, aiohttp_client, event_bus, base_db, ipc_path
-):
-    manager = DBManager(base_db)
-    with manager.run(ipc_path):
-        # Set chaindb
-        override_lengths(SERENITY_CONFIG)
-        db = DBClient.connect(ipc_path)
-        genesis_config = Eth2GenesisConfig(SERENITY_CONFIG)
-        chaindb = AsyncBeaconChainDB(db, genesis_config)
-
-        fork_choice_scoring = HigherSlotScoring()
-        genesis_state, genesis_block = create_mock_genesis(
-            pubkeys=(),
-            config=SERENITY_CONFIG,
-            keymap=dict(),
-            genesis_block_class=BeaconBlock,
-            genesis_time=0,
+    chaindb.persist_state(genesis_state)
+    chaindb.persist_block(
+        SignedBeaconBlock.create(message=genesis_block),
+        SignedBeaconBlock,
+        fork_choice_scoring,
+    )
+    try:
+        rpc = RPCServer(
+            initialize_beacon_modules(chaindb, event_bus), chaindb, event_bus
         )
+        raw_server = await aiohttp_raw_server(RPCHandler.handle(rpc.execute))
+        client = await aiohttp_client(raw_server)
 
-        chaindb.persist_state(genesis_state)
-        chaindb.persist_block(
-            SignedBeaconBlock.create(message=genesis_block),
-            SignedBeaconBlock,
-            fork_choice_scoring,
-        )
-        try:
-            rpc = RPCServer(
-                initialize_beacon_modules(chaindb, event_bus), chaindb, event_bus
-            )
-            raw_server = await aiohttp_raw_server(RPCHandler.handle(rpc.execute))
-            client = await aiohttp_client(raw_server)
+        request_id = 1
+        request_data = {
+            "jsonrpc": "2.0",
+            "method": "beacon_head",
+            "params": [],
+            "id": request_id,
+        }
 
-            request_id = 1
-            request_data = {
-                "jsonrpc": "2.0",
-                "method": "beacon_head",
-                "params": [],
-                "id": request_id,
-            }
+        response = await client.post("/", json=request_data)
+        response_data = await response.json()
 
-            response = await client.post("/", json=request_data)
-            response_data = await response.json()
-
-            assert response_data["id"] == request_id
-            result = response_data["result"]
-            assert result["slot"] == 0
-            assert decode_hex(result["block_root"]) == genesis_block.hash_tree_root
-            assert decode_hex(result["state_root"]) == genesis_state.hash_tree_root
-        except KeyboardInterrupt:
-            pass
-        finally:
-            await raw_server.close()
-            db.close()
+        assert response_data["id"] == request_id
+        result = response_data["result"]
+        assert result["slot"] == 0
+        assert decode_hex(result["block_root"]) == genesis_block.hash_tree_root
+        assert decode_hex(result["state_root"]) == genesis_state.hash_tree_root
+    except KeyboardInterrupt:
+        pass
+    finally:
+        await raw_server.close()

--- a/tests/core/database/test_db_client.py
+++ b/tests/core/database/test_db_client.py
@@ -1,53 +1,5 @@
-from eth.db.atomic import AtomicDB
-
-import pathlib
-import pytest
-import tempfile
-
 from eth.tools.db.atomic import AtomicDatabaseBatchAPITestSuite
 from eth.tools.db.base import DatabaseAPITestSuite
-
-from trinity.db.manager import (
-    DBManager,
-    DBClient,
-)
-
-
-@pytest.fixture
-def ipc_path():
-    with tempfile.TemporaryDirectory() as dir:
-        ipc_path = pathlib.Path(dir) / "db_manager.ipc"
-        yield ipc_path
-
-
-@pytest.fixture
-def base_db():
-    return AtomicDB()
-
-
-@pytest.fixture
-def db_manager(base_db, ipc_path):
-    with DBManager(base_db).run(ipc_path) as manager:
-        yield manager
-
-
-@pytest.fixture
-def db_client(ipc_path, db_manager):
-    client = DBClient.connect(ipc_path)
-    try:
-        yield client
-    finally:
-        client.close()
-
-
-@pytest.fixture
-def db(db_client):
-    return db_client
-
-
-@pytest.fixture
-def atomic_db(db):
-    return db
 
 
 class TestDBClientDatabaseAPI(DatabaseAPITestSuite):

--- a/tests/core/database/test_db_manager.py
+++ b/tests/core/database/test_db_manager.py
@@ -1,28 +1,11 @@
-from eth.db.atomic import AtomicDB
-
-import pathlib
-import pytest
-import tempfile
 from trinity.db.manager import (
     DBManager,
     DBClient,
 )
 
 
-@pytest.fixture
-def ipc_path():
-    with tempfile.TemporaryDirectory() as dir:
-        ipc_path = pathlib.Path(dir) / "db_manager.ipc"
-        yield ipc_path
-
-
-@pytest.fixture
-def db():
-    return AtomicDB()
-
-
-def test_db_manager_lifecycle(db, ipc_path):
-    manager = DBManager(db)
+def test_db_manager_lifecycle(base_db, ipc_path):
+    manager = DBManager(base_db)
 
     assert not manager.is_running
     assert not manager.is_stopped
@@ -35,8 +18,8 @@ def test_db_manager_lifecycle(db, ipc_path):
     assert manager.is_stopped
 
 
-def test_db_manager_lifecycle_with_connections(db, ipc_path):
-    manager = DBManager(db)
+def test_db_manager_lifecycle_with_connections(base_db, ipc_path):
+    manager = DBManager(base_db)
 
     assert not manager.is_running
     assert not manager.is_stopped
@@ -45,14 +28,9 @@ def test_db_manager_lifecycle_with_connections(db, ipc_path):
         assert manager.is_running
         assert not manager.is_stopped
 
-        client_a = DBClient.connect(ipc_path)
-        client_b = DBClient.connect(ipc_path)
-
-        assert manager.is_running
-        assert not manager.is_stopped
-
-    client_a.close()
-    client_b.close()
+        with DBClient.connect(ipc_path), DBClient.connect(ipc_path):
+            assert manager.is_running
+            assert not manager.is_stopped
 
     assert not manager.is_running
     assert manager.is_stopped

--- a/trinity/components/builtin/attach/console.py
+++ b/trinity/components/builtin/attach/console.py
@@ -140,8 +140,7 @@ def db_shell(use_ipython: bool, config: Dict[str, str]) -> None:
 def _get_base_db(database_dir: Path, ipc_path: Path) -> Iterator[AtomicDatabaseAPI]:
     trinity_already_running = ipc_path.exists()
     if trinity_already_running:
-        db = DBClient.connect(ipc_path)
-        with db:
+        with DBClient.connect(ipc_path) as db:
             yield db
     else:
         yield LevelDB(database_dir)

--- a/trinity/components/builtin/beam_exec/component.py
+++ b/trinity/components/builtin/beam_exec/component.py
@@ -39,9 +39,7 @@ class BeamChainExecutionComponent(AsyncioIsolatedComponent):
         app_config = trinity_config.get_app_config(Eth1AppConfig)
         chain_config = app_config.get_chain_config()
 
-        base_db = DBClient.connect(trinity_config.database_ipc_path)
-
-        with base_db:
+        with DBClient.connect(trinity_config.database_ipc_path) as base_db:
             beam_chain = make_pausing_beam_chain(
                 chain_config.vm_configuration,
                 chain_config.chain_id,

--- a/trinity/components/builtin/beam_preview/component.py
+++ b/trinity/components/builtin/beam_preview/component.py
@@ -42,9 +42,7 @@ class BeamChainPreviewComponent(AsyncioIsolatedComponent):
         app_config = trinity_config.get_app_config(Eth1AppConfig)
         chain_config = app_config.get_chain_config()
 
-        base_db = DBClient.connect(trinity_config.database_ipc_path)
-
-        with base_db:
+        with DBClient.connect(trinity_config.database_ipc_path) as base_db:
             loop = asyncio.get_event_loop()
 
             beam_chain = make_pausing_beam_chain(

--- a/trinity/components/builtin/ethstats/ethstats_service.py
+++ b/trinity/components/builtin/ethstats/ethstats_service.py
@@ -159,9 +159,8 @@ class EthstatsService(Service):
         chain_config = app_config.get_chain_config()
 
         chain: ChainAPI
-        base_db = DBClient.connect(self.boot_info.trinity_config.database_ipc_path)
 
-        with base_db:
+        with DBClient.connect(self.boot_info.trinity_config.database_ipc_path) as base_db:
             if self.boot_info.args.sync_mode == SYNC_LIGHT:
                 header_db = AsyncHeaderDB(base_db)
                 chain = chain_config.light_chain_class(

--- a/trinity/components/builtin/json_rpc/component.py
+++ b/trinity/components/builtin/json_rpc/component.py
@@ -52,9 +52,7 @@ def chain_for_eth1_config(trinity_config: TrinityConfig,
                           event_bus: EndpointAPI) -> Iterator[AsyncChainAPI]:
     chain_config = eth1_app_config.get_chain_config()
 
-    db = DBClient.connect(trinity_config.database_ipc_path)
-
-    with db:
+    with DBClient.connect(trinity_config.database_ipc_path) as db:
         if eth1_app_config.database_mode is Eth1DbMode.LIGHT:
             header_db = HeaderDB(db)
             event_bus_light_peer_chain = EventBusLightPeerChain(event_bus)
@@ -72,8 +70,7 @@ def chain_for_beacon_config(trinity_config: TrinityConfig,
                             beacon_app_config: BeaconAppConfig,
                             ) -> Iterator[AsyncBeaconChainDB]:
     chain_config = beacon_app_config.get_chain_config()
-    db = DBClient.connect(trinity_config.database_ipc_path)
-    with db:
+    with DBClient.connect(trinity_config.database_ipc_path) as db:
         yield AsyncBeaconChainDB(db, chain_config.genesis_config)
 
 

--- a/trinity/components/builtin/request_server/component.py
+++ b/trinity/components/builtin/request_server/component.py
@@ -44,8 +44,7 @@ class RequestServerComponent(AsyncioIsolatedComponent):
     @classmethod
     async def do_run(cls, boot_info: BootInfo, event_bus: EndpointAPI) -> None:
         trinity_config = boot_info.trinity_config
-        base_db = DBClient.connect(trinity_config.database_ipc_path)
-        with base_db:
+        with DBClient.connect(trinity_config.database_ipc_path) as base_db:
             if trinity_config.has_app_config(Eth1AppConfig):
                 server = cls.make_eth1_request_server(
                     trinity_config.get_app_config(Eth1AppConfig),

--- a/trinity/components/builtin/syncer/component.py
+++ b/trinity/components/builtin/syncer/component.py
@@ -329,15 +329,17 @@ class SyncerComponent(AsyncioIsolatedComponent):
                           boot_info: BootInfo,
                           event_bus: EndpointAPI) -> None:
         await node.get_manager().wait_started()
-        await strategy.sync(
-            boot_info.args,
-            cls.logger,
-            node.get_chain(),
-            node.base_db,
-            node.get_peer_pool(),
-            event_bus,
-            node.master_cancel_token
-        )
+
+        with node.db_client_ctx() as base_db:
+            await strategy.sync(
+                boot_info.args,
+                cls.logger,
+                node.get_chain(base_db),
+                base_db,
+                node.get_peer_pool(base_db),
+                event_bus,
+                node.master_cancel_token
+            )
 
         if strategy.shutdown_node_on_halt:
             cls.logger.error("Sync ended unexpectedly. Shutting down trinity")

--- a/trinity/components/builtin/tx_pool/component.py
+++ b/trinity/components/builtin/tx_pool/component.py
@@ -74,8 +74,7 @@ class TxComponent(AsyncioIsolatedComponent):
     @classmethod
     async def do_run(cls, boot_info: BootInfo, event_bus: EndpointAPI) -> None:
         trinity_config = boot_info.trinity_config
-        db = DBClient.connect(trinity_config.database_ipc_path)
-        with db:
+        with DBClient.connect(trinity_config.database_ipc_path) as db:
             app_config = trinity_config.get_app_config(Eth1AppConfig)
             chain_config = app_config.get_chain_config()
 

--- a/trinity/components/eth2/beacon/component.py
+++ b/trinity/components/eth2/beacon/component.py
@@ -93,14 +93,12 @@ class BeaconNodeComponent(AsyncioIsolatedComponent):
         trinity_config = boot_info.trinity_config
         key_pair = cls._load_or_create_node_key(boot_info)
         beacon_app_config = trinity_config.get_app_config(BeaconAppConfig)
-        base_db = DBClient.connect(trinity_config.database_ipc_path)
+        with DBClient.connect(trinity_config.database_ipc_path) as base_db:
+            if boot_info.args.debug_libp2p:
+                logging.getLogger("libp2p").setLevel(logging.DEBUG)
+            else:
+                logging.getLogger("libp2p").setLevel(logging.INFO)
 
-        if boot_info.args.debug_libp2p:
-            logging.getLogger("libp2p").setLevel(logging.DEBUG)
-        else:
-            logging.getLogger("libp2p").setLevel(logging.INFO)
-
-        with base_db:
             chain_config = beacon_app_config.get_chain_config()
             chain = chain_config.beacon_chain_class(
                 base_db, chain_config.genesis_config

--- a/trinity/components/eth2/eth1_monitor/component.py
+++ b/trinity/components/eth2/eth1_monitor/component.py
@@ -83,8 +83,8 @@ class Eth1MonitorComponent(TrioIsolatedComponent):
                 privkeys,
                 withdrawal_credentials,
             ) = create_keypair_and_mock_withdraw_credentials(
-                config, key_set
-            )  # type: ignore
+                config, key_set  # type: ignore
+            )
 
             initial_deposits = (
                 create_mock_deposit_data(


### PR DESCRIPTION
### What was wrong?

Ref: #1397 

### How was it fixed?

The new API for `DBClient.connect` is as follows:

```py
with DBClient.connect(...) as db:
    ...
```

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://media.tenor.com/images/9f6be77b15a532ba8809da65a0d6dc39/tenor.gif)
