### PR TITLE
Reorder some long-running eth2 circle ci tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -403,18 +403,19 @@ workflows:
       - py37-wheel-cli
       - py36-long_run_integration
       - py37-rpc-state-sstore
+      - py36-eth2-core
+      - py37-eth2-core
+      - py37-libp2p
 
       - py36-docs
 
       - py37-eth1-core
       - py37-p2p
       - py37-p2p-trio
-      - py37-eth2-core
       - py37-eth2-utils
       - py37-eth2-fixtures
       - py37-eth2-integration
       - py37-eth2-components
-      - py37-libp2p
       - py37-eth1-components
       - py37-eth2-trio
 
@@ -433,7 +434,6 @@ workflows:
       - py36-eth1-core
       - py36-p2p
       - py36-p2p-trio
-      - py36-eth2-core
       - py36-eth2-utils
       - py36-eth2-fixtures
       - py36-eth2-integration


### PR DESCRIPTION
By starting the long-running tests earlier, optimize for overall
CI running time. Future PRs can investigate why these tests are long
running.

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://38.media.tumblr.com/eaa80db075cbd74ae533dbd65a464e80/tumblr_n8q0c57Z5A1spvsbso2_1280.jpg)
