### PR TITLE
Cleanly factor IO into `ContextManager` of validator `KeyStore`

### DIFF
--- a/eth2/validator_client/abc.py
+++ b/eth2/validator_client/abc.py
@@ -70,7 +70,7 @@ class KeyStoreAPI(ContextManager["KeyStoreAPI"]):
         ...
 
     @abstractmethod
-    def import_private_key(self, encoded_private_key: str, password: bytes) -> None:
+    def import_private_key(self, encoded_private_key: str) -> None:
         ...
 
     @abstractmethod

--- a/eth2/validator_client/cli_parser.py
+++ b/eth2/validator_client/cli_parser.py
@@ -1,5 +1,4 @@
 import argparse
-import getpass
 import logging
 import signal
 
@@ -43,11 +42,8 @@ async def _import_key(
     logger.info("importing private key...")
     try:
         key_store = KeyStore.from_config(config)
-        logger.warn(
-            "please enter a password to protect the key on-disk (can be empty):"
-        )
-        password = getpass.getpass().encode()
-        key_store.import_private_key(arguments.private_key, password)
+        with key_store.persistence():
+            key_store.import_private_key(arguments.private_key)
     except Exception:
         logger.exception("error importing key")
 

--- a/eth2/validator_client/client.py
+++ b/eth2/validator_client/client.py
@@ -7,16 +7,12 @@ import trio
 from trio.abc import ReceiveChannel, SendChannel
 
 from eth2.validator_client.abc import BeaconNodeAPI, KeyStoreAPI, SignatoryDatabaseAPI
-from eth2.validator_client.beacon_node import MockBeaconNode as BeaconNode
-from eth2.validator_client.clock import Clock
-from eth2.validator_client.config import Config
 from eth2.validator_client.duty import Duty
 from eth2.validator_client.duty_scheduler import (
     resolve_duty,
     schedule_and_dispatch_duties_at_tick,
 )
 from eth2.validator_client.duty_store import DutyStore
-from eth2.validator_client.key_store import KeyStore
 from eth2.validator_client.randao import mk_randao_provider
 from eth2.validator_client.signatory import sign_and_broadcast_operation_if_valid
 from eth2.validator_client.signatory_db import InMemorySignatoryDB
@@ -58,14 +54,6 @@ class Client(Service):
 
         self._duty_store = DutyStore()
         self._signature_db = InMemorySignatoryDB()
-
-    @classmethod
-    def from_config(cls, config: Config) -> "Client":
-        clock = Clock.from_config(config)
-        beacon_node = BeaconNode.from_config(config)
-        key_store = KeyStore.from_config(config)
-        with key_store.persistence():
-            return cls(key_store, clock, beacon_node)
 
     async def _run_client(self) -> None:
         # NOTE: all duties dispatched from the scheduler are expected to be
@@ -124,9 +112,8 @@ class Client(Service):
 
     async def run(self) -> None:
         self.logger.debug("booting client...")
-        async with self._beacon_node:
-            await self._verify_client_state_at_boot()
-            await self._run_client()
+        await self._verify_client_state_at_boot()
+        await self._run_client()
 
     async def duty_scheduler(
         self,

--- a/eth2/validator_client/config.py
+++ b/eth2/validator_client/config.py
@@ -29,7 +29,6 @@ class Config:
         slots_per_epoch: Slot = None,
         seconds_per_slot: int = None,
         genesis_time: int = None,
-        demo_mode: bool = False,
     ) -> None:
         self.key_pairs = key_pairs
         self._root_data_dir = root_data_dir
@@ -39,7 +38,6 @@ class Config:
         self.slots_per_epoch = slots_per_epoch
         self.seconds_per_slot = seconds_per_slot
         self.genesis_time = genesis_time
-        self.demo_mode = demo_mode
 
     @cached_property
     def seconds_per_epoch(self) -> int:

--- a/eth2/validator_client/key_store.py
+++ b/eth2/validator_client/key_store.py
@@ -3,7 +3,16 @@ import json
 import logging
 from pathlib import Path
 from types import TracebackType
-from typing import Any, Collection, Dict, Optional, Type
+from typing import (
+    Any,
+    Callable,
+    Collection,
+    ContextManager,
+    Dict,
+    Optional,
+    Tuple,
+    Type,
+)
 
 import eth_keyfile
 from eth_typing import BLSPubkey
@@ -14,19 +23,37 @@ from eth2._utils.humanize import humanize_bytes
 from eth2.validator_client.abc import KeyStoreAPI
 from eth2.validator_client.config import Config
 from eth2.validator_client.tools.directory import create_dir_if_missing
-from eth2.validator_client.typing import BLSPrivateKey, KeyPair
-
-EMPTY_PASSWORD = b""
+from eth2.validator_client.typing import BLSPrivateKey
 
 
-def _compute_key_pair_from_private_key_bytes(private_key_bytes: bytes) -> KeyPair:
-    private_key = int.from_bytes(private_key_bytes, byteorder="big")
+def _serialize_private_key(private_key: BLSPrivateKey) -> bytes:
+    return private_key.to_bytes(32, "little")
+
+
+def _deserialize_private_key(private_key: bytes) -> BLSPrivateKey:
+    return int.from_bytes(private_key, "little")
+
+
+def _compute_key_pair_from_private_key_bytes(
+    private_key_bytes: bytes
+) -> Tuple[BLSPubkey, BLSPrivateKey]:
+    private_key = _deserialize_private_key(private_key_bytes)
     return (bls.privtopub(private_key), private_key)
+
+
+def _terminal_password_provider(public_key: BLSPubkey) -> bytes:
+    return getpass.getpass(
+        f"Please enter password for keyfile with public key {encode_hex(public_key)}:"
+    ).encode()
+
+
+def _insecure_password_provider(public_key: BLSPubkey) -> bytes:
+    return public_key
 
 
 class KeyStore(KeyStoreAPI):
     """
-    A ``KeyStore`` instance is a read-only repository for the private and public keys
+    A ``KeyStore`` instance is a repository for the private and public keys
     corresponding to the validators under the control of a client of this class.
     """
 
@@ -34,28 +61,62 @@ class KeyStore(KeyStoreAPI):
 
     def __init__(
         self,
-        key_store_dir: Path,
         key_pairs: Dict[BLSPubkey, BLSPrivateKey],
-        demo_mode: bool,
+        key_store_dir: Optional[Path] = None,
+        demo_mode: bool = True,
+        password_provider: Callable[[BLSPubkey], bytes] = _insecure_password_provider,
     ) -> None:
-        self._location = key_store_dir
-        self._demo_mode = demo_mode
-        # TODO(ralexstokes) reconcile ``key_pairs`` provided to this class
-        # with those serialized on disk
         self._key_pairs = key_pairs
-        # NOTE: ``_key_files`` is a temporary cache
-        # so that there may be key pairs in ``_key_pairs``
-        # that do not have key files in ``_key_files``.
-        self._key_files: Dict[str, Dict[str, Any]] = {}
+        self._key_store_dir = key_store_dir
+        if demo_mode:
+            self._password_provider = _insecure_password_provider
+        else:
+            self._password_provider = password_provider
 
-        self._ensure_dirs()
+        self._key_files: Dict[str, Dict[str, Any]] = {}
+        # Mapping of public key to key file ID
+        self._key_file_index: Dict[BLSPubkey, str] = {}
 
     @classmethod
     def from_config(cls, config: Config) -> "KeyStore":
-        return cls(config.key_store_dir, config.key_pairs, config.demo_mode)
+        return cls(
+            config.key_pairs,
+            config.key_store_dir,
+            config.demo_mode,
+            _terminal_password_provider,
+        )
+
+    def _ensure_dirs(self) -> None:
+        did_create = create_dir_if_missing(self._key_store_dir)
+        if did_create:
+            self.logger.warning(
+                "the key store location provided (%s) was created because it was missing",
+                self._key_store_dir,
+            )
+
+    def persistence(self) -> ContextManager[KeyStoreAPI]:
+        """
+        Signal to this object to {de,}serialize key pairs to disk.
+
+        Example:
+        key_store = KeyStore.from_config(config)
+        with key_store.persistence():
+            # keys are loaded from disk
+            # keys are saved to disk upon exit
+            ...
+        # key_store used outside the context block
+        # are available in memory, but not persisted to disk.
+        """
+        self._ensure_dirs()
+        return self
 
     def __enter__(self) -> KeyStoreAPI:
-        self._load_validator_key_pairs()
+        self._load_key_pairs()
+        self.logger.info(
+            "found %d validator key pair(s) for public key(s) %s",
+            len(self.public_keys),
+            tuple(map(humanize_bytes, self.public_keys)),
+        )
         return self
 
     def __exit__(
@@ -64,92 +125,63 @@ class KeyStore(KeyStoreAPI):
         exc_value: Optional[BaseException],
         traceback: Optional[TracebackType],
     ) -> None:
-        for key_file_id, key_file_json in self._key_files.items():
-            with open(self._location / (key_file_id + ".json"), "w") as key_file_handle:
-                json.dump(key_file_json, key_file_handle)
+        self._store_key_pairs()
 
-    def _ensure_dirs(self) -> None:
-        did_create = create_dir_if_missing(self._location)
-        if did_create:
-            self.logger.warning(
-                "the key store location provided (%s) was created because it was missing",
-                self._location,
-            )
-
-    def _load_validator_key_pairs(self) -> None:
+    def _load_key_pairs(self) -> None:
         """
         Load all key pairs found in the key store directory.
         """
-        for key_file in self._location.iterdir():
-            public_key, private_key = self._load_key_file(key_file)
+        for key_file in self._key_store_dir.iterdir():
+            public_key, private_key, key_file_id = self._load_key_file(key_file)
+            if public_key in self._key_pairs:
+                if private_key != self._key_pairs[public_key]:
+                    self.logger.warn(
+                        "found a mismatch between key on disk"
+                        " and key provided during construction"
+                        " for public key %s",
+                        encode_hex(public_key),
+                    )
+                continue
             self._key_pairs[public_key] = private_key
+            self._key_file_index[public_key] = key_file_id
 
-        self.logger.info(
-            "loaded %d validator(s) from the key store", len(self._key_pairs)
-        )
-
-    def _load_key_file(self, key_file: Path) -> KeyPair:
+    def _load_key_file(self, key_file: Path) -> Tuple[BLSPubkey, BLSPrivateKey, str]:
         with open(key_file) as key_file_handle:
             keyfile_json = json.load(key_file_handle)
             public_key = decode_hex(keyfile_json["public_key"])
-            if not self._demo_mode:
-                self.logger.warn(
-                    "please enter password for protected keyfile with public key %s:",
-                    humanize_bytes(public_key),
-                )
-                password = getpass.getpass().encode()
-            else:
-                password = EMPTY_PASSWORD
+            password = self._password_provider(public_key)
             private_key = eth_keyfile.decode_keyfile_json(keyfile_json, password)
-            return _compute_key_pair_from_private_key_bytes(private_key)
+            return (public_key, private_key, keyfile_json["id"])
+
+    def _is_persisted(self, public_key: BLSPubkey) -> bool:
+        return public_key in self._key_file_index
+
+    def _store_key_pairs(self) -> None:
+        for public_key, private_key in self._key_pairs.items():
+            if self._is_persisted(public_key):
+                continue
+            password = self._password_provider(public_key)
+            private_key_bytes = _serialize_private_key(private_key)
+            key_file_json = eth_keyfile.create_keyfile_json(private_key_bytes, password)
+            key_file_json["public_key"] = encode_hex(public_key)
+            self._store_key_file(key_file_json)
+
+    def _store_key_file(self, key_file_json: Dict[str, Any]) -> None:
+        key_file_id = key_file_json["id"]
+        with open(
+            self._key_store_dir / (key_file_id + ".json"), "w"
+        ) as key_file_handle:
+            json.dump(key_file_json, key_file_handle)
 
     @property
     def public_keys(self) -> Collection[BLSPubkey]:
         return tuple(self._key_pairs.keys())
 
-    def import_private_key(self, encoded_private_key: str, password: bytes) -> None:
+    def import_private_key(self, encoded_private_key: str) -> None:
         """
         Parse the ``private_key`` provided as a hex-encoded ``str`` and then stores the
         private key and public key as a key pair in the key store on disk.
         """
-        private_key_bytes = decode_hex(encoded_private_key)
-        public_key, private_key = _compute_key_pair_from_private_key_bytes(
-            private_key_bytes
-        )
-        key_file_json = eth_keyfile.create_keyfile_json(private_key_bytes, password)
-        key_file_json["public_key"] = encode_hex(public_key)
-
-        self._key_pairs[public_key] = private_key
-        self._key_files[key_file_json["id"]] = key_file_json
-
-    def private_key_for(self, public_key: BLSPubkey) -> BLSPrivateKey:
-        return self._key_pairs[public_key]
-
-
-class InMemoryKeyStore(KeyStoreAPI):
-    def __init__(self, key_pairs: Dict[BLSPubkey, BLSPrivateKey]) -> None:
-        self._key_pairs = key_pairs
-
-    @classmethod
-    def from_config(cls, config: Config) -> "InMemoryKeyStore":
-        return cls(config.key_pairs)
-
-    def __enter__(self) -> KeyStoreAPI:
-        return self
-
-    def __exit__(
-        self,
-        exc_type: Optional[Type[BaseException]],
-        exc_value: Optional[BaseException],
-        traceback: Optional[TracebackType],
-    ) -> None:
-        pass
-
-    @property
-    def public_keys(self) -> Collection[BLSPubkey]:
-        return tuple(self._key_pairs.keys())
-
-    def import_private_key(self, encoded_private_key: str, password: bytes) -> None:
         private_key_bytes = decode_hex(encoded_private_key)
         public_key, private_key = _compute_key_pair_from_private_key_bytes(
             private_key_bytes

--- a/eth2/validator_client/key_store.py
+++ b/eth2/validator_client/key_store.py
@@ -22,6 +22,7 @@ from eth2._utils.humanize import humanize_bytes
 from eth2.validator_client.abc import KeyStoreAPI
 from eth2.validator_client.config import Config
 from eth2.validator_client.tools.directory import create_dir_if_missing
+from eth2.validator_client.tools.password_providers import insecure_password_provider
 from eth2.validator_client.typing import BLSPrivateKey
 
 
@@ -40,10 +41,6 @@ def _compute_key_pair_from_private_key_bytes(
     return (bls.privtopub(private_key), private_key)
 
 
-def _insecure_password_provider(public_key: BLSPubkey) -> bytes:
-    return public_key
-
-
 class KeyStore(KeyStoreAPI):
     """
     A ``KeyStore`` instance is a repository for the private and public keys
@@ -56,7 +53,7 @@ class KeyStore(KeyStoreAPI):
         self,
         key_pairs: Optional[Dict[BLSPubkey, BLSPrivateKey]] = None,
         key_store_dir: Optional[Path] = None,
-        password_provider: Callable[[BLSPubkey], bytes] = _insecure_password_provider,
+        password_provider: Callable[[BLSPubkey], bytes] = insecure_password_provider,
     ) -> None:
         self._key_pairs = key_pairs if key_pairs else {}
         self._key_store_dir = key_store_dir
@@ -69,7 +66,7 @@ class KeyStore(KeyStoreAPI):
 
     @classmethod
     def from_config(cls, config: Config) -> "KeyStore":
-        return cls(config.key_pairs, config.key_store_dir, _insecure_password_provider)
+        return cls(config.key_pairs, config.key_store_dir, insecure_password_provider)
 
     def _ensure_dirs(self) -> None:
         did_create = create_dir_if_missing(self._key_store_dir)

--- a/eth2/validator_client/tools/password_providers.py
+++ b/eth2/validator_client/tools/password_providers.py
@@ -1,0 +1,10 @@
+import getpass
+
+from eth_typing import BLSPubkey
+from eth_utils import encode_hex
+
+
+def terminal_password_provider(public_key: BLSPubkey) -> bytes:
+    return getpass.getpass(
+        f"Please enter password for keyfile with public key {encode_hex(public_key)}:"
+    ).encode()

--- a/eth2/validator_client/tools/password_providers.py
+++ b/eth2/validator_client/tools/password_providers.py
@@ -8,3 +8,7 @@ def terminal_password_provider(public_key: BLSPubkey) -> bytes:
     return getpass.getpass(
         f"Please enter password for keyfile with public key {encode_hex(public_key)}:"
     ).encode()
+
+
+def insecure_password_provider(public_key: BLSPubkey) -> bytes:
+    return public_key

--- a/eth2/validator_client/typing.py
+++ b/eth2/validator_client/typing.py
@@ -7,8 +7,6 @@ from eth2.validator_client.duty import Duty
 
 BLSPrivateKey = int
 
-KeyPair = Tuple[BLSPubkey, BLSPrivateKey]
-
 PrivateKeyProvider = Callable[[BLSPubkey], BLSPrivateKey]
 
 RandaoProvider = Callable[[BLSPubkey, Epoch], BLSSignature]

--- a/tests-trio/eth2/validator_client/conftest.py
+++ b/tests-trio/eth2/validator_client/conftest.py
@@ -14,7 +14,7 @@ def sample_bls_public_key(sample_bls_private_key):
 
 
 @pytest.fixture
-def sample_bls_key_pair(sample_bls_private_key, sample_bls_public_key):
+def sample_bls_key_pairs(sample_bls_private_key, sample_bls_public_key):
     return {sample_bls_public_key: sample_bls_private_key}
 
 

--- a/tests-trio/eth2/validator_client/test_client.py
+++ b/tests-trio/eth2/validator_client/test_client.py
@@ -8,7 +8,7 @@ from eth2.validator_client.beacon_node import MockBeaconNode
 from eth2.validator_client.client import Client
 from eth2.validator_client.clock import Clock
 from eth2.validator_client.duty import AttestationDuty, BlockProposalDuty, DutyType
-from eth2.validator_client.key_store import InMemoryKeyStore
+from eth2.validator_client.key_store import KeyStore
 from eth2.validator_client.randao import mk_randao_provider
 from eth2.validator_client.signatory import sign
 from eth2.validator_client.tick import Tick
@@ -49,7 +49,7 @@ def _mk_duty_fetcher(public_key, slots_per_epoch, seconds_per_slot):
 
 @pytest.mark.trio
 async def test_client_works(
-    autojump_clock, sample_bls_key_pair, seconds_per_slot, slots_per_epoch
+    autojump_clock, sample_bls_key_pairs, seconds_per_slot, slots_per_epoch
 ):
     """
     This test constructs a ``Client`` with enough known inputs to compute an expected set of
@@ -71,8 +71,8 @@ async def test_client_works(
         non_aligned_time + epochs_before_genesis_to_start * seconds_per_epoch
     )
 
-    public_key = tuple(sample_bls_key_pair.keys())[0]
-    key_store = InMemoryKeyStore(sample_bls_key_pair)
+    public_key = tuple(sample_bls_key_pairs.keys())[0]
+    key_store = KeyStore(sample_bls_key_pairs)
     beacon_node = MockBeaconNode(
         slots_per_epoch,
         seconds_per_slot,

--- a/tests-trio/eth2/validator_client/test_client.py
+++ b/tests-trio/eth2/validator_client/test_client.py
@@ -88,8 +88,6 @@ async def test_client_works(
     )
     client = Client(key_store, clock, beacon_node)
 
-    randao_provider = mk_randao_provider(key_store.private_key_for)
-
     try:
         async with background_trio_service(client):
             await trio.sleep(total_epochs_to_run * seconds_per_epoch)
@@ -106,6 +104,7 @@ async def test_client_works(
         )
     )
     assert len(beacon_node.published_signatures) == len(fulfilled_duties)
+    randao_provider = mk_randao_provider(key_store.private_key_for)
     for duty in fulfilled_duties:
         if duty.duty_type == DutyType.Attestation:
             operation = await beacon_node.fetch_attestation(

--- a/tests/eth2/core/validator_client/test_key_store.py
+++ b/tests/eth2/core/validator_client/test_key_store.py
@@ -19,7 +19,6 @@ def test_key_store_can_import_private_key(tmp_path, sample_bls_key_pairs):
 @pytest.mark.parametrize(("has_key_pairs"), [(True), (False)])
 def test_key_store_can_persist_key_files(tmp_path, sample_bls_key_pairs, has_key_pairs):
     some_password = b"password"
-    password_provider = lambda _public_key: some_password
     public_key, private_key = tuple(sample_bls_key_pairs.items())[0]
     private_key_bytes = private_key.to_bytes(32, "little")
     encoded_private_key = private_key_bytes.hex()
@@ -29,7 +28,9 @@ def test_key_store_can_persist_key_files(tmp_path, sample_bls_key_pairs, has_key
     else:
         key_pairs = {}
     key_store = KeyStore(
-        key_pairs=key_pairs, key_store_dir=tmp_path, password_provider=password_provider
+        key_pairs=key_pairs,
+        key_store_dir=tmp_path,
+        password_provider=lambda _public_key: some_password,
     )
 
     with key_store.persistence():
@@ -44,5 +45,5 @@ def test_key_store_can_persist_key_files(tmp_path, sample_bls_key_pairs, has_key
         key_file_json = json.load(key_file_handle)
         assert decode_hex(key_file_json["public_key"]) == public_key
         assert private_key_bytes == eth_keyfile.decode_keyfile_json(
-            key_file_json, password_provider(public_key)
+            key_file_json, some_password
         )

--- a/trinity/main_validator.py
+++ b/trinity/main_validator.py
@@ -73,7 +73,6 @@ def main_validator() -> None:
         slots_per_epoch=slots_per_epoch,
         seconds_per_slot=seconds_per_slot,
         genesis_time=genesis_time,
-        demo_mode=arguments.demo_mode,
     )
     # NOTE: we deviate from the multiprocess-driven Component-based
     # application machinery here until said machinery is more stable


### PR DESCRIPTION
### What was wrong?

There were two types of `KeyStore`, in-memory or one that persists keys to disk, and by factoring the IO into the `ContextManager` part of the `KeyStore`, the two classes could be merged.

This is cleaning up the `KeyStore` so there is a cleaner separation of handling keys and persisting keys to disk.

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://i.pinimg.com/originals/f5/7e/00/f57e00306f3183cc39fa919fec41418b.jpg)
