### PR TITLE
Partly implement eth/65

### DIFF
--- a/newsfragments/1627.feature.rst
+++ b/newsfragments/1627.feature.rst
@@ -1,0 +1,4 @@
+Add partial support for `eth/65`. Recognize the protocol with its new commands
+and support it across all internal infrastructure. The built-in "transaction pool"
+does not yet use the ``NewPooledTransactionHashes`` command yet and answers
+``GetPooledTransactions`` with empty responses.

--- a/newsfragments/1633.doc.rst
+++ b/newsfragments/1633.doc.rst
@@ -1,0 +1,1 @@
+Add API docs for various proxy events under ``trinity.protocol.*``

--- a/tests/core/json-rpc/test_ipc.py
+++ b/tests/core/json-rpc/test_ipc.py
@@ -678,7 +678,7 @@ async def test_admin_peers(
             def to_remote_address(session):
                 return f"{session.remote.address.ip}:{session.remote.address.tcp_port}"
 
-            assert json_bob['caps'] == ['eth/63', 'eth/64']
+            assert json_bob['caps'] == ['eth/63', 'eth/65']
             assert json_bob['enode'] == alice.connection.session.remote.uri()
             assert json_bob['id'] == str(alice.connection.session.id)
             assert json_bob['name'] == 'bob'
@@ -687,7 +687,7 @@ async def test_admin_peers(
             assert bob_network['localAddress'] == '0.0.0.0:30303'
             assert bob_network['remoteAddress'] == to_remote_address(alice.connection.session)
 
-            assert json_alice['caps'] == ['eth/63', 'eth/64']
+            assert json_alice['caps'] == ['eth/63', 'eth/65']
             assert json_alice['enode'] == bob.connection.session.remote.uri()
             assert json_alice['id'] == str(bob.connection.session.id)
             assert json_alice['name'] == 'alice'

--- a/tests/integration/test_trinity_cli.py
+++ b/tests/integration/test_trinity_cli.py
@@ -202,7 +202,7 @@ async def test_web3_commands_via_attached_console(command,
             attached_trinity.expect_exact("'listenAddr': '[::]")
             attached_trinity.expect_exact("'name': 'Trinity/")
             attached_trinity.expect_exact("'ports': AttributeDict({")
-            attached_trinity.expect_exact("'protocols': AttributeDict({'eth': AttributeDict({'version': 'eth/64'")  # noqa: E501
+            attached_trinity.expect_exact("'protocols': AttributeDict({'eth': AttributeDict({'version': 'eth/65'")  # noqa: E501
             attached_trinity.expect_exact("'difficulty': ")
             attached_trinity.expect_exact(f"'genesis': '{expected_genesis_hash}'")
             attached_trinity.expect_exact("'head': '0x")

--- a/trinity/protocol/common/events.py
+++ b/trinity/protocol/common/events.py
@@ -81,7 +81,9 @@ class PeerInfo(NamedTuple):
 
 @dataclass
 class GetConnectedPeersResponse(BaseEvent):
-
+    """
+    The response class to answer a :class:`trinity.protocol.common.events.GetConnectedPeersRequest`
+    """
     peers: Tuple[PeerInfo, ...]
 
     @staticmethod
@@ -97,7 +99,10 @@ class GetConnectedPeersResponse(BaseEvent):
 
 
 class GetConnectedPeersRequest(BaseRequestResponseEvent[GetConnectedPeersResponse]):
-
+    """
+    A request class that can be dispatched from any process to be answered from another process
+    with a :class:`trinity.protocol.common.events.GetConnectedPeersResponse`.
+   """
     @staticmethod
     def expected_response_type() -> Type[GetConnectedPeersResponse]:
         return GetConnectedPeersResponse
@@ -116,12 +121,18 @@ class PeerPoolMessageEvent(BaseEvent):
 
 @dataclass
 class ProtocolCapabilitiesResponse(BaseEvent):
-
+    """
+    The response class to answer a
+    :class:`trinity.protocol.common.events.GetProtocolCapabilitiesRequest`
+    """
     capabilities: Capabilities
 
 
 class GetProtocolCapabilitiesRequest(BaseRequestResponseEvent[ProtocolCapabilitiesResponse]):
-
+    """
+    A request class that can be dispatched from any process to be answered from another process
+    with a :class:`trinity.protocol.common.events.ProtocolCapabilitiesResponse`.
+   """
     @staticmethod
     def expected_response_type() -> Type[ProtocolCapabilitiesResponse]:
         return ProtocolCapabilitiesResponse

--- a/trinity/protocol/common/peer.py
+++ b/trinity/protocol/common/peer.py
@@ -9,7 +9,6 @@ from typing import (
     List,
     Tuple,
     Type,
-    Union,
 )
 
 from cached_property import cached_property
@@ -62,14 +61,13 @@ from p2p.tracking.connection import (
 from trinity.constants import TO_NETWORKING_BROADCAST_CONFIG
 from trinity.exceptions import BaseForkIDValidationError, ENRMissingForkID
 from trinity.protocol.common.abc import ChainInfoAPI, HeadInfoAPI
-from trinity.protocol.common.api import ChainInfo, HeadInfo, choose_eth_or_les_api
-from trinity.protocol.eth.api import ETHV63API, ETHAPI
+from trinity.protocol.common.api import ChainInfo, HeadInfo, choose_eth_or_les_api, AnyETHLESAPI
+
 from trinity.protocol.eth.forkid import (
     extract_fork_blocks,
     extract_forkid,
     validate_forkid,
 )
-from trinity.protocol.les.api import LESV1API, LESV2API
 
 from trinity.components.builtin.network_db.connection.tracker import ConnectionTrackerClient
 from trinity.components.builtin.network_db.eth1_peer_db.tracker import (
@@ -94,7 +92,7 @@ class BaseChainPeer(BasePeer):
     context: ChainContext
 
     @cached_property
-    def chain_api(self) -> Union[ETHAPI, ETHV63API, LESV1API, LESV2API]:
+    def chain_api(self) -> AnyETHLESAPI:
         return choose_eth_or_les_api(self.connection)
 
     @cached_property

--- a/trinity/protocol/eth/commands.py
+++ b/trinity/protocol/eth/commands.py
@@ -8,7 +8,7 @@ from eth_utils.curried import (
 from eth_utils.toolz import compose
 from rlp import sedes
 
-from eth.abc import BlockHeaderAPI, ReceiptAPI
+from eth.abc import BlockHeaderAPI, ReceiptAPI, SignedTransactionAPI
 from eth.rlp.headers import BlockHeader
 from eth.rlp.receipts import Receipt
 from eth.rlp.transactions import BaseTransactionFields
@@ -156,6 +156,27 @@ class NewBlock(BaseCommand[NewBlockPayload]):
                 0,
             )
         )
+    )
+
+
+class NewPooledTransactionHashes(BaseCommand[Tuple[Hash32, ...]]):
+    protocol_command_id = 8
+    serialization_codec: RLPCodec[Tuple[Hash32, ...]] = RLPCodec(
+        sedes=sedes.CountableList(hash_sedes),
+    )
+
+
+class GetPooledTransactions(BaseCommand[Tuple[Hash32, ...]]):
+    protocol_command_id = 9
+    serialization_codec: RLPCodec[Tuple[Hash32, ...]] = RLPCodec(
+        sedes=sedes.CountableList(hash_sedes),
+    )
+
+
+class PooledTransactions(BaseCommand[Tuple[SignedTransactionAPI, ...]]):
+    protocol_command_id = 10
+    serialization_codec: RLPCodec[Tuple[SignedTransactionAPI, ...]] = RLPCodec(
+        sedes=sedes.CountableList(SignedTransactionAPI),
     )
 
 

--- a/trinity/protocol/eth/events.py
+++ b/trinity/protocol/eth/events.py
@@ -98,10 +98,11 @@ class NewBlockEvent(PeerPoolMessageEvent):
 
 class NewBlockHashesEvent(PeerPoolMessageEvent):
     """
-    Event to carry a ``Transactions`` command from the peer pool to any process that
+    Event to carry a ``NewBlockHashes`` command from the peer pool to any process that
     subscribes the event through the event bus.
     """
     command: NewBlockHashes
+
 
 # Events flowing from Proxy to PeerPool
 
@@ -160,6 +161,9 @@ class SendTransactionsEvent(BaseEvent):
 
 @dataclass
 class GetBlockHeadersResponse(BaseEvent):
+    """
+    The response class to answer a ``GetBlockHeadersRequest``.
+    """
 
     headers: Sequence[BlockHeaderAPI]
     error: Exception = None
@@ -167,6 +171,16 @@ class GetBlockHeadersResponse(BaseEvent):
 
 @dataclass
 class GetBlockHeadersRequest(BaseRequestResponseEvent[GetBlockHeadersResponse]):
+    """
+    A request class to delegate a :class:`trinity.protocol.proxy.eth.events.GetBlockHeaders` command
+    from any process to another process that can perform the actual
+    :class:`trinity.protocol.proxy.eth.events.GetBlockHeaders` command, wrap the result and send it
+    back to the origin process via a
+    :class:`trinity.protocol.proxy.eth.events.GetBlockHeadersResponse`.
+
+    This is a low-level event class used by :class:`trinity.protocol.proxy.ProxyETHAPI` to allow
+    any Trinity process to interact with peers through the event bus.
+    """
 
     session: SessionAPI
     block_number_or_hash: BlockIdentifier
@@ -182,13 +196,25 @@ class GetBlockHeadersRequest(BaseRequestResponseEvent[GetBlockHeadersResponse]):
 
 @dataclass
 class GetBlockBodiesResponse(BaseEvent):
-
+    """
+    The response class to answer a :class:`trinity.protocol.proxy.eth.events.GetBlockBodiesRequest`
+    """
     bundles: BlockBodyBundles
     error: Exception = None
 
 
 @dataclass
 class GetBlockBodiesRequest(BaseRequestResponseEvent[GetBlockBodiesResponse]):
+    """
+    A request class to delegate a :class:`trinity.protocol.proxy.eth.events.GetBlockBodies` command
+    from any process to another process that can perform the actual
+    :class:`trinity.protocol.proxy.eth.events.GetBlockBodies` command, wrap the result and send it
+    back to the origin process via a
+    :class:`trinity.protocol.proxy.eth.events.GetBlockBodiesResponse`.
+
+    This is a low-level event class used by :class:`trinity.protocol.proxy.ProxyETHAPI` to allow
+    any Trinity process to interact with peers through the event bus.
+    """
 
     session: SessionAPI
     headers: Sequence[BlockHeaderAPI]
@@ -201,13 +227,24 @@ class GetBlockBodiesRequest(BaseRequestResponseEvent[GetBlockBodiesResponse]):
 
 @dataclass
 class GetNodeDataResponse(BaseEvent):
-
+    """
+    The response class to answer a :class:`trinity.protocol.proxy.eth.events.GetNodeDataRequest`.
+    """
     bundles: NodeDataBundles
     error: Exception = None
 
 
 @dataclass
 class GetNodeDataRequest(BaseRequestResponseEvent[GetNodeDataResponse]):
+    """
+    A request class to delegate a :class:`trinity.protocol.proxy.eth.events.GetNodeData` command
+    from any process to another process that can perform the actual
+    :class:`trinity.protocol.proxy.eth.events.GetNodeData` command, wrap the result and send it back
+    to the origin process via a :class:`trinity.protocol.proxy.eth.events.GetNodeDataResponse`.
+
+    This is a low-level event class used by :class:`trinity.protocol.proxy.ProxyETHAPI` to allow
+    any Trinity process to interact with peers through the event bus.
+    """
 
     session: SessionAPI
     node_hashes: Sequence[Hash32]
@@ -220,13 +257,24 @@ class GetNodeDataRequest(BaseRequestResponseEvent[GetNodeDataResponse]):
 
 @dataclass
 class GetReceiptsResponse(BaseEvent):
-
+    """
+    The response class to answer a :class:`trinity.protocol.proxy.eth.events.GetReceiptsRequest`.
+    """
     bundles: ReceiptsBundles
     error: Exception = None
 
 
 @dataclass
 class GetReceiptsRequest(BaseRequestResponseEvent[GetReceiptsResponse]):
+    """
+    A request class to delegate a :class:`trinity.protocol.proxy.eth.events.GetReceipts` command
+    from any process to another process that can perform the actual
+    :class:`trinity.protocol.proxy.eth.events.GetReceipts` command, wrap the result and send it back
+    to the origin process via a :class:`trinity.protocol.proxy.eth.events.GetNodeDataResponse`.
+
+    This is a low-level event class used by :class:`trinity.protocol.proxy.ProxyETHAPI` to allow
+    any Trinity process to interact with peers through the event bus.
+    """
 
     session: SessionAPI
     headers: Sequence[BlockHeaderAPI]

--- a/trinity/protocol/eth/normalizers.py
+++ b/trinity/protocol/eth/normalizers.py
@@ -6,7 +6,7 @@ from typing import (
 from eth_utils import (
     to_tuple,
 )
-from eth.abc import BlockHeaderAPI
+from eth.abc import BlockHeaderAPI, UnsignedTransactionAPI
 from eth.db.trie import make_trie_root_and_nodes
 from eth_hash.auto import keccak
 import rlp
@@ -25,6 +25,7 @@ from .commands import (
     BlockBodies,
     NodeData,
     Receipts,
+    PooledTransactions,
 )
 
 
@@ -66,3 +67,16 @@ class GetBlockBodiesNormalizer(BaseNormalizer[BlockBodies, BlockBodyBundles]):
             uncle_hashes = keccak(rlp.encode(body.uncles))
             transaction_root_and_nodes = make_trie_root_and_nodes(body.transactions)
             yield body, transaction_root_and_nodes, uncle_hashes
+
+
+BaseGetPooledTransactionsNormalizer = BaseNormalizer[
+    PooledTransactions,
+    Tuple[UnsignedTransactionAPI, ...]
+]
+
+
+class GetPooledTransactionsNormalizer(BaseGetPooledTransactionsNormalizer):
+    @staticmethod
+    def normalize_result(
+            cmd: PooledTransactions) -> Tuple[UnsignedTransactionAPI, ...]:
+        return cmd.payload

--- a/trinity/protocol/eth/proto.py
+++ b/trinity/protocol/eth/proto.py
@@ -4,9 +4,9 @@ from typing import (
     Type,
 )
 
-from p2p.protocol import BaseProtocol
+from eth_utils import get_extended_debug_logger
 
-from trinity._utils.logging import get_logger
+from p2p.protocol import BaseProtocol
 
 from .commands import (
     BlockBodies,
@@ -22,6 +22,9 @@ from .commands import (
     Transactions,
     StatusV63,
     Status,
+    NewPooledTransactionHashes,
+    GetPooledTransactions,
+    PooledTransactions,
 )
 
 if TYPE_CHECKING:
@@ -47,11 +50,11 @@ class ETHProtocolV63(BaseETHProtocol):
     )
     command_length = 17
 
-    logger = get_logger('trinity.protocol.eth.proto.ETHProtocolV63')
+    logger = get_extended_debug_logger('trinity.protocol.eth.proto.ETHProtocolV63')
     status_command_type = StatusV63
 
 
-class ETHProtocol(BaseETHProtocol):
+class ETHProtocolV64(BaseETHProtocol):
     version = 64
     commands = (
         Status,
@@ -65,5 +68,25 @@ class ETHProtocol(BaseETHProtocol):
     )
     command_length = 17
 
-    logger = get_logger('trinity.protocol.eth.proto.ETHProtocol')
+    logger = get_extended_debug_logger('trinity.protocol.eth.proto.ETHProtocolV64')
+    status_command_type = Status
+
+
+class ETHProtocol(BaseETHProtocol):
+    version = 65
+    commands = (
+        Status,
+        NewBlockHashes,
+        Transactions,
+        GetBlockHeaders, BlockHeaders,
+        GetBlockBodies, BlockBodies,
+        NewBlock,
+        NewPooledTransactionHashes, GetPooledTransactions, PooledTransactions,
+        GetNodeData, NodeData,
+        GetReceipts, Receipts,
+    )
+    command_length = 20
+
+    logger = get_extended_debug_logger('trinity.protocol.eth.proto.ETHProtocol')
+
     status_command_type = Status

--- a/trinity/protocol/eth/trackers.py
+++ b/trinity/protocol/eth/trackers.py
@@ -1,9 +1,9 @@
 from typing import (
     Optional,
     Tuple,
-)
+    Sequence)
 
-from eth.abc import BlockHeaderAPI
+from eth.abc import BlockHeaderAPI, SignedTransactionAPI
 
 from p2p.exchange import BasePerformanceTracker
 
@@ -19,6 +19,7 @@ from .commands import (
     GetBlockHeaders,
     GetNodeData,
     GetReceipts,
+    GetPooledTransactions,
 )
 
 
@@ -86,4 +87,22 @@ class GetNodeDataTracker(BasePerformanceTracker[GetNodeData, NodeDataBundles]):
         return len(result)
 
     def _get_result_item_count(self, result: NodeDataBundles) -> int:
+        return len(result)
+
+
+BaseGetPooledTransactionsTracker = BasePerformanceTracker[
+    GetPooledTransactions,
+    Tuple[SignedTransactionAPI, ...]
+]
+
+
+class GetPooledTransactionsTracker(BaseGetPooledTransactionsTracker):
+
+    def _get_request_size(self, request: GetPooledTransactions) -> Optional[int]:
+        return len(request.payload)
+
+    def _get_result_size(self, result: Sequence[SignedTransactionAPI]) -> int:
+        return len(result)
+
+    def _get_result_item_count(self, result: Sequence[SignedTransactionAPI]) -> int:
         return len(result)


### PR DESCRIPTION
### What was wrong?

Before we can add support for `eth/66` we need to add support for [`eth/65`](https://github.com/ethereum/EIPs/pull/2464/files). That said, `eth/65` is all about optimizing transaction propagation, given that we do not have a fully fledged transaction pool yet, this PR will only partly implement what `eth/65` specifies.

### How was it fixed?

1. Add support for `NewPooledTransactionHashes`, `GetPooledTransactions` and `PooledTransactions`.

2. Wire up all the infrastructure to support these commands across the event bus and the proxy peer. 

3. Make our "Transaction Pool" answer `GetPooledTransactions` with empty responses (valid response)

#### What does that mean exactly?

The PR lays the infrastructure to support `eth/65` and recognize the new command types. Further changes to fully support `eth/65` would only need to happen in the transaction pool directly. Put another way, a 3rd party transaction pool component could be written that fully supports `eth/65` without any further needed changes to the core of Trinity.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

[//]: # (See: https://trinity-client.readthedocs.io/en/latest/contributing.html#pull-requests)
- [x] Add entry to the [release notes](https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://i.pinimg.com/originals/f3/a0/40/f3a0401eb4764908d2f080d1496c6f5e.jpg)
