### PR TITLE
Move `Eth2Config` to a dataclass

### DIFF
--- a/eth2/configs.py
+++ b/eth2/configs.py
@@ -1,90 +1,103 @@
-from typing import Any, NamedTuple, Tuple, Union, cast
+from dataclasses import Field, dataclass, fields
+from typing import Collection, Dict, Iterable, Tuple, Union, cast
 
-from eth_utils import decode_hex, encode_hex
+from eth_utils import decode_hex, encode_hex, to_dict
 
 from eth2.beacon.typing import Epoch, Gwei, Second, Slot
 
-Eth2Config = NamedTuple(
-    "Eth2Config",
-    (
-        # Misc
-        ("MAX_COMMITTEES_PER_SLOT", int),
-        ("TARGET_COMMITTEE_SIZE", int),
-        ("MAX_VALIDATORS_PER_COMMITTEE", int),
-        ("MIN_PER_EPOCH_CHURN_LIMIT", int),
-        ("CHURN_LIMIT_QUOTIENT", int),
-        ("SHUFFLE_ROUND_COUNT", int),
-        # Genesis
-        ("MIN_GENESIS_ACTIVE_VALIDATOR_COUNT", int),
-        ("MIN_GENESIS_TIME", int),
-        # Gwei values,
-        ("MIN_DEPOSIT_AMOUNT", Gwei),
-        ("MAX_EFFECTIVE_BALANCE", Gwei),
-        ("EJECTION_BALANCE", Gwei),
-        ("EFFECTIVE_BALANCE_INCREMENT", Gwei),
-        # Initial values
-        ("GENESIS_SLOT", Slot),
-        ("GENESIS_EPOCH", Epoch),
-        ("BLS_WITHDRAWAL_PREFIX", int),
-        # Time parameters
-        ("SECONDS_PER_SLOT", Second),
-        ("MIN_ATTESTATION_INCLUSION_DELAY", int),
-        ("SLOTS_PER_EPOCH", int),
-        ("MIN_SEED_LOOKAHEAD", int),
-        ("MAX_SEED_LOOKAHEAD", int),
-        ("SLOTS_PER_ETH1_VOTING_PERIOD", int),
-        ("SLOTS_PER_HISTORICAL_ROOT", int),
-        ("MIN_VALIDATOR_WITHDRAWABILITY_DELAY", int),
-        ("PERSISTENT_COMMITTEE_PERIOD", int),
-        ("MIN_EPOCHS_TO_INACTIVITY_PENALTY", int),
-        # State list lengths
-        ("EPOCHS_PER_HISTORICAL_VECTOR", int),
-        ("EPOCHS_PER_SLASHINGS_VECTOR", int),
-        ("HISTORICAL_ROOTS_LIMIT", int),
-        ("VALIDATOR_REGISTRY_LIMIT", int),
-        # Rewards and penalties
-        ("BASE_REWARD_FACTOR", int),
-        ("WHISTLEBLOWER_REWARD_QUOTIENT", int),
-        ("PROPOSER_REWARD_QUOTIENT", int),
-        ("INACTIVITY_PENALTY_QUOTIENT", int),
-        ("MIN_SLASHING_PENALTY_QUOTIENT", int),
-        # Max operations per block
-        ("MAX_PROPOSER_SLASHINGS", int),
-        ("MAX_ATTESTER_SLASHINGS", int),
-        ("MAX_ATTESTATIONS", int),
-        ("MAX_DEPOSITS", int),
-        ("MAX_VOLUNTARY_EXITS", int),
-        # Fork choice
-        ("SAFE_SLOTS_TO_UPDATE_JUSTIFIED", int),
-        # Deposit contract
-        ("DEPOSIT_CONTRACT_ADDRESS", bytes),
-    ),
-)
+ConfigTypes = Union[Gwei, Slot, Epoch, Second, bytes, int]
+EncodedConfigTypes = Union[str, int]
 
 
-def _serialize(item: Any) -> Union[int, str]:
-    if isinstance(item, bytes):
-        return encode_hex(item)
-    else:
-        return int(item)
+@to_dict
+def _decoder(
+    # NOTE: mypy incorrectly thinks `Field` is a generic type
+    data: Dict[str, EncodedConfigTypes],
+    fields: Collection[Field],  # type: ignore
+) -> Iterable[Tuple[str, ConfigTypes]]:
+    # NOTE: this code is unwieldly but it satisfies `mypy`
+    for field in fields:
+        if field.type is Gwei:
+            yield field.name, Gwei(cast(int, data[field.name]))
+        elif field.type is Slot:
+            yield field.name, Slot(cast(int, data[field.name]))
+        elif field.type is Epoch:
+            yield field.name, Epoch(cast(int, data[field.name]))
+        elif field.type is Second:
+            yield field.name, Second(cast(int, data[field.name]))
+        elif field.type is bytes:
+            yield field.name, decode_hex(cast(str, data[field.name]))
+        else:
+            yield field.name, int(data[field.name])
 
 
-def serialize(config: Eth2Config) -> Tuple[Union[int, str], ...]:
-    return tuple(_serialize(item) for item in config)
+@dataclass
+class Eth2Config:
+    # Misc
+    MAX_COMMITTEES_PER_SLOT: int
+    TARGET_COMMITTEE_SIZE: int
+    MAX_VALIDATORS_PER_COMMITTEE: int
+    MIN_PER_EPOCH_CHURN_LIMIT: int
+    CHURN_LIMIT_QUOTIENT: int
+    SHUFFLE_ROUND_COUNT: int
+    # Genesis
+    MIN_GENESIS_ACTIVE_VALIDATOR_COUNT: int
+    MIN_GENESIS_TIME: int
+    # Gwei values,
+    MIN_DEPOSIT_AMOUNT: Gwei
+    MAX_EFFECTIVE_BALANCE: Gwei
+    EJECTION_BALANCE: Gwei
+    EFFECTIVE_BALANCE_INCREMENT: Gwei
+    # Initial values
+    GENESIS_SLOT: Slot
+    GENESIS_EPOCH: Epoch
+    BLS_WITHDRAWAL_PREFIX: int
+    # Time parameters
+    SECONDS_PER_SLOT: Second
+    MIN_ATTESTATION_INCLUSION_DELAY: int
+    SLOTS_PER_EPOCH: int
+    MIN_SEED_LOOKAHEAD: int
+    MAX_SEED_LOOKAHEAD: int
+    SLOTS_PER_ETH1_VOTING_PERIOD: int
+    SLOTS_PER_HISTORICAL_ROOT: int
+    MIN_VALIDATOR_WITHDRAWABILITY_DELAY: int
+    PERSISTENT_COMMITTEE_PERIOD: int
+    MIN_EPOCHS_TO_INACTIVITY_PENALTY: int
+    # State list lengths
+    EPOCHS_PER_HISTORICAL_VECTOR: int
+    EPOCHS_PER_SLASHINGS_VECTOR: int
+    HISTORICAL_ROOTS_LIMIT: int
+    VALIDATOR_REGISTRY_LIMIT: int
+    # Rewards and penalties
+    BASE_REWARD_FACTOR: int
+    WHISTLEBLOWER_REWARD_QUOTIENT: int
+    PROPOSER_REWARD_QUOTIENT: int
+    INACTIVITY_PENALTY_QUOTIENT: int
+    MIN_SLASHING_PENALTY_QUOTIENT: int
+    # Max operations per block
+    MAX_PROPOSER_SLASHINGS: int
+    MAX_ATTESTER_SLASHINGS: int
+    MAX_ATTESTATIONS: int
+    MAX_DEPOSITS: int
+    MAX_VOLUNTARY_EXITS: int
+    # Fork choice
+    SAFE_SLOTS_TO_UPDATE_JUSTIFIED: int
+    # Deposit contract
+    DEPOSIT_CONTRACT_ADDRESS: bytes
 
+    @to_dict
+    def to_formatted_dict(self) -> Iterable[Tuple[str, EncodedConfigTypes]]:
+        for field in fields(self):
+            if field.type is bytes:
+                encoded_value = encode_hex(getattr(self, field.name))
+            else:
+                encoded_value = getattr(self, field.name)
+            yield field.name, encoded_value
 
-def _deserialize(item: Union[int, str], typ: Any) -> Any:
-    if typ is bytes:
-        return decode_hex(cast(str, item))
-    else:
-        return typ(item)
-
-
-def deserialize(config: Tuple[Union[int, str], ...]) -> Eth2Config:
-    values: Tuple[Any, ...] = ()
-    for index, (_, typ) in enumerate(Eth2Config._field_types.items()):
-        values += (_deserialize(config[index], typ),)
-    return Eth2Config(*values)
+    @classmethod
+    def from_formatted_dict(cls, data: Dict[str, EncodedConfigTypes]) -> "Eth2Config":
+        # NOTE: mypy does not recognize the kwarg unpacking here...
+        return cls(**_decoder(data, fields(cls)))  # type: ignore
 
 
 class CommitteeConfig:

--- a/trinity/components/eth2/network_generator/component.py
+++ b/trinity/components/eth2/network_generator/component.py
@@ -19,7 +19,7 @@ from eth2.beacon.tools.builder.initializer import (
     mk_withdrawal_credentials_from,
 )
 from eth2.beacon.typing import Timestamp
-from eth2.configs import Eth2Config, serialize
+from eth2.configs import Eth2Config
 from trinity.config import BeaconChainConfig, TrinityConfig
 from trinity.extensibility import Application
 
@@ -98,7 +98,7 @@ class NetworkGeneratorComponent(Application):
             config=config,
         )
         output = {
-            "eth2_config": serialize(config),
+            "eth2_config": config.to_formatted_dict(),
             "genesis_validator_key_pairs": mk_genesis_key_map(
                 validator_key_pairs, genesis_state
             ),

--- a/trinity/config.py
+++ b/trinity/config.py
@@ -72,7 +72,6 @@ from eth2.beacon.typing import (
 from eth2.configs import (
     Eth2Config,
     Eth2GenesisConfig,
-    deserialize as deserialize_eth2_config
 )
 from p2p.kademlia import (
     Node as KademliaNode,
@@ -732,7 +731,7 @@ class BeaconChainConfig:
         """
         with open(_get_eth2_genesis_config_file_path()) as config_file:
             config = json.load(config_file)
-            genesis_eth2_config = deserialize_eth2_config(config["eth2_config"])
+            genesis_eth2_config = Eth2Config.from_formatted_dict(config["eth2_config"])
             # NOTE: have to ``override_lengths`` before we can parse the ``BeaconState``
             override_lengths(genesis_eth2_config)
 

--- a/trinity/main_validator.py
+++ b/trinity/main_validator.py
@@ -10,7 +10,7 @@ from eth2.beacon.tools.builder.initializer import load_genesis_key_map
 from eth2.beacon.tools.misc.ssz_vector import override_lengths
 from eth2.beacon.types.states import BeaconState
 from eth2.beacon.typing import Slot
-from eth2.configs import deserialize
+from eth2.configs import Eth2Config
 from eth2.validator_client.cli_parser import parse_cli_args
 from eth2.validator_client.config import Config
 from eth2.validator_client.tools.directory import create_dir_if_missing
@@ -58,7 +58,7 @@ def main_validator() -> None:
     genesis_config = _load_genesis_config_at(
         validator_client_app_config.genesis_config_path
     )
-    eth2_config = deserialize(genesis_config["eth2_config"])
+    eth2_config = Eth2Config.from_formatted_dict(genesis_config["eth2_config"])
     override_lengths(eth2_config)
     key_pairs = load_genesis_key_map(genesis_config["genesis_validator_key_pairs"])
     genesis_state = from_formatted_dict(genesis_config["genesis_state"], BeaconState)


### PR DESCRIPTION
The main `Eth2Config` was implemented as a `NamedTuple` which seemed to lack introspection capabilities as would be useful for {de,}serialization. Update the implementation to use a `dataclass` which admits type information and update the serialization machinery.


#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://breakbrunch.com/wp-content/uploads/2019/11/cute-bright-smile-112419.jpg)
