### PR TITLE
Remove `CommitteeConfig` and `Eth2GenesisConfig` types

### DIFF
--- a/eth2/beacon/chains/base.py
+++ b/eth2/beacon/chains/base.py
@@ -19,7 +19,7 @@ from eth2.beacon.types.blocks import BaseBeaconBlock, BaseSignedBeaconBlock
 from eth2.beacon.types.nonspec.epoch_info import EpochInfo
 from eth2.beacon.types.states import BeaconState
 from eth2.beacon.typing import Root, Slot, Timestamp
-from eth2.configs import Eth2Config, Eth2GenesisConfig
+from eth2.configs import Eth2Config
 
 if TYPE_CHECKING:
     from eth2.beacon.state_machines.base import BaseBeaconStateMachine  # noqa: F401
@@ -38,9 +38,7 @@ class BaseBeaconChain(Configurable, ABC):
     chain_id = None  # type: int
 
     @abstractmethod
-    def __init__(
-        self, base_db: AtomicDatabaseAPI, genesis_config: Eth2GenesisConfig
-    ) -> None:
+    def __init__(self, base_db: AtomicDatabaseAPI, genesis_config: Eth2Config) -> None:
         ...
 
     #
@@ -61,7 +59,7 @@ class BaseBeaconChain(Configurable, ABC):
         base_db: AtomicDatabaseAPI,
         genesis_state: BeaconState,
         genesis_block: BaseBeaconBlock,
-        genesis_config: Eth2GenesisConfig,
+        genesis_config: Eth2Config,
     ) -> "BaseBeaconChain":
         ...
 
@@ -187,9 +185,7 @@ class BeaconChain(BaseBeaconChain):
 
     chaindb_class = BeaconChainDB  # type: Type[BaseBeaconChainDB]
 
-    def __init__(
-        self, base_db: AtomicDatabaseAPI, genesis_config: Eth2GenesisConfig
-    ) -> None:
+    def __init__(self, base_db: AtomicDatabaseAPI, genesis_config: Eth2Config) -> None:
         if not self.sm_configuration:
             raise ValueError(
                 "The Chain class cannot be instantiated with an empty `sm_configuration`"
@@ -222,7 +218,7 @@ class BeaconChain(BaseBeaconChain):
         base_db: AtomicDatabaseAPI,
         genesis_state: BeaconState,
         genesis_block: BaseBeaconBlock,
-        genesis_config: Eth2GenesisConfig,
+        genesis_config: Eth2Config,
     ) -> "BaseBeaconChain":
         """
         Initialize the ``BeaconChain`` from a genesis state and block.

--- a/eth2/beacon/committee_helpers.py
+++ b/eth2/beacon/committee_helpers.py
@@ -17,7 +17,7 @@ from eth2.beacon.signature_domain import SignatureDomain
 from eth2.beacon.types.states import BeaconState
 from eth2.beacon.types.validators import Validator
 from eth2.beacon.typing import CommitteeIndex, Epoch, Gwei, Slot, ValidatorIndex
-from eth2.configs import CommitteeConfig
+from eth2.configs import Eth2Config
 
 logger = logging.getLogger("eth2.beacon.committee_helpers")
 
@@ -89,19 +89,17 @@ def compute_proposer_index(
         i += 1
 
 
-def get_beacon_proposer_index(
-    state: BeaconState, committee_config: CommitteeConfig
-) -> ValidatorIndex:
+def get_beacon_proposer_index(state: BeaconState, config: Eth2Config) -> ValidatorIndex:
     """
     Return the current beacon proposer index.
     """
-    current_epoch = state.current_epoch(committee_config.SLOTS_PER_EPOCH)
+    current_epoch = state.current_epoch(config.SLOTS_PER_EPOCH)
     domain_type = signature_domain_to_domain_type(
         SignatureDomain.DOMAIN_BEACON_PROPOSER
     )
 
     seed = hash_eth2(
-        get_seed(state, current_epoch, domain_type, committee_config)
+        get_seed(state, current_epoch, domain_type, config)
         + state.slot.to_bytes(8, "little")
     )
     indices = get_active_validator_indices(state.validators, current_epoch)
@@ -109,8 +107,8 @@ def get_beacon_proposer_index(
         state.validators,
         indices,
         seed,
-        committee_config.MAX_EFFECTIVE_BALANCE,
-        committee_config.SHUFFLE_ROUND_COUNT,
+        config.MAX_EFFECTIVE_BALANCE,
+        config.SHUFFLE_ROUND_COUNT,
     )
 
 
@@ -177,7 +175,7 @@ def _compute_committee(
 
 
 def get_beacon_committee(
-    state: BeaconState, slot: Slot, index: CommitteeIndex, config: CommitteeConfig
+    state: BeaconState, slot: Slot, index: CommitteeIndex, config: Eth2Config
 ) -> Tuple[ValidatorIndex, ...]:
     epoch = compute_epoch_at_slot(slot, config.SLOTS_PER_EPOCH)
     committees_per_slot = get_committee_count_at_slot(
@@ -204,7 +202,7 @@ def get_beacon_committee(
 
 
 def iterate_committees_at_epoch(
-    state: BeaconState, epoch: Epoch, config: CommitteeConfig
+    state: BeaconState, epoch: Epoch, config: Eth2Config
 ) -> Iterable[Tuple[Tuple[ValidatorIndex, ...], CommitteeIndex, Slot]]:
     """
     Iterate ``committee``, ``committee_index``, ``slot`` of the given ``epoch``.
@@ -224,7 +222,7 @@ def iterate_committees_at_epoch(
 
 
 def iterate_committees_at_slot(
-    state: BeaconState, slot: Slot, committees_per_slot: int, config: CommitteeConfig
+    state: BeaconState, slot: Slot, committees_per_slot: int, config: Eth2Config
 ) -> Iterable[Tuple[Tuple[ValidatorIndex, ...], CommitteeIndex, Slot]]:
     """
     Iterate ``committee``, ``committee_index``, ``slot`` of the given ``slot``.

--- a/eth2/beacon/db/chain.py
+++ b/eth2/beacon/db/chain.py
@@ -28,7 +28,7 @@ from eth2.beacon.types.blocks import BaseBeaconBlock, BaseSignedBeaconBlock
 from eth2.beacon.types.nonspec.epoch_info import EpochInfo
 from eth2.beacon.types.states import BeaconState  # noqa: F401
 from eth2.beacon.typing import Epoch, Root, Slot
-from eth2.configs import Eth2GenesisConfig
+from eth2.configs import Eth2Config
 
 # When performing a chain sync (either fast or regular modes), we'll very often need to look
 # up recent blocks to validate the chain, and decoding their SSZ representation is
@@ -47,9 +47,7 @@ class BaseBeaconChainDB(ABC):
     db: AtomicDatabaseAPI = None
 
     @abstractmethod
-    def __init__(
-        self, db: AtomicDatabaseAPI, genesis_config: Eth2GenesisConfig
-    ) -> None:
+    def __init__(self, db: AtomicDatabaseAPI, genesis_config: Eth2Config) -> None:
         ...
 
     #
@@ -189,9 +187,7 @@ class BaseBeaconChainDB(ABC):
 
 
 class BeaconChainDB(BaseBeaconChainDB):
-    def __init__(
-        self, db: AtomicDatabaseAPI, genesis_config: Eth2GenesisConfig
-    ) -> None:
+    def __init__(self, db: AtomicDatabaseAPI, genesis_config: Eth2Config) -> None:
         self.db = db
         self.genesis_config = genesis_config
 

--- a/eth2/beacon/epoch_processing_helpers.py
+++ b/eth2/beacon/epoch_processing_helpers.py
@@ -18,7 +18,7 @@ from eth2.beacon.types.attestations import Attestation, IndexedAttestation
 from eth2.beacon.types.pending_attestations import PendingAttestation
 from eth2.beacon.types.states import BeaconState
 from eth2.beacon.typing import Epoch, Gwei, ValidatorIndex
-from eth2.configs import CommitteeConfig, Eth2Config
+from eth2.configs import Eth2Config
 
 
 def increase_balance(
@@ -40,7 +40,7 @@ def get_attesting_indices(
     state: BeaconState,
     attestation_data: AttestationData,
     bitfield: Bitfield,
-    config: CommitteeConfig,
+    config: Eth2Config,
 ) -> Set[ValidatorIndex]:
     """
     Return the attesting indices corresponding to ``attestation_data`` and ``bitfield``.
@@ -52,7 +52,7 @@ def get_attesting_indices(
 
 
 def get_indexed_attestation(
-    state: BeaconState, attestation: Attestation, config: CommitteeConfig
+    state: BeaconState, attestation: Attestation, config: Eth2Config
 ) -> IndexedAttestation:
     attesting_indices = get_attesting_indices(
         state, attestation.data, attestation.aggregation_bits, config
@@ -132,9 +132,7 @@ def get_matching_head_attestations(
 
 
 def get_unslashed_attesting_indices(
-    state: BeaconState,
-    attestations: Sequence[PendingAttestation],
-    config: CommitteeConfig,
+    state: BeaconState, attestations: Sequence[PendingAttestation], config: Eth2Config
 ) -> Set[ValidatorIndex]:
     output: Set[ValidatorIndex] = set()
     for a in attestations:
@@ -148,8 +146,7 @@ def get_attesting_balance(
     state: BeaconState, attestations: Sequence[PendingAttestation], config: Eth2Config
 ) -> Gwei:
     return get_total_balance(
-        state,
-        get_unslashed_attesting_indices(state, attestations, CommitteeConfig(config)),
+        state, get_unslashed_attesting_indices(state, attestations, config)
     )
 
 

--- a/eth2/beacon/fork_choice/lmd_ghost.py
+++ b/eth2/beacon/fork_choice/lmd_ghost.py
@@ -22,7 +22,7 @@ from eth2.beacon.types.blocks import BaseBeaconBlock, BaseSignedBeaconBlock
 from eth2.beacon.types.checkpoints import Checkpoint
 from eth2.beacon.types.states import BeaconState
 from eth2.beacon.typing import Epoch, Gwei, Root, Slot, Timestamp, ValidatorIndex
-from eth2.configs import CommitteeConfig, Eth2Config
+from eth2.configs import Eth2Config
 
 LMD_GHOST_SCORE_DATA_LENGTH = 2
 
@@ -406,7 +406,7 @@ class Store:
 
         # TODO: has this validation already been performed?
         indexed_attestation = get_indexed_attestation(
-            target_state, attestation, CommitteeConfig(self._config)
+            target_state, attestation, self._config
         )
         validate_indexed_attestation(
             target_state,

--- a/eth2/beacon/helpers.py
+++ b/eth2/beacon/helpers.py
@@ -18,7 +18,7 @@ from eth2.beacon.typing import (
     Version,
     default_version,
 )
-from eth2.configs import CommitteeConfig
+from eth2.configs import Eth2Config
 
 if TYPE_CHECKING:
     from eth2.beacon.types.states import BeaconState  # noqa: F401
@@ -130,17 +130,14 @@ def _get_seed(
     domain_type: DomainType,
     randao_provider: RandaoProvider,
     epoch_provider: Callable[[Epoch], Hash32],
-    committee_config: CommitteeConfig,
+    config: Eth2Config,
 ) -> Hash32:
     randao_mix = randao_provider(
         state,
         Epoch(
-            epoch
-            + committee_config.EPOCHS_PER_HISTORICAL_VECTOR
-            - committee_config.MIN_SEED_LOOKAHEAD
-            - 1
+            epoch + config.EPOCHS_PER_HISTORICAL_VECTOR - config.MIN_SEED_LOOKAHEAD - 1
         ),
-        committee_config.EPOCHS_PER_HISTORICAL_VECTOR,
+        config.EPOCHS_PER_HISTORICAL_VECTOR,
     )
     epoch_as_bytes = epoch_provider(epoch)
 
@@ -148,17 +145,12 @@ def _get_seed(
 
 
 def get_seed(
-    state: "BeaconState",
-    epoch: Epoch,
-    domain_type: DomainType,
-    committee_config: CommitteeConfig,
+    state: "BeaconState", epoch: Epoch, domain_type: DomainType, config: Eth2Config
 ) -> Hash32:
     """
     Generate a seed for the given ``epoch``.
     """
-    return _get_seed(
-        state, epoch, domain_type, get_randao_mix, _epoch_for_seed, committee_config
-    )
+    return _get_seed(state, epoch, domain_type, get_randao_mix, _epoch_for_seed, config)
 
 
 def get_total_balance(

--- a/eth2/beacon/state_machines/forks/serenity/block_processing.py
+++ b/eth2/beacon/state_machines/forks/serenity/block_processing.py
@@ -8,7 +8,7 @@ from eth2.beacon.state_machines.forks.serenity.block_validation import (
 from eth2.beacon.types.block_headers import BeaconBlockHeader
 from eth2.beacon.types.blocks import BaseBeaconBlock
 from eth2.beacon.types.states import BeaconState
-from eth2.configs import CommitteeConfig, Eth2Config
+from eth2.configs import Eth2Config
 
 from .block_validation import (
     validate_block_parent_root,
@@ -23,9 +23,7 @@ def process_block_header(
 ) -> BeaconState:
     validate_block_slot(state, block)
     validate_block_parent_root(state, block)
-    validate_proposer_is_not_slashed(
-        state, block.hash_tree_root, CommitteeConfig(config)
-    )
+    validate_proposer_is_not_slashed(state, block.hash_tree_root, config)
 
     return state.set(
         "latest_block_header",
@@ -42,9 +40,7 @@ def process_block_header(
 def process_randao(
     state: BeaconState, block: BaseBeaconBlock, config: Eth2Config
 ) -> BeaconState:
-    proposer_index = get_beacon_proposer_index(
-        state=state, committee_config=CommitteeConfig(config)
-    )
+    proposer_index = get_beacon_proposer_index(state=state, config=config)
 
     epoch = state.current_epoch(config.SLOTS_PER_EPOCH)
 

--- a/eth2/beacon/state_machines/forks/serenity/block_validation.py
+++ b/eth2/beacon/state_machines/forks/serenity/block_validation.py
@@ -1,4 +1,4 @@
-from typing import Iterable, Sequence, Tuple, cast  # noqa: F401
+from typing import cast  # noqa: F401
 
 from eth_typing import BLSPubkey, BLSSignature, Hash32
 from eth_utils import ValidationError, encode_hex
@@ -30,7 +30,7 @@ from eth2.beacon.types.states import BeaconState
 from eth2.beacon.types.validators import Validator
 from eth2.beacon.types.voluntary_exits import SignedVoluntaryExit
 from eth2.beacon.typing import CommitteeIndex, Epoch, Root, Slot
-from eth2.configs import CommitteeConfig, Eth2Config
+from eth2.configs import Eth2Config
 
 
 def validate_correct_number_of_deposits(
@@ -72,7 +72,7 @@ def validate_block_parent_root(state: BeaconState, block: BaseBeaconBlock) -> No
 
 
 def validate_proposer_is_not_slashed(
-    state: BeaconState, block_root: Root, config: CommitteeConfig
+    state: BeaconState, block_root: Root, config: Eth2Config
 ) -> None:
     proposer_index = get_beacon_proposer_index(state, config)
     proposer = state.validators[proposer_index]
@@ -81,17 +81,15 @@ def validate_proposer_is_not_slashed(
 
 
 def validate_proposer_signature(
-    state: BeaconState,
-    signed_block: BaseSignedBeaconBlock,
-    committee_config: CommitteeConfig,
+    state: BeaconState, signed_block: BaseSignedBeaconBlock, config: Eth2Config
 ) -> None:
     message_hash = signed_block.message.hash_tree_root
 
     # Get the public key of proposer
-    beacon_proposer_index = get_beacon_proposer_index(state, committee_config)
+    beacon_proposer_index = get_beacon_proposer_index(state, config)
     proposer_pubkey = state.validators[beacon_proposer_index].pubkey
     domain = get_domain(
-        state, SignatureDomain.DOMAIN_BEACON_PROPOSER, committee_config.SLOTS_PER_EPOCH
+        state, SignatureDomain.DOMAIN_BEACON_PROPOSER, config.SLOTS_PER_EPOCH
     )
 
     try:
@@ -386,7 +384,7 @@ def _validate_attestation_data(
 
 
 def _validate_aggregation_bits(
-    state: BeaconState, attestation: Attestation, config: CommitteeConfig
+    state: BeaconState, attestation: Attestation, config: Eth2Config
 ) -> None:
     data = attestation.data
     committee = get_beacon_committee(state, data.slot, data.index, config)
@@ -406,10 +404,10 @@ def validate_attestation(
     Raise ``ValidationError`` if it's invalid.
     """
     _validate_attestation_data(state, attestation.data, config)
-    _validate_aggregation_bits(state, attestation, CommitteeConfig(config))
+    _validate_aggregation_bits(state, attestation, config)
     validate_indexed_attestation(
         state,
-        get_indexed_attestation(state, attestation, CommitteeConfig(config)),
+        get_indexed_attestation(state, attestation, config),
         config.MAX_VALIDATORS_PER_COMMITTEE,
         config.SLOTS_PER_EPOCH,
     )

--- a/eth2/beacon/state_machines/forks/serenity/operation_processing.py
+++ b/eth2/beacon/state_machines/forks/serenity/operation_processing.py
@@ -9,7 +9,7 @@ from eth2.beacon.validator_status_helpers import (
     initiate_validator_exit,
     slash_validator,
 )
-from eth2.configs import CommitteeConfig, Eth2Config
+from eth2.configs import Eth2Config
 
 from .block_validation import (
     validate_attestation,
@@ -93,7 +93,7 @@ def process_attestations(
 
     for attestation in block.body.attestations:
         validate_attestation(state, attestation, config)
-        proposer_index = get_beacon_proposer_index(state, CommitteeConfig(config))
+        proposer_index = get_beacon_proposer_index(state, config)
         pending_attestation = PendingAttestation.create(
             aggregation_bits=attestation.aggregation_bits,
             data=attestation.data,

--- a/eth2/beacon/state_machines/forks/serenity/state_transitions.py
+++ b/eth2/beacon/state_machines/forks/serenity/state_transitions.py
@@ -2,7 +2,7 @@ from eth2.beacon.state_machines.state_transitions import BaseStateTransition
 from eth2.beacon.types.blocks import BaseSignedBeaconBlock
 from eth2.beacon.types.states import BeaconState
 from eth2.beacon.typing import Slot
-from eth2.configs import CommitteeConfig, Eth2Config
+from eth2.configs import Eth2Config
 
 from .block_processing import process_block
 from .block_validation import validate_proposer_signature
@@ -32,9 +32,7 @@ class SerenityStateTransition(BaseStateTransition):
 
         if signed_block:
             if check_proposer_signature:
-                validate_proposer_signature(
-                    state, signed_block, committee_config=CommitteeConfig(self.config)
-                )
+                validate_proposer_signature(state, signed_block, self.config)
             state = process_block(state, signed_block.message, self.config)
 
         return state

--- a/eth2/beacon/tools/builder/aggregator.py
+++ b/eth2/beacon/tools/builder/aggregator.py
@@ -20,14 +20,14 @@ from eth2.beacon.types.aggregate_and_proof import AggregateAndProof
 from eth2.beacon.types.attestations import Attestation
 from eth2.beacon.types.states import BeaconState
 from eth2.beacon.typing import Bitfield, CommitteeIndex, Slot
-from eth2.configs import CommitteeConfig
+from eth2.configs import Eth2Config
 
 # TODO: TARGET_AGGREGATORS_PER_COMMITTEE is not in Eth2Config now.
 TARGET_AGGREGATORS_PER_COMMITTEE = 16
 
 
 def get_slot_signature(
-    state: BeaconState, slot: Slot, privkey: int, config: CommitteeConfig
+    state: BeaconState, slot: Slot, privkey: int, config: Eth2Config
 ) -> BLSSignature:
     """
     Sign on ``slot`` and return the signature.
@@ -46,7 +46,7 @@ def is_aggregator(
     slot: Slot,
     index: CommitteeIndex,
     signature: BLSSignature,
-    config: CommitteeConfig,
+    config: Eth2Config,
 ) -> bool:
     """
     Check if the validator is one of the aggregators of the given ``slot``.
@@ -102,7 +102,7 @@ def validate_aggregate_and_proof(
     state: BeaconState,
     aggregate_and_proof: AggregateAndProof,
     attestation_propagation_slot_range: int,
-    config: CommitteeConfig,
+    config: Eth2Config,
 ) -> None:
     """
     Validate aggregate_and_proof
@@ -159,7 +159,7 @@ def validate_attestation_propagation_slot_range(
 
 
 def validate_aggregator_proof(
-    state: BeaconState, aggregate_and_proof: AggregateAndProof, config: CommitteeConfig
+    state: BeaconState, aggregate_and_proof: AggregateAndProof, config: Eth2Config
 ) -> None:
     slot = aggregate_and_proof.aggregate.data.slot
     pubkey = state.validators[aggregate_and_proof.aggregator_index].pubkey
@@ -180,7 +180,7 @@ def validate_aggregator_proof(
 
 
 def validate_attestation_signature(
-    state: BeaconState, attestation: Attestation, config: CommitteeConfig
+    state: BeaconState, attestation: Attestation, config: Eth2Config
 ) -> None:
     indexed_attestation = get_indexed_attestation(state, attestation, config)
     validate_indexed_attestation_aggregate_signature(

--- a/eth2/beacon/tools/builder/committee_assignment.py
+++ b/eth2/beacon/tools/builder/committee_assignment.py
@@ -6,7 +6,7 @@ from eth2.beacon.committee_helpers import iterate_committees_at_epoch
 from eth2.beacon.exceptions import NoCommitteeAssignment
 from eth2.beacon.types.states import BeaconState
 from eth2.beacon.typing import CommitteeIndex, Epoch, Slot, ValidatorIndex
-from eth2.configs import CommitteeConfig, Eth2Config
+from eth2.configs import Eth2Config
 
 CommitteeAssignment = NamedTuple(
     "CommitteeAssignment",
@@ -38,7 +38,7 @@ def get_committee_assignment(
         )
 
     for committee, committee_index, slot in iterate_committees_at_epoch(
-        state, epoch, CommitteeConfig(config)
+        state, epoch, config
     ):
         if validator_index in committee:
             return CommitteeAssignment(

--- a/eth2/beacon/tools/builder/proposer.py
+++ b/eth2/beacon/tools/builder/proposer.py
@@ -22,7 +22,7 @@ from eth2.beacon.types.deposits import Deposit
 from eth2.beacon.types.eth1_data import Eth1Data
 from eth2.beacon.types.states import BeaconState
 from eth2.beacon.typing import FromBlockParams, Slot, ValidatorIndex
-from eth2.configs import CommitteeConfig, Eth2Config
+from eth2.configs import Eth2Config
 
 
 def is_proposer(
@@ -31,7 +31,7 @@ def is_proposer(
     """
     Return if the validator is proposer of `state.slot`.
     """
-    return get_beacon_proposer_index(state, CommitteeConfig(config)) == validator_index
+    return get_beacon_proposer_index(state, config) == validator_index
 
 
 def _generate_randao_reveal(
@@ -60,9 +60,7 @@ def _generate_randao_reveal(
 def validate_proposer_index(
     state: BeaconState, config: Eth2Config, slot: Slot, validator_index: ValidatorIndex
 ) -> None:
-    beacon_proposer_index = get_beacon_proposer_index(
-        state.copy(slot=slot), CommitteeConfig(config)
-    )
+    beacon_proposer_index = get_beacon_proposer_index(state.copy(slot=slot), config)
 
     if validator_index != beacon_proposer_index:
         raise ProposerIndexError
@@ -185,7 +183,7 @@ def create_mock_block(
     Note that it doesn't return the correct ``state_root``.
     """
     future_state = advance_to_slot(state_machine, state, slot)
-    proposer_index = get_beacon_proposer_index(future_state, CommitteeConfig(config))
+    proposer_index = get_beacon_proposer_index(future_state, config)
     proposer_pubkey = state.validators[proposer_index].pubkey
     proposer_privkey = keymap[proposer_pubkey]
 

--- a/eth2/beacon/tools/builder/validator.py
+++ b/eth2/beacon/tools/builder/validator.py
@@ -52,7 +52,7 @@ from eth2.beacon.typing import (
     default_epoch,
     default_slot,
 )
-from eth2.configs import CommitteeConfig, Eth2Config
+from eth2.configs import Eth2Config
 
 
 #
@@ -117,7 +117,7 @@ def _mk_some_pending_attestations_with_some_participation_in_epoch(
         state, epoch, config.SLOTS_PER_EPOCH, config.SLOTS_PER_HISTORICAL_ROOT
     )
     for committee, committee_index, slot in iterate_committees_at_epoch(
-        state, epoch, CommitteeConfig(config)
+        state, epoch, config
     ):
         if not committee:
             continue
@@ -670,7 +670,7 @@ def create_mock_signed_attestations_at_slot(
     target_epoch = compute_epoch_at_slot(state.slot, config.SLOTS_PER_EPOCH)
 
     for committee, committee_index, _ in iterate_committees_at_slot(
-        state, attestation_slot, committees_per_slot, CommitteeConfig(config)
+        state, attestation_slot, committees_per_slot, config
     ):
         attestation_data = AttestationData.create(
             slot=attestation_slot,

--- a/eth2/beacon/tools/factories.py
+++ b/eth2/beacon/tools/factories.py
@@ -21,7 +21,6 @@ from eth2.beacon.tools.misc.ssz_vector import override_lengths
 from eth2.beacon.types.blocks import BaseSignedBeaconBlock
 from eth2.beacon.types.states import BeaconState
 from eth2.beacon.typing import Timestamp
-from eth2.configs import Eth2GenesisConfig
 
 
 class BeaconChainFactory(factory.Factory):
@@ -73,9 +72,7 @@ class BeaconChainFactory(factory.Factory):
             genesis_block = kwargs["genesis_block"]
 
         db = kwargs.pop("db", AtomicDB())
-        genesis_config = Eth2GenesisConfig(
-            model_class.get_genesis_state_machine_class().config
-        )
+        genesis_config = model_class.get_genesis_state_machine_class().config
         chain = model_class.from_genesis(
             base_db=db,
             genesis_state=genesis_state,

--- a/eth2/beacon/validator_status_helpers.py
+++ b/eth2/beacon/validator_status_helpers.py
@@ -13,7 +13,7 @@ from eth2.beacon.epoch_processing_helpers import (
 from eth2.beacon.types.states import BeaconState
 from eth2.beacon.types.validators import Validator
 from eth2.beacon.typing import Epoch, Gwei, ValidatorIndex
-from eth2.configs import CommitteeConfig, Eth2Config
+from eth2.configs import Eth2Config
 
 
 def activate_validator(validator: Validator, activation_epoch: Epoch) -> Validator:
@@ -135,7 +135,7 @@ def slash_validator(
         state, index, slashed_balance // config.MIN_SLASHING_PENALTY_QUOTIENT
     )
 
-    proposer_index = get_beacon_proposer_index(state, CommitteeConfig(config))
+    proposer_index = get_beacon_proposer_index(state, config)
     if whistleblower_index is None:
         whistleblower_index = proposer_index
     whistleblower_reward = Gwei(slashed_balance // config.WHISTLEBLOWER_REWARD_QUOTIENT)

--- a/eth2/configs.py
+++ b/eth2/configs.py
@@ -98,38 +98,3 @@ class Eth2Config:
     def from_formatted_dict(cls, data: Dict[str, EncodedConfigTypes]) -> "Eth2Config":
         # NOTE: mypy does not recognize the kwarg unpacking here...
         return cls(**_decoder(data, fields(cls)))  # type: ignore
-
-
-class CommitteeConfig:
-    def __init__(self, config: Eth2Config):
-        # Basic
-        self.GENESIS_SLOT = config.GENESIS_SLOT
-        self.GENESIS_EPOCH = config.GENESIS_EPOCH
-        self.MAX_COMMITTEES_PER_SLOT = config.MAX_COMMITTEES_PER_SLOT
-        self.SLOTS_PER_EPOCH = config.SLOTS_PER_EPOCH
-        self.TARGET_COMMITTEE_SIZE = config.TARGET_COMMITTEE_SIZE
-        self.SHUFFLE_ROUND_COUNT = config.SHUFFLE_ROUND_COUNT
-
-        # For seed
-        self.MIN_SEED_LOOKAHEAD = config.MIN_SEED_LOOKAHEAD
-        self.MAX_SEED_LOOKAHEAD = config.MAX_SEED_LOOKAHEAD
-        self.EPOCHS_PER_HISTORICAL_VECTOR = config.EPOCHS_PER_HISTORICAL_VECTOR
-        self.EPOCHS_PER_HISTORICAL_VECTOR = config.EPOCHS_PER_HISTORICAL_VECTOR
-
-        self.MAX_EFFECTIVE_BALANCE = config.MAX_EFFECTIVE_BALANCE
-        self.EFFECTIVE_BALANCE_INCREMENT = config.EFFECTIVE_BALANCE_INCREMENT
-
-
-class Eth2GenesisConfig:
-    """
-    Genesis parameters that might lives in
-    a state or a state machine config
-    but is assumed unlikely to change between forks.
-    Pass this to the chains, chain_db, or other objects that need them.
-    """
-
-    def __init__(self, config: Eth2Config) -> None:
-        self.GENESIS_SLOT = config.GENESIS_SLOT
-        self.GENESIS_EPOCH = config.GENESIS_EPOCH
-        self.SECONDS_PER_SLOT = config.SECONDS_PER_SLOT
-        self.SLOTS_PER_EPOCH = config.SLOTS_PER_EPOCH

--- a/tests/components/eth2/apis/test_http.py
+++ b/tests/components/eth2/apis/test_http.py
@@ -9,7 +9,6 @@ from eth2.beacon.state_machines.forks.serenity.configs import SERENITY_CONFIG
 from eth2.beacon.tools.builder.initializer import create_mock_genesis
 from eth2.beacon.tools.misc.ssz_vector import override_lengths
 from eth2.beacon.types.blocks import BeaconBlock, SignedBeaconBlock
-from eth2.configs import Eth2GenesisConfig
 from trinity.db.beacon.chain import AsyncBeaconChainDB
 from trinity.db.manager import DBClient, DBManager
 from trinity.http.handlers.rpc_handler import RPCHandler
@@ -31,7 +30,7 @@ async def test_json_rpc_http_server(
         # Set chaindb
         override_lengths(SERENITY_CONFIG)
         db = DBClient.connect(ipc_path)
-        genesis_config = Eth2GenesisConfig(SERENITY_CONFIG)
+        genesis_config = SERENITY_CONFIG
         chaindb = AsyncBeaconChainDB(db, genesis_config)
 
         fork_choice_scoring = HigherSlotScoring()

--- a/tests/components/eth2/beacon/test_validator.py
+++ b/tests/components/eth2/beacon/test_validator.py
@@ -21,7 +21,6 @@ from eth2.beacon.tools.builder.validator import (
 )
 from eth2.beacon.tools.factories import BeaconChainFactory
 from eth2.beacon.tools.misc.ssz_vector import override_lengths
-from eth2.configs import CommitteeConfig
 from trinity.components.eth2.beacon.slot_ticker import SlotTickEvent
 from trinity.components.eth2.beacon.validator import Validator
 from trinity.components.eth2.misc.tick_type import TickType
@@ -446,7 +445,7 @@ async def test_validator_include_ready_attestations(event_loop, event_bus, monke
         attesting_slot + MINIMAL_SERENITY_CONFIG.MIN_ATTESTATION_INCLUSION_DELAY
     )
     proposer_index = get_beacon_proposer_index(
-        state.set("slot", proposing_slot), CommitteeConfig(state_machine.config)
+        state.set("slot", proposing_slot), state_machine.config
     )
 
     head = alice.chain.get_canonical_head()

--- a/tests/eth2/core/beacon/conftest.py
+++ b/tests/eth2/core/beacon/conftest.py
@@ -39,7 +39,7 @@ from eth2.beacon.types.forks import Fork
 from eth2.beacon.types.states import BeaconState
 from eth2.beacon.types.validators import Validator
 from eth2.beacon.typing import Gwei, Timestamp, ValidatorIndex, Version
-from eth2.configs import CommitteeConfig, Eth2Config, Eth2GenesisConfig
+from eth2.configs import Eth2Config
 
 
 # SSZ
@@ -350,16 +350,6 @@ def config(
     )
 
 
-@pytest.fixture
-def committee_config(config):
-    return CommitteeConfig(config)
-
-
-@pytest.fixture
-def genesis_config(config):
-    return Eth2GenesisConfig(config)
-
-
 #
 # Sample data params
 #
@@ -661,8 +651,8 @@ def fork_choice_scoring():
 # ChainDB
 #
 @pytest.fixture
-def chaindb(base_db, genesis_config):
-    return BeaconChainDB(base_db, genesis_config)
+def chaindb(base_db, config):
+    return BeaconChainDB(base_db, config)
 
 
 @pytest.fixture

--- a/tests/eth2/core/beacon/state_machines/forks/test_serenity_block_validation.py
+++ b/tests/eth2/core/beacon/state_machines/forks/test_serenity_block_validation.py
@@ -12,7 +12,6 @@ from eth2.beacon.state_machines.forks.serenity.block_validation import (
 from eth2.beacon.tools.builder.initializer import create_mock_validator
 from eth2.beacon.types.blocks import BeaconBlock, SignedBeaconBlock
 from eth2.beacon.types.states import BeaconState
-from eth2.configs import CommitteeConfig
 
 
 @pytest.mark.parametrize(
@@ -79,10 +78,10 @@ def test_validate_proposer_signature(
     )
 
     if is_valid_signature:
-        validate_proposer_signature(state, proposed_block, CommitteeConfig(config))
+        validate_proposer_signature(state, proposed_block, config)
     else:
         with pytest.raises(ValidationError):
-            validate_proposer_signature(state, proposed_block, CommitteeConfig(config))
+            validate_proposer_signature(state, proposed_block, config)
 
 
 @pytest.mark.parametrize(

--- a/tests/eth2/core/beacon/state_machines/forks/test_serenity_epoch_processing.py
+++ b/tests/eth2/core/beacon/state_machines/forks/test_serenity_epoch_processing.py
@@ -33,7 +33,6 @@ from eth2.beacon.types.checkpoints import Checkpoint
 from eth2.beacon.types.pending_attestations import PendingAttestation
 from eth2.beacon.types.validators import Validator
 from eth2.beacon.typing import Gwei
-from eth2.configs import CommitteeConfig
 
 
 @pytest.mark.parametrize(
@@ -257,9 +256,7 @@ def test_get_attestation_deltas(
                 "inclusion_delay",
                 min_attestation_inclusion_delay,
                 "proposer_index",
-                get_beacon_proposer_index(
-                    state.set("slot", slot), CommitteeConfig(config)
-                ),
+                get_beacon_proposer_index(state.set("slot", slot), config),
                 "data",
                 AttestationData.create(**sample_attestation_data_params).mset(
                     "slot",

--- a/tests/eth2/core/beacon/state_machines/forks/test_serenity_operation_processing.py
+++ b/tests/eth2/core/beacon/state_machines/forks/test_serenity_operation_processing.py
@@ -18,7 +18,6 @@ from eth2.beacon.tools.builder.validator import (
     create_mock_voluntary_exit,
 )
 from eth2.beacon.types.blocks import BeaconBlockBody
-from eth2.configs import CommitteeConfig
 
 
 @pytest.mark.parametrize(
@@ -48,7 +47,7 @@ def test_process_proposer_slashings(
 ):
     current_slot = config.GENESIS_SLOT + 1
     state = genesis_state.set("slot", current_slot)
-    whistleblower_index = get_beacon_proposer_index(state, CommitteeConfig(config))
+    whistleblower_index = get_beacon_proposer_index(state, config)
     slashing_proposer_index = (whistleblower_index + 1) % len(state.validators)
     proposer_slashing = create_mock_proposer_slashing_at_block(
         state,

--- a/tests/eth2/core/beacon/test_committee_helpers.py
+++ b/tests/eth2/core/beacon/test_committee_helpers.py
@@ -12,7 +12,6 @@ from eth2.beacon.committee_helpers import (
 )
 from eth2.beacon.helpers import get_seed, signature_domain_to_domain_type
 from eth2.beacon.signature_domain import SignatureDomain
-from eth2.configs import CommitteeConfig
 
 
 @pytest.mark.parametrize(
@@ -96,16 +95,15 @@ def test_get_beacon_proposer_index(genesis_state, config):
     )
     for slot in range(0, config.SLOTS_PER_EPOCH):
         state = state.mset("slot", slot, "validators", validators)
-        committee_config = CommitteeConfig(config)
-        proposer_index = get_beacon_proposer_index(state, committee_config)
+        proposer_index = get_beacon_proposer_index(state, config)
         assert proposer_index
 
-        current_epoch = state.current_epoch(committee_config.SLOTS_PER_EPOCH)
+        current_epoch = state.current_epoch(config.SLOTS_PER_EPOCH)
         domain_type = signature_domain_to_domain_type(
             SignatureDomain.DOMAIN_BEACON_PROPOSER
         )
         seed = hash_eth2(
-            get_seed(state, current_epoch, domain_type, committee_config)
+            get_seed(state, current_epoch, domain_type, config)
             + state.slot.to_bytes(8, "little")
         )
         random_byte = hash_eth2(seed + (proposer_index // 32).to_bytes(8, "little"))[
@@ -133,9 +131,7 @@ def test_get_beacon_committee(genesis_state, config):
             config.TARGET_COMMITTEE_SIZE,
         )
         for committee_index in range(committees_at_slot):
-            some_committee = get_beacon_committee(
-                state, slot, committee_index, CommitteeConfig(config)
-            )
+            some_committee = get_beacon_committee(state, slot, committee_index, config)
             indices += tuple(some_committee)
 
     assert set(indices) == set(range(len(genesis_state.validators)))

--- a/tests/eth2/core/beacon/test_epoch_processing_helpers.py
+++ b/tests/eth2/core/beacon/test_epoch_processing_helpers.py
@@ -23,7 +23,6 @@ from eth2.beacon.types.attestation_data import AttestationData
 from eth2.beacon.types.checkpoints import Checkpoint
 from eth2.beacon.types.pending_attestations import PendingAttestation
 from eth2.beacon.typing import Gwei
-from eth2.configs import CommitteeConfig
 
 
 @pytest.mark.parametrize(
@@ -63,9 +62,7 @@ def test_get_attesting_indices(genesis_state, config):
     target_epoch = state.current_epoch(config.SLOTS_PER_EPOCH)
     target_slot = compute_start_slot_at_epoch(target_epoch, config.SLOTS_PER_EPOCH)
     committee_index = 0
-    some_committee = get_beacon_committee(
-        state, target_slot, committee_index, CommitteeConfig(config)
-    )
+    some_committee = get_beacon_committee(state, target_slot, committee_index, config)
 
     data = AttestationData.create(
         slot=target_slot,
@@ -80,7 +77,7 @@ def test_get_attesting_indices(genesis_state, config):
         if index in some_subset:
             bitfield = set_voted(bitfield, i)
 
-    indices = get_attesting_indices(state, data, bitfield, CommitteeConfig(config))
+    indices = get_attesting_indices(state, data, bitfield, config)
 
     assert set(indices) == set(some_subset)
     assert len(indices) == len(some_subset)
@@ -235,9 +232,7 @@ def test_get_unslashed_attesting_indices(genesis_state, config):
     target_epoch = state.current_epoch(config.SLOTS_PER_EPOCH)
     target_slot = compute_start_slot_at_epoch(target_epoch, config.SLOTS_PER_EPOCH)
     committee_index = 0
-    some_committee = get_beacon_committee(
-        state, target_slot, committee_index, CommitteeConfig(config)
-    )
+    some_committee = get_beacon_committee(state, target_slot, committee_index, config)
 
     data = AttestationData.create(
         slot=state.slot,
@@ -261,7 +256,7 @@ def test_get_unslashed_attesting_indices(genesis_state, config):
     indices = get_unslashed_attesting_indices(
         state,
         (PendingAttestation.create(data=data, aggregation_bits=bitfield),),
-        CommitteeConfig(config),
+        config,
     )
 
     assert set(indices) == set(some_subset)

--- a/tests/eth2/core/beacon/test_helpers.py
+++ b/tests/eth2/core/beacon/test_helpers.py
@@ -242,7 +242,7 @@ def test_get_domain(
 
 def test_get_seed(
     genesis_state,
-    committee_config,
+    config,
     slots_per_epoch,
     min_seed_lookahead,
     max_seed_lookahead,
@@ -258,7 +258,7 @@ def test_get_seed(
     state = genesis_state
     epoch = 1
     state = state.set(
-        "slot", compute_start_slot_at_epoch(epoch, committee_config.SLOTS_PER_EPOCH)
+        "slot", compute_start_slot_at_epoch(epoch, config.SLOTS_PER_EPOCH)
     )
 
     epoch_as_bytes = epoch.to_bytes(32, "little")
@@ -271,7 +271,7 @@ def test_get_seed(
         domain_type=domain_type,
         randao_provider=mock_get_randao_mix,
         epoch_provider=lambda *_: epoch_as_bytes,
-        committee_config=committee_config,
+        config=config,
     )
     assert seed == hash_eth2(
         domain_type

--- a/tests/eth2/core/beacon/test_validator_status_helpers.py
+++ b/tests/eth2/core/beacon/test_validator_status_helpers.py
@@ -18,7 +18,6 @@ from eth2.beacon.validator_status_helpers import (
     initiate_exit_for_validator,
     slash_validator,
 )
-from eth2.configs import CommitteeConfig
 
 
 @pytest.mark.parametrize(("is_already_activated,"), [(True), (False)])
@@ -264,7 +263,7 @@ def test_slash_validator(genesis_state, config):
         )
 
         expected_total_slashed_balance = expected_slashings[epoch]
-        proposer_index = get_beacon_proposer_index(state, CommitteeConfig(config))
+        proposer_index = get_beacon_proposer_index(state, config)
 
         expected_proposer_rewards = update_in(
             expected_proposer_rewards,

--- a/tests/eth2/core/beacon/tools/builder/test_aggregator.py
+++ b/tests/eth2/core/beacon/tools/builder/test_aggregator.py
@@ -14,7 +14,6 @@ from eth2.beacon.tools.builder.aggregator import (
 )
 from eth2.beacon.tools.builder.validator import sign_transaction
 from eth2.beacon.types.attestations import Attestation
-from eth2.configs import CommitteeConfig
 
 
 @pytest.mark.slow
@@ -22,7 +21,6 @@ from eth2.configs import CommitteeConfig
     ("validator_count", "target_committee_size", "slots_per_epoch"), [(1000, 100, 10)]
 )
 def test_aggregator_selection(validator_count, privkeys, genesis_state, config):
-    config = CommitteeConfig(config)
     state = genesis_state
     epoch = compute_epoch_at_slot(state.slot, config.SLOTS_PER_EPOCH)
 

--- a/tests/libp2p/bcc/test_receive_server.py
+++ b/tests/libp2p/bcc/test_receive_server.py
@@ -16,7 +16,6 @@ from eth2.beacon.state_machines.forks.skeleton_lake.config import (
 from eth2.beacon.types.attestation_data import AttestationData
 from eth2.beacon.types.attestations import Attestation
 from eth2.beacon.types.blocks import BaseBeaconBlock, SignedBeaconBlock
-from eth2.configs import Eth2GenesisConfig
 from trinity.db.beacon.chain import AsyncBeaconChainDB
 from trinity.protocol.bcc_libp2p.configs import (
     ATTESTATION_SUBNET_COUNT,
@@ -58,7 +57,7 @@ class FakeChain(SkeletonLakeChain):
 
 
 async def get_fake_chain() -> FakeChain:
-    genesis_config = Eth2GenesisConfig(MINIMAL_SERENITY_CONFIG)
+    genesis_config = MINIMAL_SERENITY_CONFIG
     chain_db = AsyncBeaconChainDBFactory(genesis_config=genesis_config)
     genesis_block = SignedBeaconBlockFactory()
     chain_db.persist_block(

--- a/trinity/components/eth2/beacon/validator.py
+++ b/trinity/components/eth2/beacon/validator.py
@@ -36,7 +36,7 @@ from eth2.beacon.typing import (
     SubnetId,
     ValidatorIndex,
 )
-from eth2.configs import CommitteeConfig
+from eth2.configs import Eth2Config
 from trinity._utils.shellart import bold_green
 from trinity.components.eth2.beacon.base_validator import (
     BaseValidator,
@@ -177,9 +177,7 @@ class Validator(BaseValidator):
         temp_state = state_machine.state_transition.apply_state_transition(
             state, future_slot=slot
         )
-        proposer_index = get_beacon_proposer_index(
-            temp_state, CommitteeConfig(state_machine.config)
-        )
+        proposer_index = get_beacon_proposer_index(temp_state, state_machine.config)
 
         # `latest_proposed_epoch` is used to prevent validator from erraneously proposing twice
         # in the same epoch due to service crashing.
@@ -430,7 +428,7 @@ class Validator(BaseValidator):
     #
     @to_tuple
     def _get_aggregates(
-        self, slot: Slot, committee_index: CommitteeIndex, config: CommitteeConfig
+        self, slot: Slot, committee_index: CommitteeIndex, config: Eth2Config
     ) -> Iterable[Attestation]:
         """
         Return the aggregate attestation of the given committee.
@@ -474,11 +472,9 @@ class Validator(BaseValidator):
             # 2. For each attester
             for validator_index, privkey in attesting_validator_privkeys.items():
                 # Check if the vallidator is one of the aggregators
-                signature = get_slot_signature(
-                    state, slot, privkey, CommitteeConfig(config)
-                )
+                signature = get_slot_signature(state, slot, privkey, config)
                 is_aggregator_result = is_aggregator(
-                    state, slot, committee_index, signature, CommitteeConfig(config)
+                    state, slot, committee_index, signature, config
                 )
                 if is_aggregator_result:
                     self.logger.debug(

--- a/trinity/config.py
+++ b/trinity/config.py
@@ -71,7 +71,6 @@ from eth2.beacon.typing import (
 )
 from eth2.configs import (
     Eth2Config,
-    Eth2GenesisConfig,
 )
 from p2p.kademlia import (
     Node as KademliaNode,
@@ -687,7 +686,7 @@ class Eth1AppConfig(BaseAppConfig):
 class BeaconChainConfig:
     _genesis_state: BeaconState
     _beacon_chain_class: Type['BaseBeaconChain'] = None
-    _genesis_config: Eth2GenesisConfig = None
+    _genesis_config: Eth2Config = None
     _key_map: Dict[BLSPubkey, int]
 
     def __init__(self,
@@ -699,17 +698,13 @@ class BeaconChainConfig:
         self._key_map = genesis_validator_key_map
 
     @property
-    def genesis_config(self) -> Eth2GenesisConfig:
+    def genesis_config(self) -> Eth2Config:
         """
-        NOTE: this ``genesis_config`` is derivative of the ``Eth2Config``.
+        NOTE: this ``genesis_config`` means something slightly different from the
+        genesis config referenced in other places in this class...
         TODO:(ralexstokes) patch up the names here...
         """
-        if self._genesis_config is None:
-            self._genesis_config = Eth2GenesisConfig(
-                self._eth2_config
-            )
-
-        return self._genesis_config
+        return self._eth2_config
 
     @property
     def genesis_time(self) -> Timestamp:
@@ -756,7 +751,7 @@ class BeaconChainConfig:
             base_db=base_db,
             genesis_state=state,
             genesis_block=block,
-            genesis_config=self.genesis_config,
+            genesis_config=self._eth2_config,
         )
 
 

--- a/trinity/protocol/bcc_libp2p/topic_validators.py
+++ b/trinity/protocol/bcc_libp2p/topic_validators.py
@@ -27,7 +27,7 @@ from eth2.beacon.tools.builder.aggregator import (
     validate_attestation_signature,
 )
 from eth2.beacon.typing import SubnetId
-from eth2.configs import CommitteeConfig
+from eth2.configs import Eth2Config
 
 from libp2p.peer.id import ID
 from libp2p.pubsub.pb import rpc_pb2
@@ -91,7 +91,7 @@ def get_beacon_attestation_validator(chain: BaseBeaconChain) -> Callable[..., bo
             validate_attestation_signature(
                 state,
                 attestation,
-                CommitteeConfig(state_machine.config),
+                state_machine.config,
             )
         except InvalidGossipMessage as error:
             logger.debug("%s", str(error))
@@ -134,7 +134,7 @@ def get_committee_index_beacon_attestation_validator(
             validate_attestation_signature(
                 state,
                 attestation,
-                CommitteeConfig(state_machine.config),
+                state_machine.config,
             )
         except InvalidGossipMessage as error:
             logger.debug("%s", str(error))
@@ -167,7 +167,7 @@ def get_beacon_aggregate_and_proof_validator(chain: BaseBeaconChain) -> Callable
             run_validate_aggregate_and_proof(
                 state,
                 aggregate_and_proof,
-                CommitteeConfig(state_machine.config),
+                state_machine.config,
             )
         except InvalidGossipMessage as error:
             logger.debug("%s", str(error))
@@ -199,7 +199,7 @@ def run_validate_block_proposer_signature(
         )
 
     try:
-        validate_proposer_signature(future_state, block, CommitteeConfig(state_machine.config))
+        validate_proposer_signature(future_state, block, state_machine.config)
     except ValidationError as error:
         raise InvalidGossipMessage(
             f"Failed to validate block={encode_hex(block.message.hash_tree_root)}",
@@ -239,7 +239,7 @@ def validate_voting_beacon_block(chain: BaseBeaconChain, attestation: Attestatio
 def run_validate_aggregate_and_proof(
     state: BeaconState,
     aggregate_and_proof: AggregateAndProof,
-    config: CommitteeConfig
+    config: Eth2Config
 ) -> None:
     try:
         validate_aggregate_and_proof(

--- a/trinity/sync/beacon/chain.py
+++ b/trinity/sync/beacon/chain.py
@@ -27,7 +27,7 @@ from eth2.beacon.typing import (
     Slot,
 )
 from eth2.configs import (
-    Eth2GenesisConfig,
+    Eth2Config
 )
 
 from trinity.db.beacon.chain import BaseAsyncBeaconChainDB
@@ -50,7 +50,7 @@ class BeaconChainSyncer(BaseService):
     chain_db: BaseAsyncBeaconChainDB
     peer_pool: PeerPool
     block_importer: SyncBlockImporter
-    genesis_config: Eth2GenesisConfig
+    genesis_config: Eth2Config
     sync_peer: Peer
     _event_bus: EndpointAPI
 
@@ -58,7 +58,7 @@ class BeaconChainSyncer(BaseService):
                  chain_db: BaseAsyncBeaconChainDB,
                  peer_pool: PeerPool,
                  block_importer: SyncBlockImporter,
-                 genesis_config: Eth2GenesisConfig,
+                 genesis_config: Eth2Config,
                  event_bus: EndpointAPI,
                  token: CancelToken = None) -> None:
         super().__init__(token)

--- a/trinity/tools/bcc_factories.py
+++ b/trinity/tools/bcc_factories.py
@@ -29,7 +29,6 @@ from eth2.beacon.types.blocks import (
 )
 from eth2.beacon.state_machines.forks.serenity import SERENITY_CONFIG
 from eth2.beacon.typing import Slot
-from eth2.configs import Eth2GenesisConfig
 from multiaddr import Multiaddr
 
 from trinity.db.beacon.chain import AsyncBeaconChainDB
@@ -48,7 +47,7 @@ except ImportError:
     )
 
 
-SERENITY_GENESIS_CONFIG = Eth2GenesisConfig(SERENITY_CONFIG)
+SERENITY_GENESIS_CONFIG = SERENITY_CONFIG
 
 
 #


### PR DESCRIPTION
### What was wrong?

There were two refinements of the `Eth2Config` type defined: `CommitteeConfig` and `Eth2GenesisConfig`. Their usage is linked to their domain of use so that if you would, e.g. pass the `Eth2Config` to a function that only deals with committee logic, you would provide a `CommitteeConfig` instead. The only difference is that the `CommitteeConfig` is a restriction on the fields available from the `Eth2Config`.

### How was it fixed?

These types are removed in favor of just using the broader `Eth2Config` type. This avoids the overhead of object allocation and also is an ergonomics improvement in that you only need to pass around (and consider) the one config type.

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://hips.hearstapps.com/hmg-prod.s3.amazonaws.com/images/cute-cat-breeds-toyger-1568333810.jpg)
