### PR TITLE
Fix peer disconnection when idle for too long

### DIFF
--- a/p2p/connection.py
+++ b/p2p/connection.py
@@ -131,7 +131,7 @@ class Connection(ConnectionAPI, BaseService):
                     self.run_daemon_task(self._feed_protocol_handlers(protocol))
 
                 await self.cancellation()
-        except (PeerConnectionLost, asyncio.CancelledError):
+        except asyncio.CancelledError:
             pass
         except MalformedMessage as err:
             self.logger.debug(

--- a/p2p/connection.py
+++ b/p2p/connection.py
@@ -133,7 +133,7 @@ class Connection(ConnectionAPI, BaseService):
                 await self.cancellation()
         except (PeerConnectionLost, asyncio.CancelledError):
             pass
-        except (MalformedMessage,) as err:
+        except MalformedMessage as err:
             self.logger.debug(
                 "Disconnecting peer %s for sending MalformedMessage: %s",
                 self.remote,
@@ -146,7 +146,6 @@ class Connection(ConnectionAPI, BaseService):
                     "%s went away while trying to disconnect for MalformedMessage",
                     self,
                 )
-            pass
 
     async def _cleanup(self) -> None:
         await self._multiplexer.close()

--- a/p2p/handshake.py
+++ b/p2p/handshake.py
@@ -284,6 +284,12 @@ async def negotiate_protocol_handshakes(transport: TransportAPI,
     # the `Transport` and feeds them into protocol specific queues.  Each
     # protocol is responsible for reading its own messages from that queue via
     # the `Multiplexer.stream_protocol_messages` API.
+    # XXX: A PeerConnectionLost raised during the handshake will cause the multiplex_token to be
+    # triggered in _do_multiplexing(), and this to raise an OperationCancelled, which in turn
+    # bubbles up all the way to the PeerPool and causes it to return
+    # PP.connect -> handshake -> dial_out -> negotiate_protocol_handshakes -> do_handshake
+    # Not sure if need to catch that OperationCancelled on one of the above methods, or maybe
+    # triggering the multiplex token is not the right thing?
     async with multiplexer.multiplex():
         # Concurrently perform the handshakes for each protocol, gathering up
         # the returned receipts.

--- a/p2p/multiplexer.py
+++ b/p2p/multiplexer.py
@@ -414,17 +414,6 @@ class Multiplexer(CancellableMixin, MultiplexerAPI):
         ), token=token)
         try:
             await self._handle_commands(msg_stream, stop)
-        except asyncio.TimeoutError as exc:
-            # XXX: Transport.read() used to let TimeoutErrors (from peers that have been idle to
-            # long) bubble up and those were silenced here. That is why peers could get stuck
-            # in the pool forever. I'm not sure if we still need this, and in case we do,
-            # shouldn't we cancel the peer/connection here as well?
-            self.logger.warning(
-                "Timed out waiting for command from %s, Stop: %r, exiting...",
-                self,
-                stop.is_set(),
-            )
-            self.logger.debug("Timeout %r: %s", self, exc, exc_info=True)
         except PeerConnectionLost:
             # XXX: This is the multiplex_token created in multiplex(), so I don't understand how
             # triggering it cancels the connection, but it seems to cause that.

--- a/p2p/peer_pool.py
+++ b/p2p/peer_pool.py
@@ -511,8 +511,8 @@ class BasePeerPool(BaseService, AsyncIterable[BasePeer]):
             peers = tuple(self.connected_nodes.values())
             for peer in peers:
                 if not peer.is_running:
-                    self.logger.debug(
-                        "%s is no longer alive but had not been removed from pool", peer)
+                    self.logger.info(
+                        "%s is no longer alive but has not been removed from pool", peer)
                     continue
                 self.logger.debug(
                     "%s: uptime=%s, received_msgs=%d",

--- a/p2p/service.py
+++ b/p2p/service.py
@@ -180,7 +180,7 @@ class BaseService(CancellableMixin, AsyncioServiceAPI):
                 await awaitable
             finally:
                 if not self.is_cancelled:
-                    self.logger.debug(
+                    self.logger.warning(
                         "%s finished while %s is still running, terminating as well",
                         awaitable,
                         self,

--- a/tests/core/p2p-proto/test_peer_pool.py
+++ b/tests/core/p2p-proto/test_peer_pool.py
@@ -1,0 +1,52 @@
+import asyncio
+import pytest
+
+from p2p.tools.paragon import (
+    ParagonContext,
+    ParagonPeerPool,
+)
+from p2p.tools.factories import (
+    ParagonPeerPairFactory,
+    PrivateKeyFactory,
+)
+
+
+@pytest.mark.asyncio
+async def test_peer_removed_after_disconnect():
+    alice_pk = PrivateKeyFactory()
+    async with ParagonPeerPairFactory(alice_private_key=alice_pk) as (alice, bob):
+        peer_pool = ParagonPeerPool(
+            privkey=alice_pk,
+            context=ParagonContext(),
+        )
+        assert len(peer_pool) == 0
+        peer_pool._add_peer(bob, tuple())
+        assert len(peer_pool) == 1
+
+        await bob.cancel()
+        assert len(peer_pool) == 0
+
+
+@pytest.mark.asyncio
+async def test_peer_removed_when_unresponsive():
+    async with ParagonPeerPairFactory() as (peer, remote):
+        peer_transport = peer.connection.get_multiplexer().get_transport()
+        peer_transport.idle_timeout = 0.2
+        # This is necessary to trigger another call to read() on peer's transport, using the
+        # monkey-patched timeout.
+        remote.p2p_api.send_ping()
+        await asyncio.sleep(0.1)
+
+        pool = ParagonPeerPool(privkey=PrivateKeyFactory(), context=ParagonContext())
+        pool._add_peer(peer, tuple())
+        assert len(pool) == 1
+
+        # This is to force the remote to stop responding without closing the connection or sending
+        # us a Disconnect msg, causing our transport's read() to timeout because it's been idle
+        # too long. We cannot close the remote's transport here because that would cause an
+        # IncompleteReadError on our (peer) side and it would cancel itself.
+        remote_transport = remote.connection.get_multiplexer().get_transport()
+        remote_transport.write = lambda data: None
+
+        await asyncio.sleep(0.4)
+        assert len(pool) == 0

--- a/trinity/protocol/common/peer.py
+++ b/trinity/protocol/common/peer.py
@@ -208,6 +208,9 @@ class BaseChainPeerPool(BasePeerPool):
                 ))
                 last_candidates_count = sum(candidate_counts)
             except OperationCancelled:
+                # XXX: The triggering of either the multiplex or the connection token
+                # is causing an OperationCancelled here
+                self.logger.exception("Got OperationCancelled, breaking out of loop")
                 break
             except asyncio.CancelledError:
                 # no need to log this exception, this is expected

--- a/trinity/protocol/eth/handshaker.py
+++ b/trinity/protocol/eth/handshaker.py
@@ -109,6 +109,10 @@ class ETHV63Handshaker(Handshaker[ETHProtocolV63]):
 
         protocol.send(StatusV63(self.handshake_params))
 
+        # During handshake we use the multiplexer without a wrapping connection, and both
+        # wait_iter() calls in there use _multiplex_token, so the
+        # OperationCancelled could be caused by triggering the multiplex_token in
+        # multiplexer.multiplex() or by the Multiplexer.cancel_token being triggered externally
         async for cmd in multiplexer.stream_protocol_messages(protocol):
             if not isinstance(cmd, StatusV63):
                 raise HandshakeFailure(f"Expected a ETH Status msg, got {cmd}, disconnecting")


### PR DESCRIPTION
Also as part of my work on #1302, I noticed sometimes peer would get stuck in the pool even though they were no longer reachable. After spending some time implementing something to periodically ping idle peers and disconnect if they don't reply, I found the `Transport.read()` method uses a timeout of 30s, exactly so that we close idle connections. However, that was not working because the TimeoutError was being silenced. This fixes that and adds a test to ensure it works, but I've left a few XXXs because there are things I don't completely understand here.