### PR TITLE
p2p.Multiplexer now keeps track of the time the last msg was received

### DIFF
--- a/p2p/abc.py
+++ b/p2p/abc.py
@@ -344,6 +344,11 @@ class MultiplexerAPI(ABC):
     def get_total_msg_count(self) -> int:
         ...
 
+    @property
+    @abstractmethod
+    def last_msg_time(self) -> float:
+        ...
+
     #
     # Proxy Transport properties and methods
     #

--- a/p2p/peer.py
+++ b/p2p/peer.py
@@ -220,6 +220,10 @@ class BasePeer(BaseService):
     def received_msgs_count(self) -> int:
         return self.connection.get_multiplexer().get_total_msg_count()
 
+    @property
+    def last_msg_time(self) -> float:
+        return self.connection.get_multiplexer().last_msg_time
+
     def add_subscriber(self, subscriber: 'PeerSubscriber') -> None:
         self._subscribers.append(subscriber)
 


### PR DESCRIPTION
I've implemented this because I intended to have the PeerPool
periodically check for peers that haven't sent us anything
in a long time, ping them, and if they still didn't send us
anything back after a timeout, disconnect. However, it turns
out we already have something that could achieve the same, but
it was not working as expected (see #1630).

I believe this is still useful to have anyway, and even after #1630
is merged, we might still want to periodically ping peers that we
haven't heard from in a while, to not hit the idle timeout on active
connections