### PR TITLE
Add missing API docs for proxy events

### DIFF
--- a/newsfragments/1633.doc.rst
+++ b/newsfragments/1633.doc.rst
@@ -1,0 +1,1 @@
+Add API docs for various proxy events under ``trinity.protocol.*``

--- a/trinity/protocol/common/events.py
+++ b/trinity/protocol/common/events.py
@@ -81,7 +81,9 @@ class PeerInfo(NamedTuple):
 
 @dataclass
 class GetConnectedPeersResponse(BaseEvent):
-
+    """
+    The response class to answer a :class:`trinity.protocol.common.events.GetConnectedPeersRequest`
+    """
     peers: Tuple[PeerInfo, ...]
 
     @staticmethod
@@ -97,7 +99,10 @@ class GetConnectedPeersResponse(BaseEvent):
 
 
 class GetConnectedPeersRequest(BaseRequestResponseEvent[GetConnectedPeersResponse]):
-
+    """
+    A request class that can be dispatched from any process to be answered from another process
+    with a :class:`trinity.protocol.common.events.GetConnectedPeersResponse`.
+   """
     @staticmethod
     def expected_response_type() -> Type[GetConnectedPeersResponse]:
         return GetConnectedPeersResponse
@@ -116,12 +121,18 @@ class PeerPoolMessageEvent(BaseEvent):
 
 @dataclass
 class ProtocolCapabilitiesResponse(BaseEvent):
-
+    """
+    The response class to answer a
+    :class:`trinity.protocol.common.events.GetProtocolCapabilitiesRequest`
+    """
     capabilities: Capabilities
 
 
 class GetProtocolCapabilitiesRequest(BaseRequestResponseEvent[ProtocolCapabilitiesResponse]):
-
+    """
+    A request class that can be dispatched from any process to be answered from another process
+    with a :class:`trinity.protocol.common.events.ProtocolCapabilitiesResponse`.
+   """
     @staticmethod
     def expected_response_type() -> Type[ProtocolCapabilitiesResponse]:
         return ProtocolCapabilitiesResponse

--- a/trinity/protocol/eth/events.py
+++ b/trinity/protocol/eth/events.py
@@ -98,10 +98,11 @@ class NewBlockEvent(PeerPoolMessageEvent):
 
 class NewBlockHashesEvent(PeerPoolMessageEvent):
     """
-    Event to carry a ``Transactions`` command from the peer pool to any process that
+    Event to carry a ``NewBlockHashes`` command from the peer pool to any process that
     subscribes the event through the event bus.
     """
     command: NewBlockHashes
+
 
 # Events flowing from Proxy to PeerPool
 
@@ -160,6 +161,9 @@ class SendTransactionsEvent(BaseEvent):
 
 @dataclass
 class GetBlockHeadersResponse(BaseEvent):
+    """
+    The response class to answer a ``GetBlockHeadersRequest``.
+    """
 
     headers: Sequence[BlockHeaderAPI]
     error: Exception = None
@@ -167,6 +171,16 @@ class GetBlockHeadersResponse(BaseEvent):
 
 @dataclass
 class GetBlockHeadersRequest(BaseRequestResponseEvent[GetBlockHeadersResponse]):
+    """
+    A request class to delegate a :class:`trinity.protocol.proxy.eth.events.GetBlockHeaders` command
+    from any process to another process that can perform the actual
+    :class:`trinity.protocol.proxy.eth.events.GetBlockHeaders` command, wrap the result and send it
+    back to the origin process via a
+    :class:`trinity.protocol.proxy.eth.events.GetBlockHeadersResponse`.
+
+    This is a low-level event class used by :class:`trinity.protocol.proxy.ProxyETHAPI` to allow
+    any Trinity process to interact with peers through the event bus.
+    """
 
     session: SessionAPI
     block_number_or_hash: BlockIdentifier
@@ -182,13 +196,25 @@ class GetBlockHeadersRequest(BaseRequestResponseEvent[GetBlockHeadersResponse]):
 
 @dataclass
 class GetBlockBodiesResponse(BaseEvent):
-
+    """
+    The response class to answer a :class:`trinity.protocol.proxy.eth.events.GetBlockBodiesRequest`
+    """
     bundles: BlockBodyBundles
     error: Exception = None
 
 
 @dataclass
 class GetBlockBodiesRequest(BaseRequestResponseEvent[GetBlockBodiesResponse]):
+    """
+    A request class to delegate a :class:`trinity.protocol.proxy.eth.events.GetBlockBodies` command
+    from any process to another process that can perform the actual
+    :class:`trinity.protocol.proxy.eth.events.GetBlockBodies` command, wrap the result and send it
+    back to the origin process via a
+    :class:`trinity.protocol.proxy.eth.events.GetBlockBodiesResponse`.
+
+    This is a low-level event class used by :class:`trinity.protocol.proxy.ProxyETHAPI` to allow
+    any Trinity process to interact with peers through the event bus.
+    """
 
     session: SessionAPI
     headers: Sequence[BlockHeaderAPI]
@@ -201,13 +227,24 @@ class GetBlockBodiesRequest(BaseRequestResponseEvent[GetBlockBodiesResponse]):
 
 @dataclass
 class GetNodeDataResponse(BaseEvent):
-
+    """
+    The response class to answer a :class:`trinity.protocol.proxy.eth.events.GetNodeDataRequest`.
+    """
     bundles: NodeDataBundles
     error: Exception = None
 
 
 @dataclass
 class GetNodeDataRequest(BaseRequestResponseEvent[GetNodeDataResponse]):
+    """
+    A request class to delegate a :class:`trinity.protocol.proxy.eth.events.GetNodeData` command
+    from any process to another process that can perform the actual
+    :class:`trinity.protocol.proxy.eth.events.GetNodeData` command, wrap the result and send it back
+    to the origin process via a :class:`trinity.protocol.proxy.eth.events.GetNodeDataResponse`.
+
+    This is a low-level event class used by :class:`trinity.protocol.proxy.ProxyETHAPI` to allow
+    any Trinity process to interact with peers through the event bus.
+    """
 
     session: SessionAPI
     node_hashes: Sequence[Hash32]
@@ -220,13 +257,24 @@ class GetNodeDataRequest(BaseRequestResponseEvent[GetNodeDataResponse]):
 
 @dataclass
 class GetReceiptsResponse(BaseEvent):
-
+    """
+    The response class to answer a :class:`trinity.protocol.proxy.eth.events.GetReceiptsRequest`.
+    """
     bundles: ReceiptsBundles
     error: Exception = None
 
 
 @dataclass
 class GetReceiptsRequest(BaseRequestResponseEvent[GetReceiptsResponse]):
+    """
+    A request class to delegate a :class:`trinity.protocol.proxy.eth.events.GetReceipts` command
+    from any process to another process that can perform the actual
+    :class:`trinity.protocol.proxy.eth.events.GetReceipts` command, wrap the result and send it back
+    to the origin process via a :class:`trinity.protocol.proxy.eth.events.GetNodeDataResponse`.
+
+    This is a low-level event class used by :class:`trinity.protocol.proxy.ProxyETHAPI` to allow
+    any Trinity process to interact with peers through the event bus.
+    """
 
     session: SessionAPI
     headers: Sequence[BlockHeaderAPI]


### PR DESCRIPTION
### What was wrong?

As I'm working on `eth/65` I noticed our documentation on the various proxy events could be improved.

### How was it fixed?

Added API docs for various missing proxy events.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

[//]: # (See: https://trinity-client.readthedocs.io/en/latest/contributing.html#pull-requests)
- [x] Add entry to the [release notes](https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://encrypted-tbn0.gstatic.com/images?q=tbn%3AANd9GcSL1j0lgwWQuq33JimtDJdsFJUttzyh7yCp-pzEhb9CAYLEqabz)
