### PR TITLE
Add validator APIs, using high-level `aiohttp`

### DIFF
--- a/trinity/http/apps/base_handler.py
+++ b/trinity/http/apps/base_handler.py
@@ -1,0 +1,49 @@
+import functools
+import inspect
+from typing import Iterable
+
+from aiohttp import web
+from eth_utils import to_tuple
+
+from eth2.validator_client.beacon_node import BeaconNodePath as APIEndpoint
+
+WEB_APP_HANDLER_KEY = "__web_app_handler_data"
+
+
+# NOTE: ignoring the typing until this stabilizes a bit
+def _mk_method_decorator(action):  # type: ignore
+    def _method_func(endpoint: APIEndpoint):  # type: ignore
+        def _decorator(method):  # type: ignore
+            @functools.wraps(method)
+            def _inner(*args, **kwargs):  # type: ignore
+                return method(*args, **kwargs)
+
+            setattr(
+                _inner,
+                WEB_APP_HANDLER_KEY,
+                {"_action": action, "_path": endpoint.value},
+            )
+            return _inner
+
+        return _decorator
+
+    return _method_func
+
+
+# NOTE: ignoring the typing until this stabilizes a bit
+get = _mk_method_decorator(web.get)  # type: ignore
+post = _mk_method_decorator(web.post)  # type: ignore
+
+
+def _web_app_handler_predicate(obj: object) -> bool:
+    return inspect.ismethod(obj) and hasattr(obj, WEB_APP_HANDLER_KEY)
+
+
+class BaseHandler:
+    @to_tuple
+    def make_routes(self) -> Iterable[web.RouteDef]:
+        for (_, handler) in inspect.getmembers(
+            self, predicate=_web_app_handler_predicate
+        ):
+            data = getattr(handler, WEB_APP_HANDLER_KEY)
+            yield data["_action"](data["_path"], handler)

--- a/trinity/http/apps/validator_api.py
+++ b/trinity/http/apps/validator_api.py
@@ -1,0 +1,105 @@
+import logging
+
+from aiohttp import web
+from eth_typing import BLSSignature
+from eth_utils import decode_hex, encode_hex, humanize_hash
+from lahja.base import EndpointAPI
+from ssz.tools.dump import to_formatted_dict
+from ssz.tools.parse import from_formatted_dict
+
+from eth2.beacon.chains.base import BaseBeaconChain
+from eth2.beacon.types.attestations import Attestation, AttestationData
+from eth2.beacon.types.blocks import BeaconBlock, BeaconBlockBody
+from eth2.beacon.typing import Bitfield, CommitteeIndex, Slot
+from eth2.validator_client.beacon_node import BeaconNodePath as APIEndpoint
+from trinity._utils.version import construct_trinity_client_identifier
+from trinity.http.apps.base_handler import BaseHandler, get, post
+
+
+class ValidatorAPIHandler(BaseHandler):
+    logger = logging.getLogger("trinity.http.apps.validator_api.ValidatorAPIHandler")
+
+    def __init__(
+        self, chain: BaseBeaconChain, event_bus: EndpointAPI, genesis_time: int
+    ):
+        self._chain = chain
+        self._event_bus = event_bus
+        self._genesis_time = genesis_time
+        self._client_identifier = construct_trinity_client_identifier()
+
+    @get(APIEndpoint.node_version)
+    async def _get_client_version(self, request: web.Request) -> web.Response:
+        return web.json_response(self._client_identifier)
+
+    @get(APIEndpoint.genesis_time)
+    async def _get_genesis_time(self, request: web.Request) -> web.Response:
+        return web.json_response(self._genesis_time)
+
+    @get(APIEndpoint.sync_status)
+    async def _get_sync_status(self, request: web.Request) -> web.Response:
+        # TODO: get actual status in real tim
+        status = {
+            "is_syncing": False,
+            "sync_status": {"starting_slot": 0, "current_slot": 0, "highest_slot": 0},
+        }
+        return web.json_response(status)
+
+    @get(APIEndpoint.validator_duties)
+    async def _get_validator_duties(self, request: web.Request) -> web.Response:
+        public_keys = tuple(
+            map(decode_hex, request.query["validator_pubkeys"].split(","))
+        )
+        # epoch = Epoch(request.query["epoch"])
+        duties = tuple(
+            {
+                "validator_pubkey": encode_hex(public_key),
+                "attestation_slot": 2222,
+                "attestation_shard": 22,
+                "block_proposal_slot": 90,
+            }
+            for public_key in public_keys
+        )
+        return web.json_response(duties)
+
+    @get(APIEndpoint.block_proposal)
+    async def _get_block_proposal(self, request: web.Request) -> web.Response:
+        slot = Slot(int(request.query["slot"]))
+        randao_reveal = BLSSignature(
+            decode_hex(request.query["randao_reveal"]).ljust(96, b"\x00")
+        )
+        block = BeaconBlock.create(
+            slot=slot, body=BeaconBlockBody.create(randao_reveal=randao_reveal)
+        )
+        return web.json_response(to_formatted_dict(block))
+
+    @post(APIEndpoint.block_proposal)
+    async def _post_block_proposal(self, request: web.Request) -> web.Response:
+        block_data = await request.json()
+        block = from_formatted_dict(block_data, BeaconBlock)
+        self.logger.info(
+            "broadcasting block with root %s", humanize_hash(block.hash_tree_root)
+        )
+        # TODO the actual brodcast
+        return web.Response()
+
+    @get(APIEndpoint.attestation)
+    async def _get_attestation(self, request: web.Request) -> web.Response:
+        # _public_key = BLSPubkey(decode_hex(request.query["validator_pubkey"]))
+        slot = Slot(int(request.query["slot"]))
+        committee_index = CommitteeIndex(int(request.query["committee_index"]))
+        attestation = Attestation.create(
+            aggregation_bits=Bitfield([True, False, False]),
+            data=AttestationData.create(index=committee_index, slot=slot),
+        )
+        return web.json_response(to_formatted_dict(attestation))
+
+    @post(APIEndpoint.attestation)
+    async def _post_attestation(self, request: web.Request) -> web.Response:
+        attestation_data = await request.json()
+        attestation = from_formatted_dict(attestation_data, Attestation)
+        self.logger.info(
+            "broadcasting attestation with root %s",
+            humanize_hash(attestation.hash_tree_root),
+        )
+        # TODO the actual brodcast
+        return web.Response()

--- a/trinity/http/server.py
+++ b/trinity/http/server.py
@@ -1,0 +1,46 @@
+import asyncio
+from typing import Collection
+
+from aiohttp import web
+
+from cancel_token import CancelToken
+
+from p2p.service import BaseService
+
+
+class HTTPServer(BaseService):
+    """
+    NOTE: this class differs from ``trinity.http.main.HTTPServer``
+    in that it accepts a collection of ``web.RouteDef`` and builds
+    a ``web.Application``, rather than the lower-level ``web.Server``.
+    """
+
+    host: str
+    port: int
+
+    def __init__(
+        self,
+        routes: Collection[web.RouteDef],
+        host: str = "127.0.0.1",
+        port: int = 8545,
+        token: CancelToken = None,
+        loop: asyncio.AbstractEventLoop = None,
+    ) -> None:
+        super().__init__(token=token, loop=loop)
+        self.host = host
+        self.port = port
+        app = web.Application()
+        app.add_routes(routes)
+        self._runner = web.AppRunner(app)
+
+    async def _run(self) -> None:
+        await self._runner.setup()
+        site = web.TCPSite(self._runner, self.host, self.port)
+        self.logger.info("Running HTTP Server %s:%d", self.host, self.port)
+        await site.start()
+
+        await self.cancellation()
+
+    async def _cleanup(self) -> None:
+        self.logger.info("Closing HTTPServer...")
+        await self._runner.cleanup()


### PR DESCRIPTION
The beacon node currently does not support the validator APIs.

We implement a version of them in this PR.

Additionally, we add some HTTP infrastructure to take advantage of the higher-level functionality in `aiohttp`. There was some earlier work using the lower-level primitives in `aiohttp` but that leads us to reimplementing a lot of logic that is already in the `aiohttp` library.

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://www.thesprucepets.com/thmb/wpN_ZunUaRQAc_WRdAQRxeTbyoc=/4231x2820/filters:fill(auto,1)/adorable-white-pomeranian-puppy-spitz-921029690-5c8be25d46e0fb000172effe.jpg)
