### PR TITLE
Bump py-ssz to v0.2.4

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -121,7 +121,7 @@ deps = {
         "py-ecc==1.7.1",
         "rlp>=1.1.0,<2.0.0",
         PYEVM_DEPENDENCY,
-        "ssz==0.2.3",
+        "ssz==0.2.4",
         "asks>=2.3.6,<3",  # validator client
         "eth-keyfile",  # validator client
     ],


### PR DESCRIPTION
### What was wrong?
> @ralexstokes: another dependency in trinity is using `pyrsistent` and they just dropped a new release that is breaking the trinity build bc we have incompatible deps b/t trinity and py-ssz now

### How was it fixed?
Bump `pyrsistent` dependency in py-ssz https://github.com/ethereum/py-ssz/pull/107 and then also update trinity dependency.
