### PR TITLE
Change default name of ENR directory

### DIFF
--- a/trinity/components/eth2/discv5/component.py
+++ b/trinity/components/eth2/discv5/component.py
@@ -35,9 +35,8 @@ from p2p.identity_schemes import default_identity_scheme_registry
 from p2p.kademlia import KademliaRoutingTable
 from p2p.node_db import NodeDB
 from trinity.boot_info import BootInfo
+from trinity.constants import NODE_DB_DIR as DEFAULT_NODEDB_DIR_NAME
 from trinity.extensibility import TrioIsolatedComponent
-
-DEFAULT_NODEDB_DIR_NAME = "nodes"
 
 logger = logging.getLogger("trinity.components.eth2.discv5.DiscV5Component")
 

--- a/trinity/constants.py
+++ b/trinity/constants.py
@@ -27,7 +27,7 @@ IPC_DIR = 'ipcs'
 LOG_DIR = 'logs'
 LOG_FILE = 'trinity.log'
 PID_DIR = 'pids'
-NODE_DB_DIR = 'nodes'
+NODE_DB_DIR = 'discovery-node-records'
 
 # sync modes
 SYNC_FULL = 'full'


### PR DESCRIPTION
### What was wrong?

The default name of this directory is `nodes` which is not very specific and happens to be an overloaded symbol (full node, light node, etc.)

### How was it fixed?

Change the name.


#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://freeaddon.com/wp-content/uploads/2017/12/cute-cats-0.jpg)
