### PR TITLE
Use the trinity `nodekey` for eth2

### DIFF
--- a/trinity/components/eth2/beacon/component.py
+++ b/trinity/components/eth2/beacon/component.py
@@ -13,7 +13,7 @@ from libp2p.crypto.secp256k1 import Secp256k1PrivateKey, create_new_key_pair
 from eth2.beacon.typing import SubnetId
 from p2p.service import BaseService, run_service
 from trinity.boot_info import BootInfo
-from trinity.config import BeaconAppConfig
+from trinity.config import BeaconAppConfig, TrinityConfig
 from trinity.db.beacon.chain import AsyncBeaconChainDB
 from trinity.db.manager import DBClient
 from trinity.extensibility import AsyncioIsolatedComponent
@@ -29,6 +29,10 @@ from trinity.sync.common.chain import SyncBlockImporter
 from .chain_maintainer import ChainMaintainer
 from .slot_ticker import SlotTicker
 from .validator_handler import ValidatorHandler
+
+
+def _load_secp256k1_key_pair_from(trinity_config: TrinityConfig) -> KeyPair:
+    return create_new_key_pair(trinity_config.nodekey.to_bytes())
 
 
 class BeaconNodeComponent(AsyncioIsolatedComponent):
@@ -91,7 +95,7 @@ class BeaconNodeComponent(AsyncioIsolatedComponent):
     @classmethod
     async def do_run(cls, boot_info: BootInfo, event_bus: EndpointAPI) -> None:
         trinity_config = boot_info.trinity_config
-        key_pair = KeyPair(trinity_config.nodekey, trinity_config.nodekey.public_key)
+        key_pair = _load_secp256k1_key_pair_from(trinity_config)
         beacon_app_config = trinity_config.get_app_config(BeaconAppConfig)
         base_db = DBClient.connect(trinity_config.database_ipc_path)
 

--- a/trinity/components/eth2/beacon/component.py
+++ b/trinity/components/eth2/beacon/component.py
@@ -91,7 +91,7 @@ class BeaconNodeComponent(AsyncioIsolatedComponent):
     @classmethod
     async def do_run(cls, boot_info: BootInfo, event_bus: EndpointAPI) -> None:
         trinity_config = boot_info.trinity_config
-        key_pair = cls._load_or_create_node_key(boot_info)
+        key_pair = KeyPair(trinity_config.nodekey, trinity_config.nodekey.public_key)
         beacon_app_config = trinity_config.get_app_config(BeaconAppConfig)
         base_db = DBClient.connect(trinity_config.database_ipc_path)
 

--- a/trinity/components/eth2/discv5/component.py
+++ b/trinity/components/eth2/discv5/component.py
@@ -1,7 +1,6 @@
 from argparse import ArgumentParser, _SubParsersAction
 import logging
 import pathlib
-import secrets
 
 import async_service
 from eth.db.backends.level import LevelDB
@@ -52,10 +51,9 @@ def get_nodedb_dir(boot_info: BootInfo) -> pathlib.Path:
 def get_local_private_key(boot_info: BootInfo) -> PrivateKey:
     if boot_info.args.discovery_private_key:
         local_private_key_bytes = decode_hex(boot_info.args.discovery_private_key)
+        return PrivateKey(local_private_key_bytes)
     else:
-        logger.debug("No private key given, using random one")
-        local_private_key_bytes = secrets.token_bytes(32)
-    return PrivateKey(local_private_key_bytes)
+        return boot_info.trinity_config.nodekey
 
 
 async def get_local_enr(


### PR DESCRIPTION
### What was wrong?

We were not piping the `nodekey` into eth2's components.

### How was it fixed?

Connect the bytes.

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://encrypted-tbn0.gstatic.com/images?q=tbn%3AANd9GcRICv_x9byH2oAuR8Ec4HQ3PLx2QQ_ltU81HBr0nm5U8knpCI3H)
