### PR TITLE
Raise error in `AsyncioIsolatedComponent`

### DIFF
--- a/trinity/extensibility/asyncio.py
+++ b/trinity/extensibility/asyncio.py
@@ -33,7 +33,7 @@ class AsyncioIsolatedComponent(BaseIsolatedComponent):
         )
         async with proc_ctx as proc:
             try:
-                await proc.wait()
+                await proc.wait_result()
             except asyncio.CancelledError as err:
                 logger.debug('Component %s exiting. Sending SIGINT to pid=%d', self, proc.pid)
                 proc.send_signal(signal.SIGINT)


### PR DESCRIPTION
### What was wrong?

Errors happening in `AsyncioIsolatedComponent`s are silently swallowed.

### How was it fixed?

Raise the error if there is one as reported by the process.

It is possible this should be part of the `asyncio-open-in-process` library -- i'll ping @pipermerriam  and @gsalgado to chime in further.

Also note: with the current multiprocess machinery, a user does not know about this error until shutting down the `trinity` platform (although they do eventually learn of it). Ideally individual components run with `run_component` can log the status of their run if they terminate early but it looks like this would introduce more substantial changes the `ComponentManager`

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://media-cdn.tripadvisor.com/media/photo-s/0e/08/a8/c0/cute-cats-very-busy-place.jpg)
