### PR TITLE
Remove unused parameter

### DIFF
--- a/tests/core/components/test_isolated_component.py
+++ b/tests/core/components/test_isolated_component.py
@@ -51,7 +51,7 @@ async def test_asyncio_isolated_component(boot_info,
                                           log_listener):
     # Test the lifecycle management for isolated process components to be sure
     # they start and stop as expected
-    component_manager = ComponentManager(boot_info, (AsyncioComponentForTest,), lambda reason: None)
+    component_manager = ComponentManager(boot_info, (AsyncioComponentForTest,))
 
     async with background_asyncio_service(component_manager):
         event_bus = await component_manager.get_event_bus()

--- a/trinity/bootstrap.py
+++ b/trinity/bootstrap.py
@@ -255,7 +255,6 @@ def main_entry(trinity_boot: BootFn,
         component_manager_service = ComponentManager(
             boot_info,
             runtime_component_types,
-            kill_trinity_with_reason,
         )
         manager = AsyncioManager(component_manager_service)
 

--- a/trinity/extensibility/component_manager.py
+++ b/trinity/extensibility/component_manager.py
@@ -1,8 +1,6 @@
 import asyncio
 import logging
 from typing import (
-    Any,
-    Callable,
     Sequence,
     Type,
     Tuple,
@@ -36,11 +34,10 @@ class ComponentManager(Service):
 
     def __init__(self,
                  boot_info: BootInfo,
-                 component_types: Sequence[Type[ComponentAPI]],
-                 kill_trinity_fn: Callable[[str], Any]) -> None:
+                 component_types: Sequence[Type[ComponentAPI]]) -> None:
         self._boot_info = boot_info
         self._component_types = component_types
-        self._kill_trinity_fn = kill_trinity_fn
+
         self._endpoint_available = asyncio.Event()
         self._trigger_component_exit = asyncio.Event()
 


### PR DESCRIPTION
### What was wrong?

An unused function was being passed into the `ComponentManager`. Given the complexity of the class, I think it is best to simplify as much as possible.

### How was it fixed?

Removed the param.

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://cdn.shopify.com/s/files/1/0140/6858/0410/products/O1CN01YMfmiW1GiUIUxVNf7__2205280656_2400x.jpg?v=1575480026)
