### PR TITLE
Extract genesis config generation into reusable library function

### DIFF
--- a/eth2/configs.py
+++ b/eth2/configs.py
@@ -1,5 +1,5 @@
 from dataclasses import Field, dataclass, fields
-from typing import Any, Collection, Dict, Iterable, Tuple, Union, cast
+from typing import Any, Collection, Dict, Iterable, Optional, Tuple, Union, cast
 
 from eth.constants import ZERO_HASH32
 from eth_utils import decode_hex, encode_hex, to_dict
@@ -117,7 +117,7 @@ class Eth2Config:
 
 def generate_genesis_config(
     config_profile: Literal["minimal", "mainnet"],
-    genesis_time: Timestamp = None,
+    genesis_time: Optional[Timestamp] = None,
 ) -> Dict[str, Any]:
     eth2_config = _get_eth2_config(config_profile)
     override_lengths(eth2_config)
@@ -142,7 +142,6 @@ def generate_genesis_config(
 
     if genesis_time:
         initial_state.set("genesis_time", genesis_time)
-    # instead of genesis_state = adjust_
 
     return {
         "eth2_config": eth2_config.to_formatted_dict(),

--- a/eth2/configs.py
+++ b/eth2/configs.py
@@ -1,24 +1,9 @@
 from dataclasses import Field, dataclass, fields
-from typing import Any, Collection, Dict, Iterable, Optional, Tuple, Union, cast
+from typing import Collection, Dict, Iterable, Tuple, Union, cast
 
-from eth.constants import ZERO_HASH32
 from eth_utils import decode_hex, encode_hex, to_dict
-from ssz.tools.dump import to_formatted_dict
-from typing_extensions import Literal
 
-from eth2.beacon.genesis import initialize_beacon_state_from_eth1
-from eth2.beacon.state_machines.forks.serenity.configs import SERENITY_CONFIG
-from eth2.beacon.state_machines.forks.skeleton_lake.config import (
-    MINIMAL_SERENITY_CONFIG,
-)
-from eth2.beacon.tools.builder.initializer import (
-    create_genesis_deposits_from,
-    create_key_pairs_for,
-    mk_genesis_key_map,
-    mk_withdrawal_credentials_from,
-)
-from eth2.beacon.tools.misc.ssz_vector import override_lengths
-from eth2.beacon.typing import Epoch, Gwei, Second, Slot, Timestamp
+from eth2.beacon.typing import Epoch, Gwei, Second, Slot
 
 ConfigTypes = Union[Gwei, Slot, Epoch, Second, bytes, int]
 EncodedConfigTypes = Union[str, int]
@@ -113,44 +98,3 @@ class Eth2Config:
     def from_formatted_dict(cls, data: Dict[str, EncodedConfigTypes]) -> "Eth2Config":
         # NOTE: mypy does not recognize the kwarg unpacking here...
         return cls(**_decoder(data, fields(cls)))  # type: ignore
-
-
-def generate_genesis_config(
-    config_profile: Literal["minimal", "mainnet"],
-    genesis_time: Optional[Timestamp] = None,
-) -> Dict[str, Any]:
-    eth2_config = _get_eth2_config(config_profile)
-    override_lengths(eth2_config)
-    validator_count = eth2_config.MIN_GENESIS_ACTIVE_VALIDATOR_COUNT
-
-    validator_key_pairs = create_key_pairs_for(validator_count)
-    deposits = create_genesis_deposits_from(
-        validator_key_pairs,
-        withdrawal_credentials_provider=mk_withdrawal_credentials_from(
-            eth2_config.BLS_WITHDRAWAL_PREFIX.to_bytes(1, byteorder="little")
-        ),
-        amount_provider=lambda _public_key: eth2_config.MAX_EFFECTIVE_BALANCE,
-    )
-    eth1_block_hash = ZERO_HASH32
-    eth1_timestamp = eth2_config.MIN_GENESIS_TIME
-    initial_state = initialize_beacon_state_from_eth1(
-        eth1_block_hash=eth1_block_hash,
-        eth1_timestamp=Timestamp(eth1_timestamp),
-        deposits=deposits,
-        config=eth2_config,
-    )
-
-    if genesis_time:
-        initial_state.set("genesis_time", genesis_time)
-
-    return {
-        "eth2_config": eth2_config.to_formatted_dict(),
-        "genesis_validator_key_pairs": mk_genesis_key_map(
-            validator_key_pairs, initial_state
-        ),
-        "genesis_state": to_formatted_dict(initial_state),
-    }
-
-
-def _get_eth2_config(profile: str) -> Eth2Config:
-    return {"minimal": MINIMAL_SERENITY_CONFIG, "mainnet": SERENITY_CONFIG}[profile]

--- a/eth2/genesis.py
+++ b/eth2/genesis.py
@@ -1,0 +1,61 @@
+from typing import Any, Dict, Optional
+
+from eth.constants import ZERO_HASH32
+from ssz.tools.dump import to_formatted_dict
+from typing_extensions import Literal
+
+from eth2.beacon.genesis import initialize_beacon_state_from_eth1
+from eth2.beacon.state_machines.forks.serenity.configs import SERENITY_CONFIG
+from eth2.beacon.state_machines.forks.skeleton_lake.config import (
+    MINIMAL_SERENITY_CONFIG,
+)
+from eth2.beacon.tools.builder.initializer import (
+    create_genesis_deposits_from,
+    create_key_pairs_for,
+    mk_genesis_key_map,
+    mk_withdrawal_credentials_from,
+)
+from eth2.beacon.tools.misc.ssz_vector import override_lengths
+from eth2.beacon.typing import Timestamp
+from eth2.configs import Eth2Config
+
+
+def generate_genesis_config(
+    config_profile: Literal["minimal", "mainnet"],
+    genesis_time: Optional[Timestamp] = None,
+) -> Dict[str, Any]:
+    eth2_config = _get_eth2_config(config_profile)
+    override_lengths(eth2_config)
+    validator_count = eth2_config.MIN_GENESIS_ACTIVE_VALIDATOR_COUNT
+
+    validator_key_pairs = create_key_pairs_for(validator_count)
+    deposits = create_genesis_deposits_from(
+        validator_key_pairs,
+        withdrawal_credentials_provider=mk_withdrawal_credentials_from(
+            eth2_config.BLS_WITHDRAWAL_PREFIX.to_bytes(1, byteorder="little")
+        ),
+        amount_provider=lambda _public_key: eth2_config.MAX_EFFECTIVE_BALANCE,
+    )
+    eth1_block_hash = ZERO_HASH32
+    eth1_timestamp = eth2_config.MIN_GENESIS_TIME
+    initial_state = initialize_beacon_state_from_eth1(
+        eth1_block_hash=eth1_block_hash,
+        eth1_timestamp=Timestamp(eth1_timestamp),
+        deposits=deposits,
+        config=eth2_config,
+    )
+
+    if genesis_time:
+        initial_state.set("genesis_time", genesis_time)
+
+    return {
+        "eth2_config": eth2_config.to_formatted_dict(),
+        "genesis_validator_key_pairs": mk_genesis_key_map(
+            validator_key_pairs, initial_state
+        ),
+        "genesis_state": to_formatted_dict(initial_state),
+    }
+
+
+def _get_eth2_config(profile: str) -> Eth2Config:
+    return {"minimal": MINIMAL_SERENITY_CONFIG, "mainnet": SERENITY_CONFIG}[profile]

--- a/trinity/components/eth2/network_generator/component.py
+++ b/trinity/components/eth2/network_generator/component.py
@@ -3,11 +3,12 @@ import json
 import logging
 import pathlib
 import time
-from typing import Optional
+from typing import Any, Dict, Optional
 
 from eth.constants import ZERO_HASH32
 from eth_utils import humanize_hash
 from ssz.tools.dump import to_formatted_dict
+from typing_extensions import Literal
 
 from eth2.beacon.genesis import initialize_beacon_state_from_eth1
 from eth2.beacon.state_machines.forks.serenity.configs import SERENITY_CONFIG
@@ -102,9 +103,10 @@ class NetworkGeneratorComponent(Application):
     def _generate_network_as_json(
         cls, args: Namespace, trinity_config: TrinityConfig
     ) -> None:
-        config = _get_eth2_config(args.config_profile)
-        override_lengths(config)
-        validator_count = config.MIN_GENESIS_ACTIVE_VALIDATOR_COUNT
+        eth2_config = _get_eth2_config(args.config_profile)
+        override_lengths(eth2_config)
+        validator_count = eth2_config.MIN_GENESIS_ACTIVE_VALIDATOR_COUNT
+
         output_file_path = args.output
 
         cls.logger.info(
@@ -113,37 +115,51 @@ class NetworkGeneratorComponent(Application):
             output_file_path,
             validator_count,
         )
-        validator_key_pairs = create_key_pairs_for(validator_count)
-        deposits = create_genesis_deposits_from(
-            validator_key_pairs,
-            withdrawal_credentials_provider=mk_withdrawal_credentials_from(
-                config.BLS_WITHDRAWAL_PREFIX.to_bytes(1, byteorder="little")
-            ),
-            amount_provider=lambda _public_key: config.MAX_EFFECTIVE_BALANCE,
+
+        genesis_config = _generate_genesis_config(
+            args.config_profile, args.genesis_time, args.genesis_delay
         )
-        eth1_block_hash = ZERO_HASH32
-        eth1_timestamp = config.MIN_GENESIS_TIME
-        initial_state = initialize_beacon_state_from_eth1(
-            eth1_block_hash=eth1_block_hash,
-            eth1_timestamp=Timestamp(eth1_timestamp),
-            deposits=deposits,
-            config=config,
-        )
-        genesis_state = _adjust_genesis_time(
-            initial_state, args.genesis_time, args.genesis_delay
-        )
-        output = {
-            "eth2_config": config.to_formatted_dict(),
-            "genesis_validator_key_pairs": mk_genesis_key_map(
-                validator_key_pairs, genesis_state
-            ),
-            "genesis_state": to_formatted_dict(genesis_state),
-        }
+
         cls.logger.info(
             "configuration generated; genesis state has root %s with genesis time %d",
-            humanize_hash(genesis_state.hash_tree_root),
-            genesis_state.genesis_time,
+            humanize_hash(genesis_config["genesis_state"].hash_tree_root),
+            genesis_config["genesis_state"].genesis_time,
         )
         output_file_path.parent.mkdir(parents=True, exist_ok=True)
         with open(output_file_path, "w") as output_file:
-            output_file.write(json.dumps(output))
+            output_file.write(json.dumps(genesis_config))
+
+
+def _generate_genesis_config(
+    config_profile: Literal["minimal", "mainnet"],
+    genesis_time: Timestamp = None,
+    genesis_delay: int = None,
+) -> Dict[str, Any]:
+    eth2_config = _get_eth2_config(config_profile)
+    override_lengths(eth2_config)
+    validator_count = eth2_config.MIN_GENESIS_ACTIVE_VALIDATOR_COUNT
+
+    validator_key_pairs = create_key_pairs_for(validator_count)
+    deposits = create_genesis_deposits_from(
+        validator_key_pairs,
+        withdrawal_credentials_provider=mk_withdrawal_credentials_from(
+            eth2_config.BLS_WITHDRAWAL_PREFIX.to_bytes(1, byteorder="little")
+        ),
+        amount_provider=lambda _public_key: eth2_config.MAX_EFFECTIVE_BALANCE,
+    )
+    eth1_block_hash = ZERO_HASH32
+    eth1_timestamp = eth2_config.MIN_GENESIS_TIME
+    initial_state = initialize_beacon_state_from_eth1(
+        eth1_block_hash=eth1_block_hash,
+        eth1_timestamp=Timestamp(eth1_timestamp),
+        deposits=deposits,
+        config=eth2_config,
+    )
+    genesis_state = _adjust_genesis_time(initial_state, genesis_time, genesis_delay)
+    return {
+        "eth2_config": eth2_config.to_formatted_dict(),
+        "genesis_validator_key_pairs": mk_genesis_key_map(
+            validator_key_pairs, genesis_state
+        ),
+        "genesis_state": to_formatted_dict(genesis_state),
+    }

--- a/trinity/components/eth2/network_generator/component.py
+++ b/trinity/components/eth2/network_generator/component.py
@@ -6,7 +6,7 @@ import time
 
 from eth_utils import humanize_hash
 
-from eth2.configs import generate_genesis_config
+from eth2.genesis import generate_genesis_config
 from trinity.config import BeaconChainConfig, TrinityConfig
 from trinity.extensibility import Application
 
@@ -75,9 +75,7 @@ class NetworkGeneratorComponent(Application):
         else:
             genesis_time = None
 
-        genesis_config = generate_genesis_config(
-            args.config_profile, genesis_time
-        )
+        genesis_config = generate_genesis_config(args.config_profile, genesis_time)
 
         output_file_path = args.output
         cls.logger.info(

--- a/trinity/components/eth2/network_generator/component.py
+++ b/trinity/components/eth2/network_generator/component.py
@@ -3,28 +3,10 @@ import json
 import logging
 import pathlib
 import time
-from typing import Any, Dict, Optional
 
-from eth.constants import ZERO_HASH32
 from eth_utils import humanize_hash
-from ssz.tools.dump import to_formatted_dict
-from typing_extensions import Literal
 
-from eth2.beacon.genesis import initialize_beacon_state_from_eth1
-from eth2.beacon.state_machines.forks.serenity.configs import SERENITY_CONFIG
-from eth2.beacon.state_machines.forks.skeleton_lake.config import (
-    MINIMAL_SERENITY_CONFIG,
-)
-from eth2.beacon.tools.builder.initializer import (
-    create_genesis_deposits_from,
-    create_key_pairs_for,
-    mk_genesis_key_map,
-    mk_withdrawal_credentials_from,
-)
-from eth2.beacon.tools.misc.ssz_vector import override_lengths
-from eth2.beacon.types.states import BeaconState
-from eth2.beacon.typing import Timestamp
-from eth2.configs import Eth2Config
+from eth2.configs import generate_genesis_config
 from trinity.config import BeaconChainConfig, TrinityConfig
 from trinity.extensibility import Application
 
@@ -36,25 +18,8 @@ Use this profile of configuration to determine minimal parameters in the system.
 """
 
 
-def _get_eth2_config(profile: str) -> Eth2Config:
-    return {"minimal": MINIMAL_SERENITY_CONFIG, "mainnet": SERENITY_CONFIG}[profile]
-
-
 def _get_network_config_path_from() -> pathlib.Path:
     return BeaconChainConfig.get_genesis_config_file_path()
-
-
-def _adjust_genesis_time(
-    initial_state: BeaconState,
-    genesis_time: Optional[int],
-    genesis_delay: Optional[int],
-) -> BeaconState:
-    if genesis_time:
-        return initial_state.set("genesis_time", genesis_time)
-    elif genesis_delay:
-        return initial_state.set("genesis_time", int(time.time()) + genesis_delay)
-    else:
-        return initial_state
 
 
 class NetworkGeneratorComponent(Application):
@@ -103,63 +68,24 @@ class NetworkGeneratorComponent(Application):
     def _generate_network_as_json(
         cls, args: Namespace, trinity_config: TrinityConfig
     ) -> None:
-        eth2_config = _get_eth2_config(args.config_profile)
-        override_lengths(eth2_config)
-        validator_count = eth2_config.MIN_GENESIS_ACTIVE_VALIDATOR_COUNT
+        if args.genesis_time:
+            genesis_time = args.genesis_time
+        elif args.genesis_delay:
+            genesis_time = int(time.time()) + args.genesis_delay
+        else:
+            genesis_time = None
+
+        genesis_config = generate_genesis_config(
+            args.config_profile, genesis_time
+        )
 
         output_file_path = args.output
-
         cls.logger.info(
-            "generating a configuration file at '%s'"
-            " for %d validators and the genesis state containing them...",
-            output_file_path,
-            validator_count,
-        )
-
-        genesis_config = _generate_genesis_config(
-            args.config_profile, args.genesis_time, args.genesis_delay
-        )
-
-        cls.logger.info(
-            "configuration generated; genesis state has root %s with genesis time %d",
+            "configuration generated; genesis state has root %s with genesis time %d; writing to '%s'",
             humanize_hash(genesis_config["genesis_state"].hash_tree_root),
             genesis_config["genesis_state"].genesis_time,
+            output_file_path,
         )
         output_file_path.parent.mkdir(parents=True, exist_ok=True)
         with open(output_file_path, "w") as output_file:
             output_file.write(json.dumps(genesis_config))
-
-
-def _generate_genesis_config(
-    config_profile: Literal["minimal", "mainnet"],
-    genesis_time: Timestamp = None,
-    genesis_delay: int = None,
-) -> Dict[str, Any]:
-    eth2_config = _get_eth2_config(config_profile)
-    override_lengths(eth2_config)
-    validator_count = eth2_config.MIN_GENESIS_ACTIVE_VALIDATOR_COUNT
-
-    validator_key_pairs = create_key_pairs_for(validator_count)
-    deposits = create_genesis_deposits_from(
-        validator_key_pairs,
-        withdrawal_credentials_provider=mk_withdrawal_credentials_from(
-            eth2_config.BLS_WITHDRAWAL_PREFIX.to_bytes(1, byteorder="little")
-        ),
-        amount_provider=lambda _public_key: eth2_config.MAX_EFFECTIVE_BALANCE,
-    )
-    eth1_block_hash = ZERO_HASH32
-    eth1_timestamp = eth2_config.MIN_GENESIS_TIME
-    initial_state = initialize_beacon_state_from_eth1(
-        eth1_block_hash=eth1_block_hash,
-        eth1_timestamp=Timestamp(eth1_timestamp),
-        deposits=deposits,
-        config=eth2_config,
-    )
-    genesis_state = _adjust_genesis_time(initial_state, genesis_time, genesis_delay)
-    return {
-        "eth2_config": eth2_config.to_formatted_dict(),
-        "genesis_validator_key_pairs": mk_genesis_key_map(
-            validator_key_pairs, genesis_state
-        ),
-        "genesis_state": to_formatted_dict(genesis_state),
-    }

--- a/trinity/components/eth2/network_generator/component.py
+++ b/trinity/components/eth2/network_generator/component.py
@@ -81,7 +81,8 @@ class NetworkGeneratorComponent(Application):
 
         output_file_path = args.output
         cls.logger.info(
-            "configuration generated; genesis state has root %s with genesis time %d; writing to '%s'",
+            "configuration generated; genesis state has root %s with genesis time %d; "
+            "writing to '%s'",
             humanize_hash(genesis_config["genesis_state"].hash_tree_root),
             genesis_config["genesis_state"].genesis_time,
             output_file_path,

--- a/trinity/config.py
+++ b/trinity/config.py
@@ -71,6 +71,8 @@ from eth2.beacon.typing import (
 )
 from eth2.configs import (
     Eth2Config,
+)
+from eth2.genesis import (
     generate_genesis_config,
 )
 from p2p.kademlia import (
@@ -736,8 +738,10 @@ class BeaconChainConfig:
         override_lengths(eth2_config)
 
         genesis_state = from_formatted_dict(genesis_config["genesis_state"], BeaconState)
-        genesis_validator_key_map = load_genesis_key_map(genesis_config["genesis_validator_key_pairs"])
-        return cls(genesis_state, genesis_eth2_config, genesis_validator_key_map)
+        genesis_validator_key_map = load_genesis_key_map(
+            genesis_config["genesis_validator_key_pairs"]
+        )
+        return cls(genesis_state, eth2_config, genesis_validator_key_map)
 
     @classmethod
     def get_genesis_config_file_path(cls) -> Path:

--- a/trinity/config.py
+++ b/trinity/config.py
@@ -71,6 +71,7 @@ from eth2.beacon.typing import (
 )
 from eth2.configs import (
     Eth2Config,
+    generate_genesis_config,
 )
 from p2p.kademlia import (
     Node as KademliaNode,
@@ -724,15 +725,19 @@ class BeaconChainConfig:
         Construct an instance of ``cls`` reading the genesis configuration
         data under the local data directory.
         """
-        with open(_get_eth2_genesis_config_file_path()) as config_file:
-            config = json.load(config_file)
-            genesis_eth2_config = Eth2Config.from_formatted_dict(config["eth2_config"])
-            # NOTE: have to ``override_lengths`` before we can parse the ``BeaconState``
-            override_lengths(genesis_eth2_config)
+        try:
+            with open(_get_eth2_genesis_config_file_path()) as config_file:
+                genesis_config = json.load(config_file)
+        except FileNotFoundError:
+            genesis_config = generate_genesis_config("minimal")
 
-            genesis_state = from_formatted_dict(config["genesis_state"], BeaconState)
-            genesis_validator_key_map = load_genesis_key_map(config["genesis_validator_key_pairs"])
-            return cls(genesis_state, genesis_eth2_config, genesis_validator_key_map)
+        eth2_config = Eth2Config.from_formatted_dict(genesis_config["eth2_config"])
+        # NOTE: have to ``override_lengths`` before we can parse the ``BeaconState``
+        override_lengths(eth2_config)
+
+        genesis_state = from_formatted_dict(genesis_config["genesis_state"], BeaconState)
+        genesis_validator_key_map = load_genesis_key_map(genesis_config["genesis_validator_key_pairs"])
+        return cls(genesis_state, genesis_eth2_config, genesis_validator_key_map)
 
     @classmethod
     def get_genesis_config_file_path(cls) -> Path:

--- a/trinity/main_validator.py
+++ b/trinity/main_validator.py
@@ -10,7 +10,8 @@ from eth2.beacon.tools.builder.initializer import load_genesis_key_map
 from eth2.beacon.tools.misc.ssz_vector import override_lengths
 from eth2.beacon.types.states import BeaconState
 from eth2.beacon.typing import Slot
-from eth2.configs import Eth2Config, generate_genesis_config
+from eth2.configs import Eth2Config
+from eth2.genesis import generate_genesis_config
 from eth2.validator_client.cli_parser import parse_cli_args
 from eth2.validator_client.config import Config
 from eth2.validator_client.tools.directory import create_dir_if_missing

--- a/trinity/main_validator.py
+++ b/trinity/main_validator.py
@@ -10,13 +10,12 @@ from eth2.beacon.tools.builder.initializer import load_genesis_key_map
 from eth2.beacon.tools.misc.ssz_vector import override_lengths
 from eth2.beacon.types.states import BeaconState
 from eth2.beacon.typing import Slot
-from eth2.configs import Eth2Config
+from eth2.configs import Eth2Config, generate_genesis_config
 from eth2.validator_client.cli_parser import parse_cli_args
 from eth2.validator_client.config import Config
 from eth2.validator_client.tools.directory import create_dir_if_missing
 from trinity._utils.logging import LOG_FORMATTER
 from trinity.bootstrap import load_trinity_config_from_parser_args
-from trinity.components.eth2.network_generator.component import _generate_genesis_config
 from trinity.config import ValidatorClientAppConfig
 from trinity.constants import APP_IDENTIFIER_VALIDATOR_CLIENT
 
@@ -61,7 +60,7 @@ def main_validator() -> None:
             validator_client_app_config.genesis_config_path
         )
     except FileNotFoundError:
-        genesis_config = _generate_genesis_config("minimal")
+        genesis_config = generate_genesis_config("minimal")
 
     eth2_config = Eth2Config.from_formatted_dict(genesis_config["eth2_config"])
     override_lengths(eth2_config)

--- a/trinity/main_validator.py
+++ b/trinity/main_validator.py
@@ -16,6 +16,7 @@ from eth2.validator_client.config import Config
 from eth2.validator_client.tools.directory import create_dir_if_missing
 from trinity._utils.logging import LOG_FORMATTER
 from trinity.bootstrap import load_trinity_config_from_parser_args
+from trinity.components.eth2.network_generator.component import _generate_genesis_config
 from trinity.config import ValidatorClientAppConfig
 from trinity.constants import APP_IDENTIFIER_VALIDATOR_CLIENT
 
@@ -55,9 +56,13 @@ def main_validator() -> None:
     root_dir = validator_client_app_config.root_dir
     create_dir_if_missing(root_dir)
 
-    genesis_config = _load_genesis_config_at(
-        validator_client_app_config.genesis_config_path
-    )
+    try:
+        genesis_config = _load_genesis_config_at(
+            validator_client_app_config.genesis_config_path
+        )
+    except FileNotFoundError:
+        genesis_config = _generate_genesis_config("minimal")
+
     eth2_config = Eth2Config.from_formatted_dict(genesis_config["eth2_config"])
     override_lengths(eth2_config)
     key_pairs = load_genesis_key_map(genesis_config["genesis_validator_key_pairs"])


### PR DESCRIPTION
### What was wrong?
#### Context
To facilitate genesis of a testnet, we define a self-contained configuration file that any software in the network can read and find the relevant information to begin their job at genesis.

There is a trinity `Application` defined under `trinity.components.eth2.network_generator` that generates this configuration and writes the data to disk. It would be nice to pull out the configuration generation code into a library function so that it can be used in other places.

The main use case is if the configuration on disk is missing for some reason:
```python
try:
    config = _read_genesis_config()
except FileNotFoundError:
    config = _generate_config_anyway()
finally:
    ...  # do stuff with config
```

### How was it fixed?
Extracted genesis config logic into `_generate_genesis_config()`

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

[//]: # (See: https://trinity-client.readthedocs.io/en/latest/contributing.html#pull-requests)
- [x] Add entry to the [release notes](https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://i.redd.it/a18ppro242p41.jpg)
