### PR TITLE
Monitor peer connections and disconnect if idle for too long

### DIFF
--- a/p2p/abc.py
+++ b/p2p/abc.py
@@ -482,6 +482,13 @@ class AsyncioServiceAPI(ABC):
                    timeout: float = None) -> TReturn:
         ...
 
+    @abstractmethod
+    async def wait_first(self,
+                         *awaitables: Awaitable[TReturn],
+                         token: CancelToken = None,
+                         timeout: float = None) -> TReturn:
+        ...
+
 
 class HandshakeCheckAPI(ABC):
     """
@@ -618,6 +625,16 @@ class ConnectionAPI(AsyncioServiceAPI):
                             command_type: Type[CommandAPI[Any]],
                             handler_fn: HandlerFn,
                             ) -> SubscriptionAPI:
+        """
+        Add a handler for messages of the given type.
+        """
+        ...
+
+    @abstractmethod
+    def add_msg_handler(self, handler_fn: HandlerFn) -> SubscriptionAPI:
+        """
+        Add a handler for messages of any type.
+        """
         ...
 
     #

--- a/tests/p2p/test_connection.py
+++ b/tests/p2p/test_connection.py
@@ -129,6 +129,7 @@ async def test_connection_protocol_and_command_handlers():
         bob_handshakers=bob_handshakers,
     )
     async with pair_factory as (alice_connection, bob_connection):
+        all_msgs = []
         messages_cmd_A = []
         messages_cmd_D = []
         messages_second_protocol = []
@@ -147,10 +148,14 @@ async def test_connection_protocol_and_command_handlers():
         async def _handler_cmd_C(conn, cmd):
             done.set()
 
+        async def _handler_all_msgs(conn, cmd):
+            all_msgs.append(cmd)
+
         alice_connection.add_protocol_handler(SecondProtocol, _handler_second_protocol)
         alice_connection.add_command_handler(CommandA, _handler_cmd_A)
         alice_connection.add_command_handler(CommandC, _handler_cmd_C)
         alice_connection.add_command_handler(CommandD, _handler_cmd_D)
+        alice_connection.add_msg_handler(_handler_all_msgs)
 
         alice_connection.start_protocol_streams()
         bob_connection.start_protocol_streams()
@@ -173,3 +178,4 @@ async def test_connection_protocol_and_command_handlers():
         assert len(messages_second_protocol) == 5
         assert len(messages_cmd_A) == 2
         assert len(messages_cmd_D) == 3
+        assert len(all_msgs) == 9


### PR DESCRIPTION
After CONN_IDLE_TIMEOUT/2 seconds without receiving any messages on a
connection, we send a ping. If CONN_IDLE_TIMEOUT/2 seconds pass and we
still haven't received any messages, cancel the connection.