### PR TITLE
Fix broken Transaction propagation

### DIFF
--- a/newsfragments/1649.bugfix.rst
+++ b/newsfragments/1649.bugfix.rst
@@ -1,0 +1,5 @@
+Fix the propagation of transactions which was broken when the transaction pool
+was moved into an isolated component.
+
+Also the transaction pool tests now do assertions based on what the remote
+pool actually receives instead of based on what we appear to be sending out.

--- a/trinity/protocol/common/events.py
+++ b/trinity/protocol/common/events.py
@@ -111,9 +111,12 @@ class GetConnectedPeersRequest(BaseRequestResponseEvent[GetConnectedPeersRespons
 @dataclass
 class PeerPoolMessageEvent(BaseEvent):
     """
-    Base event for all peer messages that are relayed on the event bus. The events are mapped
+    Base event for all peer messages that are routed through the event bus. The events are mapped
     to individual subclasses for every different ``cmd`` to allow efficient consumption through
     the event bus.
+    The event type is used bidirectionally, for peer messages that originate in the peer pool and
+    are propagated to any consuming party but also for peer messages that originate elsewhere but
+    are propagated toward the peer pool to be dispatched on a peer.
     """
     session: SessionAPI
     command: CommandAPI[Any]

--- a/trinity/protocol/eth/events.py
+++ b/trinity/protocol/eth/events.py
@@ -136,7 +136,7 @@ class PooledTransactionsEvent(PeerPoolMessageEvent):
 
 
 @dataclass
-class SendBlockHeadersEvent(BaseEvent):
+class SendBlockHeadersEvent(PeerPoolMessageEvent):
     """
     Event to proxy a ``ETHPeer.sub_proto.send_block_headers`` call from a proxy peer to the actual
     peer that sits in the peer pool.
@@ -146,7 +146,7 @@ class SendBlockHeadersEvent(BaseEvent):
 
 
 @dataclass
-class SendBlockBodiesEvent(BaseEvent):
+class SendBlockBodiesEvent(PeerPoolMessageEvent):
     """
     Event to proxy a ``ETHPeer.sub_proto.send_block_bodies`` call from a proxy peer to the actual
     peer that sits in the peer pool.
@@ -156,7 +156,7 @@ class SendBlockBodiesEvent(BaseEvent):
 
 
 @dataclass
-class SendNodeDataEvent(BaseEvent):
+class SendNodeDataEvent(PeerPoolMessageEvent):
     """
     Event to proxy a ``ETHPeer.sub_proto.send_node_data`` call from a proxy peer to the actual
     peer that sits in the peer pool.
@@ -166,7 +166,7 @@ class SendNodeDataEvent(BaseEvent):
 
 
 @dataclass
-class SendReceiptsEvent(BaseEvent):
+class SendReceiptsEvent(PeerPoolMessageEvent):
     """
     Event to proxy a ``ETHPeer.sub_proto.send_receipts`` call from a proxy peer to the actual
     peer that sits in the peer pool.
@@ -176,7 +176,7 @@ class SendReceiptsEvent(BaseEvent):
 
 
 @dataclass
-class SendTransactionsEvent(BaseEvent):
+class SendTransactionsEvent(PeerPoolMessageEvent):
     """
     Event to proxy a ``ETHPeer.sub_proto.send_transactions`` call from a proxy peer to the actual
     peer that sits in the peer pool.
@@ -186,7 +186,7 @@ class SendTransactionsEvent(BaseEvent):
 
 
 @dataclass
-class SendPooledTransactionsEvent(BaseEvent):
+class SendPooledTransactionsEvent(PeerPoolMessageEvent):
     """
     Event to proxy a ``ETHPeer.sub_proto.send_pooled_transactions`` call from a proxy peer to
     the actual peer that sits in the peer pool.

--- a/trinity/protocol/eth/peer.py
+++ b/trinity/protocol/eth/peer.py
@@ -72,6 +72,7 @@ from .events import (
     GetPooledTransactionsEvent,
     GetPooledTransactionsRequest,
     SendPooledTransactionsEvent,
+    SendTransactionsEvent
 )
 from .payloads import StatusV63Payload, StatusPayload
 from .proto import ETHProtocolV63, ETHProtocol, ETHProtocolV64
@@ -197,6 +198,7 @@ class ETHPeerPoolEventServer(PeerPoolEventServer[ETHPeer]):
         self.run_daemon_event(SendNodeDataEvent, self.handle_node_data_event)
         self.run_daemon_event(SendReceiptsEvent, self.handle_receipts_event)
         self.run_daemon_event(SendPooledTransactionsEvent, self.handle_pooled_transactions_event)
+        self.run_daemon_event(SendTransactionsEvent, self.handle_transactions_event)
 
         self.run_daemon_request(GetBlockHeadersRequest, self.handle_get_block_headers_request)
         self.run_daemon_request(GetReceiptsRequest, self.handle_get_receipts_request)
@@ -239,6 +241,13 @@ class ETHPeerPoolEventServer(PeerPoolEventServer[ETHPeer]):
 
     @async_fire_and_forget
     async def handle_pooled_transactions_event(self, event: SendPooledTransactionsEvent) -> None:
+        await self.try_with_session(
+            event.session,
+            lambda peer: peer.sub_proto.send(event.command)
+        )
+
+    @async_fire_and_forget
+    async def handle_transactions_event(self, event: SendTransactionsEvent) -> None:
         await self.try_with_session(
             event.session,
             lambda peer: peer.sub_proto.send(event.command)

--- a/trinity/protocol/les/events.py
+++ b/trinity/protocol/les/events.py
@@ -127,7 +127,7 @@ class GetBlockHeadersEvent(PeerPoolMessageEvent):
 
 
 @dataclass
-class SendBlockHeadersEvent(BaseEvent):
+class SendBlockHeadersEvent(PeerPoolMessageEvent):
     """
     Event to proxy a ``LESPeer.sub_proto.send_block_headers`` call from a proxy peer to the actual
     peer that sits in the peer pool.

--- a/trinity/protocol/les/peer.py
+++ b/trinity/protocol/les/peer.py
@@ -169,13 +169,7 @@ class LESPeerPoolEventServer(PeerPoolEventServer[LESPeer]):
 
     async def run(self) -> None:
 
-        self.run_daemon_event(
-            SendBlockHeadersEvent,
-            lambda ev: self.try_with_session(
-                ev.session,
-                lambda peer: peer.sub_proto.send(ev.command)
-            )
-        )
+        self.run_daemon_event(SendBlockHeadersEvent, self.handle_send_command)
 
         self.run_daemon_request(
             GetBlockHeaderByHashRequest,


### PR DESCRIPTION
### What was wrong?

Turns out Trinity did not propagate transactions to peers since we moved the tx pool into an isolated plugin a loooong time ago. 

#### Wait, I'm sure we had tests for that, no?

Kind of, unfortunately, the tests we had only ensured that the transaction pool would send out the correct transactions to the correct peers. In fact there was nothing wrong with the transaction pool directly.

Because of Trinitys multiprocess nature peer interactions from outside of the peer pool are a bit more involved. When the transaction pool wants to send out transactions to a peer, it doesn't act on the peer directly but rather dispatches a message on the event bus which is then later "replayed" on the actual peer in the peer pool. Turns out, that part was broken, there was no code to listen for the `SendTransactionsEvent` that the transaction pool was sending. They ended in the void.

### How was it fixed?

1. The `TransactionSendEvent` is now picked up and the transactions are forwarded to the peer

2. The tests were rewritten to use two actual connected transaction pools and do real assertions about what transaction pool B receives from transaction pool a and vice versa.

3. Bonus, I added a little refactoring to delete much of the code that handles these simple `SendXEvent`'s which hopefully will reduce the chance of such error in the future.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

[//]: # (See: https://trinity-client.readthedocs.io/en/latest/contributing.html#pull-requests)
- [x] Add entry to the [release notes](https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://i.pinimg.com/originals/4f/1e/db/4f1edb0c09e732facf65547ec4022074.jpg)
