### PR TITLE
Use AsyncContextGroup instead of AsyncExitStack in the ComponentManager

### DIFF
--- a/tests/core/test_contextgroup.py
+++ b/tests/core/test_contextgroup.py
@@ -1,0 +1,110 @@
+import asyncio
+
+import pytest
+
+from trio import MultiError
+
+from async_generator import asynccontextmanager
+
+from trinity.contextgroup import AsyncContextGroup
+
+
+@pytest.mark.asyncio
+async def test_basic():
+    exit_count = 0
+
+    @asynccontextmanager
+    async def ctx(v):
+        nonlocal exit_count
+        await asyncio.sleep(0)
+        yield v
+        await asyncio.sleep(0)
+        exit_count += 1
+
+    group = AsyncContextGroup([ctx(i) for i in range(3)])
+    async with group as yielded_values:
+        assert yielded_values == tuple(range(3))
+
+    assert exit_count == 3
+
+
+@pytest.mark.asyncio
+async def test_exception_entering_context():
+    exit_count = 0
+
+    @asynccontextmanager
+    async def ctx(should_raise=False):
+        nonlocal exit_count
+        await asyncio.sleep(0)
+        if should_raise:
+            raise ValueError()
+        try:
+            yield
+        finally:
+            await asyncio.sleep(0)
+            exit_count += 1
+
+    group = AsyncContextGroup([ctx(), ctx(True), ctx()])
+    with pytest.raises(ValueError):
+        async with group:
+            # the body of the with block should never execute if an exception is raised when
+            # entering the context group.
+            assert False  # noqa: B011
+
+    # One of our contexts was not entered so we didn't exit it either.
+    assert exit_count == 2
+
+
+@pytest.mark.asyncio
+async def test_exception_inside_context_block():
+    exit_count = 0
+
+    async def f(should_raise):
+        await asyncio.sleep(0)
+        if should_raise:
+            raise ValueError()
+
+    @asynccontextmanager
+    async def ctx(should_raise=False):
+        nonlocal exit_count
+        await asyncio.sleep(0)
+        try:
+            yield f(should_raise)
+        finally:
+            await asyncio.sleep(0)
+            exit_count += 1
+
+    group = AsyncContextGroup([ctx(), ctx(True), ctx()])
+    with pytest.raises(ValueError):
+        async with group as awaitables:
+            for awaitable in awaitables:
+                await awaitable
+
+    assert exit_count == 3
+
+
+@pytest.mark.asyncio
+async def test_exception_exiting():
+    exit_count = 0
+
+    @asynccontextmanager
+    async def ctx(should_raise=False):
+        nonlocal exit_count
+        await asyncio.sleep(0)
+        try:
+            yield
+        finally:
+            exit_count += 1
+            if should_raise:
+                raise ValueError()
+
+    group = AsyncContextGroup([ctx(), ctx(True), ctx(True)])
+    with pytest.raises(MultiError) as exc_info:
+        async with group:
+            pass
+
+    exc = exc_info.value
+    assert len(exc.exceptions) == 2
+    assert isinstance(exc.exceptions[0], ValueError)
+    assert isinstance(exc.exceptions[1], ValueError)
+    assert exit_count == 3

--- a/trinity/contextgroup.py
+++ b/trinity/contextgroup.py
@@ -1,0 +1,57 @@
+import asyncio
+import sys
+from types import TracebackType
+from typing import Any, AsyncContextManager, List, Optional, Sequence, Tuple, Type
+
+from trio import MultiError
+
+
+class AsyncContextGroup:
+
+    def __init__(self, context_managers: Sequence[AsyncContextManager[Any]]) -> None:
+        self.cms = tuple(context_managers)
+        self.cms_to_exit: Sequence[AsyncContextManager[Any]] = tuple()
+
+    async def __aenter__(self) -> Tuple[Any, ...]:
+        futures = [asyncio.ensure_future(cm.__aenter__()) for cm in self.cms]
+        await asyncio.wait(futures)
+        # Exclude futures not successfully entered from the list so that we don't attempt to exit
+        # them.
+        self.cms_to_exit = tuple(
+            cm for cm, future in zip(self.cms, futures)
+            if not future.cancelled() and not future.exception())
+        try:
+            return tuple(future.result() for future in futures)
+        except:  # noqa: E722
+            await self._exit(*sys.exc_info())
+            raise
+
+    async def _exit(self,
+                    exc_type: Optional[Type[BaseException]],
+                    exc_value: Optional[BaseException],
+                    traceback: Optional[TracebackType],
+                    ) -> None:
+        # don't use gather() to ensure that we wait for all __aexit__s
+        # to complete even if one of them raises
+        done, _pending = await asyncio.wait(
+            [cm.__aexit__(exc_type, exc_value, traceback) for cm in self.cms_to_exit])
+        # This is to ensure we re-raise any exceptions our coroutines raise when exiting.
+        errors: List[Tuple[Type[BaseException], BaseException, TracebackType]] = []
+        for d in done:
+            try:
+                d.result()
+            except Exception:
+                errors.append(sys.exc_info())
+        if errors:
+            raise MultiError(
+                tuple(exc_value.with_traceback(exc_tb) for _, exc_value, exc_tb in errors))
+
+    async def __aexit__(self,
+                        exc_type: Optional[Type[BaseException]],
+                        exc_value: Optional[BaseException],
+                        traceback: Optional[TracebackType],
+                        ) -> None:
+        # Since exits are running in parallel, they can't see each
+        # other exceptions, so send exception info from `async with`
+        # body to all.
+        await self._exit(exc_type, exc_value, traceback)


### PR DESCRIPTION
This way the components are terminated concurrently rather than in
sequence.

This makes for a better user experience as the whole shutdown process
now takes just a few seconds instead of ages, makes manual testing a lot
less time consuming when one needs to restart trinity frequently, and
should also shave off some time from our integration tests.