### PR TITLE
Upgrade to lahja 0.16.0

### DIFF
--- a/newsfragments/1653.internal.rst
+++ b/newsfragments/1653.internal.rst
@@ -1,0 +1,6 @@
+Upgrade latest lahja 0.16.0
+
+With the new release the event bus raises exceptions if events or requests
+are send into the void, meaning when no active subscribers exist. This can
+be explicitly allowed if desired by setting ``require_subscriber`` to ``False``
+when broadcasting events or making requests.

--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,7 @@ deps = {
         "plyvel==1.1.0",
         PYEVM_DEPENDENCY,
         "web3==5.4.0",
-        "lahja>=0.15.2,<0.16",
+        "lahja>=0.16.0,<0.17",
         "termcolor>=1.1.0,<2.0.0",
         "uvloop==0.14.0;platform_system=='Linux' or platform_system=='Darwin' or platform_system=='FreeBSD'",  # noqa: E501
         "websockets>=8.1.0",

--- a/tests-trio/p2p-trio/test_discovery.py
+++ b/tests-trio/p2p-trio/test_discovery.py
@@ -349,6 +349,7 @@ async def test_handle_new_upnp_mapping(manually_driven_discovery, endpoint_serve
 
     await trio.hazmat.checkpoint()
     external_ip = '43.248.27.0'
+    await endpoint_server.wait_until_any_endpoint_subscribed_to(NewUPnPMapping)
     await endpoint_server.broadcast(NewUPnPMapping(external_ip))
 
     with trio.fail_after(0.5):

--- a/tests/core/p2p-proto/test_requests.py
+++ b/tests/core/p2p-proto/test_requests.py
@@ -167,6 +167,12 @@ async def test_proxy_peer_requests_with_timeouts(request,
             server_event_bus, server_peer_pool, handler_type=ETHPeerPoolEventServer
         ))
 
+        # We just want an ETHRequestServer that doesn't answer us but we still have to run
+        # *something* to at least subscribe to the events. Otherwise Lahja's safety check will yell
+        # at us for sending requests into the void.
+        for event_type in ETHRequestServer(None, None, None)._subscribed_events:
+            server_event_bus.subscribe(event_type, lambda _: None)
+
         client_proxy_peer_pool = ETHProxyPeerPool(client_event_bus, TO_NETWORKING_BROADCAST_CONFIG)
         await stack.enter_async_context(run_service(client_proxy_peer_pool))
 

--- a/trinity/components/builtin/upnp/nat.py
+++ b/trinity/components/builtin/upnp/nat.py
@@ -18,6 +18,7 @@ from p2p.exceptions import (
 )
 
 from trinity.components.builtin.upnp.events import NewUPnPMapping
+from trinity.constants import FIRE_AND_FORGET_BROADCASTING
 from trinity._utils.logging import get_logger
 
 
@@ -74,7 +75,7 @@ class UPnPService(Service):
                     event = NewUPnPMapping(external_ip)
                     self.logger.debug(
                         "NAT portmap created, broadcasting NewUPnPMapping event: %s", event)
-                    await self.event_bus.broadcast(event)
+                    await self.event_bus.broadcast(event, FIRE_AND_FORGET_BROADCASTING)
                 else:
                     self.logger.info("Unable to setup NAT portmap")
                 # Wait for the port mapping lifetime, and then try registering it again

--- a/trinity/constants.py
+++ b/trinity/constants.py
@@ -40,6 +40,8 @@ NETWORKDB_EVENTBUS_ENDPOINT = 'network-db'
 NETWORKING_EVENTBUS_ENDPOINT = 'networking'
 UPNP_EVENTBUS_ENDPOINT = 'upnp'
 TO_NETWORKING_BROADCAST_CONFIG = BroadcastConfig(filter_endpoint=NETWORKING_EVENTBUS_ENDPOINT)
+FIRE_AND_FORGET_BROADCASTING = BroadcastConfig(require_subscriber=False)
+
 
 # Network IDs: https://ethereum.stackexchange.com/questions/17051/how-to-select-a-network-id-or-is-there-a-list-of-network-ids/17101#17101  # noqa: E501
 MAINNET_NETWORK_ID = 1

--- a/trinity/protocol/common/peer_pool_event_bus.py
+++ b/trinity/protocol/common/peer_pool_event_bus.py
@@ -34,6 +34,7 @@ from p2p.peer import (
 from p2p.peer_pool import BasePeerPool
 from p2p.service import BaseService
 
+from trinity.constants import FIRE_AND_FORGET_BROADCASTING
 from trinity._utils.logging import get_logger
 from trinity._utils.decorators import async_suppress_exceptions
 
@@ -253,11 +254,11 @@ class PeerPoolEventServer(Service, PeerSubscriber, Generic[TPeer]):
 
     def register_peer(self, peer: BasePeer) -> None:
         self.logger.debug2("Broadcasting PeerJoinedEvent for %s", peer)
-        self.event_bus.broadcast_nowait(PeerJoinedEvent(peer.session))
+        self.event_bus.broadcast_nowait(PeerJoinedEvent(peer.session), FIRE_AND_FORGET_BROADCASTING)
 
     def deregister_peer(self, peer: BasePeer) -> None:
         self.logger.debug2("Broadcasting PeerLeftEvent for %s", peer)
-        self.event_bus.broadcast_nowait(PeerLeftEvent(peer.session))
+        self.event_bus.broadcast_nowait(PeerLeftEvent(peer.session), FIRE_AND_FORGET_BROADCASTING)
 
 
 class DefaultPeerPoolEventServer(PeerPoolEventServer[BasePeer]):

--- a/trinity/protocol/eth/peer.py
+++ b/trinity/protocol/eth/peer.py
@@ -26,6 +26,7 @@ from trinity.protocol.common.peer_pool_event_bus import (
     BaseProxyPeer,
     BaseProxyPeerPool,
     PeerPoolEventServer,
+    FIRE_AND_FORGET_BROADCASTING,
 )
 from trinity.protocol.common.typing import (
     BlockBodyBundles,
@@ -261,24 +262,53 @@ class ETHPeerPoolEventServer(PeerPoolEventServer[ETHPeer]):
                                          session: SessionAPI,
                                          cmd: CommandAPI[Any]) -> None:
 
+        # These are broadcasted without a specific target. We shouldn't worry if they are consumed
+        # or not (e.g. transaction pool is enabled or disabled etc)
         if isinstance(cmd, GetBlockHeaders):
-            await self.event_bus.broadcast(GetBlockHeadersEvent(session, cmd))
+            await self.event_bus.broadcast(
+                GetBlockHeadersEvent(session, cmd),
+                FIRE_AND_FORGET_BROADCASTING,
+            )
         elif isinstance(cmd, GetBlockBodies):
-            await self.event_bus.broadcast(GetBlockBodiesEvent(session, cmd))
+            await self.event_bus.broadcast(
+                GetBlockBodiesEvent(session, cmd),
+                FIRE_AND_FORGET_BROADCASTING,
+            )
         elif isinstance(cmd, GetReceipts):
-            await self.event_bus.broadcast(GetReceiptsEvent(session, cmd))
+            await self.event_bus.broadcast(
+                GetReceiptsEvent(session, cmd),
+                FIRE_AND_FORGET_BROADCASTING,
+            )
         elif isinstance(cmd, GetNodeData):
-            await self.event_bus.broadcast(GetNodeDataEvent(session, cmd))
+            await self.event_bus.broadcast(
+                GetNodeDataEvent(session, cmd),
+                FIRE_AND_FORGET_BROADCASTING,
+            )
         elif isinstance(cmd, NewBlock):
-            await self.event_bus.broadcast(NewBlockEvent(session, cmd))
+            await self.event_bus.broadcast(
+                NewBlockEvent(session, cmd),
+                FIRE_AND_FORGET_BROADCASTING,
+            )
         elif isinstance(cmd, NewBlockHashes):
-            await self.event_bus.broadcast(NewBlockHashesEvent(session, cmd))
+            await self.event_bus.broadcast(
+                NewBlockHashesEvent(session, cmd),
+                FIRE_AND_FORGET_BROADCASTING,
+            )
         elif isinstance(cmd, Transactions):
-            await self.event_bus.broadcast(TransactionsEvent(session, cmd))
+            await self.event_bus.broadcast(
+                TransactionsEvent(session, cmd),
+                FIRE_AND_FORGET_BROADCASTING,
+            )
         elif isinstance(cmd, NewPooledTransactionHashes):
-            await self.event_bus.broadcast(NewPooledTransactionHashesEvent(session, cmd))
+            await self.event_bus.broadcast(
+                NewPooledTransactionHashesEvent(session, cmd),
+                FIRE_AND_FORGET_BROADCASTING
+            )
         elif isinstance(cmd, GetPooledTransactions):
-            await self.event_bus.broadcast(GetPooledTransactionsEvent(session, cmd))
+            await self.event_bus.broadcast(
+                GetPooledTransactionsEvent(session, cmd),
+                FIRE_AND_FORGET_BROADCASTING
+            )
         else:
             raise Exception(f"Command {cmd} is not broadcasted")
 

--- a/trinity/sync/beam/chain.py
+++ b/trinity/sync/beam/chain.py
@@ -32,6 +32,7 @@ import rlp
 from p2p.service import BaseService
 
 from trinity.chains.base import AsyncChainAPI
+from trinity.constants import FIRE_AND_FORGET_BROADCASTING
 from trinity.db.eth1.chain import BaseAsyncChainDB
 from trinity.db.eth1.header import BaseAsyncHeaderDB
 from trinity.protocol.eth.peer import ETHPeerPool
@@ -627,7 +628,8 @@ class BeamBlockImporter(BaseBlockImporter, BaseService):
         # Always broadcast, to start previewing transactions that are further ahead in the block
         old_state_header = header.copy(state_root=parent_state_root)
         self._event_bus.broadcast_nowait(
-            DoStatelessBlockPreview(old_state_header, transactions)
+            DoStatelessBlockPreview(old_state_header, transactions),
+            FIRE_AND_FORGET_BROADCASTING
         )
 
         self._backfiller.set_root_hash(parent_state_root)


### PR DESCRIPTION
### What was wrong?

It is easy to end up in a scenario where important events are forgotten to get subscribed to. This can lead to fatal bugs such as [Trinity not propagating any transactions to its peers](https://github.com/ethereum/trinity/pull/1649)

### How was it fixed?

1. The latest lahja release [raises `NoSubscriber` exceptions](https://github.com/ethereum/lahja/pull/176) by default whenever events or requests are send into the void.

2. Events/Requests can still be fired if there are no subscribers but it needs to be made explicit via `BroadcastConfig(require_subscriber=False)`. 

This PR updates to lahja `0.16.0` and adjusts some tests and sets `require_subscriber=False` where ever it is appropriate.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/lahja/blob/master/newsfragments/README.md)

[//]: # (See: https://lahja.readthedocs.io/en/latest/contributing.html#pull-requests)
- [x] Add entry to the [release notes](https://github.com/ethereum/lahja/blob/master/newsfragments/README.md)

- [x] Change `setup.py` when the Lahja release is cut

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://assets3.thrillist.com/v1/image/2831871/size/tmg-article_tall;jpeg_quality=20.jpg)