### PR TITLE
`trinity` on `trio`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -207,6 +207,7 @@ setup(
         'console_scripts': [
             'trinity=trinity:main',
             'trinity-beacon=trinity:main_beacon',
+            'trinity-beacon-trio=trinity:main_beacon_trio',
             'trinity-validator=trinity:main_validator'
         ],
     },

--- a/trinity/__init__.py
+++ b/trinity/__init__.py
@@ -36,6 +36,10 @@ from .main_beacon import (  # noqa: F401
     main_beacon,
 )
 
+from .main_beacon_trio import (  # noqa: F401
+    main_beacon as main_beacon_trio,
+)
+
 from .main_validator import (  # noqa: F401
     main_validator
 )

--- a/trinity/_utils/trio_utils.py
+++ b/trinity/_utils/trio_utils.py
@@ -1,0 +1,9 @@
+import signal
+
+import trio
+
+
+async def wait_for_interrupts() -> None:
+    with trio.open_signal_receiver(signal.SIGINT, signal.SIGTERM) as stream:
+        async for _ in stream:
+            return

--- a/trinity/bootstrap.py
+++ b/trinity/bootstrap.py
@@ -301,9 +301,6 @@ def construct_boot_info(app_identifier: str,
         common_log_level
     )
 
-    # This prints out the ASCII "trinity" header in the terminal
-    display_launch_logs(trinity_config)
-
     boot_info = BootInfo(
         args=args,
         trinity_config=trinity_config,
@@ -330,6 +327,9 @@ def main_entry(trinity_boot: BootFn,
     if hasattr(args, 'func'):
         args.func(args, trinity_config)
         return
+
+    # This prints out the ASCII "trinity" header in the terminal
+    display_launch_logs(trinity_config)
 
     # Setup the log listener which child processes relay their logs through
     with IPCListener(*handlers).run(trinity_config.logging_ipc_path):

--- a/trinity/bootstrap.py
+++ b/trinity/bootstrap.py
@@ -8,6 +8,7 @@ import shutil
 import signal
 from typing import (
     Callable,
+    Dict,
     Iterable,
     Sequence,
     Tuple,
@@ -16,6 +17,7 @@ from typing import (
 
 from async_service import AsyncioManager
 from eth_utils import ValidationError
+from eth_utils.toolz import curry
 
 from trinity.exceptions import (
     AmbigiousFileSystem,
@@ -116,17 +118,14 @@ def ensure_data_dir_is_initialized(trinity_config: TrinityConfig) -> None:
             )
 
 
-def main_entry(trinity_boot: BootFn,
-               app_identifier: str,
-               component_types: Tuple[Type[BaseComponentAPI], ...],
-               sub_configs: Sequence[Type[BaseAppConfig]]) -> None:
-    if is_prerelease():
-        # this modifies the asyncio logger, but will be overridden by any custom settings below
-        enable_warnings_by_default()
-
+def configure_parsers(parser: argparse.ArgumentParser,
+                      subparser: argparse._SubParsersAction,
+                      component_types: Tuple[Type[BaseComponentAPI], ...]) -> None:
     for component_cls in component_types:
         component_cls.configure_parser(parser, subparser)
 
+
+def parse_and_validate_cli() -> argparse.Namespace:
     argcomplete.autocomplete(parser)
 
     args = parser.parse_args()
@@ -139,6 +138,10 @@ def main_entry(trinity_boot: BootFn,
             "directory with `--data-dir path/to/data/directory`"
         )
 
+    return args
+
+
+def resolve_common_log_level_or_error(args: argparse.Namespace) -> str:
     # The `common_log_level` is derived from `--log-level <Level>` / `-l <Level>` without
     # specifying any module. If present, it is used for both `stderr` and `file` logging.
     common_log_level = args.log_levels and args.log_levels.get(None)
@@ -162,18 +165,16 @@ def main_entry(trinity_boot: BootFn,
             flags to share one single log level across both handlers.
             """
         )
+    else:
+        return common_log_level
 
-    trinity_config = load_trinity_config_from_parser_args(parser,
-                                                          args,
-                                                          app_identifier,
-                                                          sub_configs)
 
-    ensure_data_dir_is_initialized(trinity_config)
+LoggingResult = Tuple[Tuple[logging.Handler, ...], int, Dict[str, int]]
 
-    # +---------------+
-    # | LOGGING SETUP |
-    # +---------------+
 
+def install_logging(args: argparse.Namespace,
+                    trinity_config: TrinityConfig,
+                    common_log_level: str) -> LoggingResult:
     # Setup logging to stderr
     stderr_logger_level = (
         args.stderr_log_level
@@ -205,13 +206,104 @@ def main_entry(trinity_boot: BootFn,
     logger = logging.getLogger()
     logger.setLevel(min_log_level)
 
+    return (handler_stderr, handler_file), min_log_level, logger_levels
+
+
+def validate_component_cli(component_types: Tuple[Type[BaseComponentAPI], ...],
+                           boot_info: BootInfo) -> None:
+    # Let the components do runtime validation
+    for component_cls in component_types:
+        try:
+            component_cls.validate_cli(boot_info)
+        except ValidationError as exc:
+            parser.exit(message=str(exc))
+
+
+@curry
+def kill_trinity_with_reason(trinity_config: TrinityConfig,
+                             processes: Tuple[multiprocessing.Process, ...],
+                             reason: str) -> None:
+    logger = logging.getLogger()
+    kill_trinity_gracefully(
+        trinity_config,
+        logger,
+        processes,
+        reason=reason
+    )
+
+
+def _run_asyncio_components(component_types: Tuple[Type[BaseComponentAPI], ...],
+                            boot_info: BootInfo,
+                            processes: Tuple[multiprocessing.Process, ...]) -> None:
+    runtime_component_types = tuple(
+        component_cls
+        for component_cls in component_types
+        if issubclass(component_cls, ComponentAPI)
+    )
+
+    trinity_config = boot_info.trinity_config
+
+    component_manager_service = ComponentManager(
+        boot_info,
+        runtime_component_types,
+    )
+    manager = AsyncioManager(component_manager_service)
+
+    loop = asyncio.get_event_loop()
+    loop.add_signal_handler(
+        signal.SIGTERM,
+        manager.cancel,
+        'SIGTERM',
+    )
+    loop.add_signal_handler(
+        signal.SIGINT,
+        component_manager_service.shutdown,
+        'CTRL+C',
+    )
+
+    try:
+        loop.run_until_complete(manager.run())
+    except BaseException as err:
+        logger = logging.getLogger()
+        logger.error("Error during trinity run: %r", err)
+        raise
+    finally:
+        kill_trinity_with_reason(trinity_config, processes, component_manager_service.reason)
+        if trinity_config.trinity_tmp_root_dir:
+            shutil.rmtree(trinity_config.trinity_root_dir)
+
+
+BootPrologueData = Tuple[BootInfo, Tuple[logging.Handler, ...]]
+
+
+def construct_boot_info(app_identifier: str,
+                        component_types: Tuple[Type[BaseComponentAPI], ...],
+                        sub_configs: Sequence[Type[BaseAppConfig]]) -> BootPrologueData:
+    if is_prerelease():
+        # this modifies the asyncio logger, but will be overridden by any custom settings below
+        enable_warnings_by_default()
+
+    configure_parsers(parser, subparser, component_types)
+
+    args = parse_and_validate_cli()
+
+    common_log_level = resolve_common_log_level_or_error(args)
+
+    trinity_config = load_trinity_config_from_parser_args(parser,
+                                                          args,
+                                                          app_identifier,
+                                                          sub_configs)
+
+    ensure_data_dir_is_initialized(trinity_config)
+    handlers, min_log_level, logger_levels = install_logging(
+        args,
+        trinity_config,
+        common_log_level
+    )
+
     # This prints out the ASCII "trinity" header in the terminal
     display_launch_logs(trinity_config)
 
-    # Setup the log listener which child processes relay their logs through
-    log_listener = IPCListener(handler_stderr, handler_file)
-
-    # Determine what logging level child processes should use.
     boot_info = BootInfo(
         args=args,
         trinity_config=trinity_config,
@@ -220,12 +312,18 @@ def main_entry(trinity_boot: BootFn,
         profile=bool(args.profile),
     )
 
-    # Let the components do runtime validation
-    for component_cls in component_types:
-        try:
-            component_cls.validate_cli(boot_info)
-        except ValidationError as exc:
-            parser.exit(message=str(exc))
+    validate_component_cli(component_types, boot_info)
+
+    return boot_info, handlers
+
+
+def main_entry(trinity_boot: BootFn,
+               app_identifier: str,
+               component_types: Tuple[Type[BaseComponentAPI], ...],
+               sub_configs: Sequence[Type[BaseAppConfig]]) -> None:
+    boot_info, handlers = construct_boot_info(app_identifier, component_types, sub_configs)
+    args = boot_info.args
+    trinity_config = boot_info.trinity_config
 
     # Components can provide a subcommand with a `func` which does then control
     # the entire process from here.
@@ -233,52 +331,10 @@ def main_entry(trinity_boot: BootFn,
         args.func(args, trinity_config)
         return
 
-    runtime_component_types = tuple(
-        component_cls
-        for component_cls in component_types
-        if issubclass(component_cls, ComponentAPI)
-    )
-
-    with log_listener.run(trinity_config.logging_ipc_path):
-
+    # Setup the log listener which child processes relay their logs through
+    with IPCListener(*handlers).run(trinity_config.logging_ipc_path):
         processes = trinity_boot(boot_info)
-
-        loop = asyncio.get_event_loop()
-
-        def kill_trinity_with_reason(reason: str) -> None:
-            kill_trinity_gracefully(
-                trinity_config,
-                logger,
-                processes,
-                reason=reason
-            )
-
-        component_manager_service = ComponentManager(
-            boot_info,
-            runtime_component_types,
-        )
-        manager = AsyncioManager(component_manager_service)
-
-        loop.add_signal_handler(
-            signal.SIGTERM,
-            manager.cancel,
-            'SIGTERM',
-        )
-        loop.add_signal_handler(
-            signal.SIGINT,
-            component_manager_service.shutdown,
-            'CTRL+C',
-        )
-
-        try:
-            loop.run_until_complete(manager.run())
-        except BaseException as err:
-            logger.error("Error during trinity run: %r", err)
-            raise
-        finally:
-            kill_trinity_with_reason(component_manager_service.reason)
-            if trinity_config.trinity_tmp_root_dir:
-                shutil.rmtree(trinity_config.trinity_root_dir)
+        _run_asyncio_components(component_types, boot_info, processes)
 
 
 def display_launch_logs(trinity_config: TrinityConfig) -> None:

--- a/trinity/components/eth2/beacon_trio/component.py
+++ b/trinity/components/eth2/beacon_trio/component.py
@@ -1,0 +1,26 @@
+from argparse import ArgumentParser, _SubParsersAction
+import logging
+
+from trinity.config import BeaconAppConfig
+from trinity.extensibility.trio import TrioComponent
+
+
+class BeaconNodeComponent(TrioComponent):
+    name = "Beacon Node"
+
+    logger = logging.getLogger("trinity.components.beacon.BeaconNode[trio]")
+
+    @classmethod
+    def configure_parser(
+        cls, arg_parser: ArgumentParser, subparser: _SubParsersAction
+    ) -> None:
+        arg_parser.add_argument(
+            "--validator-api-port", type=int, help="API server port", default=5005
+        )
+
+    @property
+    def is_enabled(self) -> bool:
+        return self._boot_info.trinity_config.has_app_config(BeaconAppConfig)
+
+    async def run(self) -> None:
+        self.logger.warn("running bcc!")

--- a/trinity/components/eth2/discv5/component.py
+++ b/trinity/components/eth2/discv5/component.py
@@ -125,7 +125,7 @@ class DiscV5Component(TrioIsolatedComponent):
 
     @property
     def is_enabled(self) -> bool:
-        return True
+        return False
 
     @classmethod
     async def do_run(cls, boot_info: BootInfo, event_bus: EndpointAPI) -> None:

--- a/trinity/components/registry.py
+++ b/trinity/components/registry.py
@@ -50,6 +50,9 @@ from trinity.components.builtin.upnp.component import (
     UpnpComponent,
 )
 from trinity.components.eth2.beacon.component import BeaconNodeComponent
+from trinity.components.eth2.beacon_trio.component import (
+    BeaconNodeComponent as TrioBeaconNodeComponent,
+)
 from trinity.components.eth2.discv5.component import DiscV5Component
 from trinity.components.eth2.network_generator.component import NetworkGeneratorComponent
 from trinity.components.builtin.tx_pool.component import (
@@ -111,3 +114,13 @@ def get_components_for_eth1_client() -> Tuple[Type[BaseComponentAPI], ...]:
 
 def get_components_for_beacon_client() -> Tuple[Type[BaseComponentAPI], ...]:
     return BEACON_NODE_COMPONENTS
+
+
+def get_components_for_trio_beacon_client() -> Tuple[Type[BaseComponentAPI], ...]:
+    return (
+        TrioBeaconNodeComponent,
+        # NOTE: we import this just for the cli parsing...
+        # TODO: pull cli options into beacon node when we merge these components
+        DiscV5Component,
+        NetworkGeneratorComponent,
+    )

--- a/trinity/config.py
+++ b/trinity/config.py
@@ -765,6 +765,10 @@ class BeaconChainConfig:
 
 
 class BeaconAppConfig(BaseEth2AppConfig):
+    def __init__(self, config: TrinityConfig) -> None:
+        super().__init__(config)
+        self.bootstrap_nodes = config.bootstrap_nodes
+        self.preferred_nodes = config.preferred_nodes
 
     @classmethod
     def from_parser_args(cls,
@@ -776,12 +780,14 @@ class BeaconAppConfig(BaseEth2AppConfig):
         """
         if args is not None:
             # This is quick and dirty way to get bootstrap_nodes
-            trinity_config.bootstrap_nodes = tuple(
-                Multiaddr(maddr.strip()) for maddr in args.bootstrap_nodes.split(',') if maddr
-            ) if args.bootstrap_nodes is not None else tuple()
-            trinity_config.preferred_nodes = tuple(
-                Multiaddr(maddr.strip()) for maddr in args.preferred_nodes.split(',') if maddr
-            ) if args.preferred_nodes is not None else tuple()
+            if 'bootstrap_nodes' in args:
+                trinity_config.bootstrap_nodes = tuple(
+                    Multiaddr(maddr.strip()) for maddr in args.bootstrap_nodes.split(',') if maddr
+                ) if args.bootstrap_nodes is not None else tuple()
+            if 'preferred_nodes' in args:
+                trinity_config.preferred_nodes = tuple(
+                    Multiaddr(maddr.strip()) for maddr in args.preferred_nodes.split(',') if maddr
+                ) if args.preferred_nodes is not None else tuple()
         return cls(trinity_config)
 
     @property

--- a/trinity/config.py
+++ b/trinity/config.py
@@ -98,6 +98,7 @@ from trinity._utils.eip1085 import (
 from trinity._utils.filesystem import (
     PidFile,
 )
+from trinity._utils.version import construct_trinity_client_identifier
 from trinity._utils.xdg import (
     get_xdg_trinity_root,
 )
@@ -769,6 +770,7 @@ class BeaconAppConfig(BaseEth2AppConfig):
         super().__init__(config)
         self.bootstrap_nodes = config.bootstrap_nodes
         self.preferred_nodes = config.preferred_nodes
+        self.client_identifier = construct_trinity_client_identifier()
 
     @classmethod
     def from_parser_args(cls,

--- a/trinity/extensibility/trio.py
+++ b/trinity/extensibility/trio.py
@@ -12,8 +12,16 @@ from trinity._utils.mp import ctx
 from trinity._utils.profiling import profiler
 from trinity.boot_info import BootInfo
 
-from .component import BaseIsolatedComponent
+from .component import BaseComponent, BaseIsolatedComponent
 from .event_bus import TrioEventBusService
+
+
+class TrioComponent(BaseComponent):
+    """
+    ``TrioComponent`` is a component that executes in-process
+    with the ``trio`` concurrency library.
+    """
+    pass
 
 
 class TrioIsolatedComponent(BaseIsolatedComponent):

--- a/trinity/main_beacon_trio.py
+++ b/trinity/main_beacon_trio.py
@@ -10,6 +10,7 @@ from trinity.boot_info import BootInfo
 from trinity.bootstrap import construct_boot_info, display_launch_logs
 from trinity.config import BaseAppConfig, BeaconAppConfig
 from trinity.constants import APP_IDENTIFIER_BEACON
+from trinity.components.registry import get_components_for_trio_beacon_client
 from trinity.extensibility import BaseComponentAPI
 from trinity.extensibility.trio import TrioComponent
 from trinity.initialization import (
@@ -76,6 +77,6 @@ def main_entry_trio(
 
 def main_beacon() -> None:
     app_identifier = APP_IDENTIFIER_BEACON
-    component_types = tuple()
+    component_types = get_components_for_trio_beacon_client()
     sub_configs = (BeaconAppConfig,)
     main_entry_trio(app_identifier, component_types, sub_configs)

--- a/trinity/main_beacon_trio.py
+++ b/trinity/main_beacon_trio.py
@@ -1,0 +1,81 @@
+import shutil
+from typing import Collection, Sequence, Tuple, Type
+
+from eth.db.backends.level import LevelDB
+import trio
+
+from eth2.beacon.db.chain import BeaconChainDB
+from trinity._utils.trio_utils import wait_for_interrupts
+from trinity.boot_info import BootInfo
+from trinity.bootstrap import construct_boot_info, display_launch_logs
+from trinity.config import BaseAppConfig, BeaconAppConfig
+from trinity.constants import APP_IDENTIFIER_BEACON
+from trinity.extensibility import BaseComponentAPI
+from trinity.extensibility.trio import TrioComponent
+from trinity.initialization import (
+    ensure_beacon_dirs,
+    initialize_beacon_database,
+    is_beacon_database_initialized,
+)
+
+
+async def _run_trio_components_until_interrupt(
+    components: Collection[Type[TrioComponent]], boot_info: BootInfo
+) -> None:
+    async with trio.open_nursery() as nursery:
+        for component_cls in components:
+            component = component_cls(boot_info)
+            if not component.is_enabled:
+                continue
+            nursery.start_soon(component.run)
+        await wait_for_interrupts()
+        nursery.cancel_scope.cancel()
+
+
+def _initialize_beacon_filesystem_and_db(boot_info: BootInfo) -> None:
+    app_config = boot_info.trinity_config.get_app_config(BeaconAppConfig)
+    ensure_beacon_dirs(app_config)
+
+    base_db = LevelDB(db_path=app_config.database_dir)
+    chain_config = app_config.get_chain_config()
+    chaindb = BeaconChainDB(base_db, chain_config.genesis_config)
+
+    if not is_beacon_database_initialized(chaindb):
+        initialize_beacon_database(chain_config, chaindb, base_db)
+
+
+def main_entry_trio(
+    app_identifier: str,
+    component_types: Tuple[Type[BaseComponentAPI], ...],
+    sub_configs: Sequence[Type[BaseAppConfig]],
+) -> None:
+    boot_info, _ = construct_boot_info(app_identifier, component_types, sub_configs)
+    args = boot_info.args
+    trinity_config = boot_info.trinity_config
+
+    # Components can provide a subcommand with a `func` which does then control
+    # the entire process from here.
+    if hasattr(args, "func"):
+        args.func(args, trinity_config)
+        return
+
+    _initialize_beacon_filesystem_and_db(boot_info)
+
+    display_launch_logs(trinity_config)
+
+    runtime_component_types = tuple(
+        component_cls
+        for component_cls in component_types
+        if issubclass(component_cls, TrioComponent)
+    )
+    trio.run(_run_trio_components_until_interrupt, runtime_component_types, boot_info)
+    # NOTE: mypy bug that does not type this... it works in `./bootstrap.py`
+    if trinity_config.trinity_tmp_root_dir:  # type: ignore
+        shutil.rmtree(trinity_config.trinity_root_dir)
+
+
+def main_beacon() -> None:
+    app_identifier = APP_IDENTIFIER_BEACON
+    component_types = tuple()
+    sub_configs = (BeaconAppConfig,)
+    main_entry_trio(app_identifier, component_types, sub_configs)


### PR DESCRIPTION
NOTE: supersedes #1645.
NOTE: part of a series

I'm working on exposing a `trio`-based Trinity. I'm also taking the opportunity to see if we can't run the beacon node as a single-process (eliminating the fusion of `multiprocessing` and `asyncio` that still seems to be a source of arcane bugs); I'm aiming to write the `trio`-based beacon node in a way that we can easily port to a multiprocess architecture if and when we need that on the eth2 side of things.

I'd suggest reviewing commit by commit. Ideally each commit is a separate PR that is based off the PR made from the previous commit.

This PR introduces the machinery required to run trio-based components on top of the `trinity` platform and demos a basic one in the `beacon_trio.component.BeaconNodeComponent`.

I was originally going to put more commits in this PR to add the beacon node component but this is self-contained at the moment.

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://www.thesprucepets.com/thmb/djRNhvnuikTtQ8vEVdCPUCSn3-8=/960x0/filters:no_upscale():max_bytes(150000):strip_icc()/cutest-cats-on-the-internet-4-57eead1f5f9b586c354d7ecd.jpeg)
