### PR TITLE
Wait for standalone components to cleanup when shutting down

### DIFF
--- a/trinity/components/builtin/network_db/component.py
+++ b/trinity/components/builtin/network_db/component.py
@@ -252,6 +252,5 @@ class NetworkDBComponent(AsyncioIsolatedComponent):
 
 
 if __name__ == "__main__":
-    from trinity.extensibility.component import run_standalone_eth1_component
-    loop = asyncio.get_event_loop()
-    loop.run_until_complete(run_standalone_eth1_component(NetworkDBComponent))
+    from trinity.extensibility.component import run_asyncio_eth1_component
+    run_asyncio_eth1_component(NetworkDBComponent)

--- a/trinity/components/builtin/peer_discovery/component.py
+++ b/trinity/components/builtin/peer_discovery/component.py
@@ -116,5 +116,5 @@ async def generate_eth_cap_enr_field(
 
 
 if __name__ == "__main__":
-    from trinity.extensibility.component import run_standalone_eth1_component
-    trio.run(run_standalone_eth1_component, PeerDiscoveryComponent)
+    from trinity.extensibility.component import run_trio_eth1_component
+    run_trio_eth1_component(PeerDiscoveryComponent)

--- a/trinity/components/builtin/syncer/component.py
+++ b/trinity/components/builtin/syncer/component.py
@@ -349,7 +349,5 @@ if __name__ == "__main__":
     # you must pass the path to the discovery component's IPC file, like:
     # $ python .../syncer/component.py --trinity-root-dir /tmp/syncer \
     #        --connect-to-endpoints /tmp/syncer/mainnet/ipcs-eth1/discovery.ipc
-    import asyncio
-    from trinity.extensibility.component import run_standalone_eth1_component
-    loop = asyncio.get_event_loop()
-    loop.run_until_complete(run_standalone_eth1_component(SyncerComponent))
+    from trinity.extensibility.component import run_asyncio_eth1_component
+    run_asyncio_eth1_component(SyncerComponent)

--- a/trinity/components/builtin/upnp/component.py
+++ b/trinity/components/builtin/upnp/component.py
@@ -3,7 +3,7 @@ from argparse import (
     _SubParsersAction,
 )
 
-from async_service import run_asyncio_service
+from async_service import background_asyncio_service
 from lahja import EndpointAPI
 
 from trinity.boot_info import BootInfo
@@ -41,11 +41,10 @@ class UpnpComponent(AsyncioIsolatedComponent):
         port = boot_info.trinity_config.port
         upnp_service = UPnPService(port, event_bus)
 
-        await run_asyncio_service(upnp_service)
+        async with background_asyncio_service(upnp_service) as manager:
+            await manager.wait_finished()
 
 
 if __name__ == "__main__":
-    import asyncio
-    from trinity.extensibility.component import run_standalone_eth1_component
-    loop = asyncio.get_event_loop()
-    loop.run_until_complete(run_standalone_eth1_component(UpnpComponent))
+    from trinity.extensibility.component import run_asyncio_eth1_component
+    run_asyncio_eth1_component(UpnpComponent)

--- a/trinity/components/eth2/discv5/component.py
+++ b/trinity/components/eth2/discv5/component.py
@@ -232,6 +232,6 @@ class DiscV5Component(TrioIsolatedComponent):
 
 
 if __name__ == "__main__":
-    from trinity.extensibility.component import run_standalone_eth2_component
+    from trinity.extensibility.component import run_trio_eth1_component
 
-    trio.run(run_standalone_eth2_component, DiscV5Component)
+    run_trio_eth1_component(DiscV5Component)

--- a/trinity/extensibility/asyncio.py
+++ b/trinity/extensibility/asyncio.py
@@ -72,7 +72,7 @@ class AsyncioIsolatedComponent(BaseIsolatedComponent):
 
     @classmethod
     @abstractmethod
-    async def do_run(self, boot_info: BootInfo, event_bus: EndpointAPI) -> None:
+    async def do_run(cls, boot_info: BootInfo, event_bus: EndpointAPI) -> None:
         """
         Define the entry point of the component. Should be overwritten in subclasses.
         """


### PR DESCRIPTION
We were not waiting for components to cleanup when shutting them down.
Now we use the same cleanup logic used by the ComponentManager