### PR TITLE
Fix broken eth/64 support

### DIFF
--- a/tests/core/p2p-proto/test_eth_api.py
+++ b/tests/core/p2p-proto/test_eth_api.py
@@ -25,9 +25,9 @@ from trinity.protocol.eth.commands import (
 )
 from trinity.protocol.eth.handshaker import ETHHandshakeReceipt, ETHV63HandshakeReceipt
 from trinity.protocol.eth.proto import (
-    ETHProtocol,
     ETHProtocolV63,
     ETHProtocolV64,
+    ETHProtocolV65,
 )
 
 from trinity.tools.factories.common import (
@@ -115,7 +115,7 @@ def protocol_specific_classes(alice):
         return ETHV63API, ETHV63HandshakeReceipt, StatusV63, StatusV63PayloadFactory
     elif alice.connection.has_protocol(ETHProtocolV64):
         return ETHV64API, ETHHandshakeReceipt, Status, StatusPayloadFactory
-    elif alice.connection.has_protocol(ETHProtocol):
+    elif alice.connection.has_protocol(ETHProtocolV65):
         return ETHAPI, ETHHandshakeReceipt, Status, StatusPayloadFactory
     else:
         raise Exception("No ETH protocol found")

--- a/tests/core/p2p-proto/test_eth_api.py
+++ b/tests/core/p2p-proto/test_eth_api.py
@@ -15,7 +15,7 @@ from eth.vm.forks import MuirGlacierVM, PetersburgVM
 from trinity._utils.assertions import assert_type_equality
 from trinity.db.eth1.header import AsyncHeaderDB
 from trinity.exceptions import WrongForkIDFailure
-from trinity.protocol.eth.api import ETHAPI, ETHV63API, ETHV64API
+from trinity.protocol.eth.api import ETHV65API, ETHV63API, ETHV64API
 from trinity.protocol.eth.commands import (
     GetBlockHeaders,
     GetNodeData,
@@ -116,7 +116,7 @@ def protocol_specific_classes(alice):
     elif alice.connection.has_protocol(ETHProtocolV64):
         return ETHV64API, ETHHandshakeReceipt, Status, StatusPayloadFactory
     elif alice.connection.has_protocol(ETHProtocolV65):
-        return ETHAPI, ETHHandshakeReceipt, Status, StatusPayloadFactory
+        return ETHV65API, ETHHandshakeReceipt, Status, StatusPayloadFactory
     else:
         raise Exception("No ETH protocol found")
 

--- a/tests/core/p2p-proto/test_peer.py
+++ b/tests/core/p2p-proto/test_peer.py
@@ -5,7 +5,10 @@ import pytest
 from p2p.disconnect import DisconnectReason
 
 from trinity.protocol.eth.peer import ETHPeer
-from trinity.protocol.eth.proto import ETHProtocol, ETHProtocolV63
+from trinity.protocol.eth.proto import (
+    ETHProtocolV63,
+    ETHProtocolV65,
+)
 from trinity.protocol.les.peer import LESPeer
 from trinity.protocol.les.proto import (
     LESProtocolV1,
@@ -60,8 +63,8 @@ async def test_ETH_peers():
         assert isinstance(alice, ETHPeer)
         assert isinstance(bob, ETHPeer)
 
-        assert isinstance(alice.sub_proto, ETHProtocol)
-        assert isinstance(bob.sub_proto, ETHProtocol)
+        assert isinstance(alice.sub_proto, ETHProtocolV65)
+        assert isinstance(bob.sub_proto, ETHProtocolV65)
 
 
 @pytest.mark.asyncio

--- a/trinity/protocol/common/api.py
+++ b/trinity/protocol/common/api.py
@@ -7,7 +7,7 @@ from p2p.abc import ConnectionAPI
 from p2p.logic import Application
 from p2p.qualifiers import HasProtocol
 
-from trinity.protocol.eth.api import ETHV63API, ETHAPI, ETHV64API
+from trinity.protocol.eth.api import ETHV63API, ETHV65API, ETHV64API
 from trinity.protocol.eth.proto import ETHProtocolV63, ETHProtocolV64, ETHProtocolV65
 from trinity.protocol.les.api import LESV1API, LESV2API
 from trinity.protocol.les.proto import LESProtocolV1, LESProtocolV2
@@ -17,14 +17,14 @@ from .abc import ChainInfoAPI, HeadInfoAPI
 AnyETHLES = HasProtocol(ETHProtocolV65) | HasProtocol(ETHProtocolV64) | HasProtocol(
     ETHProtocolV63) | HasProtocol(LESProtocolV2) | HasProtocol(LESProtocolV1)
 
-AnyETHLESAPI = Union[ETHAPI, ETHV64API, ETHV63API, LESV1API, LESV2API]
+AnyETHLESAPI = Union[ETHV65API, ETHV64API, ETHV63API, LESV1API, LESV2API]
 
 
 def choose_eth_or_les_api(
         connection: ConnectionAPI) -> AnyETHLESAPI:
 
     if connection.has_protocol(ETHProtocolV65):
-        return connection.get_logic(ETHAPI.name, ETHAPI)
+        return connection.get_logic(ETHV65API.name, ETHV65API)
     elif connection.has_protocol(ETHProtocolV64):
         return connection.get_logic(ETHV64API.name, ETHV64API)
     elif connection.has_protocol(ETHProtocolV63):

--- a/trinity/protocol/common/api.py
+++ b/trinity/protocol/common/api.py
@@ -8,13 +8,13 @@ from p2p.logic import Application
 from p2p.qualifiers import HasProtocol
 
 from trinity.protocol.eth.api import ETHV63API, ETHAPI, ETHV64API
-from trinity.protocol.eth.proto import ETHProtocolV63, ETHProtocol, ETHProtocolV64
+from trinity.protocol.eth.proto import ETHProtocolV63, ETHProtocolV64, ETHProtocolV65
 from trinity.protocol.les.api import LESV1API, LESV2API
 from trinity.protocol.les.proto import LESProtocolV1, LESProtocolV2
 
 from .abc import ChainInfoAPI, HeadInfoAPI
 
-AnyETHLES = HasProtocol(ETHProtocol) | HasProtocol(ETHProtocolV64) | HasProtocol(
+AnyETHLES = HasProtocol(ETHProtocolV65) | HasProtocol(ETHProtocolV64) | HasProtocol(
     ETHProtocolV63) | HasProtocol(LESProtocolV2) | HasProtocol(LESProtocolV1)
 
 AnyETHLESAPI = Union[ETHAPI, ETHV64API, ETHV63API, LESV1API, LESV2API]
@@ -23,7 +23,7 @@ AnyETHLESAPI = Union[ETHAPI, ETHV64API, ETHV63API, LESV1API, LESV2API]
 def choose_eth_or_les_api(
         connection: ConnectionAPI) -> AnyETHLESAPI:
 
-    if connection.has_protocol(ETHProtocol):
+    if connection.has_protocol(ETHProtocolV65):
         return connection.get_logic(ETHAPI.name, ETHAPI)
     elif connection.has_protocol(ETHProtocolV64):
         return connection.get_logic(ETHV64API.name, ETHV64API)

--- a/trinity/protocol/eth/api.py
+++ b/trinity/protocol/eth/api.py
@@ -228,7 +228,7 @@ class ETHV63API(BaseETHAPI):
     head_info_tracker_cls = ETHV63HeadInfoTracker
 
     @cached_property
-    def protocol(self) -> ETHProtocolV63:
+    def protocol(self) -> ProtocolAPI:
         return self.connection.get_protocol_by_type(ETHProtocolV63)
 
     @cached_property
@@ -244,8 +244,8 @@ class ETHV64API(BaseETHAPI):
     head_info_tracker_cls = ETHHeadInfoTracker
 
     @cached_property
-    def protocol(self) -> ETHProtocol:
-        return self.connection.get_protocol_by_type(ETHProtocol)
+    def protocol(self) -> ProtocolAPI:
+        return self.connection.get_protocol_by_type(ETHProtocolV64)
 
     @cached_property
     def receipt(self) -> ETHHandshakeReceipt:
@@ -257,6 +257,10 @@ class ETHV64API(BaseETHAPI):
 
 class ETHAPI(ETHV64API):
     qualifier = HasProtocol(ETHProtocol)
+
+    @cached_property
+    def protocol(self) -> ProtocolAPI:
+        return self.connection.get_protocol_by_type(ETHProtocol)
 
     def __init__(self) -> None:
         super().__init__()

--- a/trinity/protocol/eth/api.py
+++ b/trinity/protocol/eth/api.py
@@ -255,7 +255,7 @@ class ETHV64API(BaseETHAPI):
         self.protocol.send(Status(payload))
 
 
-class ETHAPI(ETHV64API):
+class ETHV65API(ETHV64API):
     qualifier = HasProtocol(ETHProtocolV65)
 
     @cached_property
@@ -273,4 +273,4 @@ class ETHAPI(ETHV64API):
         self.protocol.send(GetPooledTransactions(tuple(transaction_hashes)))
 
 
-AnyETHAPI = Union[ETHV63API, ETHV64API, ETHAPI]
+AnyETHAPI = Union[ETHV63API, ETHV64API, ETHV65API]

--- a/trinity/protocol/eth/api.py
+++ b/trinity/protocol/eth/api.py
@@ -52,7 +52,7 @@ from .payloads import (
     StatusV63Payload,
     StatusPayload,
 )
-from .proto import ETHProtocolV63, ETHProtocol, ETHProtocolV64
+from .proto import ETHProtocolV63, ETHProtocolV65, ETHProtocolV64
 
 THandshakeReceipt = TypeVar("THandshakeReceipt", bound=BaseETHHandshakeReceipt[Any])
 
@@ -256,11 +256,11 @@ class ETHV64API(BaseETHAPI):
 
 
 class ETHAPI(ETHV64API):
-    qualifier = HasProtocol(ETHProtocol)
+    qualifier = HasProtocol(ETHProtocolV65)
 
     @cached_property
     def protocol(self) -> ProtocolAPI:
-        return self.connection.get_protocol_by_type(ETHProtocol)
+        return self.connection.get_protocol_by_type(ETHProtocolV65)
 
     def __init__(self) -> None:
         super().__init__()

--- a/trinity/protocol/eth/handshaker.py
+++ b/trinity/protocol/eth/handshaker.py
@@ -23,7 +23,7 @@ from trinity.exceptions import (
 from .commands import StatusV63, Status
 from .forkid import ForkID, ForkIDHandshakeCheck, validate_forkid
 from .payloads import StatusV63Payload, StatusPayload
-from .proto import ETHProtocolV63, ETHProtocol
+from .proto import ETHProtocolV63, ETHProtocolV65
 
 
 THandshakeParams = TypeVar("THandshakeParams", bound=Union[StatusPayload, StatusV63Payload])
@@ -124,8 +124,8 @@ class ETHV63Handshaker(Handshaker[ETHProtocolV63]):
         return receipt
 
 
-class ETHHandshaker(Handshaker[ETHProtocol]):
-    protocol_class = ETHProtocol
+class ETHHandshaker(Handshaker[ETHProtocolV65]):
+    protocol_class = ETHProtocolV65
 
     def __init__(self,
                  handshake_params: StatusPayload,
@@ -137,7 +137,7 @@ class ETHHandshaker(Handshaker[ETHProtocol]):
 
     async def do_handshake(self,
                            multiplexer: MultiplexerAPI,
-                           protocol: ETHProtocol) -> ETHHandshakeReceipt:
+                           protocol: ETHProtocolV65) -> ETHHandshakeReceipt:
         """
         Perform the handshake for the sub-protocol agreed with the remote peer.
 

--- a/trinity/protocol/eth/peer.py
+++ b/trinity/protocol/eth/peer.py
@@ -70,7 +70,7 @@ from .events import (
     SendTransactionsEvent,
 )
 from .payloads import StatusV63Payload, StatusPayload
-from .proto import ETHProtocolV63, ETHProtocol, ETHProtocolV64
+from .proto import ETHProtocolV63, ETHProtocolV64, ETHProtocolV65
 from .proxy import ProxyETHAPI
 from .handshaker import ETHV63Handshaker, ETHHandshaker
 
@@ -78,8 +78,8 @@ from .handshaker import ETHV63Handshaker, ETHHandshaker
 class ETHPeer(BaseChainPeer):
     max_headers_fetch = MAX_HEADERS_FETCH
 
-    supported_sub_protocols = (ETHProtocolV63, ETHProtocolV64, ETHProtocol)
-    sub_proto: ETHProtocol = None
+    supported_sub_protocols = (ETHProtocolV63, ETHProtocolV64, ETHProtocolV65)
+    sub_proto: ETHProtocolV65 = None
 
     def get_behaviors(self) -> Tuple[BehaviorAPI, ...]:
         return super().get_behaviors() + (
@@ -94,7 +94,7 @@ class ETHPeer(BaseChainPeer):
             return self.connection.get_logic(ETHV63API.name, ETHV63API)
         if self.connection.has_protocol(ETHProtocolV64):
             return self.connection.get_logic(ETHV64API.name, ETHV64API)
-        elif self.connection.has_protocol(ETHProtocol):
+        elif self.connection.has_protocol(ETHProtocolV65):
             return self.connection.get_logic(ETHAPI.name, ETHAPI)
         else:
             raise Exception("Unreachable code")
@@ -161,7 +161,7 @@ class ETHPeerFactory(BaseChainPeerFactory):
             total_difficulty=total_difficulty,
             genesis_hash=genesis_hash,
             network_id=self.context.network_id,
-            version=ETHProtocol.version,
+            version=ETHProtocolV65.version,
             fork_id=our_forkid
         )
 

--- a/trinity/protocol/eth/peer.py
+++ b/trinity/protocol/eth/peer.py
@@ -34,7 +34,7 @@ from trinity.protocol.common.typing import (
 )
 from . import forkid
 
-from .api import ETHV63API, ETHAPI, AnyETHAPI, ETHV64API
+from .api import ETHV63API, ETHV65API, AnyETHAPI, ETHV64API
 from .commands import (
     GetBlockHeaders,
     GetBlockBodies,
@@ -85,7 +85,7 @@ class ETHPeer(BaseChainPeer):
         return super().get_behaviors() + (
             ETHV63API().as_behavior(),
             ETHV64API().as_behavior(),
-            ETHAPI().as_behavior()
+            ETHV65API().as_behavior()
         )
 
     @cached_property
@@ -95,7 +95,7 @@ class ETHPeer(BaseChainPeer):
         if self.connection.has_protocol(ETHProtocolV64):
             return self.connection.get_logic(ETHV64API.name, ETHV64API)
         elif self.connection.has_protocol(ETHProtocolV65):
-            return self.connection.get_logic(ETHAPI.name, ETHAPI)
+            return self.connection.get_logic(ETHV65API.name, ETHV65API)
         else:
             raise Exception("Unreachable code")
 

--- a/trinity/protocol/eth/peer.py
+++ b/trinity/protocol/eth/peer.py
@@ -78,11 +78,15 @@ from .handshaker import ETHV63Handshaker, ETHHandshaker
 class ETHPeer(BaseChainPeer):
     max_headers_fetch = MAX_HEADERS_FETCH
 
-    supported_sub_protocols = (ETHProtocolV63, ETHProtocol)
+    supported_sub_protocols = (ETHProtocolV63, ETHProtocolV64, ETHProtocol)
     sub_proto: ETHProtocol = None
 
     def get_behaviors(self) -> Tuple[BehaviorAPI, ...]:
-        return super().get_behaviors() + (ETHV63API().as_behavior(), ETHAPI().as_behavior())
+        return super().get_behaviors() + (
+            ETHV63API().as_behavior(),
+            ETHV64API().as_behavior(),
+            ETHAPI().as_behavior()
+        )
 
     @cached_property
     def eth_api(self) -> AnyETHAPI:

--- a/trinity/protocol/eth/proto.py
+++ b/trinity/protocol/eth/proto.py
@@ -72,7 +72,7 @@ class ETHProtocolV64(BaseETHProtocol):
     status_command_type = Status
 
 
-class ETHProtocol(BaseETHProtocol):
+class ETHProtocolV65(BaseETHProtocol):
     version = 65
     commands = (
         Status,

--- a/trinity/tools/factories/__init__.py
+++ b/trinity/tools/factories/__init__.py
@@ -17,6 +17,7 @@ from .eth.proto import (  # noqa: F401
     ETHHandshakerFactory,
     ETHPeerPairFactory,
     ETHV63PeerPairFactory,
+    ETHV64PeerPairFactory,
 )
 from .headers import BlockHeaderFactory  # noqa: F401
 from .receipts import ReceiptFactory  # noqa: F401

--- a/trinity/tools/factories/eth/payloads.py
+++ b/trinity/tools/factories/eth/payloads.py
@@ -23,7 +23,7 @@ from trinity.protocol.eth.payloads import (
     BlockFields,
     StatusPayload,
 )
-from trinity.protocol.eth.proto import ETHProtocolV63, ETHProtocol
+from trinity.protocol.eth.proto import ETHProtocolV63, ETHProtocolV65
 
 from trinity.tools.factories.block_hash import BlockHashFactory
 from trinity.tools.factories.headers import BlockHeaderFactory
@@ -57,7 +57,7 @@ class StatusPayloadFactory(factory.Factory):
     class Meta:
         model = StatusPayload
 
-    version = ETHProtocol.version
+    version = ETHProtocolV65.version
     network_id = MAINNET_NETWORK_ID
     total_difficulty = 1
     head_hash = factory.SubFactory(BlockHashFactory)

--- a/trinity/tools/factories/eth/proto.py
+++ b/trinity/tools/factories/eth/proto.py
@@ -1,5 +1,5 @@
 from p2p.abc import HandshakerAPI
-from trinity.protocol.eth.proto import ETHProtocolV63
+from trinity.protocol.eth.proto import ETHProtocolV63, ETHProtocolV64
 
 try:
     import factory
@@ -11,7 +11,7 @@ from typing import (
     AsyncContextManager,
     Tuple,
     Any,
-)
+    Type)
 
 from lahja import EndpointAPI
 
@@ -57,47 +57,27 @@ class ETHV63PeerFactory(ETHPeerFactory):
         )
 
 
-def ETHV63PeerPairFactory(*,
-                          alice_peer_context: ChainContext = None,
-                          alice_remote: kademlia.Node = None,
-                          alice_private_key: keys.PrivateKey = None,
-                          alice_client_version: str = 'alice',
-                          bob_peer_context: ChainContext = None,
-                          bob_remote: kademlia.Node = None,
-                          bob_private_key: keys.PrivateKey = None,
-                          bob_client_version: str = 'bob',
-                          cancel_token: CancelToken = None,
-                          event_bus: EndpointAPI = None,
-                          ) -> AsyncContextManager[Tuple[ETHPeer, ETHPeer]]:
-    if alice_peer_context is None:
-        alice_peer_context = ChainContextFactory()
-
-    if bob_peer_context is None:
-        alice_genesis = alice_peer_context.headerdb.get_canonical_block_header_by_number(
-            BlockNumber(GENESIS_BLOCK_NUMBER),
-        )
-        bob_peer_context = ChainContextFactory(
-            headerdb__genesis_params={'timestamp': alice_genesis.timestamp},
-        )
-
-    return cast(AsyncContextManager[Tuple[ETHPeer, ETHPeer]], PeerPairFactory(
-        alice_peer_context=alice_peer_context,
-        alice_peer_factory_class=ETHV63PeerFactory,
-        bob_peer_context=bob_peer_context,
-        bob_peer_factory_class=ETHV63PeerFactory,
-        alice_remote=alice_remote,
-        alice_private_key=alice_private_key,
-        alice_client_version=alice_client_version,
-        bob_remote=bob_remote,
-        bob_private_key=bob_private_key,
-        bob_client_version=bob_client_version,
-        cancel_token=cancel_token,
-        event_bus=event_bus,
-    ))
+class ETHV64Handshaker(ETHHandshaker):
+    protocol_class = ETHProtocolV64  # type: ignore
 
 
-def ETHPeerPairFactory(*,
-                       alice_peer_context: ChainContext = None,
+class ETHV64Peer(ETHPeer):
+    supported_sub_protocols = (ETHProtocolV64,)  # type: ignore
+
+
+class ETHV64PeerFactory(ETHPeerFactory):
+    peer_class = ETHV64Peer
+
+    async def get_handshakers(self) -> Tuple[HandshakerAPI[Any], ...]:
+        latest_protocol = (await super().get_handshakers())[-1]
+        # The handshaker reports the latest ETH protocol version that Trinity supports which is
+        # higher than what we want to simulate. We manually set it to a lower version to simulate
+        # a client where ETH/64 is the highest supported protocol.
+        latest_protocol.protocol_class = ETHProtocolV64
+        return (latest_protocol,)
+
+
+def ETHPeerPairFactory(alice_peer_context: ChainContext = None,
                        alice_remote: kademlia.Node = None,
                        alice_private_key: keys.PrivateKey = None,
                        alice_client_version: str = 'alice',
@@ -107,6 +87,7 @@ def ETHPeerPairFactory(*,
                        bob_client_version: str = 'bob',
                        cancel_token: CancelToken = None,
                        event_bus: EndpointAPI = None,
+                       peer_factory_class: Type[ETHPeerFactory] = ETHPeerFactory,
                        ) -> AsyncContextManager[Tuple[ETHPeer, ETHPeer]]:
     if alice_peer_context is None:
         alice_peer_context = ChainContextFactory()
@@ -121,9 +102,9 @@ def ETHPeerPairFactory(*,
 
     return cast(AsyncContextManager[Tuple[ETHPeer, ETHPeer]], PeerPairFactory(
         alice_peer_context=alice_peer_context,
-        alice_peer_factory_class=ETHPeerFactory,
+        alice_peer_factory_class=peer_factory_class,
         bob_peer_context=bob_peer_context,
-        bob_peer_factory_class=ETHPeerFactory,
+        bob_peer_factory_class=peer_factory_class,
         alice_remote=alice_remote,
         alice_private_key=alice_private_key,
         alice_client_version=alice_client_version,
@@ -133,3 +114,59 @@ def ETHPeerPairFactory(*,
         cancel_token=cancel_token,
         event_bus=event_bus,
     ))
+
+
+def ETHV63PeerPairFactory(*,
+                          alice_peer_context: ChainContext = None,
+                          alice_remote: kademlia.Node = None,
+                          alice_private_key: keys.PrivateKey = None,
+                          alice_client_version: str = 'alice',
+                          bob_peer_context: ChainContext = None,
+                          bob_remote: kademlia.Node = None,
+                          bob_private_key: keys.PrivateKey = None,
+                          bob_client_version: str = 'bob',
+                          cancel_token: CancelToken = None,
+                          event_bus: EndpointAPI = None,
+                          peer_factory_class: Type[ETHPeerFactory] = ETHV63PeerFactory,
+                          ) -> AsyncContextManager[Tuple[ETHPeer, ETHPeer]]:
+    return ETHPeerPairFactory(
+        alice_peer_context=alice_peer_context,
+        alice_remote=alice_remote,
+        alice_private_key=alice_private_key,
+        alice_client_version=alice_client_version,
+        bob_peer_context=bob_peer_context,
+        bob_remote=bob_remote,
+        bob_private_key=bob_private_key,
+        bob_client_version=bob_client_version,
+        cancel_token=cancel_token,
+        event_bus=event_bus,
+        peer_factory_class=peer_factory_class
+    )
+
+
+def ETHV64PeerPairFactory(*,
+                          alice_peer_context: ChainContext = None,
+                          alice_remote: kademlia.Node = None,
+                          alice_private_key: keys.PrivateKey = None,
+                          alice_client_version: str = 'alice',
+                          bob_peer_context: ChainContext = None,
+                          bob_remote: kademlia.Node = None,
+                          bob_private_key: keys.PrivateKey = None,
+                          bob_client_version: str = 'bob',
+                          cancel_token: CancelToken = None,
+                          event_bus: EndpointAPI = None,
+                          peer_factory_class: Type[ETHPeerFactory] = ETHV64PeerFactory,
+                          ) -> AsyncContextManager[Tuple[ETHPeer, ETHPeer]]:
+    return ETHPeerPairFactory(
+        alice_peer_context=alice_peer_context,
+        alice_remote=alice_remote,
+        alice_private_key=alice_private_key,
+        alice_client_version=alice_client_version,
+        bob_peer_context=bob_peer_context,
+        bob_remote=bob_remote,
+        bob_private_key=bob_private_key,
+        bob_client_version=bob_client_version,
+        cancel_token=cancel_token,
+        event_bus=event_bus,
+        peer_factory_class=peer_factory_class
+    )


### PR DESCRIPTION
### What was wrong?

Turns out as I added support for `eth/65` recently, I accidentally broke support for `eth/64`. 

### How was it fixed?

- Added `ETHProtocolV64` to `supported_sub_protocols` on `ETHPeer`
- Added `ETHV64API` to `get_behaviors`
- Created `ETHV64PeerPairFactory` and added it to the parameters of `test_eth_api` so that we have test coverage. 

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

[//]: # (See: https://trinity-client.readthedocs.io/en/latest/contributing.html#pull-requests)
- [x]  No need for release notes as the bug was never released

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://english.newstrack.com/wp-content/uploads/2017/07/Tiger_2017.gif)
