### PR TITLE
Write reusable PayloadNormalizer to make code more DRY

### DIFF
--- a/p2p/exchange/normalizers.py
+++ b/p2p/exchange/normalizers.py
@@ -1,6 +1,29 @@
+from typing import Type
+
 from .abc import NormalizerAPI
 from .typing import TResponseCommand, TResult
 
 
 class BaseNormalizer(NormalizerAPI[TResponseCommand, TResult]):
     is_normalization_slow = False
+
+
+class PayloadNormalizer(NormalizerAPI[TResponseCommand, TResult]):
+    """
+    A normalizer that directly delegates to the payload of the response command.
+    """
+
+    def __init__(self,
+                 command_type: Type[TResponseCommand],
+                 payload_type: Type[TResult],
+                 is_normalization_slow: bool = False):
+        self.is_normalization_slow = is_normalization_slow
+
+        # The constructor allows mypy to defer typehints automatically from something like:
+        # normalizer = DefaultNormalizer(BlockHeadersV66, Tuple[BlockHeaderAPI, ...])
+        # instead of the slightly longer form:
+        # normalizer: DefaultNormalizer[BlockHeadersV66, Tuple[BlockHeaderAPI, ...]] = DefaultNormalizer() # noqa: E501
+
+    @staticmethod
+    def normalize_result(cmd: TResponseCommand) -> TResult:
+        return cmd.payload

--- a/trinity/protocol/eth/exchanges.py
+++ b/trinity/protocol/eth/exchanges.py
@@ -13,6 +13,7 @@ from p2p.exchange import (
     BaseExchange,
     noop_payload_validator,
 )
+from p2p.exchange.normalizers import PayloadNormalizer
 from trinity.protocol.common.payloads import (
     BlockHeadersQuery,
 )
@@ -35,11 +36,9 @@ from .commands import (
     PooledTransactions,
 )
 from .normalizers import (
-    BlockHeadersNormalizer,
     GetBlockBodiesNormalizer,
     GetNodeDataNormalizer,
     ReceiptsNormalizer,
-    GetPooledTransactionsNormalizer,
 )
 from .trackers import (
     GetBlockHeadersTracker,
@@ -64,7 +63,7 @@ BaseGetBlockHeadersExchange = BaseExchange[
 
 
 class GetBlockHeadersExchange(BaseGetBlockHeadersExchange):
-    _normalizer = BlockHeadersNormalizer()
+    _normalizer = PayloadNormalizer(BlockHeaders, Tuple[BlockHeaderAPI, ...])
     tracker_class = GetBlockHeadersTracker
 
     _request_command_type = GetBlockHeaders
@@ -178,7 +177,7 @@ BasePooledTransactionsExchange = BaseExchange[
 
 
 class GetPooledTransactionsExchange(BasePooledTransactionsExchange):
-    _normalizer = GetPooledTransactionsNormalizer()
+    _normalizer = PayloadNormalizer(PooledTransactions, Tuple[SignedTransactionAPI, ...])
     tracker_class = GetPooledTransactionsTracker
 
     _request_command_type = GetPooledTransactions

--- a/trinity/protocol/eth/normalizers.py
+++ b/trinity/protocol/eth/normalizers.py
@@ -1,12 +1,11 @@
 from typing import (
     Iterable,
-    Tuple,
 )
 
 from eth_utils import (
     to_tuple,
 )
-from eth.abc import BlockHeaderAPI, UnsignedTransactionAPI
+
 from eth.db.trie import make_trie_root_and_nodes
 from eth_hash.auto import keccak
 import rlp
@@ -21,21 +20,10 @@ from trinity.protocol.common.typing import (
 )
 
 from .commands import (
-    BlockHeaders,
     BlockBodies,
     NodeData,
     Receipts,
-    PooledTransactions,
 )
-
-
-BaseBlockHeadersNormalizer = BaseNormalizer[BlockHeaders, Tuple[BlockHeaderAPI, ...]]
-
-
-class BlockHeadersNormalizer(BaseBlockHeadersNormalizer):
-    @staticmethod
-    def normalize_result(cmd: BlockHeaders) -> Tuple[BlockHeaderAPI, ...]:
-        return cmd.payload
 
 
 class GetNodeDataNormalizer(BaseNormalizer[NodeData, NodeDataBundles]):
@@ -67,16 +55,3 @@ class GetBlockBodiesNormalizer(BaseNormalizer[BlockBodies, BlockBodyBundles]):
             uncle_hashes = keccak(rlp.encode(body.uncles))
             transaction_root_and_nodes = make_trie_root_and_nodes(body.transactions)
             yield body, transaction_root_and_nodes, uncle_hashes
-
-
-BaseGetPooledTransactionsNormalizer = BaseNormalizer[
-    PooledTransactions,
-    Tuple[UnsignedTransactionAPI, ...]
-]
-
-
-class GetPooledTransactionsNormalizer(BaseGetPooledTransactionsNormalizer):
-    @staticmethod
-    def normalize_result(
-            cmd: PooledTransactions) -> Tuple[UnsignedTransactionAPI, ...]:
-        return cmd.payload


### PR DESCRIPTION
### What was wrong?

While working on `eth/66` I noticed we have to create the same kind of normalizer over and over just with different type hints.

### How was it fixed?

Created an reusable `PayloadNormalizer` that will simply normalize to the `payload` property of the result command.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

[//]: # (See: https://trinity-client.readthedocs.io/en/latest/contributing.html#pull-requests)
- [ ] Add entry to the [release notes](https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://www.nationalgeographic.com/content/dam/animals/2018/09/comedy-wildlife-awards-photos/comedy-wildlife-awards-squirel-stop.ngsversion.1537203605960.adapt.1900.1.jpg)
