### PR TITLE
Fix bug for non-linux machines when sync with metrics enabled

### DIFF
--- a/newsfragments/1662.bugfix.rst
+++ b/newsfragments/1662.bugfix.rst
@@ -1,1 +1,0 @@
-Fix sync bug on non-linux machines when metrics are enabled.

--- a/newsfragments/1662.bugfix.rst
+++ b/newsfragments/1662.bugfix.rst
@@ -1,0 +1,1 @@
+Fix sync bug on non-linux machines when metrics are enabled.

--- a/trinity/components/builtin/metrics/system_metrics_collector.py
+++ b/trinity/components/builtin/metrics/system_metrics_collector.py
@@ -49,9 +49,14 @@ class SystemStats(NamedTuple):
 
 def read_cpu_stats() -> CpuStats:
     stats = psutil.cpu_times()
+    try:
+        # iowait is only available with linux
+        wait = stats.iowait
+    except AttributeError:
+        wait = 0
     return CpuStats(
         global_time=int(stats.user + stats.nice + stats.system),
-        global_wait_io=int(stats.iowait),
+        global_wait_io=int(wait),
     )
 
 

--- a/trinity/components/builtin/metrics/system_metrics_collector.py
+++ b/trinity/components/builtin/metrics/system_metrics_collector.py
@@ -51,12 +51,12 @@ def read_cpu_stats() -> CpuStats:
     stats = psutil.cpu_times()
     try:
         # iowait is only available with linux
-        wait = stats.iowait
+        iowait = stats.iowait
     except AttributeError:
-        wait = 0
+        iowait = 0
     return CpuStats(
         global_time=int(stats.user + stats.nice + stats.system),
-        global_wait_io=int(wait),
+        global_wait_io=int(iowait),
     )
 
 


### PR DESCRIPTION
### What was wrong?
Syncing with the `--enable-metrics` flag breaks on non-linux machines. The `iowait` attribute is only [supported on linux](https://psutil.readthedocs.io/en/latest/#cpu). 


### How was it fixed?
Added an `AttributeError` catch, and if attribute is unavailable, the `wait` value defaults to 0.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

[//]: # (See: https://trinity-client.readthedocs.io/en/latest/contributing.html#pull-requests)
- [x] Add entry to the [release notes](https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

#### Cute Animal Picture
![image](https://user-images.githubusercontent.com/9753150/78831111-b5d30f80-79ae-11ea-8699-daecf13a86bf.png)
