### PR TITLE
Every component's process is now its own process group leader

### DIFF
--- a/tests/integration/test_trinity_cli.py
+++ b/tests/integration/test_trinity_cli.py
@@ -40,6 +40,11 @@ MAINNET_GENESIS_HASH = '0xd4e56740f876aef8c010b86a40d5f56745a118d0906a34e69aec8c
 #         assert await contains_all(runner.stdout, {'bytes from'})
 
 
+@pytest.fixture(autouse=True)
+def single_process_group(monkeypatch):
+    monkeypatch.setenv('TRINITY_SINGLE_PROCESS_GROUP', 1)
+
+
 def amend_command_for_unused_port(command, unused_tcp_port):
     # use a random port each time, in case a previous run went awry and left behind a
     # trinity instance

--- a/trinity/extensibility/trio.py
+++ b/trinity/extensibility/trio.py
@@ -31,6 +31,8 @@ class TrioIsolatedComponent(BaseIsolatedComponent):
         - _do_run -> do_run
             * sets up event bus and then enters user function.
         """
+        # FIXME: Use subprocess.Popen() so that we can make every process be its own process group
+        # leader, like in AsyncioIsolatedComponent.
         process = ctx.Process(
             target=self.run_process,
             args=(self._boot_info,),

--- a/trinity/tools/_component_isolation.py
+++ b/trinity/tools/_component_isolation.py
@@ -11,6 +11,8 @@ from async_service import Service
 from async_service import background_asyncio_service
 from asyncio_run_in_process.typing import SubprocessKwargs
 
+from eth_utils.toolz import merge
+
 from lahja import EndpointAPI, BaseEvent
 
 from trinity.boot_info import BootInfo
@@ -48,11 +50,14 @@ class AsyncioComponentForTest(AsyncioIsolatedComponent):
     logger = logging.getLogger('trinity.testing.ComponentForTest')
 
     def get_subprocess_kwargs(self) -> SubprocessKwargs:
-        return {
-            'stdin': subprocess.PIPE,
-            'stdout': subprocess.PIPE,
-            'stderr': subprocess.PIPE,
-        }
+        return merge(
+            super().get_subprocess_kwargs(),
+            {
+                'stdin': subprocess.PIPE,
+                'stdout': subprocess.PIPE,
+                'stderr': subprocess.PIPE,
+            }
+        )
 
     @property
     def is_enabled(self) -> bool:

--- a/trinity/tools/async_process_runner.py
+++ b/trinity/tools/async_process_runner.py
@@ -15,6 +15,8 @@ from async_timeout import timeout
 
 
 class AsyncProcessRunner():
+    # Note: This relies on trinity using a single process group for all its sub processes, which
+    # is achieved by setting the env var TRINITY_SINGLE_PROCESS_GROUP=1.
     logger = logging.getLogger("trinity.tools.async_process_runner.AsyncProcessRunner")
     proc: asyncio.subprocess.Process
 


### PR DESCRIPTION
IOW, for every process we start, we create a new process group.
This way a Ctrl-C in the terminal won't cause a SIGINT to be sent
to each of our processes, instead a single one will be sent to the
parent process, which will then send SIGINTs to every child (via
asyncio-run-in-process' open_in_process()).

Turns out our integration [tests rely on all processes belonging to a single process group so that they can be correctly terminated](https://github.com/ethereum/trinity/blob/5937306437735be2bcea5c6e054101299a994a24/trinity/tools/async_process_runner.py#L69-L73) between tests, so I had to add this new env var to control whether or not to use separate process groups.