### PR TITLE
Update make create docker image context directory

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -84,7 +84,7 @@ release: clean
 	git config commit.gpgSign "$(CURRENT_SIGN_SETTING)"
 
 create-docker-image: clean
-	docker build -t ethereum/trinity:latest -t ethereum/trinity:$(version) -f ./docker/Dockerfile ./docker
+	docker build -t ethereum/trinity:latest -t ethereum/trinity:$(version) -f ./docker/Dockerfile .
 
 create-dappnode-image: clean
 	sed -i -e 's/ARG GITREF=\w*/ARG GITREF=$(trinity_version)/g' ./dappnode/build/Dockerfile


### PR DESCRIPTION
### What was wrong?
`make create-docker-image` command uses the wrong directory (`./docker`) for context to build the image. The make command `COPY . /usr/src/app` would only copy the two dockerfiles inside `./docker` - so there was no `setup.py` / application for pip to install. 

### How was it fixed?
Updated the context directory from `./docker` to `./`.  Mirrors how the `docker build` command is used in the [circle ci config](https://github.com/ethereum/trinity/blob/master/.circleci/config.yml#L386). 

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

[//]: # (See: https://trinity-client.readthedocs.io/en/latest/contributing.html#pull-requests)
- [ ] Add entry to the [release notes](https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![image](https://user-images.githubusercontent.com/9753150/79081767-f6e85e00-7ce5-11ea-80ae-545257db7b53.png)

