### PR TITLE
Remove support for Python 3.6

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -113,24 +113,12 @@ eth2_fixtures: &eth2_fixtures
           - ./eth2-fixtures
         key: cache-v3-{{ arch }}-{{ .Environment.CIRCLE_JOB }}-{{ checksum "setup.py" }}-{{ checksum "tox.ini" }}-{{ checksum "./.circleci/get_eth2_fixtures.sh" }}-{{ checksum "./.circleci/build_geth.sh" }}
 jobs:
-  py36-lint:
-    <<: *common
-    docker:
-      - image: circleci/python:3.6
-        environment:
-          TOXENV: py36-lint
   py37-lint:
     <<: *common
     docker:
       - image: circleci/python:3.7
         environment:
           TOXENV: py37-lint
-  py36-lint-eth2:
-    <<: *common
-    docker:
-      - image: circleci/python:3.6
-        environment:
-          TOXENV: py36-lint-eth2
   py37-lint-eth2:
     <<: *common
     docker:
@@ -138,148 +126,82 @@ jobs:
         environment:
           TOXENV: py37-lint-eth2
 
-  py36-docs:
+  py37-docs:
     <<: *common
     docker:
-      - image: circleci/python:3.6
+      - image: circleci/python:3.7
         environment:
-          TOXENV: py36-docs
+          TOXENV: py37-docs
 
-  py36-rpc-state-byzantium:
+  py37-rpc-state-byzantium:
     <<: *common
     docker:
-      - image: circleci/python:3.6
+      - image: circleci/python:3.7
         environment:
-          TOXENV: py36-rpc-state-byzantium
-  py36-rpc-state-constantinople:
+          TOXENV: py37-rpc-state-byzantium
+  py37-rpc-state-constantinople:
     <<: *common
     docker:
-      - image: circleci/python:3.6
+      - image: circleci/python:3.7
         environment:
-          TOXENV: py36-rpc-state-constantinople
-  py36-rpc-state-frontier:
+          TOXENV: py37-rpc-state-constantinople
+  py37-rpc-state-frontier:
     <<: *common
     docker:
-      - image: circleci/python:3.6
+      - image: circleci/python:3.7
         environment:
-          TOXENV: py36-rpc-state-frontier
-  py36-rpc-state-homestead:
+          TOXENV: py37-rpc-state-frontier
+  py37-rpc-state-homestead:
     <<: *common
     docker:
-      - image: circleci/python:3.6
+      - image: circleci/python:3.7
         environment:
-          TOXENV: py36-rpc-state-homestead
-  py36-rpc-state-istanbul:
+          TOXENV: py37-rpc-state-homestead
+  py37-rpc-state-istanbul:
     <<: *common
     docker:
-      - image: circleci/python:3.6
+      - image: circleci/python:3.7
         environment:
-          TOXENV: py36-rpc-state-istanbul
-  py36-rpc-state-petersburg:
+          TOXENV: py37-rpc-state-istanbul
+  py37-rpc-state-petersburg:
     <<: *common
     docker:
-      - image: circleci/python:3.6
+      - image: circleci/python:3.7
         environment:
-          TOXENV: py36-rpc-state-petersburg
+          TOXENV: py37-rpc-state-petersburg
 
-  py36-rpc-state-tangerine_whistle:
+  py37-rpc-state-tangerine_whistle:
     <<: *common
     docker:
-      - image: circleci/python:3.6
+      - image: circleci/python:3.7
         environment:
-          TOXENV: py36-rpc-state-tangerine_whistle
-  py36-rpc-state-spurious_dragon:
+          TOXENV: py37-rpc-state-tangerine_whistle
+  py37-rpc-state-spurious_dragon:
     <<: *common
     docker:
-      - image: circleci/python:3.6
+      - image: circleci/python:3.7
         environment:
-          TOXENV: py36-rpc-state-spurious_dragon
-  py36-rpc-blockchain:
+          TOXENV: py37-rpc-state-spurious_dragon
+  py37-rpc-blockchain:
     <<: *common
     docker:
-      - image: circleci/python:3.6
+      - image: circleci/python:3.7
         environment:
-          TOXENV: py36-rpc-blockchain
+          TOXENV: py37-rpc-blockchain
 
-  py36-eth1-core:
-    <<: *common
-    docker:
-      - image: circleci/python:3.6
-        environment:
-          TOXENV: py36-eth1-core
-  py36-integration:
-    <<: *common
-    docker:
-      - image: circleci/python:3.6
-        environment:
-          TOXENV: py36-integration
-  py36-lightchain_integration:
+  py37-lightchain_integration:
     <<: *geth_steps
     docker:
-      - image: circleci/python:3.6
+      - image: circleci/python:3.7
         environment:
-          TOXENV: py36-lightchain_integration
+          TOXENV: py37-lightchain_integration
           GETH_VERSION: v1.8.22
-  py36-long_run_integration:
+  py37-long_run_integration:
     <<: *common
     docker:
-      - image: circleci/python:3.6
+      - image: circleci/python:3.7
         environment:
-          TOXENV: py36-long_run_integration
-  py36-p2p:
-    <<: *common
-    docker:
-      - image: circleci/python:3.6
-        environment:
-          TOXENV: py36-p2p
-  py36-p2p-trio:
-    <<: *common
-    docker:
-      - image: circleci/python:3.6
-        environment:
-          TOXENV: py36-p2p-trio
-  py36-eth2-core:
-    <<: *common
-    docker:
-      - image: circleci/python:3.6
-        environment:
-          TOXENV: py36-eth2-core
-  py36-eth2-utils:
-    <<: *common
-    docker:
-      - image: circleci/python:3.6
-        environment:
-          TOXENV: py36-eth2-utils
-  py36-eth2-fixtures:
-    <<: *eth2_fixtures
-    docker:
-      - image: circleci/python:3.6
-        environment:
-          TOXENV: py36-eth2-fixtures
-  py36-eth2-integration:
-    <<: *common
-    docker:
-      - image: circleci/python:3.6
-        environment:
-          TOXENV: py36-eth2-integration
-  py36-wheel-cli:
-    <<: *common
-    docker:
-      - image: circleci/python:3.6
-        environment:
-          TOXENV: py36-wheel-cli
-  py36-eth1-components:
-    <<: *common
-    docker:
-      - image: circleci/python:3.6
-        environment:
-          TOXENV: py36-eth1-components
-  py36-eth2-trio:
-    <<: *common
-    docker:
-      - image: circleci/python:3.6
-        environment:
-          TOXENV: py36-eth2-trio
+          TOXENV: py37-long_run_integration
 
   py37-rpc-state-quadratic:
     <<: *common
@@ -398,16 +320,14 @@ workflows:
   test:
     jobs:
       # These tests are long, so should be started first to optimize for total suite run time
-      - py36-integration
-      - py36-wheel-cli
+      - py37-integration
       - py37-wheel-cli
-      - py36-long_run_integration
+      - py37-long_run_integration
       - py37-rpc-state-sstore
-      - py36-eth2-core
       - py37-eth2-core
       - py37-libp2p
 
-      - py36-docs
+      - py37-docs
 
       - py37-eth1-core
       - py37-p2p
@@ -422,28 +342,17 @@ workflows:
       - py37-rpc-state-quadratic
       - py37-rpc-state-zero_knowledge
 
-      - py36-rpc-state-byzantium
-      - py36-rpc-state-constantinople
-      - py36-rpc-state-frontier
-      - py36-rpc-state-homestead
-      - py36-rpc-state-petersburg
-      - py36-rpc-state-spurious_dragon
-      - py36-rpc-state-tangerine_whistle
-      - py36-rpc-blockchain
+      - py37-rpc-state-byzantium
+      - py37-rpc-state-constantinople
+      - py37-rpc-state-frontier
+      - py37-rpc-state-homestead
+      - py37-rpc-state-petersburg
+      - py37-rpc-state-spurious_dragon
+      - py37-rpc-state-tangerine_whistle
+      - py37-rpc-blockchain
 
-      - py36-eth1-core
-      - py36-p2p
-      - py36-p2p-trio
-      - py36-eth2-utils
-      - py36-eth2-fixtures
-      - py36-eth2-integration
-      - py36-eth1-components
-      - py36-eth2-trio
+      - py37-lightchain_integration
 
-      - py36-lightchain_integration
-
-      - py36-lint
-      - py36-lint-eth2
       - py37-lint
       - py37-lint-eth2
 

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -3,7 +3,7 @@ version: 2
 build:
   image: latest
 python:
-  version: 3.6
+  version: 3.7
   install:
     - method: pip
       path: .

--- a/docs/guides/quickstart.rst
+++ b/docs/guides/quickstart.rst
@@ -12,8 +12,8 @@ To develop on top of Trinity or to contribute to the project, check out the
 Installing on Ubuntu
 --------------------
 
-Trinity requires Python 3.6 as well as some tools to compile its dependencies. On Ubuntu, the
-``python3.6-dev`` package contains everything we need. Run the following command to install it.
+Trinity requires Python 3.7 as well as some tools to compile its dependencies. On Ubuntu, the
+``python3.7-dev`` package contains everything we need. Run the following command to install it.
 
 .. code:: sh
 

--- a/newsfragments/1675.removal.rst
+++ b/newsfragments/1675.removal.rst
@@ -1,0 +1,1 @@
+Drop support for Python 3.6 making Python 3.7 the minimal supported Python version.

--- a/setup.py
+++ b/setup.py
@@ -188,7 +188,7 @@ setup(
     url='https://github.com/ethereum/trinity',
     include_package_data=True,
     py_modules=['trinity', 'p2p', 'eth2'],
-    python_requires=">=3.6,<4",
+    python_requires=">=3.7,<4",
     install_requires=install_requires,
     extras_require=deps,
     license='MIT',
@@ -200,7 +200,7 @@ setup(
         'Intended Audience :: Developers',
         'License :: OSI Approved :: MIT License',
         'Natural Language :: English',
-        'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
     ],
     # trinity
     entry_points={

--- a/tox.ini
+++ b/tox.ini
@@ -1,15 +1,15 @@
 [tox]
 envlist=
-    py{36,37}-{eth1-core,p2p,p2p-trio,integration,lightchain_integration,eth2-core,eth2-fixtures,eth2-integration,eth1-components,eth2-utils,eth2-trio}
-    py36-long_run_integration
-    py36-rpc-blockchain
-    py36-rpc-state-{frontier,homestead,tangerine_whistle,spurious_dragon,byzantium,constantinople,petersburg,istanbul}
+    py{37}-{eth1-core,p2p,p2p-trio,integration,lightchain_integration,eth2-core,eth2-fixtures,eth2-integration,eth1-components,eth2-utils,eth2-trio}
+    py37-long_run_integration
+    py37-rpc-blockchain
+    py37-rpc-state-{frontier,homestead,tangerine_whistle,spurious_dragon,byzantium,constantinople,petersburg,istanbul}
     py37-rpc-state-{quadratic,sstore,zero_knowledge}
     py37-{libp2p,eth2-components}
-    py{36,37}-lint
-    py{36,37}-lint-eth2
-    py{36,37}-wheel-cli
-    py36-docs
+    py{37}-lint
+    py{37}-lint-eth2
+    py{37}-wheel-cli
+    py37-docs
 
 [flake8]
 max-line-length= 100
@@ -60,26 +60,17 @@ commands=
 deps = .[p2p,trinity,eth2,test,test-asyncio]
 
 basepython =
-    py36: python3.6
     py37: python3.7
-
-[testenv:py36-p2p-trio]
-deps = .[p2p,test,test-trio]
-commands = pytest -n 4 {posargs:tests-trio/p2p-trio}
 
 [testenv:py37-p2p-trio]
 deps = .[p2p,test,test-trio]
 commands = pytest -n 4 {posargs:tests-trio/p2p-trio}
 
-[testenv:py36-eth2-trio]
-deps = .[eth2,trinity,test,test-trio]
-commands = pytest -n 4 {posargs:tests-trio/eth2}
-
 [testenv:py37-eth2-trio]
 deps = .[eth2,trinity,test,test-trio]
 commands = pytest -n 4 {posargs:tests-trio/eth2}
 
-[testenv:py36-docs]
+[testenv:py37-docs]
 whitelist_externals=
     make
 deps = .[p2p, trinity, eth2, doc]
@@ -104,13 +95,6 @@ commands=
     /bin/bash -c 'pip install --upgrade "$(ls dist/*.whl)""[p2p,trinity]" --progress-bar off'
     pytest {posargs:tests/integration/ -k 'trinity_cli' --log-cli-level 0}
 
-[testenv:py36-wheel-cli]
-deps = {[common-wheel-cli]deps}
-whitelist_externals = {[common-wheel-cli]whitelist_externals}
-commands = {[common-wheel-cli]commands}
-skip_install=true
-usedevelop=false
-
 [testenv:py37-wheel-cli]
 deps = {[common-wheel-cli]deps}
 whitelist_externals = {[common-wheel-cli]whitelist_externals}
@@ -131,17 +115,12 @@ commands=
     # The `trinity_cli` tests are already run by the pyxx-wheel-cli jobs. No need to repeat them here
     pytest --integration -n 1 {posargs:tests/integration/ -k 'not lightchain_integration and not trinity_cli'}
 
-[testenv:py36-integration]
-deps = {[common-integration]deps}
-passenv = {[common-integration]passenv}
-commands = {[common-integration]commands}
-
 [testenv:py37-integration]
 deps = {[common-integration]deps}
 passenv = {[common-integration]passenv}
 commands = {[common-integration]commands}
 
-[testenv:py36-long_run_integration]
+[testenv:py37-long_run_integration]
 deps = {[common-integration]deps}
 passenv = {[common-integration]passenv}
 commands =
@@ -176,11 +155,6 @@ commands=
     mypy -p p2p --config-file {toxinidir}/mypy.ini
 
 
-[testenv:py36-lint]
-deps = {[common-lint]deps}
-commands= {[common-lint]commands}
-
-
 [testenv:py37-lint]
 deps = {[common-lint]deps}
 commands= {[common-lint]commands}
@@ -193,10 +167,6 @@ commands=
     black --check eth2 trinity/components/eth2 tests/eth2 tests/libp2p tests/components/eth2 tests-trio/eth2
     isort --recursive --check-only eth2 trinity/components/eth2 tests/eth2 tests/libp2p tests/components/eth2 tests-trio/eth2
 
-[testenv:py36-lint-eth2]
-deps = {[common-lint-eth2]deps}
-commands= {[common-lint-eth2]commands}
-
 [testenv:py37-lint-eth2]
 deps = {[common-lint-eth2]deps}
 commands= {[common-lint-eth2]commands}
@@ -204,17 +174,8 @@ commands= {[common-lint-eth2]commands}
 [common-eth2-utils]
 deps = .[eth2,eth2-extra,test]
 
-[testenv:py36-eth2-utils]
-deps = {[common-eth2-utils]deps}
-
 [testenv:py37-eth2-utils]
 deps = {[common-eth2-utils]deps}
-
-[testenv:py36-eth2-fixtures]
-deps = .[eth2,eth2-extra,test]
-commands=
-    pytest -n 4 --config minimal {posargs:tests/eth2/fixtures/}
-    pytest -n 4 --config mainnet {posargs:tests/eth2/fixtures/}
 
 
 [testenv:py37-eth2-fixtures]

--- a/trinity/_utils/version.py
+++ b/trinity/_utils/version.py
@@ -9,7 +9,7 @@ def construct_trinity_client_identifier() -> str:
     """
     Constructs the client identifier string
 
-    e.g. 'Trinity/v1.2.3/darwin-amd64/python3.6.5'
+    e.g. 'Trinity/v1.2.3/darwin-amd64/python3.7.3'
     """
     return (
         "Trinity/"


### PR DESCRIPTION
### What was wrong?

Python 3.7 has been out for almost two years and continuing to support Python 3.6 is starting to feel unnecessary especially when we consider that the latest Ubuntu LTS ships with Python 3.8.

### How was it fixed?

Removed all Python 3.6 jobs from CI and adjusted some references in texts.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

[//]: # (See: https://trinity-client.readthedocs.io/en/latest/contributing.html#pull-requests)
- [x] Add entry to the [release notes](https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://cdn.hswstatic.com/gif/raccoons-wash-food-135558184.jpg)
