### PR TITLE
Reactivate test that ensures clean shutdowns

### DIFF
--- a/tests/integration/test_trinity_cli.py
+++ b/tests/integration/test_trinity_cli.py
@@ -352,15 +352,12 @@ async def test_logger_configuration(command,
 @pytest.mark.parametrize(
     'command',
     (
-        ('trinity', ),
+        # This should also cover beam sync but currently shutting down from beam sync causes errors.
+        ('trinity', '--sync-mode=full', ),
     )
 )
 @pytest.mark.asyncio
-# The test ensures Trinity shuts down without reporting any errors. It is currently skipped because
-# Trinity shuts down with errors *most* of the time but often enough shuts down cleanly. This leaves
-# us in a state where we can neither activate the test nor mark it as xfail.
-# See: https://github.com/ethereum/trinity/issues/1307
-@pytest.mark.skip("Currently unreliable")
+# The test ensures Trinity shuts down without reporting any errors.
 async def test_shutdown_does_not_throw_errors(command, unused_tcp_port):
 
     command = amend_command_for_unused_port(command, unused_tcp_port)


### PR DESCRIPTION
### What was wrong?

Now that we have clean shutdowns we need to fight for them to remain clean.

### How was it fixed?

Reactivate test that checks whether Trinity shuts down cleanly or not. This doesn't yet work for beam sync but seems to work fine for `full` sync.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

[//]: # (See: https://trinity-client.readthedocs.io/en/latest/contributing.html#pull-requests)
- [ ] Add entry to the [release notes](https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://i.ytimg.com/vi/v0Ma5UOhMIU/maxresdefault.jpg)
