### PR TITLE
Add support for Python 3.8

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -113,24 +113,12 @@ eth2_fixtures: &eth2_fixtures
           - ./eth2-fixtures
         key: cache-v3-{{ arch }}-{{ .Environment.CIRCLE_JOB }}-{{ checksum "setup.py" }}-{{ checksum "tox.ini" }}-{{ checksum "./.circleci/get_eth2_fixtures.sh" }}-{{ checksum "./.circleci/build_geth.sh" }}
 jobs:
-  py36-lint:
-    <<: *common
-    docker:
-      - image: circleci/python:3.6
-        environment:
-          TOXENV: py36-lint
   py37-lint:
     <<: *common
     docker:
       - image: circleci/python:3.7
         environment:
           TOXENV: py37-lint
-  py36-lint-eth2:
-    <<: *common
-    docker:
-      - image: circleci/python:3.6
-        environment:
-          TOXENV: py36-lint-eth2
   py37-lint-eth2:
     <<: *common
     docker:
@@ -138,148 +126,82 @@ jobs:
         environment:
           TOXENV: py37-lint-eth2
 
-  py36-docs:
+  py37-docs:
     <<: *common
     docker:
-      - image: circleci/python:3.6
+      - image: circleci/python:3.7
         environment:
-          TOXENV: py36-docs
+          TOXENV: py37-docs
 
-  py36-rpc-state-byzantium:
+  py37-rpc-state-byzantium:
     <<: *common
     docker:
-      - image: circleci/python:3.6
+      - image: circleci/python:3.7
         environment:
-          TOXENV: py36-rpc-state-byzantium
-  py36-rpc-state-constantinople:
+          TOXENV: py37-rpc-state-byzantium
+  py37-rpc-state-constantinople:
     <<: *common
     docker:
-      - image: circleci/python:3.6
+      - image: circleci/python:3.7
         environment:
-          TOXENV: py36-rpc-state-constantinople
-  py36-rpc-state-frontier:
+          TOXENV: py37-rpc-state-constantinople
+  py37-rpc-state-frontier:
     <<: *common
     docker:
-      - image: circleci/python:3.6
+      - image: circleci/python:3.7
         environment:
-          TOXENV: py36-rpc-state-frontier
-  py36-rpc-state-homestead:
+          TOXENV: py37-rpc-state-frontier
+  py37-rpc-state-homestead:
     <<: *common
     docker:
-      - image: circleci/python:3.6
+      - image: circleci/python:3.7
         environment:
-          TOXENV: py36-rpc-state-homestead
-  py36-rpc-state-istanbul:
+          TOXENV: py37-rpc-state-homestead
+  py37-rpc-state-istanbul:
     <<: *common
     docker:
-      - image: circleci/python:3.6
+      - image: circleci/python:3.7
         environment:
-          TOXENV: py36-rpc-state-istanbul
-  py36-rpc-state-petersburg:
+          TOXENV: py37-rpc-state-istanbul
+  py37-rpc-state-petersburg:
     <<: *common
     docker:
-      - image: circleci/python:3.6
+      - image: circleci/python:3.7
         environment:
-          TOXENV: py36-rpc-state-petersburg
+          TOXENV: py37-rpc-state-petersburg
 
-  py36-rpc-state-tangerine_whistle:
+  py37-rpc-state-tangerine_whistle:
     <<: *common
     docker:
-      - image: circleci/python:3.6
+      - image: circleci/python:3.7
         environment:
-          TOXENV: py36-rpc-state-tangerine_whistle
-  py36-rpc-state-spurious_dragon:
+          TOXENV: py37-rpc-state-tangerine_whistle
+  py37-rpc-state-spurious_dragon:
     <<: *common
     docker:
-      - image: circleci/python:3.6
+      - image: circleci/python:3.7
         environment:
-          TOXENV: py36-rpc-state-spurious_dragon
-  py36-rpc-blockchain:
+          TOXENV: py37-rpc-state-spurious_dragon
+  py37-rpc-blockchain:
     <<: *common
     docker:
-      - image: circleci/python:3.6
+      - image: circleci/python:3.7
         environment:
-          TOXENV: py36-rpc-blockchain
+          TOXENV: py37-rpc-blockchain
 
-  py36-eth1-core:
-    <<: *common
-    docker:
-      - image: circleci/python:3.6
-        environment:
-          TOXENV: py36-eth1-core
-  py36-integration:
-    <<: *common
-    docker:
-      - image: circleci/python:3.6
-        environment:
-          TOXENV: py36-integration
-  py36-lightchain_integration:
+  py37-lightchain_integration:
     <<: *geth_steps
     docker:
-      - image: circleci/python:3.6
+      - image: circleci/python:3.7
         environment:
-          TOXENV: py36-lightchain_integration
+          TOXENV: py37-lightchain_integration
           GETH_VERSION: v1.8.22
-  py36-long_run_integration:
+  py37-long_run_integration:
     <<: *common
     docker:
-      - image: circleci/python:3.6
+      - image: circleci/python:3.7
         environment:
-          TOXENV: py36-long_run_integration
-  py36-p2p:
-    <<: *common
-    docker:
-      - image: circleci/python:3.6
-        environment:
-          TOXENV: py36-p2p
-  py36-p2p-trio:
-    <<: *common
-    docker:
-      - image: circleci/python:3.6
-        environment:
-          TOXENV: py36-p2p-trio
-  py36-eth2-core:
-    <<: *common
-    docker:
-      - image: circleci/python:3.6
-        environment:
-          TOXENV: py36-eth2-core
-  py36-eth2-utils:
-    <<: *common
-    docker:
-      - image: circleci/python:3.6
-        environment:
-          TOXENV: py36-eth2-utils
-  py36-eth2-fixtures:
-    <<: *eth2_fixtures
-    docker:
-      - image: circleci/python:3.6
-        environment:
-          TOXENV: py36-eth2-fixtures
-  py36-eth2-integration:
-    <<: *common
-    docker:
-      - image: circleci/python:3.6
-        environment:
-          TOXENV: py36-eth2-integration
-  py36-wheel-cli:
-    <<: *common
-    docker:
-      - image: circleci/python:3.6
-        environment:
-          TOXENV: py36-wheel-cli
-  py36-eth1-components:
-    <<: *common
-    docker:
-      - image: circleci/python:3.6
-        environment:
-          TOXENV: py36-eth1-components
-  py36-eth2-trio:
-    <<: *common
-    docker:
-      - image: circleci/python:3.6
-        environment:
-          TOXENV: py36-eth2-trio
+          TOXENV: py37-long_run_integration
 
   py37-rpc-state-quadratic:
     <<: *common
@@ -398,16 +320,14 @@ workflows:
   test:
     jobs:
       # These tests are long, so should be started first to optimize for total suite run time
-      - py36-integration
-      - py36-wheel-cli
+      - py37-integration
       - py37-wheel-cli
-      - py36-long_run_integration
+      - py37-long_run_integration
       - py37-rpc-state-sstore
-      - py36-eth2-core
       - py37-eth2-core
       - py37-libp2p
 
-      - py36-docs
+      - py37-docs
 
       - py37-eth1-core
       - py37-p2p
@@ -422,28 +342,17 @@ workflows:
       - py37-rpc-state-quadratic
       - py37-rpc-state-zero_knowledge
 
-      - py36-rpc-state-byzantium
-      - py36-rpc-state-constantinople
-      - py36-rpc-state-frontier
-      - py36-rpc-state-homestead
-      - py36-rpc-state-petersburg
-      - py36-rpc-state-spurious_dragon
-      - py36-rpc-state-tangerine_whistle
-      - py36-rpc-blockchain
+      - py37-rpc-state-byzantium
+      - py37-rpc-state-constantinople
+      - py37-rpc-state-frontier
+      - py37-rpc-state-homestead
+      - py37-rpc-state-petersburg
+      - py37-rpc-state-spurious_dragon
+      - py37-rpc-state-tangerine_whistle
+      - py37-rpc-blockchain
 
-      - py36-eth1-core
-      - py36-p2p
-      - py36-p2p-trio
-      - py36-eth2-utils
-      - py36-eth2-fixtures
-      - py36-eth2-integration
-      - py36-eth1-components
-      - py36-eth2-trio
+      - py37-lightchain_integration
 
-      - py36-lightchain_integration
-
-      - py36-lint
-      - py36-lint-eth2
       - py37-lint
       - py37-lint-eth2
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -138,68 +138,68 @@ jobs:
         environment:
           TOXENV: py37-lint-eth2
 
-  py38-docs:
+  py37-docs:
     <<: *common
     docker:
-      - image: circleci/python:3.8
+      - image: circleci/python:3.7
         environment:
-          TOXENV: py38-docs
+          TOXENV: py37-docs
 
-  py38-rpc-state-byzantium:
+  py37-rpc-state-byzantium:
     <<: *common
     docker:
-      - image: circleci/python:3.8
+      - image: circleci/python:3.7
         environment:
-          TOXENV: py38-rpc-state-byzantium
-  py38-rpc-state-constantinople:
+          TOXENV: py37-rpc-state-byzantium
+  py37-rpc-state-constantinople:
     <<: *common
     docker:
-      - image: circleci/python:3.8
+      - image: circleci/python:3.7
         environment:
-          TOXENV: py38-rpc-state-constantinople
-  py38-rpc-state-frontier:
+          TOXENV: py37-rpc-state-constantinople
+  py37-rpc-state-frontier:
     <<: *common
     docker:
-      - image: circleci/python:3.8
+      - image: circleci/python:3.7
         environment:
-          TOXENV: py38-rpc-state-frontier
-  py38-rpc-state-homestead:
+          TOXENV: py37-rpc-state-frontier
+  py37-rpc-state-homestead:
     <<: *common
     docker:
-      - image: circleci/python:3.8
+      - image: circleci/python:3.7
         environment:
-          TOXENV: py38-rpc-state-homestead
-  py38-rpc-state-istanbul:
+          TOXENV: py37-rpc-state-homestead
+  py37-rpc-state-istanbul:
     <<: *common
     docker:
-      - image: circleci/python:3.8
+      - image: circleci/python:3.7
         environment:
-          TOXENV: py38-rpc-state-istanbul
-  py38-rpc-state-petersburg:
+          TOXENV: py37-rpc-state-istanbul
+  py37-rpc-state-petersburg:
     <<: *common
     docker:
-      - image: circleci/python:3.8
+      - image: circleci/python:3.7
         environment:
-          TOXENV: py38-rpc-state-petersburg
+          TOXENV: py37-rpc-state-petersburg
 
-  py38-rpc-state-tangerine_whistle:
+  py37-rpc-state-tangerine_whistle:
     <<: *common
     docker:
-      - image: circleci/python:3.8
+      - image: circleci/python:3.7
         environment:
-          TOXENV: py38-rpc-state-tangerine_whistle
-  py38-rpc-state-spurious_dragon:
+          TOXENV: py37-rpc-state-tangerine_whistle
+  py37-rpc-state-spurious_dragon:
     <<: *common
     docker:
-      - image: circleci/python:3.8
+      - image: circleci/python:3.7
         environment:
-          TOXENV: py38-rpc-state-spurious_dragon
-  py38-rpc-blockchain:
+          TOXENV: py37-rpc-state-spurious_dragon
+  py37-rpc-blockchain:
     <<: *common
     docker:
-      - image: circleci/python:3.8
+      - image: circleci/python:3.7
         environment:
-          TOXENV: py38-rpc-blockchain
+          TOXENV: py37-rpc-blockchain
 
   py38-eth1-core:
     <<: *common
@@ -213,19 +213,19 @@ jobs:
       - image: circleci/python:3.8
         environment:
           TOXENV: py38-integration
-  py38-lightchain_integration:
+  py37-lightchain_integration:
     <<: *geth_steps
     docker:
-      - image: circleci/python:3.8
+      - image: circleci/python:3.7
         environment:
-          TOXENV: py38-lightchain_integration
+          TOXENV: py37-lightchain_integration
           GETH_VERSION: v1.8.22
-  py38-long_run_integration:
+  py37-long_run_integration:
     <<: *common
     docker:
-      - image: circleci/python:3.8
+      - image: circleci/python:3.7
         environment:
-          TOXENV: py38-long_run_integration
+          TOXENV: py37-long_run_integration
   py38-p2p:
     <<: *common
     docker:
@@ -399,15 +399,16 @@ workflows:
     jobs:
       # These tests are long, so should be started first to optimize for total suite run time
       - py38-integration
+      - py37-integration
       - py38-wheel-cli
       - py37-wheel-cli
-      - py38-long_run_integration
+      - py37-long_run_integration
       - py37-rpc-state-sstore
       - py38-eth2-core
       - py37-eth2-core
       - py37-libp2p
 
-      - py38-docs
+      - py37-docs
 
       - py37-eth1-core
       - py37-p2p
@@ -422,14 +423,14 @@ workflows:
       - py37-rpc-state-quadratic
       - py37-rpc-state-zero_knowledge
 
-      - py38-rpc-state-byzantium
-      - py38-rpc-state-constantinople
-      - py38-rpc-state-frontier
-      - py38-rpc-state-homestead
-      - py38-rpc-state-petersburg
-      - py38-rpc-state-spurious_dragon
-      - py38-rpc-state-tangerine_whistle
-      - py38-rpc-blockchain
+      - py37-rpc-state-byzantium
+      - py37-rpc-state-constantinople
+      - py37-rpc-state-frontier
+      - py37-rpc-state-homestead
+      - py37-rpc-state-petersburg
+      - py37-rpc-state-spurious_dragon
+      - py37-rpc-state-tangerine_whistle
+      - py37-rpc-blockchain
 
       - py38-eth1-core
       - py38-p2p
@@ -440,7 +441,7 @@ workflows:
       - py38-eth1-components
       - py38-eth2-trio
 
-      - py38-lightchain_integration
+      - py37-lightchain_integration
 
       - py38-lint
       - py38-lint-eth2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -113,12 +113,24 @@ eth2_fixtures: &eth2_fixtures
           - ./eth2-fixtures
         key: cache-v3-{{ arch }}-{{ .Environment.CIRCLE_JOB }}-{{ checksum "setup.py" }}-{{ checksum "tox.ini" }}-{{ checksum "./.circleci/get_eth2_fixtures.sh" }}-{{ checksum "./.circleci/build_geth.sh" }}
 jobs:
+  py38-lint:
+    <<: *common
+    docker:
+      - image: circleci/python:3.8
+        environment:
+          TOXENV: py38-lint
   py37-lint:
     <<: *common
     docker:
       - image: circleci/python:3.7
         environment:
           TOXENV: py37-lint
+  py38-lint-eth2:
+    <<: *common
+    docker:
+      - image: circleci/python:3.8
+        environment:
+          TOXENV: py38-lint-eth2
   py37-lint-eth2:
     <<: *common
     docker:
@@ -126,82 +138,148 @@ jobs:
         environment:
           TOXENV: py37-lint-eth2
 
-  py37-docs:
+  py38-docs:
     <<: *common
     docker:
-      - image: circleci/python:3.7
+      - image: circleci/python:3.8
         environment:
-          TOXENV: py37-docs
+          TOXENV: py38-docs
 
-  py37-rpc-state-byzantium:
+  py38-rpc-state-byzantium:
     <<: *common
     docker:
-      - image: circleci/python:3.7
+      - image: circleci/python:3.8
         environment:
-          TOXENV: py37-rpc-state-byzantium
-  py37-rpc-state-constantinople:
+          TOXENV: py38-rpc-state-byzantium
+  py38-rpc-state-constantinople:
     <<: *common
     docker:
-      - image: circleci/python:3.7
+      - image: circleci/python:3.8
         environment:
-          TOXENV: py37-rpc-state-constantinople
-  py37-rpc-state-frontier:
+          TOXENV: py38-rpc-state-constantinople
+  py38-rpc-state-frontier:
     <<: *common
     docker:
-      - image: circleci/python:3.7
+      - image: circleci/python:3.8
         environment:
-          TOXENV: py37-rpc-state-frontier
-  py37-rpc-state-homestead:
+          TOXENV: py38-rpc-state-frontier
+  py38-rpc-state-homestead:
     <<: *common
     docker:
-      - image: circleci/python:3.7
+      - image: circleci/python:3.8
         environment:
-          TOXENV: py37-rpc-state-homestead
-  py37-rpc-state-istanbul:
+          TOXENV: py38-rpc-state-homestead
+  py38-rpc-state-istanbul:
     <<: *common
     docker:
-      - image: circleci/python:3.7
+      - image: circleci/python:3.8
         environment:
-          TOXENV: py37-rpc-state-istanbul
-  py37-rpc-state-petersburg:
+          TOXENV: py38-rpc-state-istanbul
+  py38-rpc-state-petersburg:
     <<: *common
     docker:
-      - image: circleci/python:3.7
+      - image: circleci/python:3.8
         environment:
-          TOXENV: py37-rpc-state-petersburg
+          TOXENV: py38-rpc-state-petersburg
 
-  py37-rpc-state-tangerine_whistle:
+  py38-rpc-state-tangerine_whistle:
     <<: *common
     docker:
-      - image: circleci/python:3.7
+      - image: circleci/python:3.8
         environment:
-          TOXENV: py37-rpc-state-tangerine_whistle
-  py37-rpc-state-spurious_dragon:
+          TOXENV: py38-rpc-state-tangerine_whistle
+  py38-rpc-state-spurious_dragon:
     <<: *common
     docker:
-      - image: circleci/python:3.7
+      - image: circleci/python:3.8
         environment:
-          TOXENV: py37-rpc-state-spurious_dragon
-  py37-rpc-blockchain:
+          TOXENV: py38-rpc-state-spurious_dragon
+  py38-rpc-blockchain:
     <<: *common
     docker:
-      - image: circleci/python:3.7
+      - image: circleci/python:3.8
         environment:
-          TOXENV: py37-rpc-blockchain
+          TOXENV: py38-rpc-blockchain
 
-  py37-lightchain_integration:
+  py38-eth1-core:
+    <<: *common
+    docker:
+      - image: circleci/python:3.8
+        environment:
+          TOXENV: py38-eth1-core
+  py38-integration:
+    <<: *common
+    docker:
+      - image: circleci/python:3.8
+        environment:
+          TOXENV: py38-integration
+  py38-lightchain_integration:
     <<: *geth_steps
     docker:
-      - image: circleci/python:3.7
+      - image: circleci/python:3.8
         environment:
-          TOXENV: py37-lightchain_integration
+          TOXENV: py38-lightchain_integration
           GETH_VERSION: v1.8.22
-  py37-long_run_integration:
+  py38-long_run_integration:
     <<: *common
     docker:
-      - image: circleci/python:3.7
+      - image: circleci/python:3.8
         environment:
-          TOXENV: py37-long_run_integration
+          TOXENV: py38-long_run_integration
+  py38-p2p:
+    <<: *common
+    docker:
+      - image: circleci/python:3.8
+        environment:
+          TOXENV: py38-p2p
+  py38-p2p-trio:
+    <<: *common
+    docker:
+      - image: circleci/python:3.8
+        environment:
+          TOXENV: py38-p2p-trio
+  py38-eth2-core:
+    <<: *common
+    docker:
+      - image: circleci/python:3.8
+        environment:
+          TOXENV: py38-eth2-core
+  py38-eth2-utils:
+    <<: *common
+    docker:
+      - image: circleci/python:3.8
+        environment:
+          TOXENV: py38-eth2-utils
+  py38-eth2-fixtures:
+    <<: *eth2_fixtures
+    docker:
+      - image: circleci/python:3.8
+        environment:
+          TOXENV: py38-eth2-fixtures
+  py38-eth2-integration:
+    <<: *common
+    docker:
+      - image: circleci/python:3.8
+        environment:
+          TOXENV: py38-eth2-integration
+  py38-wheel-cli:
+    <<: *common
+    docker:
+      - image: circleci/python:3.8
+        environment:
+          TOXENV: py38-wheel-cli
+  py38-eth1-components:
+    <<: *common
+    docker:
+      - image: circleci/python:3.8
+        environment:
+          TOXENV: py38-eth1-components
+  py38-eth2-trio:
+    <<: *common
+    docker:
+      - image: circleci/python:3.8
+        environment:
+          TOXENV: py38-eth2-trio
 
   py37-rpc-state-quadratic:
     <<: *common
@@ -320,14 +398,16 @@ workflows:
   test:
     jobs:
       # These tests are long, so should be started first to optimize for total suite run time
-      - py37-integration
+      - py38-integration
+      - py38-wheel-cli
       - py37-wheel-cli
-      - py37-long_run_integration
+      - py38-long_run_integration
       - py37-rpc-state-sstore
+      - py38-eth2-core
       - py37-eth2-core
       - py37-libp2p
 
-      - py37-docs
+      - py38-docs
 
       - py37-eth1-core
       - py37-p2p
@@ -342,17 +422,28 @@ workflows:
       - py37-rpc-state-quadratic
       - py37-rpc-state-zero_knowledge
 
-      - py37-rpc-state-byzantium
-      - py37-rpc-state-constantinople
-      - py37-rpc-state-frontier
-      - py37-rpc-state-homestead
-      - py37-rpc-state-petersburg
-      - py37-rpc-state-spurious_dragon
-      - py37-rpc-state-tangerine_whistle
-      - py37-rpc-blockchain
+      - py38-rpc-state-byzantium
+      - py38-rpc-state-constantinople
+      - py38-rpc-state-frontier
+      - py38-rpc-state-homestead
+      - py38-rpc-state-petersburg
+      - py38-rpc-state-spurious_dragon
+      - py38-rpc-state-tangerine_whistle
+      - py38-rpc-blockchain
 
-      - py37-lightchain_integration
+      - py38-eth1-core
+      - py38-p2p
+      - py38-p2p-trio
+      - py38-eth2-utils
+      - py38-eth2-fixtures
+      - py38-eth2-integration
+      - py38-eth1-components
+      - py38-eth2-trio
 
+      - py38-lightchain_integration
+
+      - py38-lint
+      - py38-lint-eth2
       - py37-lint
       - py37-lint-eth2
 

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -3,7 +3,7 @@ version: 2
 build:
   image: latest
 python:
-  version: 3.6
+  version: 3.7
   install:
     - method: pip
       path: .

--- a/docs/guides/quickstart.rst
+++ b/docs/guides/quickstart.rst
@@ -12,8 +12,8 @@ To develop on top of Trinity or to contribute to the project, check out the
 Installing on Ubuntu
 --------------------
 
-Trinity requires Python 3.6 as well as some tools to compile its dependencies. On Ubuntu, the
-``python3.6-dev`` package contains everything we need. Run the following command to install it.
+Trinity requires Python 3.7 as well as some tools to compile its dependencies. On Ubuntu, the
+``python3.7-dev`` package contains everything we need. Run the following command to install it.
 
 .. code:: sh
 

--- a/newsfragments/1675.removal.rst
+++ b/newsfragments/1675.removal.rst
@@ -1,0 +1,1 @@
+Drop support for Python 3.6 making Python 3.7 the minimal supported Python version.

--- a/p2p/_utils.py
+++ b/p2p/_utils.py
@@ -1,5 +1,5 @@
 import collections
-from typing import Hashable, Sequence, Tuple, TypeVar
+from typing import Hashable, Sequence, Tuple, TypeVar, AsyncGenerator, Any
 
 import rlp
 
@@ -93,3 +93,18 @@ def duplicates(elements: Sequence[TValue]) -> Tuple[TValue, ...]:
         collections.Counter(elements).items()
         if count > 1
     )
+
+
+TCo = TypeVar('TCo')
+TContra = TypeVar('TContra')
+
+
+class aclosing:
+    def __init__(self, aiter: AsyncGenerator[TCo, TContra]) -> None:
+        self._aiter = aiter
+
+    async def __aenter__(self) -> AsyncGenerator[TCo, TContra]:
+        return self._aiter
+
+    async def __aexit__(self, *args: Any) -> None:
+        await self._aiter.aclose()

--- a/p2p/behaviors.py
+++ b/p2p/behaviors.py
@@ -1,8 +1,7 @@
+import contextlib
 from typing import (
     AsyncIterator,
 )
-
-from async_generator import asynccontextmanager
 
 from eth_utils import ValidationError
 
@@ -36,7 +35,7 @@ class Behavior(BehaviorAPI):
         # mypy bug: https://github.com/python/mypy/issues/708
         return self.qualifier(connection, self.logic)  # type: ignore
 
-    @asynccontextmanager
+    @contextlib.asynccontextmanager
     async def apply(self, connection: ConnectionAPI) -> AsyncIterator[None]:
         if self._applied_to is not None:
             raise ValidationError(

--- a/p2p/discovery.py
+++ b/p2p/discovery.py
@@ -29,8 +29,6 @@ from typing import (
     TypeVar,
 )
 
-from async_generator import aclosing
-
 import trio
 
 import eth_utils.toolz
@@ -82,7 +80,7 @@ from p2p.exceptions import (
 )
 from p2p.kademlia import (
     Address, Node, check_relayed_addr, create_stub_enr, sort_by_distance, KademliaRoutingTable)
-from p2p._utils import get_logger
+from p2p._utils import get_logger, aclosing
 from p2p import trio_utils
 
 # V4 handler are async methods that take a Node, payload and msg_hash as arguments.

--- a/p2p/discv5/message_dispatcher.py
+++ b/p2p/discv5/message_dispatcher.py
@@ -1,3 +1,4 @@
+import contextlib
 import logging
 import random
 from types import (
@@ -13,8 +14,6 @@ from typing import (
     Type,
     TypeVar,
 )
-
-from async_generator import asynccontextmanager
 
 import trio
 from trio.abc import (
@@ -289,7 +288,7 @@ class MessageDispatcher(Service, MessageDispatcherAPI):
 
         return Endpoint(ip_address, udp_port)
 
-    @asynccontextmanager
+    @contextlib.asynccontextmanager
     async def request_response_subscription(self,
                                             receiver_node_id: NodeID,
                                             message: BaseMessage,

--- a/p2p/exchange/exchange.py
+++ b/p2p/exchange/exchange.py
@@ -1,11 +1,11 @@
 from functools import partial
+import contextlib
 from typing import (
     AsyncIterator,
     Callable,
     Type,
 )
 
-from async_generator import asynccontextmanager
 from async_service import background_asyncio_service
 
 from p2p.abc import ConnectionAPI
@@ -25,7 +25,7 @@ class BaseExchange(ExchangeAPI[TRequestCommand, TResponseCommand, TResult]):
     def __init__(self) -> None:
         self.tracker = self.tracker_class()
 
-    @asynccontextmanager
+    @contextlib.asynccontextmanager
     async def run_exchange(self, connection: ConnectionAPI) -> AsyncIterator[None]:
         protocol = connection.get_protocol_for_command_type(self.get_request_cmd_type())
 

--- a/p2p/exchange/logic.py
+++ b/p2p/exchange/logic.py
@@ -1,6 +1,5 @@
+import contextlib
 from typing import Any, AsyncIterator
-
-from async_generator import asynccontextmanager
 
 from p2p.abc import ConnectionAPI, LogicAPI
 from p2p.exceptions import UnknownProtocol
@@ -29,7 +28,7 @@ class ExchangeLogic(BaseLogic):
         else:
             return protocol.supports_command(self.exchange.get_response_cmd_type())
 
-    @asynccontextmanager
+    @contextlib.asynccontextmanager
     async def apply(self, connection: ConnectionAPI) -> AsyncIterator[None]:
         async with self.exchange.run_exchange(connection):
             yield

--- a/p2p/logic.py
+++ b/p2p/logic.py
@@ -1,4 +1,5 @@
 from abc import abstractmethod
+import contextlib
 from typing import (
     cast,
     AsyncIterator,
@@ -6,9 +7,6 @@ from typing import (
     Tuple,
     Type,
 )
-
-from async_generator import asynccontextmanager
-from async_exit_stack import AsyncExitStack
 
 from p2p.abc import (
     BehaviorAPI,
@@ -49,7 +47,7 @@ class CommandHandler(BaseLogic, Generic[TCommand]):
     def qualifier(self) -> QualifierFn:  # type: ignore
         return HasCommand(self.command_type)
 
-    @asynccontextmanager
+    @contextlib.asynccontextmanager
     async def apply(self, connection: ConnectionAPI) -> AsyncIterator[None]:
         self.connection = connection
 
@@ -76,11 +74,11 @@ class Application(BaseLogic):
     def add_child_behavior(self, behavior: BehaviorAPI) -> None:
         self._behaviors += (behavior,)
 
-    @asynccontextmanager
+    @contextlib.asynccontextmanager
     async def apply(self, connection: ConnectionAPI) -> AsyncIterator[None]:
         self.connection = connection
 
-        async with AsyncExitStack() as stack:
+        async with contextlib.AsyncExitStack() as stack:
             # First apply all the child behaviors
             for behavior in self._behaviors:
                 if behavior.should_apply_to(connection):

--- a/p2p/multiplexer.py
+++ b/p2p/multiplexer.py
@@ -1,5 +1,6 @@
 import asyncio
 import collections
+import contextlib
 import time
 from typing import (
     Any,
@@ -14,8 +15,6 @@ from typing import (
 )
 
 from cached_property import cached_property
-
-from async_generator import asynccontextmanager
 
 from eth_utils import ValidationError
 from eth_utils.toolz import cons
@@ -291,7 +290,7 @@ class Multiplexer(MultiplexerAPI):
     #
     # Message reading and streaming API
     #
-    @asynccontextmanager
+    @contextlib.asynccontextmanager
     async def multiplex(self) -> AsyncIterator[None]:
         """
         API for running the background task that feeds individual protocol

--- a/p2p/p2p_api.py
+++ b/p2p/p2p_api.py
@@ -1,7 +1,6 @@
 import asyncio
+import contextlib
 from typing import Any, AsyncIterator, cast
-
-from async_generator import asynccontextmanager
 
 from cached_property import cached_property
 
@@ -91,7 +90,7 @@ class DisconnectIfIdle(BaseLogic):
     def __init__(self, idle_timeout: float) -> None:
         self.idle_timeout = idle_timeout
 
-    @asynccontextmanager
+    @contextlib.asynccontextmanager
     async def apply(self, connection: ConnectionAPI) -> AsyncIterator[None]:
         service = PingAndDisconnectIfIdle(connection, self.idle_timeout)
         async with background_asyncio_service(service):

--- a/p2p/peer.py
+++ b/p2p/peer.py
@@ -18,8 +18,6 @@ from typing import (
     TYPE_CHECKING,
 )
 
-from async_exit_stack import AsyncExitStack
-
 from async_service import Service
 
 from lahja import EndpointAPI
@@ -261,7 +259,7 @@ class BasePeer(Service):
         self._start_time = time.monotonic()
         self.connection.add_command_handler(Disconnect, cast(HandlerFn, self._handle_disconnect))
         try:
-            async with AsyncExitStack() as stack:
+            async with contextlib.AsyncExitStack() as stack:
                 await stack.enter_async_context(P2PAPI().as_behavior().apply(self.connection))
                 self.p2p_api = self.connection.get_logic('p2p', P2PAPI)
 

--- a/p2p/resource_lock.py
+++ b/p2p/resource_lock.py
@@ -1,9 +1,8 @@
 import asyncio
 from collections import defaultdict
 from collections.abc import Hashable
+import contextlib
 from typing import AsyncIterator, DefaultDict, Dict, Generic, TypeVar
-
-from async_generator import asynccontextmanager
 
 
 TResource = TypeVar('TResource', bound=Hashable)
@@ -20,7 +19,7 @@ class ResourceLock(Generic[TResource]):
         self._locks = {}
         self._reference_counts = defaultdict(int)
 
-    @asynccontextmanager
+    @contextlib.asynccontextmanager
     async def lock(self, resource: TResource) -> AsyncIterator[None]:
         if resource not in self._locks:
             self._locks[resource] = asyncio.Lock()

--- a/p2p/service.py
+++ b/p2p/service.py
@@ -1,6 +1,7 @@
 from abc import abstractmethod
 import asyncio
 import concurrent
+import contextlib
 import functools
 import time
 from typing import (
@@ -15,7 +16,6 @@ from typing import (
 from weakref import WeakSet
 
 from async_service import Service, ServiceAPI
-from async_generator import asynccontextmanager
 
 from cancel_token import CancelToken, OperationCancelled
 from eth_utils import (
@@ -423,7 +423,7 @@ class EmptyService(BaseService):
 TService = TypeVar('TService', bound=AsyncioServiceAPI)
 
 
-@asynccontextmanager
+@contextlib.asynccontextmanager
 async def run_service(service: TService) -> AsyncIterator[TService]:
     task = asyncio.ensure_future(service.run())
     await service.events.started.wait()

--- a/p2p/tools/asyncio_streams.py
+++ b/p2p/tools/asyncio_streams.py
@@ -71,7 +71,11 @@ TConnectedStreams = Tuple[
 
 
 def get_directly_connected_streams(alice_extra_info: Dict[str, Any] = None,
-                                   bob_extra_info: Dict[str, Any] = None) -> TConnectedStreams:
+                                   bob_extra_info: Dict[str, Any] = None,
+                                   loop: asyncio.AbstractEventLoop = None) -> TConnectedStreams:
+    if loop is None:
+        loop = asyncio.get_event_loop()
+
     alice_reader = asyncio.StreamReader()
     bob_reader = asyncio.StreamReader()
 
@@ -83,8 +87,8 @@ def get_directly_connected_streams(alice_extra_info: Dict[str, Any] = None,
 
     # Link the alice's writer to the bob's reader, and the bob's writer to the
     # alice's reader.
-    bob_writer = asyncio.StreamWriter(bob_transport, bob_protocol, alice_reader, loop=None)
-    alice_writer = asyncio.StreamWriter(alice_transport, alice_protocol, bob_reader, loop=None)
+    bob_writer = asyncio.StreamWriter(bob_transport, bob_protocol, alice_reader, loop=loop)
+    alice_writer = asyncio.StreamWriter(alice_transport, alice_protocol, bob_reader, loop=loop)
     return (
         (alice_reader, alice_writer),
         (bob_reader, bob_writer),

--- a/p2p/tools/factories/connection.py
+++ b/p2p/tools/factories/connection.py
@@ -1,7 +1,6 @@
 import asyncio
+import contextlib
 from typing import AsyncIterator, Tuple
-
-from async_generator import asynccontextmanager
 
 from async_service import background_asyncio_service
 
@@ -20,7 +19,7 @@ from .p2p_proto import DevP2PHandshakeParamsFactory
 from .transport import MemoryTransportPairFactory
 
 
-@asynccontextmanager
+@contextlib.asynccontextmanager
 async def ConnectionPairFactory(*,
                                 alice_handshakers: Tuple[HandshakerAPI[ProtocolAPI], ...] = (),
                                 bob_handshakers: Tuple[HandshakerAPI[ProtocolAPI], ...] = (),

--- a/p2p/tools/factories/peer.py
+++ b/p2p/tools/factories/peer.py
@@ -1,7 +1,6 @@
 import asyncio
+import contextlib
 from typing import cast, AsyncContextManager, AsyncIterator, Tuple, Type
-
-from async_generator import asynccontextmanager
 
 from lahja import EndpointAPI
 
@@ -15,7 +14,7 @@ from p2p.tools.paragon import ParagonPeer, ParagonContext, ParagonPeerFactory
 from .connection import ConnectionPairFactory
 
 
-@asynccontextmanager
+@contextlib.asynccontextmanager
 async def PeerPairFactory(*,
                           alice_peer_context: BasePeerContext,
                           alice_peer_factory_class: Type[BasePeerFactory],

--- a/setup.py
+++ b/setup.py
@@ -198,6 +198,7 @@ setup(
         'License :: OSI Approved :: MIT License',
         'Natural Language :: English',
         'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
     ],
     # trinity
     entry_points={

--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ deps = {
         # idna 2.7 is not supported by requests 2.18
         "requests>=2.20,<3",
         "ipython>=7.8.0,<7.10.0",  # attach fails with v7.10.{0,1}
-        "plyvel==1.1.0",
+        "plyvel==1.2.0",
         PYEVM_DEPENDENCY,
         "web3>=5.10.0,<6",
         "lahja>=0.16.0,<0.17",
@@ -52,7 +52,7 @@ deps = {
         "jsonschema==3.0.1",
         "mypy-extensions>=0.4.3,<0.5.0",
         "typing_extensions>=3.7.4,<4.0.0",
-        "ruamel.yaml==0.15.98",
+        "ruamel.yaml==0.16.10",
         "argcomplete>=1.10.0,<2",
         "multiaddr>=0.0.8,<0.1.0",
         "prometheus-client==0.7.1",
@@ -76,7 +76,7 @@ deps = {
         # xdist pinned at <1.29 due to: https://github.com/pytest-dev/pytest-xdist/issues/472
         "pytest-xdist>=1.29.0,<1.30",
         # only for eth2
-        "ruamel.yaml==0.15.98",
+        "ruamel.yaml==0.16.10",
         "eth-tester==0.4.0b2",
     ],
     # We have to keep some separation between trio and asyncio based tests
@@ -125,7 +125,7 @@ deps = {
         "eth-keyfile",  # validator client
     ],
     'eth2-extra': [
-        "milagro-bls-binding==0.1.3",
+        "milagro-bls-binding==0.1.4",
     ],
     'eth2-lint': [
         "black==19.3b0",

--- a/setup.py
+++ b/setup.py
@@ -188,7 +188,7 @@ setup(
     url='https://github.com/ethereum/trinity',
     include_package_data=True,
     py_modules=['trinity', 'p2p', 'eth2'],
-    python_requires=">=3.6,<4",
+    python_requires=">=3.7,<4",
     install_requires=install_requires,
     extras_require=deps,
     license='MIT',
@@ -200,7 +200,7 @@ setup(
         'Intended Audience :: Developers',
         'License :: OSI Approved :: MIT License',
         'Natural Language :: English',
-        'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
     ],
     # trinity
     entry_points={

--- a/setup.py
+++ b/setup.py
@@ -9,8 +9,6 @@ PYEVM_DEPENDENCY = "py-evm==0.3.0a15"
 
 deps = {
     'p2p': [
-        "async-exit-stack==1.0.1",
-        "async-generator==1.10",
         "async-service==0.1.0a8",
         "asyncio-cancel-token>=0.2,<0.3",
         "async_lru>=0.1.0,<1.0.0",
@@ -34,7 +32,6 @@ deps = {
         "bloom-filter==1.3",
         "cachetools>=3.1.0,<4.0.0",
         "coincurve>=10.0.0,<11.0.0",
-        "dataclasses>=0.6, <1;python_version<'3.7'",
         "eth-utils>=1.8.4,<2",
         # Fixing this dependency due to: requests 2.20.1 has requirement
         # idna<2.8,>=2.5, but you'll have idna 2.8 which is incompatible.

--- a/tests-trio/p2p-trio/conftest.py
+++ b/tests-trio/p2p-trio/conftest.py
@@ -1,9 +1,8 @@
+import contextlib
 import logging
 
 import trio
 import pytest_trio
-
-from async_generator import asynccontextmanager
 
 from async_service import background_trio_service
 
@@ -38,7 +37,7 @@ async def socket_pair():
     return sending_socket, receiving_socket
 
 
-@asynccontextmanager
+@contextlib.asynccontextmanager
 async def _manually_driven_discovery(seed, socket, nursery):
     _, port = socket.getsockname()
     discovery = ManuallyDrivenDiscoveryService(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,13 +1,11 @@
 import asyncio
+import contextlib
 import logging
 import os
 from pathlib import Path
 import tempfile
 import uuid
 
-from async_generator import (
-    asynccontextmanager,
-)
 import pytest
 
 from async_service import background_asyncio_service
@@ -105,7 +103,7 @@ def event_loop():
         loop.close()
 
 
-@asynccontextmanager
+@contextlib.asynccontextmanager
 async def make_networking_event_bus():
     # Tests run concurrently, therefore we need unique IPC paths
     ipc_path = Path(f"networking-{uuid.uuid4()}.ipc")

--- a/tests/core/integration_test_helpers.py
+++ b/tests/core/integration_test_helpers.py
@@ -1,12 +1,10 @@
 import asyncio
+import contextlib
 from enum import Enum
 from pathlib import Path
 from tempfile import TemporaryDirectory
 from zipfile import ZipFile
 
-from async_generator import (
-    asynccontextmanager,
-)
 from async_service import background_asyncio_service
 from cancel_token import OperationCancelled
 from eth_keys import keys
@@ -93,7 +91,7 @@ def load_fixture_db(db_fixture, db_class=LevelDB):
         yield db_class(Path(tmpdir) / db_fixture.value)
 
 
-@asynccontextmanager
+@contextlib.asynccontextmanager
 async def run_peer_pool_event_server(event_bus, peer_pool, handler_type=None):
 
     handler_type = DefaultPeerPoolEventServer if handler_type is None else handler_type

--- a/tests/core/json-rpc/test_ipc.py
+++ b/tests/core/json-rpc/test_ipc.py
@@ -96,13 +96,13 @@ async def get_ipc_response(
 
     assert wait_for(jsonrpc_ipc_pipe_path), "IPC server did not successfully start with IPC file"
 
-    reader, writer = await asyncio.open_unix_connection(str(jsonrpc_ipc_pipe_path), loop=event_loop)
+    reader, writer = await asyncio.open_unix_connection(str(jsonrpc_ipc_pipe_path))
 
     writer.write(request_msg)
     await writer.drain()
     result_bytes = b''
     while not can_decode_json(result_bytes):
-        result_bytes += await asyncio.tasks.wait_for(reader.readuntil(b'}'), 0.25, loop=event_loop)
+        result_bytes += await asyncio.tasks.wait_for(reader.readuntil(b'}'), 0.25)
 
     writer.close()
     return json.loads(result_bytes.decode())

--- a/tests/core/json-rpc/test_rpc_during_beam_sync.py
+++ b/tests/core/json-rpc/test_rpc_during_beam_sync.py
@@ -80,13 +80,13 @@ async def get_ipc_response(
 
     assert wait_for(jsonrpc_ipc_pipe_path), "IPC server did not successfully start with IPC file"
 
-    reader, writer = await asyncio.open_unix_connection(str(jsonrpc_ipc_pipe_path), loop=event_loop)
+    reader, writer = await asyncio.open_unix_connection(str(jsonrpc_ipc_pipe_path))
 
     writer.write(request_msg)
     await writer.drain()
     result_bytes = b''
     while not can_decode_json(result_bytes):
-        result_bytes += await asyncio.tasks.wait_for(reader.readuntil(b'}'), 0.25, loop=event_loop)
+        result_bytes += await asyncio.tasks.wait_for(reader.readuntil(b'}'), 0.25)
 
     writer.close()
     return json.loads(result_bytes.decode())

--- a/tests/core/json-rpc/test_rpc_during_beam_sync.py
+++ b/tests/core/json-rpc/test_rpc_during_beam_sync.py
@@ -1,11 +1,10 @@
 import asyncio
+import contextlib
 import json
 import os
 import pytest
 import time
 from typing import Dict
-
-from async_generator import asynccontextmanager
 
 from eth_hash.auto import keccak
 from eth_utils.toolz import (
@@ -158,7 +157,7 @@ def ipc_request(jsonrpc_ipc_pipe_path, event_loop, event_bus, ipc_server):
 
 @pytest.fixture
 def fake_beam_syncer(chain, event_bus):
-    @asynccontextmanager
+    @contextlib.asynccontextmanager
     async def fake_beam_sync(removed_nodes: Dict):
         # beam sync starts, it fetches requested nodes from remote peers
 

--- a/tests/core/p2p-proto/test_requests.py
+++ b/tests/core/p2p-proto/test_requests.py
@@ -1,8 +1,8 @@
 import asyncio
+import contextlib
 
 import pytest
 
-from async_exit_stack import AsyncExitStack
 from async_service import background_asyncio_service
 from eth_utils import decode_hex
 
@@ -64,7 +64,7 @@ async def test_proxy_peer_requests(request,
     client_peer_pool = MockPeerPoolWithConnectedPeers([client_peer], event_bus=client_event_bus)
     server_peer_pool = MockPeerPoolWithConnectedPeers([server_peer], event_bus=server_event_bus)
 
-    async with AsyncExitStack() as stack:
+    async with contextlib.AsyncExitStack() as stack:
         await stack.enter_async_context(run_peer_pool_event_server(
             client_event_bus, client_peer_pool, handler_type=ETHPeerPoolEventServer
         ))
@@ -124,7 +124,7 @@ async def test_get_pooled_transactions_request(request,
     client_peer_pool = MockPeerPoolWithConnectedPeers([client_peer], event_bus=client_event_bus)
     server_peer_pool = MockPeerPoolWithConnectedPeers([server_peer], event_bus=server_event_bus)
 
-    async with AsyncExitStack() as stack:
+    async with contextlib.AsyncExitStack() as stack:
         await stack.enter_async_context(run_peer_pool_event_server(
             client_event_bus, client_peer_pool, handler_type=ETHPeerPoolEventServer
         ))
@@ -171,7 +171,7 @@ async def test_proxy_peer_requests_with_timeouts(request,
     client_peer_pool = MockPeerPoolWithConnectedPeers([client_peer], event_bus=client_event_bus)
     server_peer_pool = MockPeerPoolWithConnectedPeers([server_peer], event_bus=server_event_bus)
 
-    async with AsyncExitStack() as stack:
+    async with contextlib.AsyncExitStack() as stack:
         await stack.enter_async_context(run_peer_pool_event_server(
             client_event_bus, client_peer_pool, handler_type=ETHPeerPoolEventServer
         ))
@@ -221,7 +221,7 @@ async def test_requests_when_peer_in_client_vanishs(request,
     client_peer_pool = MockPeerPoolWithConnectedPeers([client_peer], event_bus=client_event_bus)
     server_peer_pool = MockPeerPoolWithConnectedPeers([server_peer], event_bus=server_event_bus)
 
-    async with AsyncExitStack() as stack:
+    async with contextlib.AsyncExitStack() as stack:
         await stack.enter_async_context(run_peer_pool_event_server(
             client_event_bus, client_peer_pool, handler_type=ETHPeerPoolEventServer
         ))

--- a/tests/core/test_contextgroup.py
+++ b/tests/core/test_contextgroup.py
@@ -1,10 +1,9 @@
 import asyncio
+import contextlib
 
 import pytest
 
 from trio import MultiError
-
-from async_generator import asynccontextmanager
 
 from trinity.contextgroup import AsyncContextGroup
 
@@ -13,7 +12,7 @@ from trinity.contextgroup import AsyncContextGroup
 async def test_basic():
     exit_count = 0
 
-    @asynccontextmanager
+    @contextlib.asynccontextmanager
     async def ctx(v):
         nonlocal exit_count
         await asyncio.sleep(0)
@@ -32,7 +31,7 @@ async def test_basic():
 async def test_exception_entering_context():
     exit_count = 0
 
-    @asynccontextmanager
+    @contextlib.asynccontextmanager
     async def ctx(should_raise=False):
         nonlocal exit_count
         await asyncio.sleep(0)
@@ -64,7 +63,7 @@ async def test_exception_inside_context_block():
         if should_raise:
             raise ValueError()
 
-    @asynccontextmanager
+    @contextlib.asynccontextmanager
     async def ctx(should_raise=False):
         nonlocal exit_count
         await asyncio.sleep(0)
@@ -87,7 +86,7 @@ async def test_exception_inside_context_block():
 async def test_exception_exiting():
     exit_count = 0
 
-    @asynccontextmanager
+    @contextlib.asynccontextmanager
     async def ctx(should_raise=False):
         nonlocal exit_count
         await asyncio.sleep(0)

--- a/tests/core/tx-pool/test_tx_pool.py
+++ b/tests/core/tx-pool/test_tx_pool.py
@@ -1,8 +1,8 @@
 import asyncio
+import contextlib
 import pytest
 import uuid
 
-from async_exit_stack import AsyncExitStack
 from async_service import background_asyncio_service
 from eth._utils.address import (
     force_bytes_to_address
@@ -74,7 +74,7 @@ async def two_connected_tx_pools(event_bus,
     bob_peer_pool = MockPeerPoolWithConnectedPeers([bob], event_bus=bob_event_bus)
     alice_peer_pool = MockPeerPoolWithConnectedPeers([alice], event_bus=alice_event_bus)
 
-    async with AsyncExitStack() as stack:
+    async with contextlib.AsyncExitStack() as stack:
         await stack.enter_async_context(run_peer_pool_event_server(
             bob_event_bus, bob_peer_pool, handler_type=ETHPeerPoolEventServer
         ))

--- a/tests/libp2p/bcc/test_syncing.py
+++ b/tests/libp2p/bcc/test_syncing.py
@@ -1,6 +1,6 @@
 import asyncio
+import contextlib
 
-from async_generator import asynccontextmanager
 import pytest
 
 from trinity.tools.bcc_factories import (
@@ -11,7 +11,7 @@ from trinity.tools.bcc_factories import (
 )
 
 
-@asynccontextmanager
+@contextlib.asynccontextmanager
 async def get_sync_setup(
     request,
     event_loop,

--- a/tests/p2p/test_behavior_and_logic_api.py
+++ b/tests/p2p/test_behavior_and_logic_api.py
@@ -1,7 +1,6 @@
 import asyncio
+import contextlib
 import pytest
-
-from async_generator import asynccontextmanager
 
 from eth_utils import ValidationError
 
@@ -18,7 +17,7 @@ from p2p.tools.factories import ConnectionPairFactory
 
 
 class SimpleLogic(BaseLogic):
-    @asynccontextmanager
+    @contextlib.asynccontextmanager
     async def apply(self, connection):
         yield
 

--- a/tests/p2p/test_qualifiers.py
+++ b/tests/p2p/test_qualifiers.py
@@ -1,6 +1,5 @@
+import contextlib
 import pytest
-
-from async_generator import asynccontextmanager
 
 from p2p.abc import ConnectionAPI, LogicAPI
 from p2p.logic import BaseLogic
@@ -18,7 +17,7 @@ from p2p.tools.paragon import ParagonProtocol, BroadcastData
 
 
 class SimpleLogic(BaseLogic):
-    @asynccontextmanager
+    @contextlib.asynccontextmanager
     async def apply(self, connection):
         yield
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,15 +1,15 @@
 [tox]
 envlist=
     py{37,38}-{eth1-core,p2p,p2p-trio,integration,lightchain_integration,eth2-core,eth2-fixtures,eth2-integration,eth1-components,eth2-utils,eth2-trio}
-    py38-long_run_integration
-    py38-rpc-blockchain
+    py37-long_run_integration
+    py37-rpc-blockchain
     py38-rpc-state-{frontier,homestead,tangerine_whistle,spurious_dragon,byzantium,constantinople,petersburg,istanbul}
     py37-rpc-state-{quadratic,sstore,zero_knowledge}
     py37-{libp2p,eth2-components}
     py{38,37}-lint
     py{38,37}-lint-eth2
     py{38,37}-wheel-cli
-    py38-docs
+    py37-docs
 
 [flake8]
 max-line-length= 100
@@ -79,7 +79,7 @@ commands = pytest -n 4 {posargs:tests-trio/eth2} {posargs:tests-trio/trinity} {p
 deps = .[eth2,trinity,test,test-trio]
 commands = pytest -n 4 {posargs:tests-trio/eth2} {posargs:tests-trio/trinity} {posargs:tests-trio/integration}
 
-[testenv:py38-docs]
+[testenv:py37-docs]
 whitelist_externals=
     make
 deps = .[p2p, trinity, eth2, doc]
@@ -141,7 +141,7 @@ deps = {[common-integration]deps}
 passenv = {[common-integration]passenv}
 commands = {[common-integration]commands}
 
-[testenv:py38-long_run_integration]
+[testenv:py37-long_run_integration]
 deps = {[common-integration]deps}
 passenv = {[common-integration]passenv}
 commands =

--- a/tox.ini
+++ b/tox.ini
@@ -1,15 +1,15 @@
 [tox]
 envlist=
-    py{37}-{eth1-core,p2p,p2p-trio,integration,lightchain_integration,eth2-core,eth2-fixtures,eth2-integration,eth1-components,eth2-utils,eth2-trio}
-    py37-long_run_integration
-    py37-rpc-blockchain
-    py37-rpc-state-{frontier,homestead,tangerine_whistle,spurious_dragon,byzantium,constantinople,petersburg,istanbul}
+    py{37,38}-{eth1-core,p2p,p2p-trio,integration,lightchain_integration,eth2-core,eth2-fixtures,eth2-integration,eth1-components,eth2-utils,eth2-trio}
+    py38-long_run_integration
+    py38-rpc-blockchain
+    py38-rpc-state-{frontier,homestead,tangerine_whistle,spurious_dragon,byzantium,constantinople,petersburg,istanbul}
     py37-rpc-state-{quadratic,sstore,zero_knowledge}
     py37-{libp2p,eth2-components}
-    py{37}-lint
-    py{37}-lint-eth2
-    py{37}-wheel-cli
-    py37-docs
+    py{38,37}-lint
+    py{38,37}-lint-eth2
+    py{38,37}-wheel-cli
+    py38-docs
 
 [flake8]
 max-line-length= 100
@@ -61,22 +61,25 @@ deps = .[p2p,trinity,eth2,test,test-asyncio]
 
 basepython =
     py37: python3.7
+    py38: python3.8
+
+[testenv:py38-p2p-trio]
+deps = .[p2p,test,test-trio]
+commands = pytest -n 4 {posargs:tests-trio/p2p-trio}
 
 [testenv:py37-p2p-trio]
 deps = .[p2p,test,test-trio]
 commands = pytest -n 4 {posargs:tests-trio/p2p-trio}
 
-
 [testenv:py38-eth2-trio]
 deps = .[eth2,trinity,test,test-trio]
 commands = pytest -n 4 {posargs:tests-trio/eth2} {posargs:tests-trio/trinity} {posargs:tests-trio/integration}
-
 
 [testenv:py37-eth2-trio]
 deps = .[eth2,trinity,test,test-trio]
 commands = pytest -n 4 {posargs:tests-trio/eth2} {posargs:tests-trio/trinity} {posargs:tests-trio/integration}
 
-[testenv:py37-docs]
+[testenv:py38-docs]
 whitelist_externals=
     make
 deps = .[p2p, trinity, eth2, doc]
@@ -101,6 +104,13 @@ commands=
     /bin/bash -c 'pip install --upgrade "$(ls dist/*.whl)""[p2p,trinity]" --progress-bar off'
     pytest {posargs:tests/integration/ -k 'trinity_cli' --log-cli-level 0}
 
+[testenv:py38-wheel-cli]
+deps = {[common-wheel-cli]deps}
+whitelist_externals = {[common-wheel-cli]whitelist_externals}
+commands = {[common-wheel-cli]commands}
+skip_install=true
+usedevelop=false
+
 [testenv:py37-wheel-cli]
 deps = {[common-wheel-cli]deps}
 whitelist_externals = {[common-wheel-cli]whitelist_externals}
@@ -121,12 +131,17 @@ commands=
     # The `trinity_cli` tests are already run by the pyxx-wheel-cli jobs. No need to repeat them here
     pytest --integration -n 1 {posargs:tests/integration/ -k 'not lightchain_integration and not trinity_cli'}
 
+[testenv:py38-integration]
+deps = {[common-integration]deps}
+passenv = {[common-integration]passenv}
+commands = {[common-integration]commands}
+
 [testenv:py37-integration]
 deps = {[common-integration]deps}
 passenv = {[common-integration]passenv}
 commands = {[common-integration]commands}
 
-[testenv:py37-long_run_integration]
+[testenv:py38-long_run_integration]
 deps = {[common-integration]deps}
 passenv = {[common-integration]passenv}
 commands =
@@ -161,6 +176,11 @@ commands=
     mypy -p p2p --config-file {toxinidir}/mypy.ini
 
 
+[testenv:py38-lint]
+deps = {[common-lint]deps}
+commands= {[common-lint]commands}
+
+
 [testenv:py37-lint]
 deps = {[common-lint]deps}
 commands= {[common-lint]commands}
@@ -173,6 +193,10 @@ commands=
     black --check eth2 trinity/components/eth2 tests/eth2 tests/libp2p tests/components/eth2 tests-trio/eth2
     isort --recursive --check-only eth2 trinity/components/eth2 tests/eth2 tests/libp2p tests/components/eth2 tests-trio/eth2
 
+[testenv:py38-lint-eth2]
+deps = {[common-lint-eth2]deps}
+commands= {[common-lint-eth2]commands}
+
 [testenv:py37-lint-eth2]
 deps = {[common-lint-eth2]deps}
 commands= {[common-lint-eth2]commands}
@@ -180,8 +204,17 @@ commands= {[common-lint-eth2]commands}
 [common-eth2-utils]
 deps = .[eth2,eth2-extra,test]
 
+[testenv:py38-eth2-utils]
+deps = {[common-eth2-utils]deps}
+
 [testenv:py37-eth2-utils]
 deps = {[common-eth2-utils]deps}
+
+[testenv:py38-eth2-fixtures]
+deps = .[eth2,eth2-extra,test]
+commands=
+    pytest -n 4 --config minimal {posargs:tests/eth2/fixtures/}
+    pytest -n 4 --config mainnet {posargs:tests/eth2/fixtures/}
 
 
 [testenv:py37-eth2-fixtures]

--- a/tox.ini
+++ b/tox.ini
@@ -1,15 +1,15 @@
 [tox]
 envlist=
-    py{36,37}-{eth1-core,p2p,p2p-trio,integration,lightchain_integration,eth2-core,eth2-fixtures,eth2-integration,eth1-components,eth2-utils,eth2-trio}
-    py36-long_run_integration
-    py36-rpc-blockchain
-    py36-rpc-state-{frontier,homestead,tangerine_whistle,spurious_dragon,byzantium,constantinople,petersburg,istanbul}
+    py{37}-{eth1-core,p2p,p2p-trio,integration,lightchain_integration,eth2-core,eth2-fixtures,eth2-integration,eth1-components,eth2-utils,eth2-trio}
+    py37-long_run_integration
+    py37-rpc-blockchain
+    py37-rpc-state-{frontier,homestead,tangerine_whistle,spurious_dragon,byzantium,constantinople,petersburg,istanbul}
     py37-rpc-state-{quadratic,sstore,zero_knowledge}
     py37-{libp2p,eth2-components}
-    py{36,37}-lint
-    py{36,37}-lint-eth2
-    py{36,37}-wheel-cli
-    py36-docs
+    py{37}-lint
+    py{37}-lint-eth2
+    py{37}-wheel-cli
+    py37-docs
 
 [flake8]
 max-line-length= 100
@@ -60,26 +60,23 @@ commands=
 deps = .[p2p,trinity,eth2,test,test-asyncio]
 
 basepython =
-    py36: python3.6
     py37: python3.7
-
-[testenv:py36-p2p-trio]
-deps = .[p2p,test,test-trio]
-commands = pytest -n 4 {posargs:tests-trio/p2p-trio}
 
 [testenv:py37-p2p-trio]
 deps = .[p2p,test,test-trio]
 commands = pytest -n 4 {posargs:tests-trio/p2p-trio}
 
-[testenv:py36-eth2-trio]
+
+[testenv:py38-eth2-trio]
 deps = .[eth2,trinity,test,test-trio]
 commands = pytest -n 4 {posargs:tests-trio/eth2} {posargs:tests-trio/trinity} {posargs:tests-trio/integration}
+
 
 [testenv:py37-eth2-trio]
 deps = .[eth2,trinity,test,test-trio]
 commands = pytest -n 4 {posargs:tests-trio/eth2} {posargs:tests-trio/trinity} {posargs:tests-trio/integration}
 
-[testenv:py36-docs]
+[testenv:py37-docs]
 whitelist_externals=
     make
 deps = .[p2p, trinity, eth2, doc]
@@ -104,13 +101,6 @@ commands=
     /bin/bash -c 'pip install --upgrade "$(ls dist/*.whl)""[p2p,trinity]" --progress-bar off'
     pytest {posargs:tests/integration/ -k 'trinity_cli' --log-cli-level 0}
 
-[testenv:py36-wheel-cli]
-deps = {[common-wheel-cli]deps}
-whitelist_externals = {[common-wheel-cli]whitelist_externals}
-commands = {[common-wheel-cli]commands}
-skip_install=true
-usedevelop=false
-
 [testenv:py37-wheel-cli]
 deps = {[common-wheel-cli]deps}
 whitelist_externals = {[common-wheel-cli]whitelist_externals}
@@ -131,17 +121,12 @@ commands=
     # The `trinity_cli` tests are already run by the pyxx-wheel-cli jobs. No need to repeat them here
     pytest --integration -n 1 {posargs:tests/integration/ -k 'not lightchain_integration and not trinity_cli'}
 
-[testenv:py36-integration]
-deps = {[common-integration]deps}
-passenv = {[common-integration]passenv}
-commands = {[common-integration]commands}
-
 [testenv:py37-integration]
 deps = {[common-integration]deps}
 passenv = {[common-integration]passenv}
 commands = {[common-integration]commands}
 
-[testenv:py36-long_run_integration]
+[testenv:py37-long_run_integration]
 deps = {[common-integration]deps}
 passenv = {[common-integration]passenv}
 commands =
@@ -176,11 +161,6 @@ commands=
     mypy -p p2p --config-file {toxinidir}/mypy.ini
 
 
-[testenv:py36-lint]
-deps = {[common-lint]deps}
-commands= {[common-lint]commands}
-
-
 [testenv:py37-lint]
 deps = {[common-lint]deps}
 commands= {[common-lint]commands}
@@ -193,10 +173,6 @@ commands=
     black --check eth2 trinity/components/eth2 tests/eth2 tests/libp2p tests/components/eth2 tests-trio/eth2
     isort --recursive --check-only eth2 trinity/components/eth2 tests/eth2 tests/libp2p tests/components/eth2 tests-trio/eth2
 
-[testenv:py36-lint-eth2]
-deps = {[common-lint-eth2]deps}
-commands= {[common-lint-eth2]commands}
-
 [testenv:py37-lint-eth2]
 deps = {[common-lint-eth2]deps}
 commands= {[common-lint-eth2]commands}
@@ -204,17 +180,8 @@ commands= {[common-lint-eth2]commands}
 [common-eth2-utils]
 deps = .[eth2,eth2-extra,test]
 
-[testenv:py36-eth2-utils]
-deps = {[common-eth2-utils]deps}
-
 [testenv:py37-eth2-utils]
 deps = {[common-eth2-utils]deps}
-
-[testenv:py36-eth2-fixtures]
-deps = .[eth2,eth2-extra,test]
-commands=
-    pytest -n 4 --config minimal {posargs:tests/eth2/fixtures/}
-    pytest -n 4 --config mainnet {posargs:tests/eth2/fixtures/}
 
 
 [testenv:py37-eth2-fixtures]

--- a/trinity/_utils/version.py
+++ b/trinity/_utils/version.py
@@ -9,7 +9,7 @@ def construct_trinity_client_identifier() -> str:
     """
     Constructs the client identifier string
 
-    e.g. 'Trinity/v1.2.3/darwin-amd64/python3.6.5'
+    e.g. 'Trinity/v1.2.3/darwin-amd64/python3.7.3'
     """
     return (
         "Trinity/"

--- a/trinity/components/builtin/json_rpc/component.py
+++ b/trinity/components/builtin/json_rpc/component.py
@@ -6,7 +6,6 @@ import contextlib
 from typing import Iterator, Tuple, Union
 
 from async_service import background_asyncio_service, Service
-from async_exit_stack import AsyncExitStack
 
 from lahja import EndpointAPI
 
@@ -147,7 +146,7 @@ class JsonRpcServerComponent(AsyncioIsolatedComponent):
                 )
                 services_to_exit += (http_server,)
 
-            async with AsyncExitStack() as stack:
+            async with contextlib.AsyncExitStack() as stack:
                 managers = tuple([
                     await stack.enter_async_context(background_asyncio_service(service))
                     for service in services_to_exit

--- a/trinity/components/builtin/metrics/component.py
+++ b/trinity/components/builtin/metrics/component.py
@@ -4,9 +4,9 @@ from argparse import (
     Namespace,
     _SubParsersAction,
 )
+import contextlib
 from typing import Type
 
-from async_exit_stack import AsyncExitStack
 from async_service import background_trio_service
 from eth_utils import ValidationError
 
@@ -164,7 +164,7 @@ class MetricsComponent(TrioIsolatedComponent):
             blockchain_metrics_collector,
         )
 
-        async with AsyncExitStack() as stack:
+        async with contextlib.AsyncExitStack() as stack:
             managers = tuple([
                 await stack.enter_async_context(background_trio_service(service))
                 for service in services_to_exit

--- a/trinity/components/builtin/network_db/component.py
+++ b/trinity/components/builtin/network_db/component.py
@@ -4,10 +4,10 @@ from argparse import (
     _SubParsersAction,
 )
 import asyncio
+import contextlib
 import logging
 from typing import ClassVar, Iterable
 
-from async_exit_stack import AsyncExitStack
 from async_service import background_asyncio_service, Service
 from eth_utils import ValidationError, to_tuple
 from lahja import EndpointAPI
@@ -240,7 +240,7 @@ class NetworkDBComponent(AsyncioIsolatedComponent):
         except BadDatabaseError as err:
             cls.logger.exception(f"Unrecoverable error in Network Component: {err}")
 
-        async with AsyncExitStack() as stack:
+        async with contextlib.AsyncExitStack() as stack:
             tracker_managers = tuple([
                 await stack.enter_async_context(background_asyncio_service(service))
                 for service in tracker_services

--- a/trinity/components/eth2/beacon/component.py
+++ b/trinity/components/eth2/beacon/component.py
@@ -1,9 +1,9 @@
 from argparse import ArgumentParser, _SubParsersAction
 import asyncio
+import contextlib
 import logging
 from typing import Set, Tuple
 
-from async_exit_stack import AsyncExitStack
 from lahja import EndpointAPI
 from libp2p.crypto.keys import KeyPair
 from libp2p.crypto.secp256k1 import create_new_key_pair
@@ -174,7 +174,7 @@ class BeaconNodeComponent(AsyncioIsolatedComponent):
             if boot_info.args.bn_only:
                 services += (chain_maintainer, validator_handler)
 
-            async with AsyncExitStack() as stack:
+            async with contextlib.AsyncExitStack() as stack:
                 for service in services:
                     await stack.enter_async_context(run_service(service))
 

--- a/trinity/extensibility/component.py
+++ b/trinity/extensibility/component.py
@@ -7,14 +7,15 @@ from argparse import (
     _SubParsersAction,
 )
 import asyncio
+import contextlib
 import logging
 import os
 import pathlib
 import signal
 from typing import AsyncIterator, Optional, Type, TYPE_CHECKING, Union
 
-from async_generator import asynccontextmanager
 from asyncio_run_in_process.typing import SubprocessKwargs
+
 
 from lahja import AsyncioEndpoint, ConnectionConfig, EndpointAPI, TrioEndpoint
 
@@ -141,7 +142,7 @@ async def _cleanup_component_task(component_name: str, task: "asyncio.Future[Non
     logger.debug("Stopped component: %s", component_name)
 
 
-@asynccontextmanager
+@contextlib.asynccontextmanager
 async def run_component(component: ComponentAPI) -> AsyncIterator[None]:
     task = asyncio.ensure_future(component.run())
     logger.debug("Starting component: %s", component.name)
@@ -151,7 +152,7 @@ async def run_component(component: ComponentAPI) -> AsyncIterator[None]:
         await _cleanup_component_task(component.name, task)
 
 
-@asynccontextmanager
+@contextlib.asynccontextmanager
 async def _run_asyncio_component_in_proc(
         component_type: Type['AsyncioIsolatedComponent'],
         event_bus: EndpointAPI,
@@ -169,7 +170,7 @@ async def _run_asyncio_component_in_proc(
         await _cleanup_component_task(component.name, task)
 
 
-@asynccontextmanager
+@contextlib.asynccontextmanager
 async def _run_trio_component_in_proc(
         component_type: Type['TrioIsolatedComponent'],
         event_bus: EndpointAPI,
@@ -187,7 +188,7 @@ async def _run_trio_component_in_proc(
         logger.debug("Stopped component: %s", component_type.name)
 
 
-@asynccontextmanager
+@contextlib.asynccontextmanager
 async def _run_standalone_component(
     component_type: Union[Type['TrioIsolatedComponent'], Type['AsyncioIsolatedComponent']],
     app_identifier: str,

--- a/trinity/protocol/bcc_libp2p/node.py
+++ b/trinity/protocol/bcc_libp2p/node.py
@@ -1,4 +1,5 @@
 import asyncio
+import contextlib
 from dataclasses import dataclass
 import logging
 import operator
@@ -152,7 +153,6 @@ from .utils import (
     get_requested_beacon_blocks,
     get_beacon_blocks_by_root,
 )
-from async_generator import asynccontextmanager
 
 from trinity.metrics.events import (
     Libp2pPeersRequest,
@@ -547,7 +547,7 @@ class Node(BaseService):
     async def new_stream(self, peer_id: ID, protocol: TProtocol) -> INetStream:
         return await self.host.new_stream(peer_id, [protocol])
 
-    @asynccontextmanager
+    @contextlib.asynccontextmanager
     async def new_handshake_interaction(self, stream: INetStream) -> AsyncIterator[Interaction]:
         try:
             async with Interaction(stream) as interaction:
@@ -567,7 +567,7 @@ class Node(BaseService):
             )
             raise HandshakeFailure from error
 
-    @asynccontextmanager
+    @contextlib.asynccontextmanager
     async def post_handshake_handler_interaction(
         self,
         stream: INetStream
@@ -585,7 +585,7 @@ class Node(BaseService):
             await stream.reset()
             return
 
-    @asynccontextmanager
+    @contextlib.asynccontextmanager
     async def my_request_interaction(self, stream: INetStream) -> AsyncIterator[Interaction]:
         try:
             async with Interaction(stream) as interaction:

--- a/trinity/server.py
+++ b/trinity/server.py
@@ -1,5 +1,6 @@
 from abc import abstractmethod
 import asyncio
+import contextlib
 from typing import (
     AsyncIterator,
     Generic,
@@ -8,7 +9,6 @@ from typing import (
     TypeVar,
 )
 
-from async_generator import asynccontextmanager
 
 from async_service import Service
 
@@ -103,7 +103,7 @@ class BaseServer(Service, Generic[TPeerPool]):
     def _make_peer_pool(self) -> TPeerPool:
         ...
 
-    @asynccontextmanager
+    @contextlib.asynccontextmanager
     async def tcp_listener(self) -> AsyncIterator[None]:
         # TODO: Support IPv6 addresses as well.
         tcp_listener = await asyncio.start_server(

--- a/trinity/sync/common/headers.py
+++ b/trinity/sync/common/headers.py
@@ -1,6 +1,7 @@
 from abc import ABC, abstractmethod
 import asyncio
 from concurrent.futures import CancelledError
+import contextlib
 from functools import partial
 from operator import attrgetter, itemgetter
 from random import randrange
@@ -19,9 +20,6 @@ from typing import (
 
 from async_service import Service, background_asyncio_service
 
-from async_generator import (
-    asynccontextmanager,
-)
 from eth_typing import (
     BlockIdentifier,
     BlockNumber,
@@ -908,7 +906,7 @@ class BaseHeaderChainSyncer(Service, HeaderSyncerAPI, Generic[TChainPeer]):
                 async with self._get_skeleton_syncer(peer) as syncer:
                     await self._full_skeleton_sync(syncer)
 
-    @asynccontextmanager
+    @contextlib.asynccontextmanager
     async def _get_skeleton_syncer(
             self, peer: TChainPeer) -> AsyncIterator[SkeletonSyncer[TChainPeer]]:
         if self._is_syncing_skeleton:

--- a/trinity/tools/async_process_runner.py
+++ b/trinity/tools/async_process_runner.py
@@ -1,4 +1,5 @@
 import asyncio
+import contextlib
 import logging
 import os
 import signal
@@ -10,7 +11,6 @@ from typing import (
     Tuple,
 )
 
-from async_generator import asynccontextmanager
 from async_timeout import timeout
 
 
@@ -21,7 +21,7 @@ class AsyncProcessRunner():
     proc: asyncio.subprocess.Process
 
     @classmethod
-    @asynccontextmanager
+    @contextlib.asynccontextmanager
     async def run(cls,
                   cmds: Tuple[str, ...],
                   timeout_sec: int = 10) -> AsyncIterator['AsyncProcessRunner']:

--- a/trinity/tools/bcc_factories.py
+++ b/trinity/tools/bcc_factories.py
@@ -1,8 +1,7 @@
 from eth2.beacon.tools.factories import BeaconChainFactory
 import asyncio
+import contextlib
 from typing import Any, AsyncIterator, Dict, Iterable, Collection, Tuple, Type, Sequence
-
-from async_generator import asynccontextmanager
 
 from cancel_token import CancelToken
 
@@ -90,7 +89,7 @@ class PeerFactory(factory.Factory):
     head_slot = 0
 
 
-@asynccontextmanager
+@contextlib.asynccontextmanager
 async def ConnectionPairFactory(
     alice_chaindb: AsyncBeaconChainDB = None,
     alice_branch: Collection[BaseSignedBeaconBlock] = None,

--- a/trinity/tools/event_bus.py
+++ b/trinity/tools/event_bus.py
@@ -1,11 +1,11 @@
 import asyncio
+import contextlib
 from typing import AsyncIterator, Type
 
-from async_generator import asynccontextmanager
 from lahja import BaseEvent, EndpointAPI
 
 
-@asynccontextmanager
+@contextlib.asynccontextmanager
 async def mock_request_response(request_type: Type[BaseEvent],
                                 response: BaseEvent,
                                 event_bus: EndpointAPI) -> AsyncIterator[None]:


### PR DESCRIPTION
### What was wrong?

When we get rid of Python 3.6 support we should make sure we support Python 3.8 by testing against it in CI.

### How was it fixed?

Add CI jobs for Python 3.8

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

[//]: # (See: https://trinity-client.readthedocs.io/en/latest/contributing.html#pull-requests)
- [x] Add entry to the [release notes](https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://pbs.twimg.com/media/DArLyIzXoAAe-zR.jpg:large)
