### PR TITLE
Add influxdb port and protocol cli args for collecting metrics

### DIFF
--- a/newsfragments/1680.feature.rst
+++ b/newsfragments/1680.feature.rst
@@ -1,0 +1,1 @@
+Allow for Influxdb port & protocol to be configured via cli arguments.

--- a/trinity/components/builtin/metrics/abc.py
+++ b/trinity/components/builtin/metrics/abc.py
@@ -13,6 +13,8 @@ class MetricsServiceAPI(ServiceAPI):
                  influx_password: str,
                  influx_database: str,
                  host: str,
+                 port: int,
+                 protocol: str,
                  reporting_frequency: int) -> None:
         ...
 

--- a/trinity/components/builtin/metrics/component.py
+++ b/trinity/components/builtin/metrics/component.py
@@ -31,6 +31,8 @@ def metrics_service_from_args(
         influx_password=args.metrics_influx_password,
         influx_database=args.metrics_influx_database,
         host=args.metrics_host,
+        port=args.metrics_influx_port,
+        protocol=args.metrics_influx_protocol,
         reporting_frequency=args.metrics_reporting_frequency,
     )
 
@@ -60,7 +62,7 @@ class MetricsComponent(TrioIsolatedComponent):
 
         metrics_parser.add_argument(
             '--metrics-host',
-            help='Host name to tag the metrics data (e.g. trinity-bootnode-europe-pt',
+            help='Host name to tag the metrics data (e.g. trinity-bootnode-europe-pt)',
             default=os.environ.get('TRINITY_METRICS_HOST'),
         )
 
@@ -86,6 +88,21 @@ class MetricsComponent(TrioIsolatedComponent):
             '--metrics-influx-server',
             help='Influx DB server. Defaults to ENV var TRINITY_METRICS_INFLUX_DB_SERVER',
             default=os.environ.get('TRINITY_METRICS_INFLUX_DB_SERVER'),
+        )
+
+        metrics_parser.add_argument(
+            '--metrics-influx-port',
+            help='Influx DB port. Defaults to ENV var TRINITY_METRICS_INFLUX_DB_PORT or 8086',
+            default=os.environ.get('TRINITY_METRICS_INFLUX_DB_PORT'),
+        )
+
+        metrics_parser.add_argument(
+            '--metrics-influx-protocol',
+            help=(
+                'Influx DB protocol. Defaults to ENV var '
+                'TRINITY_METRICS_INFLUX_DB_PROTOCOL or http'
+            ),
+            default=os.environ.get('TRINITY_METRICS_INFLUX_DB_PROTOCOL'),
         )
 
         metrics_parser.add_argument(

--- a/trinity/components/builtin/metrics/service/base.py
+++ b/trinity/components/builtin/metrics/service/base.py
@@ -20,17 +20,19 @@ class BaseMetricsService(Service, MetricsServiceAPI):
                  influx_password: str,
                  influx_database: str,
                  host: str,
+                 port: int = 8086,
+                 protocol: str = 'http',
                  reporting_frequency: int = 10):
         self._influx_server = influx_server
         self._reporting_frequency = reporting_frequency
         self._registry = HostMetricsRegistry(host)
         self._reporter = InfluxReporter(
             registry=self._registry,
-            protocol='https',
-            port=443,
             database=influx_database,
             username=influx_user,
             password=influx_password,
+            protocol=protocol,
+            port=port,
             server=influx_server
         )
 


### PR DESCRIPTION
### What was wrong?
There were no command line flags for setting the influxdb port/protocol.


### How was it fixed?
Added a `--metrics-influx-port` and `--metrics-influx-protocol` flag that default to environment variables `TRINITY_METRICS_INFLUX_DB_PORT `, `TRINITY_METRICS_INFLUX_DB_PROTOCOL ` or to a port of `8086` and protocol of `http` (the default values of a fresh influxdb config) if no environment variables are found. 

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

[//]: # (See: https://trinity-client.readthedocs.io/en/latest/contributing.html#pull-requests)
- [x] Add entry to the [release notes](https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

#### Cute Animal Picture
![image](https://user-images.githubusercontent.com/9753150/79582893-01ae4480-8092-11ea-9a65-364710a4e671.png)

