### PR TITLE
Upgrade to py-evm v0.3.0-alpha.15

### DIFF
--- a/newsfragments/1681.feature.rst
+++ b/newsfragments/1681.feature.rst
@@ -1,0 +1,1 @@
+Upgrade to py-evm v0.3.0-alpha.15 -- gives access to block state witnesses

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ import os
 import re
 from setuptools import setup, find_packages
 
-PYEVM_DEPENDENCY = "py-evm==0.3.0a14"
+PYEVM_DEPENDENCY = "py-evm==0.3.0a15"
 
 
 deps = {

--- a/trinity/chains/base.py
+++ b/trinity/chains/base.py
@@ -7,6 +7,7 @@ from eth.abc import (
     BlockAPI,
     ChainAPI,
     BlockHeaderAPI,
+    BlockImportResult,
     ReceiptAPI,
     SignedTransactionAPI,
 )
@@ -19,7 +20,7 @@ class AsyncChainAPI(ChainAPI):
     async def coro_import_block(self,
                                 block: BlockHeaderAPI,
                                 perform_validation: bool = True,
-                                ) -> Tuple[BlockAPI, Tuple[BlockAPI, ...], Tuple[BlockAPI, ...]]:
+                                ) -> BlockImportResult:
         ...
 
     @abstractmethod

--- a/trinity/sync/beam/chain.py
+++ b/trinity/sync/beam/chain.py
@@ -10,7 +10,7 @@ from async_service import Service, background_asyncio_service
 
 from lahja import EndpointAPI
 
-from eth.abc import AtomicDatabaseAPI, DatabaseAPI
+from eth.abc import AtomicDatabaseAPI, BlockImportResult, DatabaseAPI
 from eth.constants import GENESIS_PARENT_HASH
 from eth.exceptions import (
     HeaderNotFound,
@@ -572,7 +572,7 @@ class BeamBlockImporter(BaseBlockImporter, Service):
 
     async def import_block(
             self,
-            block: BaseBlock) -> Tuple[BaseBlock, Tuple[BaseBlock, ...], Tuple[BaseBlock, ...]]:
+            block: BaseBlock) -> BlockImportResult:
         self.logger.info("Beam importing %s (%d txns) ...", block.header, len(block.transactions))
 
         parent_header = await self._chain.coro_get_block_header_by_hash(block.header.parent_hash)

--- a/trinity/sync/beam/importer.py
+++ b/trinity/sync/beam/importer.py
@@ -18,6 +18,7 @@ from eth.abc import (
     AtomicDatabaseAPI,
     BlockAPI,
     BlockHeaderAPI,
+    BlockImportResult,
     ConsensusContextAPI,
     SignedTransactionAPI,
     StateAPI,
@@ -65,8 +66,6 @@ from trinity.sync.common.events import (
     StatelessBlockImportDone,
 )
 from trinity._utils.logging import get_logger
-
-ImportBlockType = Tuple[BlockAPI, Tuple[BlockAPI, ...], Tuple[BlockAPI, ...]]
 
 
 class BeamStats:
@@ -397,7 +396,7 @@ def _broadcast_import_complete(
         event_bus: EndpointAPI,
         block: BlockAPI,
         broadcast_config: BroadcastConfig,
-        future: 'asyncio.Future[ImportBlockType]') -> None:
+        future: 'asyncio.Future[BlockImportResult]') -> None:
     completed = not future.cancelled()
     event_bus.broadcast_nowait(
         StatelessBlockImportDone(
@@ -412,11 +411,11 @@ def _broadcast_import_complete(
 
 def partial_import_block(beam_chain: BeamChain,
                          block: BlockAPI,
-                         ) -> Callable[[], Tuple[BlockAPI, Tuple[BlockAPI, ...], Tuple[BlockAPI, ...]]]:  # noqa: E501
+                         ) -> Callable[[], BlockImportResult]:  # noqa: E501
     """
     Get an argument-free function that will import the given block.
     """
-    def _import_block() -> Tuple[BlockAPI, Tuple[BlockAPI, ...], Tuple[BlockAPI, ...]]:
+    def _import_block() -> BlockImportResult:
         t = Timer()
         beam_chain.clear_first_vm()
         try:

--- a/trinity/sync/common/chain.py
+++ b/trinity/sync/common/chain.py
@@ -11,6 +11,7 @@ from cancel_token import (
     OperationCancelled,
 )
 
+from eth.abc import BlockImportResult
 from eth.constants import GENESIS_BLOCK_NUMBER
 from eth.exceptions import (
     HeaderNotFound,
@@ -255,7 +256,7 @@ class BaseBlockImporter(ABC):
     @abstractmethod
     async def import_block(
             self,
-            block: BlockAPI) -> Tuple[BlockAPI, Tuple[BlockAPI, ...], Tuple[BlockAPI, ...]]:
+            block: BlockAPI) -> BlockImportResult:
         ...
 
     async def preview_transactions(
@@ -287,7 +288,7 @@ class SimpleBlockImporter(BaseBlockImporter):
 
     async def import_block(
             self,
-            block: BlockAPI) -> Tuple[BlockAPI, Tuple[BlockAPI, ...], Tuple[BlockAPI, ...]]:
+            block: BlockAPI) -> BlockImportResult:
         return await self._chain.coro_import_block(block, perform_validation=True)
 
 

--- a/trinity/sync/common/events.py
+++ b/trinity/sync/common/events.py
@@ -7,6 +7,7 @@ from typing import (
     Type,
 )
 
+from eth.abc import BlockImportResult
 from eth.rlp.blocks import BaseBlock
 from eth.rlp.headers import BlockHeader
 from eth.rlp.transactions import BaseTransaction
@@ -126,9 +127,8 @@ class StatelessBlockImportDone(BaseEvent):
 
     block: BaseBlock
     completed: bool
-    result: Tuple[BaseBlock, Tuple[BaseBlock, ...], Tuple[BaseBlock, ...]]
-    # flake8 gets confused by the Tuple syntax above
-    exception: BaseException  # noqa: E701
+    result: BlockImportResult
+    exception: BaseException
 
 
 @dataclass

--- a/trinity/sync/full/chain.py
+++ b/trinity/sync/full/chain.py
@@ -1160,8 +1160,9 @@ class RegularChainBodySyncer(BaseBodyChainSyncer):
         # Log the latest import block so that we can accurately report lag
         self._latest_block_number = block.number
 
-        _, new_canonical_blocks, old_canonical_blocks = await self._block_importer.import_block(
-            block)
+        import_result = await self._block_importer.import_block(block)
+        new_canonical_blocks = import_result.new_canonical_blocks
+        old_canonical_blocks = import_result.old_canonical_blocks
 
         # How much is the imported block's header behind the current time?
         lag = time.time() - block.header.timestamp


### PR DESCRIPTION
### What was wrong?

Wanted access to some of the latest evm updates, like:
- witness data in the `Chain.import_block()` result
- eth-keys could be updated

### How was it fixed?

Upgrade to py-evm v0.3.0-alpha.15, then:
- Handle the new BlockImportResult returned by Chain.import_block()
- py-evm's AtomicDB type signature was improved. A custom version of
AtomicDBWriteBatch had to be updated. It was shrunk down significantly,
depending on the functionality provided in py-evm's version.

~Also updated web3.py, eth-tester and eth-keys.~ This was too big, moved to #1725 

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

[//]: # (See: https://trinity-client.readthedocs.io/en/latest/contributing.html#pull-requests)
- [x] Add entry to the [release notes](https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://static.boredpanda.com/blog/wp-content/uploads/2015/12/tool-dog-dachshund-suit-auto-mechanic-fb1.png)
