### PR TITLE
Support blockchain stats for grafana

### DIFF
--- a/trinity/_utils/connect.py
+++ b/trinity/_utils/connect.py
@@ -9,7 +9,10 @@ from trinity.db.eth1.header import AsyncHeaderDB
 from trinity.chains.light_eventbus import (
     EventBusLightPeerChain,
 )
-from trinity.config import TAppConfig
+from trinity.config import (
+    Eth1AppConfig,
+    TAppConfig,
+)
 from trinity.constants import (
     SYNC_LIGHT,
 )
@@ -17,12 +20,10 @@ from trinity.db.manager import DBClient
 
 
 @contextlib.contextmanager
-def get_chain(app_config_type: Type[TAppConfig],
-              boot_info: BootInfo,
-              event_bus: EndpointAPI) -> Iterator[ChainAPI]:
-    app_config = boot_info.trinity_config.get_app_config(app_config_type)
-    # ignore b/c TAppConfig has no attribute get_chain_config
-    chain_config = app_config.get_chain_config()  # type: ignore
+def get_eth1_chain_with_remote_db(boot_info: BootInfo,
+                                  event_bus: EndpointAPI) -> Iterator[ChainAPI]:
+    app_config = boot_info.trinity_config.get_app_config(Eth1AppConfig)
+    chain_config = app_config.get_chain_config()
 
     chain: ChainAPI
     base_db = DBClient.connect(boot_info.trinity_config.database_ipc_path)

--- a/trinity/_utils/connect.py
+++ b/trinity/_utils/connect.py
@@ -1,0 +1,39 @@
+from typing import Iterator, Type
+import contextlib
+
+from eth.abc import ChainAPI
+
+from lahja import EndpointAPI
+from trinity.boot_info import BootInfo
+from trinity.db.eth1.header import AsyncHeaderDB
+from trinity.chains.light_eventbus import (
+    EventBusLightPeerChain,
+)
+from trinity.config import TAppConfig
+from trinity.constants import (
+    SYNC_LIGHT,
+)
+from trinity.db.manager import DBClient
+
+
+@contextlib.contextmanager
+def get_chain(app_config_type: Type[TAppConfig],
+              boot_info: BootInfo,
+              event_bus: EndpointAPI) -> Iterator[ChainAPI]:
+    app_config = boot_info.trinity_config.get_app_config(app_config_type)
+    # ignore b/c TAppConfig has no attribute get_chain_config
+    chain_config = app_config.get_chain_config()  # type: ignore
+
+    chain: ChainAPI
+    base_db = DBClient.connect(boot_info.trinity_config.database_ipc_path)
+    with base_db:
+        if boot_info.args.sync_mode == SYNC_LIGHT:
+            header_db = AsyncHeaderDB(base_db)
+            chain = chain_config.light_chain_class(
+                header_db,
+                peer_chain=EventBusLightPeerChain(event_bus)
+            )
+        else:
+            chain = chain_config.full_chain_class(base_db)
+
+        yield chain

--- a/trinity/_utils/connect.py
+++ b/trinity/_utils/connect.py
@@ -1,4 +1,4 @@
-from typing import Iterator, Type
+from typing import Iterator
 import contextlib
 
 from eth.abc import ChainAPI
@@ -11,7 +11,6 @@ from trinity.chains.light_eventbus import (
 )
 from trinity.config import (
     Eth1AppConfig,
-    TAppConfig,
 )
 from trinity.constants import (
     SYNC_LIGHT,

--- a/trinity/components/builtin/ethstats/ethstats_service.py
+++ b/trinity/components/builtin/ethstats/ethstats_service.py
@@ -10,13 +10,10 @@ from lahja import EndpointAPI
 
 from eth.abc import ChainAPI
 
-from trinity.config import (
-    Eth1AppConfig,
-)
 from trinity.constants import (
     TO_NETWORKING_BROADCAST_CONFIG,
 )
-from trinity._utils.connect import get_chain as get_connected_chain
+from trinity._utils.connect import get_eth1_chain_with_remote_db
 from trinity._utils.version import (
     construct_trinity_client_identifier,
 )
@@ -148,4 +145,4 @@ class EthstatsService(Service):
         }
 
     def get_chain(self) -> ContextManager[ChainAPI]:
-        return get_connected_chain(Eth1AppConfig, self.boot_info, self.event_bus)
+        return get_eth1_chain_with_remote_db(self.boot_info, self.event_bus)

--- a/trinity/components/builtin/ethstats/ethstats_service.py
+++ b/trinity/components/builtin/ethstats/ethstats_service.py
@@ -1,8 +1,7 @@
 import asyncio
-import contextlib
 import logging
 import platform
-from typing import Iterator
+from typing import ContextManager
 
 import websockets
 
@@ -15,14 +14,9 @@ from trinity.config import (
     Eth1AppConfig,
 )
 from trinity.constants import (
-    SYNC_LIGHT,
     TO_NETWORKING_BROADCAST_CONFIG,
 )
-from trinity.chains.light_eventbus import (
-    EventBusLightPeerChain,
-)
-from trinity.db.eth1.header import AsyncHeaderDB
-from trinity.db.manager import DBClient
+from trinity._utils.connect import get_chain as get_connected_chain
 from trinity._utils.version import (
     construct_trinity_client_identifier,
 )
@@ -153,22 +147,5 @@ class EthstatsService(Service):
             'peers': peer_count,
         }
 
-    @contextlib.contextmanager
-    def get_chain(self) -> Iterator[ChainAPI]:
-        app_config = self.boot_info.trinity_config.get_app_config(Eth1AppConfig)
-        chain_config = app_config.get_chain_config()
-
-        chain: ChainAPI
-        base_db = DBClient.connect(self.boot_info.trinity_config.database_ipc_path)
-
-        with base_db:
-            if self.boot_info.args.sync_mode == SYNC_LIGHT:
-                header_db = AsyncHeaderDB(base_db)
-                chain = chain_config.light_chain_class(
-                    header_db,
-                    peer_chain=EventBusLightPeerChain(self.event_bus)
-                )
-            else:
-                chain = chain_config.full_chain_class(base_db)
-
-            yield chain
+    def get_chain(self) -> ContextManager[ChainAPI]:
+        return get_connected_chain(Eth1AppConfig, self.boot_info, self.event_bus)

--- a/trinity/components/builtin/metrics/blockchain_metrics_collector.py
+++ b/trinity/components/builtin/metrics/blockchain_metrics_collector.py
@@ -15,9 +15,7 @@ from trinity._utils.connect import get_eth1_chain_with_remote_db
 
 
 class BlockchainStats(NamedTuple):
-    latest_header: int
     latest_block: int
-    latest_receipt: int
 
 
 def read_blockchain_stats(boot_info: BootInfo, event_bus: EndpointAPI) -> BlockchainStats:
@@ -25,9 +23,7 @@ def read_blockchain_stats(boot_info: BootInfo, event_bus: EndpointAPI) -> Blockc
         latest_block_number = chain.get_canonical_head().block_number
 
     return BlockchainStats(
-        latest_header=latest_block_number,
         latest_block=latest_block_number,
-        latest_receipt=latest_block_number,
     )
 
 
@@ -37,12 +33,8 @@ async def collect_blockchain_metrics(manager: ManagerAPI,
                                      event_bus: EndpointAPI,
                                      registry: HostMetricsRegistry,
                                      frequency_seconds: int) -> None:
-    blockchain_header_gauge = registry.gauge('trinity.blockchain/head/header.gauge')
     blockchain_block_gauge = registry.gauge('trinity.blockchain/head/block.gauge')
-    blockchain_receipt_gauge = registry.gauge('trinity.blockchain/head/receipt.gauge')
 
     async for _ in trio_utils.every(frequency_seconds):
         current = read_blockchain_stats(boot_info, event_bus)
-        blockchain_header_gauge.set_value(current.latest_header)
         blockchain_block_gauge.set_value(current.latest_block)
-        blockchain_receipt_gauge.set_value(current.latest_receipt)

--- a/trinity/components/builtin/metrics/blockchain_metrics_collector.py
+++ b/trinity/components/builtin/metrics/blockchain_metrics_collector.py
@@ -1,0 +1,67 @@
+import pathlib
+from typing import (
+    NamedTuple,
+)
+
+from async_service import (
+    as_service,
+    ManagerAPI,
+)
+from eth_utils import to_int
+from p2p import trio_utils
+import web3
+
+from trinity.components.builtin.metrics.registry import HostMetricsRegistry
+from trinity.config import TrinityConfig
+
+
+class BlockchainStats(NamedTuple):
+    latest_header: int
+    latest_block: int
+    latest_receipt: int
+
+
+def read_blockchain_stats(ipc_path: pathlib.Path) -> BlockchainStats:
+    if not ipc_path.exists():
+        return BlockchainStats(
+            latest_header=0,
+            latest_block=0,
+            latest_receipt=0,
+        )
+
+    # Is there a better way to get this data and avoid importing web3
+    ipc_provider = web3.IPCProvider(ipc_path)
+    response = ipc_provider.make_request('eth_blockNumber', None)
+
+    # PersistentSocket must be closed here to avoid unclosed socket error
+    socket = ipc_provider._socket.__enter__()
+    socket.close()
+
+    block = to_int(hexstr=response['result'])
+    return BlockchainStats(
+        latest_header=block,  # ?
+        latest_block=block,
+        latest_receipt=block,  # ?
+    )
+
+
+@as_service
+async def collect_blockchain_metrics(manager: ManagerAPI,
+                                     trinity_config: TrinityConfig,
+                                     registry: HostMetricsRegistry,
+                                     frequency_seconds: int) -> None:
+    ipc_path = trinity_config.jsonrpc_ipc_path
+
+    previous: BlockchainStats = None
+
+    blockchain_header_gauge = registry.gauge('trinity.blockchain/head/header.gauge')
+    blockchain_block_gauge = registry.gauge('trinity.blockchain/head/block.gauge')
+    blockchain_receipt_gauge = registry.gauge('trinity.blockchain/head/receipt.gauge')
+
+    async for _ in trio_utils.every(frequency_seconds):
+        if previous is not None:
+            current = read_blockchain_stats(ipc_path)
+            blockchain_header_gauge.set_value(current.latest_header)
+            blockchain_block_gauge.set_value(current.latest_block)
+            blockchain_receipt_gauge.set_value(current.latest_receipt)
+        previous = current

--- a/trinity/components/builtin/metrics/blockchain_metrics_collector.py
+++ b/trinity/components/builtin/metrics/blockchain_metrics_collector.py
@@ -11,10 +11,7 @@ from p2p import trio_utils
 from lahja import EndpointAPI
 from trinity.boot_info import BootInfo
 from trinity.components.builtin.metrics.registry import HostMetricsRegistry
-from trinity.config import (
-    Eth1AppConfig,
-)
-from trinity._utils.connect import get_chain
+from trinity._utils.connect import get_eth1_chain_with_remote_db
 
 
 class BlockchainStats(NamedTuple):
@@ -24,7 +21,7 @@ class BlockchainStats(NamedTuple):
 
 
 def read_blockchain_stats(boot_info: BootInfo, event_bus: EndpointAPI) -> BlockchainStats:
-    with get_chain(Eth1AppConfig, boot_info, event_bus) as chain:
+    with get_eth1_chain_with_remote_db(boot_info, event_bus) as chain:
         latest_block_number = chain.get_canonical_head().block_number
 
     return BlockchainStats(

--- a/trinity/components/builtin/metrics/component.py
+++ b/trinity/components/builtin/metrics/component.py
@@ -120,6 +120,12 @@ class MetricsComponent(TrioIsolatedComponent):
             default=3,
         )
 
+        metrics_parser.add_argument(
+            '--metrics-blockchain-collector-frequency',
+            help='The frequency in seconds at which blockchain metrics are collected',
+            default=15,
+        )
+
     @classmethod
     def validate_cli(cls, boot_info: BootInfo) -> None:
         args = boot_info.args
@@ -146,9 +152,10 @@ class MetricsComponent(TrioIsolatedComponent):
 
         # types ignored due to https://github.com/ethereum/async-service/issues/5
         blockchain_metrics_collector = collect_blockchain_metrics(  # type: ignore
-            boot_info.trinity_config,
+            boot_info,
+            event_bus,
             metrics_service.registry,
-            frequency_seconds=boot_info.args.metrics_system_collector_frequency
+            frequency_seconds=boot_info.args.metrics_blockchain_collector_frequency
         )
 
         services_to_exit = (

--- a/trinity/components/builtin/metrics/system_metrics_collector.py
+++ b/trinity/components/builtin/metrics/system_metrics_collector.py
@@ -74,7 +74,7 @@ def read_network_stats() -> NetworkStats:
     stats = psutil.net_io_counters()
     return NetworkStats(
         in_packets=stats.packets_recv,
-        out_packets=stats.packets_sent
+        out_packets=stats.packets_sent,
     )
 
 


### PR DESCRIPTION
### What was wrong?
Some endpoints were missing for influxdb/grafana metrics reporting. 


### How was it fixed?
First stab at supporting the `blockchain` stats from the geth dashboard in trinity. 
- `latest block`
- `latest header`
- `latest receipt`

I wanted to play around / experiment with implementing these endpoints (partially inspired by how the `attach` component works), but I'm sure there might be a better solution for grabbing this data. I'm also a little confused by what exactly `latest receipt` and `latest header` means - and if they would ever differ from `latest block` (which they don't seem to on the geth dashboard).


### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

[//]: # (See: https://trinity-client.readthedocs.io/en/latest/contributing.html#pull-requests)
- [ ] Add entry to the [release notes](https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

#### Cute Animal Picture
![image](https://user-images.githubusercontent.com/9753150/79689425-609ec580-821a-11ea-849e-1c24ca0367fa.png)
