### PR TITLE
Make sure _handle_shutdown_request() doesn't exit early

### DIFF
--- a/trinity/components/builtin/peer_discovery/component.py
+++ b/trinity/components/builtin/peer_discovery/component.py
@@ -100,7 +100,7 @@ class PeerDiscoveryComponent(TrioIsolatedComponent):
             with db:
                 await async_service.run_trio_service(discovery_service)
         except Exception:
-            await event_bus.broadcast(ShutdownRequest("Discovery ended unexpectedly"))
+            event_bus.broadcast_nowait(ShutdownRequest("Discovery ended unexpectedly"))
             raise
 
 

--- a/trinity/components/builtin/syncer/component.py
+++ b/trinity/components/builtin/syncer/component.py
@@ -341,7 +341,7 @@ class SyncerComponent(AsyncioIsolatedComponent):
 
         if strategy.shutdown_node_on_halt:
             cls.logger.error("Sync ended unexpectedly. Shutting down trinity")
-            await event_bus.broadcast(ShutdownRequest("Sync ended unexpectedly"))
+            event_bus.broadcast_nowait(ShutdownRequest("Sync ended unexpectedly"))
 
 
 if __name__ == "__main__":

--- a/trinity/nodes/base.py
+++ b/trinity/nodes/base.py
@@ -137,4 +137,5 @@ class Node(Service, Generic[TPeer]):
                 await self.manager.wait_finished()
             finally:
                 self.master_cancel_token.trigger()
-                await self.event_bus.broadcast(ShutdownRequest("Node exiting. Triggering shutdown"))
+                self.event_bus.broadcast_nowait(
+                    ShutdownRequest("Node exiting. Triggering shutdown"))


### PR DESCRIPTION
The ComponentManager runs _handle_shutdown_request() as a daemon, but it
would exit as soon as it received the first shutdown request, causing
asyncio-service to raise a DaemonTaskExit. Now it will loop for as long
as the manager is running and ignore (albeit with a log warning) any
requests but the first one.

Also change callsites that emit a ShutdownRequest() to use
broadcast_nowait(), to avoid potential hangs