### PR TITLE
Convert AsyncioIsolatedComponent classmethods into instance methods

### DIFF
--- a/trinity/extensibility/asyncio.py
+++ b/trinity/extensibility/asyncio.py
@@ -41,10 +41,9 @@ class AsyncioIsolatedComponent(BaseIsolatedComponent):
         async with proc_ctx as proc:
             await proc.wait_result_or_raise()
 
-    @classmethod
-    async def _do_run(cls, boot_info: BootInfo) -> None:
+    async def _do_run(self, boot_info: BootInfo) -> None:
         with child_process_logging(boot_info):
-            endpoint_name = cls.get_endpoint_name()
+            endpoint_name = self.get_endpoint_name()
             event_bus_service = AsyncioEventBusService(
                 boot_info.trinity_config,
                 endpoint_name,
@@ -54,16 +53,15 @@ class AsyncioIsolatedComponent(BaseIsolatedComponent):
 
                 try:
                     if boot_info.profile:
-                        with profiler(f'profile_{cls.get_endpoint_name()}'):
-                            await cls.do_run(boot_info, event_bus)
+                        with profiler(f'profile_{self.get_endpoint_name()}'):
+                            await self.do_run(boot_info, event_bus)
                     else:
-                        await cls.do_run(boot_info, event_bus)
+                        await self.do_run(boot_info, event_bus)
                 except KeyboardInterrupt:
                     return
 
-    @classmethod
     @abstractmethod
-    async def do_run(cls, boot_info: BootInfo, event_bus: EndpointAPI) -> None:
+    async def do_run(self, boot_info: BootInfo, event_bus: EndpointAPI) -> None:
         """
         Define the entry point of the component. Should be overwritten in subclasses.
         """

--- a/trinity/extensibility/component.py
+++ b/trinity/extensibility/component.py
@@ -78,12 +78,6 @@ class BaseComponent(ComponentAPI):
             raise AttributeError(f"No name attribute defined for {self.__class__}")
         self._boot_info = boot_info
 
-    def __str__(self) -> str:
-        return f"<Component[{self.name}]>"
-
-    def __repr__(self) -> str:
-        return f"{type(self).__name__}(boot_info={self._boot_info})"
-
     @classmethod
     def configure_parser(cls, arg_parser: ArgumentParser, subparser: _SubParsersAction) -> None:
         pass
@@ -144,12 +138,13 @@ async def _run_asyncio_component_in_proc(
     """
     Run the given AsyncioIsolatedComponent in the same process as ourselves.
     """
-    task = asyncio.ensure_future(component_type.do_run(boot_info, event_bus))
-    logger.info("Starting component: %s", component_type.name)
+    component = component_type(boot_info)
+    task = asyncio.ensure_future(component.do_run(boot_info, event_bus))
+    logger.info("Starting component: %s", component.name)
     try:
         yield
     finally:
-        await _cleanup_component_task(component_type.name, task)
+        await _cleanup_component_task(component.name, task)
 
 
 @asynccontextmanager


### PR DESCRIPTION
By using classmethods there, most asyncio-run-in-service logs would
be useless because they'd include just the class on which the method
is defined (AsyncioIsolatedComponent) and not the instance (the
actual component).