### PR TITLE
Rewrite UPnP service and convert it to use trio

### DIFF
--- a/p2p/discovery.py
+++ b/p2p/discovery.py
@@ -223,8 +223,8 @@ class DiscoveryService(Service):
             await self.consume_datagram()
 
     async def handle_new_upnp_mapping(self) -> None:
-        from trinity.components.builtin.upnp.events import NewUPnPMapping
-        async for event in self._event_bus.stream(NewUPnPMapping):
+        from trinity.components.builtin.upnp.events import UPnPMapping
+        async for event in self._event_bus.stream(UPnPMapping):
             external_ip = event.ip
             self.logger.debug(
                 "Got new external IP address via UPnP mapping: %s", external_ip)

--- a/scripts/upnp.py
+++ b/scripts/upnp.py
@@ -5,7 +5,7 @@ import trio
 
 from lahja import ConnectionConfig, TrioEndpoint
 
-from trinity.components.builtin.upnp.events import NewUPnPMapping
+from trinity.components.builtin.upnp.events import UPnPMapping
 from trinity.constants import UPNP_EVENTBUS_ENDPOINT
 
 
@@ -19,11 +19,11 @@ async def main() -> None:
         with trio.fail_after(1):
             await client.connect_to_endpoints(connection_config)
 
-        async for event in client.stream(NewUPnPMapping):
+        async for event in client.stream(UPnPMapping):
             external_ip = event.ip
             print("Got new UPnP mapping:", external_ip)
 
 
 if __name__ == "__main__":
-    # Connect to a running UPnPService and prints any NewUPnPMapping it broadcasts.
+    # Connect to a running UPnPService and prints any UPnPMapping it broadcasts.
     trio.run(main)

--- a/tests-trio/p2p-trio/test_discovery.py
+++ b/tests-trio/p2p-trio/test_discovery.py
@@ -43,7 +43,7 @@ from p2p.tools.factories import (
     PrivateKeyFactory,
 )
 
-from trinity.components.builtin.upnp.events import NewUPnPMapping
+from trinity.components.builtin.upnp.events import UPnPMapping
 
 
 # Force our tests to fail quickly if they accidentally get stuck waiting for a response that will
@@ -349,8 +349,8 @@ async def test_handle_new_upnp_mapping(manually_driven_discovery, endpoint_serve
 
     await trio.hazmat.checkpoint()
     external_ip = '43.248.27.0'
-    await endpoint_server.wait_until_any_endpoint_subscribed_to(NewUPnPMapping)
-    await endpoint_server.broadcast(NewUPnPMapping(external_ip))
+    await endpoint_server.wait_until_any_endpoint_subscribed_to(UPnPMapping)
+    await endpoint_server.broadcast(UPnPMapping(external_ip))
 
     with trio.fail_after(0.5):
         while True:

--- a/trinity/components/builtin/upnp/component.py
+++ b/trinity/components/builtin/upnp/component.py
@@ -3,18 +3,18 @@ from argparse import (
     _SubParsersAction,
 )
 
-from async_service import background_asyncio_service
+from async_service import background_trio_service
 from lahja import EndpointAPI
 
 from trinity.boot_info import BootInfo
 from trinity.extensibility import (
-    AsyncioIsolatedComponent,
+    TrioIsolatedComponent,
 )
 from trinity.components.builtin.upnp.nat import UPnPService
 from trinity.constants import UPNP_EVENTBUS_ENDPOINT
 
 
-class UpnpComponent(AsyncioIsolatedComponent):
+class UpnpComponent(TrioIsolatedComponent):
     """
     Continously try to map external to internal ip address/port using the
     Universal Plug 'n' Play (upnp) standard.
@@ -41,10 +41,10 @@ class UpnpComponent(AsyncioIsolatedComponent):
         port = boot_info.trinity_config.port
         upnp_service = UPnPService(port, event_bus)
 
-        async with background_asyncio_service(upnp_service) as manager:
+        async with background_trio_service(upnp_service) as manager:
             await manager.wait_finished()
 
 
 if __name__ == "__main__":
-    from trinity.extensibility.component import run_asyncio_eth1_component
-    run_asyncio_eth1_component(UpnpComponent)
+    from trinity.extensibility.component import run_trio_eth1_component
+    run_trio_eth1_component(UpnpComponent)

--- a/trinity/components/builtin/upnp/events.py
+++ b/trinity/components/builtin/upnp/events.py
@@ -4,5 +4,5 @@ from lahja import BaseEvent
 
 
 @dataclass
-class NewUPnPMapping(BaseEvent):
+class UPnPMapping(BaseEvent):
     ip: str

--- a/trinity/components/builtin/upnp/nat.py
+++ b/trinity/components/builtin/upnp/nat.py
@@ -1,29 +1,122 @@
-import asyncio
-from concurrent.futures import ThreadPoolExecutor
 import ipaddress
 import netifaces
-from typing import (
-    AsyncGenerator,
-)
 from urllib.parse import urlparse
-
-import upnpclient
+from typing import Tuple
 
 from lahja import EndpointAPI
+import trio
+import upnpclient
 
 from async_service import Service
 
+from p2p.trio_utils import every
 from p2p.exceptions import (
     NoInternalAddressMatchesDevice,
 )
 
-from trinity.components.builtin.upnp.events import NewUPnPMapping
+from trinity.components.builtin.upnp.events import UPnPMapping
 from trinity.constants import FIRE_AND_FORGET_BROADCASTING
 from trinity._utils.logging import get_logger
 
 
+class PortMapFailed(Exception):
+    pass
+
+
+class WANServiceNotFound(Exception):
+    pass
+
+
 # UPnP discovery can take a long time, so use a loooong timeout here.
 UPNP_DISCOVER_TIMEOUT_SECONDS = 30
+UPNP_PORTMAP_DURATION = 30 * 60  # 30 minutes
+
+
+logger = get_logger('trinity.components.upnp')
+
+
+class UPnPService(Service):
+    logger = get_logger('trinity.components.upnp.UPnPService')
+
+    def __init__(self, port: int, event_bus: EndpointAPI) -> None:
+        """
+        :param port: The port that a server wants to bind to on this machine, and
+        make publicly accessible.
+        """
+        self.port = port
+        self.event_bus = event_bus
+
+    async def run(self) -> None:
+        """Run an infinite loop refreshing our NAT port mapping.
+
+        On every iteration we configure the port mapping with a lifetime of 30 minutes and then
+        sleep for that long as well.
+        """
+        while self.manager.is_running:
+            async for _ in every(UPNP_PORTMAP_DURATION):
+                with trio.move_on_after(UPNP_DISCOVER_TIMEOUT_SECONDS) as scope:
+                    try:
+                        internal_ip, external_ip = await trio.to_thread.run_sync(
+                            setup_port_map,
+                            self.port,
+                            UPNP_PORTMAP_DURATION,
+                        )
+                        event = UPnPMapping(external_ip)
+                        self.logger.debug(
+                            "NAT portmap created, broadcasting UPnPMapping event: %s", event)
+                        await self.event_bus.broadcast(event, FIRE_AND_FORGET_BROADCASTING)
+                    except PortMapFailed as err:
+                        self.logger.error("Failed to setup NAP portmap: %s", err)
+                    except Exception:
+                        self.logger.exception("Error setuping NAT portmap")
+
+                if scope.cancelled_caught:
+                    self.logger.error("Timeout attempting to setup UPnP port map")
+
+
+def setup_port_map(port: int, duration: int = UPNP_PORTMAP_DURATION) -> Tuple[str, str]:
+    """
+    Set up the port mapping
+
+    :return: the IP address of the new mapping (or None if failed)
+    """
+    devices = upnpclient.discover()
+    if not devices:
+        raise PortMapFailed("No UPnP devices available")
+
+    for upnp_dev in devices:
+        try:
+            internal_ip, external_ip = setup_device_port_map(upnp_dev, port, duration)
+            logger.info(
+                "NAT port forwarding successfully set up: internal=%s:%d external=%s:%d",
+                internal_ip, port,
+                external_ip, port,
+            )
+            break
+        except NoInternalAddressMatchesDevice:
+            logger.debug(
+                "No internal addresses were managed by the UPnP device at %s",
+                upnp_dev.location,
+            )
+            continue
+        except WANServiceNotFound:
+            logger.debug(
+                "No WAN services managed by the UPnP device at %s",
+                upnp_dev.location,
+            )
+            continue
+        except PortMapFailed:
+            logger.debug(
+                "Failed to setup portmap on UPnP divec at %s",
+                upnp_dev.location,
+                exc_info=True,
+            )
+            continue
+    else:
+        logger.info("Failed to setup NAT portmap.  Tried %d devices", len(devices))
+        raise PortMapFailed(f"Failed to setup NAT portmap.  Tried {len(devices)} devices.")
+
+    return internal_ip, external_ip
 
 
 def find_internal_ip_on_device_network(upnp_dev: upnpclient.upnp.Device) -> str:
@@ -41,138 +134,59 @@ def find_internal_ip_on_device_network(upnp_dev: upnpclient.upnp.Device) -> str:
                 continue
             for item in addresses:
                 if ipaddress.ip_address(item['addr']) in upnp_dev_net:
-                    return item['addr']
-    raise NoInternalAddressMatchesDevice(device_hostname=parsed_url.hostname)
+                    return str(item['addr'])
+    raise NoInternalAddressMatchesDevice(parsed_url.hostname)
 
 
-class UPnPService(Service):
-    """
-    Generate a mapping of external network IP address/port to internal IP address/port,
-    using the Universal Plug 'n' Play standard.
-    """
-    logger = get_logger('trinity.components.upnp.UPnPService')
+WAN_SERVICE_NAMES = (
+    'WANIPConn1',
+    'WANIPConnection.1',  # Nighthawk C7800
+    'WANPPPConnection.1',  # CenturyLink C1100Z
+)
 
-    _nat_portmap_lifetime = 30 * 60
 
-    def __init__(self, port: int, event_bus: EndpointAPI) -> None:
-        """
-        :param port: The port that a server wants to bind to on this machine, and
-        make publicly accessible.
-        """
-        self.port = port
-        self.event_bus = event_bus
-
-    async def run(self) -> None:
-        """Run an infinite loop refreshing our NAT port mapping.
-
-        On every iteration we configure the port mapping with a lifetime of 30 minutes and then
-        sleep for that long as well.
-        """
-        while self.manager.is_running:
-            try:
-                external_ip = await self.add_nat_portmap()
-                if external_ip is not None:
-                    event = NewUPnPMapping(external_ip)
-                    self.logger.debug(
-                        "NAT portmap created, broadcasting NewUPnPMapping event: %s", event)
-                    await self.event_bus.broadcast(event, FIRE_AND_FORGET_BROADCASTING)
-                else:
-                    self.logger.info("Unable to setup NAT portmap")
-                # Wait for the port mapping lifetime, and then try registering it again
-                await asyncio.sleep(self._nat_portmap_lifetime)
-            except asyncio.CancelledError:
-                # Re-raise to prevent it being logged as an unexpected exception.
-                raise
-            except Exception:
-                self.logger.exception("Failed to setup NAT portmap")
-
-    async def add_nat_portmap(self) -> str:
-        """
-        Set up the port mapping
-
-        :return: the IP address of the new mapping (or None if failed)
-        """
-        self.logger.info("Setting up NAT portmap...")
+def get_wan_service(upnp_dev: upnpclient.upnp.Device) -> upnpclient.upnp.Service:
+    for service_name in WAN_SERVICE_NAMES:
         try:
-            async for upnp_dev in self._discover_upnp_devices():
-                try:
-                    external_ip = await self._add_nat_portmap(upnp_dev)
-                except NoInternalAddressMatchesDevice as exc:
-                    self.logger.info(
-                        "No internal addresses were managed by the UPnP device at %s",
-                        exc.device_hostname,
-                    )
-                    continue
-                else:
-                    return external_ip
-        except upnpclient.soap.SOAPError as e:
-            if e.args == (718, 'ConflictInMappingEntry'):
-                # An entry already exists with the parameters we specified. Maybe the router
-                # didn't clean it up after it expired or it has been configured by other piece
-                # of software, either way we should not override it.
-                # https://tools.ietf.org/id/draft-ietf-pcp-upnp-igd-interworking-07.html#errors
-                self.logger.info("NAT port mapping already configured, not overriding it")
-            else:
-                self.logger.exception("Failed to setup NAT portmap")
+            return upnp_dev[service_name]
+        except KeyError:
+            continue
+    else:
+        raise WANServiceNotFound()
 
-        return None
 
-    async def _add_nat_portmap(self, upnp_dev: upnpclient.upnp.Device) -> str:
-        # Detect our internal IP address (which raises if there are no matches)
-        internal_ip = find_internal_ip_on_device_network(upnp_dev)
+def setup_device_port_map(upnp_dev: upnpclient.upnp.Device,
+                          port: int,
+                          duration: int) -> Tuple[str, str]:
+    internal_ip = find_internal_ip_on_device_network(upnp_dev)
+    wan_service = get_wan_service(upnp_dev)
 
-        external_ip = upnp_dev.WANIPConn1.GetExternalIPAddress()['NewExternalIPAddress']
-        for protocol, description in [('TCP', 'ethereum p2p'), ('UDP', 'ethereum discovery')]:
-            try:
-                upnp_dev.WANIPConn1.AddPortMapping(
-                    NewRemoteHost=external_ip,
-                    NewExternalPort=self.port,
-                    NewProtocol=protocol,
-                    NewInternalPort=self.port,
-                    NewInternalClient=internal_ip,
-                    NewEnabled='1',
-                    NewPortMappingDescription=description,
-                    NewLeaseDuration=self._nat_portmap_lifetime,
-                )
-            except upnpclient.soap.SOAPError as exc:
-                self.logger.warning(
-                    "Failed to setup port mapping for %s/%s: %s",
-                    protocol,
-                    description,
-                    exc
-                )
-            else:
-                self.logger.info(
-                    "NAT port forwarding successfully set up at %s:%d", external_ip, self.port)
-        return external_ip
+    external_ip = wan_service.GetExternalIPAddress()['NewExternalIPAddress']
 
-    async def _discover_upnp_devices(self) -> AsyncGenerator[upnpclient.upnp.Device, None]:
-        loop = asyncio.get_event_loop()
-        # Use loop.run_in_executor() because upnpclient.discover() is blocking and may take a
-        # while to complete. We must use a ThreadPoolExecutor() because the
-        # response from upnpclient.discover() can't be pickled.
-        with ThreadPoolExecutor() as executor:
-            try:
-                devices = await asyncio.wait_for(
-                    loop.run_in_executor(executor, upnpclient.discover),
-                    timeout=UPNP_DISCOVER_TIMEOUT_SECONDS,
-                )
-            except asyncio.TimeoutError:
-                self.logger.info("Timeout waiting for UPNP-enabled devices")
-                return
-            else:
-                self.logger.debug("Found %d candidate NAT devices", len(devices))
-
-        # If there are no UPNP devices we can exit early
-        if not devices:
-            self.logger.info("No UPNP-enabled devices found")
-            return
-
-        # Now we loop over all of the devices until we find one that we can use.
-        for device in devices:
-            try:
-                device.WANIPConn1
-            except AttributeError:
-                self.logger.debug2("Skipping non UPNP-enabled device: %s", device)
-                continue
-            yield device
+    try:
+        wan_service.AddPortMapping(
+            NewRemoteHost=external_ip,
+            NewExternalPort=port,
+            NewProtocol='UDP',
+            NewInternalPort=port,
+            NewInternalClient=internal_ip,
+            NewEnabled='1',
+            NewPortMappingDescription='trinity',
+            NewLeaseDuration=duration,
+        )
+    except upnpclient.soap.SOAPError as exc:
+        if exc.args == (718, 'ConflictInMappingEntry'):
+            # An entry already exists with the parameters we specified. Maybe the router
+            # didn't clean it up after it expired or it has been configured by other piece
+            # of software, either way we should not override it.
+            # https://tools.ietf.org/id/draft-ietf-pcp-upnp-igd-interworking-07.html#errors
+            logger.debug("NAT port mapping already configured, not overriding it")
+            return internal_ip, external_ip
+        else:
+            logger.debug(
+                "Failed to setup NAT portmap on device: %s",
+                upnp_dev.location,
+            )
+            raise PortMapFailed from exc
+    else:
+        return internal_ip, external_ip


### PR DESCRIPTION
### What was wrong?

I spent some time recently while working in the `alexandria` codebase refactoring the UPnP code and converting it to use `trio`.  Those changes seemed valuable as they provide what I think is a slightly cleaner interface and include some bugfixes to cover a broader range of UPnP devices.

### How was it fixed?

Ported the code from https://github.com/ethereum/alexandria/blob/adba4114fbd5f707181da602abd977e008e463c9/alexandria/upnp.py back into the trinity codebase.

#### Cute Animal Picture

![September-01-2011-22-25-12-imgres10](https://user-images.githubusercontent.com/824194/79901559-39d4c080-83cd-11ea-966a-2414da63effb.jpeg)

