### PR TITLE
Fix import of snappy.CompressedLengthError

### DIFF
--- a/p2p/multiplexer.py
+++ b/p2p/multiplexer.py
@@ -13,7 +13,6 @@ from typing import (
     Union,
 )
 
-import snappy
 from cached_property import cached_property
 
 from async_generator import asynccontextmanager
@@ -39,7 +38,10 @@ from p2p.exceptions import (
 )
 from p2p.p2p_proto import BaseP2PProtocol
 from p2p.transport_state import TransportState
-from p2p._utils import get_logger
+from p2p._utils import (
+    get_logger,
+    snappy_CompressedLengthError,
+)
 
 
 async def stream_transport_messages(transport: TransportAPI,
@@ -84,7 +86,7 @@ async def stream_transport_messages(transport: TransportAPI,
 
         try:
             cmd = command_type.decode(msg, msg_proto.snappy_support)
-        except (rlp.exceptions.DeserializationError, snappy.CompressedLengthError) as err:
+        except (rlp.exceptions.DeserializationError, snappy_CompressedLengthError) as err:
             raise MalformedMessage(f"Failed to decode {msg} for {command_type}") from err
 
         yield msg_proto, cmd


### PR DESCRIPTION
### What was wrong?

`snappy.CompressedLengthError` crashes, it's not a publicly accessible API.

Fix #1691 

### How was it fixed?

Import snappy exception from private API

Include some fallbacks in case the private API disappears, or is
otherwise missing.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

[//]: # (See: https://trinity-client.readthedocs.io/en/latest/contributing.html#pull-requests)
- [x] Add entry to the [release notes](https://github.com/ethereum/trinity/blob/master/newsfragments/README.md) (bug was never released, so no release note entry needed)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://thenypost.files.wordpress.com/2020/03/031120-cute-animals-anti-corona-01.jpg?quality=80&strip=all)
