### PR TITLE
Ensure trio components terminate when trinity crashes

### DIFF
--- a/tests/core/components/test_isolated_component.py
+++ b/tests/core/components/test_isolated_component.py
@@ -6,14 +6,16 @@ import os
 from async_service import background_asyncio_service
 import pytest
 
-from trinity._utils.chains import (
-    get_local_data_dir,
-)
+from trinity._utils.chains import get_local_data_dir
 from trinity._utils.logging import IPCListener
 from trinity.boot_info import BootInfo
 from trinity.config import TrinityConfig
 from trinity.extensibility import ComponentManager
-from trinity.tools._component_isolation import IsStarted, AsyncioComponentForTest
+from trinity.tools._component_isolation import (
+    AsyncioComponentForTest,
+    IsStarted,
+    TrioComponentForTest,
+)
 
 
 @pytest.fixture
@@ -46,12 +48,12 @@ def log_listener(trinity_config):
         yield
 
 
+@pytest.mark.parametrize("component", (AsyncioComponentForTest, TrioComponentForTest))
 @pytest.mark.asyncio
-async def test_asyncio_isolated_component(boot_info,
-                                          log_listener):
+async def test_isolated_component(boot_info, log_listener, component):
     # Test the lifecycle management for isolated process components to be sure
     # they start and stop as expected
-    component_manager = ComponentManager(boot_info, (AsyncioComponentForTest,))
+    component_manager = ComponentManager(boot_info, (component,))
 
     async with background_asyncio_service(component_manager):
         event_bus = await component_manager.get_event_bus()

--- a/trinity/_utils/ipc.py
+++ b/trinity/_utils/ipc.py
@@ -61,42 +61,6 @@ def kill_process_gracefully(
     kill_process_id_gracefully(process.pid, process.join, logger, SIGINT_timeout, SIGTERM_timeout)
 
 
-def kill_processes_gracefully(
-        processes: Iterable[Process],
-        logger: Logger,
-        SIGINT_timeout: int = DEFAULT_SIGINT_TIMEOUT,
-        SIGTERM_timeout: int = DEFAULT_SIGTERM_TIMEOUT) -> None:
-
-    # Send SIGINT to each process without blocking
-    for process in processes:
-        sigint_process_id(process.pid, lambda _: None, logger, SIGINT_timeout)
-
-    # Now block on each process as long as we have time left in the budget
-    sigint_at = time.time()
-    for process in processes:
-        waited_sec = time.time() - sigint_at
-        if waited_sec >= SIGINT_timeout:
-            logger.debug("Waited %d on SIGINT, moving on", waited_sec)
-            break
-        process.join(SIGINT_timeout)
-
-    # Send SIGTERM to each process without blocking
-    for process in processes:
-        sigterm_process_id(process.pid, lambda _: None, logger, SIGTERM_timeout)
-
-    # Now block on each process as long as we have time left in the budget
-    sigterm_at = time.time()
-    for process in processes:
-        waited_sec = time.time() - sigterm_at
-        if waited_sec >= SIGTERM_timeout:
-            logger.debug("Waited %d on SIGINT, moving on", waited_sec)
-            break
-        process.join(SIGTERM_timeout)
-
-    for process in processes:
-        sigkill_process_id(process.pid, logger)
-
-
 def kill_popen_gracefully(
         popen: 'subprocess.Popen[Any]',
         logger: Logger,

--- a/trinity/extensibility/trio.py
+++ b/trinity/extensibility/trio.py
@@ -1,13 +1,16 @@
 from abc import abstractmethod
 import asyncio
+from multiprocessing import Process
+import os
 import signal
 
 import trio
 from async_service import background_trio_service
+from asyncio_run_in_process.constants import SIGINT_TIMEOUT_SECONDS, SIGTERM_TIMEOUT_SECONDS
 
 from lahja import EndpointAPI
 
-from trinity._utils.logging import child_process_logging
+from trinity._utils.logging import child_process_logging, get_logger
 from trinity._utils.mp import ctx
 from trinity._utils.profiling import profiler
 from trinity.boot_info import BootInfo
@@ -25,6 +28,8 @@ class TrioComponent(BaseComponent):
 
 
 class TrioIsolatedComponent(BaseIsolatedComponent):
+    logger = get_logger('trinity.extensibility.TrioIsolatedComponent')
+
     async def run(self) -> None:
         """
         Call chain is:
@@ -49,14 +54,36 @@ class TrioIsolatedComponent(BaseIsolatedComponent):
         try:
             await loop.run_in_executor(None, process.join)
         finally:
-            # XXX: Disabling this for now as our trio-based components currently run in the same
-            # process group (see comment above) as the main process and because of that they
-            # already get a SIGINT from the terminal.
-            # kill_process_gracefully(
-            #     process,
-            #     get_logger('trinity.extensibility.TrioIsolatedComponent'),
-            # )
-            pass
+            # NOTE: Since the subprocess we start here runs in the same process group as us (see
+            # comment above as to why), when we get a Ctrl-C in the terminal the subprocess will
+            # get it as well, so we first wait a fraction of SIGINT_TIMEOUT_SECONDS for it to
+            # terminate (which is usually enough for trio to terminate all pending tasks), and
+            # only if it hasn't finished by then we send it a SIGINT. If we send a SIGINT straight
+            # away we cause trio to crash when we've been Ctrl-C'ed (because it would get two
+            # SIGINTs), and if we don't send one at all the subprocess never terminates when
+            # trinity exits because of a crash.
+            self.logger.debug("Waiting for process %d to terminate", process.pid)
+            await loop.run_in_executor(None, process.join, SIGINT_TIMEOUT_SECONDS / 4)
+            if process.is_alive():
+                self.logger.debug("Process %d did not terminate, sending SIGINT", process.pid)
+                self._send_signal_and_join(process, signal.SIGINT, SIGINT_TIMEOUT_SECONDS)
+            if process.is_alive():
+                self.logger.debug("Process %d did not terminate, sending SIGTERM", process.pid)
+                self._send_signal_and_join(process, signal.SIGTERM, SIGTERM_TIMEOUT_SECONDS)
+
+    def _send_signal_and_join(self, process: Process, sig: int, timeout: int) -> None:
+        try:
+            os.kill(process.pid, sig)
+        except ProcessLookupError:
+            self.logger.debug("Process %d has already terminated", process.pid)
+            return
+        # XXX: Using process.join() here is far from ideal as it blocks the main process,
+        # forcing us to wait in sequence for every trio components, but try and run it
+        # asynchronously (using an executor, like above) and you'll get a
+        #   RuntimeError: cannot reuse already awaited coroutine
+        process.join(timeout)
+        self.logger.debug(
+            "process (%d) .join() returned, exitcode=%s", process.pid, process.exitcode)
 
     @classmethod
     def run_process(cls, boot_info: BootInfo) -> None:


### PR DESCRIPTION
I recently changed TrioIsolatedComponent to not send a SIGINT to the
subprocess as they run on the same process group of the main process and
thus get that when there's a Ctrl-C in the terminal, but that doesn't
happen when trinity crashes, so trio components were left running after
everything else had terminated. This fixes that (in a suboptimal way),
although hopefully it will be temporary

Another issue I thought would be straightforward to fix, but in the
end spent quite some time trying to figure out the RuntimeError
mentioned in one of the comments.