### PR TITLE
Collect and visualize the current head of peers

### DIFF
--- a/newsfragments/1699.feature.rst
+++ b/newsfragments/1699.feature.rst
@@ -1,0 +1,1 @@
+Support reporting of the current head for connected peers to influx / grafana.

--- a/p2p/abc.py
+++ b/p2p/abc.py
@@ -105,6 +105,7 @@ class AddressAPI(ABC):
 
 
 TNode = TypeVar('TNode', bound='NodeAPI')
+TPeer = TypeVar('TPeer', bound='BasePeer')
 
 
 class NodeAPI(ABC):

--- a/p2p/exceptions.py
+++ b/p2p/exceptions.py
@@ -220,3 +220,10 @@ class CorruptTransport(BaseP2PError):
     and terminate the peer connection, when this exception is raised.
     """
     pass
+
+
+class PeerReporterRegistryError(BaseP2PError):
+    """
+    Raised when there is an error assigning or unassigning peers in the PeerReporterRegistry.
+    """
+    pass

--- a/p2p/metrics.py
+++ b/p2p/metrics.py
@@ -1,0 +1,62 @@
+from typing import Dict, Generic
+from pyformance import MetricsRegistry
+
+from p2p.abc import TPeer
+from p2p.exceptions import PeerReporterRegistryError
+
+
+class PeerReporterRegistry(Generic[TPeer]):
+    """
+    Registry to track active peers and report metrics to influxdb/grafana.
+    """
+    def __init__(self, metrics_registry: MetricsRegistry) -> None:
+        self.metrics_registry = metrics_registry
+        self._peer_reporters: Dict[TPeer, int] = {}
+
+    def assign_peer_reporter(self, peer: TPeer) -> None:
+        if peer in self._peer_reporters.keys():
+            raise PeerReporterRegistryError(
+                f"Cannot reassign peer: {peer} to PeerReporterRegistry. "
+                "Peer already assigned."
+            )
+        min_unclaimed_id = self._get_min_unclaimed_gauge_id()
+        self._peer_reporters[peer] = min_unclaimed_id
+        self.reset_peer_meters(min_unclaimed_id)
+
+    def unassign_peer_reporter(self, peer: TPeer) -> None:
+        try:
+            gauge_id = self._peer_reporters[peer]
+        except AttributeError:
+            raise PeerReporterRegistryError(
+                f"Cannot unassign peer: {peer} to PeerReporterRegistry. "
+                "Peer not found in peer reporter registry."
+            )
+        self.reset_peer_meters(gauge_id)
+        del self._peer_reporters[peer]
+
+    def _get_min_unclaimed_gauge_id(self) -> int:
+        try:
+            max_claimed_id = max(self._peer_reporters.values())
+        except ValueError:
+            return 0
+
+        unclaimed_ids = [
+            num for num in range(0, max_claimed_id + 1) if num not in self._peer_reporters.values()
+        ]
+        if len(unclaimed_ids) == 0:
+            return max_claimed_id + 1
+
+        return min(unclaimed_ids)
+
+    def trigger_peer_reports(self) -> None:
+        for peer, peer_id in self._peer_reporters.items():
+            if peer.get_manager().is_running:
+                self.make_periodic_update(peer, peer_id)
+
+    def reset_peer_meters(self, peer_id: int) -> None:
+        # subclasses are responsible for implementing method that resets all implemented meters
+        pass
+
+    def make_periodic_update(self, peer: TPeer, peer_id: int) -> None:
+        # subclasses are responsible for implementing method that updates all implemented meters
+        pass

--- a/p2p/peer_pool.py
+++ b/p2p/peer_pool.py
@@ -3,6 +3,7 @@ import asyncio
 import functools
 import operator
 from typing import (
+    Any,
     AsyncContextManager,
     AsyncIterator,
     AsyncIterable,
@@ -57,6 +58,7 @@ from p2p.exceptions import (
     UnknownAPI,
     UnreachablePeer,
 )
+from p2p.metrics import PeerReporterRegistry
 from p2p.peer import (
     BasePeer,
     BasePeerFactory,
@@ -102,11 +104,13 @@ class BasePeerPool(Service, AsyncIterable[BasePeer]):
     """
     PeerPool maintains connections to up-to max_peers on a given network.
     """
-    _report_interval = 60
+    _report_stats_interval = 60
+    _report_metrics_interval = 15  # for influxdb/grafana reporting
     _peer_boot_timeout = DEFAULT_PEER_BOOT_TIMEOUT
     _event_bus: EndpointAPI = None
 
     _handshake_locks: ResourceLock[NodeAPI]
+    peer_reporter_registry_class: Type[PeerReporterRegistry[Any]] = PeerReporterRegistry[BasePeer]
 
     def __init__(self,
                  privkey: datatypes.PrivateKey,
@@ -131,6 +135,7 @@ class BasePeerPool(Service, AsyncIterable[BasePeer]):
             # This is so that we don't need to pass a MetricsRegistry in tests and mocked pools.
             metrics_registry = MetricsRegistry()
         self._active_peer_counter = metrics_registry.counter('trinity.p2p/peers.counter')
+        self._peer_reporter_registry = self.get_peer_reporter_registry(metrics_registry)
 
         # Restricts the number of concurrent connection attempts can be made
         self._connection_attempt_lock = asyncio.BoundedSemaphore(MAX_CONCURRENT_CONNECTION_ATTEMPTS)
@@ -230,6 +235,11 @@ class BasePeerPool(Service, AsyncIterable[BasePeer]):
             event_bus=self._event_bus,
         )
 
+    def get_peer_reporter_registry(
+        self, metrics_registry: MetricsRegistry
+    ) -> PeerReporterRegistry[BasePeer]:
+        return self.peer_reporter_registry_class(metrics_registry)
+
     async def get_protocol_capabilities(self) -> Tuple[Tuple[str, int], ...]:
         return tuple(
             (handshaker.protocol_class.name, handshaker.protocol_class.version)
@@ -303,6 +313,7 @@ class BasePeerPool(Service, AsyncIterable[BasePeer]):
         logger("Adding %s to pool", peer)
         self.connected_nodes[peer.session] = peer
         self._active_peer_counter.inc()
+        self._peer_reporter_registry.assign_peer_reporter(peer)
         peer.add_finished_callback(self._peer_finished)
         for subscriber in self._subscribers:
             subscriber.register_peer(peer)
@@ -319,6 +330,7 @@ class BasePeerPool(Service, AsyncIterable[BasePeer]):
             self.manager.run_daemon_task(self.maybe_connect_more_peers)
 
         self.manager.run_daemon_task(self._periodically_report_stats)
+        self.manager.run_daemon_task(self._periodically_report_metrics)
         await self.manager.wait_finished()
 
     async def connect(self, remote: NodeAPI) -> BasePeer:
@@ -477,6 +489,7 @@ class BasePeerPool(Service, AsyncIterable[BasePeer]):
             subscriber.deregister_peer(peer)
 
         self._active_peer_counter.dec()
+        self._peer_reporter_registry.unassign_peer_reporter(peer)
 
     async def __aiter__(self) -> AsyncIterator[BasePeer]:
         for peer in tuple(self.connected_nodes.values()):
@@ -485,6 +498,11 @@ class BasePeerPool(Service, AsyncIterable[BasePeer]):
             await asyncio.sleep(0)
             if peer.get_manager().is_running and not peer.is_closing:
                 yield peer
+
+    async def _periodically_report_metrics(self) -> None:
+        while self.manager.is_running:
+            self._peer_reporter_registry.trigger_peer_reports()
+            await asyncio.sleep(self._report_metrics_interval)
 
     async def _periodically_report_stats(self) -> None:
         while self.manager.is_running:
@@ -525,4 +543,4 @@ class BasePeerPool(Service, AsyncIterable[BasePeer]):
                     self.logger.debug("    Failure during stats lookup: %r", exc)
 
             self.logger.debug("== End peer details == ")
-            await asyncio.sleep(self._report_interval)
+            await asyncio.sleep(self._report_stats_interval)

--- a/tests/p2p/test_metrics.py
+++ b/tests/p2p/test_metrics.py
@@ -1,0 +1,34 @@
+import pytest
+
+from pyformance import MetricsRegistry
+
+from p2p.metrics import PeerReporterRegistry
+from trinity.protocol.eth.peer import ETHPeer
+from trinity.tools.factories import LatestETHPeerPairFactory
+
+
+@pytest.mark.asyncio
+async def test_peer_reporter_registry():
+    async with LatestETHPeerPairFactory() as (alice, bob):
+        assert isinstance(alice, ETHPeer)
+        assert isinstance(bob, ETHPeer)
+
+        metrics_registry = MetricsRegistry()
+        peer_reporter_registry = PeerReporterRegistry(metrics_registry)
+        assert len(peer_reporter_registry._peer_reporters.keys()) == 0
+
+        peer_reporter_registry.assign_peer_reporter(alice)
+        assert len(peer_reporter_registry._peer_reporters.keys()) == 1
+        assert peer_reporter_registry._peer_reporters[alice] == 0
+
+        peer_reporter_registry.assign_peer_reporter(bob)
+        assert len(peer_reporter_registry._peer_reporters.keys()) == 2
+        assert peer_reporter_registry._peer_reporters[bob] == 1
+
+        peer_reporter_registry.unassign_peer_reporter(alice)
+        assert alice not in peer_reporter_registry._peer_reporters.keys()
+        assert len(peer_reporter_registry._peer_reporters.keys()) == 1
+
+        peer_reporter_registry.unassign_peer_reporter(bob)
+        assert bob not in peer_reporter_registry._peer_reporters.keys()
+        assert len(peer_reporter_registry._peer_reporters.keys()) == 0

--- a/trinity/components/builtin/metrics/component.py
+++ b/trinity/components/builtin/metrics/component.py
@@ -147,7 +147,7 @@ class MetricsComponent(TrioIsolatedComponent):
         # types ignored due to https://github.com/ethereum/async-service/issues/5
         system_metrics_collector = collect_process_metrics(  # type: ignore
             metrics_service.registry,
-            frequency_seconds=boot_info.args.metrics_system_collector_frequency
+            frequency_seconds=boot_info.args.metrics_system_collector_frequency,
         )
 
         # types ignored due to https://github.com/ethereum/async-service/issues/5
@@ -155,7 +155,7 @@ class MetricsComponent(TrioIsolatedComponent):
             boot_info,
             event_bus,
             metrics_service.registry,
-            frequency_seconds=boot_info.args.metrics_blockchain_collector_frequency
+            frequency_seconds=boot_info.args.metrics_blockchain_collector_frequency,
         )
 
         services_to_exit = (


### PR DESCRIPTION
### What was wrong?
Re: https://github.com/ethereum/trinity/pull/1682#pullrequestreview-397441551

Visualize the current heads of our peers in grafana. 

### How was it fixed?
Added a `PeerReporter` class and `PeerReporterRegistry` to track the current head for each connected peer. I'm still quite unfamiliar with the trinity/p2p codebase - so if there's a cleaner  solution or a better place to put this code, i'm happy to make any changes.

Here are some screenshots of the metrics reporting locally. Though these were captured using a `_reporting_frequency` of `15` rather than the default `60`. I'd be curious if anybody has thoughts on the frequency - and whether it should be left to `60` (which I did in this pr) to match the frequency with which peer connection info is logged to the terminal - or perhaps if it should be increased? 

<img width="713" alt="Screen Shot 2020-04-27 at 9 41 57 AM" src="https://user-images.githubusercontent.com/9753150/80385842-37121980-886c-11ea-828b-6356a4bad846.png">

<img width="705" alt="Screen Shot 2020-04-27 at 9 36 39 AM" src="https://user-images.githubusercontent.com/9753150/80385861-3bd6cd80-886c-11ea-9b91-369afb7fe5d0.png">


### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

[//]: # (See: https://trinity-client.readthedocs.io/en/latest/contributing.html#pull-requests)
- [x] Add entry to the [release notes](https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![image](https://user-images.githubusercontent.com/9753150/80386259-c28baa80-886c-11ea-8eb6-576bc93f59b6.png)

