### PR TITLE
Do not leak BrokenPipeError/ConnectionResetError when closing transport

### DIFF
--- a/p2p/transport.py
+++ b/p2p/transport.py
@@ -330,7 +330,10 @@ class Transport(TransportAPI):
 
         This will cause the peer to stop in case it is running.
         """
-        await self._writer.drain()
+        try:
+            await self._writer.drain()
+        except (ConnectionResetError, BrokenPipeError) as e:
+            self.logger.debug("Could not drain writer (%s), closing transport writer anyway", e)
         self._writer.close()
 
     @property


### PR DESCRIPTION
Our Transport.close() method will first try to drain the writer, but
that may raise BrokenPipeError/ConnectionResetError (just like when
reading from the transport's reader), so we need to catch them to
ensure we still close the writer.

Closes: #1683