### PR TITLE
Blacklist peers that send us a malformed message during handshake

### DIFF
--- a/p2p/peer_pool.py
+++ b/p2p/peer_pool.py
@@ -346,13 +346,14 @@ class BasePeerPool(Service, AsyncIterable[BasePeer]):
             # dump the full stacktrace in the debug logs
             self.logger.debug('Got bad auth ack from %r', remote, exc_info=True)
             raise
-        except MalformedMessage:
+        except MalformedMessage as e:
             # This is kept separate from the
             # `COMMON_PEER_CONNECTION_EXCEPTIONS` to be sure that we aren't
             # silencing an error in how we decode messages during handshake.
             self.logger.error('Got malformed response from %r during handshake', remote)
             # dump the full stacktrace in the debug logs
             self.logger.debug('Got malformed response from %r', remote, exc_info=True)
+            self.connection_tracker.record_failure(remote, e)
             raise
         except HandshakeFailure as e:
             self.logger.debug("Could not complete handshake with %r: %s", remote, repr(e))

--- a/p2p/tracking/connection.py
+++ b/p2p/tracking/connection.py
@@ -29,7 +29,7 @@ def register_error(exception: Type[BaseP2PError], timeout_seconds: int) -> None:
 register_error(HandshakeFailure, 10)  # 10 seconds
 register_error(HandshakeFailureTooManyPeers, 60)  # one minute
 # A MalformedMessage is usually not a transient issue, so blacklist the remote for a long time.
-register_error(MalformedMessage, 3600)  # 1 hour
+register_error(MalformedMessage, 60 * 10)  # 10 minutes
 
 
 def get_timeout_for_failure(failure: BaseP2PError) -> int:

--- a/p2p/tracking/connection.py
+++ b/p2p/tracking/connection.py
@@ -12,6 +12,7 @@ from p2p.exceptions import (
     BaseP2PError,
     HandshakeFailure,
     HandshakeFailureTooManyPeers,
+    MalformedMessage,
 )
 from p2p.typing import NodeID
 
@@ -27,6 +28,8 @@ def register_error(exception: Type[BaseP2PError], timeout_seconds: int) -> None:
 
 register_error(HandshakeFailure, 10)  # 10 seconds
 register_error(HandshakeFailureTooManyPeers, 60)  # one minute
+# A MalformedMessage is usually not a transient issue, so blacklist the remote for a long time.
+register_error(MalformedMessage, 3600)  # 1 hour
 
 
 def get_timeout_for_failure(failure: BaseP2PError) -> int:

--- a/trinity/protocol/common/peer_pool_event_bus.py
+++ b/trinity/protocol/common/peer_pool_event_bus.py
@@ -298,7 +298,7 @@ class BaseProxyPeerPool(Service, Generic[TProxyPeer]):
     async def handle_joining_peers(self) -> None:
         async for peer in self.stream_peers_joining():
             # We just want to consume the AsyncIterator
-            self.logger.info("New Proxy Peer joined %s", peer)
+            self.logger.debug("New Proxy Peer joined %s", peer)
 
     async def handle_leaving_peers(self) -> None:
         async for ev in self.event_bus.stream(PeerLeftEvent):
@@ -309,7 +309,7 @@ class BaseProxyPeerPool(Service, Generic[TProxyPeer]):
                 # TODO: Double check based on some session id if we are indeed
                 # removing the right peer
                 await proxy_peer.manager.stop()
-                self.logger.warning("Removed proxy peer from proxy pool %s", ev.session)
+                self.logger.debug("Removed proxy peer from proxy pool %s", ev.session)
 
     async def fetch_initial_peers(self) -> Tuple[TProxyPeer, ...]:
         response = await self.event_bus.request(GetConnectedPeersRequest(), self.broadcast_config)


### PR DESCRIPTION
I am getting malformed messages during handshake with one specific peer all the time, and since we
were not recording failures for those in  the connection tracker, the PeerPool would keep
attempting to connect to that peer. Now we blacklist those for 1h

```
Got malformed response from <Node(0xf974a7082d8bdeb3753fbe2c2f705c419bc762a699860e856f8bacbc2a3185aa94f005da76cd1217285e82fd3af8abbe3ec48d38398339245db5e27409c1e0f7@104.248.49.16:30303)> during handshake
```