### PR TITLE
Add --sync-mode header + a few other goodies

### DIFF
--- a/docs/api/api.cli.rst
+++ b/docs/api/api.cli.rst
@@ -27,7 +27,7 @@ We can also generate an always up-to-date version of them by running ``trinity -
                   [--ethstats-interval ETHSTATS_INTERVAL]
                   [--disable-request-server]
                   [--force-beam-block-number FORCE_BEAM_BLOCK_NUMBER]
-                  [--beam-from-checkpoint BEAM_FROM_CHECKPOINT]
+                  [--sync-from-checkpoint SYNC_FROM_CHECKPOINT]
                   [--sync-mode {full,beam,light,none}] [--disable-tx-pool]
                   {attach,db-shell,fix-unclean-shutdown,remove-network-db,export,import}
                   ...
@@ -58,7 +58,7 @@ We can also generate an always up-to-date version of them by running ``trinity -
       --force-beam-block-number FORCE_BEAM_BLOCK_NUMBER
                             Force beam sync to activate on a specific block number
                             (for testing)
-      --beam-from-checkpoint BEAM_FROM_CHECKPOINT
+      --sync-from-checkpoint SYNC_FROM_CHECKPOINT
                             Start beam sync from a trusted checkpoint specified
                             using URI syntax:By specific block,
                             eth://block/byhash/<hash>?score=<score>Let etherscan

--- a/newsfragments/1707.feature.rst
+++ b/newsfragments/1707.feature.rst
@@ -1,1 +1,6 @@
 Rename ``--beam-from-checkpoint`` to ``--sync-from-checkpoint``
+
+Ensure sync related flags show up under ``--sync-mode`` section in ``--help``
+
+Add new ``--sync-mode header`` to only sync the header chain on the ETH network.
+This does also support launching from a checkpoint via ``--sync-from-checkpoint`` flag.

--- a/newsfragments/1707.feature.rst
+++ b/newsfragments/1707.feature.rst
@@ -1,0 +1,1 @@
+Rename ``--beam-from-checkpoint`` to ``--sync-from-checkpoint``

--- a/trinity/components/builtin/syncer/component.py
+++ b/trinity/components/builtin/syncer/component.py
@@ -69,6 +69,18 @@ from trinity.sync.light.chain import (
 from trinity.components.builtin.syncer.cli import NormalizeCheckpointURI
 
 
+def add_sync_from_checkpoint_arg(arg_parser: ArgumentParser):
+    arg_parser.add_argument(
+        '--sync-from-checkpoint',
+        action=NormalizeCheckpointURI,
+        help=(
+            "Start syncing from a trusted checkpoint specified using URI syntax:"
+            "By specific block, eth://block/byhash/<hash>?score=<score>"
+            "Let etherscan pick a block near the tip, eth://block/byetherscan/latest"
+        ),
+        default=None,
+    )
+
 class BaseSyncStrategy(ABC):
 
     @property
@@ -162,16 +174,7 @@ class BeamSyncStrategy(BaseSyncStrategy):
             default=None,
         )
 
-        arg_parser.add_argument(
-            '--beam-from-checkpoint',
-            action=NormalizeCheckpointURI,
-            help=(
-                "Start beam sync from a trusted checkpoint specified using URI syntax:"
-                "By specific block, eth://block/byhash/<hash>?score=<score>"
-                "Let etherscan pick a block near the tip, eth://block/byetherscan/latest"
-            ),
-            default=None,
-        )
+        add_sync_from_checkpoint_arg(arg_parser)
 
     async def sync(self,
                    args: Namespace,
@@ -187,7 +190,7 @@ class BeamSyncStrategy(BaseSyncStrategy):
             base_db,
             cast(ETHPeerPool, peer_pool),
             event_bus,
-            args.beam_from_checkpoint,
+            args.sync_from_checkpoint,
             args.force_beam_block_number,
         )
 

--- a/trinity/sync/header/chain.py
+++ b/trinity/sync/header/chain.py
@@ -1,0 +1,85 @@
+import asyncio
+from async_service import Service
+
+from trinity.chains.base import AsyncChainAPI
+from trinity.db.eth1.chain import BaseAsyncChainDB
+from trinity.protocol.eth.peer import ETHPeerPool
+from trinity.protocol.eth.sync import ETHHeaderChainSyncer
+from trinity._utils.timer import Timer
+from trinity._utils.logging import get_logger
+from trinity.sync.common.checkpoint import Checkpoint
+from trinity.sync.common.strategies import (
+    FromCheckpointLaunchStrategy,
+    FromGenesisLaunchStrategy,
+    SyncLaunchStrategyAPI,
+)
+
+
+class HeaderChainSyncer(Service):
+    def __init__(self,
+                 chain: AsyncChainAPI,
+                 db: BaseAsyncChainDB,
+                 peer_pool: ETHPeerPool,
+                 checkpoint: Checkpoint = None) -> None:
+        self.logger = get_logger('trinity.sync.header.chain.HeaderChainSyncer')
+        self._db = db
+        self._checkpoint = checkpoint
+
+        if checkpoint is None:
+            self._launch_strategy: SyncLaunchStrategyAPI = FromGenesisLaunchStrategy(
+                db,
+                chain
+            )
+        else:
+            self._launch_strategy = FromCheckpointLaunchStrategy(
+                db,
+                chain,
+                checkpoint,
+                peer_pool,
+            )
+
+        self._header_syncer = ETHHeaderChainSyncer(chain, db, peer_pool, self._launch_strategy)
+
+    async def run(self) -> None:
+        head = await self._db.coro_get_canonical_head()
+
+        if self._checkpoint is not None:
+            self.logger.info(
+                "Initializing header-sync; current head: %s, using checkpoint: %s",
+                head,
+                self._checkpoint,
+            )
+        else:
+            self.logger.info("Initializing header-sync; current head: %s", head)
+
+        try:
+            await self._launch_strategy.fulfill_prerequisites()
+        except asyncio.TimeoutError as exc:
+            self.logger.exception(
+                "Timed out while trying to fulfill prerequisites of "
+                f"sync launch strategy: {exc} from {self._launch_strategy}"
+            )
+            self.manager.cancel()
+            return
+
+        self.manager.run_daemon_child_service(self._header_syncer)
+        self.manager.run_daemon_task(self._persist_headers)
+        # run sync until cancelled
+        await self.manager.wait_finished()
+
+    async def _persist_headers(self) -> None:
+        async for headers in self._header_syncer.new_sync_headers():
+
+            self._header_syncer._chain.validate_chain_extension(headers)
+
+            timer = Timer()
+            new_canonical_headers, _ = await self._db.coro_persist_header_chain(headers)
+
+            if len(new_canonical_headers) > 0:
+                head = new_canonical_headers[-1]
+            else:
+                head = await self._db.coro_get_canonical_head()
+
+            self.logger.info(
+                "Imported %d headers in %0.2f seconds, new head: %s",
+                len(headers), timer.elapsed, head)


### PR DESCRIPTION
### What was wrong?

Once upon a time...eh no, let's skip this part.

### How was it fixed?

1. This adds support for `--sync-mode header` to only sync the header chain on the ETH network. Notice that this is almost what `--sync-mode light` does but a.) it does it on the ETH network, not LES and b.) light sync is on the road to removal but it is nice to keep this feature. This does also support launching header sync from a checkpoint via `--sync-from checkpoint <uri>`

2. `--beam-from-checkpoint` is now `--sync-from-checkpoint` to not have two different names for the exact same concept

3. Sync related flags such as `--beam-from-checkpoint` or `--force-beam-block-number` are now grouped under `sync-mode` in `--trinity-help`

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

[//]: # (See: https://trinity-client.readthedocs.io/en/latest/contributing.html#pull-requests)
- [x] Add entry to the [release notes](https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://i.pinimg.com/originals/bf/b3/67/bfb36708f37e96b8e8251b6c5a94c099.jpg)
