### PR TITLE
Fix a new intermittent Beam Sync test crash

### DIFF
--- a/trinity/sync/beam/chain.py
+++ b/trinity/sync/beam/chain.py
@@ -605,6 +605,10 @@ class BeamBlockImporter(BaseBlockImporter, Service):
             parent_state_root: Hash32,
             lagging: bool = True) -> None:
 
+        if not self.manager.is_running:
+            # If the service is shutting down, we can ignore preview requests
+            return
+
         self.manager.run_task(self._preview_address_load, header, parent_state_root, transactions)
 
         # This is a hack, so that preview executions can load ancestor block-hashes


### PR DESCRIPTION
### What was wrong?

Fix #1704 

### How was it fixed?

This bug was introduced in the switchover to async-service. The old BaseService didn't require a service to be active in order to call run_task(). The new one does, so it exposes a situation where a run_task was being triggered at the time that BeamBlockImporter was closing.

The fix? Exit early from the method if you're about to run a task when the service is shutting down.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

[//]: # (See: https://trinity-client.readthedocs.io/en/latest/contributing.html#pull-requests)
- [x] Add entry to the [release notes](https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://images-na.ssl-images-amazon.com/images/I/51eYw10jMVL._AC_.jpg)
