### PR TITLE
Remove unused method from SyncLaunchStrategyAPI

### DIFF
--- a/trinity/sync/common/strategies.py
+++ b/trinity/sync/common/strategies.py
@@ -8,7 +8,6 @@ import logging
 from cancel_token import OperationCancelled
 from eth_typing import (
     BlockNumber,
-    Hash32,
 )
 from eth_utils import (
     humanize_seconds,
@@ -20,7 +19,6 @@ from eth.abc import (
 )
 from eth.constants import (
     GENESIS_BLOCK_NUMBER,
-    GENESIS_PARENT_HASH,
 )
 from eth.exceptions import (
     HeaderNotFound,
@@ -55,10 +53,6 @@ class SyncLaunchStrategyAPI(ABC):
         ...
 
     @abstractmethod
-    def get_genesis_parent_hash(self) -> Hash32:
-        ...
-
-    @abstractmethod
     async def get_starting_block_number(self) -> BlockNumber:
         ...
 
@@ -71,9 +65,6 @@ class FromGenesisLaunchStrategy(SyncLaunchStrategyAPI):
 
     async def fulfill_prerequisites(self) -> None:
         pass
-
-    def get_genesis_parent_hash(self) -> Hash32:
-        return GENESIS_PARENT_HASH
 
     async def get_starting_block_number(self) -> BlockNumber:
         head = await self._db.coro_get_canonical_head()
@@ -254,9 +245,6 @@ class FromCheckpointLaunchStrategy(SyncLaunchStrategyAPI):
         raise asyncio.TimeoutError(
             f"Failed to get checkpoint header within {max_attempts} attempts"
         )
-
-    def get_genesis_parent_hash(self) -> Hash32:
-        return self._checkpoint.block_hash
 
     async def get_starting_block_number(self) -> BlockNumber:
         block_number = await self._genesis_strategy.get_starting_block_number()


### PR DESCRIPTION
### What was wrong?

The `SyncLaunchStrategyAPI` demanded a method that we did not end up using. I believe this is a leftover from earlier stages of the `SyncLaunchStrategyAPI` design that was just forgotten to get cleaned up.

### How was it fixed?

Removed API and implementations.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

[//]: # (See: https://trinity-client.readthedocs.io/en/latest/contributing.html#pull-requests)
- [ ] Add entry to the [release notes](https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://image.freepik.com/free-photo/white-duck-water-swimming-river_3544-586.jpg)
