### PR TITLE
Report trinity process and thread count to grafana

### DIFF
--- a/newsfragments/1713.feature.rst
+++ b/newsfragments/1713.feature.rst
@@ -1,0 +1,1 @@
+Report trinity process and thread count to grafana.

--- a/trinity/exceptions.py
+++ b/trinity/exceptions.py
@@ -141,3 +141,10 @@ class ENRMissingForkID(BaseTrinityError):
     Raised when a peer sends us an ENR without a ForkID.
     """
     pass
+
+
+class MetricsReportingError(BaseTrinityError):
+    """
+    Raised when there is an error while reporting metrics.
+    """
+    pass


### PR DESCRIPTION
### What was wrong?
Metrics needed for number of processes spawned from main `trinity` process and number  of threads.


### How was it fixed?
Added metrics for total number of processes and threads via `psutil`.

<img width="808" alt="Screen Shot 2020-05-04 at 10 11 43 PM" src="https://user-images.githubusercontent.com/9753150/81033649-fb71e380-8e59-11ea-85af-6005f38b2ffe.png">

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

[//]: # (See: https://trinity-client.readthedocs.io/en/latest/contributing.html#pull-requests)
- [x] Add entry to the [release notes](https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

#### Cute Animal Picture
![image](https://user-images.githubusercontent.com/9753150/81033367-00826300-8e59-11ea-90d9-0a75c67096a1.png)

