### PR TITLE
Handle lost peer connection while checking idle connection

### DIFF
--- a/p2p/p2p_api.py
+++ b/p2p/p2p_api.py
@@ -58,7 +58,11 @@ class PingAndDisconnectIfIdle(Service):
                 try:
                     _send_ping(conn)
                 except PeerConnectionLost:
-                    conn.get_manager.cancel()
+                    conn.logger.debug(
+                        "Lost peer connection to %s while sending ping to check idle connection",
+                        conn,
+                    )
+                    conn.get_manager().cancel()
                     return
 
                 try:


### PR DESCRIPTION
fixes #1715 

### What was wrong?

The `PingAndDisconnectIfIdle` behavior was leaking a `PeerConnectionLost` which resulted in a broader crash of the trinity process.

### How was it fixed?

Wrap the call to `send_ping` in a `try/except` and terminate the service if the connection has been lost.

#### Cute Animal Picture

![hqdefault](https://user-images.githubusercontent.com/824194/81426008-d14c4a00-9115-11ea-983a-e432b21f893a.jpg)

