### PR TITLE
the default `trinity-validator` command talks to `trinity-beacon-trio`

### DIFF
--- a/eth2/validator_client/cli_parser.py
+++ b/eth2/validator_client/cli_parser.py
@@ -5,7 +5,7 @@ import argcomplete
 from async_service.trio import background_trio_service
 
 from eth2.clock import Clock
-from eth2.validator_client.beacon_node import MockBeaconNode as BeaconNode
+from eth2.validator_client.beacon_node import BeaconNode
 from eth2.validator_client.client import Client
 from eth2.validator_client.config import Config
 from eth2.validator_client.key_store import KeyStore

--- a/eth2/validator_client/config.py
+++ b/eth2/validator_client/config.py
@@ -7,7 +7,7 @@ from eth_typing import BLSPubkey
 from eth2.beacon.typing import Slot
 from eth2.validator_client.typing import BLSPrivateKey
 
-DEFAULT_BEACON_NODE_ENDPOINT = "http://127.0.0.1:30303"
+DEFAULT_BEACON_NODE_ENDPOINT = "http://127.0.0.1:5005"
 DEFAULT_VALIDATOR_DATA_DIR = Path("validator_client")
 DEFAULT_KEY_STORE_DIR_SUFFIX = Path("key_store")
 DEFAULT_SIGNATORY_DB_DIR_SUFFIX = Path("db") / "signatory"


### PR DESCRIPTION
...command by default now

just synchronizing each command line default given recent changes...



### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

[//]: # (See: https://trinity-client.readthedocs.io/en/latest/contributing.html#pull-requests)
- [ ] Add entry to the [release notes](https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://www.thesprucepets.com/thmb/upDm2VDhldsbteoR2P_kaJ52Ggk=/3000x2652/filters:no_upscale():max_bytes(150000):strip_icc()/GettyImages-989887678-5bd32726c9e77c0051280bf2.jpg)
