### PR TITLE
eth-keys, eth-tester, Web3.py update

### DIFF
--- a/newsfragments/1724.bugfix.rst
+++ b/newsfragments/1724.bugfix.rst
@@ -1,1 +1,2 @@
-Squash some deprecation warnings, by upgrading eth-keys & eth-tester
+Squash some deprecation warnings, by upgrading to eth-keys v0.3.3, eth-tester v0.4.0-beta.2,
+and web3.py v5.9.0

--- a/newsfragments/1724.bugfix.rst
+++ b/newsfragments/1724.bugfix.rst
@@ -1,0 +1,1 @@
+Squash some deprecation warnings, by upgrading eth-keys & eth-tester

--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,7 @@ deps = {
         "ipython>=7.8.0,<7.10.0",  # attach fails with v7.10.{0,1}
         "plyvel==1.1.0",
         PYEVM_DEPENDENCY,
-        "web3>=5.9.0,<6",
+        "web3>=5.10.0,<6",
         "lahja>=0.16.0,<0.17",
         "termcolor>=1.1.0,<2.0.0",
         "uvloop==0.14.0;platform_system=='Linux' or platform_system=='Darwin' or platform_system=='FreeBSD'",  # noqa: E501

--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,7 @@ deps = {
         "ipython>=7.8.0,<7.10.0",  # attach fails with v7.10.{0,1}
         "plyvel==1.1.0",
         PYEVM_DEPENDENCY,
-        "web3==5.4.0",
+        "web3>=5.9.0,<6",
         "lahja>=0.16.0,<0.17",
         "termcolor>=1.1.0,<2.0.0",
         "uvloop==0.14.0;platform_system=='Linux' or platform_system=='Darwin' or platform_system=='FreeBSD'",  # noqa: E501

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ deps = {
         # cryptography does not use semver and allows breaking changes within `0.3` version bumps.
         "cryptography>=2.5,<2.7",
         "eth-hash>=0.1.4,<1",
-        "eth-keys>=0.2.4,<0.3.0",
+        "eth-keys>=0.3.3,<0.4.0",
         "netifaces>=0.10.7<1",
         "pysha3>=1.0.0,<2.0.0",
         "python-snappy>=0.5.3",
@@ -77,7 +77,7 @@ deps = {
         "pytest-xdist>=1.29.0,<1.30",
         # only for eth2
         "ruamel.yaml==0.15.98",
-        "eth-tester==0.2.0b3",
+        "eth-tester==0.4.0b2",
     ],
     # We have to keep some separation between trio and asyncio based tests
     # because `pytest-asyncio` is greedy and tries to run all asyncio fixtures.

--- a/tox.ini
+++ b/tox.ini
@@ -14,7 +14,7 @@ envlist=
 [flake8]
 max-line-length= 100
 exclude=
-ignore=W504
+ignore=W504,W503
 
 [isort]
 force_sort_within_sections=True

--- a/trinity/components/builtin/attach/console.py
+++ b/trinity/components/builtin/attach/console.py
@@ -16,6 +16,8 @@ from eth.chains.base import MiningChain
 from eth.db.chain import ChainDB
 from eth.db.backends.level import LevelDB
 
+from web3.types import RPCEndpoint, RPCResponse
+
 from eth2.beacon.db.chain import BeaconChainDB
 from eth2.beacon.types.blocks import BeaconBlock
 
@@ -95,7 +97,7 @@ def console(ipc_path: Path,
     w3 = web3.Web3(ipc_provider)
 
     # Allow omitting params by defaulting to `None`
-    def rpc(method: str, params: Dict[str, Any] = None) -> str:
+    def rpc(method: RPCEndpoint, params: Dict[str, Any] = None) -> RPCResponse:
         return ipc_provider.make_request(method, params)
 
     namespace = merge({'w3': w3, 'rpc': rpc}, env)

--- a/trinity/components/eth2/eth1_monitor/eth1_monitor.py
+++ b/trinity/components/eth2/eth1_monitor/eth1_monitor.py
@@ -374,9 +374,7 @@ class Eth1Monitor(Service):
                 for i in range(1, self._num_blocks_confirmed + 1):
                     lookback_number = block_number - i
                     if lookback_number < 0:
-                        raise ValueError(
-                            f"These shifted block numbers must be >=0, got {lookback_number}"
-                        )
+                        break
                     else:
                         shifted_block = BlockNumber(lookback_number)
                     block = self._eth1_data_provider.get_block(shifted_block)

--- a/trinity/components/eth2/eth1_monitor/eth1_monitor.py
+++ b/trinity/components/eth2/eth1_monitor/eth1_monitor.py
@@ -372,7 +372,14 @@ class Eth1Monitor(Service):
                 block_number = block.number
                 # Try the latest `self._num_blocks_confirmed` blocks until we give up
                 for i in range(1, self._num_blocks_confirmed + 1):
-                    block = self._eth1_data_provider.get_block(block_number - i)
+                    lookback_number = block_number - i
+                    if lookback_number < 0:
+                        raise ValueError(
+                            f"These shifted block numbers must be >=0, got {lookback_number}"
+                        )
+                    else:
+                        shifted_block = BlockNumber(lookback_number)
+                    block = self._eth1_data_provider.get_block(shifted_block)
                     if block.timestamp <= timestamp:
                         return block.number
                 raise Eth1BlockNotFound(


### PR DESCRIPTION
### What was wrong?

Fixes #1724 

### How was it fixed?

Upgraded various libraries. web3.py seems to have started exporting types since the last version, so a lot of new type warnings were triggered.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history
- [x] Rebase on #1681 

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

[//]: # (See: https://trinity-client.readthedocs.io/en/latest/contributing.html#pull-requests)
- [x] Add entry to the [release notes](https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://cdn.mos.cms.futurecdn.net/eWcEDHDCcgWrqVhHjRzSgE-320-80.jpg)
