### PR TITLE
Beacon node now imports blocks from the validator API

### DIFF
--- a/eth2/api/http/validator.py
+++ b/eth2/api/http/validator.py
@@ -71,6 +71,11 @@ class SyncerAPI(ABC):
         ...
 
 
+class BlockBroadcasterAPI(ABC):
+    async def broadcast_block(self, block: SignedBeaconBlock) -> None:
+        ...
+
+
 @dataclass
 class ValidatorDuty:
     validator_pubkey: BLSPubkey
@@ -87,6 +92,7 @@ class Context:
     syncer: SyncerAPI
     chain: BaseBeaconChain
     clock: Clock
+    block_broadcaster: BlockBroadcasterAPI
     _broadcast_operations: Set[Root] = field(default_factory=set)
 
     async def get_sync_status(self) -> SyncStatus:
@@ -137,9 +143,9 @@ class Context:
             slot, parent_block_root, randao_reveal, parent_state, state_machine
         )
 
-        # TODO the actual brodcast
     async def broadcast_block(self, block: SignedBeaconBlock) -> bool:
         logger.warning("broadcasting block with root %s", block.hash_tree_root.hex())
+        await self.block_broadcaster.broadcast_block(block)
         self._broadcast_operations.add(block.hash_tree_root)
         return True
 

--- a/eth2/api/http/validator.py
+++ b/eth2/api/http/validator.py
@@ -127,11 +127,12 @@ class Context:
     def get_block_proposal(
         self, slot: Slot, randao_reveal: BLSSignature
     ) -> BeaconBlock:
-        target_slot = Slot(max(slot - 1, 0))
-        head_state = self.chain.get_head_state()
-        parent_state = self.chain.advance_state_to_slot(target_slot, head_state)
-        parent_block_root = parent_state.latest_block_header.hash_tree_root
-        state_machine = self.chain.get_state_machine(at_slot=target_slot)
+        parent_slot = Slot(max(slot - 1, 0))
+        parent = self.chain.get_canonical_head()
+        parent_block_root = parent.message.hash_tree_root
+        head_state = self.chain.get_state_by_root(parent.message.state_root)
+        parent_state = self.chain.advance_state_to_slot(parent_slot, head_state)
+        state_machine = self.chain.get_state_machine(at_slot=slot)
         return create_block_proposal(
             slot, parent_block_root, randao_reveal, parent_state, state_machine
         )

--- a/eth2/api/http/validator.py
+++ b/eth2/api/http/validator.py
@@ -4,6 +4,7 @@ This module contains the eth2 HTTP validator API connecting a validator client t
 from abc import ABC
 from dataclasses import asdict, dataclass, field
 from enum import Enum, unique
+import logging
 from typing import Collection, Iterable, Set
 
 from eth.exceptions import BlockNotFound
@@ -29,6 +30,8 @@ from eth2.beacon.typing import Bitfield, CommitteeIndex, Epoch, Root, Slot
 from eth2.clock import Clock
 from eth2.configs import Eth2Config
 from trinity._utils.trio_utils import Request, Response
+
+logger = logging.getLogger("eth2.api.http.validator")
 
 
 def _get_target_checkpoint(
@@ -129,12 +132,10 @@ class Context:
             slot, parent_block_root, randao_reveal, parent_state, state_machine
         )
 
-    async def broadcast_block(self, signed_block: SignedBeaconBlock) -> bool:
-        # self.logger.info(
-        #     "broadcasting block with root %s", humanize_hash(block.hash_tree_root)
-        #   )
         # TODO the actual brodcast
-        self._broadcast_operations.add(signed_block.hash_tree_root)
+    async def broadcast_block(self, block: SignedBeaconBlock) -> bool:
+        logger.warning("broadcasting block with root %s", block.hash_tree_root.hex())
+        self._broadcast_operations.add(block.hash_tree_root)
         return True
 
     def get_attestation(
@@ -174,7 +175,7 @@ class Context:
         return Attestation.create(aggregation_bits=aggregation_bits, data=data)
 
     async def broadcast_attestation(self, attestation: Attestation) -> bool:
-        # self.logger.info(
+        # logger.info(
         #     "broadcasting attestation with root %s",
         #     humanize_hash(attestation.hash_tree_root),
         # )

--- a/eth2/api/http/validator.py
+++ b/eth2/api/http/validator.py
@@ -108,7 +108,11 @@ class Context:
                 continue
 
             if is_proposer(state, validator_index, self.eth2_config):
-                block_proposal_slot = state.slot
+                # TODO (ralexstokes) clean this up!
+                if state.slot != 0:
+                    block_proposal_slot = state.slot
+                else:
+                    block_proposal_slot = Slot((1 << 64) - 1)
             else:
                 # NOTE: temporary sentinel value for "no slot"
                 # The API has since been updated w/ much better ergonomics

--- a/eth2/validator_client/beacon_node.py
+++ b/eth2/validator_client/beacon_node.py
@@ -250,7 +250,7 @@ class BeaconNode(BeaconNodeAPI):
             self._is_connected = True
         except OSError as e:
             if retry:
-                self.logger.warn(
+                self.logger.warning(
                     "could not connect to beacon node at %s; retrying connection in %d seconds",
                     self._beacon_node_endpoint,
                     CONNECTION_RETRY_INTERVAL,

--- a/eth2/validator_client/beacon_node.py
+++ b/eth2/validator_client/beacon_node.py
@@ -157,6 +157,13 @@ def _parse_duties(
     return duties
 
 
+def _is_current_duty(duty: Duty) -> bool:
+    # NOTE: there is an argument to be made for the validator that tries to
+    # service _all_ duties with in the current epoch to play "catch up" but
+    # it is simpler to just discard things we missed...
+    return duty.tick_for_execution.slot >= duty.discovered_at_tick.slot
+
+
 async def _get_attestation_from_beacon_node(
     session: Session,
     url: str,
@@ -306,16 +313,19 @@ class BeaconNode(BeaconNodeAPI):
             self._session, url, public_keys, target_epoch
         )
         return tuple(
-            mapcat(
-                lambda data: _parse_duties(
-                    data,
-                    current_tick,
-                    target_epoch,
-                    self._genesis_time,
-                    self._seconds_per_slot,
-                    self._ticks_per_slot,
+            filter(
+                _is_current_duty,
+                mapcat(
+                    lambda data: _parse_duties(
+                        data,
+                        current_tick,
+                        target_epoch,
+                        self._genesis_time,
+                        self._seconds_per_slot,
+                        self._ticks_per_slot,
+                    ),
+                    duties_data,
                 ),
-                duties_data,
             )
         )
 

--- a/eth2/validator_client/duty_store.py
+++ b/eth2/validator_client/duty_store.py
@@ -7,25 +7,41 @@ from eth2.beacon.typing import Slot
 from eth2.clock import Tick
 from eth2.validator_client.duty import Duty
 
+# A particular subdivision of a slot:
+# Tick(t, slot, epoch, count) => (slot, count)
+TickCount = Tuple[Slot, int]
+
+
+def to_tick_count(tick: Tick) -> TickCount:
+    return (tick.slot, tick.count)
+
+
+def _contains_duty_at_tick(duties: Tuple[Duty, ...], duty: Duty) -> bool:
+    """
+    ``duties`` are a collection of duties at one particular tick
+    """
+    return duty.validator_public_key in map(
+        lambda duty: duty.validator_public_key, duties
+    )
+
 
 class DutyStore:
     def __init__(self) -> None:
-        self._store: Dict[Slot, Dict[int, Tuple[Duty, ...]]] = {}
+        self._store: Dict[TickCount, Tuple[Duty, ...]] = defaultdict(tuple)
         self._store_lock = trio.Lock()
 
     async def duties_at_tick(self, tick: Tick) -> Collection[Duty]:
+        target = to_tick_count(tick)
         async with self._store_lock:
-            if tick.slot in self._store:
-                duties_by_tick = self._store[tick.slot]
-                return duties_by_tick.get(tick.count, ())
-            else:
-                return ()
+            return self._store[target]
 
     async def add_duties(self, *duties: Duty) -> None:
         async with self._store_lock:
             for duty in duties:
-                tick = duty.tick_for_execution
-                if tick.slot not in self._store:
-                    self._store[tick.slot] = defaultdict(tuple)
-
-                self._store[tick.slot][tick.count] += (duty,)
+                target = to_tick_count(duty.tick_for_execution)
+                existing_duties = self._store[target]
+                if _contains_duty_at_tick(existing_duties, duty):
+                    continue
+                else:
+                    existing_duties += (duty,)
+                    self._store[target] = existing_duties

--- a/tests-trio/integration/test_validator_api.py
+++ b/tests-trio/integration/test_validator_api.py
@@ -1,3 +1,5 @@
+import platform
+
 from async_service.trio import background_trio_service
 import pytest
 import trio
@@ -8,6 +10,12 @@ from eth2.validator_client.client import Client as ValidatorClient
 from eth2.validator_client.key_store import KeyStore
 from trinity._utils.version import construct_trinity_client_identifier
 from trinity.nodes.beacon.full import BeaconNode
+
+# NOTE: seeing differences in ability to connect depending on platform.
+# This could be specific to our trio HTTP server (somehow...) so try removing after deprecation...
+local_host_name = "127.0.0.1"  # linux default
+if platform.system() == "Darwin":
+    local_host_name = "localhost"  # macOS variant
 
 
 @pytest.mark.trio
@@ -50,7 +58,7 @@ async def test_beacon_node_and_validator_client_can_talk(
 
         api_client = BeaconNodeClient(
             chain_config.genesis_time,
-            f"http://127.0.0.1:{node.validator_api_port}",
+            f"http://{local_host_name}:{node.validator_api_port}",
             eth2_config.SECONDS_PER_SLOT,
         )
         async with api_client:

--- a/tests-trio/integration/test_validator_api.py
+++ b/tests-trio/integration/test_validator_api.py
@@ -53,6 +53,9 @@ async def test_beacon_node_and_validator_client_can_talk(
         client_id,
     )
 
+    starting_head_slot = node._chain.get_canonical_head().message.slot
+    assert starting_head_slot == eth2_config.GENESIS_SLOT
+
     async with trio.open_nursery() as nursery:
         await nursery.start(node.run)
 
@@ -68,15 +71,21 @@ async def test_beacon_node_and_validator_client_can_talk(
             key_store = KeyStore(sample_bls_key_pairs)
             validator = ValidatorClient(key_store, clock, api_client)
 
-            with trio.move_on_after(seconds_per_epoch * 2):
+            with trio.move_on_after(seconds_per_epoch):
                 async with background_trio_service(validator):
-                    await trio.sleep(seconds_per_epoch * 3)
+                    await trio.sleep(seconds_per_epoch * 2)
             nursery.cancel_scope.cancel()
     sent_operations_for_broadcast = api_client._broadcast_operations
     received_operations_for_broadcast = node._api_context._broadcast_operations
+
+    # temporary until we update to the new API
+    # NOTE: with new API, remove assertion and deletion
+    assert validator._duty_store._store[((1 << 64) - 1, 0)]
+    del validator._duty_store._store[((1 << 64) - 1, 0)]
 
     # NOTE: this is the easiest condition to pass while suggesting this is working
     # As the other parts of the project shore up, we should do stricter testing to ensure
     # the operations we expect (and that they exist...) get across the gap from
     # validator to beacon node
     assert received_operations_for_broadcast.issubset(sent_operations_for_broadcast)
+    assert node._chain.get_canonical_head().slot > starting_head_slot


### PR DESCRIPTION
### What was wrong?

The beacon node could accept blocks directly but was not wired to accept them from a validator client.

### How was it fixed?


The beacon node imports blocks from that source now.


#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://jasonlefkowitz.net/wp-content/uploads/2013/07/Cute-Cat-Photos-wallpaper.jpg)
