### PR TITLE
Fix PeerConnectionLost related crash in metrics reporting

### DIFF
--- a/trinity/protocol/common/peer.py
+++ b/trinity/protocol/common/peer.py
@@ -166,15 +166,16 @@ class BaseChainPeerReporterRegistry(PeerReporterRegistry[BaseChainPeer]):
     def make_periodic_update(self, peer: BaseChainPeer, peer_id: int) -> None:
         head_gauge = self._get_blockheight_gauge(peer_id)
         td_gauge = self._get_td_gauge(peer_id)
+        expected_errors = (AttributeError, PeerConnectionLost)
         # set to 0 if head_number unavailable on head_info
         try:
             head_gauge.set_value(peer.head_info.head_number)
-        except AttributeError:
+        except expected_errors:
             head_gauge.set_value(0)
         # set to 0 if head_td unavailable on head_info
         try:
             td_gauge.set_value(peer.head_info.head_td)
-        except AttributeError:
+        except expected_errors:
             td_gauge.set_value(0)
 
     def _get_blockheight_gauge(self, peer_id: int) -> SimpleGauge:

--- a/trinity/protocol/common/peer.py
+++ b/trinity/protocol/common/peer.py
@@ -173,6 +173,8 @@ class BaseChainPeerReporterRegistry(PeerReporterRegistry[BaseChainPeer]):
             head_gauge.set_value(0)
             td_gauge.set_value(0)
         else:
+            td_gauge.set_value(head_info.head_td)
+
             try:
                 head_number = head_info.head_number
             except AttributeError:
@@ -180,14 +182,6 @@ class BaseChainPeerReporterRegistry(PeerReporterRegistry[BaseChainPeer]):
                 head_gauge.set_value(0)
             else:
                 head_gauge.set_value(head_number)
-
-            try:
-                head_td = head_info.head_td
-            except AttributeError:
-                # set to 0 if head_td unavailable on head_info
-                td_gauge.set_value(0)
-            else:
-                td_gauge.set_value(head_td)
 
     def _get_blockheight_gauge(self, peer_id: int) -> SimpleGauge:
         return self.metrics_registry.gauge(f"trinity.p2p/peer_{peer_id}_blockheight.gauge")


### PR DESCRIPTION
### What was wrong?

See #1732, the whole node crashes when we try to read `head_td` and friends from a peer that is in the process of shutting down. 

### How was it fixed?

Catch the `PeerConnectionLost` error and set gauge to `0`.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

[//]: # (See: https://trinity-client.readthedocs.io/en/latest/contributing.html#pull-requests)
- [ ] ~~Add entry to the [release notes](https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)~~ Unreleased bug

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://static.boredpanda.com/blog/wp-content/uploads/2014/01/unusual-animal-friendship-coverimage.jpg)
