### PR TITLE
Change our geth integration test to do a regular instead of light sync

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -213,13 +213,13 @@ jobs:
       - image: circleci/python:3.8
         environment:
           TOXENV: py38-integration
-  py37-lightchain_integration:
+  py37-sync_integration:
     <<: *geth_steps
     docker:
       - image: circleci/python:3.7
         environment:
-          TOXENV: py37-lightchain_integration
-          GETH_VERSION: v1.8.22
+          TOXENV: py37-sync_integration
+          GETH_VERSION: v1.9.6
   py37-long_run_integration:
     <<: *common
     docker:
@@ -435,7 +435,7 @@ workflows:
       - py38-eth1-components
       - py38-eth2-trio
 
-      - py37-lightchain_integration
+      - py37-sync_integration
 
       - py38-lint
       - py38-lint-eth2

--- a/scripts/peer.py
+++ b/scripts/peer.py
@@ -124,5 +124,4 @@ async def _main() -> None:
 
 
 if __name__ == "__main__":
-    loop = asyncio.get_event_loop()
-    loop.run_until_complete(_main())
+    asyncio.run(_main())

--- a/tests/core/integration_test_helpers.py
+++ b/tests/core/integration_test_helpers.py
@@ -1,4 +1,3 @@
-import asyncio
 import contextlib
 from enum import Enum
 from pathlib import Path
@@ -6,7 +5,6 @@ from tempfile import TemporaryDirectory
 from zipfile import ZipFile
 
 from async_service import background_asyncio_service
-from cancel_token import OperationCancelled
 from eth_keys import keys
 from eth_utils import decode_hex
 
@@ -27,17 +25,6 @@ from trinity.tools.chain import AsyncMiningChain
 
 
 ZIPPED_FIXTURES_PATH = Path(__file__).parent.parent / 'integration' / 'fixtures'
-
-
-async def connect_to_peers_loop(peer_pool, nodes):
-    """Loop forever trying to connect to one of the given nodes if the pool is not yet full."""
-    while peer_pool.manager.is_running:
-        try:
-            if not peer_pool.is_full:
-                await peer_pool.connect_to_nodes(nodes)
-            await asyncio.sleep(2)
-        except OperationCancelled:
-            break
 
 
 FUNDED_ACCT = keys.PrivateKey(

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist=
-    py{37,38}-{eth1-core,p2p,p2p-trio,integration,lightchain_integration,eth2-core,eth2-fixtures,eth2-integration,eth1-components,eth2-utils,eth2-trio}
+    py{37,38}-{eth1-core,p2p,p2p-trio,integration,sync_integration,eth2-core,eth2-fixtures,eth2-integration,eth1-components,eth2-utils,eth2-trio}
     py37-long_run_integration
     py37-rpc-blockchain
     py38-rpc-state-{frontier,homestead,tangerine_whistle,spurious_dragon,byzantium,constantinople,petersburg,istanbul}
@@ -55,7 +55,7 @@ commands=
     rpc-state-quadratic: pytest -n 4 {posargs:tests/json-fixtures-over-rpc/test_rpc_fixtures.py -k 'GeneralStateTests and stQuadraticComplexityTest'}
     rpc-state-sstore: pytest -n 4 {posargs:tests/json-fixtures-over-rpc/test_rpc_fixtures.py -k 'GeneralStateTests and stSStoreTest'}
     rpc-state-zero_knowledge: pytest -n 4 {posargs:tests/json-fixtures-over-rpc/test_rpc_fixtures.py -k 'GeneralStateTests and stZeroKnowledge'}
-    lightchain_integration: pytest --integration {posargs:tests/integration/test_lightchain_integration.py}
+    sync_integration: pytest -s --integration {posargs:tests/integration/test_sync.py --log-cli-level=debug}
 
 deps = .[p2p,trinity,eth2,test,test-asyncio]
 
@@ -129,7 +129,7 @@ commands=
     # due to multiple Trinity instances competing for the same ports
 
     # The `trinity_cli` tests are already run by the pyxx-wheel-cli jobs. No need to repeat them here
-    pytest --integration -n 1 {posargs:tests/integration/ -k 'not lightchain_integration and not trinity_cli'}
+    pytest --integration -n 1 {posargs:tests/integration/ -k 'not sync_integration and not trinity_cli'}
 
 [testenv:py38-integration]
 deps = {[common-integration]deps}

--- a/trinity/sync/common/peers.py
+++ b/trinity/sync/common/peers.py
@@ -53,7 +53,7 @@ class WaitingPeers(Generic[TChainPeer]):
 
         if isinstance(response_command_type, type):
             self._response_command_type = (response_command_type,)
-        elif isinstance(response_command_type, collections.Sequence):
+        elif isinstance(response_command_type, collections.abc.Sequence):
             self._response_command_type = tuple(response_command_type)
         else:
             raise TypeError(f"Unsupported value: {response_command_type}")


### PR DESCRIPTION
Also use a newer geth version.

As we're considering abandoning the LES protocol (#1366), it makes more sense to do a regular sync in the integration test.

This would have caught the regression in #1001 earlier as well, as for some reason that didn't happen when using the LES protocol