### PR TITLE
Guard against subproc not having returncode set in isolatedcomponents

### DIFF
--- a/trinity/extensibility/asyncio.py
+++ b/trinity/extensibility/asyncio.py
@@ -34,7 +34,8 @@ class AsyncioIsolatedComponent(BaseIsolatedComponent):
             # Only attempt to log the proc's returncode if we succesfully entered the context
             # manager above.
             if 'proc' in locals():
-                self.logger.debug("%s terminated: returncode=%s", self, proc.returncode)
+                returncode = getattr(proc, 'returncode', 'unset')
+                self.logger.debug("%s terminated: returncode=%s", self, returncode)
 
     async def _do_run(self, boot_info: BootInfo) -> None:
         with child_process_logging(boot_info):

--- a/trinity/extensibility/trio.py
+++ b/trinity/extensibility/trio.py
@@ -40,7 +40,8 @@ class TrioIsolatedComponent(BaseIsolatedComponent):
             # Only attempt to log the proc's returncode if we succesfully entered the context
             # manager above.
             if 'proc' in locals():
-                self.logger.debug("%s terminated: returncode=%s", self.name, proc.returncode)
+                returncode = getattr(proc, 'returncode', 'unset')
+                self.logger.debug("%s terminated: returncode=%s", self.name, returncode)
 
     async def run_process(self, boot_info: BootInfo, event_bus: EndpointAPI) -> None:
         try:


### PR DESCRIPTION
When the process started by our IsolatedComponents is killed, they will
not have a `.returncode`, so check that before attempting to log it