### PR TITLE
Use originating exception's args when doing "raise Exc from"

### DIFF
--- a/p2p/commands.py
+++ b/p2p/commands.py
@@ -64,7 +64,7 @@ class RLPCodec(SerializationCodecAPI[TCommandPayload]):
                 rlp.decode(data, strict=self.decode_strict, sedes=self.sedes, recursive_cache=True)
             )
         except rlp.DecodingError as err:
-            raise MalformedMessage from err
+            raise MalformedMessage(*err.args) from err
 
 
 #

--- a/p2p/connection.py
+++ b/p2p/connection.py
@@ -137,11 +137,12 @@ class Connection(ConnectionAPI, Service):
                 await self.manager.wait_finished()
         except PeerConnectionLost:
             pass
-        except (MalformedMessage,) as err:
+        except MalformedMessage as err:
             self.logger.debug(
                 "Disconnecting peer %s for sending MalformedMessage: %s",
                 self.remote,
                 err,
+                exc_info=True,
             )
             try:
                 self.get_base_protocol().send(Disconnect(DisconnectReason.BAD_PROTOCOL))

--- a/p2p/transport.py
+++ b/p2p/transport.py
@@ -285,7 +285,7 @@ class Transport(TransportAPI):
                 "Bad message header from peer %s: Error: %r",
                 self, err,
             )
-            raise MalformedMessage from err
+            raise MalformedMessage(*err.args) from err
         # TODO: use `int.from_bytes(...)`
         frame_size = self._get_frame_size(padded_header)
         # The frame_size specified in the header does not include the padding to 16-byte boundary,
@@ -299,7 +299,7 @@ class Transport(TransportAPI):
                 "Bad message body from peer %s: Error: %r",
                 self, err,
             )
-            raise MalformedMessage from err
+            raise MalformedMessage(*err.args) from err
 
         # Reset status back to IDLE
         self.read_state = TransportState.IDLE
@@ -308,7 +308,7 @@ class Transport(TransportAPI):
         try:
             header_data = _decode_header_data(padded_header[3:])
         except rlp.exceptions.DeserializationError as err:
-            raise MalformedMessage from err
+            raise MalformedMessage(*err.args) from err
 
         header = padded_header[:3] + rlp.encode(header_data)
 


### PR DESCRIPTION
Our MalformedMessage exceptions were being raised withh no
description passed to its constructor as they were using the
`raise Exception from ...` form, so it was assumed that the
info from the originating exception would be enough, but
in that case when we catch a MalformedMessage and log, it
would be empty.