### PR TITLE
Multiplexer now consumes transport messages in a background task

### DIFF
--- a/p2p/connection.py
+++ b/p2p/connection.py
@@ -72,7 +72,11 @@ class Connection(ConnectionAPI, Service):
                  protocol_receipts: Sequence[HandshakeReceiptAPI],
                  is_dial_out: bool) -> None:
         self.logger = get_logger('p2p.connection.Connection')
+        # The multiplexer passed to us will have been started when performing the handshake, so it
+        # is already reading messages from the transport and storing them in per-protocol queues.
         self._multiplexer = multiplexer
+        # Stop early in case the multiplexer is no longer streaming.
+        self._multiplexer.raise_if_streaming_error()
         self._devp2p_receipt = devp2p_receipt
         self.protocol_receipts = tuple(protocol_receipts)
         self.is_dial_out = is_dial_out
@@ -128,13 +132,23 @@ class Connection(ConnectionAPI, Service):
     def is_closing(self) -> bool:
         return self._multiplexer.is_closing
 
-    async def run(self) -> None:
-        try:
-            async with self._multiplexer.multiplex():
-                for protocol in self._multiplexer.get_protocols():
-                    self.manager.run_daemon_task(self._feed_protocol_handlers, protocol)
+    def __del__(self) -> None:
+        # This is necessary because the multiplexer passed to our constructor will be streaming,
+        # and if for some reason our run() method is not called, we'd leave the multiplexer
+        # streaming indefinitely. We might still get ayncio warnings (about a task being destroyed
+        # while still pending) if that happens, but this is the best we can do.
+        self._multiplexer.cancel_streaming()
 
-                await self.manager.wait_finished()
+    async def run(self) -> None:
+        # Our multiplexer will already be streaming in the background (as it was used during
+        # handshake), so we do this to ensure we only start if it is still running.
+        self._multiplexer.raise_if_streaming_error()
+
+        for protocol in self._multiplexer.get_protocols():
+            self.manager.run_daemon_task(self._feed_protocol_handlers, protocol)
+
+        try:
+            await self._multiplexer.wait_streaming_finished()
         except PeerConnectionLost:
             pass
         except MalformedMessage as err:
@@ -151,8 +165,6 @@ class Connection(ConnectionAPI, Service):
                     "%s went away while trying to disconnect for MalformedMessage",
                     self,
                 )
-        finally:
-            await self._multiplexer.close()
 
     #
     # Subscriptions/Handler API
@@ -170,8 +182,6 @@ class Connection(ConnectionAPI, Service):
                 "`Connection.start_protocol_streams()` is being called"
             ) from err
 
-        # we don't need to use wait_iter here because the multiplexer does it
-        # for us.
         async for cmd in self._multiplexer.stream_protocol_messages(protocol):
             self.logger.debug2('Handling command: %s', type(cmd))
             # local copy to prevent multation while iterating

--- a/p2p/exceptions.py
+++ b/p2p/exceptions.py
@@ -213,15 +213,6 @@ class CouldNotRetrieveENR(BaseP2PError):
     pass
 
 
-class CorruptTransport(BaseP2PError):
-    """
-    We lost our place in the stream due to a read operation being interrupted at some point.
-    This isn't recoverable at the moment, so typically this means we should close the transport
-    and terminate the peer connection, when this exception is raised.
-    """
-    pass
-
-
 class PeerReporterRegistryError(BaseP2PError):
     """
     Raised when there is an error assigning or unassigning peers in the PeerReporterRegistry.

--- a/p2p/multiplexer.py
+++ b/p2p/multiplexer.py
@@ -1,6 +1,5 @@
 import asyncio
 import collections
-import contextlib
 import time
 from typing import (
     Any,
@@ -8,6 +7,7 @@ from typing import (
     cast,
     DefaultDict,
     Dict,
+    Optional,
     Sequence,
     Tuple,
     Type,
@@ -30,13 +30,11 @@ from p2p.abc import (
     TProtocol,
 )
 from p2p.exceptions import (
-    CorruptTransport,
     UnknownProtocol,
     UnknownProtocolCommand,
     MalformedMessage,
 )
 from p2p.p2p_proto import BaseP2PProtocol
-from p2p.transport_state import TransportState
 from p2p._utils import (
     get_logger,
     snappy_CompressedLengthError,
@@ -117,9 +115,7 @@ class Multiplexer(MultiplexerAPI):
         # the sub-protocol instances
         self._protocols = protocols
 
-        # Lock to ensure that multiple call sites cannot concurrently stream
-        # messages.
-        self._multiplex_lock = asyncio.Lock()
+        self._streaming_task: asyncio.Future[None] = None
 
         # Lock management on a per-protocol basis to ensure we only have one
         # stream consumer for each protocol.
@@ -139,6 +135,7 @@ class Multiplexer(MultiplexerAPI):
 
         self._msg_counts = collections.defaultdict(int)
         self._last_msg_time = 0
+        self._started_streaming = asyncio.Event()
 
     def __str__(self) -> str:
         protocol_infos = ','.join(tuple(
@@ -263,8 +260,6 @@ class Multiplexer(MultiplexerAPI):
 
         if self._protocol_locks[protocol_class].locked():
             raise Exception(f"Streaming lock for {protocol_class} is not free.")
-        elif not self._multiplex_lock.locked():
-            raise Exception("Not multiplexed.")
 
         return self._stream_protocol_messages(protocol_class)
 
@@ -275,8 +270,9 @@ class Multiplexer(MultiplexerAPI):
         Stream the messages for the specified protocol.
         """
         async with self._protocol_locks[protocol_class]:
+            self.raise_if_streaming_error()
             msg_queue = self._protocol_queues[protocol_class]
-            while not self.is_closing:
+            while self.is_streaming:
                 try:
                     # We use an optimistic strategy here of using
                     # `get_nowait()` to reduce the number of times we yield to
@@ -290,96 +286,56 @@ class Multiplexer(MultiplexerAPI):
     #
     # Message reading and streaming API
     #
-    @contextlib.asynccontextmanager
-    async def multiplex(self) -> AsyncIterator[None]:
-        """
-        API for running the background task that feeds individual protocol
-        queues that allows each individual protocol to stream only its own
-        messages.
-        """
-        async with self._multiplex_lock:
-            stop = asyncio.Event()
-            fut = asyncio.ensure_future(self._do_multiplexing(stop))
-            # wait for the multiplexing to actually start
-            try:
-                yield
-            finally:
-                #
-                # Prevent corruption of the Transport:
-                #
-                # On exit the `Transport` can be in a few states:
-                #
-                # 1. IDLE: between reads
-                # 2. HEADER: waiting to read the bytes for the message header
-                # 3. BODY: already read the header, waiting for body bytes.
-                #
-                # In the IDLE case we get a clean shutdown by simply signaling
-                # to `_do_multiplexing` that it should exit which is done with
-                # an `asyncio.EVent`
-                #
-                # In the HEADER case we can issue a hard stop either via
-                # cancellation or the cancel token.  The read *should* be
-                # interrupted without consuming any bytes from the
-                # `StreamReader`.
-                #
-                # In the BODY case we want to give the `Transport.recv` call a
-                # moment to finish reading the body after which it will be IDLE
-                # and will exit via the IDLE exit mechanism.
-                stop.set()
+    async def stream_in_background(self) -> None:
+        self._streaming_task = asyncio.ensure_future(self._do_multiplexing())
+        await self._started_streaming.wait()
 
-                # If the transport is waiting to read the body of the message
-                # we want to give it a moment to finish that read.  Otherwise
-                # this leaves the transport in a corrupt state.
-                if self._transport.read_state is TransportState.BODY:
-                    try:
-                        await asyncio.wait_for(fut, timeout=1)
-                    except asyncio.TimeoutError:
-                        pass
-                    except CorruptTransport as exc:
-                        self.logger.error("Corrupt transport, waiting on body %s: %r", self, exc)
-                        self.logger.debug("Corrupt transport, body trace: %s", self, exc_info=True)
+    @property
+    def is_streaming(self) -> bool:
+        return self._streaming_task is not None and not self._streaming_task.done()
 
-                # After giving the transport an opportunity to shutdown cleanly, we issue a hard
-                # shutdown via cancellation. This should only end up corrupting the transport in
-                # the case where the header data is read but the body data takes too long to
-                # arrive which should be very rare and would likely indicate a malicious or broken
-                # peer.
-                if fut.done():
-                    fut.result()
-                else:
-                    fut.cancel()
-                    try:
-                        await fut
-                    except asyncio.CancelledError:
-                        pass
+    async def wait_streaming_finished(self) -> None:
+        if self._streaming_task is None:
+            raise Exception("Multiplexer has not started streaming")
+        await self._streaming_task
 
-    async def _do_multiplexing(self, stop: asyncio.Event) -> None:
+    def get_streaming_error(self) -> Optional[BaseException]:
+        if self._streaming_task is None:
+            raise Exception("Multiplexer has not started streaming")
+        elif self._streaming_task.cancelled():
+            return asyncio.CancelledError()
+        elif not self._streaming_task.done():
+            return None
+        return self._streaming_task.exception()
+
+    def raise_if_streaming_error(self) -> None:
+        err = self.get_streaming_error()
+        if err:
+            raise err
+
+    async def _do_multiplexing(self) -> None:
         """
         Background task that reads messages from the transport and feeds them
         into individual queues for each of the protocols.
         """
+        self._started_streaming.set()
         msg_stream = stream_transport_messages(
             self._transport,
             self._base_protocol,
             *self._protocols,
         )
         try:
-            await self._handle_commands(msg_stream, stop)
+            await self._handle_commands(msg_stream)
         except asyncio.TimeoutError as exc:
             self.logger.warning(
-                "Timed out waiting for command from %s, Stop: %r, exiting...",
-                self,
-                stop.is_set(),
-            )
+                "Timed out waiting for command from %s, exiting...", self,)
             self.logger.debug("Timeout %r: %s", self, exc, exc_info=True)
-        except CorruptTransport as exc:
-            self.logger.error("Corrupt transport, while multiplexing %s: %r", self, exc)
-            self.logger.debug("Corrupt transport, multiplexing trace: %s", self, exc_info=True)
+        finally:
+            await self.close()
 
     async def _handle_commands(
             self,
-            msg_stream: AsyncIterator[Tuple[ProtocolAPI, CommandAPI[Any]]],
-            stop: asyncio.Event) -> None:
+            msg_stream: AsyncIterator[Tuple[ProtocolAPI, CommandAPI[Any]]]) -> None:
 
         async for protocol, cmd in msg_stream:
             self._last_msg_time = time.monotonic()
@@ -402,5 +358,13 @@ class Multiplexer(MultiplexerAPI):
                     cmd,
                 )
 
-            if stop.is_set():
-                break
+    def cancel_streaming(self) -> None:
+        if self._streaming_task is not None and not self._streaming_task.done():
+            self._streaming_task.cancel()
+
+    async def stop_streaming(self) -> None:
+        self.cancel_streaming()
+        try:
+            await self._streaming_task
+        except asyncio.CancelledError:
+            pass

--- a/p2p/tools/factories/connection.py
+++ b/p2p/tools/factories/connection.py
@@ -132,6 +132,10 @@ async def ConnectionPairFactoryNotRunning(
         )
         alice_protocol_receipts = ()
         bob_protocol_receipts = ()
+        # Here we need to manually start the multiplexers as we don't use
+        # negotiate_protocol_handshakes() as above.
+        await alice_multiplexer.stream_in_background()
+        await bob_multiplexer.stream_in_background()
 
     alice_connection = Connection(
         multiplexer=alice_multiplexer,

--- a/p2p/transport.py
+++ b/p2p/transport.py
@@ -44,13 +44,11 @@ from p2p.exceptions import (
     DecryptionError,
     MalformedMessage,
     PeerConnectionLost,
-    CorruptTransport,
     UnreachablePeer,
 )
 from p2p.kademlia import Address, Node
 from p2p.message import Message
 from p2p.session import Session
-from p2p.transport_state import TransportState
 
 
 HEADER_DATA_SEDES = rlp.sedes.List((rlp.sedes.big_endian_int, rlp.sedes.big_endian_int))
@@ -64,12 +62,6 @@ def _decode_header_data(data: ByteString) -> Tuple[int, int]:
 
 class Transport(TransportAPI):
     logger = get_extended_debug_logger('p2p.transport.Transport')
-
-    # This status flag allows those managing a `Transport` to determine the
-    # proper cancellation strategy if the transport is mid-read.  Hard
-    # cancellations are allowed for both `IDLE` and `HEADER`.  A hard
-    # cancellation during `BODY` will leave the transport in a corrupt state.
-    read_state: TransportState = TransportState.IDLE
 
     def __init__(self,
                  remote: NodeAPI,
@@ -107,11 +99,6 @@ class Transport(TransportAPI):
     @classmethod
     async def connect(cls, remote: NodeAPI, private_key: datatypes.PrivateKey) -> TransportAPI:
         """Perform the auth handshake with the given remote.
-
-        Return an instance of the given peer_class (must be a subclass of
-        BasePeer) connected to that remote in case both handshakes are
-        successful and at least one of the sub-protocols supported by
-        peer_class is also supported by the remote.
 
         Raises UnreachablePeer if we cannot connect to the peer or
         HandshakeFailure if the remote disconnects before completing the
@@ -254,30 +241,7 @@ class Transport(TransportAPI):
         self._writer.write(data)
 
     async def recv(self) -> MessageAPI:
-        # Check that Transport read state is IDLE.
-        if self.read_state is not TransportState.IDLE:
-            # This is logged at INFO level because it indicates we are not
-            # properly managing the Transport and are interrupting it mid-read
-            # somewhere.
-            self.logger.info(
-                'Corrupted transport: %s - state=%s',
-                self,
-                self.read_state.name,
-            )
-            raise CorruptTransport(f"Corrupted transport: {self} - state={self.read_state.name}")
-
-        # Set status to indicate we are waiting to read the message header
-        self.read_state = TransportState.HEADER
-
-        try:
-            header_bytes = await self.read(HEADER_LEN + MAC_LEN)
-        except asyncio.CancelledError:
-            self.logger.debug('Transport cancelled during header read. resetting to IDLE state')
-            self.read_state = TransportState.IDLE
-            raise
-
-        # Set status to indicate we are waiting to read the message body
-        self.read_state = TransportState.BODY
+        header_bytes = await self.read(HEADER_LEN + MAC_LEN)
         try:
             padded_header = self._decrypt_header(header_bytes)
         except DecryptionError as err:
@@ -300,9 +264,6 @@ class Transport(TransportAPI):
                 self, err,
             )
             raise MalformedMessage(*err.args) from err
-
-        # Reset status back to IDLE
-        self.read_state = TransportState.IDLE
 
         # Decode the header data and re-encode to recover the unpadded header size.
         try:

--- a/p2p/transport_state.py
+++ b/p2p/transport_state.py
@@ -1,8 +1,0 @@
-import enum
-
-
-@enum.unique
-class TransportState(enum.Enum):
-    IDLE = enum.auto()
-    HEADER = enum.auto()
-    BODY = enum.auto()

--- a/tests-trio/p2p-trio/test_discovery.py
+++ b/tests-trio/p2p-trio/test_discovery.py
@@ -210,7 +210,7 @@ async def test_request_enr(nursery, manually_driven_discovery_pair):
     # Bob will now consume one datagram containing the ENR_REQUEST from alice, and as part of that
     # will send an ENR_RESPONSE, which will then be consumed by alice, and as part of that it will
     # be fed into the request_enr() task we're running the background.
-    with trio.fail_after(0.1):
+    with trio.fail_after(0.5):
         await bob.consume_datagram()
         await alice.consume_datagram()
 
@@ -235,7 +235,7 @@ async def test_request_enr(nursery, manually_driven_discovery_pair):
     received_enr = None
     got_new_enr = trio.Event()
     nursery.start_soon(fetch_enr, got_new_enr)
-    with trio.fail_after(0.1):
+    with trio.fail_after(0.5):
         await bob.consume_datagram()
         await alice.consume_datagram()
 

--- a/tests/core/tx-pool/test_tx_pool.py
+++ b/tests/core/tx-pool/test_tx_pool.py
@@ -126,7 +126,7 @@ async def test_tx_propagation(two_connected_tx_pools,
     # Alice sends some txs (Important we let the TxPool send them to feed the bloom)
     await alice_tx_pool._handle_tx(bob.session, txs_broadcasted_by_alice)
 
-    await asyncio.wait_for(bob_got_tx.wait(), timeout=0.01)
+    await asyncio.wait_for(bob_got_tx.wait(), timeout=0.2)
     assert len(bob_incoming_tx) == 1
 
     assert bob_incoming_tx[0].as_dict() == txs_broadcasted_by_alice[0].as_dict()
@@ -140,7 +140,7 @@ async def test_tx_propagation(two_connected_tx_pools,
 
     # Check that Bob doesn't receive them again
     with pytest.raises(asyncio.TimeoutError):
-        await asyncio.wait_for(bob_got_tx.wait(), timeout=0.01)
+        await asyncio.wait_for(bob_got_tx.wait(), timeout=0.2)
     assert len(bob_incoming_tx) == 0
 
     # Bob sends exact same txs back (Important we let the TxPool send them to feed the bloom)
@@ -148,7 +148,7 @@ async def test_tx_propagation(two_connected_tx_pools,
 
     # Check that Alice won't get them as that is where they originally came from
     with pytest.raises(asyncio.TimeoutError):
-        await asyncio.wait_for(alice_got_tx.wait(), timeout=0.01)
+        await asyncio.wait_for(alice_got_tx.wait(), timeout=0.2)
     assert len(alice_incoming_tx) == 0
 
     txs_broadcasted_by_bob = [
@@ -159,7 +159,7 @@ async def test_tx_propagation(two_connected_tx_pools,
     # Bob sends old + new tx
     await bob_tx_pool._handle_tx(alice.session, txs_broadcasted_by_bob)
 
-    await asyncio.wait_for(alice_got_tx.wait(), timeout=0.01)
+    await asyncio.wait_for(alice_got_tx.wait(), timeout=0.2)
 
     # Check that Alice receives only the one tx that it didn't know about
     assert alice_incoming_tx[0].as_dict() == txs_broadcasted_by_bob[0].as_dict()

--- a/tests/p2p/test_auth.py
+++ b/tests/p2p/test_auth.py
@@ -164,20 +164,23 @@ async def test_handshake():
         remote_public_key=responder.privkey.public_key.to_bytes(),
     )))
 
-    async with initiator_multiplexer.multiplex():
-        async with responder_multiplexer.multiplex():
-            initiator_stream = initiator_multiplexer.stream_protocol_messages(
-                initiator_p2p_protocol,
-            )
-            responder_stream = responder_multiplexer.stream_protocol_messages(
-                responder_p2p_protocol,
-            )
+    await initiator_multiplexer.stream_in_background()
+    await responder_multiplexer.stream_in_background()
 
-            initiator_hello = await asyncio.wait_for(initiator_stream.asend(None), timeout=0.1)
-            responder_hello = await asyncio.wait_for(responder_stream.asend(None), timeout=0.1)
+    initiator_stream = initiator_multiplexer.stream_protocol_messages(
+        initiator_p2p_protocol,
+    )
+    responder_stream = responder_multiplexer.stream_protocol_messages(
+        responder_p2p_protocol,
+    )
 
-            await initiator_stream.aclose()
-            await responder_stream.aclose()
+    initiator_hello = await asyncio.wait_for(initiator_stream.asend(None), timeout=0.1)
+    responder_hello = await asyncio.wait_for(responder_stream.asend(None), timeout=0.1)
+
+    await initiator_stream.aclose()
+    await responder_stream.aclose()
+    await initiator_multiplexer.stop_streaming()
+    await responder_multiplexer.stop_streaming()
 
     assert isinstance(responder_hello, Hello)
     assert isinstance(initiator_hello, Hello)
@@ -300,20 +303,23 @@ async def test_handshake_eip8():
         remote_public_key=responder.privkey.public_key.to_bytes(),
     )))
 
-    async with initiator_multiplexer.multiplex():
-        async with responder_multiplexer.multiplex():
-            initiator_stream = initiator_multiplexer.stream_protocol_messages(
-                initiator_p2p_protocol,
-            )
-            responder_stream = responder_multiplexer.stream_protocol_messages(
-                responder_p2p_protocol,
-            )
+    await initiator_multiplexer.stream_in_background()
+    await responder_multiplexer.stream_in_background()
 
-            initiator_hello = await initiator_stream.asend(None)
-            responder_hello = await responder_stream.asend(None)
+    initiator_stream = initiator_multiplexer.stream_protocol_messages(
+        initiator_p2p_protocol,
+    )
+    responder_stream = responder_multiplexer.stream_protocol_messages(
+        responder_p2p_protocol,
+    )
 
-            await initiator_stream.aclose()
-            await responder_stream.aclose()
+    initiator_hello = await initiator_stream.asend(None)
+    responder_hello = await responder_stream.asend(None)
+
+    await initiator_stream.aclose()
+    await responder_stream.aclose()
+    await initiator_multiplexer.stop_streaming()
+    await responder_multiplexer.stop_streaming()
 
     assert isinstance(responder_hello, Hello)
     assert isinstance(initiator_hello, Hello)


### PR DESCRIPTION
This way we don't have to deal with pausing/resuming, which led to issues like #1001, and it also fixes a subtle bug I'd recently identified in `Connection`, in which any errors from the multiplexer were only reported once the `Connection` was cancelled. Now the connection starts its daemon tasks and blocks on an `await multiplexer.wait_streaming_finished()` which will raise any multiplexing errors as soon as they happen

Closes: #1001 