### PR TITLE
Fix incorrect tox env setup

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,7 @@ envlist=
     py{37,38}-{eth1-core,p2p,p2p-trio,integration,lightchain_integration,eth2-core,eth2-fixtures,eth2-integration,eth1-components,eth2-utils,eth2-trio}
     py37-long_run_integration
     py37-rpc-blockchain
-    py38-rpc-state-{frontier,homestead,tangerine_whistle,spurious_dragon,byzantium,constantinople,petersburg,istanbul}
+    py37-rpc-state-{frontier,homestead,tangerine_whistle,spurious_dragon,byzantium,constantinople,petersburg,istanbul}
     py37-rpc-state-{quadratic,sstore,zero_knowledge}
     py37-eth2-components
     py{38,37}-lint


### PR DESCRIPTION
### What was wrong?

I introduced a bug when I swapped Py36 against Py38 support where we ended up creating the wrong tox environments for some jobs. 

### How was it fixed?

Swapped `py37` against `py38`

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

[//]: # (See: https://trinity-client.readthedocs.io/en/latest/contributing.html#pull-requests)
- [ ] Add entry to the [release notes](https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses]()
