### PR TITLE
Update which RPC tests are being run

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -194,12 +194,12 @@ jobs:
       - image: circleci/python:3.7
         environment:
           TOXENV: py37-rpc-state-spurious_dragon
-  py37-rpc-blockchain:
+  py37-rpc-state-fork-transition:
     <<: *common
     docker:
       - image: circleci/python:3.7
         environment:
-          TOXENV: py37-rpc-blockchain
+          TOXENV: py37-rpc-state-fork-transition
 
   py38-eth1-core:
     <<: *common
@@ -424,7 +424,7 @@ workflows:
       - py37-rpc-state-petersburg
       - py37-rpc-state-spurious_dragon
       - py37-rpc-state-tangerine_whistle
-      - py37-rpc-blockchain
+      - py37-rpc-state-fork-transition
 
       - py38-eth1-core
       - py38-p2p

--- a/tox.ini
+++ b/tox.ini
@@ -2,8 +2,7 @@
 envlist=
     py{37,38}-{eth1-core,p2p,p2p-trio,integration,sync_integration,eth2-core,eth2-fixtures,eth2-integration,eth1-components,eth2-utils,eth2-trio}
     py37-long_run_integration
-    py37-rpc-blockchain
-    py38-rpc-state-{frontier,homestead,tangerine_whistle,spurious_dragon,byzantium,constantinople,petersburg,istanbul}
+    py37-rpc-state-{fork-transition,frontier,homestead,tangerine_whistle,spurious_dragon,byzantium,constantinople,petersburg,istanbul}
     py37-rpc-state-{quadratic,sstore,zero_knowledge}
     py37-eth2-components
     py{38,37}-lint
@@ -40,17 +39,19 @@ commands=
     p2p-trio: pytest -n 4 {posargs:tests-trio/p2p-trio}
     eth1-components: pytest -n 4 {posargs:tests/components/tx_pool/}
     eth2-components: pytest -n 4 {posargs:tests/components/eth2/}
-    rpc-blockchain: pytest -n 4 {posargs:tests/json-fixtures-over-rpc/test_rpc_fixtures.py -k 'not GeneralStateTests'}
+    # Fixtures that test transitioning from one VM to another. These are otherwise filtered out by
+    # the --fork <ForkName> mechanism because they have a fork such as `FrontierToHomesteadAt5`
+    rpc-state-fork-transition: pytest -n 4 {posargs:tests/json-fixtures-over-rpc/test_rpc_fixtures.py -k 'BlockchainTests/TransitionTests'}
     # Fork/VM-specific state transition tests; long-running categories run separately!
-    rpc-state-frontier: pytest -n 4 {posargs:tests/json-fixtures-over-rpc/test_rpc_fixtures.py --fork Frontier -k 'GeneralStateTests and not stQuadraticComplexityTest and not stSStoreTest and not stZeroKnowledge'}
-    rpc-state-homestead: pytest -n 4 {posargs:tests/json-fixtures-over-rpc/test_rpc_fixtures.py --fork Homestead -k 'GeneralStateTests and not stQuadraticComplexityTest and not stSStoreTest and not stZeroKnowledge'}
-    rpc-state-tangerine_whistle: pytest -n 4 {posargs:tests/json-fixtures-over-rpc/test_rpc_fixtures.py --fork EIP150 -k 'GeneralStateTests and not stQuadraticComplexityTest and not stSStoreTest and not stZeroKnowledge'}
-    rpc-state-spurious_dragon: pytest -n 4 {posargs:tests/json-fixtures-over-rpc/test_rpc_fixtures.py --fork EIP158 -k 'GeneralStateTests and not stQuadraticComplexityTest and not stSStoreTest and not stZeroKnowledge'}
+    rpc-state-frontier: pytest -n 4 {posargs:tests/json-fixtures-over-rpc/test_rpc_fixtures.py --fork Frontier -k 'not stQuadraticComplexityTest and not stSStoreTest and not stZeroKnowledge'}
+    rpc-state-homestead: pytest -n 4 {posargs:tests/json-fixtures-over-rpc/test_rpc_fixtures.py --fork Homestead -k 'not stQuadraticComplexityTest and not stSStoreTest and not stZeroKnowledge'}
+    rpc-state-tangerine_whistle: pytest -n 4 {posargs:tests/json-fixtures-over-rpc/test_rpc_fixtures.py --fork EIP150 -k 'not stQuadraticComplexityTest and not stSStoreTest and not stZeroKnowledge'}
+    rpc-state-spurious_dragon: pytest -n 4 {posargs:tests/json-fixtures-over-rpc/test_rpc_fixtures.py --fork EIP158 -k 'not stQuadraticComplexityTest and not stSStoreTest and not stZeroKnowledge'}
     # The following test seems to consume a lot of memory. Restricting to 3 processes reduces crashes
-    rpc-state-byzantium: pytest -n 3 {posargs:tests/json-fixtures-over-rpc/test_rpc_fixtures.py --fork Byzantium -k 'GeneralStateTests and not stQuadraticComplexityTest and not stSStoreTest and not stZeroKnowledge'}
-    rpc-state-constantinople: pytest -n 3 {posargs:tests/json-fixtures-over-rpc/test_rpc_fixtures.py --fork Constantinople -k 'GeneralStateTests and not stQuadraticComplexityTest and not stSStoreTest and not stZeroKnowledge'}
-    rpc-state-petersburg: pytest -n 3 {posargs:tests/json-fixtures-over-rpc/test_rpc_fixtures.py --fork ConstantinopleFix -k 'GeneralStateTests and not stQuadraticComplexityTest and not stSStoreTest and not stZeroKnowledge'}
-    rpc-state-istanbul: pytest -n 3 {posargs:tests/json-fixtures-over-rpc/test_rpc_fixtures.py --fork Istanbul -k 'GeneralStateTests and not stQuadraticComplexityTest and not stSStoreTest and not stZeroKnowledge'}
+    rpc-state-byzantium: pytest -n 3 {posargs:tests/json-fixtures-over-rpc/test_rpc_fixtures.py --fork Byzantium -k 'not stQuadraticComplexityTest and not stSStoreTest and not stZeroKnowledge'}
+    rpc-state-constantinople: pytest -n 3 {posargs:tests/json-fixtures-over-rpc/test_rpc_fixtures.py --fork Constantinople -k 'not stQuadraticComplexityTest and not stSStoreTest and not stZeroKnowledge'}
+    rpc-state-petersburg: pytest -n 3 {posargs:tests/json-fixtures-over-rpc/test_rpc_fixtures.py --fork ConstantinopleFix -k 'not stQuadraticComplexityTest and not stSStoreTest and not stZeroKnowledge'}
+    rpc-state-istanbul: pytest -n 3 {posargs:tests/json-fixtures-over-rpc/test_rpc_fixtures.py --fork Istanbul -k 'not stQuadraticComplexityTest and not stSStoreTest and not stZeroKnowledge'}
     # Long-running categories.
     rpc-state-quadratic: pytest -n 4 {posargs:tests/json-fixtures-over-rpc/test_rpc_fixtures.py -k 'GeneralStateTests and stQuadraticComplexityTest'}
     rpc-state-sstore: pytest -n 4 {posargs:tests/json-fixtures-over-rpc/test_rpc_fixtures.py -k 'GeneralStateTests and stSStoreTest'}


### PR DESCRIPTION
### What was wrong?

Trying to address #1755 

### How was it fixed?

Do not filter for `GeneralStateTests` when running the RPC tests.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

[//]: # (See: https://trinity-client.readthedocs.io/en/latest/contributing.html#pull-requests)
- [ ] Add entry to the [release notes](https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://i.chzbgr.com/full/8004603904/h4D4B522C/)
