### PR TITLE
Workaround to prevent a DaemonTaskExit error in Connection

### DIFF
--- a/p2p/peer_pool.py
+++ b/p2p/peer_pool.py
@@ -472,7 +472,7 @@ class BasePeerPool(Service, AsyncIterable[BasePeer]):
         This is passed as a callback to be called when a peer finishes.
         """
         if peer.session in self.connected_nodes:
-            self.logger.debug(
+            self.logger.info(
                 "Removing %s from pool: local_reason=%s remote_reason=%s",
                 peer,
                 peer.p2p_api.local_disconnect_reason,


### PR DESCRIPTION
One of the daemons started when we run a Connection service will exit as
soon as the transport is closed and that may happen immediately after we
received a Disconnect+EOF from a remote, but before we've had a chance
to process the disconnect (and cancel the Connection), which would cause
a DaemonTaskExit error (https://github.com/ethereum/trinity/issues/1733)
That is somewhat tricky to fix because the daemon relies on a stream
from the multiplexer, which only has access to the transport, so as a
workaround the daemon (_feed_protocol_handlers) will now wait a bit for
the connection to be cancelled when the msg stream ends.

Closes: #1733