### PR TITLE
Updating Contributing page (docs) to Python3.7

### DIFF
--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -20,7 +20,7 @@ After we have activated our virtual environment, installing all dependencies tha
 
 .. code:: sh
 
-    pip3.7 install -e .[dev]
+    pip3 install -e .[dev]
 
 
 Running the tests

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -20,7 +20,7 @@ After we have activated our virtual environment, installing all dependencies tha
 
 .. code:: sh
 
-    pip install -e .[dev]
+    pip3.7 install -e .[dev]
 
 
 Running the tests

--- a/docs/fragments/virtualenv_explainer.rst
+++ b/docs/fragments/virtualenv_explainer.rst
@@ -10,7 +10,7 @@ Then, we can initialize a new virtual environment ``venv``, like:
 
 .. code:: sh
 
-  virtualenv -p python3 venv
+  virtualenv -p python3.7 venv
 
 This creates a new directory ``venv`` where packages are installed isolated from any other global
 packages.


### PR DESCRIPTION
### What was wrong?

Docs (Contributing Page) wasn't accurate anymore since dropping Python 3.6 Support. 

### How was it fixed?

Updated the command to install the dependencies with `pip3.7 install -e .[dev]` instead of `pip install -e .[dev]`
