### PR TITLE
Upgrade py-evm to 0.3.0a16

### DIFF
--- a/newsfragments/1761.feature.rst
+++ b/newsfragments/1761.feature.rst
@@ -1,0 +1,2 @@
+Upgraded py-evm to v0.3.0-alpha.16 -- See `py-evm's release notes
+<https://py-evm.readthedocs.io/en/latest/release_notes.html#py-evm-0-3-0-alpha-16-2020-05-27>`_

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ import os
 import re
 from setuptools import setup, find_packages
 
-PYEVM_DEPENDENCY = "py-evm==0.3.0a15"
+PYEVM_DEPENDENCY = "py-evm==0.3.0a16"
 
 
 deps = {


### PR DESCRIPTION
### What was wrong?

Get the latest evm changes.

### How was it fixed?

~At least one issue: seems to not persist transactions during beam sync anymore :/. Maybe need to use the new API?~ Nope, this was a local bug with a bad install of py-trie. Looks like an uneventful upgrade.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

[//]: # (See: https://trinity-client.readthedocs.io/en/latest/contributing.html#pull-requests)
- [x] Add entry to the [release notes](https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://i.chzbgr.com/full/6674597888/h2F8B398A/squee-spree-flying-squeerel)
