### PR TITLE
A block is being passed somewhere that expects a header

### DIFF
--- a/tests/core/p2p-proto/test_sync.py
+++ b/tests/core/p2p-proto/test_sync.py
@@ -165,7 +165,7 @@ async def test_beam_syncer_with_checkpoint(
 # This test was reduced to a few cases for speed. To run the full suite, use
 # range(1, 130) for beam_to_block. (and optionally follow the instructions at target_head)
 @pytest.mark.asyncio
-@pytest.mark.parametrize('beam_to_block', [1, 66, 68, 129])
+@pytest.mark.parametrize('beam_to_block', [1, 5, 66, 68, 129])
 async def test_beam_syncer(
         request,
         event_loop,


### PR DESCRIPTION
### What was wrong?

Something about running the beam sync test at block 5 reproducibly gives this error:
> AttributeError: 'PetersburgBlock' object has no attribute 'parent_hash'

I also reproduced this locally on block 2.

(I have run the full range before, so this is "new" at least since beam sync started working)

Rough stack trace:

```
   trinity/sync/beam/chain.py:212: in run
       await self._download_blocks(final_headers[0])
   trinity/sync/beam/chain.py:284: in _download_blocks
       await manager.wait_finished()
   venv/lib/python3.7/site-packages/async_generator/_util.py:42: in __aexit__
       await self._agen.asend(None)
   venv/lib/python3.7/site-packages/async_service/asyncio.py:444: in background_asyncio_service
       for _, exc_value, exc_tb in manager._errors
   venv/lib/python3.7/site-packages/async_service/base.py:300: in _run_and_manage_task
       await task.run()
   venv/lib/python3.7/site-packages/async_service/asyncio.py:35: in run
       await self._async_fn(*self._async_fn_args)
   trinity/sync/full/chain.py:620: in run
       self._block_persist_tracker.set_finished_dependency(head)

   > dependency_id = self._dependency_of(finished_task)
```

~I am running a few custom things locally (py-trie v2a1, a custom py-evm), so I wanted to use CI to confirm that this isn't some local ghost I'm chasing among my changeset, but it looks totally
unrelated.~
Yup, looks like this is in master.

### How was it fixed?

:man_shrugging: 

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

[//]: # (See: https://trinity-client.readthedocs.io/en/latest/contributing.html#pull-requests)
- [ ] Add entry to the [release notes](https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://i.pinimg.com/originals/88/f5/38/88f538b3b4457d0ad6e7d72daed2fdb8.jpg)
