### PR TITLE
Some cleanups on helpers to run standalone components

### DIFF
--- a/trinity/components/builtin/beam_exec/component.py
+++ b/trinity/components/builtin/beam_exec/component.py
@@ -3,7 +3,6 @@ import asyncio
 from async_service import background_asyncio_service
 from lahja import EndpointAPI
 
-from trinity.boot_info import BootInfo
 from trinity.config import Eth1AppConfig
 from trinity.constants import SYNC_BEAM
 from trinity.db.manager import DBClient
@@ -33,9 +32,8 @@ class BeamChainExecutionComponent(AsyncioIsolatedComponent):
     def is_enabled(self) -> bool:
         return self._boot_info.args.sync_mode.upper() == SYNC_BEAM.upper()
 
-    @classmethod
-    async def do_run(cls, boot_info: BootInfo, event_bus: EndpointAPI) -> None:
-        trinity_config = boot_info.trinity_config
+    async def do_run(self, event_bus: EndpointAPI) -> None:
+        trinity_config = self._boot_info.trinity_config
         app_config = trinity_config.get_app_config(Eth1AppConfig)
         chain_config = app_config.get_chain_config()
 

--- a/trinity/components/builtin/beam_preview/component.py
+++ b/trinity/components/builtin/beam_preview/component.py
@@ -3,7 +3,6 @@ import asyncio
 from async_service import background_asyncio_service
 from lahja import EndpointAPI
 
-from trinity.boot_info import BootInfo
 from trinity.config import (
     Eth1AppConfig,
 )
@@ -36,9 +35,8 @@ class BeamChainPreviewComponent(AsyncioIsolatedComponent):
     def is_enabled(self) -> bool:
         return self._boot_info.args.sync_mode.upper() == SYNC_BEAM.upper()
 
-    @classmethod
-    async def do_run(cls, boot_info: BootInfo, event_bus: EndpointAPI) -> None:
-        trinity_config = boot_info.trinity_config
+    async def do_run(self, event_bus: EndpointAPI) -> None:
+        trinity_config = self._boot_info.trinity_config
         app_config = trinity_config.get_app_config(Eth1AppConfig)
         chain_config = app_config.get_chain_config()
 
@@ -58,7 +56,7 @@ class BeamChainPreviewComponent(AsyncioIsolatedComponent):
                 urgent=False,
             )
 
-            preview_server = BlockPreviewServer(event_bus, beam_chain, cls.shard_num)
+            preview_server = BlockPreviewServer(event_bus, beam_chain, self.shard_num)
 
             async with background_asyncio_service(preview_server) as manager:
                 await manager.wait_finished()

--- a/trinity/components/builtin/ethstats/component.py
+++ b/trinity/components/builtin/ethstats/component.py
@@ -102,8 +102,8 @@ class EthstatsComponent(AsyncioIsolatedComponent):
     def is_enabled(self) -> bool:
         return bool(self._boot_info.args.enable_ethstats)
 
-    @classmethod
-    async def do_run(cls, boot_info: BootInfo, event_bus: EndpointAPI) -> None:
+    async def do_run(self, event_bus: EndpointAPI) -> None:
+        boot_info = self._boot_info
         args = boot_info.args
 
         if args.ethstats_server_url:

--- a/trinity/components/builtin/json_rpc/component.py
+++ b/trinity/components/builtin/json_rpc/component.py
@@ -13,7 +13,6 @@ from eth.db.header import (
     HeaderDB,
 )
 
-from trinity.boot_info import BootInfo
 from trinity.config import (
     Eth1AppConfig,
     Eth1DbMode,
@@ -118,8 +117,8 @@ class JsonRpcServerComponent(AsyncioIsolatedComponent):
             default=8545,
         )
 
-    @classmethod
-    async def do_run(cls, boot_info: BootInfo, event_bus: EndpointAPI) -> None:
+    async def do_run(self, event_bus: EndpointAPI) -> None:
+        boot_info = self._boot_info
         trinity_config = boot_info.trinity_config
 
         with chain_for_config(trinity_config, event_bus) as chain:

--- a/trinity/components/builtin/metrics/component.py
+++ b/trinity/components/builtin/metrics/component.py
@@ -139,9 +139,8 @@ class MetricsComponent(TrioIsolatedComponent):
                 'to tag the data via `--metrics-host`'
             )
 
-    @classmethod
-    async def do_run(cls, boot_info: BootInfo, event_bus: EndpointAPI) -> None:
-
+    async def do_run(self, event_bus: EndpointAPI) -> None:
+        boot_info = self._boot_info
         metrics_service = metrics_service_from_args(boot_info.args)
 
         # types ignored due to https://github.com/ethereum/async-service/issues/5

--- a/trinity/components/builtin/network_db/component.py
+++ b/trinity/components/builtin/network_db/component.py
@@ -233,12 +233,12 @@ class NetworkDBComponent(AsyncioIsolatedComponent):
         else:
             yield cls._get_eth1_peer_server(boot_info, event_bus)
 
-    @classmethod
-    async def do_run(cls, boot_info: BootInfo, event_bus: EndpointAPI) -> None:
+    async def do_run(self, event_bus: EndpointAPI) -> None:
+        boot_info = self._boot_info
         try:
-            tracker_services = cls._get_services(boot_info, event_bus)
+            tracker_services = self._get_services(boot_info, event_bus)
         except BadDatabaseError as err:
-            cls.logger.exception(f"Unrecoverable error in Network Component: {err}")
+            self.logger.exception(f"Unrecoverable error in Network Component: {err}")
 
         async with contextlib.AsyncExitStack() as stack:
             tracker_managers = tuple([

--- a/trinity/components/builtin/peer_discovery/component.py
+++ b/trinity/components/builtin/peer_discovery/component.py
@@ -33,7 +33,6 @@ from p2p.discovery import (
 from p2p.node_db import NodeDB
 from p2p.identity_schemes import default_identity_scheme_registry
 
-from trinity.boot_info import BootInfo
 from trinity.config import Eth1AppConfig
 from trinity.db.eth1.header import BaseAsyncHeaderDB
 from trinity.db.manager import DBClient
@@ -66,8 +65,8 @@ class PeerDiscoveryComponent(TrioIsolatedComponent):
             help="Disable peer discovery",
         )
 
-    @classmethod
-    async def do_run(cls, boot_info: BootInfo, event_bus: EndpointAPI) -> None:
+    async def do_run(self, event_bus: EndpointAPI) -> None:
+        boot_info = self._boot_info
         config = boot_info.trinity_config
         db = DBClient.connect(config.database_ipc_path)
 

--- a/trinity/components/builtin/request_server/component.py
+++ b/trinity/components/builtin/request_server/component.py
@@ -8,7 +8,6 @@ from lahja import EndpointAPI
 
 from eth.db.backends.base import BaseAtomicDB
 
-from trinity.boot_info import BootInfo
 from trinity.config import (
     Eth1AppConfig,
     Eth1DbMode,
@@ -41,13 +40,13 @@ class RequestServerComponent(AsyncioIsolatedComponent):
             help="Disables the Request Server",
         )
 
-    @classmethod
-    async def do_run(cls, boot_info: BootInfo, event_bus: EndpointAPI) -> None:
+    async def do_run(self, event_bus: EndpointAPI) -> None:
+        boot_info = self._boot_info
         trinity_config = boot_info.trinity_config
         base_db = DBClient.connect(trinity_config.database_ipc_path)
         with base_db:
             if trinity_config.has_app_config(Eth1AppConfig):
-                server = cls.make_eth1_request_server(
+                server = self.make_eth1_request_server(
                     trinity_config.get_app_config(Eth1AppConfig),
                     base_db,
                     event_bus,

--- a/trinity/components/builtin/syncer/component.py
+++ b/trinity/components/builtin/syncer/component.py
@@ -343,8 +343,8 @@ class SyncerComponent(AsyncioIsolatedComponent):
         else:
             return active_strategy
 
-    @classmethod
-    async def do_run(cls, boot_info: BootInfo, event_bus: EndpointAPI) -> None:
+    async def do_run(self, event_bus: EndpointAPI) -> None:
+        boot_info = self._boot_info
 
         if boot_info.args.enable_metrics:
             metrics_service = metrics_service_from_args(boot_info.args, AsyncioMetricsService)
@@ -356,10 +356,10 @@ class SyncerComponent(AsyncioIsolatedComponent):
         trinity_config = boot_info.trinity_config
         NodeClass = trinity_config.get_app_config(Eth1AppConfig).node_class
         node = NodeClass(event_bus, metrics_service, trinity_config)
-        strategy = cls.get_active_strategy(boot_info)
+        strategy = self.get_active_strategy(boot_info)
 
         async with background_asyncio_service(node) as manager:
-            await cls.launch_sync(node, strategy, boot_info, event_bus)
+            await self.launch_sync(node, strategy, boot_info, event_bus)
             await manager.wait_finished()
 
     @classmethod

--- a/trinity/components/builtin/tx_pool/component.py
+++ b/trinity/components/builtin/tx_pool/component.py
@@ -71,8 +71,8 @@ class TxComponent(AsyncioIsolatedComponent):
 
         return is_enabled
 
-    @classmethod
-    async def do_run(cls, boot_info: BootInfo, event_bus: EndpointAPI) -> None:
+    async def do_run(self, event_bus: EndpointAPI) -> None:
+        boot_info = self._boot_info
         trinity_config = boot_info.trinity_config
         db = DBClient.connect(trinity_config.database_ipc_path)
         with db:

--- a/trinity/components/builtin/upnp/component.py
+++ b/trinity/components/builtin/upnp/component.py
@@ -6,7 +6,6 @@ from argparse import (
 from async_service import background_trio_service
 from lahja import EndpointAPI
 
-from trinity.boot_info import BootInfo
 from trinity.extensibility import (
     TrioIsolatedComponent,
 )
@@ -36,9 +35,8 @@ class UpnpComponent(TrioIsolatedComponent):
             help="Disable upnp mapping",
         )
 
-    @classmethod
-    async def do_run(cls, boot_info: BootInfo, event_bus: EndpointAPI) -> None:
-        port = boot_info.trinity_config.port
+    async def do_run(self, event_bus: EndpointAPI) -> None:
+        port = self._boot_info.trinity_config.port
         upnp_service = UPnPService(port, event_bus)
 
         async with background_trio_service(upnp_service) as manager:

--- a/trinity/components/eth2/beacon/component.py
+++ b/trinity/components/eth2/beacon/component.py
@@ -10,7 +10,6 @@ from libp2p.crypto.secp256k1 import create_new_key_pair
 
 from eth2.beacon.typing import SubnetId
 from p2p.service import BaseService, run_service
-from trinity.boot_info import BootInfo
 from trinity.config import BeaconAppConfig, TrinityConfig
 from trinity.db.beacon.chain import AsyncBeaconChainDB
 from trinity.db.manager import DBClient
@@ -67,8 +66,8 @@ class BeaconNodeComponent(AsyncioIsolatedComponent):
     def is_enabled(self) -> bool:
         return self._boot_info.trinity_config.has_app_config(BeaconAppConfig)
 
-    @classmethod
-    async def do_run(cls, boot_info: BootInfo, event_bus: EndpointAPI) -> None:
+    async def do_run(self, event_bus: EndpointAPI) -> None:
+        boot_info = self._boot_info
         trinity_config = boot_info.trinity_config
         key_pair = _load_secp256k1_key_pair_from(trinity_config)
         beacon_app_config = trinity_config.get_app_config(BeaconAppConfig)

--- a/trinity/components/eth2/discv5/component.py
+++ b/trinity/components/eth2/discv5/component.py
@@ -126,8 +126,8 @@ class DiscV5Component(TrioIsolatedComponent):
     def is_enabled(self) -> bool:
         return False
 
-    @classmethod
-    async def do_run(cls, boot_info: BootInfo, event_bus: EndpointAPI) -> None:
+    async def do_run(self, event_bus: EndpointAPI) -> None:
+        boot_info = self._boot_info
         identity_scheme_registry = default_identity_scheme_registry
         message_type_registry = default_message_type_registry
 

--- a/trinity/components/eth2/eth1_monitor/component.py
+++ b/trinity/components/eth2/eth1_monitor/component.py
@@ -12,7 +12,6 @@ from eth2.beacon.tools.builder.initializer import (
 from eth2.beacon.tools.builder.validator import create_mock_deposit_data
 from eth2.beacon.tools.fixtures.loading import load_yaml_at
 from eth2.beacon.typing import Timestamp
-from trinity.boot_info import BootInfo
 from trinity.components.eth2.beacon.base_validator import ETH1_FOLLOW_DISTANCE
 from trinity.components.eth2.eth1_monitor.configs import deposit_contract_json
 from trinity.components.eth2.eth1_monitor.eth1_data_provider import FakeEth1DataProvider
@@ -56,9 +55,8 @@ class Eth1MonitorComponent(TrioIsolatedComponent):
         #     help="RPC HTTP endpoint of Eth1 client ",
         # )
 
-    @classmethod
-    async def do_run(cls, boot_info: BootInfo, event_bus: EndpointAPI) -> None:
-        trinity_config = boot_info.trinity_config
+    async def do_run(self, event_bus: EndpointAPI) -> None:
+        trinity_config = self._boot_info.trinity_config
         beacon_app_config = trinity_config.get_app_config(BeaconAppConfig)
         chain_config = beacon_app_config.get_chain_config()
         base_db = DBClient.connect(trinity_config.database_ipc_path)

--- a/trinity/extensibility/asyncio.py
+++ b/trinity/extensibility/asyncio.py
@@ -8,7 +8,6 @@ from lahja import EndpointAPI
 
 from trinity._utils.logging import child_process_logging, get_logger
 from trinity._utils.profiling import profiler
-from trinity.boot_info import BootInfo
 from trinity.events import ShutdownRequest
 
 from .component import BaseIsolatedComponent
@@ -21,7 +20,6 @@ class AsyncioIsolatedComponent(BaseIsolatedComponent):
     async def run(self) -> None:
         proc_ctx = open_in_process(
             self._do_run,
-            self._boot_info,
             subprocess_kwargs=self.get_subprocess_kwargs(),
         )
         try:
@@ -37,27 +35,27 @@ class AsyncioIsolatedComponent(BaseIsolatedComponent):
                 returncode = getattr(proc, 'returncode', 'unset')
                 self.logger.debug("%s terminated: returncode=%s", self, returncode)
 
-    async def _do_run(self, boot_info: BootInfo) -> None:
-        with child_process_logging(boot_info):
+    async def _do_run(self) -> None:
+        with child_process_logging(self._boot_info):
             endpoint_name = self.get_endpoint_name()
             event_bus_service = AsyncioEventBusService(
-                boot_info.trinity_config,
+                self._boot_info.trinity_config,
                 endpoint_name,
             )
             async with background_asyncio_service(event_bus_service):
                 event_bus = await event_bus_service.get_event_bus()
 
                 try:
-                    if boot_info.profile:
+                    if self._boot_info.profile:
                         with profiler(f'profile_{self.get_endpoint_name()}'):
-                            await self.do_run(boot_info, event_bus)
+                            await self.do_run(event_bus)
                     else:
                         # XXX: When open_in_process() injects a KeyboardInterrupt into us (via
                         # coro.throw()), we hang forever here, until open_in_process() times out
                         # and sends us a SIGTERM, at which point we exit without executing either
                         # the except or the finally blocks below.
                         # See https://github.com/ethereum/trinity/issues/1711 for more.
-                        await self.do_run(boot_info, event_bus)
+                        await self.do_run(event_bus)
                 except KeyboardInterrupt:
                     # Currently we never reach this code path, but when we fix the issue above it
                     # will be needed.
@@ -80,7 +78,7 @@ class AsyncioIsolatedComponent(BaseIsolatedComponent):
                     self.logger.debug("%s: do_run() finished", self)
 
     @abstractmethod
-    async def do_run(self, boot_info: BootInfo, event_bus: EndpointAPI) -> None:
+    async def do_run(self, event_bus: EndpointAPI) -> None:
         """
         Define the entry point of the component. Should be overwritten in subclasses.
         """

--- a/trinity/tools/_component_isolation.py
+++ b/trinity/tools/_component_isolation.py
@@ -12,7 +12,6 @@ from asyncio_run_in_process.typing import SubprocessKwargs
 from eth_utils.toolz import merge
 from lahja import EndpointAPI, BaseEvent
 
-from trinity.boot_info import BootInfo
 from trinity.extensibility import AsyncioIsolatedComponent, TrioIsolatedComponent
 
 
@@ -62,7 +61,7 @@ class AsyncioComponentForTest(AsyncioIsolatedComponent):
     def is_enabled(self) -> bool:
         return True
 
-    async def do_run(self, boot_info: BootInfo, event_bus: EndpointAPI) -> None:
+    async def do_run(self, event_bus: EndpointAPI) -> None:
         self.logger.info('Entered `do_run`')
         service = ComponentTestService(event_bus)
         try:
@@ -99,7 +98,7 @@ class TrioComponentForTest(TrioIsolatedComponent):
     def is_enabled(self) -> bool:
         return True
 
-    async def do_run(self, boot_info: BootInfo, event_bus: EndpointAPI) -> None:
+    async def do_run(self, event_bus: EndpointAPI) -> None:
         self.logger.info('Entered `do_run`')
         service = ComponentTestService(event_bus)
         try:
@@ -130,7 +129,7 @@ class AsyncioBrokenComponent(AsyncioComponentForTest):
     name = "component-test-asyncio-broken"
     endpoint_name = 'component-test-asyncio-broken'
 
-    async def do_run(self, boot_info: BootInfo, event_bus: EndpointAPI) -> None:
+    async def do_run(self, event_bus: EndpointAPI) -> None:
         async with background_asyncio_service(IdleService(event_bus)):
             raise ComponentException("This is a component that crashes after starting a service")
 
@@ -139,6 +138,6 @@ class TrioBrokenComponent(TrioComponentForTest):
     name = "component-test-trio-broken"
     endpoint_name = 'component-test-trio-broken'
 
-    async def do_run(self, boot_info: BootInfo, event_bus: EndpointAPI) -> None:
+    async def do_run(self, event_bus: EndpointAPI) -> None:
         async with background_trio_service(IdleService(event_bus)):
             raise ComponentException("This is a component that crashes after starting a service")


### PR DESCRIPTION
Mainly to avoid the async context block fire-and-forget anti pattern

Also get rid of unnecessary boot_info argument to IsolatedComponent
instance methods and convert leftover do_run() `@classmethods` to be
instance methods, matching the base class.