### PR TITLE
Reliably detect trinity process with metrics enabled

### DIFF
--- a/trinity/components/builtin/metrics/component.py
+++ b/trinity/components/builtin/metrics/component.py
@@ -96,7 +96,7 @@ class MetricsComponent(TrioIsolatedComponent):
         metrics_parser.add_argument(
             '--metrics-influx-port',
             help='Influx DB port. Defaults to ENV var TRINITY_METRICS_INFLUX_DB_PORT or 8086',
-            default=os.environ.get('TRINITY_METRICS_INFLUX_DB_PORT'),
+            default=os.environ.get('TRINITY_METRICS_INFLUX_DB_PORT', 8086),
         )
 
         metrics_parser.add_argument(
@@ -105,7 +105,7 @@ class MetricsComponent(TrioIsolatedComponent):
                 'Influx DB protocol. Defaults to ENV var '
                 'TRINITY_METRICS_INFLUX_DB_PROTOCOL or http'
             ),
-            default=os.environ.get('TRINITY_METRICS_INFLUX_DB_PROTOCOL'),
+            default=os.environ.get('TRINITY_METRICS_INFLUX_DB_PROTOCOL', 'http'),
         )
 
         metrics_parser.add_argument(

--- a/trinity/components/builtin/metrics/service/base.py
+++ b/trinity/components/builtin/metrics/service/base.py
@@ -20,9 +20,9 @@ class BaseMetricsService(Service, MetricsServiceAPI):
                  influx_password: str,
                  influx_database: str,
                  host: str,
-                 port: int = 8086,
-                 protocol: str = 'http',
-                 reporting_frequency: int = 10):
+                 port: int,
+                 protocol: str,
+                 reporting_frequency: int):
         self._influx_server = influx_server
         self._reporting_frequency = reporting_frequency
         self._registry = HostMetricsRegistry(host)

--- a/trinity/components/builtin/metrics/system_metrics_collector.py
+++ b/trinity/components/builtin/metrics/system_metrics_collector.py
@@ -91,19 +91,19 @@ def read_network_stats() -> NetworkStats:
 def get_all_python_processes() -> Iterator[psutil.Process]:
     for process in psutil.process_iter():
         try:
-            process.cmdline()
+            commands = process.cmdline()
         except psutil.AccessDenied:
             continue
         except psutil.ZombieProcess:
             continue
-        if 'python' in process.name():
+        if any('python' in cmd for cmd in commands):
             yield process
 
 
 def get_main_trinity_process() -> psutil.Process:
     python_processes = get_all_python_processes()
     for process in python_processes:
-        if 'trinity' in process.cmdline():
+        if any('trinity' in cmd for cmd in process.cmdline()):
             return process
     raise MetricsReportingError("No 'trinity' process found.")
 


### PR DESCRIPTION
### What was wrong?
re: https://github.com/ethereum/py-evm/issues/1944

With metrics enabled, the strategy to measure total trinity processes/threads would raise an error on ubuntu. 

There was also a bug for some of the default arguments. For `metrics-influx-port` and `metrics-influx-protocol`, it would use `None` (returned from the `os.environ.get()` call). So I removed those default environment calls, and set the default value directly in the parser - rather than in the `BaseMetricsService` class. 

### How was it fixed?
Changed the strategy to be ubuntu-compatible

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

[//]: # (See: https://trinity-client.readthedocs.io/en/latest/contributing.html#pull-requests)
- [ ] Add entry to the [release notes](https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

#### Cute Animal Picture
![image](https://user-images.githubusercontent.com/9753150/83453504-d69c6c00-a417-11ea-9dce-1e2696a2a629.png)

