### PR TITLE
LogicAPI.apply() now yields a Future 

### DIFF
--- a/p2p/behaviors.py
+++ b/p2p/behaviors.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+import asyncio
 import contextlib
 from typing import (
     AsyncIterator,
@@ -36,7 +38,7 @@ class Behavior(BehaviorAPI):
         return self.qualifier(connection, self.logic)  # type: ignore
 
     @contextlib.asynccontextmanager
-    async def apply(self, connection: ConnectionAPI) -> AsyncIterator[None]:
+    async def apply(self, connection: ConnectionAPI) -> AsyncIterator[asyncio.Future[None]]:
         if self._applied_to is not None:
             raise ValidationError(
                 f"Reentrance: Behavior has already been applied to a "
@@ -56,5 +58,5 @@ class Behavior(BehaviorAPI):
             self.logic._behavior = self
 
         # once the logic is bound to the connection we enter it's context.
-        async with self.logic.apply(connection):
-            yield
+        async with self.logic.apply(connection) as task:
+            yield task

--- a/p2p/exchange/abc.py
+++ b/p2p/exchange/abc.py
@@ -1,8 +1,9 @@
+from __future__ import annotations
 from abc import ABC, abstractmethod
+import contextlib
 from typing import (
     Any,
     AsyncIterator,
-    AsyncContextManager,
     Callable,
     Dict,
     Generic,
@@ -203,7 +204,8 @@ class ExchangeAPI(ABC, Generic[TRequestCommand, TResponseCommand, TResult]):
         ...
 
     @abstractmethod
-    def run_exchange(self, connection: ConnectionAPI) -> AsyncContextManager[None]:
+    @contextlib.asynccontextmanager
+    def run_exchange(self, connection: ConnectionAPI) -> AsyncIterator[asyncio.Future[None]]:
         ...
 
     @abstractmethod

--- a/p2p/exchange/logic.py
+++ b/p2p/exchange/logic.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+import asyncio
 import contextlib
 from typing import Any, AsyncIterator
 
@@ -29,6 +31,6 @@ class ExchangeLogic(BaseLogic):
             return protocol.supports_command(self.exchange.get_response_cmd_type())
 
     @contextlib.asynccontextmanager
-    async def apply(self, connection: ConnectionAPI) -> AsyncIterator[None]:
-        async with self.exchange.run_exchange(connection):
-            yield
+    async def apply(self, connection: ConnectionAPI) -> AsyncIterator[asyncio.Future[None]]:
+        async with self.exchange.run_exchange(connection) as future:
+            yield future

--- a/p2p/p2p_api.py
+++ b/p2p/p2p_api.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 import asyncio
 import contextlib
 from typing import Any, AsyncIterator, cast
@@ -91,10 +92,10 @@ class DisconnectIfIdle(BaseLogic):
         self.idle_timeout = idle_timeout
 
     @contextlib.asynccontextmanager
-    async def apply(self, connection: ConnectionAPI) -> AsyncIterator[None]:
+    async def apply(self, connection: ConnectionAPI) -> AsyncIterator[asyncio.Future[None]]:
         service = PingAndDisconnectIfIdle(connection, self.idle_timeout)
-        async with background_asyncio_service(service):
-            yield
+        async with background_asyncio_service(service) as manager:
+            yield asyncio.create_task(manager.wait_finished())
 
 
 class P2PAPI(Application):


### PR DESCRIPTION
This way callsites can detect misbehaving behaviors/applications that crash or exit before the Connection is cancelled.
