### PR TITLE
Upgrade to py-evm 0.3.0a17

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ import os
 import re
 from setuptools import setup, find_packages
 
-PYEVM_DEPENDENCY = "py-evm==0.3.0a16"
+PYEVM_DEPENDENCY = "py-evm==0.3.0a17"
 
 
 deps = {

--- a/trinity/sync/beam/chain.py
+++ b/trinity/sync/beam/chain.py
@@ -13,7 +13,7 @@ from lahja import EndpointAPI
 from eth.abc import AtomicDatabaseAPI, BlockImportResult, DatabaseAPI
 from eth.constants import GENESIS_PARENT_HASH
 from eth.exceptions import (
-    HeaderNotFound,
+    BlockNotFound,
 )
 from eth.rlp.blocks import BaseBlock
 from eth.rlp.headers import BlockHeader
@@ -327,8 +327,7 @@ class RigorousFastChainBodySyncer(FastChainBodySyncer):
             return False
         try:
             await self.chain.coro_get_block_by_header(header)
-        except (HeaderNotFound, KeyError):
-            # TODO unify these exceptions in py-evm, returning BlockBodyNotFound instead
+        except BlockNotFound:
             return False
         else:
             return True


### PR DESCRIPTION
### What was wrong?

Wanted the newest py-trie APIs supported in the latest py-evm, to help with backfilling cold state.

Related to #854 

### How was it fixed?

Upgrade to latest py-evm, and handle new exception.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

[//]: # (See: https://trinity-client.readthedocs.io/en/latest/contributing.html#pull-requests)
- [ ] Add entry to the [release notes](https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://media.mnn.com/assets/images/2013/05/White-Gibbon-Hanging-Tree-Branch.jpg.638x0_q80_crop-smart.jpg)