### PR TITLE
Beam Sync storage & bytecode backfill

### DIFF
--- a/newsfragments/854.feature.rst
+++ b/newsfragments/854.feature.rst
@@ -1,6 +1,5 @@
 During Beam Sync, Trinity now collects account data that is not touched by
 active blocks. We often call this "state backfill".
-Storage and Bytecode backfill are not yet included, but will be shortly.
 Obtaining the full state is the best way to make sure that your node cannot be
 knocked offline with a Denial-of-Service attack that accesses a bunch of state
 in a series of blocks.

--- a/tests/json-fixtures-over-rpc/test_rpc_fixtures.py
+++ b/tests/json-fixtures-over-rpc/test_rpc_fixtures.py
@@ -65,9 +65,11 @@ BASE_FIXTURE_PATH = ROOT_PROJECT_DIR / 'fixtures' / 'BlockchainTests'
 
 SLOW_TESTS = (
     'bcExploitTest/SuicideIssue.json',
+    'CALLBlake2f_MaxRounds.json',
     'Call1024PreCalls_d0g0v0',
     'ContractCreationSpam_d0g0v0_Homestead',
     'ContractCreationSpam_d0g0v0_Frontier',
+    'ContractCreationSpam_d0g0v0_Istanbul',
     'Create2Recursive_d0g0v0',
     'Create2Recursive_d0g1v0',
     'DelegateCallSpam',
@@ -83,6 +85,7 @@ SLOW_TESTS = (
     'static_Call1024PreCalls2_d0g0v0',
     'static_Call1024PreCalls2_d1g0v0',
     'static_Call1024PreCalls3_d1g0v0',
+    'static_Call1MB1024Calldepth.json',
     'static_Call50000bytesContract50_1_d0g0v0',
     'static_Call50000_ecrec_d0g0v0',
     'static_Call50000_ecrec_d1g0v0',

--- a/trinity/sync/beam/backfill.py
+++ b/trinity/sync/beam/backfill.py
@@ -5,7 +5,7 @@ from functools import partial
 import typing
 from typing import (
     AsyncIterator,
-    AsyncIterable,
+    Dict,
     Iterable,
     NamedTuple,
     Optional,
@@ -19,7 +19,10 @@ from eth.abc import (
     AtomicDatabaseAPI,
     BlockHeaderAPI,
 )
+from eth.constants import EMPTY_SHA3
+from eth.rlp.accounts import Account
 from eth_typing import Hash32
+import rlp
 from trie import (
     HexaryTrie,
     exceptions as trie_exceptions,
@@ -85,6 +88,9 @@ class BeamStateBackfill(Service, QueenTrackerAPI):
         # Track the nodes that we are requesting in the account trie
         self._account_tracker = TrieNodeRequestTracker()
 
+        self._storage_trackers: Dict[Hash32, TrieNodeRequestTracker] = {}
+        self._bytecode_trackers: Dict[Hash32, TrieNodeRequestTracker] = {}
+
         # The most recent root hash to use to navigate the trie
         self._next_trie_root_hash: Optional[Hash32] = None
         self._begin_backfill = asyncio.Event()
@@ -101,6 +107,7 @@ class BeamStateBackfill(Service, QueenTrackerAPI):
         queening_manager = self.manager.run_daemon_child_service(self._queening_queue)
         await queening_manager.wait_started()
         await self._run_backfill()
+        self.manager.cancel()
 
     async def _run_backfill(self) -> None:
         await self._begin_backfill.wait()
@@ -117,8 +124,8 @@ class BeamStateBackfill(Service, QueenTrackerAPI):
 
             if len(required_data) == 0:
                 # Nothing available to request, for one of two reasons:
-                if self._is_complete():
-                    self.logger.info("Downloaded all account state")
+                if self._check_complete():
+                    self.logger.info("Downloaded all accounts, storage and bytecode state")
                     return
                 else:
                     # There are active requests to peers, and we don't have enough information to
@@ -134,9 +141,22 @@ class BeamStateBackfill(Service, QueenTrackerAPI):
 
             self.manager.run_task(self._make_request, peer, required_data)
 
-    def _is_complete(self) -> bool:
+    def _check_complete(self) -> bool:
         if self._account_tracker.is_complete:
-            return True
+            storage_complete = all(
+                storage_tracker.is_complete
+                for storage_tracker in self._storage_trackers.values()
+            )
+            if storage_complete:
+                bytecode_complete = all(
+                    bytecode_tracker.is_complete
+                    for bytecode_tracker in self._bytecode_trackers.values()
+                )
+                # All backfill is complete only if the account and storage and bytecodes are present
+                return bytecode_complete
+            else:
+                # At least one account is missing a storage trie node
+                return False
         else:
             # At least one account trie node is missing
             return False
@@ -153,42 +173,96 @@ class BeamStateBackfill(Service, QueenTrackerAPI):
         Will exit when all known node hashes are already actively being
         requested, or if there are no more missing nodes.
         """
-        while self.manager.is_running:
-            try:
-                starting_root_hash = self._next_trie_root_hash
+        # For each account, when we have asked for all known storage and bytecode
+        #   hashes, but some are still not present, we "pause" the account so we can look
+        #   for neighboring nodes.
+        # This is a list of paused accounts, using the path to the leaf node,
+        #   because that's how the account tracker is indexed.
+        exhausted_account_leaves: Tuple[Nibbles, ...] = ()
+
+        starting_root_hash = self._next_trie_root_hash
+
+        try:
+            while self.manager.is_running:
+                # Get the next account
+
+                # We have to rebuild the account iterator every time because...
+                #   something about an exception during a manual __anext__()?
                 account_iterator = self._request_tracking_trie_items(
                     self._account_tracker,
                     starting_root_hash,
                 )
-                async for path_to_leaf, _, _ in account_iterator:
-                    self._account_tracker.confirm_leaf(path_to_leaf)
+                try:
+                    next_account_info = await account_iterator.__anext__()
+                except trie_exceptions.MissingTraversalNode as exc:
+                    # Found a missing trie node while looking for the next account
+                    yield self._account_tracker.generate_request(
+                        exc.missing_node_hash,
+                        exc.nibbles_traversed,
+                    )
+                    continue
+                except StopAsyncIteration:
+                    # Finished iterating over all available accounts
+                    break
 
-            except trie_exceptions.MissingTraversalNode as exc:
-                self.logger.debug2("Requesting account node: %s", exc)
-                yield self._account_tracker.generate_request(
-                    exc.missing_node_hash,
-                    exc.nibbles_traversed,
+                # Decode account
+                path_to_leaf, address_hash_nibbles, encoded_account = next_account_info
+                account = rlp.decode(encoded_account, sedes=Account)
+
+                # Iterate over all missing hashes of subcomponents (storage & bytecode)
+                subcomponent_hashes_iterator = self._missing_subcomponent_hashes(
+                    address_hash_nibbles,
+                    account,
+                    starting_root_hash,
                 )
-            else:
-                # Possible scenarios:
-                #   1. We have completed backfill
-                #   2. We have iterated the available nodes, and only their children are missing,
-                #       for example: if 0 nodes are available, and we walk to the root and request
-                #       the root from a peer, we do not have any available information to ask for
-                #       more nodes.
-                #
-                # In response to these situations, we might like to:
-                #   1. Log and celebrate that the full state has been downloaded
-                #   2. Exit this search and sleep a bit, waiting for new trie nodes to arrive
-                #
-                # 1 and 2 are a little more cleanly handled outside this iterator, so we just
-                #   exit and let the caller deal with it.
-                return
+                async for node_request in subcomponent_hashes_iterator:
+                    yield node_request
+
+                # Check if account is fully downloaded
+                account_components_complete = self._are_account_components_complete(
+                    address_hash_nibbles,
+                    account.code_hash,
+                )
+                if account_components_complete:
+                    # Mark fully downloaded accounts as complete, and do some cleanup
+                    self._mark_account_complete(path_to_leaf, address_hash_nibbles)
+                else:
+                    # Pause accounts that are not fully downloaded, and track the account
+                    #   to resume when the generator exits.
+                    self._account_tracker.pause_review(path_to_leaf)
+                    exhausted_account_leaves += (path_to_leaf, )
+
+        except GeneratorExit:
+            # As the generator is exiting, we want to resume any paused accounts. This
+            #   allows us to find missing storage/bytecode on the next iteration.
+            for path_to_leaf in exhausted_account_leaves:
+                self._account_tracker.mark_for_review(path_to_leaf)
+            raise
+        else:
+            # If we pause a few accounts and then run out of nodes to ask for, then we
+            #   still need to resume the paused accounts to prepare for the next iteration.
+            for path_to_leaf in exhausted_account_leaves:
+                self._account_tracker.mark_for_review(path_to_leaf)
+
+            # Possible scenarios:
+            #   1. We have completed backfill
+            #   2. We have iterated the available nodes, and all known hashes are being requested.
+            #       For example: if 0 nodes are available, and we walk to the root and request
+            #       the root from a peer, we do not have any available information to ask for
+            #       more nodes, and exit cleanly.
+            #
+            # In response to these situations, we might like to:
+            #   1. Log and celebrate that the full state has been downloaded
+            #   2. Exit this search and sleep a bit, waiting for new trie nodes to arrive
+            #
+            # 1 and 2 are a little more cleanly handled outside this iterator, so we just
+            #   exit and let the caller deal with it, using a _check_complete() check.
+            return
 
     async def _request_tracking_trie_items(
             self,
             request_tracker: TrieNodeRequestTracker,
-            root_hash: Hash32) -> AsyncIterable[Tuple[Nibbles, Nibbles, bytes]]:
+            root_hash: Hash32) -> AsyncIterator[Tuple[Nibbles, Nibbles, bytes]]:
         """
         Walk through the supplied trie, yielding the request tracker and node
         request for any missing trie nodes.
@@ -264,6 +338,166 @@ class BeamStateBackfill(Service, QueenTrackerAPI):
             else:
                 # If this is just an intermediate node, then we can mark it as confirmed.
                 request_tracker.confirm_prefix(path_to_node, node)
+
+    async def _missing_subcomponent_hashes(
+            self,
+            address_hash_nibbles: Nibbles,
+            account: Account,
+            starting_main_root: Hash32) -> AsyncIterator[TrackedRequest]:
+
+        storage_node_iterator = self._missing_storage_hashes(
+            address_hash_nibbles,
+            account.storage_root,
+            starting_main_root,
+        )
+        async for node_request in storage_node_iterator:
+            yield node_request
+
+        bytecode_node_iterator = self._missing_bytecode_hashes(
+            address_hash_nibbles,
+            account.code_hash,
+            starting_main_root,
+        )
+        async for node_request in bytecode_node_iterator:
+            yield node_request
+
+        # Note that completing this iterator does NOT mean we're done with the
+        #   account. It just means that all known missing hashes are actively
+        #   being requested.
+
+    async def _missing_storage_hashes(
+            self,
+            address_hash_nibbles: Nibbles,
+            storage_root: Hash32,
+            starting_main_root: Hash32) -> AsyncIterator[TrackedRequest]:
+        """
+        Walks through the storage trie at the given root, yielding one missing
+        storage node hash/prefix at a time.
+
+        The yielded node info is wrapped in a ``TrackedRequest``. The hash is
+        marked as active until it is explicitly marked for review again. The
+        hash/prefix will be marked for review asking a peer for the data.
+
+        Will exit when all known node hashes are already actively being
+        requested, or if there are no more missing nodes.
+        """
+
+        storage_tracker = self._get_storage_tracker(address_hash_nibbles)
+        storage_iterator = self._request_tracking_trie_items(
+            storage_tracker,
+            storage_root,
+        )
+        while self.manager.is_running:
+            try:
+                async for path_to_leaf, hashed_key, _storage_value in storage_iterator:
+                    # We don't actually care to look at the storage keys/values during backfill
+                    storage_tracker.confirm_leaf(path_to_leaf)
+
+            except trie_exceptions.MissingTraversalNode as exc:
+                yield storage_tracker.generate_request(
+                    exc.missing_node_hash,
+                    exc.nibbles_traversed,
+                )
+            else:
+                # Possible scenarios:
+                #   1. We have completed backfilling this account's storage
+                #   2. We have iterated the available nodes, and only their children are missing,
+                #       for example: if 0 nodes are available, and we walk to the root and request
+                #       the root from a peer, we do not have any available information to ask for
+                #       more nodes.
+                #
+                # In response to these situations, we might like to:
+                #   1. Debug log?
+                #   2. Look for more missing nodes in neighboring accounts and their storage, etc.
+                #
+                # 1 and 2 are a little more cleanly handled outside this iterator, so we just
+                #   exit and let the caller deal with it.
+                return
+
+    async def _missing_bytecode_hashes(
+            self,
+            address_hash_nibbles: Nibbles,
+            code_hash: Hash32,
+            starting_main_root: Hash32) -> AsyncIterator[TrackedRequest]:
+        """
+        Checks if this bytecode is missing. If so, yield it and then exit.
+        If not, then exit immediately.
+
+        This may seem like overkill, and it is right now. But...
+        Code merkelization is coming (theoretically), and the other account
+        and storage trie iterators work similarly to this, so in some ways
+        it's easier to do this "over-generalized" solution now. It makes
+        request tracking a bit easier too, to have the same TrackedRequest
+        result mechanism.
+        """
+
+        if code_hash == EMPTY_SHA3:
+            # Nothing to do if the bytecode is for the empty hash
+            return
+
+        bytecode_tracker = self._get_bytecode_tracker(address_hash_nibbles)
+        if bytecode_tracker.is_complete:
+            # All bytecode has been collected
+            return
+
+        # If there is an active request (for now, there can only be one), then skip
+        #   any database checks until the active request is resolved.
+        if not bytecode_tracker.has_active_requests:
+            if code_hash not in self._db:
+                # The bytecode isn't present, so we ask for it.
+                # A bit hacky here, since there is no trie, we just treat it as
+                #   if it were a leaf node at the root.
+                yield bytecode_tracker.generate_request(code_hash, prefix=())
+            else:
+                # The bytecode is already present, but the tracker isn't marked
+                #   as completed yet, so finish it off.
+                bytecode_tracker.confirm_leaf(path_to_leaf=())
+
+    def _get_storage_tracker(self, address_hash_nibbles: Nibbles) -> TrieNodeRequestTracker:
+        if address_hash_nibbles in self._storage_trackers:
+            return self._storage_trackers[address_hash_nibbles]
+        else:
+            new_tracker = TrieNodeRequestTracker()
+            self._storage_trackers[address_hash_nibbles] = new_tracker
+            return new_tracker
+
+    def _get_bytecode_tracker(self, address_hash_nibbles: Nibbles) -> TrieNodeRequestTracker:
+        if address_hash_nibbles in self._bytecode_trackers:
+            return self._bytecode_trackers[address_hash_nibbles]
+        else:
+            new_tracker = TrieNodeRequestTracker()
+            self._bytecode_trackers[address_hash_nibbles] = new_tracker
+            return new_tracker
+
+    def _mark_account_complete(self, path_to_leaf: Nibbles, address_hash_nibbles: Nibbles) -> None:
+        self._account_tracker.confirm_leaf(path_to_leaf)
+
+        # Clear the storage tracker, to reduce memory usage
+        #   and the time to check self._check_complete()
+        if address_hash_nibbles in self._storage_trackers:
+            del self._storage_trackers[address_hash_nibbles]
+
+        # Clear the bytecode tracker, for the same reason
+        if address_hash_nibbles in self._bytecode_trackers:
+            del self._bytecode_trackers[address_hash_nibbles]
+
+    def _are_account_components_complete(
+            self,
+            address_hash_nibbles: Nibbles,
+            code_hash: Hash32) -> bool:
+
+        storage_tracker = self._get_storage_tracker(address_hash_nibbles)
+        if storage_tracker.is_complete:
+            if code_hash == EMPTY_SHA3:
+                # All storage is downloaded, and no bytecode to download
+                return True
+            else:
+                bytecode_tracker = self._get_bytecode_tracker(address_hash_nibbles)
+                # All storage is downloaded, return True only if bytecode is downloaded
+                return bytecode_tracker.is_complete
+        else:
+            # Missing some storage
+            return False
 
     async def _make_request(
             self,
@@ -423,6 +657,12 @@ class TrieNodeRequestTracker:
     @property
     def is_complete(self) -> bool:
         return self._trie_fog.is_complete
+
+    def __repr__(self) -> str:
+        return (
+            f"TrieNodeRequestTracker(trie_fog={self._trie_fog!r},"
+            f" active_prefixes={self._active_prefixes!r})"
+        )
 
 
 class TrackedRequest(NamedTuple):

--- a/trinity/sync/beam/chain.py
+++ b/trinity/sync/beam/chain.py
@@ -247,7 +247,7 @@ class BeamSyncer(Service):
         self.manager.run_daemon_child_service(self._state_downloader)
 
         # Start state background service
-        self.manager.run_daemon_child_service(self._backfiller)
+        self.manager.run_child_service(self._backfiller)
 
         # run sync until cancelled
         await self.manager.wait_finished()


### PR DESCRIPTION
### What was wrong?

Fixes #854 

### How was it fixed?

Combine all storage/bytecode/account missing nodes into a single iterator. Wait to mark account as finished until all storage/bytecode is collected.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Rebase on #1768 
- [x] py-evm release, and upgrade to published version
- [x] Clean up commit history (_after_ review :+1: )
- [x] Rebase on #1844 
- [x] lint
- [x] Peel off a couple of isolated PRs
- [x] Rebase on merged, isolated PRs
- [x] Refactor duplicate logic for cleaning up paused account search
- [x] Replace all TODOs with issues
- [x] Build special test database with cold data
- [x] Test that accounts are missing
- [x] Backfill accounts
- [x] Test that storage is missing
- [x] Backfill storage
- [x] Test that bytecode is missing (need new fixture!)
- [x] Backfill bytecode
- [x] new issue: Save progress so that exiting and restarting trinity doesn't require rewalking the trie from scratch #1817
- [x] new issue: test that epoch crossover is happening #1815
- [x] new issue: test a state change that triggers a `TraversedPartialPath` to make sure that code path is tested #1816
- [x] ~Probably in new issue:~ find keys based on recent state root

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

[//]: # (See: https://trinity-client.readthedocs.io/en/latest/contributing.html#pull-requests)
- [x] Add entry to the [release notes](https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://i.pinimg.com/originals/2e/85/57/2e85576b95f9fd7e507fdaf3f0e28548.jpg)