### PR TITLE
Add missing release notes entry

### DIFF
--- a/newsfragments/1768.feature.rst
+++ b/newsfragments/1768.feature.rst
@@ -1,0 +1,2 @@
+Upgraded py-evm to v0.3.0-alpha.17 -- See `py-evm's release notes
+<https://py-evm.readthedocs.io/en/latest/release_notes.html#py-evm-0-3-0-alpha-17-2020-06-02>`_


### PR DESCRIPTION
### What was wrong?

I had rage merged #1768 and overlooked that the release notes entry was missing.

### How was it fixed?

Add release notes entry.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

[//]: # (See: https://trinity-client.readthedocs.io/en/latest/contributing.html#pull-requests)
- [x] Add entry to the [release notes](https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://i.pinimg.com/originals/ec/d8/72/ecd872756bba11f6ec144efdb5b57d8f.jpg)
