### PR TITLE
Tune default value for etherscan checkpoint resolver

### DIFF
--- a/newsfragments/1781.feature.rst
+++ b/newsfragments/1781.feature.rst
@@ -1,0 +1,1 @@
+Increase the tip distance for etherscan checkpoint resolving from 50 to 5000 blocks.

--- a/trinity/components/builtin/syncer/cli.py
+++ b/trinity/components/builtin/syncer/cli.py
@@ -51,7 +51,7 @@ def parse_checkpoint_uri(uri: str, network_id: int) -> Checkpoint:
         raise ValidationError("Not a valid checkpoint URI")
 
 
-BLOCKS_FROM_TIP = 50
+BLOCKS_FROM_TIP = 5000
 
 
 def parse_byetherscan_uri(parsed: urllib.parse.ParseResult, network_id: int) -> Checkpoint:


### PR DESCRIPTION
### What was wrong?

When resolving a checkpoint via etherscan we currently resolve to a block that is 50 blocks away from the tip of the chain.

This is problematic not only because of reorgs but also because it limits the set of peers that we can use to start with (and verify the checkpoint).

### How was it fixed?

Changed it to 5000.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

[//]: # (See: https://trinity-client.readthedocs.io/en/latest/contributing.html#pull-requests)
- [x] Add entry to the [release notes](https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://i.guim.co.uk/img/media/b1809228b6923ad374371a37f86a8c555c3607ac/0_43_5029_3018/master/5029.jpg?width=1200&height=1200&quality=85&auto=format&fit=crop&s=0879dace1d651af0263b8a557ac0435b)
