### PR TITLE
Fix broken etherscan checkpoint resolving for goerli and ropsten

### DIFF
--- a/newsfragments/1782.bugfix.rst
+++ b/newsfragments/1782.bugfix.rst
@@ -1,0 +1,1 @@
+Fix etherscan checkpoint resolving for Ropsten and Görli.

--- a/tests/integration/test_etherscan_checkpoint_resolver.py
+++ b/tests/integration/test_etherscan_checkpoint_resolver.py
@@ -5,21 +5,28 @@ from trinity.components.builtin.syncer.cli import (
     parse_checkpoint_uri,
     is_block_hash,
 )
-from trinity.constants import MAINNET_NETWORK_ID
+from trinity.constants import (
+    MAINNET_NETWORK_ID,
+    GOERLI_NETWORK_ID,
+    ROPSTEN_NETWORK_ID,
+)
 
 
-# This is just the score at the tip as it was at some point on August 26th 2019
-# It serves as anchor so that we have *some* minimal expected score to test against.
-MIN_EXPECTED_SCORE = 11631608640717612820968
+# These are just arbitrarily choosen scores that we know can serve as a rough validity check.
+MIN_EXPECTED_MAINNET_SCORE = 11631608640717612820968
+MIN_EXPECTED_GOERLI_SCORE = 4216548
+MIN_EXPECTED_ROPSTEN_SCORE = 30423839501145616
 
 
 @pytest.mark.parametrize(
-    'uri',
+    'uri,network_id,min_expected_score',
     (
-        'eth://block/byetherscan/latest',
+        ('eth://block/byetherscan/latest', MAINNET_NETWORK_ID, MIN_EXPECTED_MAINNET_SCORE),
+        ('eth://block/byetherscan/latest', GOERLI_NETWORK_ID, MIN_EXPECTED_GOERLI_SCORE),
+        ('eth://block/byetherscan/latest', ROPSTEN_NETWORK_ID, MIN_EXPECTED_ROPSTEN_SCORE)
     )
 )
-def test_parse_checkpoint(uri):
-    checkpoint = parse_checkpoint_uri(uri, MAINNET_NETWORK_ID)
-    assert checkpoint.score >= MIN_EXPECTED_SCORE
+def test_parse_checkpoint(uri, network_id, min_expected_score):
+    checkpoint = parse_checkpoint_uri(uri, network_id)
+    assert checkpoint.score >= min_expected_score
     assert is_block_hash(encode_hex(checkpoint.block_hash))

--- a/trinity/components/builtin/syncer/etherscan_api.py
+++ b/trinity/components/builtin/syncer/etherscan_api.py
@@ -10,6 +10,7 @@ from eth_utils import (
 
 import requests
 
+from trinity._utils.version import construct_trinity_client_identifier
 from trinity.constants import (
     MAINNET_NETWORK_ID,
     GOERLI_NETWORK_ID,
@@ -36,7 +37,7 @@ API_URLS = {
 
 # The Etherscan API for Goerli and Ropsten rejects any requests without User-Agent
 
-COMMON_REQUEST_HEADERS = {'User-Agent': 'Trinity'}
+COMMON_REQUEST_HEADERS = {'User-Agent': construct_trinity_client_identifier()}
 
 
 class Etherscan:

--- a/trinity/components/builtin/syncer/etherscan_api.py
+++ b/trinity/components/builtin/syncer/etherscan_api.py
@@ -24,8 +24,8 @@ class EtherscanAPIError(BaseTrinityError):
 
 class Network(enum.IntEnum):
     MAINNET = MAINNET_NETWORK_ID
-    GOERLI = ROPSTEN_NETWORK_ID
-    ROPSTEN = GOERLI_NETWORK_ID
+    GOERLI = GOERLI_NETWORK_ID
+    ROPSTEN = ROPSTEN_NETWORK_ID
 
 
 API_URLS = {
@@ -33,6 +33,10 @@ API_URLS = {
     Network.GOERLI: "https://api-goerli.etherscan.io/api",
     Network.ROPSTEN: "https://api-ropsten.etherscan.io/api",
 }
+
+# The Etherscan API for Goerli and Ropsten rejects any requests without User-Agent
+
+COMMON_REQUEST_HEADERS = {'User-Agent': 'Trinity'}
 
 
 class Etherscan:
@@ -47,8 +51,10 @@ class Etherscan:
         return f"{API_URLS[network]}?module=proxy&apikey={self.api_key}"
 
     def post(self, action: str, network: Network) -> Any:
-        response = requests.post(f"{self.get_proxy_api_url(network)}&action={action}")
-
+        response = requests.post(
+            f"{self.get_proxy_api_url(network)}&action={action}",
+            headers=COMMON_REQUEST_HEADERS
+        )
         if response.status_code not in [200, 201]:
             raise EtherscanAPIError(
                 f"Invalid status code: {response.status_code}, {response.reason}"


### PR DESCRIPTION
### What was wrong?

Resolving checkpoints through etherscan is broken for Ropsten and Goerli because:

1. The Networks are swapped
2. The Etherscan API for goerli and ropsten rejects requests without user agent (mainnet works!)

### How was it fixed?

1. Swapped Networks
2. Added Trinity user agent

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

[//]: # (See: https://trinity-client.readthedocs.io/en/latest/contributing.html#pull-requests)
- [x] Add entry to the [release notes](https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://img5.goodfon.com/wallpaper/nbig/6/4e/sobaki-dve-para-parochka-duet-priroda-druzia-druzhba-iazyk-l.jpg)
