### PR TITLE
Fix beam sync crash with clique consensus

### DIFF
--- a/newsfragments/1786.bugfix.rst
+++ b/newsfragments/1786.bugfix.rst
@@ -1,0 +1,1 @@
+Fix beam sync crashing when running under Clique consensus (e.g. Görli)

--- a/trinity/sync/beam/importer.py
+++ b/trinity/sync/beam/importer.py
@@ -160,6 +160,7 @@ def make_pausing_beam_chain(
         for starting_block, vm in vm_config
     )
     PausingBeamChain = BeamChain.configure(
+        consensus_context_class=consensus_context_class,
         vm_configuration=pausing_vm_config,
         chain_id=chain_id,
     )


### PR DESCRIPTION
### What was wrong?

Beam sync is crashing when being used with clique sync. This is due to the `consensus_context_class` not being properly used.

### How was it fixed?

Set `consensus_context_class` in `BeamChain.configure(..)`

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

[//]: # (See: https://trinity-client.readthedocs.io/en/latest/contributing.html#pull-requests)
- [x] Add entry to the [release notes](https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://en.bcdn.biz/Images/2014/10/19/16508e1d-d20c-4424-9eda-f27012097ffb.jpg)
