### PR TITLE
Adds latest iteration of Dockerfile for trio beacon node and validator

### DIFF
--- a/docker/Dockerfile.trinity-beacon-trio
+++ b/docker/Dockerfile.trinity-beacon-trio
@@ -1,0 +1,17 @@
+FROM python:3.8
+
+# Set up code directory
+RUN mkdir -p /usr/src/app
+WORKDIR /usr/src/app
+
+# Install deps
+RUN apt-get update
+RUN apt-get -y install libsnappy-dev gcc g++ cmake
+
+RUN git clone https://github.com/ethereum/trinity.git .
+RUN pip install -e .[eth2-dev] --no-cache-dir
+
+RUN echo "Type \`trinity-beacon-trio\` to boot or \`trinity-beacon-trio --help\` for an overview of commands"
+
+EXPOSE 12000 30303/udp
+ENTRYPOINT ["trinity-beacon-trio", "--log-level", "debug"]

--- a/docker/Dockerfile.trinity-validator
+++ b/docker/Dockerfile.trinity-validator
@@ -1,0 +1,17 @@
+FROM python:3.8
+
+# Set up code directory
+RUN mkdir -p /usr/src/app
+WORKDIR /usr/src/app
+
+# Install deps
+RUN apt-get update
+RUN apt-get -y install libsnappy-dev gcc g++ cmake
+
+RUN git clone https://github.com/ethereum/trinity.git .
+RUN pip install -e .[eth2-dev] --no-cache-dir
+
+RUN echo "Type \`trinity-validator\` to boot or \`trinity-validator --help\` for an overview of commands"
+
+EXPOSE 5005
+ENTRYPOINT ["trinity-validator"]


### PR DESCRIPTION
### What was wrong?

Need to update Dockerfile for trinity-beacon-trio. Can likely deprecate the existing dockerfile for `trinity-beacon`.

### How was it fixed?

Add the Dockerfiles.

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://image.freepik.com/free-vector/cute-panda-dabbing-pose_1366-626.jpg)
