### PR TITLE
Also monitor NewBlockHashes in ETHChainTipMonitor

### DIFF
--- a/newsfragments/1791.feature.rst
+++ b/newsfragments/1791.feature.rst
@@ -1,0 +1,1 @@
+When monitoring the tip of the chain, also monitor the ``NewBlockHashes`` event.

--- a/newsfragments/1791.feature.rst
+++ b/newsfragments/1791.feature.rst
@@ -1,1 +1,1 @@
-When monitoring the tip of the chain, also monitor the ``NewBlockHashes`` event.
+Keep up with the tip of the chain a bit better. (By also listening to ``NewBlockHashes``)

--- a/trinity/protocol/eth/monitors.py
+++ b/trinity/protocol/eth/monitors.py
@@ -3,4 +3,4 @@ from trinity.protocol.eth import commands
 
 
 class ETHChainTipMonitor(BaseChainTipMonitor):
-    subscription_msg_types = frozenset({commands.NewBlock})
+    subscription_msg_types = frozenset({commands.NewBlock, commands.NewBlockHashes})


### PR DESCRIPTION
### What was wrong?

While working on #1788 I noticed that we can recognize changes at the tip of the chain a little faster if we also listen for `NewBlockHashes` in addition to `NewBlock`.

### How was it fixed?

Add `NewBlockHashes` to the observed events of `ETHChainTipMonitor`

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

[//]: # (See: https://trinity-client.readthedocs.io/en/latest/contributing.html#pull-requests)
- [x] Add entry to the [release notes](https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://www.top13.net/wp-content/uploads/2017/06/dogs-being-weird-17.jpg)
