### PR TITLE
Fix skeleton recycling

### DIFF
--- a/p2p/constants.py
+++ b/p2p/constants.py
@@ -217,3 +217,13 @@ TCP_PORT_ENR_KEY = b"tcp"
 IP_V4_SIZE = 4  # size of an IPv4 address
 IP_V6_SIZE = 16  # size of an IPv6 address
 NUM_ROUTING_TABLE_BUCKETS = 256  # number of buckets in the routing table
+
+# Stringified objects longer than this will be trimmed before emitting to log.
+#   Some commands were >200k characters as a string, and choked up the
+#   AsyncProcessRunner.stderr which overreaches the buffer limit in the
+#   internal StreamReader.readuntil() call. The 10k limit is informed by:
+#   - should be much smaller than the ~200k buffer limit (because some logs
+#       might print multiple commands)
+#   - should be big enough not to clip typical logs (On a test DEBUG2 run
+#       on mainnet, the largest logs were <2k characters)
+LONGEST_ALLOWED_LOG_STRING = 10000

--- a/p2p/logging.py
+++ b/p2p/logging.py
@@ -1,0 +1,10 @@
+from typing import (
+    Any,
+)
+
+from p2p._utils import trim_middle
+from p2p.constants import LONGEST_ALLOWED_LOG_STRING
+
+
+def loggable(log_object: Any) -> str:
+    return trim_middle(str(log_object), LONGEST_ALLOWED_LOG_STRING)

--- a/p2p/peer.py
+++ b/p2p/peer.py
@@ -54,6 +54,7 @@ from p2p.handshake import (
     dial_out,
     DevP2PHandshakeParams,
 )
+from p2p.logging import loggable
 from p2p.logic import wait_first
 from p2p.p2p_api import P2PAPI
 from p2p.p2p_proto import BaseP2PProtocol, Disconnect
@@ -426,21 +427,30 @@ class PeerSubscriber(ABC):
                 self.logger.debug2(  # type: ignore
                     "Discarding %s msg from %s; not subscribed to msg type; "
                     "subscriptions: %s",
-                    cmd, peer, self.subscription_msg_types,
+                    loggable(cmd),
+                    peer,
+                    self.subscription_msg_types,
                 )
             return False
 
         try:
             if hasattr(self, 'logger'):
                 self.logger.debug2(  # type: ignore
-                    "Adding %s msg from %s to queue; queue_size=%d", cmd, peer, self.queue_size)
+                    "Adding %s msg from %s to queue; queue_size=%d",
+                    loggable(cmd),
+                    peer,
+                    self.queue_size,
+                )
             self.msg_queue.put_nowait(msg)
             return True
         except asyncio.queues.QueueFull:
             if hasattr(self, 'logger'):
                 self.logger.warning(  # type: ignore
                     "%s msg queue is full; discarding %s msg from %s",
-                    self.__class__.__name__, cmd, peer)
+                    self.__class__.__name__,
+                    loggable(cmd),
+                    peer,
+                )
             return False
 
     @contextlib.contextmanager

--- a/tests/core/p2p-proto/test_sync.py
+++ b/tests/core/p2p-proto/test_sync.py
@@ -624,4 +624,14 @@ async def wait_for_head(headerdb, header, sync_timeout=10):
             else:
                 break
         assert header_at_block == header
-    await asyncio.wait_for(wait_loop(), sync_timeout)
+    try:
+        await asyncio.wait_for(wait_loop(), sync_timeout)
+    except asyncio.TimeoutError:
+        canonical_head = headerdb.get_canonical_head()
+        logging.error(
+            "Could not finish syncing to %s within %ds, only arrived at %s",
+            header,
+            sync_timeout,
+            canonical_head,
+        )
+        raise

--- a/tests/core/p2p-proto/test_sync.py
+++ b/tests/core/p2p-proto/test_sync.py
@@ -5,6 +5,7 @@ import uuid
 from async_service import Service, background_asyncio_service
 from eth.consensus import ConsensusContext
 from eth.db.atomic import AtomicDB
+from eth.db.schema import SchemaV1
 from eth.exceptions import HeaderNotFound
 from eth.vm.forks.petersburg import PetersburgVM
 from eth_utils import decode_hex
@@ -86,7 +87,7 @@ def chaindb_with_gaps(chaindb_fresh, chaindb_1000):
 
 
 @pytest.mark.asyncio
-async def test_skeleton_syncer(request, event_loop, event_bus, chaindb_fresh, chaindb_1000):
+async def test_fast_syncer(request, event_loop, event_bus, chaindb_fresh, chaindb_1000):
 
     client_context = ChainContextFactory(headerdb__db=chaindb_fresh.db)
     server_context = ChainContextFactory(headerdb__db=chaindb_1000.db)
@@ -115,6 +116,7 @@ async def test_skeleton_syncer(request, event_loop, event_bus, chaindb_fresh, ch
 
             head = chaindb_fresh.get_canonical_head()
             assert head == chaindb_1000.get_canonical_head()
+            # TODO assert that the block transactions and uncles are present too.
 
 
 @pytest.mark.asyncio
@@ -413,9 +415,9 @@ async def test_header_syncer(request,
                              event_loop,
                              event_bus,
                              chaindb_fresh,
-                             chaindb_20):
+                             chaindb_1000):
     client_context = ChainContextFactory(headerdb__db=chaindb_fresh.db)
-    server_context = ChainContextFactory(headerdb__db=chaindb_20.db)
+    server_context = ChainContextFactory(headerdb__db=chaindb_1000.db)
     peer_pair = LatestETHPeerPairFactory(
         alice_peer_context=client_context,
         bob_peer_context=server_context,
@@ -433,14 +435,44 @@ async def test_header_syncer(request,
         async with run_peer_pool_event_server(
             event_bus, server_peer_pool, handler_type=ETHPeerPoolEventServer
         ), background_asyncio_service(ETHRequestServer(
-            event_bus, TO_NETWORKING_BROADCAST_CONFIG, AsyncChainDB(chaindb_20.db),
+            event_bus, TO_NETWORKING_BROADCAST_CONFIG, AsyncChainDB(chaindb_1000.db),
         )):
 
-            server_peer.logger.info("%s is serving 20 blocks", server_peer)
-            client_peer.logger.info("%s is syncing up 20", client_peer)
+            server_peer.logger.info("%s is serving 1000 blocks", server_peer)
+            client_peer.logger.info("%s is syncing up 1000", client_peer)
+
+            # Artificially split header sync into two parts, to verify that
+            #   cycling to the next sync works properly. Split by erasing the canonical
+            #   lookups in a middle chunk. We have to erase a range of them because of
+            #   the way that the skeleton sync skips over headers on the first request,
+            #   it expects the peer to have all headers in the 192-header gaps in between.
+            erase_block_numbers = range(500, 700)
+            erased_canonicals = []
+            for blocknum in erase_block_numbers:
+                dbkey = SchemaV1.make_block_number_to_hash_lookup_key(blocknum)
+                canonical_hash = chaindb_1000.db[dbkey]
+                erased_canonicals.append((dbkey, canonical_hash))
+                del chaindb_1000.db[dbkey]
 
             async with background_asyncio_service(client):
-                await wait_for_head(chaindb_fresh, chaindb_20.get_canonical_head())
+                target_head = chaindb_1000.get_canonical_block_header_by_number(
+                    # TODO? Look back from the first erased block number, because the skeleton
+                    #   may not properly fill in right up to the missing tip
+                    erase_block_numbers[0] - 1
+                )
+                await wait_for_head(chaindb_fresh, target_head, sync_timeout=20)
+
+                # TODO validate that the skeleton syncer has cycled??
+
+                # Replace the missing headers so that syncing can resume
+                for dbkey, canonical_hash in erased_canonicals:
+                    chaindb_1000.db[dbkey] = canonical_hash
+
+                # Do we have to do anything here to have the server notify the client
+                #   that it's capable of serving more headers now?
+
+                await wait_for_head(chaindb_fresh, chaindb_1000.get_canonical_head())
+
 
 
 @pytest.mark.asyncio

--- a/tests/core/p2p-proto/test_sync.py
+++ b/tests/core/p2p-proto/test_sync.py
@@ -444,8 +444,8 @@ async def test_header_syncer(request,
             # Artificially split header sync into two parts, to verify that
             #   cycling to the next sync works properly. Split by erasing the canonical
             #   lookups in a middle chunk. We have to erase a range of them because of
-            #   the way that the skeleton sync skips over headers on the first request,
-            #   it expects the peer to have all headers in the 192-header gaps in between.
+            #   how the skeleton syncer asks for every ~192 headers. The skeleton request
+            #   would skip right over a single missing header.
             erase_block_numbers = range(500, 700)
             erased_canonicals = []
             for blocknum in erase_block_numbers:
@@ -456,8 +456,6 @@ async def test_header_syncer(request,
 
             async with background_asyncio_service(client):
                 target_head = chaindb_1000.get_canonical_block_header_by_number(
-                    # TODO? Look back from the first erased block number, because the skeleton
-                    #   may not properly fill in right up to the missing tip
                     erase_block_numbers[0] - 1
                 )
                 await wait_for_head(chaindb_fresh, target_head)
@@ -473,7 +471,7 @@ async def test_header_syncer(request,
                     chaindb_1000.db[dbkey] = canonical_hash
 
                 # Do we have to do anything here to have the server notify the client
-                #   that it's capable of serving more headers now?
+                #   that it's capable of serving more headers now? ... Apparently not.
 
                 await wait_for_head(chaindb_fresh, chaindb_1000.get_canonical_head())
 

--- a/tests/core/p2p-proto/test_sync.py
+++ b/tests/core/p2p-proto/test_sync.py
@@ -623,4 +623,5 @@ async def wait_for_head(headerdb, header, sync_timeout=10):
                 await asyncio.sleep(0.1)
             else:
                 break
+        assert header_at_block == header
     await asyncio.wait_for(wait_loop(), sync_timeout)

--- a/tests/core/p2p-proto/test_sync.py
+++ b/tests/core/p2p-proto/test_sync.py
@@ -460,7 +460,11 @@ async def test_header_syncer(request,
                     #   may not properly fill in right up to the missing tip
                     erase_block_numbers[0] - 1
                 )
-                await wait_for_head(chaindb_fresh, target_head, sync_timeout=20)
+                await wait_for_head(chaindb_fresh, target_head)
+
+                # gut check that we didn't skip past the erased range of blocks
+                head = chaindb_fresh.get_canonical_head()
+                assert head.block_number < erase_block_numbers[0]
 
                 # TODO validate that the skeleton syncer has cycled??
 

--- a/tests/core/p2p-proto/test_sync.py
+++ b/tests/core/p2p-proto/test_sync.py
@@ -478,7 +478,6 @@ async def test_header_syncer(request,
                 await wait_for_head(chaindb_fresh, chaindb_1000.get_canonical_head())
 
 
-
 @pytest.mark.asyncio
 async def test_header_gapfill_syncer(request,
                                      event_loop,

--- a/tests/core/task-queue-utils/test_task_queue.py
+++ b/tests/core/task-queue-utils/test_task_queue.py
@@ -16,6 +16,7 @@ from eth_utils.toolz import (
 from hypothesis import (
     example,
     given,
+    settings,
     strategies as st,
 )
 
@@ -63,6 +64,7 @@ def run_in_event_loop(async_func):
     add_size=2,
     get_size=5,
 )
+@settings(deadline=300)
 @run_in_event_loop
 async def test_no_asyncio_exception_leaks(operations, queue_size, add_size, get_size, event_loop):
     """

--- a/tests/integration/test_trinity_cli.py
+++ b/tests/integration/test_trinity_cli.py
@@ -243,7 +243,7 @@ async def test_does_not_throw_errors_on_short_run(command, unused_tcp_port):
 @pytest.mark.parametrize(
     'command,expected_stderr_logs,unexpected_stderr_logs,expected_file_logs,unexpected_file_logs',
     (
-        (
+        pytest.param(
             # Default run without any flag
             ('trinity',),
             # Expected stderr logs
@@ -254,21 +254,25 @@ async def test_does_not_throw_errors_on_short_run(command, unused_tcp_port):
             {'Started main process', 'Logging initialized'},
             # Unexpected file logs
             {'>>> ping'},
+            id="noflag:starts-both,loginit-file,ping-none",
         ),
-        (
+        pytest.param(
             # Enable DEBUG2 logs across the board
             ('trinity', '-l=DEBUG2'),
             {'Started main process', '>>> ping'},
             {},
             {'Started main process', '>>> ping'},
             {},
+            id="all>=debug2:starts-both,ping-both",
         ),
-        (   # Enable DEBUG2 logs for everything except discovery which is reduced to ERROR logs
+        pytest.param(
+            # Enable DEBUG2 logs for everything except discovery which is reduced to ERROR logs
             ('trinity', '-l=DEBUG2', '-l', 'p2p.discovery=ERROR'),
             {'Started main process', '<Manager[ConnectionTrackerServer] flags=SRcfe>: running root task run[daemon=False]'},  # noqa: E501
             {'>>> ping'},
             {'Started main process', '<Manager[ConnectionTrackerServer] flags=SRcfe>: running root task run[daemon=False]'},  # noqa: E501
             {'>>> ping'},
+            id="all>=debug2,p2p>=error:starts-both,manager_debug-both,ping-none",
         ),
         # Commented out because sometimes it passes and sometimes it fails.
         # pytest.param(
@@ -295,6 +299,7 @@ async def test_does_not_throw_errors_on_short_run(command, unused_tcp_port):
             # {'Started main process'},
             # TODO: investigate in #1347
             marks=(pytest.mark.xfail),
+            id="all>=error,p2p>=debug2:starts-nostderr,ping-stderr",
         ),
     )
 )

--- a/trinity/sync/common/headers.py
+++ b/trinity/sync/common/headers.py
@@ -51,6 +51,7 @@ from lahja import EndpointAPI
 from p2p.abc import CommandAPI
 from p2p.constants import SEAL_CHECK_RANDOM_SAMPLE_RATE
 from p2p.exceptions import BaseP2PError, PeerConnectionLost
+from p2p.logging import loggable
 from p2p.peer import BasePeer, PeerSubscriber
 from trinity._utils.timer import Timer
 
@@ -465,7 +466,7 @@ class SkeletonSyncer(Service, Generic[TChainPeer]):
                 reverse=False,
             )
 
-            self.logger.debug2('sync received new headers: %s', headers)
+            self.logger.debug2("sync received new headers: %s", loggable(headers))
         except PeerConnectionLost:
             self.logger.debug("Lost connection to %s while retrieving headers", peer)
             return tuple()

--- a/trinity/sync/common/headers.py
+++ b/trinity/sync/common/headers.py
@@ -20,11 +20,7 @@ from typing import (
     NamedTuple,
 )
 
-from async_service import (
-    Service,
-    LifecycleError,
-    background_asyncio_service,
-)
+from async_service import Service, background_asyncio_service
 
 from eth.abc import BlockHeaderAPI
 
@@ -122,12 +118,8 @@ class SkeletonSyncer(Service, Generic[TChainPeer]):
 
     async def skeleton_segments(self) -> AsyncIterator[Tuple[BlockHeader, ...]]:
         while self.manager.is_running:
-            try:
-                yield await self.manager.await_task(self._fetched_headers.get)
-            except LifecycleError:
-                break
-            else:
-                self._fetched_headers.task_done()
+            yield await self._fetched_headers.get()
+            self._fetched_headers.task_done()
 
     async def run(self) -> None:
         self.manager.run_daemon_task(self._display_stats)
@@ -931,7 +923,13 @@ class BaseHeaderChainSyncer(Service, HeaderSyncerAPI, Generic[TChainPeer]):
                 self.logger.debug("At or behind peer %s, skipping skeleton sync", peer)
             else:
                 async with self._get_skeleton_syncer(peer) as syncer:
-                    await self._full_skeleton_sync(syncer)
+                    # We cannot simply await self._full_skeleton_sync(syncer) here because
+                    #   if the service exits, we get stuck waiting for the next header to appear
+                    #   from skeleton_segments(). By running it async and waiting until the manager
+                    #   exits, we ensure that _full_skeleton_sync gets cancelled when the service
+                    #   exits, even if it's hanging on skeleton_segments().
+                    syncer.manager.run_task(self._full_skeleton_sync, syncer)
+                    await syncer.manager.wait_finished()
 
     @contextlib.asynccontextmanager
     async def _get_skeleton_syncer(

--- a/trinity/sync/common/headers.py
+++ b/trinity/sync/common/headers.py
@@ -2,7 +2,7 @@ from abc import ABC, abstractmethod
 import asyncio
 from concurrent.futures import CancelledError
 import contextlib
-from functools import partial
+import functools
 from operator import attrgetter, itemgetter
 from random import randrange
 from typing import (
@@ -716,7 +716,7 @@ class HeaderMeatSyncer(Service, PeerSubscriber, Generic[TChainPeer]):
                     len(completed_headers),
                 )
                 loop = asyncio.get_event_loop()
-                loop.call_later(delay, partial(self._waiting_peers.put_nowait, peer))
+                loop.call_later(delay, functools.partial(self._waiting_peers.put_nowait, peer))
                 fail_task_fn()
 
     async def _fetch_segment(


### PR DESCRIPTION
### What was wrong?

Fix #1788 

### How was it fixed?

Parallel work, with a nod to #1790 

When waiting on the next header batch to show up in `next_skeleton_segment()`, exit the iterable if the service exits (rather than hanging, waiting on the next `Queue` element to appear).

Added a test that fails before this bugfix.

As a side-effect, this seemed to uncover some barely-related bug about handling duplicate headers during sync. If the parent of a chain of headers was missing, and the headers were duplicates of in-flight headers being processed, then it would queue them up despite being duplicates. Fixed that bug too.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] Clean up commit history
- [ ] extract a code block that filters duplicate headers into its own method: 
https://github.com/ethereum/trinity/pull/1792/files#diff-e2a97e2edf2590b9aa6a324ee9648a5cR195
- [ ] internal changelog for trimmed debug2 log, plus an extended hypothesis deadline, for two fewer flaky tests

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://i.ytimg.com/vi/IwUrGEcyg_w/maxresdefault.jpg)
