### PR TITLE
Make HTTP Listen Address configurable

### DIFF
--- a/docs/api/api.cli.rst
+++ b/docs/api/api.cli.rst
@@ -7,30 +7,43 @@ We can also generate an always up-to-date version of them by running ``trinity -
 .. code-block:: shell
 
     usage: trinity [-h] [--version] [--trinity-root-dir TRINITY_ROOT_DIR]
-                  [--port PORT] [--trinity-tmp-root-dir] [-l LEVEL]
-                  [--stderr-log-level STDERR_LOG_LEVEL]
-                  [--file-log-level FILE_LOG_LEVEL]
-                  [--network-id NETWORK_ID | --ropsten]
-                  [--preferred-node PREFERRED_NODES] [--discv5]
-                  [--max-peers MAX_PEERS] [--genesis GENESIS]
-                  [--data-dir DATA_DIR] [--nodekey NODEKEY] [--profile]
-                  [--disable-rpc] [--enable-http] [--rpcport RPCPORT]
-                  [--network-tracking-backend {sqlite3,memory,do-not-track}]
-                  [--disable-networkdb-component] [--disable-blacklistdb]
-                  [--disable-eth1-peer-db]
-                  [--enable-experimental-eth1-peer-tracking]
-                  [--disable-discovery] [--disable-upnp] [--enable-ethstats]
-                  [--ethstats-server-url ETHSTATS_SERVER_URL]
-                  [--ethstats-server-secret ETHSTATS_SERVER_SECRET]
-                  [--ethstats-node-id ETHSTATS_NODE_ID]
-                  [--ethstats-node-contact ETHSTATS_NODE_CONTACT]
-                  [--ethstats-interval ETHSTATS_INTERVAL]
-                  [--disable-request-server]
-                  [--force-beam-block-number FORCE_BEAM_BLOCK_NUMBER]
-                  [--sync-from-checkpoint SYNC_FROM_CHECKPOINT]
-                  [--sync-mode {full,beam,light,none}] [--disable-tx-pool]
-                  {attach,db-shell,fix-unclean-shutdown,remove-network-db,export,import}
-                  ...
+                   [--port PORT] [--trinity-tmp-root-dir] [-l LEVEL]
+                   [--stderr-log-level STDERR_LOG_LEVEL]
+                   [--file-log-level FILE_LOG_LEVEL]
+                   [--network-id NETWORK_ID | --ropsten | --goerli]
+                   [--preferred-node PREFERRED_NODES] [--max-peers MAX_PEERS]
+                   [--genesis GENESIS] [--data-dir DATA_DIR] [--nodekey NODEKEY]
+                   [--profile] [--disable-rpc] [--enable-http]
+                   [--http-listen-address HTTP_LISTEN_ADDRESS]
+                   [--http-port HTTP_PORT]
+                   [--network-tracking-backend {sqlite3,memory,do-not-track}]
+                   [--disable-networkdb-component] [--disable-blacklistdb]
+                   [--disable-eth1-peer-db]
+                   [--enable-experimental-eth1-peer-tracking]
+                   [--disable-discovery] [--disable-upnp] [--enable-ethstats]
+                   [--ethstats-server-url ETHSTATS_SERVER_URL]
+                   [--ethstats-server-secret ETHSTATS_SERVER_SECRET]
+                   [--ethstats-node-id ETHSTATS_NODE_ID]
+                   [--ethstats-node-contact ETHSTATS_NODE_CONTACT]
+                   [--ethstats-interval ETHSTATS_INTERVAL] [--enable-metrics]
+                   [--metrics-host METRICS_HOST]
+                   [--metrics-influx-user METRICS_INFLUX_USER]
+                   [--metrics-influx-database METRICS_INFLUX_DATABASE]
+                   [--metrics-influx-password METRICS_INFLUX_PASSWORD]
+                   [--metrics-influx-server METRICS_INFLUX_SERVER]
+                   [--metrics-influx-port METRICS_INFLUX_PORT]
+                   [--metrics-influx-protocol METRICS_INFLUX_PROTOCOL]
+                   [--metrics-reporting-frequency METRICS_REPORTING_FREQUENCY]
+                   [--metrics-system-collector-frequency METRICS_SYSTEM_COLLECTOR_FREQUENCY]
+                   [--metrics-blockchain-collector-frequency METRICS_BLOCKCHAIN_COLLECTOR_FREQUENCY]
+                   [--disable-request-server]
+                   [--sync-mode {header,full,beam,light,none}]
+                   [--sync-from-checkpoint SYNC_FROM_CHECKPOINT]
+                   [--disable-backfill]
+                   [--force-beam-block-number FORCE_BEAM_BLOCK_NUMBER]
+                   [--disable-tx-pool]
+                   {attach,db-shell,fix-unclean-shutdown,remove-network-db,export,import}
+                   ...
 
     Trinity
 
@@ -48,22 +61,16 @@ We can also generate an always up-to-date version of them by running ``trinity -
 
     optional arguments:
       -h, --help            show this help message and exit
-      --disable-rpc         Disables the JSON-RPC Server
-      --enable-http         Enables the HTTP Server
-      --rpcport RPCPORT     JSON-RPC server port
+      --disable-rpc         Disables the JSON-RPC server
+      --enable-http         Enables the HTTP server
+      --http-listen-address HTTP_LISTEN_ADDRESS
+                            Address for the HTTP server to listen on
+      --http-port HTTP_PORT
+                            JSON-RPC server port
       --disable-discovery   Disable peer discovery
       --disable-upnp        Disable upnp mapping
       --disable-request-server
                             Disables the Request Server
-      --force-beam-block-number FORCE_BEAM_BLOCK_NUMBER
-                            Force beam sync to activate on a specific block number
-                            (for testing)
-      --sync-from-checkpoint SYNC_FROM_CHECKPOINT
-                            Start beam sync from a trusted checkpoint specified
-                            using URI syntax:By specific block,
-                            eth://block/byhash/<hash>?score=<score>Let etherscan
-                            pick a block near the tip,
-                            eth://block/byetherscan/latest
       --disable-tx-pool     Disables the Transaction Pool
 
     core:
@@ -97,10 +104,11 @@ We can also generate an always up-to-date version of them by running ``trinity -
                             Network identifier (1=Mainnet, 3=Ropsten)
       --ropsten             Ropsten network: pre configured proof-of-work test
                             network. Shortcut for `--networkid=3`
+      --goerli              Goerli network: pre configured proof-of-authority
+                            (Clique) test network. Shortcut for `--networkid=5`
       --preferred-node PREFERRED_NODES
                             An enode address which will be 'preferred' above nodes
                             found using the discovery protocol
-      --discv5              Enable experimental v5 (topic) discovery mechanism
       --max-peers MAX_PEERS
                             Maximum number of network peers
 
@@ -152,8 +160,49 @@ We can also generate an always up-to-date version of them by running ``trinity -
       --ethstats-interval ETHSTATS_INTERVAL
                             The interval at which data is reported back
 
+    metrics:
+      --enable-metrics      Enable metrics component
+      --metrics-host METRICS_HOST
+                            Host name to tag the metrics data (e.g. trinity-
+                            bootnode-europe-pt)
+      --metrics-influx-user METRICS_INFLUX_USER
+                            Influx DB user. Defaults to `trinity`
+      --metrics-influx-database METRICS_INFLUX_DATABASE
+                            Influx DB name. Defaults to `trinity`
+      --metrics-influx-password METRICS_INFLUX_PASSWORD
+                            Influx DB password. Defaults to ENV var
+                            TRINITY_METRICS_INFLUX_DB_PW
+      --metrics-influx-server METRICS_INFLUX_SERVER
+                            Influx DB server. Defaults to ENV var
+                            TRINITY_METRICS_INFLUX_DB_SERVER
+      --metrics-influx-port METRICS_INFLUX_PORT
+                            Influx DB port. Defaults to ENV var
+                            TRINITY_METRICS_INFLUX_DB_PORT or 8086
+      --metrics-influx-protocol METRICS_INFLUX_PROTOCOL
+                            Influx DB protocol. Defaults to ENV var
+                            TRINITY_METRICS_INFLUX_DB_PROTOCOL or http
+      --metrics-reporting-frequency METRICS_REPORTING_FREQUENCY
+                            The frequency in seconds at which metrics are reported
+      --metrics-system-collector-frequency METRICS_SYSTEM_COLLECTOR_FREQUENCY
+                            The frequency in seconds at which system metrics are
+                            collected
+      --metrics-blockchain-collector-frequency METRICS_BLOCKCHAIN_COLLECTOR_FREQUENCY
+                            The frequency in seconds at which blockchain metrics
+                            are collected
+
     sync mode:
-      --sync-mode {full,beam,light,none}
+      --sync-mode {header,full,beam,light,none}
+      --sync-from-checkpoint SYNC_FROM_CHECKPOINT
+                            Start syncing from a trusted checkpoint specified
+                            using URI syntax:By specific block,
+                            eth://block/byhash/<hash>?score=<score>Let etherscan
+                            pick a block near the tip,
+                            eth://block/byetherscan/latest
+      --disable-backfill    Disable backfilling of headers (introduced through
+                            checkpointing)
+      --force-beam-block-number FORCE_BEAM_BLOCK_NUMBER
+                            Force beam sync to activate on a specific block number
+                            (for testing)
 
 
 Attach a REPL to a running Trinity instance

--- a/eth2/beacon/scripts/run_beacon_nodes.py
+++ b/eth2/beacon/scripts/run_beacon_nodes.py
@@ -51,7 +51,7 @@ class Node:
     node_privkey: str
     port: int
     preferred_nodes: Tuple["Node", ...]
-    rpcport: Optional[int]
+    http_port: Optional[int]
     metrics_port: Optional[int]
     api_port: Optional[int]
 
@@ -75,7 +75,7 @@ class Node:
         port: int,
         start_time: float,
         validators: Sequence[int],
-        rpcport: Optional[int] = None,
+        http_port: Optional[int] = None,
         metrics_port: Optional[int] = None,
         api_port: Optional[int] = None,
         preferred_nodes: Optional[Tuple["Node", ...]] = None,
@@ -87,7 +87,7 @@ class Node:
         if preferred_nodes is None:
             preferred_nodes = []
         self.preferred_nodes = preferred_nodes
-        self.rpcport = rpcport
+        self.http_port = http_port
         self.metrics_port = metrics_port
         self.api_port = api_port
 
@@ -130,7 +130,7 @@ class Node:
             f"--trinity-root-dir={self.root_dir}",
             f"--beacon-nodekey={remove_0x_prefix(encode_hex(self.node_privkey.to_bytes()))}",
             f"--preferred_nodes={','.join(str(node.maddr) for node in self.preferred_nodes)}",
-            f"--rpcport={self.rpcport}",
+            f"--http-port={self.http_port}",
             "--enable-http",
             "--enable-metrics",
             "--enable-api",
@@ -230,7 +230,7 @@ async def main():
         port=30304,
         preferred_nodes=[],
         validators=[0, 1, 2, 3, 4, 5, 6, 7],
-        rpcport=8555,
+        http_port=8555,
         api_port=5555,
         start_time=start_time,
         metrics_port=9555,
@@ -241,7 +241,7 @@ async def main():
         port=30305,
         preferred_nodes=[node_alice],
         validators=[8, 9, 10, 11, 12, 13, 14, 15],
-        rpcport=8666,
+        http_port=8666,
         api_port=5666,
         start_time=start_time,
         metrics_port=9666,

--- a/newsfragments/1795.feature.rst
+++ b/newsfragments/1795.feature.rst
@@ -1,0 +1,1 @@
+Make the JSON-RPC API HTTP listen address configurable via ``--http-listen-address``

--- a/newsfragments/1803.feature.rst
+++ b/newsfragments/1803.feature.rst
@@ -1,0 +1,1 @@
+Rename ``--rpcport``  to `--http-port`` to better align with related flags

--- a/trinity/components/builtin/json_rpc/component.py
+++ b/trinity/components/builtin/json_rpc/component.py
@@ -103,12 +103,18 @@ class JsonRpcServerComponent(AsyncioIsolatedComponent):
         arg_parser.add_argument(
             "--disable-rpc",
             action="store_true",
-            help="Disables the JSON-RPC Server",
+            help="Disables the JSON-RPC server",
         )
         arg_parser.add_argument(
             "--enable-http",
             action="store_true",
-            help="Enables the HTTP Server",
+            help="Enables the HTTP server",
+        )
+        arg_parser.add_argument(
+            "--http-listen-address",
+            type=str,
+            help="Address for the HTTP server to listen on",
+            default="127.0.0.1",
         )
         arg_parser.add_argument(
             "--rpcport",
@@ -140,6 +146,7 @@ class JsonRpcServerComponent(AsyncioIsolatedComponent):
             # Run HTTP Server
             if boot_info.args.enable_http:
                 http_server = HTTPServer(
+                    host=boot_info.args.http_listen_address,
                     handler=RPCHandler.handle(rpc.execute),
                     port=boot_info.args.rpcport,
                 )

--- a/trinity/components/builtin/json_rpc/component.py
+++ b/trinity/components/builtin/json_rpc/component.py
@@ -117,7 +117,7 @@ class JsonRpcServerComponent(AsyncioIsolatedComponent):
             default="127.0.0.1",
         )
         arg_parser.add_argument(
-            "--rpcport",
+            "--http-port",
             type=int,
             help="JSON-RPC server port",
             default=8545,
@@ -148,7 +148,7 @@ class JsonRpcServerComponent(AsyncioIsolatedComponent):
                 http_server = HTTPServer(
                     host=boot_info.args.http_listen_address,
                     handler=RPCHandler.handle(rpc.execute),
-                    port=boot_info.args.rpcport,
+                    port=boot_info.args.http_port,
                 )
                 services_to_exit += (http_server,)
 


### PR DESCRIPTION
### What was wrong?

As explained in #1795, Trinity does currently not allow accessing its JSON RPC HTTP API from an external address. This should be configureable.

### How was it fixed?

1. Exposed the listen address as `--http-listen-address` but kept the default at `127.0.0.1`

2. Fixed some casing inconsistencies in the help texts (Server > server)

3. Renamed `--rpcport` to `--http-port` to be more aligned and precise (RPC doesn't necessarily refer to the HTTP API as it is an umbrella term that includes RPC access via HTTP, IPC and potentially WS in the future) 

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

[//]: # (See: https://trinity-client.readthedocs.io/en/latest/contributing.html#pull-requests)
- [x] Add entry to the [release notes](https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://i.pinimg.com/originals/89/06/de/8906de9585b9f3ce53178908eecae5d8.jpg)
