### PR TITLE
Don't print every HTTP request on log level INFO

### DIFF
--- a/newsfragments/1804.feature.rst
+++ b/newsfragments/1804.feature.rst
@@ -1,0 +1,1 @@
+Only print JSON HTTP API request access logs when Trinity runs with ``DEBUG2`` logs.

--- a/trinity/http/main.py
+++ b/trinity/http/main.py
@@ -1,4 +1,5 @@
 import asyncio
+import logging
 from typing import (
     Any,
     Callable,
@@ -9,6 +10,7 @@ from aiohttp import web
 from cancel_token import (
     CancelToken,
 )
+from eth_utils import DEBUG2_LEVEL_NUM
 
 from p2p.service import (
     BaseService,
@@ -31,6 +33,11 @@ class HTTPServer(BaseService):
         self.host = host
         self.port = port
         self.server = web.Server(handler)
+
+        # aiohttp logs every HTTP request as INFO so we want to reduce the general log level for
+        # this particular logger to WARNING except if the Trinity is configured to write DEBUG2 logs
+        if logging.getLogger().level != DEBUG2_LEVEL_NUM:
+            logging.getLogger('aiohttp.access').setLevel(logging.WARNING)
 
     async def _run(self) -> None:
         runner = web.ServerRunner(self.server)


### PR DESCRIPTION
### What was wrong?

As described in #1799 Trinity does currently print every request that is hitting the HTTP JSON RPC API with log level `INFO`.

### How was it fixed?

We can not change the log level that is used to print these as the log level is defined in 3rd party code, but this change tames the `aiohttp.access` logger to `WARNING`  **unless** Trinity itself runs with `DEBUG2` logs.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

[//]: # (See: https://trinity-client.readthedocs.io/en/latest/contributing.html#pull-requests)
- [x] Add entry to the [release notes](https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://66.media.tumblr.com/18e2f6bf6c44969cb63ebcccde5f8816/7b3647511aa13a05-e1/s500x750/d09bb365e2e599d3ff068d631d3ee1791cb86c5c.png)
