### PR TITLE
Handle ConnectionBusy exception in skeleton syncer

### DIFF
--- a/trinity/sync/common/headers.py
+++ b/trinity/sync/common/headers.py
@@ -50,7 +50,7 @@ from lahja import EndpointAPI
 
 from p2p.abc import CommandAPI
 from p2p.constants import SEAL_CHECK_RANDOM_SAMPLE_RATE
-from p2p.exceptions import BaseP2PError, PeerConnectionLost
+from p2p.exceptions import BaseP2PError, ConnectionBusy, PeerConnectionLost
 from p2p.logging import loggable
 from p2p.peer import BasePeer, PeerSubscriber
 from trinity._utils.timer import Timer
@@ -472,6 +472,9 @@ class SkeletonSyncer(Service, Generic[TChainPeer]):
             return tuple()
         except asyncio.TimeoutError:
             self.logger.debug("Timeout waiting for headers (skip=%s) from %s", skip, peer)
+            return tuple()
+        except ConnectionBusy:
+            self.logger.debug("Already waiting for headers from %s", peer)
             return tuple()
         except ValidationError as err:
             self.logger.warning(


### PR DESCRIPTION
### What was wrong?

This is an attempt to fix #1797 which consistently takes my node down. I will try this overnight to see if that actually fixes the error.

Also I wonder if running into this error actually means there's some underlying problem that should be addressed :thinking: 

### How was it fixed?


### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

[//]: # (See: https://trinity-client.readthedocs.io/en/latest/contributing.html#pull-requests)
- [ ] Add entry to the [release notes](https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses]()
