### PR TITLE
Bugfix: beam sync hung when only peer is penalized

### DIFF
--- a/newsfragments/1811.bugfix.rst
+++ b/newsfragments/1811.bugfix.rst
@@ -1,0 +1,3 @@
+Beam Sync hung indefinitely if your best peer gave you an empty response for
+state data, and it was your only peer. Now, Beam Sync recovers gracefully and
+the best peer is asked for state data again, after a brief pause.


### PR DESCRIPTION
### What was wrong?

A call to `QueeningQueue.get_queen_peer()` is meant to hang when there
is no queen. This fixed bug meant that after a queen was penalized, and
then reinserted at the end of a penalty, the get_queen_peer() call would
hang until a second peer was inserted and retrieved by
pop_fastest_peasant(). That means it hangs forever if you are only
connected to a single peer and it gets penalized.

Related to #1806 

### How was it fixed?

Did a fairly significant refactor of how `QueeningQueue` works: peer inserts now go to a helper method rather than directly into its `WaitingPeers` queue. Every insert does a queen-check. Now, any time a queen is set, an `asyncio.Event()` is fired. This allows us to decouple the `get_queen_peer()` logic from the `WaitingPeers` queue. 

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

[//]: # (See: https://trinity-client.readthedocs.io/en/latest/contributing.html#pull-requests)
- [x] Add entry to the [release notes](https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://i.pinimg.com/236x/57/bf/e1/57bfe1e70bdb2891a71fe85f487f9d34.jpg)
