### PR TITLE
Drop unused constructor argument to FromGenesisLaunchStrategy

### DIFF
--- a/trinity/sync/beam/chain.py
+++ b/trinity/sync/beam/chain.py
@@ -111,10 +111,7 @@ class BeamSyncer(Service):
             enable_backfill: bool = True) -> None:
         self.logger = get_logger('trinity.sync.beam.chain.BeamSyncer')
         if checkpoint is None:
-            self._launch_strategy: SyncLaunchStrategyAPI = FromGenesisLaunchStrategy(
-                chain_db,
-                chain
-            )
+            self._launch_strategy: SyncLaunchStrategyAPI = FromGenesisLaunchStrategy(chain_db)
         else:
             self._launch_strategy = FromCheckpointLaunchStrategy(
                 chain_db,

--- a/trinity/sync/common/headers.py
+++ b/trinity/sync/common/headers.py
@@ -110,7 +110,7 @@ class SkeletonSyncer(Service, Generic[TChainPeer]):
         self._chain = chain
         self._db = db
         if launch_strategy is None:
-            launch_strategy = FromGenesisLaunchStrategy(db, chain)
+            launch_strategy = FromGenesisLaunchStrategy(db)
 
         self._launch_strategy = launch_strategy
         self.peer = peer
@@ -839,7 +839,7 @@ class BaseHeaderChainSyncer(Service, HeaderSyncerAPI, Generic[TChainPeer]):
         self._skeleton: SkeletonSyncer[TChainPeer] = None
 
         if launch_strategy is None:
-            launch_strategy = FromGenesisLaunchStrategy(self._db, self._chain)
+            launch_strategy = FromGenesisLaunchStrategy(self._db)
 
         self._launch_strategy = launch_strategy
 

--- a/trinity/sync/common/strategies.py
+++ b/trinity/sync/common/strategies.py
@@ -58,9 +58,8 @@ class SyncLaunchStrategyAPI(ABC):
 
 class FromGenesisLaunchStrategy(SyncLaunchStrategyAPI):
 
-    def __init__(self, db: BaseAsyncHeaderDB, chain: AsyncChainAPI) -> None:
+    def __init__(self, db: BaseAsyncHeaderDB) -> None:
         self._db = db
-        self._chain = chain
 
     async def fulfill_prerequisites(self) -> None:
         pass
@@ -99,7 +98,7 @@ class FromCheckpointLaunchStrategy(SyncLaunchStrategyAPI):
         self._chain = chain
         # We wrap the `FromGenesisLaunchStrategy` because we delegate to it at times and
         # reaching for inheritance seems wrong in this case.
-        self._genesis_strategy = FromGenesisLaunchStrategy(self._db, self._chain)
+        self._genesis_strategy = FromGenesisLaunchStrategy(self._db)
         self._checkpoint = checkpoint
         self._peer_pool = peer_pool
 

--- a/trinity/sync/header/chain.py
+++ b/trinity/sync/header/chain.py
@@ -37,10 +37,7 @@ class HeaderChainSyncer(Service):
         self._peer_pool = peer_pool
 
         if checkpoint is None:
-            self._launch_strategy: SyncLaunchStrategyAPI = FromGenesisLaunchStrategy(
-                db,
-                chain
-            )
+            self._launch_strategy: SyncLaunchStrategyAPI = FromGenesisLaunchStrategy(db)
         else:
             self._launch_strategy = FromCheckpointLaunchStrategy(
                 db,


### PR DESCRIPTION
### What was wrong?

The `chain` parameter to the constructor of `FromGenesisLaunchStrategy` isn't used anywhere.

### How was it fixed?

Dropped it and removed it from all call sites.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

- no release notes entry needed

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://i.pinimg.com/originals/45/e4/9c/45e49c45a80edeb025e3e8e6365f5ef8.jpg)
