### PR TITLE
Upgrade Py-EVM to v0.3.0a18

### DIFF
--- a/newsfragments/1818.internal.rst
+++ b/newsfragments/1818.internal.rst
@@ -1,0 +1,2 @@
+Upgrade Py-EVM to v0.3.0-alpha.18 -- See `py-evm's release notes
+<https://py-evm.readthedocs.io/en/latest/release_notes.html#py-evm-0-3-0-alpha-18-2020-06-25>`_

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ import os
 import re
 from setuptools import setup, find_packages
 
-PYEVM_DEPENDENCY = "py-evm==0.3.0a17"
+PYEVM_DEPENDENCY = "py-evm==0.3.0a18"
 
 
 deps = {


### PR DESCRIPTION
### What was wrong?

Beam backfill of state and backfill of blocks depend on a newer version of Py-EVM

### How was it fixed?

Updated to latest version

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

[//]: # (See: https://trinity-client.readthedocs.io/en/latest/contributing.html#pull-requests)
- [x] Add entry to the [release notes](https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://i.ytimg.com/vi/IZJoKf1yFuo/maxresdefault.jpg)
