### PR TITLE
Implement backfill of historical blocks during beam sync

### DIFF
--- a/newsfragments/1819.feature.rst
+++ b/newsfragments/1819.feature.rst
@@ -1,0 +1,4 @@
+Implement backfill of historicial blocks during beam sync.
+The backfill automatically pauses if beam sync starts lagging behind and resumes
+as soon as it catches up again. It can also be disabled altogether
+via the ``--disable-backfill`` flag.

--- a/trinity/sync/beam/constants.py
+++ b/trinity/sync/beam/constants.py
@@ -58,3 +58,13 @@ BEAM_PIVOT_BUFFER_FRACTION = 1 / 2
 # We need MAX_UNCLE_DEPTH + 1 headers to check during uncle validation
 # We need to request one more header, to set the starting tip
 FULL_BLOCKS_NEEDED_TO_START_BEAM = MAX_UNCLE_DEPTH + 2
+
+# The number of blocks that beam sync is allowed to lag behind when resuming backfill
+MAX_LAG_TO_RESUME_BACKFILL = 0
+
+# The number of blocks that, when lagged behind, will cause backfill to pause
+MAX_LAG_TO_PAUSE_BACKFILL = 5
+
+# The time that the block backfill should idle when there are concurrently no blocks to fill.
+# Once gaps are closed they can only re-occur when beam sync pivots so it's ok to idle a fair while.
+BLOCK_BACKFILL_IDLE_TIME = PREDICTED_BLOCK_TIME * 500


### PR DESCRIPTION
### What was wrong?

As explained in #1665 we need to backfill historical blocks during beam sync.

### How was it fixed?

1. Refactored `FastChainBodySyncer` to be a little more flexible to be reused for this.
2. Added a new service `BodyChainGapSyncer` that:

- stay in an infinite loop of checking for block gaps (since they can get re-introduced indefinitely during beam sync)
- allows pause and resume

3. Run the service in `BeamSyncer`
4. Monitor the service to pause and resume based on current block lag.

### Known issues

One thing this doesn't do yet is to ensure the backfill does not use the queen peer. Not sure if this is needed for this PR? There are also questions to resolve like, what if we are only connected to a single peer? Would backfill have to wait for a second peer or would we rather say we use the single peer for backfill despite that not being optimal.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

[//]: # (See: https://trinity-client.readthedocs.io/en/latest/contributing.html#pull-requests)
- [x] Add entry to the [release notes](https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://i0.wp.com/theverybesttop10.com/wp-content/uploads/2015/12/Top-10-Very-Patient-Dogs-Waiting-In-Lines-And-Queues-4.jpg?resize=600%2C645)
