### PR TITLE
Bugfix: catch PeerConnectionLost during Pong

### DIFF
--- a/newsfragments/1821.bugfix.rst
+++ b/newsfragments/1821.bugfix.rst
@@ -1,0 +1,2 @@
+Fix for when a connection is lost while sending ``Pong``: ``p2p.exceptions.PeerConnectionLost:
+Attempted to send msg with cmd id 3 to ...``

--- a/p2p/p2p_api.py
+++ b/p2p/p2p_api.py
@@ -28,7 +28,10 @@ class PongWhenPinged(CommandHandler[Ping]):
 
     async def handle(self, connection: ConnectionAPI, cmd: Ping) -> None:
         connection.logger.debug2("Received ping on %s, replying with pong", connection)
-        connection.get_base_protocol().send(Pong(None))
+        try:
+            connection.get_base_protocol().send(Pong(None))
+        except PeerConnectionLost:
+            connection.logger.debug2("%s disconnected while sending pong", connection)
 
 
 class PingAndDisconnectIfIdle(Service):


### PR DESCRIPTION
### What was wrong?

`PeerConnectionLost` during `Pong` was uncaught and could crash the node.

### How was it fixed?

Catch it and drop it. If the peer who pinged us disappears, we don't really care and can take no action.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

[//]: # (See: https://trinity-client.readthedocs.io/en/latest/contributing.html#pull-requests)
- [x] Add entry to the [release notes](https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://i.pinimg.com/originals/b4/7c/ea/b47cea3e86db2f34ea8268c0f0b30f2e.jpg)