### PR TITLE
Fix intermittent failures in test_peer_pool_connect

### DIFF
--- a/p2p/multiplexer.py
+++ b/p2p/multiplexer.py
@@ -30,9 +30,9 @@ from p2p.abc import (
     TProtocol,
 )
 from p2p.exceptions import (
+    MalformedMessage,
     UnknownProtocol,
     UnknownProtocolCommand,
-    MalformedMessage,
 )
 from p2p.p2p_proto import BaseP2PProtocol
 from p2p._utils import (

--- a/tests/core/p2p-proto/test_server.py
+++ b/tests/core/p2p-proto/test_server.py
@@ -173,6 +173,8 @@ async def test_peer_pool_connect(monkeypatch, server, receiver_remote):
     start_peer = server.peer_pool.start_peer
 
     async def mock_start_peer(peer):
+        # Call the original start_peer() so that we create and run Peer/Connection objects,
+        # which will ensure everything is cleaned up properly.
         await start_peer(peer)
         peer_started.set()
 

--- a/tests/p2p/test_handshake.py
+++ b/tests/p2p/test_handshake.py
@@ -1,4 +1,5 @@
 import asyncio
+import contextlib
 import pytest
 
 from p2p.tools.factories import (
@@ -14,31 +15,30 @@ from p2p.handshake import (
 from p2p.tools.handshake import NoopHandshaker
 
 
-@pytest.mark.asyncio
-async def test_handshake_with_v4_and_v5_disables_snappy():
+@contextlib.asynccontextmanager
+async def _do_handshake(alice_handshakers, alice_version, bob_handshakers, bob_version):
     alice_transport, bob_transport = MemoryTransportPairFactory()
 
     alice_p2p_params = DevP2PHandshakeParamsFactory(
         client_version_string='alice-client',
         listen_port=alice_transport.remote.address.tcp_port,
+        version=alice_version,
     )
     bob_p2p_params = DevP2PHandshakeParams(
         client_version_string='bob-client',
         listen_port=bob_transport.remote.address.tcp_port,
-        version=4,
+        version=bob_version,
     )
-
-    protocol_class = ProtocolFactory()
 
     alice_coro = negotiate_protocol_handshakes(
         alice_transport,
         alice_p2p_params,
-        (NoopHandshaker(protocol_class),),
+        alice_handshakers,
     )
     bob_coro = negotiate_protocol_handshakes(
         bob_transport,
         bob_p2p_params,
-        (NoopHandshaker(protocol_class),),
+        bob_handshakers,
     )
 
     alice_result, bob_result = await asyncio.gather(alice_coro, bob_coro)
@@ -46,72 +46,69 @@ async def test_handshake_with_v4_and_v5_disables_snappy():
     alice_multiplexer, alice_p2p_receipt, alice_receipts = alice_result
     bob_multiplexer, bob_p2p_receipt, bob_receipts = bob_result
 
-    alice_p2p_protocol = alice_p2p_receipt.protocol
-    bob_p2p_protocol = bob_p2p_receipt.protocol
+    yield (alice_multiplexer, alice_p2p_receipt, alice_receipts,
+           bob_multiplexer, bob_p2p_receipt, bob_receipts)
 
-    assert isinstance(alice_p2p_protocol, P2PProtocolV5)
-    assert alice_p2p_protocol.snappy_support is False
+    # Need to manually stop the background streaming task started by
+    # negotiate_protocol_handshakes() because we never use the multiplexers in a Connection, which
+    # would do that for us.
+    await alice_multiplexer.stop_streaming()
+    await bob_multiplexer.stop_streaming()
 
-    assert isinstance(bob_p2p_protocol, P2PProtocolV4)
-    assert bob_p2p_protocol.snappy_support is False
+
+@pytest.mark.asyncio
+async def test_handshake_with_v4_and_v5_disables_snappy():
+    protocol_class = ProtocolFactory()
+    alice_handshakers = bob_handshakers = (NoopHandshaker(protocol_class),)
+    alice_version = 5
+    bob_version = 4
+    async with _do_handshake(alice_handshakers, alice_version, bob_handshakers, bob_version) as (
+        _, alice_p2p_receipt, _, _, bob_p2p_receipt, _
+    ):
+        alice_p2p_protocol = alice_p2p_receipt.protocol
+        bob_p2p_protocol = bob_p2p_receipt.protocol
+
+        assert isinstance(alice_p2p_protocol, P2PProtocolV5)
+        assert alice_p2p_protocol.snappy_support is False
+
+        assert isinstance(bob_p2p_protocol, P2PProtocolV4)
+        assert bob_p2p_protocol.snappy_support is False
 
 
 @pytest.mark.asyncio
 async def test_handshake_with_single_protocol():
-    alice_transport, bob_transport = MemoryTransportPairFactory()
-
-    alice_p2p_params = DevP2PHandshakeParamsFactory(
-        client_version_string='alice-client',
-        listen_port=alice_transport.remote.address.tcp_port,
-    )
-    bob_p2p_params = DevP2PHandshakeParamsFactory(
-        client_version_string='bob-client',
-        listen_port=bob_transport.remote.address.tcp_port,
-    )
-
     protocol_class = ProtocolFactory()
+    alice_handshakers = bob_handshakers = (NoopHandshaker(protocol_class),)
+    alice_version = bob_version = 5
+    async with _do_handshake(alice_handshakers, alice_version, bob_handshakers, bob_version) as (
+        alice_multiplexer, alice_p2p_receipt, alice_receipts,
+        bob_multiplexer, bob_p2p_receipt, bob_receipts
+    ):
+        assert len(alice_receipts) == 1
+        assert len(bob_receipts) == 1
 
-    alice_coro = negotiate_protocol_handshakes(
-        alice_transport,
-        alice_p2p_params,
-        (NoopHandshaker(protocol_class),),
-    )
-    bob_coro = negotiate_protocol_handshakes(
-        bob_transport,
-        bob_p2p_params,
-        (NoopHandshaker(protocol_class),),
-    )
+        alice_receipt = alice_receipts[0]
+        bob_receipt = bob_receipts[0]
 
-    alice_result, bob_result = await asyncio.gather(alice_coro, bob_coro)
+        assert alice_p2p_receipt.client_version_string == 'bob-client'
+        assert bob_p2p_receipt.client_version_string == 'alice-client'
 
-    alice_multiplexer, alice_p2p_receipt, alice_receipts = alice_result
-    bob_multiplexer, bob_p2p_receipt, bob_receipts = bob_result
+        assert isinstance(alice_receipt.protocol, protocol_class)
+        assert isinstance(bob_receipt.protocol, protocol_class)
 
-    assert len(alice_receipts) == 1
-    assert len(bob_receipts) == 1
+        assert isinstance(alice_multiplexer.get_base_protocol(), P2PProtocolV5)
+        assert isinstance(alice_multiplexer.get_protocols()[0], P2PProtocolV5)
+        assert isinstance(alice_multiplexer.get_protocols()[1], protocol_class)
 
-    alice_receipt = alice_receipts[0]
-    bob_receipt = bob_receipts[0]
+        assert isinstance(bob_multiplexer.get_base_protocol(), P2PProtocolV5)
+        assert isinstance(bob_multiplexer.get_protocols()[0], P2PProtocolV5)
+        assert isinstance(bob_multiplexer.get_protocols()[1], protocol_class)
 
-    assert alice_p2p_receipt.client_version_string == 'bob-client'
-    assert bob_p2p_receipt.client_version_string == 'alice-client'
+        alice_p2p_protocol = alice_p2p_receipt.protocol
+        assert alice_p2p_protocol.snappy_support is True
 
-    assert isinstance(alice_receipt.protocol, protocol_class)
-    assert isinstance(bob_receipt.protocol, protocol_class)
-
-    assert isinstance(alice_multiplexer.get_base_protocol(), P2PProtocolV5)
-    assert isinstance(alice_multiplexer.get_protocols()[0], P2PProtocolV5)
-    assert isinstance(alice_multiplexer.get_protocols()[1], protocol_class)
-
-    assert isinstance(bob_multiplexer.get_base_protocol(), P2PProtocolV5)
-    assert isinstance(bob_multiplexer.get_protocols()[0], P2PProtocolV5)
-    assert isinstance(bob_multiplexer.get_protocols()[1], protocol_class)
-
-    alice_p2p_protocol = alice_p2p_receipt.protocol
-    assert alice_p2p_protocol.snappy_support is True
-
-    bob_p2p_protocol = bob_p2p_receipt.protocol
-    assert bob_p2p_protocol.snappy_support is True
+        bob_p2p_protocol = bob_p2p_receipt.protocol
+        assert bob_p2p_protocol.snappy_support is True
 
 
 @pytest.mark.asyncio
@@ -131,51 +128,29 @@ async def test_handshake_with_multiple_protocols():
 
     alice_handshakers = tuple(map(NoopHandshaker, alice_protos))
     bob_handshakers = tuple(map(NoopHandshaker, bob_protos))
+    alice_version = bob_version = 5
 
-    alice_transport, bob_transport = MemoryTransportPairFactory()
+    async with _do_handshake(alice_handshakers, alice_version, bob_handshakers, bob_version) as (
+        alice_multiplexer, alice_p2p_receipt, alice_receipts,
+        bob_multiplexer, bob_p2p_receipt, bob_receipts
+    ):
+        assert len(alice_receipts) == 2
+        assert len(bob_receipts) == 2
 
-    alice_p2p_params = DevP2PHandshakeParamsFactory(
-        client_version_string='alice-client',
-        listen_port=alice_transport.remote.address.tcp_port,
-    )
-    bob_p2p_params = DevP2PHandshakeParamsFactory(
-        client_version_string='bob-client',
-        listen_port=bob_transport.remote.address.tcp_port,
-    )
+        assert isinstance(alice_p2p_receipt.protocol, P2PProtocolV5)
+        assert isinstance(alice_receipts[0].protocol, A2)
+        assert isinstance(alice_receipts[1].protocol, C3)
 
-    alice_coro = negotiate_protocol_handshakes(
-        alice_transport,
-        alice_p2p_params,
-        alice_handshakers,
-    )
-    bob_coro = negotiate_protocol_handshakes(
-        bob_transport,
-        bob_p2p_params,
-        bob_handshakers,
-    )
+        assert isinstance(alice_p2p_receipt.protocol, P2PProtocolV5)
+        assert isinstance(bob_receipts[0].protocol, A2)
+        assert isinstance(bob_receipts[1].protocol, C3)
 
-    alice_result, bob_result = await asyncio.gather(alice_coro, bob_coro)
+        assert isinstance(alice_multiplexer.get_base_protocol(), P2PProtocolV5)
+        assert isinstance(alice_multiplexer.get_protocols()[0], P2PProtocolV5)
+        assert isinstance(alice_multiplexer.get_protocols()[1], A2)
+        assert isinstance(alice_multiplexer.get_protocols()[2], C3)
 
-    alice_multiplexer, alice_p2p_receipt, alice_receipts = alice_result
-    bob_multiplexer, bob_p2p_receipt, bob_receipts = bob_result
-
-    assert len(alice_receipts) == 2
-    assert len(bob_receipts) == 2
-
-    assert isinstance(alice_p2p_receipt.protocol, P2PProtocolV5)
-    assert isinstance(alice_receipts[0].protocol, A2)
-    assert isinstance(alice_receipts[1].protocol, C3)
-
-    assert isinstance(alice_p2p_receipt.protocol, P2PProtocolV5)
-    assert isinstance(bob_receipts[0].protocol, A2)
-    assert isinstance(bob_receipts[1].protocol, C3)
-
-    assert isinstance(alice_multiplexer.get_base_protocol(), P2PProtocolV5)
-    assert isinstance(alice_multiplexer.get_protocols()[0], P2PProtocolV5)
-    assert isinstance(alice_multiplexer.get_protocols()[1], A2)
-    assert isinstance(alice_multiplexer.get_protocols()[2], C3)
-
-    assert isinstance(bob_multiplexer.get_base_protocol(), P2PProtocolV5)
-    assert isinstance(bob_multiplexer.get_protocols()[0], P2PProtocolV5)
-    assert isinstance(bob_multiplexer.get_protocols()[1], A2)
-    assert isinstance(bob_multiplexer.get_protocols()[2], C3)
+        assert isinstance(bob_multiplexer.get_base_protocol(), P2PProtocolV5)
+        assert isinstance(bob_multiplexer.get_protocols()[0], P2PProtocolV5)
+        assert isinstance(bob_multiplexer.get_protocols()[1], A2)
+        assert isinstance(bob_multiplexer.get_protocols()[2], C3)


### PR DESCRIPTION
That test used to sleep for 0.2s to wait for the handshake to complete, but
that was not always enough on CI. Now we use an event with a longer
timeout.

Also fixes P2P handshake tests that were causing asyncio warnings
as they were calling negotiate_protocol_handshakes() directly but were
not ensuring the background task started by that was cancelled/awaited at
the end.

Closes: #1504