### PR TITLE
Remove the ShutdownRequest feature from ComponentManager

### DIFF
--- a/p2p/logic.py
+++ b/p2p/logic.py
@@ -80,6 +80,10 @@ async def wait_first(futures: Sequence[asyncio.Future[None]]) -> None:
 
     If the task running us is cancelled, all futures will be cancelled.
     """
+    for future in futures:
+        if not isinstance(future, asyncio.Future):
+            raise ValueError("{future} is not an asyncio.Future")
+
     try:
         done, pending = await asyncio.wait(futures, return_when=asyncio.FIRST_COMPLETED)
     except asyncio.CancelledError:

--- a/trinity/components/builtin/peer_discovery/component.py
+++ b/trinity/components/builtin/peer_discovery/component.py
@@ -37,7 +37,6 @@ from trinity.config import Eth1AppConfig
 from trinity.db.eth1.header import BaseAsyncHeaderDB
 from trinity.db.manager import DBClient
 from trinity.db.eth1.header import TrioHeaderDB
-from trinity.events import ShutdownRequest
 from trinity.extensibility import (
     TrioIsolatedComponent,
 )
@@ -95,12 +94,8 @@ class PeerDiscoveryComponent(TrioIsolatedComponent):
                 (eth_cap_provider,),
             )
 
-        try:
-            with db:
-                await async_service.run_trio_service(discovery_service)
-        except Exception:
-            event_bus.broadcast_nowait(ShutdownRequest("Discovery ended unexpectedly"))
-            raise
+        with db:
+            await async_service.run_trio_service(discovery_service)
 
 
 async def generate_eth_cap_enr_field(

--- a/trinity/components/eth2/eth1_monitor/component.py
+++ b/trinity/components/eth2/eth1_monitor/component.py
@@ -17,7 +17,6 @@ from trinity.components.eth2.eth1_monitor.configs import deposit_contract_json
 from trinity.components.eth2.eth1_monitor.eth1_data_provider import FakeEth1DataProvider
 from trinity.config import BeaconAppConfig
 from trinity.db.manager import DBClient
-from trinity.events import ShutdownRequest
 from trinity.extensibility import TrioIsolatedComponent
 
 from .eth1_data_provider import AVERAGE_BLOCK_TIME
@@ -112,10 +111,4 @@ class Eth1MonitorComponent(TrioIsolatedComponent):
                 base_db=base_db,
             )
 
-            try:
-                await TrioManager.run_service(eth1_monitor_service)
-            except Exception:
-                await event_bus.broadcast(
-                    ShutdownRequest("Eth1 Monitor ended unexpectedly")
-                )
-                raise
+            await TrioManager.run_service(eth1_monitor_service)

--- a/trinity/events.py
+++ b/trinity/events.py
@@ -10,12 +10,6 @@ from lahja import (
 
 
 @dataclass
-class ShutdownRequest(BaseEvent):
-
-    reason: str = ""
-
-
-@dataclass
 class EventBusConnected(BaseEvent):
     """
     Broadcasted when a new :class:`~lahja.endpoint.Endpoint` connects to the ``main``

--- a/trinity/extensibility/asyncio.py
+++ b/trinity/extensibility/asyncio.py
@@ -12,7 +12,6 @@ from lahja import EndpointAPI
 
 from trinity._utils.logging import child_process_logging, get_logger
 from trinity._utils.profiling import profiler
-from trinity.events import ShutdownRequest
 
 from .component import BaseIsolatedComponent, TReturn
 from .event_bus import AsyncioEventBusService
@@ -54,18 +53,6 @@ class AsyncioIsolatedComponent(BaseIsolatedComponent):
                     # Currently we never reach this code path, but when we fix the issue above it
                     # will be needed.
                     return
-                except BaseException:
-                    # Leaving trinity running after a component crashes can lead to unexpected
-                    # behavior that'd be hard to debug/reproduce, so for now we shut it down if
-                    # any component crashes unexpectedly.
-                    event_bus.broadcast_nowait(ShutdownRequest(f"Unexpected error in {self}"))
-                    # Because of an issue in the ComponentManager (see comment in
-                    # _cleanup_component_task), when a component crashes and requests trinity to
-                    # shutdown, there's still a chance its exception could be lost, so we log it
-                    # here as well.
-                    self.logger.exception(
-                        "Unexpected error in component %s, shutting down trinity", self)
-                    raise
                 finally:
                     # Once we start seeing this in the logs after a Ctrl-C, we'll likely have
                     # figured out the issue above.

--- a/trinity/extensibility/component.py
+++ b/trinity/extensibility/component.py
@@ -150,27 +150,6 @@ class BaseIsolatedComponent(BaseComponent):
         yield future
 
 
-async def _cleanup_component_task(component_name: str, task: "asyncio.Future[None]") -> None:
-    logger.debug("Stopping component: %s", component_name)
-    if not task.done():
-        # XXX: This could be a component that crashed and sent a ShutdownRequest to trinity, and
-        # in that case by cancelling it we will throw away the exception that caused it to crash.
-        # Unfortunately there's no way to distinguish between a component that crashed and just
-        # hasn't terminated yet and one that is still running, as in both cases all we have is a
-        # task that is not done(), so the best thing we can do is make sure our *Component base
-        # classes log any exceptions coming from subclasses (i.e. the do_run() method) before
-        # propagating them.
-        logger.debug("%s component not done yet, cancelling it", component_name)
-        task.cancel()
-    else:
-        logger.debug("%s component already done", component_name)
-    try:
-        await task
-    except asyncio.CancelledError:
-        pass
-    logger.debug("Stopped component: %s", component_name)
-
-
 @contextlib.asynccontextmanager
 async def _run_asyncio_component_in_proc(
         component: 'AsyncioIsolatedComponent',

--- a/trinity/extensibility/trio.py
+++ b/trinity/extensibility/trio.py
@@ -14,7 +14,6 @@ from asyncio_run_in_process.typing import SubprocessKwargs
 
 from trinity._utils.logging import child_process_logging, get_logger
 from trinity._utils.profiling import profiler
-from trinity.events import ShutdownRequest
 
 from .component import BaseComponent, BaseIsolatedComponent, TReturn
 from .event_bus import TrioEventBusService
@@ -51,18 +50,6 @@ class TrioIsolatedComponent(BaseIsolatedComponent):
                 await self.do_run(event_bus)
         except (trio.Cancelled, trio.MultiError):
             # These are expected, when trinity is terminating because of a Ctrl-C
-            raise
-        except BaseException:
-            # Leaving trinity running after a component crashes can lead to unexpected
-            # behavior that'd be hard to debug/reproduce, so for now we shut it down if
-            # any component crashes unexpectedly.
-            event_bus.broadcast_nowait(ShutdownRequest(f"Unexpected error in {self}"))
-            # Because of an issue in the ComponentManager (see comment in
-            # _cleanup_component_task), when a component crashes and requests trinity to
-            # shutdown, there's still a chance its exception could be lost, so we log it
-            # here as well.
-            self.logger.exception(
-                "Unexpected error in component %s, shutting down trinity", self)
             raise
 
     async def _do_run(self) -> None:

--- a/trinity/nodes/base.py
+++ b/trinity/nodes/base.py
@@ -19,7 +19,6 @@ from trinity.db.eth1.header import (
     AsyncHeaderDB,
     BaseAsyncHeaderDB,
 )
-from trinity.events import ShutdownRequest
 from trinity.config import (
     Eth1ChainConfig,
     Eth1AppConfig,
@@ -131,8 +130,4 @@ class Node(Service, Generic[TPeer]):
             self.manager.run_daemon_child_service(self.get_p2p_server())
             self.manager.run_daemon_child_service(self.get_event_server())
             self.manager.run_daemon_child_service(self.metrics_service)
-            try:
-                await self.manager.wait_finished()
-            finally:
-                self.event_bus.broadcast_nowait(
-                    ShutdownRequest("Node exiting. Triggering shutdown"))
+            await self.manager.wait_finished()


### PR DESCRIPTION
The CM used to spawn components and only terminate if a component
explicitly sent it a ShutdownRequest, but now it terminates as soon
as any component terminates, so the ShutdownRequest mechanism became
unnecessary.