### PR TITLE
Terminate components when any of their background services do so

### DIFF
--- a/trinity/_utils/services.py
+++ b/trinity/_utils/services.py
@@ -1,0 +1,36 @@
+import asyncio
+import contextlib
+from typing import AsyncContextManager, Callable, Sequence
+
+from async_service import (
+    background_asyncio_service,
+    background_trio_service,
+    ManagerAPI,
+    ServiceAPI,
+)
+
+from p2p.logic import wait_first
+
+
+async def run_background_asyncio_services(services: Sequence[ServiceAPI]) -> None:
+    await _run_background_services(services, background_asyncio_service)
+
+
+async def run_background_trio_services(services: Sequence[ServiceAPI]) -> None:
+    await _run_background_services(services, background_trio_service)
+
+
+async def _run_background_services(
+        services: Sequence[ServiceAPI],
+        runner: Callable[[ServiceAPI], AsyncContextManager[ManagerAPI]]
+) -> None:
+    async with contextlib.AsyncExitStack() as stack:
+        managers = tuple([
+            await stack.enter_async_context(runner(service))
+            for service in services
+        ])
+        # If any of the services terminate, we do so as well.
+        await wait_first([
+            asyncio.create_task(manager.wait_finished())
+            for manager in managers
+        ])

--- a/trinity/components/builtin/json_rpc/component.py
+++ b/trinity/components/builtin/json_rpc/component.py
@@ -5,7 +5,7 @@ from argparse import (
 import contextlib
 from typing import Iterator, Tuple, Union
 
-from async_service import background_asyncio_service, Service
+from async_service import Service
 
 from lahja import EndpointAPI
 
@@ -42,6 +42,7 @@ from trinity.http.handlers.rpc_handler import RPCHandler
 from trinity.http.main import (
     HTTPServer,
 )
+from trinity._utils.services import run_background_asyncio_services
 
 
 @contextlib.contextmanager
@@ -151,9 +152,4 @@ class JsonRpcServerComponent(AsyncioIsolatedComponent):
                 )
                 services_to_exit += (http_server,)
 
-            async with contextlib.AsyncExitStack() as stack:
-                managers = tuple([
-                    await stack.enter_async_context(background_asyncio_service(service))
-                    for service in services_to_exit
-                ])
-                await managers[0].wait_finished()
+            await run_background_asyncio_services(services_to_exit)


### PR DESCRIPTION
MetricsComponent, JsonRpcServerComponent and NetworkDBComponent would
continue running until all of their background services terminated,
which could lead to malfunction and other crashes. Now they will
exit as soon as any of their services terminate

Closes: #1773
Closes: #1774
Closes: #1775