### PR TITLE
Refactor to hoist eth2 fork choice out of DB layer

### DIFF
--- a/eth2/beacon/chains/abc.py
+++ b/eth2/beacon/chains/abc.py
@@ -1,0 +1,35 @@
+from abc import ABC, abstractmethod
+
+from eth.abc import AtomicDatabaseAPI
+
+from eth2.beacon.types.attestations import Attestation
+from eth2.beacon.types.blocks import BaseSignedBeaconBlock, BeaconBlock
+from eth2.beacon.types.states import BeaconState
+from eth2.clock import Tick
+
+
+class BaseBeaconChain(ABC):
+    @classmethod
+    @abstractmethod
+    def from_genesis(
+        cls, base_db: AtomicDatabaseAPI, genesis_state: BeaconState
+    ) -> "BaseBeaconChain":
+        ...
+
+    @abstractmethod
+    def get_canonical_head(self) -> BeaconBlock:
+        ...
+
+    @abstractmethod
+    def on_tick(self, tick: Tick) -> None:
+        ...
+
+    @abstractmethod
+    def on_block(
+        self, block: BaseSignedBeaconBlock, perform_validation: bool = True
+    ) -> None:
+        ...
+
+    @abstractmethod
+    def on_attestation(self, attestation: Attestation) -> None:
+        ...

--- a/eth2/beacon/chains/testnet/altona.py
+++ b/eth2/beacon/chains/testnet/altona.py
@@ -1,0 +1,384 @@
+import logging
+from typing import Collection, Container, Iterable, Optional, Tuple, Type
+
+from eth.abc import AtomicDatabaseAPI
+from eth.exceptions import BlockNotFound
+from eth_utils import to_dict, toolz
+
+from eth2._utils.ssz import validate_imported_block_unchanged
+from eth2.beacon.chains.abc import BaseBeaconChain
+from eth2.beacon.chains.exceptions import ParentNotFoundError, SlashableBlockError
+from eth2.beacon.constants import FAR_FUTURE_SLOT, GENESIS_SLOT
+from eth2.beacon.db.abc import BaseBeaconChainDB
+from eth2.beacon.db.chain2 import BeaconChainDB, StateNotFound
+from eth2.beacon.epoch_processing_helpers import get_attesting_indices
+from eth2.beacon.fork_choice.abc import BaseForkChoice, BlockSink
+from eth2.beacon.state_machines.abc import BaseBeaconStateMachine
+from eth2.beacon.state_machines.forks.altona.state_machine import AltonaStateMachine
+from eth2.beacon.tools.misc.ssz_vector import override_lengths
+from eth2.beacon.types.attestations import Attestation
+from eth2.beacon.types.blocks import (
+    BaseBeaconBlock,
+    BaseSignedBeaconBlock,
+    BeaconBlock,
+    SignedBeaconBlock,
+)
+from eth2.beacon.types.checkpoints import Checkpoint, default_checkpoint
+from eth2.beacon.types.states import BeaconState
+from eth2.beacon.typing import Root, Slot, ValidatorIndex
+from eth2.clock import Tick
+
+StateMachineConfiguration = Tuple[Tuple[Slot, Type[BaseBeaconStateMachine]], ...]
+
+
+def _sm_configuration_has_increasing_slot(
+    sm_configuration: StateMachineConfiguration
+) -> bool:
+    last_slot = GENESIS_SLOT
+    for (slot, _state_machine_class) in sm_configuration:
+        if slot < last_slot:
+            return False
+        else:
+            last_slot = slot
+    return True
+
+
+def _validate_sm_configuration(sm_configuration: StateMachineConfiguration) -> None:
+    if not sm_configuration:
+        raise ValueError(
+            "The Chain class cannot be instantiated with an empty `sm_configuration`"
+        )
+    if not _sm_configuration_has_increasing_slot(sm_configuration):
+        raise ValueError(
+            "The Chain class requires a state machine configuration"
+            " with monotonically increasing slot number"
+        )
+
+
+@to_dict
+def _load_state_machines(
+    sm_configuration: StateMachineConfiguration
+) -> Iterable[Tuple[Container[int], BaseBeaconStateMachine]]:
+    sm_configuration += ((FAR_FUTURE_SLOT, None),)
+    for (first_fork, second_fork) in toolz.sliding_window(2, sm_configuration):
+        valid_range = range(first_fork[0], second_fork[0])
+        valid_sm = first_fork[1]()
+        yield (valid_range, valid_sm)
+
+
+class ChainDBBlockSink(BlockSink):
+    def __init__(self, chain_db: BaseBeaconChainDB) -> None:
+        self._chain_db = chain_db
+
+    def on_pruned_block(self, block: BaseBeaconBlock, canonical: bool) -> None:
+        if canonical:
+            self._chain_db.mark_canonical_block(block)
+
+
+class BeaconChain(BaseBeaconChain):
+    logger = logging.getLogger("eth2.beacon.chains.BeaconChain")
+
+    _chain_db: BaseBeaconChainDB
+    _sm_configuration = ((GENESIS_SLOT, AltonaStateMachine),)
+    _fork_choice: BaseForkChoice
+    _current_head: BeaconBlock
+    _justified_checkpoint: Checkpoint = default_checkpoint
+    _finalized_checkpoint: Checkpoint = default_checkpoint
+
+    def __init__(
+        self, chain_db: BaseBeaconChainDB, fork_choice: BaseForkChoice
+    ) -> None:
+        self._chain_db = chain_db
+
+        _validate_sm_configuration(self._sm_configuration)
+        self._state_machines_by_range = _load_state_machines(self._sm_configuration)
+
+        self._fork_choice = fork_choice
+        self._current_head = fork_choice.find_head()
+        head_state = self._chain_db.get_state_by_root(
+            self._current_head.state_root, BeaconState
+        )
+
+        self._reconcile_justification_and_finality(head_state)
+
+    @classmethod
+    def from_genesis(
+        cls, base_db: AtomicDatabaseAPI, genesis_state: BeaconState
+    ) -> "BeaconChain":
+        for starting_slot, state_machine_class in cls._sm_configuration:
+            if starting_slot == GENESIS_SLOT:
+                signed_block_class = state_machine_class.signed_block_class
+                fork_choice_class = state_machine_class.fork_choice_class
+                config = state_machine_class.config
+                # NOTE: important this happens as soon as it can...
+                override_lengths(config)
+                break
+        else:
+            raise Exception("state machine configuration missing genesis era")
+
+        assert genesis_state.slot == GENESIS_SLOT
+
+        chain_db = BeaconChainDB.from_genesis(
+            base_db, genesis_state, signed_block_class
+        )
+
+        block_sink = ChainDBBlockSink(chain_db)
+        fork_choice = fork_choice_class.from_genesis(genesis_state, config, block_sink)
+        return cls(chain_db, fork_choice)
+
+    def _get_fork_choice(self, slot: Slot) -> BaseForkChoice:
+        # NOTE: ignoring slot polymorphism for now...
+        expected_class = self._get_state_machine(slot).fork_choice_class
+        if expected_class == self._fork_choice.__class__:
+            return self._fork_choice
+        else:
+            raise NotImplementedError(
+                "a fork choice different than the one implemented was requested by slot"
+            )
+
+    def _get_state_machine(self, slot: Slot) -> BaseBeaconStateMachine:
+        """
+        Return the ``StateMachine`` instance for the given slot number.
+        """
+        # TODO iterate over ``reversed(....items())`` once we support only >=py3.8
+        for (slot_range, state_machine) in self._state_machines_by_range.items():
+            if slot in slot_range:
+                return state_machine
+        else:
+            raise Exception("state machine configuration was incorrect")
+
+    def get_canonical_head(self) -> BeaconBlock:
+        return self._current_head
+
+    def on_tick(self, tick: Tick) -> None:
+        if tick.is_first_in_slot():
+            fork_choice = self._get_fork_choice(tick.slot)
+            head = fork_choice.find_head()
+            self._update_head_if_new(head)
+
+    def _get_block_by_slot(
+        self, slot: Slot, block_class: Type[SignedBeaconBlock]
+    ) -> Optional[SignedBeaconBlock]:
+        # check in db first, implying a finalized chain
+        block = self._chain_db.get_block_by_slot(slot, block_class.block_class)
+        if block:
+            signature = self._chain_db.get_block_signature_by_root(block.hash_tree_root)
+            return SignedBeaconBlock.create(message=block, signature=signature)
+        else:
+            # check in the canonical chain according to fork choice
+            # NOTE: likely want a more efficient way to determine block by slot...
+            for block in self._fork_choice.get_canonical_chain():
+                if block.slot == slot:
+                    signature = self._chain_db.get_block_signature_by_root(
+                        block.hash_tree_root
+                    )
+                    return SignedBeaconBlock.create(message=block, signature=signature)
+            else:
+                return None
+
+    def _import_block(
+        self, block: BaseSignedBeaconBlock, perform_validation: bool = True
+    ) -> BaseSignedBeaconBlock:
+        try:
+            # NOTE: would need to introduce a "root to slot" look up here for polymorphism
+            parent_block = self._chain_db.get_block_by_root(
+                block.parent_root, BeaconBlock
+            )
+        except BlockNotFound:
+            raise ParentNotFoundError(
+                f"attempt to import block {block} but missing parent block"
+            )
+
+        # NOTE: check if block is in the canonical chain
+        # First, see if we have a block already at that slot...
+        existing_block = self._get_block_by_slot(block.slot, block.__class__)
+        if existing_block:
+            if existing_block != block:
+                # NOTE: we want to keep the block but avoid heavy state transition for now...
+                # Rationale: this block may simply be a slashable block. It could also be on
+                # a fork. Choose to defer the state materialization until we re-org via fork choice.
+                self._chain_db.persist_block(block)
+
+                raise SlashableBlockError(
+                    block,
+                    f"attempt to import {block} but canonical chain"
+                    " already has a block at this slot",
+                )
+            else:
+                # NOTE: block already imported!
+                return block
+        else:
+            head = self.get_canonical_head()
+            extension_of_head = block.parent_root == head.hash_tree_root
+            if not extension_of_head:
+                # NOTE: this arm implies we received a block for a slot _ahead_ of our head
+                # on the canonical chain...
+                # NOTE: block validity _should_ reject a block before it gets to this layer
+                # but we will double-check in the event that invariant is violated or does not hold
+                # NOTE: we elect to the block in the event of a
+                # re-org later, but do no further processing.
+                self._chain_db.persist_block(block)
+
+                raise SlashableBlockError(
+                    block,
+                    f"attempt to import {block} but canonical chain is not as far ahead",
+                )
+
+        state_machine = self._get_state_machine(block.slot)
+        state_class = state_machine.state_class
+        pre_state = self._chain_db.get_state_by_root(
+            parent_block.state_root, state_class
+        )
+
+        state, imported_block = state_machine.apply_state_transition(
+            pre_state, block, check_proposer_signature=perform_validation
+        )
+
+        if perform_validation:
+            validate_imported_block_unchanged(imported_block, block)
+
+        # NOTE: if we have a valid block/state, then record in the database.
+        self._chain_db.persist_block(block)
+        self._chain_db.persist_state(state)
+
+        self._reconcile_justification_and_finality(state)
+
+        return imported_block
+
+    def _reconcile_justification_and_finality(self, state: BeaconState) -> None:
+        justified_checkpoint = state.current_justified_checkpoint
+        finalized_checkpoint = state.finalized_checkpoint
+
+        if justified_checkpoint.epoch > self._justified_checkpoint.epoch:
+            self._justified_checkpoint = justified_checkpoint
+            self._fork_choice.update_justified(state)
+
+        if finalized_checkpoint.epoch > self._finalized_checkpoint.epoch:
+            self._finalized_checkpoint = finalized_checkpoint
+            finalized_head = self._chain_db.get_block_by_root(
+                self._finalized_checkpoint.root, BeaconBlock
+            )
+            self._chain_db.mark_finalized_head(finalized_head)
+
+    def _update_head_if_new(self, block: BeaconBlock) -> None:
+        if block != self._current_head:
+            self._current_head = block
+            self.logger.debug("new head of chain: %s", block)
+
+    def _update_fork_choice_with_block(self, block: BeaconBlock) -> None:
+        """
+        NOTE: it is assumed that ``_import_block`` has successfully be called
+        before this method is run as the fork choice shares state with the underlying
+        chain db.
+
+        Adding a new ``block`` likely updates the head so we also call
+        ``_update_head_if_new`` after registering the new data with the
+        fork choice module.
+        """
+        fork_choice = self._get_fork_choice(block.slot)
+        fork_choice.on_block(block)
+        for attestation in block.body.attestations:
+            self._update_fork_choice_with_attestation(fork_choice, attestation)
+        head = fork_choice.find_head()
+        self._update_head_if_new(head)
+
+    def _update_fork_choice_with_attestation(
+        self, fork_choice: BaseForkChoice, attestation: Attestation
+    ) -> None:
+        block_root = attestation.data.beacon_block_root
+        target_epoch = attestation.data.target.epoch
+        indices = self._get_indices_from_attestation(attestation)
+        fork_choice.on_attestation(block_root, target_epoch, *indices)
+
+    def _find_present_ancestor_state(
+        self, block_root: Root
+    ) -> Tuple[BeaconState, Tuple[SignedBeaconBlock, ...]]:
+        """
+        Find the first state we have persisted that is an ancestor of ``target_block``.
+        """
+        try:
+            block = self._chain_db.get_block_by_root(block_root, BeaconBlock)
+            blocks: Tuple[SignedBeaconBlock, ...] = ()
+            # NOTE: re: bounds here; worst case, we return the genesis state.
+            for slot in range(block.slot, GENESIS_SLOT - 1, -1):
+                try:
+                    state_machine = self._get_state_machine(Slot(slot))
+                    state = self._chain_db.get_state_by_root(
+                        block.state_root, state_machine.state_class
+                    )
+                    return (state, blocks)
+                except StateNotFound:
+                    signature = self._chain_db.get_block_signature_by_root(
+                        block.hash_tree_root
+                    )
+                    blocks += (
+                        SignedBeaconBlock.create(message=block, signature=signature),
+                    )
+                    block = self._chain_db.get_block_by_root(
+                        block.parent_root, BeaconBlock
+                    )
+        except BlockNotFound:
+            raise Exception(
+                "invariant violated: querying a block that has not been persisted"
+            )
+        # NOTE: `mypy` complains without this although execution should never get here...
+        return (None, ())
+
+    def _compute_missing_state(self, target_block: BeaconBlock) -> BeaconState:
+        """
+        Calculate the state for the ``target_block``.
+
+        The chain persist states for canonical blocks.
+        In the even that we need a state that has not been persisted;
+        for example, if we are executing a re-org, then we will
+        need to compute it.
+
+        NOTE: this method will persist the new (potentially non-canonical) states.
+        """
+        state, blocks = self._find_present_ancestor_state(target_block.parent_root)
+
+        for block in reversed(blocks):
+            state_machine = self._get_state_machine(block.slot)
+            state, _ = state_machine.apply_state_transition(state, block)
+            self._chain_db.persist_state(state)
+
+        return state
+
+    def _get_indices_from_attestation(
+        self, attestation: Attestation
+    ) -> Collection[ValidatorIndex]:
+        target_block = self._chain_db.get_block_by_root(
+            attestation.data.target.root, BeaconBlock
+        )
+        try:
+            target_state = self._chain_db.get_state_by_root(
+                target_block.state_root, BeaconState
+            )
+        except StateNotFound:
+            target_state = self._compute_missing_state(target_block)
+        sm = self._get_state_machine(target_block.slot)
+        return get_attesting_indices(
+            target_state, attestation.data, attestation.aggregation_bits, sm.config
+        )
+
+    def on_block(
+        self, block: BaseSignedBeaconBlock, perform_validation: bool = True
+    ) -> None:
+        self.logger.debug("attempting import of block %s", block)
+        try:
+            imported_block = self._import_block(block, perform_validation)
+            self.logger.debug("imported new block: %s", imported_block)
+            self._update_fork_choice_with_block(block.message)
+        except SlashableBlockError:
+            # still register a block if it is a duplicate, in event of a re-org
+            # other exceptions should not add the block to the fork choice
+            self._update_fork_choice_with_block(block.message)
+            raise
+
+    def on_attestation(self, attestation: Attestation) -> None:
+        """
+        This method expects ``attestation`` to come from the wire, not one in a
+        (valid) block; attestations in blocks are handled in ``on_block``
+        """
+        fork_choice = self._get_fork_choice(attestation.data.slot)
+        self._update_fork_choice_with_attestation(fork_choice, attestation)

--- a/eth2/beacon/committee_helpers.py
+++ b/eth2/beacon/committee_helpers.py
@@ -63,7 +63,7 @@ def compute_proposer_index(
     Return from ``indices`` a random index sampled by effective balance.
     """
     if len(indices) == 0:
-        raise ValidationError("There is no any active validator.")
+        raise ValidationError("There is no active validators.")
 
     i = 0
     while True:
@@ -77,7 +77,6 @@ def compute_proposer_index(
         if effective_balance * MAX_RANDOM_BYTE >= max_effective_balance * random_byte:
             return candidate_index
 
-        # Log the warning message in case it happends.
         if i % len(indices) == 0 and i > 0:
             logger.warning(
                 "Tried over %d times in compute_proposer_index while loop.", i

--- a/eth2/beacon/db/abc.py
+++ b/eth2/beacon/db/abc.py
@@ -1,0 +1,91 @@
+from abc import ABC, abstractmethod
+from typing import Optional, Type
+
+from eth.abc import AtomicDatabaseAPI
+
+from eth2.beacon.types.blocks import BaseBeaconBlock, BaseSignedBeaconBlock
+from eth2.beacon.types.states import BeaconState
+from eth2.beacon.typing import BLSSignature, Root, Slot
+
+
+class BaseBeaconChainDB(ABC):
+    """
+    Persist data relating to a beacon chain.
+
+    Stores blocks and states with ``persist_{block,state}`` methods.
+    Any stored block or state can be subsequently queried by its hash tree root.
+
+    Once a block has been finalized (according to the fork choice) it is marked
+    as "canonical" and is available to be queried by "canonical" slot.
+    NOTE: Blocks and states are not stored by slot until they have
+    been finalized. To get data for non-finalized slots, defer to the fork choice computation.
+    """
+
+    @abstractmethod
+    def __init__(self, db: AtomicDatabaseAPI) -> None:
+        ...
+
+    @classmethod
+    @abstractmethod
+    def from_genesis(
+        cls,
+        db: AtomicDatabaseAPI,
+        genesis_state: BeaconState,
+        signed_block_class: Type[BaseSignedBeaconBlock],
+    ) -> "BaseBeaconChainDB":
+        ...
+
+    @abstractmethod
+    def get_block_by_slot(
+        self, slot: Slot, block_class: Type[BaseBeaconBlock]
+    ) -> Optional[BaseBeaconBlock]:
+        ...
+
+    @abstractmethod
+    def get_block_by_root(
+        self, block_root: Root, block_class: Type[BaseBeaconBlock]
+    ) -> BaseBeaconBlock:
+        ...
+
+    @abstractmethod
+    def get_block_signature_by_root(self, block_root: Root) -> BLSSignature:
+        """
+        ``block_root`` is the hash tree root of a beacon block.
+        This method provides a way to reconstruct the ``SignedBeaconBlock`` if required.
+        """
+        ...
+
+    @abstractmethod
+    def persist_block(self, block: BaseSignedBeaconBlock) -> None:
+        ...
+
+    @abstractmethod
+    def mark_canonical_block(self, block: BaseBeaconBlock) -> None:
+        """
+        Record the ``block`` as part of the canonical ("finalized") chain.
+        """
+        ...
+
+    @abstractmethod
+    def mark_finalized_head(self, block: BaseBeaconBlock) -> None:
+        ...
+
+    @abstractmethod
+    def get_finalized_head(self, block_class: Type[BaseBeaconBlock]) -> BaseBeaconBlock:
+        ...
+
+    @abstractmethod
+    def get_state_by_slot(
+        self, slot: Slot, state_class: Type[BeaconState]
+    ) -> Optional[BeaconState]:
+        ...
+
+    @abstractmethod
+    def get_state_by_root(
+        self, state_root: Root, state_class: Type[BeaconState]
+    ) -> BeaconState:
+        ...
+
+    @abstractmethod
+    def persist_state(self, state: BeaconState) -> None:
+        ...

--- a/eth2/beacon/db/chain2.py
+++ b/eth2/beacon/db/chain2.py
@@ -1,0 +1,126 @@
+from typing import Optional, Type
+
+from eth.abc import AtomicDatabaseAPI
+from eth.exceptions import BlockNotFound
+from eth.typing import Hash32
+import ssz
+
+from eth2.beacon.db.abc import BaseBeaconChainDB
+import eth2.beacon.db.schema2 as SchemaV1
+from eth2.beacon.genesis import get_genesis_block
+from eth2.beacon.types.blocks import BaseBeaconBlock, BaseSignedBeaconBlock
+from eth2.beacon.types.states import BeaconState
+from eth2.beacon.typing import BLSSignature, Root, Slot
+
+
+class StateNotFound(Exception):
+    pass
+
+
+class BeaconChainDB(BaseBeaconChainDB):
+    def __init__(self, db: AtomicDatabaseAPI) -> None:
+        self.db = db
+
+    @classmethod
+    def from_genesis(
+        cls,
+        db: AtomicDatabaseAPI,
+        genesis_state: BeaconState,
+        signed_block_class: Type[BaseSignedBeaconBlock],
+    ) -> "BeaconChainDB":
+        chain_db = cls(db)
+
+        genesis_block = get_genesis_block(
+            genesis_state.hash_tree_root, signed_block_class.block_class
+        )
+
+        chain_db.persist_block(signed_block_class.create(message=genesis_block))
+        chain_db.persist_state(genesis_state)
+
+        chain_db.mark_canonical_block(genesis_block)
+        chain_db.mark_finalized_head(genesis_block)
+
+        return chain_db
+
+    def get_block_by_slot(
+        self, slot: Slot, block_class: Type[BaseBeaconBlock]
+    ) -> Optional[BaseBeaconBlock]:
+        key = SchemaV1.slot_to_block_root(slot)
+        try:
+            root = Root(Hash32(self.db[key]))
+        except KeyError:
+            return None
+        return self.get_block_by_root(root, block_class)
+
+    def get_block_by_root(
+        self, block_root: Root, block_class: Type[BaseBeaconBlock]
+    ) -> BaseBeaconBlock:
+        key = SchemaV1.block_root_to_block(block_root)
+        try:
+            block_data = self.db[key]
+        except KeyError:
+            raise BlockNotFound()
+        return ssz.decode(block_data, block_class)
+
+    def get_block_signature_by_root(self, block_root: Root) -> BLSSignature:
+        """
+        ``block_root`` is the hash tree root of a beacon block.
+        This method provides a way to reconstruct the ``SignedBeaconBlock`` if required.
+        """
+        key = SchemaV1.block_root_to_signature(block_root)
+        try:
+            return BLSSignature(self.db[key])
+        except KeyError:
+            raise BlockNotFound()
+
+    def persist_block(self, signed_block: BaseSignedBeaconBlock) -> None:
+        block = signed_block.message
+        block_root = block.hash_tree_root
+
+        block_root_to_block = SchemaV1.block_root_to_block(block_root)
+        self.db[block_root_to_block] = ssz.encode(block)
+
+        signature = signed_block.signature
+        block_root_to_signature = SchemaV1.block_root_to_signature(block_root)
+        self.db[block_root_to_signature] = signature
+
+    def mark_canonical_block(self, block: BaseBeaconBlock) -> None:
+        slot_to_block_root = SchemaV1.slot_to_block_root(block.slot)
+        self.db[slot_to_block_root] = block.hash_tree_root
+
+        slot_to_state_root = SchemaV1.slot_to_state_root(block.slot)
+        self.db[slot_to_state_root] = block.state_root
+
+    def mark_finalized_head(self, block: BaseBeaconBlock) -> None:
+        finalized_head_root = SchemaV1.finalized_head_root()
+        self.db[finalized_head_root] = block.hash_tree_root
+
+    def get_finalized_head(self, block_class: Type[BaseBeaconBlock]) -> BaseBeaconBlock:
+        finalized_head_root_key = SchemaV1.finalized_head_root()
+        finalized_head_root = Root(Hash32(self.db[finalized_head_root_key]))
+        return self.get_block_by_root(finalized_head_root, block_class)
+
+    def get_state_by_slot(
+        self, slot: Slot, state_class: Type[BeaconState]
+    ) -> Optional[BeaconState]:
+        key = SchemaV1.slot_to_state_root(slot)
+        try:
+            root = Root(Hash32(self.db[key]))
+        except KeyError:
+            return None
+        return self.get_state_by_root(root, state_class)
+
+    def get_state_by_root(
+        self, state_root: Root, state_class: Type[BeaconState]
+    ) -> BeaconState:
+        key = SchemaV1.state_root_to_state(state_root)
+        try:
+            state_data = self.db[key]
+        except KeyError:
+            raise StateNotFound()
+        return ssz.decode(state_data, state_class)
+
+    def persist_state(self, state: BeaconState) -> None:
+        state_root = state.hash_tree_root
+        state_root_to_state = SchemaV1.state_root_to_state(state_root)
+        self.db[state_root_to_state] = ssz.encode(state)

--- a/eth2/beacon/db/schema2.py
+++ b/eth2/beacon/db/schema2.py
@@ -1,0 +1,27 @@
+import ssz
+
+from eth2.beacon.typing import Root, Slot
+
+
+def finalized_head_root() -> bytes:
+    return b"v1:beacon:finalized-head-root"
+
+
+def slot_to_block_root(slot: Slot) -> bytes:
+    return b"v1:beacon:slot-to-block-root:" + ssz.encode(slot, ssz.uint64)
+
+
+def block_root_to_block(root: Root) -> bytes:
+    return b"v1:beacon:block-root-to-block:" + root
+
+
+def block_root_to_signature(root: Root) -> bytes:
+    return b"v1:beacon:block-root-to-signature:" + root
+
+
+def slot_to_state_root(slot: Slot) -> bytes:
+    return b"v1:beacon:slot-to-state-root:" + ssz.encode(slot, ssz.uint64)
+
+
+def state_root_to_state(root: Root) -> bytes:
+    return b"v1:beacon:state-root-to-state:" + root

--- a/eth2/beacon/fork_choice/abc.py
+++ b/eth2/beacon/fork_choice/abc.py
@@ -1,0 +1,57 @@
+from abc import ABC, abstractmethod
+from typing import Iterable
+
+from typing_extensions import Protocol
+
+from eth2.beacon.db.abc import BaseBeaconChainDB
+from eth2.beacon.types.blocks import BaseBeaconBlock
+from eth2.beacon.types.states import BeaconState
+from eth2.beacon.typing import Epoch, Root, ValidatorIndex
+from eth2.configs import Eth2Config
+
+
+class BlockSink(Protocol):
+    def on_pruned_block(self, block: BaseBeaconBlock, canonical: bool) -> None:
+        """
+        When a block is not part of fork-choice anymore.
+        If canonical, it is finalized. If not canonical, it is orphaned.
+        """
+        ...
+
+
+class BaseForkChoice(ABC):
+    @classmethod
+    @abstractmethod
+    def from_genesis(
+        cls, genesis_state: BeaconState, config: Eth2Config, block_sink: BlockSink
+    ) -> "BaseForkChoice":
+        ...
+
+    @classmethod
+    @abstractmethod
+    def from_db(
+        cls, chain_db: BaseBeaconChainDB, config: Eth2Config, block_sink: BlockSink
+    ) -> "BaseForkChoice":
+        ...
+
+    @abstractmethod
+    def update_justified(self, state: BeaconState) -> None:
+        ...
+
+    @abstractmethod
+    def get_canonical_chain(self) -> Iterable[BaseBeaconBlock]:
+        ...
+
+    @abstractmethod
+    def on_block(self, block: BaseBeaconBlock) -> None:
+        ...
+
+    @abstractmethod
+    def on_attestation(
+        self, block_root: Root, target_epoch: Epoch, *indices: ValidatorIndex
+    ) -> None:
+        ...
+
+    @abstractmethod
+    def find_head(self) -> BaseBeaconBlock:
+        ...

--- a/eth2/beacon/fork_choice/lmd_ghost2.py
+++ b/eth2/beacon/fork_choice/lmd_ghost2.py
@@ -1,0 +1,614 @@
+from dataclasses import dataclass
+from typing import (
+    Dict,
+    Generic,
+    Iterable,
+    List,
+    NewType,
+    Optional,
+    Sequence,
+    TypeVar,
+    cast,
+)
+
+from eth2.beacon.db.abc import BaseBeaconChainDB
+from eth2.beacon.epoch_processing_helpers import get_active_validator_indices
+from eth2.beacon.fork_choice.abc import BaseForkChoice, BlockSink
+from eth2.beacon.genesis import get_genesis_block
+from eth2.beacon.helpers import compute_epoch_at_slot
+from eth2.beacon.types.blocks import BaseBeaconBlock, BeaconBlock
+from eth2.beacon.types.checkpoints import Checkpoint
+from eth2.beacon.types.states import BeaconState
+from eth2.beacon.typing import Epoch, Gwei, Root, Slot, ValidatorIndex, default_root
+from eth2.configs import Eth2Config
+
+# NOTE: copying `proto_array` implementation from:
+# https://github.com/protolambda/eth2-py-hacks/proto_array.py
+
+# Note: The Python implementation of Proto-array is an adaption of the Rust
+# implementation by Sigma Prime (Apache 2.0). The Rust implementation is in
+# turn an adaption of the original Proto-array work of @protolambda (licensed under MIT).
+# However, as part of the Eth2 specification effort, and wider discussions
+# with Eth2 implementers, the general idea of this implementation can be regarded as
+# licensed under CC0 1.0 Universal, like the Eth2 specification.
+
+ProtoNodeIndex = NewType("ProtoNodeIndex", int)
+
+T = TypeVar("T")
+
+
+class BlockNode(Generic[T]):
+    slot: Slot
+    root: Root
+    data: T
+
+    def __init__(self, slot: Slot, root: Root, data: T):
+        self.slot = slot
+        self.root = root
+        self.data = data
+
+
+class ProtoNode(Generic[T]):
+    block: BlockNode[T]
+    parent: Optional[ProtoNodeIndex]
+    justified_epoch: Epoch
+    finalized_epoch: Epoch
+    weight: int
+    best_child: Optional[ProtoNodeIndex]
+    best_descendant: Optional[ProtoNodeIndex]
+
+    def __init__(
+        self,
+        block: BlockNode[T],
+        parent: Optional[ProtoNodeIndex],
+        justified_epoch: Epoch,
+        finalized_epoch: Epoch,
+    ):
+        self.block = block
+        self.parent = parent
+        self.justified_epoch = justified_epoch
+        self.finalized_epoch = finalized_epoch
+        self.weight = 0
+        self.best_child = None
+        self.best_descendant = None
+
+
+class ProtoArray(Generic[T]):
+    _block_sink: BlockSink
+    _index_offset: ProtoNodeIndex
+    _finalized_root: Root
+    _justified_epoch: Epoch
+    _finalized_epoch: Epoch
+    nodes: List[ProtoNode[T]]
+    indices: Dict[Root, ProtoNodeIndex]
+
+    def __init__(
+        self,
+        justified_epoch: Epoch,
+        finalized_block: BlockNode[T],
+        block_sink: BlockSink,
+        config: Eth2Config,
+    ):
+        self._block_sink = block_sink
+        self._index_offset = ProtoNodeIndex(0)
+        self._justified_epoch = justified_epoch
+        finalized_epoch = compute_epoch_at_slot(
+            finalized_block.slot, config.SLOTS_PER_EPOCH
+        )
+        self._finalized_epoch = finalized_epoch
+        finalized_node = ProtoNode[T](
+            block=finalized_block,
+            parent=None,
+            justified_epoch=justified_epoch,
+            finalized_epoch=finalized_epoch,
+        )
+        self.nodes = [finalized_node]
+        self.indices = {finalized_block.root: ProtoNodeIndex(0)}
+
+    def _get_node(self, index: ProtoNodeIndex) -> ProtoNode[T]:
+        if index < self._index_offset:
+            raise IndexError(f"Minimum proto-array index is {self._index_offset}")
+        i = index - self._index_offset
+        if i > len(self.nodes):
+            raise IndexError(
+                f"Maximum proto-array index is {self._index_offset + len(self.nodes)}"
+            )
+        return self.nodes[i]
+
+    def canonical_chain(self, anchor_root: Root) -> Iterable[BlockNode[T]]:
+        """From head back to anchor root (including the anchor itself)"""
+        index: Optional[ProtoNodeIndex] = self.indices[
+            self.find_head(anchor_root).root
+        ]  # KeyError if unknown root
+        while index is not None and index >= self._index_offset:
+            node = self._get_node(index)
+            yield node.block
+            if node.block.root == anchor_root:
+                break
+            index = node.parent
+
+    def apply_score_changes(
+        self, deltas: Iterable[int], justified_epoch: Epoch, finalized_epoch: Epoch
+    ) -> None:
+        """
+        Iterate backwards through the array, touching all nodes and their parents and potentially
+        the best-child of each parent.
+
+        The structure of the `self.nodes` array ensures that the child of each node is always
+        touched before its parent.
+
+        For each node, the following is done:
+
+        - Update the node's weight with the corresponding delta (can be negative).
+        - Back-propagate each node's delta to its parents delta.
+        - Compare the current node with the parents best-child, updating it if the current node
+        should become the best child.
+        - If required, update the parents best-descendant
+          with the current node or its best-descendant.
+        """
+        deltas = list(deltas)  # Copy, during back-prop the contents are mutated.
+        assert len(deltas) == len(self.nodes) == len(self.indices)
+
+        if (
+            justified_epoch != self._justified_epoch
+            or finalized_epoch != self._finalized_epoch
+        ):
+            self._justified_epoch = justified_epoch
+            self._finalized_epoch = finalized_epoch
+
+        # Iterate backwards through all indices in `self.nodes`.
+        min_bound = self._index_offset - 1
+        max_bound = min_bound + len(self.nodes)
+        for node_index, node in zip(
+            range(max_bound, min_bound, -1), reversed(self.nodes)
+        ):
+            node_delta = deltas[node_index - self._index_offset]
+
+            # Apply the delta to the node.
+            node.weight = node.weight + node_delta
+
+            # If the node has a parent, try to update its best-child and best-descendant.
+            if node.parent is not None and node.parent >= self._index_offset:
+                # Back-propagate the nodes delta to its parent.
+                parent_index = node.parent - self._index_offset
+                deltas[parent_index] += node_delta
+
+                self._maybe_update_best_child_and_descendant(
+                    node.parent, ProtoNodeIndex(node_index)
+                )
+
+    def on_block(
+        self,
+        block: BlockNode[T],
+        parent_opt: Optional[Root],
+        justified_epoch: Epoch,
+        finalized_epoch: Epoch,
+    ) -> None:
+        """
+        Register a block with the fork choice.
+
+        It is only sane to supply a `None` parent for the genesis block.
+        """
+        # If the block is already known, simply ignore it.
+        if block.root in self.indices:
+            return
+
+        node_index = ProtoNodeIndex(self._index_offset + len(self.nodes))
+
+        parent_index = (
+            None if parent_opt is None else self.indices.get(parent_opt, None)
+        )
+
+        node = ProtoNode[T](block, parent_index, justified_epoch, finalized_epoch)
+
+        self.indices[block.root] = node_index
+        self.nodes.append(node)
+
+        if node.parent is not None:
+            self._maybe_update_best_child_and_descendant(node.parent, node_index)
+
+    def find_head(self, anchor_root: Root) -> BlockNode[T]:
+        """
+        Finds the head, starting from the anchor_root
+        subtree. (justified_root for regular fork-choice)
+
+        Follows the best-descendant links to find the best-block (i.e., head-block).
+
+        The result of this function is not guaranteed to be accurate if `on_block` has
+        been called without a subsequent `apply_score_changes` call. This is because
+        `on_block` does not attempt to walk backwards through the tree and update the
+        best-child/best-descendant links.
+        """
+        anchor_index = self.indices.get(anchor_root)  # Key error if not there
+
+        anchor_node = self._get_node(anchor_index)
+        best_descendant_index = anchor_node.best_descendant
+        if best_descendant_index is None:
+            best_descendant_index = anchor_index
+
+        best_node = self._get_node(best_descendant_index)
+
+        # Perform a sanity check that the node is indeed valid to be the head.
+        assert self._node_is_viable_for_head(best_node)
+
+        return best_node.block
+
+    def on_prune(self, anchor_root: Root) -> None:
+        """
+        Update the tree with new finalization information (or alternatively another trusted root)
+        """
+        anchor_index = self.indices[anchor_root]  # KeyError if unknown root
+        if anchor_index == self._index_offset:
+            return  # nothing to do
+
+        assert anchor_index > self._index_offset
+
+        best_index = self.indices[self.find_head(anchor_root).root]
+
+        # Remove the `self.indices` key/values for all the to-be-deleted nodes.
+        # And send the nodes to the block sink.
+        for idx, node in zip(range(self._index_offset, anchor_index), self.nodes):
+            canonical = node.best_descendant == best_index
+            self._block_sink.on_pruned_block(
+                _block_node_to_block(node.block), canonical
+            )
+            root = self.nodes[idx - self._index_offset].block.root
+            del self.indices[root]
+
+        # Drop all the nodes prior to finalization.
+        prune_index = anchor_index - self._index_offset
+        self.nodes = list(self.nodes[prune_index:])
+        # update offset
+        self._index_offset = anchor_index
+
+    def _maybe_update_best_child_and_descendant(
+        self, parent_index: ProtoNodeIndex, child_index: ProtoNodeIndex
+    ) -> None:
+        """
+        Observe the parent at `parent_index` with respect to the child at `child_index` and
+        potentially modify the `parent.best_child` and `parent.best_descendant` values.
+
+        There are four outcomes:
+
+        - The child is already the best child but it's now invalid due
+          to a FFG change and should be removed.
+        - The child is already the best child and the parent is updated
+          with the new best-descendant.
+        - The child is not the best child but becomes the best child.
+        - The child is not the best child and does not become the best child.
+        """
+        child = self._get_node(child_index)
+        parent = self._get_node(parent_index)
+
+        child_leads_to_viable_head = self._node_leads_to_viable_head(child)
+
+        # The three options that we may set the `parent.best_child` and `parent.best_descendant` to.
+
+        def change_to_none() -> None:
+            parent.best_child = None
+            parent.best_descendant = None
+
+        def change_to_child() -> None:
+            parent.best_child = child_index
+            if child.best_descendant is None:
+                parent.best_descendant = child_index
+            else:
+                parent.best_descendant = child.best_descendant
+
+        def no_change() -> None:
+            pass
+
+        if parent.best_child is not None:
+            if parent.best_child == child_index:
+                if not child_leads_to_viable_head:
+                    # If the child is already the best-child of the parent
+                    # but it's not viable for the head, remove it.
+                    change_to_none()
+                else:
+                    # If the child is the best-child already, set it again to ensure that the
+                    # best-descendant of the parent is updated.
+                    change_to_child()
+            else:
+                best_child = self._get_node(parent.best_child)
+                best_child_leads_to_viable_head = self._node_leads_to_viable_head(
+                    best_child
+                )
+
+                if child_leads_to_viable_head and (not best_child_leads_to_viable_head):
+                    # The child leads to a viable head, but the current best-child doesn't.
+                    change_to_child()
+                elif (
+                    not child_leads_to_viable_head
+                ) and best_child_leads_to_viable_head:
+                    # The best child leads to a viable head, but the child doesn't.
+                    no_change()
+                elif child.weight == best_child.weight:
+                    # Tie-breaker of equal weights by root.
+                    if child.block.root >= best_child.block.root:
+                        change_to_child()
+                    else:
+                        no_change()
+                else:
+                    # Choose the winner by weight.
+                    if child.weight >= best_child.weight:
+                        change_to_child()
+                    else:
+                        no_change()
+        else:
+            if child_leads_to_viable_head:
+                # There is no current best-child and the child is viable.
+                change_to_child()
+            else:
+                # There is no current best-child but the child is not viable.
+                no_change()
+
+    def _node_leads_to_viable_head(self, node: ProtoNode[T]) -> bool:
+        """Indicates if the node itself is viable for the head,
+           or if it's best descendant is viable for the head."""
+        if node.best_descendant is not None:
+            best_descendant = self._get_node(node.best_descendant)
+            return self._node_is_viable_for_head(best_descendant)
+        else:
+            return self._node_is_viable_for_head(node)
+
+    def _node_is_viable_for_head(self, node: ProtoNode[T]) -> bool:
+        """
+        This is the equivalent to the `filter_block_tree` function in the eth2 spec:
+
+        https://github.com/ethereum/eth2.0-specs/blob/v0.10.0/specs/phase0/fork-choice.md#filter_block_tree
+
+        Any node that has a different finalized or
+        justified epoch should not be viable for the head.
+        """
+        return (
+            node.justified_epoch == self._justified_epoch or self._justified_epoch == 0
+        ) and (
+            node.finalized_epoch == self._finalized_epoch or self._finalized_epoch == 0
+        )
+
+
+@dataclass
+class VoteTracker:
+    current_root: Root
+    next_root: Root
+    next_epoch: Epoch
+
+
+class ProtoArrayForkChoice(Generic[T]):
+    proto_array: ProtoArray[T]
+    votes: List[VoteTracker]
+    balances: Sequence[Gwei]
+
+    justified: Checkpoint
+    finalized: Checkpoint
+
+    def __init__(
+        self,
+        finalized_block: BlockNode[T],
+        finalized: Checkpoint,
+        justified: Checkpoint,
+        block_sink: BlockSink,
+        config: Eth2Config,
+    ):
+        finalized_epoch = compute_epoch_at_slot(
+            finalized_block.slot, config.SLOTS_PER_EPOCH
+        )
+        assert finalized_epoch == finalized.epoch
+        self.proto_array = ProtoArray(
+            justified.epoch, finalized_block, block_sink, config
+        )
+        self.balances = []
+        self.votes = []
+
+    def on_prune(self, anchor_root: Root) -> None:
+        self.proto_array.on_prune(anchor_root)
+
+    def get_canonical_chain(self, anchor_root: Root) -> Iterable[BlockNode[T]]:
+        self._reconcile_changes()
+        for block in self.proto_array.canonical_chain(anchor_root):
+            yield block
+
+    def process_attestation(
+        self, validator_index: ValidatorIndex, block_root: Root, target_epoch: Epoch
+    ) -> None:
+        if validator_index >= len(self.votes):
+            self.votes.extend(
+                [
+                    VoteTracker(default_root, default_root, Epoch(0))
+                    for _ in range(validator_index - len(self.votes) + 1)
+                ]
+            )
+        vote = self.votes[validator_index]
+        if target_epoch > vote.next_epoch:
+            vote.next_root = block_root
+            vote.next_epoch = target_epoch
+
+    def process_block(
+        self,
+        block: BlockNode[T],
+        parent_root: Root,
+        justified_epoch: Epoch,
+        finalized_epoch: Epoch,
+    ) -> None:
+        # NOTE: we need to patch the chain towards genesis
+        # where we take the convention that the block root of the
+        # genesis block is the ``default_root``.
+        if block.slot == 1:
+            parent_root = default_root
+        self.proto_array.on_block(block, parent_root, justified_epoch, finalized_epoch)
+
+    def update_justified(
+        self,
+        justified: Checkpoint,
+        finalized: Checkpoint,
+        justified_state_balances: Sequence[Gwei],
+    ) -> None:
+        old_balances = self.balances
+        new_balances = justified_state_balances
+
+        deltas = _compute_deltas(
+            self.proto_array.indices,
+            self.proto_array._index_offset,
+            self.votes,
+            old_balances,
+            new_balances,
+        )
+
+        self.proto_array.apply_score_changes(deltas, justified.epoch, finalized.epoch)
+
+        self.balances = new_balances
+        self.justified = justified
+        self.finalized = finalized
+
+    def _reconcile_changes(self) -> None:
+        """
+        NOTE: we call ``apply_score_changes``, see comment under ``ProtoArray.find_head``.
+        This should be called before reading the canonical chain.
+        """
+        old_balances = self.balances
+        new_balances = old_balances
+
+        deltas = _compute_deltas(
+            self.proto_array.indices,
+            self.proto_array._index_offset,
+            self.votes,
+            old_balances,
+            new_balances,
+        )
+
+        self.proto_array.apply_score_changes(
+            deltas, self.justified.epoch, self.finalized.epoch
+        )
+
+    def find_head(self) -> BlockNode[T]:
+        self._reconcile_changes()
+        # NOTE: can skip some work by starting from justified, rather than finalized head
+        return self.proto_array.find_head(self.justified.root)
+
+
+def _compute_deltas(
+    indices: Dict[Root, ProtoNodeIndex],
+    index_offset: int,
+    votes: List[VoteTracker],
+    old_balances: Sequence[Gwei],
+    new_balances: Sequence[Gwei],
+) -> Sequence[int]:
+    """
+    Returns a list of `deltas`, where there is one delta for each of the ProtoArray nodes.
+
+    The deltas are calculated between `old_balances` and `new_balances`, and/or a change of vote.
+    """
+    deltas = [0] * len(indices)
+
+    for val_index, vote in enumerate(votes):
+        # There is no need to create a score change
+        # if the validator has never voted (may not be active)
+        # or both their votes are for the zero hash (alias to the genesis block).
+        if vote.current_root == default_root and vote.next_root == default_root:
+            continue
+
+        # Validator sets may have different sizes (but attesters are not different,
+        # activation only under finality)
+        old_balance = old_balances[val_index] if val_index < len(old_balances) else 0
+        new_balance = new_balances[val_index] if val_index < len(new_balances) else 0
+
+        if vote.current_root != vote.next_root or old_balance != new_balance:
+            # Ignore the current or next vote if it is not known in `indices`.
+            # We assume that it is outside of our tree (i.e., pre-finalization)
+            # and therefore not interesting.
+            if vote.current_root in indices:
+                deltas[indices[vote.current_root] - index_offset] -= old_balance
+
+            if vote.next_root in indices:
+                deltas[indices[vote.next_root] - index_offset] += new_balance
+
+            vote.current_root = vote.next_root
+
+    return deltas
+
+
+def _block_node_to_block(node: BlockNode[T]) -> BaseBeaconBlock:
+    return cast(BaseBeaconBlock, node.data)
+
+
+def _block_to_block_node(block: BaseBeaconBlock) -> BlockNode[BaseBeaconBlock]:
+    return BlockNode(block.slot, block.hash_tree_root, block)
+
+
+class LMDGHOSTForkChoice(BaseForkChoice):
+    def __init__(
+        self,
+        finalized_block_node: BlockNode[BaseBeaconBlock],
+        finalized_state: BeaconState,
+        config: Eth2Config,
+        block_sink: BlockSink,
+    ) -> None:
+        self._config = config
+        self._impl = ProtoArrayForkChoice(
+            finalized_block_node,
+            finalized_state.finalized_checkpoint,
+            finalized_state.current_justified_checkpoint,
+            block_sink,
+            config,
+        )
+        self.update_justified(finalized_state)
+
+    @classmethod
+    def from_genesis(
+        cls, genesis_state: BeaconState, config: Eth2Config, block_sink: BlockSink
+    ) -> "LMDGHOSTForkChoice":
+        # NOTE: patch up genesis state to reflect the genesis block as an initial checkpoint
+        # this only has to be patched once at genesis
+        genesis_block = get_genesis_block(genesis_state.hash_tree_root, BeaconBlock)
+        genesis_block_node = BlockNode(genesis_block.slot, default_root, genesis_block)
+        return cls(genesis_block_node, genesis_state, config, block_sink)
+
+    @classmethod
+    def from_db(
+        cls, chain_db: BaseBeaconChainDB, config: Eth2Config, block_sink: BlockSink
+    ) -> "LMDGHOSTForkChoice":
+        finalized_head = chain_db.get_finalized_head(BeaconBlock)
+        finalized_state = chain_db.get_state_by_root(
+            finalized_head.state_root, BeaconState
+        )
+        finalized_head_node = _block_to_block_node(finalized_head)
+        # TODO: need genesis patch up here as well....
+        return cls(finalized_head_node, finalized_state, config, block_sink)
+
+    def update_justified(self, state: BeaconState) -> None:
+        """
+        Call when a new ``state`` is justified.
+        """
+        self._justified = state.current_justified_checkpoint
+        self._finalized = state.finalized_checkpoint
+
+        # NOTE: prune before updating justified as it touches some internal state...
+        self._impl.on_prune(self._finalized.root)
+        current_epoch = state.current_epoch(self._config.SLOTS_PER_EPOCH)
+        balances = tuple(
+            state.validators[i].effective_balance
+            for i in get_active_validator_indices(state.validators, current_epoch)
+        )
+        self._impl.update_justified(self._justified, self._finalized, balances)
+
+    def get_canonical_chain(self) -> Iterable[BaseBeaconBlock]:
+        for block_node in self._impl.get_canonical_chain(self._finalized.root):
+            yield _block_node_to_block(block_node)
+
+    def on_block(self, block: BaseBeaconBlock) -> None:
+        self._impl.process_block(
+            _block_to_block_node(block),
+            block.parent_root,
+            self._justified.epoch,
+            self._finalized.epoch,
+        )
+
+    def on_attestation(
+        self, block_root: Root, target_epoch: Epoch, *indices: ValidatorIndex
+    ) -> None:
+        for validator_index in indices:
+            self._impl.process_attestation(validator_index, block_root, target_epoch)
+
+    def find_head(self) -> BaseBeaconBlock:
+        node = self._impl.find_head()
+        return _block_node_to_block(node)

--- a/eth2/beacon/state_machines/abc.py
+++ b/eth2/beacon/state_machines/abc.py
@@ -1,0 +1,30 @@
+from abc import ABC, abstractmethod
+import logging
+from typing import Tuple, Type
+
+from eth2.beacon.fork_choice.abc import BaseForkChoice
+from eth2.beacon.types.blocks import BaseBeaconBlock, BaseSignedBeaconBlock
+from eth2.beacon.types.states import BeaconState
+from eth2.beacon.typing import Slot
+from eth2.configs import Eth2Config
+
+logger = logging.getLogger("trinity.beacon.state_machines")
+
+
+class BaseBeaconStateMachine(ABC):
+    config: Eth2Config = None
+
+    block_class: Type[BaseBeaconBlock] = None
+    signed_block_class: Type[BaseSignedBeaconBlock] = None
+    state_class: Type[BeaconState] = None
+    fork_choice_class: Type[BaseForkChoice]
+
+    @abstractmethod
+    def apply_state_transition(
+        self,
+        state: BeaconState,
+        signed_block: BaseSignedBeaconBlock = None,
+        future_slot: Slot = None,
+        check_proposer_signature: bool = True,
+    ) -> Tuple[BeaconState, BaseSignedBeaconBlock]:
+        ...

--- a/eth2/beacon/state_machines/forks/altona/state_machine.py
+++ b/eth2/beacon/state_machines/forks/altona/state_machine.py
@@ -1,0 +1,45 @@
+from typing import Tuple, Type  # noqa: F401
+
+from eth2.beacon.fork_choice.abc import BaseForkChoice
+from eth2.beacon.fork_choice.lmd_ghost2 import LMDGHOSTForkChoice
+from eth2.beacon.state_machines.abc import BaseBeaconStateMachine
+from eth2.beacon.state_machines.forks.serenity.state_transitions import (
+    apply_state_transition,
+)
+from eth2.beacon.state_machines.forks.skeleton_lake.configs import (
+    MINIMAL_SERENITY_CONFIG,
+)
+from eth2.beacon.types.blocks import (
+    BaseBeaconBlock,
+    BaseSignedBeaconBlock,
+    BeaconBlock,
+    SignedBeaconBlock,
+)
+from eth2.beacon.types.states import BeaconState
+from eth2.beacon.typing import Slot
+
+
+class AltonaStateMachine(BaseBeaconStateMachine):
+    config = MINIMAL_SERENITY_CONFIG
+    block_class: Type[BaseBeaconBlock] = BeaconBlock
+    signed_block_class: Type[BaseSignedBeaconBlock] = SignedBeaconBlock
+    state_class: Type[BeaconState] = BeaconState
+    fork_choice_class: Type[BaseForkChoice] = LMDGHOSTForkChoice
+
+    def apply_state_transition(
+        self,
+        state: BeaconState,
+        signed_block: BaseSignedBeaconBlock = None,
+        future_slot: Slot = None,
+        check_proposer_signature: bool = True,
+    ) -> Tuple[BeaconState, BaseSignedBeaconBlock]:
+        state = apply_state_transition(
+            self.config, state, signed_block, future_slot, check_proposer_signature
+        )
+
+        if signed_block:
+            signed_block = signed_block.transform(
+                ("message", "state_root"), state.hash_tree_root
+            )
+
+        return state, signed_block

--- a/eth2/beacon/state_machines/forks/serenity/block_validation.py
+++ b/eth2/beacon/state_machines/forks/serenity/block_validation.py
@@ -111,7 +111,9 @@ def validate_proposer_signature(
         bls.validate(signing_root, signed_block.signature, proposer_pubkey)
     except SignatureError as error:
         raise ValidationError(
-            f"Invalid Proposer Signature on block, beacon_proposer_index={beacon_proposer_index}",
+            f"Invalid proposer signature on block with proposer index"
+            f" {signed_block.message.proposer_index} and"
+            f" expected proposer index {beacon_proposer_index}",
             error,
         )
 

--- a/eth2/beacon/tools/builder/validator.py
+++ b/eth2/beacon/tools/builder/validator.py
@@ -615,6 +615,9 @@ def create_mock_signed_attestations_at_slot(
     """
     Create the mocking attestations of the given ``attestation_slot`` slot with ``keymap``.
     """
+    if voted_attesters_ratio == 0:
+        return ()
+
     committees_per_slot = get_committee_count_at_slot(
         state,
         attestation_slot,

--- a/eth2/beacon/types/blocks.py
+++ b/eth2/beacon/types/blocks.py
@@ -242,6 +242,10 @@ class BaseSignedBeaconBlock(HashableContainer):
         return self.message.state_root
 
     @property
+    def proposer_index(self) -> ValidatorIndex:
+        return self.message.proposer_index
+
+    @property
     def is_genesis(self) -> bool:
         return self.message.is_genesis
 
@@ -259,6 +263,7 @@ class BaseSignedBeaconBlock(HashableContainer):
             f" [block_root]={humanize_hash(self.message.hash_tree_root)},"
             f" [signature]={humanize_hash(self.signature)},"
             f" slot={self.slot},"
+            f" proposer_index={self.proposer_index},"
             f" parent_root={humanize_hash(self.parent_root)},"
             f" state_root={humanize_hash(self.state_root)},"
             f" body=({self.body})"

--- a/eth2/beacon/types/checkpoints.py
+++ b/eth2/beacon/types/checkpoints.py
@@ -25,5 +25,8 @@ class Checkpoint(HashableContainer):
     def __str__(self) -> str:
         return f"{self.epoch}, {humanize_hash(self.root)}"
 
+    def __repr__(self) -> str:
+        return f"{super().__repr__()}({self.epoch}, {humanize_hash(self.root)})"
+
 
 default_checkpoint = Checkpoint.create()

--- a/eth2/beacon/types/states.py
+++ b/eth2/beacon/types/states.py
@@ -177,6 +177,12 @@ class BeaconState(HashableContainer):
             f"[hash_tree_root]={humanize_hash(self.hash_tree_root)}, slot={self.slot}"
         )
 
+    def __repr__(self) -> str:
+        return (
+            f"{super().__repr__()}: [hash_tree_root]={humanize_hash(self.hash_tree_root)},"
+            f" slot={self.slot}"
+        )
+
     @property
     def validator_count(self) -> int:
         return len(self.validators)

--- a/eth2/clock/tick.py
+++ b/eth2/clock/tick.py
@@ -31,3 +31,6 @@ class Tick:
 
     def slot_in_epoch(self, slots_per_epoch: int) -> Slot:
         return Slot(self.slot % slots_per_epoch)
+
+    def is_first_in_slot(self) -> bool:
+        return self.count == 0

--- a/pytest.ini
+++ b/pytest.ini
@@ -4,3 +4,5 @@ python_paths= .
 xfail_strict=true
 log_format = %(levelname)8s  %(asctime)s  %(filename)20s  %(message)s
 log_date_format = %m-%d %H:%M:%S
+markers =
+  slow: test is known to be excessively slow...

--- a/tests/components/eth2/beacon/test_slot_ticker.py
+++ b/tests/components/eth2/beacon/test_slot_ticker.py
@@ -25,7 +25,6 @@ async def test_slot_ticker_ticking(event_bus, event_loop):
     await slot_ticker.cancel()
 
 
-@pytest.mark.slow
 @pytest.mark.asyncio
 async def test_slot_ticker_all_ticks(event_bus, event_loop):
     seconds_per_slot = 3

--- a/tests/eth2/core/beacon/chains/test_lmd_ghost_chain.py
+++ b/tests/eth2/core/beacon/chains/test_lmd_ghost_chain.py
@@ -1,0 +1,218 @@
+import random
+
+from eth_utils import to_tuple
+import pytest
+
+from eth2.beacon.chains.exceptions import SlashableBlockError
+from eth2.beacon.chains.testnet.altona import BeaconChain
+from eth2.beacon.committee_helpers import get_beacon_proposer_index
+from eth2.beacon.constants import ZERO_HASH32
+from eth2.beacon.tools.builder.proposer import create_block, generate_randao_reveal
+from eth2.beacon.tools.builder.validator import create_mock_signed_attestations_at_slot
+from eth2.beacon.types.eth1_data import Eth1Data
+from eth2.beacon.typing import Epoch, Slot
+from eth2.clock import Tick
+
+
+@pytest.fixture(scope="module")
+def validator_count():
+    """
+    NOTE: overriding here for fork choice test where
+    it is easier to test weights with more validators
+    """
+    return 64
+
+
+def _build_chain_of_blocks_with_states(
+    chain,
+    state,
+    parent_block,
+    slots,
+    config,
+    keymap,
+    attestation_participation=1.0,
+    eth1_block_hash=ZERO_HASH32,
+):
+    blocks = ()
+    states = ()
+    for slot in range(parent_block.slot + 1, parent_block.slot + 1 + slots):
+        sm = chain._get_state_machine(state.slot)
+        pre_state, _ = sm.apply_state_transition(state, future_slot=slot)
+        proposer_index = get_beacon_proposer_index(pre_state, config)
+        public_key = state.validators[proposer_index].pubkey
+        private_key = keymap[public_key]
+        randao_reveal = generate_randao_reveal(private_key, slot, pre_state, config)
+
+        attestations = create_mock_signed_attestations_at_slot(
+            state,
+            config,
+            sm,
+            slot - 1,
+            parent_block.hash_tree_root,
+            keymap,
+            voted_attesters_ratio=attestation_participation,
+        )
+        block = create_block(
+            slot,
+            parent_block.hash_tree_root,
+            randao_reveal,
+            Eth1Data.create(block_hash=eth1_block_hash),
+            attestations,
+            state,
+            sm,
+            private_key,
+        )
+
+        parent_block = block.message
+        state, block = sm.apply_state_transition(state, block)
+
+        blocks += (block,)
+        states += (state,)
+    return blocks, states
+
+
+@to_tuple
+def _mk_attestations_from(blocks, states, chain, config, keymap):
+    for block, state in zip(blocks, states):
+        sm = chain._get_state_machine(block.slot)
+        yield from create_mock_signed_attestations_at_slot(
+            state, config, sm, block.slot, block.message.hash_tree_root, keymap
+        )
+
+
+@pytest.mark.slow
+def test_chain_can_track_canonical_head_without_attestations(
+    base_db, genesis_state, genesis_block, config, keymap
+):
+    chain = BeaconChain.from_genesis(base_db, genesis_state)
+
+    genesis_head = chain.get_canonical_head()
+    assert genesis_head == genesis_block.message
+
+    some_epochs = 4
+    some_slots = some_epochs * config.SLOTS_PER_EPOCH
+    blocks, _ = _build_chain_of_blocks_with_states(
+        chain,
+        genesis_state,
+        genesis_block.message,
+        some_slots,
+        config,
+        keymap,
+        attestation_participation=0,
+    )
+    for block in blocks:
+        chain.on_block(block)
+
+    head = chain.get_canonical_head()
+    assert head == blocks[-1].message
+
+
+@pytest.mark.slow
+def test_chain_can_track_canonical_head(
+    base_db, genesis_state, genesis_block, config, keymap
+):
+    chain = BeaconChain.from_genesis(base_db, genesis_state)
+
+    genesis_head = chain.get_canonical_head()
+    assert genesis_head == genesis_block.message
+
+    some_epochs = 5
+    some_slots = some_epochs * config.SLOTS_PER_EPOCH
+    blocks, states = _build_chain_of_blocks_with_states(
+        chain, genesis_state, genesis_block.message, some_slots, config, keymap
+    )
+    for block in blocks:
+        chain.on_block(block)
+
+    head = chain.get_canonical_head()
+    assert head == blocks[-1].message
+
+    some_attack_slot = random.randint(2, head.slot)
+    blocks, _ = _build_chain_of_blocks_with_states(
+        chain,
+        states[some_attack_slot - 1],
+        blocks[some_attack_slot - 1].message,
+        5,
+        config,
+        keymap,
+        attestation_participation=0,
+    )
+    for block in blocks:
+        with pytest.raises(SlashableBlockError):
+            chain.on_block(block)
+    existing_head = head
+    head = chain.get_canonical_head()
+    assert head == existing_head
+
+
+@pytest.mark.slow
+def test_chain_can_reorg_with_attestations(
+    base_db, genesis_state, genesis_block, config, keymap
+):
+    chain = BeaconChain.from_genesis(base_db, genesis_state)
+
+    genesis_head = chain.get_canonical_head()
+    assert genesis_head == genesis_block.message
+
+    some_epochs = 5
+    some_slots = some_epochs * config.SLOTS_PER_EPOCH
+    blocks, states = _build_chain_of_blocks_with_states(
+        chain,
+        genesis_state,
+        genesis_block.message,
+        some_slots,
+        config,
+        keymap,
+        attestation_participation=0.25,
+    )
+    for block in blocks:
+        chain.on_block(block)
+
+    head = chain.get_canonical_head()
+    assert head == blocks[-1].message
+
+    # NOTE: ideally we can randomly pick a reorg slot and successfully execute a reorg...
+    # however, it becomes tricky to do reliably at low validator count as the numbers
+    # may be too low to easily get enough stake one way or the other...
+    # The following numbers are somewhat handcrafted and it would greatly improve this test
+    # if it were made more resilient to these parameters. However, the big thing blocking
+    # that is performance work so that the test runs in a short time at high validator count.
+    some_reorg_slot = 12
+    # NOTE: this block hash is selected so that
+    # we do not re-org in the chain import due to the tie breaker...
+    some_block_hash = b"\x12" * 32
+
+    blocks, states = _build_chain_of_blocks_with_states(
+        chain,
+        states[some_reorg_slot - 1],
+        blocks[some_reorg_slot - 1].message,
+        25,
+        config,
+        keymap,
+        attestation_participation=0,
+        eth1_block_hash=some_block_hash,
+    )
+    for block in blocks:
+        with pytest.raises(SlashableBlockError):
+            chain.on_block(block)
+    existing_head = head
+    head = chain.get_canonical_head()
+    assert head == existing_head
+
+    attestations = _mk_attestations_from(blocks, states, chain, config, keymap)
+    for attestation in attestations:
+        chain.on_attestation(attestation)
+    # NOTE: we have not updated the fork choice yet...
+    # This is essentially to prevent what would otherwise be a DoS
+    # vector according to this test...
+    head = chain.get_canonical_head()
+    assert head == existing_head
+
+    # NOTE: simulate a tick to run the fork choice
+    # in this case, we do not care which tick it is,
+    # as long as it is the first tick in the slot
+    chain.on_tick(Tick(0, Slot(0), Epoch(0), 0))
+
+    head = chain.get_canonical_head()
+    assert head != existing_head
+    assert head == blocks[-1].message

--- a/tests/eth2/core/beacon/db/test_chain2.py
+++ b/tests/eth2/core/beacon/db/test_chain2.py
@@ -1,0 +1,55 @@
+from eth2.beacon.constants import EMPTY_SIGNATURE, GENESIS_SLOT
+from eth2.beacon.db.chain2 import BeaconChainDB
+from eth2.beacon.types.blocks import BeaconBlock, SignedBeaconBlock
+from eth2.beacon.types.states import BeaconState
+from eth2.beacon.typing import Slot
+
+
+def test_chain2_at_genesis(base_db, genesis_state, genesis_block):
+    genesis_block = genesis_block.message
+    chain_db = BeaconChainDB.from_genesis(base_db, genesis_state, SignedBeaconBlock)
+
+    block_at_genesis = chain_db.get_block_by_slot(GENESIS_SLOT, BeaconBlock)
+    assert block_at_genesis == genesis_block
+
+    block_at_genesis = chain_db.get_block_by_root(
+        genesis_block.hash_tree_root, BeaconBlock
+    )
+    assert block_at_genesis == genesis_block
+
+    genesis_signature = chain_db.get_block_signature_by_root(
+        genesis_block.hash_tree_root
+    )
+    assert genesis_signature == EMPTY_SIGNATURE
+
+    state_at_genesis = chain_db.get_state_by_slot(GENESIS_SLOT, BeaconState)
+    assert state_at_genesis == genesis_state
+
+    state_at_genesis = chain_db.get_state_by_root(
+        genesis_state.hash_tree_root, BeaconState
+    )
+    assert state_at_genesis == genesis_state
+
+    finalized_head = chain_db.get_finalized_head(BeaconBlock)
+    assert finalized_head == genesis_block
+
+    some_future_slot = Slot(22)
+    assert not chain_db.get_block_by_slot(some_future_slot, BeaconBlock)
+    assert not chain_db.get_state_by_slot(some_future_slot, BeaconState)
+
+    block_at_future_slot = SignedBeaconBlock.create(
+        message=BeaconBlock.create(slot=some_future_slot)
+    )
+    chain_db.persist_block(block_at_future_slot)
+    future_block = chain_db.get_block_by_root(
+        block_at_future_slot.message.hash_tree_root, BeaconBlock
+    )
+    assert block_at_future_slot.message == future_block
+
+    # NOTE: only finalized blocks are stored by slot in the DB
+    # non-finalized but canonical blocks are determined by fork choice, separately from the DB
+    assert not chain_db.get_block_by_slot(some_future_slot, BeaconBlock)
+
+    # assume the fork choice did finalize this block...
+    chain_db.mark_canonical_block(block_at_future_slot.message)
+    assert chain_db.get_block_by_slot(some_future_slot, BeaconBlock) == future_block

--- a/tests/eth2/core/beacon/test_committee_helpers.py
+++ b/tests/eth2/core/beacon/test_committee_helpers.py
@@ -60,14 +60,13 @@ def test_compute_proposer_index(genesis_validators, config):
     validators = tuple()
     # NOTE: validators supplied to ``compute_proposer_index``
     # should at a minimum have 17 ETH as ``effective_balance``.
-    # Using 1 ETH should maintain the same spirit of the test and
+    # Using 0 ETH should maintain the same spirit of the test and
     # ensure we can know the candidate ahead of time.
-    one_eth_in_gwei = 1 * 10 ** 9
     for index, validator in enumerate(genesis_validators):
         if index == proposer_index:
             validators += (validator,)
         else:
-            validators += (validator.set("effective_balance", one_eth_in_gwei),)
+            validators += (validator.set("effective_balance", 0),)
 
     assert (
         compute_proposer_index(

--- a/tests/eth2/core/beacon/tools/builder/test_aggregator.py
+++ b/tests/eth2/core/beacon/tools/builder/test_aggregator.py
@@ -16,7 +16,6 @@ from eth2.beacon.tools.builder.validator import sign_transaction
 from eth2.beacon.types.attestations import Attestation
 
 
-@pytest.mark.slow
 @pytest.mark.parametrize(
     ("validator_count", "target_committee_size", "slots_per_epoch"), [(1000, 100, 10)]
 )

--- a/tests/eth2/core/beacon/tools/builder/test_validator.py
+++ b/tests/eth2/core/beacon/tools/builder/test_validator.py
@@ -8,7 +8,6 @@ from eth2._utils.bls import bls
 from eth2.beacon.tools.builder.validator import aggregate_votes, verify_votes
 
 
-@pytest.mark.slow
 @settings(max_examples=1, deadline=None)
 @given(random=st.randoms())
 @pytest.mark.parametrize(("votes_count"), [(0), (9)])

--- a/tox.ini
+++ b/tox.ini
@@ -32,7 +32,7 @@ passenv =
     TRAVIS_EVENT_TYPE
 commands=
     eth1-core: pytest -n 4 {posargs:tests/core/}
-    eth2-core: pytest -n 4 {posargs:tests/eth2/core/}
+    eth2-core: pytest -n 4 -m "not slow" {posargs:tests/eth2/core/}
     eth2-utils: pytest -n 4 {posargs:tests/eth2/utils-tests/}
     eth2-integration: pytest -n 4 {posargs:tests/eth2/integration/}
     p2p: pytest -n 4 {posargs:tests/p2p}


### PR DESCRIPTION
The existing pattern in eth1 to score each individual block (and moreover to persist that score to the DB) doesn't make as much sense in eth2 as the score of a block can change in real-time depending on messages we see on the wire.

Rather than recompute a "score" re-org if a fork appears and go to the hassle of patching up data in the DB, we lift the fork choice computation out of the DB layer. This requires some refactoring.

I'm also taking the opportunity to put down some infrastructure for our Altona testnet beacon node along the way.

#### TODO

- [x] Debug pruning to a new finalized state
- [x] Debug producing the canonical chain from a new(er) justified state
~- [ ] persist relevant fork choice context to save/restore fork choice module~
  ~- [ ] can remove `{get,mark}_get_finalized_head`?~
  ~- [ ] `from_db` vs. `from_finalized_root`?~
- [x] demonstrate re-org via attestations in test
  - [x] tighten up slashable block handling? state provision if fork-choice reorgs here?
- [x] remove `chain_db` from `LMDGHOSTForkChoice`

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://qph.fs.quoracdn.net/main-qimg-2204056be553694e42f0feb207089975)
