### PR TITLE
A collection of mini improvements

### DIFF
--- a/newsfragments/1834.bugfix.rst
+++ b/newsfragments/1834.bugfix.rst
@@ -1,0 +1,4 @@
+Only return unique trie nodes in NodeData responses to peers. Before this fix, Trinity<->Trinity
+connections where one sends a GetNodeData with duplicate hashes would cause the receiving end to
+never get the response. (it failed a validation check, and couldn't be certain the response was even
+intended for the given request)

--- a/tests/core/test_contextgroup.py
+++ b/tests/core/test_contextgroup.py
@@ -76,8 +76,10 @@ async def test_exception_inside_context_block():
     group = AsyncContextGroup([ctx(), ctx(True), ctx()])
     with pytest.raises(ValueError):
         async with group as awaitables:
-            for awaitable in awaitables:
-                await awaitable
+            empty1, exception, empty2 = await asyncio.gather(*awaitables, return_exceptions=True)
+            assert empty1 is None
+            assert empty2 is None
+            raise exception
 
     assert exit_count == 3
 

--- a/tests/core/utils/test_async_iter.py
+++ b/tests/core/utils/test_async_iter.py
@@ -1,0 +1,39 @@
+import pytest
+
+from trinity._utils.async_iter import async_take
+
+
+async def empty_iterator():
+    # trick to convince python that this is an iterator, despite yielding nothing
+    if False:
+        yield "NEVER"
+        raise AssertionError("This should never have been yielded in the first place")
+
+
+async def single_val_iterator():
+    yield "just_once"
+
+
+async def canned_iterator():
+    while True:
+        yield "spam"
+
+
+@pytest.mark.parametrize(
+    "take_count, iterator, expected_list",
+    (
+        (0, empty_iterator(), []),
+        (1, empty_iterator(), []),
+        (2, empty_iterator(), []),
+        (0, single_val_iterator(), []),
+        (1, single_val_iterator(), ["just_once"]),
+        (2, single_val_iterator(), ["just_once"]),
+        (0, canned_iterator(), []),
+        (1, canned_iterator(), ["spam"]),
+        (2, canned_iterator(), ["spam", "spam"]),
+    ),
+)
+@pytest.mark.asyncio
+async def test_async_take(take_count, iterator, expected_list):
+    actual_result = [val async for val in async_take(take_count, iterator)]
+    assert actual_result == expected_list

--- a/trinity/_utils/async_iter.py
+++ b/trinity/_utils/async_iter.py
@@ -1,7 +1,10 @@
 from typing import (
     AsyncIterable,
     Set,
+    TypeVar,
 )
+
+from eth_utils import ValidationError
 
 
 async def contains_all(async_gen: AsyncIterable[str], keywords: Set[str]) -> bool:
@@ -18,3 +21,21 @@ async def contains_all(async_gen: AsyncIterable[str], keywords: Set[str]) -> boo
         if seen_keywords == keywords:
             return True
     return False
+
+
+TYield = TypeVar('TYield')
+
+
+async def async_take(take_count: int, iterator: AsyncIterable[TYield]) -> AsyncIterable[TYield]:
+
+    if take_count < 0:
+        raise ValidationError(f"Cannot take a negative number of items: tried to take {take_count}")
+    elif take_count == 0:
+        return
+    else:
+        taken = 0
+        async for val in iterator:
+            taken += 1
+            yield val
+            if taken == take_count:
+                break

--- a/trinity/protocol/eth/servers.py
+++ b/trinity/protocol/eth/servers.py
@@ -143,7 +143,7 @@ class ETHPeerRequestHandler(BasePeerRequestHandler):
         nodes = []
         missing_node_hashes = []
         # Only serve up to MAX_STATE_FETCH items in every request.
-        for node_hash in node_hashes[:MAX_STATE_FETCH]:
+        for node_hash in set(node_hashes[:MAX_STATE_FETCH]):
             try:
                 node = await self.db.coro_get(node_hash)
             except KeyError:

--- a/trinity/protocol/eth/validators.py
+++ b/trinity/protocol/eth/validators.py
@@ -13,6 +13,7 @@ from eth.abc import BlockHeaderAPI, SignedTransactionAPI
 
 from p2p.exchange import ValidatorAPI
 
+from trinity._utils.logging import get_logger
 from trinity.protocol.common.validators import (
     BaseBlockHeadersValidator,
 )
@@ -31,7 +32,18 @@ class GetBlockHeadersValidator(BaseBlockHeadersValidator):
 
 class GetNodeDataValidator(ValidatorAPI[NodeDataBundles]):
     def __init__(self, node_hashes: Sequence[Hash32]) -> None:
+        self.logger = get_logger("trinity.protocol.eth.validators.GetNodeDataValidator")
         self.node_hashes = node_hashes
+
+        # Check for uniqueness
+        num_requested = len(node_hashes)
+        num_unique = len(set(node_hashes))
+        if num_requested != num_unique:
+            self.logger.warning(
+                "GetNodeData: Asked peer for %d trie nodes, but %d were duplicates",
+                num_requested,
+                num_requested - num_unique,
+            )
 
     def validate_result(self, response: NodeDataBundles) -> None:
         if not response:


### PR DESCRIPTION
### What was wrong?

- The `ETHRequestServer` was responding with duplicate nodes, which we considered a validation error (interestingly, we did not check the *outgoing* request for the same thing)
- `test_exception_inside_context_block()` was displaying the warning "coroutine 'test_exception_inside_context_block.<locals>.f' was never awaited"
- No (known?) existing utility to take the first N elements from an asynchronous iterator

### How was it fixed?

- Added a test for requesting multiple hashes, and make sure that the server de-duplicates the result (plus the actual fix)
- Collect, await, cancel any un-awaited coroutines in `test_exception_inside_context_block()`
- Added a new `async_take()`, with some basic tests

These are all peeled off of #1769 

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

[//]: # (See: https://trinity-client.readthedocs.io/en/latest/contributing.html#pull-requests)
- [x] Add entry to the [release notes](https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://upload.wikimedia.org/wikipedia/commons/1/18/Western_Scrub_Jay.jpg)
