### PR TITLE
Several improvements to Peer/Connection APIs 

### DIFF
--- a/p2p/connection.py
+++ b/p2p/connection.py
@@ -277,6 +277,8 @@ class Connection(ConnectionAPI, Service):
 
     def has_logic(self, name: str) -> bool:
         if self.is_closing:
+            # This is a safety net, really, as the Peer should never call this if it is no longer
+            # alive.
             raise PeerConnectionLost("Cannot look up subprotocol when connection is closing")
         return name in self._logics
 

--- a/p2p/peer.py
+++ b/p2p/peer.py
@@ -115,7 +115,7 @@ class BasePeer(Service):
     _event_bus: EndpointAPI = None
 
     base_protocol: BaseP2PProtocol
-    p2p_api: P2PAPI
+    _p2p_api: P2PAPI
 
     def __init__(self,
                  connection: ConnectionAPI,
@@ -252,11 +252,19 @@ class BasePeer(Service):
         pass
 
     async def _handle_disconnect(self, connection: ConnectionAPI, cmd: Disconnect) -> None:
-        self.p2p_api.remote_disconnect_reason = cmd.payload
+        self._p2p_api.remote_disconnect_reason = cmd.payload
         # We run as a daemon child of the connection, so cancel the connection instead of
         # ourselves to ensure asyncio-service doesn't think we're exiting when the connection is
         # still active, as that would cause a DaemonTaskExit.
         self.connection.get_manager().cancel()
+
+    @property
+    def is_alive(self) -> bool:
+        # We need this because when a remote disconnects from us the connection may be closed
+        # before the Disconnect msg is processed and cancels ourselves.
+        if not hasattr(self, 'manager'):
+            return False
+        return self.manager.is_running and not self.connection.is_closing
 
     async def run(self) -> None:
         self._start_time = time.monotonic()
@@ -265,7 +273,7 @@ class BasePeer(Service):
             async with contextlib.AsyncExitStack() as stack:
                 fut = await stack.enter_async_context(P2PAPI().as_behavior().apply(self.connection))
                 futures = [fut]
-                self.p2p_api = self.connection.get_logic('p2p', P2PAPI)
+                self._p2p_api = self.connection.get_logic('p2p', P2PAPI)
 
                 for behavior in self.get_behaviors():
                     if behavior.should_apply_to(self.connection):
@@ -295,8 +303,8 @@ class BasePeer(Service):
         finally:
             for callback in self._finished_callbacks:
                 callback(self)
-            if (self.p2p_api.local_disconnect_reason is None and
-                    self.p2p_api.remote_disconnect_reason is None):
+            if (self.local_disconnect_reason is None and
+                    self.remote_disconnect_reason is None):
                 self._send_disconnect(DisconnectReason.CLIENT_QUITTING)
             # We run as a child service of the connection, but we don't want to leave a connection
             # open if somebody cancels just us, so this ensures the connection gets closed as well.
@@ -331,9 +339,21 @@ class BasePeer(Service):
 
     def _send_disconnect(self, reason: DisconnectReason) -> None:
         try:
-            self.p2p_api.disconnect(reason)
+            self._p2p_api.disconnect(reason)
         except PeerConnectionLost:
             self.logger.debug("Tried to disconnect from %s, but already disconnected", self)
+
+    @property
+    def safe_client_version_string(self) -> str:
+        return self._p2p_api.safe_client_version_string
+
+    @property
+    def local_disconnect_reason(self) -> DisconnectReason:
+        return self._p2p_api.local_disconnect_reason
+
+    @property
+    def remote_disconnect_reason(self) -> DisconnectReason:
+        return self._p2p_api.remote_disconnect_reason
 
 
 class PeerMessage(NamedTuple):

--- a/p2p/peer_pool.py
+++ b/p2p/peer_pool.py
@@ -475,8 +475,8 @@ class BasePeerPool(Service, AsyncIterable[BasePeer]):
             self.logger.info(
                 "Removing %s from pool: local_reason=%s remote_reason=%s",
                 peer,
-                peer.p2p_api.local_disconnect_reason,
-                peer.p2p_api.remote_disconnect_reason,
+                peer.local_disconnect_reason,
+                peer.remote_disconnect_reason,
             )
             self.connected_nodes.pop(peer.session)
         else:
@@ -535,7 +535,7 @@ class BasePeerPool(Service, AsyncIterable[BasePeer]):
                 )
                 self.logger.debug(
                     "client_version_string='%s'",
-                    peer.p2p_api.safe_client_version_string,
+                    peer.safe_client_version_string,
                 )
                 try:
                     for line in peer.get_extra_stats():

--- a/scripts/peer.py
+++ b/scripts/peer.py
@@ -96,10 +96,11 @@ async def _main() -> None:
         peer = peer_pool.highest_td_peer
         if peer_class == ETHPeer:
             peer = cast(ETHPeer, peer)
-            headers = await peer.eth_api.get_block_headers(BlockNumber(2440319), max_headers=100)
+            headers = await peer.get_eth_api().get_block_headers(
+                BlockNumber(2440319), max_headers=100)
             hashes = tuple(header.hash for header in headers)
-            peer.eth_api.send_get_block_bodies(hashes)
-            peer.eth_api.send_get_receipts(hashes)
+            peer.get_eth_api().send_get_block_bodies(hashes)
+            peer.get_eth_api().send_get_receipts(hashes)
         else:
             peer = cast(LESPeer, peer)
             headers = await peer.les_api.get_block_headers(BlockNumber(2440319), max_headers=100)

--- a/tests/core/p2p-proto/test_eth_api.py
+++ b/tests/core/p2p-proto/test_eth_api.py
@@ -152,7 +152,7 @@ async def test_eth_api_properties(alice, ETHAPI_class, ETHHandshakeReceipt_class
     assert alice.connection.has_logic(ETHAPI_class.name)
     eth_api = alice.connection.get_logic(ETHAPI_class.name, ETHAPI_class)
 
-    assert eth_api is alice.eth_api
+    assert eth_api is alice.get_eth_api()
 
     eth_receipt = alice.connection.get_receipt_by_type(ETHHandshakeReceipt_class)
 
@@ -216,7 +216,7 @@ async def test_eth_api_send_status(alice, bob, StatusPayloadFactory_class, Statu
         command_fut.set_result(cmd)
 
     bob.connection.add_command_handler(Status_class, _handle_cmd)
-    alice.eth_api.send_status(payload)
+    alice.get_eth_api().send_status(payload)
 
     result = await asyncio.wait_for(command_fut, timeout=1)
     assert isinstance(result, Status_class)
@@ -233,7 +233,7 @@ async def test_eth_api_send_get_node_data(alice, bob):
         command_fut.set_result(cmd)
 
     bob.connection.add_command_handler(GetNodeDataV65, _handle_cmd)
-    alice.eth_api.send_get_node_data(payload)
+    alice.get_eth_api().send_get_node_data(payload)
 
     result = await asyncio.wait_for(command_fut, timeout=1)
     assert isinstance(result, GetNodeDataV65)
@@ -250,7 +250,7 @@ async def test_eth_api_send_get_block_headers(alice, bob):
         command_fut.set_result(cmd)
 
     bob.connection.add_command_handler(GetBlockHeadersV65, _handle_cmd)
-    alice.eth_api.send_get_block_headers(
+    alice.get_eth_api().send_get_block_headers(
         block_number_or_hash=payload.block_number_or_hash,
         max_headers=payload.block_number_or_hash,
         skip=payload.skip,

--- a/tests/core/p2p-proto/test_peer_block_body_validator_api.py
+++ b/tests/core/p2p-proto/test_peer_block_body_validator_api.py
@@ -87,10 +87,10 @@ async def test_eth_peer_get_block_bodies_round_trip_with_empty_response(eth_peer
     headers, bodies, transactions_roots, trie_data_dicts, uncles_hashes = zip(*headers_bundle)
 
     async def send_block_bodies():
-        remote.eth_api.send_block_bodies([])
+        remote.get_eth_api().send_block_bodies([])
         await asyncio.sleep(0)
 
-    get_bodies_task = asyncio.ensure_future(peer.eth_api.get_block_bodies(headers))
+    get_bodies_task = asyncio.ensure_future(peer.get_eth_api().get_block_bodies(headers))
     asyncio.ensure_future(send_block_bodies())
 
     response = await get_bodies_task
@@ -106,13 +106,13 @@ async def test_eth_peer_get_block_bodies_round_trip_with_full_response(eth_peer_
     headers, bodies, transactions_roots, trie_data_dicts, uncles_hashes = zip(*headers_bundle)
 
     async def send_block_bodies():
-        remote.eth_api.send_block_bodies(bodies)
+        remote.get_eth_api().send_block_bodies(bodies)
         await asyncio.sleep(0)
 
     transactions_bundles = tuple(zip(transactions_roots, trie_data_dicts))
     bodies_bundle = tuple(zip(bodies, transactions_bundles, uncles_hashes))
 
-    get_bodies_task = asyncio.ensure_future(peer.eth_api.get_block_bodies(headers))
+    get_bodies_task = asyncio.ensure_future(peer.get_eth_api().get_block_bodies(headers))
     asyncio.ensure_future(send_block_bodies())
 
     response = await get_bodies_task
@@ -129,13 +129,13 @@ async def test_eth_peer_get_block_bodies_round_trip_with_partial_response(eth_pe
     headers, bodies, transactions_roots, trie_data_dicts, uncles_hashes = zip(*headers_bundle)
 
     async def send_block_bodies():
-        remote.eth_api.send_block_bodies(bodies[1:])
+        remote.get_eth_api().send_block_bodies(bodies[1:])
         await asyncio.sleep(0)
 
     transactions_bundles = tuple(zip(transactions_roots, trie_data_dicts))
     bodies_bundle = tuple(zip(bodies, transactions_bundles, uncles_hashes))
 
-    get_bodies_task = asyncio.ensure_future(peer.eth_api.get_block_bodies(headers))
+    get_bodies_task = asyncio.ensure_future(peer.get_eth_api().get_block_bodies(headers))
     asyncio.ensure_future(send_block_bodies())
 
     response = await get_bodies_task
@@ -152,17 +152,17 @@ async def test_eth_peer_get_block_bodies_round_trip_with_noise(eth_peer_and_remo
     headers, bodies, transactions_roots, trie_data_dicts, uncles_hashes = zip(*headers_bundle)
 
     async def send_block_bodies():
-        remote.eth_api.send_node_data((b'', b'arst'))
+        remote.get_eth_api().send_node_data((b'', b'arst'))
         await asyncio.sleep(0)
-        remote.eth_api.send_block_bodies(bodies)
+        remote.get_eth_api().send_block_bodies(bodies)
         await asyncio.sleep(0)
-        remote.eth_api.send_node_data((b'', b'arst'))
+        remote.get_eth_api().send_node_data((b'', b'arst'))
         await asyncio.sleep(0)
 
     transactions_bundles = tuple(zip(transactions_roots, trie_data_dicts))
     bodies_bundle = tuple(zip(bodies, transactions_bundles, uncles_hashes))
 
-    get_bodies_task = asyncio.ensure_future(peer.eth_api.get_block_bodies(headers))
+    get_bodies_task = asyncio.ensure_future(peer.get_eth_api().get_block_bodies(headers))
     asyncio.ensure_future(send_block_bodies())
 
     response = await get_bodies_task
@@ -182,15 +182,15 @@ async def test_eth_peer_get_block_bodies_round_trip_no_match_invalid_response(et
     _, wrong_bodies, _, _, _ = zip(*wrong_headers_bundle)
 
     async def send_block_bodies():
-        remote.eth_api.send_block_bodies(wrong_bodies)
+        remote.get_eth_api().send_block_bodies(wrong_bodies)
         await asyncio.sleep(0)
-        remote.eth_api.send_block_bodies(bodies)
+        remote.get_eth_api().send_block_bodies(bodies)
         await asyncio.sleep(0)
 
     transactions_bundles = tuple(zip(transactions_roots, trie_data_dicts))
     bodies_bundle = tuple(zip(bodies, transactions_bundles, uncles_hashes))
 
-    get_bodies_task = asyncio.ensure_future(peer.eth_api.get_block_bodies(headers))
+    get_bodies_task = asyncio.ensure_future(peer.get_eth_api().get_block_bodies(headers))
     asyncio.ensure_future(send_block_bodies())
 
     response = await get_bodies_task

--- a/tests/core/p2p-proto/test_peer_block_header_validator_api.py
+++ b/tests/core/p2p-proto/test_peer_block_header_validator_api.py
@@ -73,9 +73,9 @@ async def test_eth_peer_get_headers_round_trip(eth_peer_and_remote,
     peer, remote = eth_peer_and_remote
 
     async def send_headers():
-        remote.eth_api.send_block_headers(headers)
+        remote.get_eth_api().send_block_headers(headers)
 
-    get_headers_task = asyncio.ensure_future(peer.chain_api.get_block_headers(*params))
+    get_headers_task = asyncio.ensure_future(peer.get_chain_api().get_block_headers(*params))
     asyncio.ensure_future(send_headers())
 
     response = await get_headers_task
@@ -92,18 +92,18 @@ async def test_eth_peer_get_headers_round_trip_concurrent_requests(eth_peer_and_
 
     async def send_headers():
         await asyncio.sleep(0.01)
-        remote.eth_api.send_block_headers(headers)
+        remote.get_eth_api().send_block_headers(headers)
         await asyncio.sleep(0.01)
-        remote.eth_api.send_block_headers(headers)
+        remote.get_eth_api().send_block_headers(headers)
         await asyncio.sleep(0.01)
-        remote.eth_api.send_block_headers(headers)
+        remote.get_eth_api().send_block_headers(headers)
 
     params = (0, 1, 0, False)
 
     tasks = [
-        asyncio.ensure_future(peer.chain_api.get_block_headers(*params)),
-        asyncio.ensure_future(peer.chain_api.get_block_headers(*params)),
-        asyncio.ensure_future(peer.chain_api.get_block_headers(*params)),
+        asyncio.ensure_future(peer.get_chain_api().get_block_headers(*params)),
+        asyncio.ensure_future(peer.get_chain_api().get_block_headers(*params)),
+        asyncio.ensure_future(peer.get_chain_api().get_block_headers(*params)),
     ]
     asyncio.ensure_future(send_headers())
     results = await asyncio.gather(*tasks)
@@ -130,7 +130,7 @@ async def test_les_peer_get_headers_round_trip(les_peer_and_remote,
 
     request_id_monitor = RequestIDMonitor()
     with request_id_monitor.subscribe_peer(remote):
-        get_headers_task = asyncio.ensure_future(peer.chain_api.get_block_headers(*params))
+        get_headers_task = asyncio.ensure_future(peer.get_chain_api().get_block_headers(*params))
         request_id = await request_id_monitor.next_request_id()
 
     remote.les_api.send_block_headers(headers, 0, request_id)
@@ -149,12 +149,13 @@ async def test_eth_peer_get_headers_round_trip_with_noise(eth_peer_and_remote):
     headers = mk_header_chain(10)
 
     async def send_responses():
-        remote.eth_api.send_node_data([b'arst', b'tsra'])
+        remote.get_eth_api().send_node_data([b'arst', b'tsra'])
         await asyncio.sleep(0)
-        remote.eth_api.send_block_headers(headers)
+        remote.get_eth_api().send_block_headers(headers)
         await asyncio.sleep(0)
 
-    get_headers_task = asyncio.ensure_future(peer.chain_api.get_block_headers(0, 10, 0, False))
+    get_headers_task = asyncio.ensure_future(
+        peer.get_chain_api().get_block_headers(0, 10, 0, False))
     asyncio.ensure_future(send_responses())
 
     response = await get_headers_task
@@ -173,14 +174,14 @@ async def test_eth_peer_get_headers_round_trip_does_not_match_invalid_response(e
     wrong_headers = mk_header_chain(10)[3:8]
 
     async def send_responses():
-        remote.eth_api.send_node_data([b'arst', b'tsra'])
+        remote.get_eth_api().send_node_data([b'arst', b'tsra'])
         await asyncio.sleep(0)
-        remote.eth_api.send_block_headers(wrong_headers)
+        remote.get_eth_api().send_block_headers(wrong_headers)
         await asyncio.sleep(0)
-        remote.eth_api.send_block_headers(headers)
+        remote.get_eth_api().send_block_headers(headers)
         await asyncio.sleep(0)
 
-    get_headers_task = asyncio.ensure_future(peer.chain_api.get_block_headers(0, 5, 0, False))
+    get_headers_task = asyncio.ensure_future(peer.get_chain_api().get_block_headers(0, 5, 0, False))
     asyncio.ensure_future(send_responses())
 
     response = await get_headers_task

--- a/tests/core/p2p-proto/test_peer_node_data_validator_api.py
+++ b/tests/core/p2p-proto/test_peer_node_data_validator_api.py
@@ -51,9 +51,9 @@ async def test_eth_peer_get_node_data_round_trip(eth_peer_and_remote, node_keys,
     node_data = tuple(zip(node_keys, nodes))
 
     async def send_node_data():
-        remote.eth_api.send_node_data(nodes)
+        remote.get_eth_api().send_node_data(nodes)
 
-    request = asyncio.ensure_future(peer.eth_api.get_node_data(node_keys))
+    request = asyncio.ensure_future(peer.get_eth_api().get_node_data(node_keys))
     asyncio.ensure_future(send_node_data())
     response = await request
 
@@ -69,13 +69,13 @@ async def test_eth_peer_get_headers_round_trip_partial_response(eth_peer_and_rem
     node_data = tuple(zip(node_keys, nodes))
 
     async def send_responses():
-        remote.eth_api.send_transactions([])
+        remote.get_eth_api().send_transactions([])
         await asyncio.sleep(0)
-        remote.eth_api.send_node_data(nodes[:10])
+        remote.get_eth_api().send_node_data(nodes[:10])
         await asyncio.sleep(0)
 
     asyncio.ensure_future(send_responses())
-    response = await peer.eth_api.get_node_data(node_keys)
+    response = await peer.get_eth_api().get_node_data(node_keys)
 
     assert len(response) == 10
     assert response[:10] == node_data[:10]
@@ -89,13 +89,13 @@ async def test_eth_peer_get_headers_round_trip_with_noise(eth_peer_and_remote):
     node_data = tuple(zip(node_keys, nodes))
 
     async def send_responses():
-        remote.eth_api.send_transactions([])
+        remote.get_eth_api().send_transactions([])
         await asyncio.sleep(0)
-        remote.eth_api.send_node_data(nodes)
+        remote.get_eth_api().send_node_data(nodes)
         await asyncio.sleep(0)
 
     asyncio.ensure_future(send_responses())
-    response = await peer.eth_api.get_node_data(node_keys)
+    response = await peer.get_eth_api().get_node_data(node_keys)
 
     assert len(response) == len(nodes)
     assert response == node_data
@@ -111,15 +111,15 @@ async def test_eth_peer_get_headers_round_trip_does_not_match_invalid_response(e
     wrong_nodes = tuple(set(mk_node() for _ in range(32)).difference(nodes))
 
     async def send_responses():
-        remote.eth_api.send_node_data(wrong_nodes)
+        remote.get_eth_api().send_node_data(wrong_nodes)
         await asyncio.sleep(0)
-        remote.eth_api.send_transactions([])
+        remote.get_eth_api().send_transactions([])
         await asyncio.sleep(0)
-        remote.eth_api.send_node_data(nodes)
+        remote.get_eth_api().send_node_data(nodes)
         await asyncio.sleep(0)
 
     asyncio.ensure_future(send_responses())
-    response = await peer.eth_api.get_node_data(node_keys)
+    response = await peer.get_eth_api().get_node_data(node_keys)
 
     assert len(response) == len(nodes)
     assert response == node_data

--- a/tests/core/p2p-proto/test_peer_receipts_validator_api.py
+++ b/tests/core/p2p-proto/test_peer_receipts_validator_api.py
@@ -58,10 +58,10 @@ async def test_eth_peer_get_receipts_round_trip_with_full_response(eth_peer_and_
     receipts_bundle = tuple(zip(receipts, trie_roots_and_data))
 
     async def send_receipts():
-        remote.eth_api.send_receipts(receipts)
+        remote.get_eth_api().send_receipts(receipts)
         await asyncio.sleep(0)
 
-    get_receipts_task = asyncio.ensure_future(peer.eth_api.get_receipts(headers))
+    get_receipts_task = asyncio.ensure_future(peer.get_eth_api().get_receipts(headers))
     asyncio.ensure_future(send_receipts())
 
     response = await get_receipts_task
@@ -79,10 +79,10 @@ async def test_eth_peer_get_receipts_round_trip_with_partial_response(eth_peer_a
     receipts_bundle = tuple(zip(receipts, trie_roots_and_data))
 
     async def send_receipts():
-        remote.eth_api.send_receipts((receipts[2], receipts[1], receipts[4]))
+        remote.get_eth_api().send_receipts((receipts[2], receipts[1], receipts[4]))
         await asyncio.sleep(0)
 
-    get_receipts_task = asyncio.ensure_future(peer.eth_api.get_receipts(headers))
+    get_receipts_task = asyncio.ensure_future(peer.get_eth_api().get_receipts(headers))
     asyncio.ensure_future(send_receipts())
 
     response = await get_receipts_task
@@ -100,14 +100,14 @@ async def test_eth_peer_get_receipts_round_trip_with_noise(eth_peer_and_remote):
     receipts_bundle = tuple(zip(receipts, trie_roots_and_data))
 
     async def send_receipts():
-        remote.eth_api.send_transactions([])
+        remote.get_eth_api().send_transactions([])
         await asyncio.sleep(0)
-        remote.eth_api.send_receipts(receipts)
+        remote.get_eth_api().send_receipts(receipts)
         await asyncio.sleep(0)
-        remote.eth_api.send_transactions([])
+        remote.get_eth_api().send_transactions([])
         await asyncio.sleep(0)
 
-    get_receipts_task = asyncio.ensure_future(peer.eth_api.get_receipts(headers))
+    get_receipts_task = asyncio.ensure_future(peer.get_eth_api().get_receipts(headers))
     asyncio.ensure_future(send_receipts())
 
     response = await get_receipts_task
@@ -128,12 +128,12 @@ async def test_eth_peer_get_receipts_round_trip_no_match_invalid_response(eth_pe
     _, wrong_receipts, _ = zip(*wrong_headers)
 
     async def send_receipts():
-        remote.eth_api.send_receipts(wrong_receipts)
+        remote.get_eth_api().send_receipts(wrong_receipts)
         await asyncio.sleep(0)
-        remote.eth_api.send_receipts(receipts)
+        remote.get_eth_api().send_receipts(receipts)
         await asyncio.sleep(0)
 
-    get_receipts_task = asyncio.ensure_future(peer.eth_api.get_receipts(headers))
+    get_receipts_task = asyncio.ensure_future(peer.get_eth_api().get_receipts(headers))
     asyncio.ensure_future(send_receipts())
 
     response = await get_receipts_task

--- a/tests/core/p2p-proto/test_requests.py
+++ b/tests/core/p2p-proto/test_requests.py
@@ -292,7 +292,8 @@ async def test_no_duplicate_node_data(request, event_loop, event_bus, chaindb_fr
             root_hash = chaindb_20.get_canonical_head().state_root
             state_root = chaindb_20.db[root_hash]
 
-            returned_nodes = await client_to_server.eth_api.get_node_data((root_hash, root_hash))
+            returned_nodes = await client_to_server.get_eth_api().get_node_data(
+                (root_hash, root_hash))
             assert returned_nodes == (
                 # Server must not send back duplicates, just the single root node
                 (root_hash, state_root),

--- a/tests/core/p2p-proto/test_stats.py
+++ b/tests/core/p2p-proto/test_stats.py
@@ -44,7 +44,7 @@ def mk_header_chain(length):
 @pytest.mark.asyncio
 async def test_eth_get_headers_empty_stats():
     async with LatestETHPeerPairFactory() as (peer, remote):
-        stats = peer.eth_api.get_extra_stats()
+        stats = peer.get_eth_api().get_extra_stats()
         assert all('None' in line for line in stats)
         assert any('BlockHeader' in line for line in stats)
 
@@ -53,17 +53,17 @@ async def test_eth_get_headers_empty_stats():
 async def test_eth_get_headers_stats():
     async with LatestETHPeerPairFactory() as (peer, remote):
         async def send_headers():
-            remote.eth_api.send_block_headers(mk_header_chain(1))
+            remote.get_eth_api().send_block_headers(mk_header_chain(1))
 
         for idx in range(1, 5):
             get_headers_task = asyncio.ensure_future(
-                peer.eth_api.get_block_headers(0, 1, 0, False)
+                peer.get_eth_api().get_block_headers(0, 1, 0, False)
             )
             asyncio.ensure_future(send_headers())
 
             await get_headers_task
 
-            stats = peer.eth_api.get_extra_stats()
+            stats = peer.get_eth_api().get_extra_stats()
 
             for line in stats:
                 if 'BlockHeaders' in line:

--- a/tests/p2p/test_peer.py
+++ b/tests/p2p/test_peer.py
@@ -22,7 +22,7 @@ async def test_disconnect_on_cancellation():
         bob.connection.add_command_handler(Disconnect, _handle_disconnect)
         await alice.manager.stop()
         await asyncio.wait_for(got_disconnect.wait(), timeout=1)
-        assert bob.p2p_api.remote_disconnect_reason == DisconnectReason.CLIENT_QUITTING
+        assert bob.remote_disconnect_reason == DisconnectReason.CLIENT_QUITTING
 
 
 @pytest.mark.asyncio
@@ -40,10 +40,10 @@ async def test_cancels_on_received_disconnect():
         # cancel itself even if alice accidentally leaves her connection open. If we used
         # alice.cancel() to send the Disconnect msg, alice would also close its connection,
         # causing bob to detect it, close its own and cause the peer to be cancelled.
-        alice.p2p_api.disconnect(DisconnectReason.CLIENT_QUITTING)
+        alice._p2p_api.disconnect(DisconnectReason.CLIENT_QUITTING)
         await asyncio.wait_for(bob.connection.manager.wait_finished(), timeout=1)
         assert bob.connection.is_closing
-        assert bob.p2p_api.remote_disconnect_reason == DisconnectReason.CLIENT_QUITTING
+        assert bob.remote_disconnect_reason == DisconnectReason.CLIENT_QUITTING
 
 
 class BehaviorCrash(Exception):

--- a/tests/p2p/test_peer_pair_factory.py
+++ b/tests/p2p/test_peer_pair_factory.py
@@ -14,7 +14,7 @@ async def test_connection_factory_with_ParagonPeer():
 
         async def handle_ping(conn, msg):
             got_ping.set()
-            bob.p2p_api.send_pong()
+            bob._p2p_api.send_pong()
 
         async def handle_pong(conn, msg):
             got_pong.set()
@@ -22,7 +22,7 @@ async def test_connection_factory_with_ParagonPeer():
         alice.connection.add_command_handler(Pong, handle_pong)
         bob.connection.add_command_handler(Ping, handle_ping)
 
-        alice.p2p_api.send_ping()
+        alice._p2p_api.send_ping()
 
         await asyncio.wait_for(got_ping.wait(), timeout=1)
         await asyncio.wait_for(got_pong.wait(), timeout=1)

--- a/trinity/components/builtin/network_db/eth1_peer_db/tracker.py
+++ b/trinity/components/builtin/network_db/eth1_peer_db/tracker.py
@@ -111,10 +111,10 @@ class BaseEth1PeerTracker(BasePeerBackend, PeerSubscriber):
             remote=peer.remote,
             is_outbound=not peer.inbound,
             last_connected_at=None,
-            genesis_hash=peer.chain_info.genesis_hash,
+            genesis_hash=peer.get_chain_info().genesis_hash,
             protocol=peer.sub_proto.name,
             protocol_version=peer.sub_proto.version,
-            network_id=peer.chain_info.network_id,
+            network_id=peer.get_chain_info().network_id,
         )
 
     def deregister_peer(self, peer: BasePeer) -> None:
@@ -125,7 +125,7 @@ class BaseEth1PeerTracker(BasePeerBackend, PeerSubscriber):
         # prevent circular import
         from trinity.protocol.common.peer import BaseChainPeer
         peer = cast(BaseChainPeer, peer)
-        if peer.p2p_api.remote_disconnect_reason is None and peer.p2p_api.remote_disconnect_reason is None:  # noqa: E501
+        if peer.remote_disconnect_reason is None and peer.remote_disconnect_reason is None:
             # we don't care about peers that don't properly disconnect
             self.logger.debug(
                 'Not tracking disconnecting peer %s[%s] missing disconnect reason',
@@ -139,7 +139,7 @@ class BaseEth1PeerTracker(BasePeerBackend, PeerSubscriber):
             self.logger.debug(
                 'Not tracking disconnecting peer %s[%s][%s] due to insufficient uptime (%s < %s)',
                 peer,
-                peer.p2p_api.local_disconnect_reason,
+                peer.local_disconnect_reason,
                 'inbound' if peer.inbound else 'outbound',
                 humanize_seconds(peer.uptime),
                 humanize_seconds(MIN_QUALIFYING_UPTIME),
@@ -150,7 +150,7 @@ class BaseEth1PeerTracker(BasePeerBackend, PeerSubscriber):
                 'Tracking disconnecting peer %s[%s][%s] with uptime: %s',
                 peer,
                 'inbound' if peer.inbound else 'outbound',
-                peer.p2p_api.local_disconnect_reason,
+                peer.local_disconnect_reason,
                 humanize_seconds(peer.uptime),
             )
 
@@ -158,10 +158,10 @@ class BaseEth1PeerTracker(BasePeerBackend, PeerSubscriber):
             remote=peer.remote,
             is_outbound=not peer.inbound,
             last_connected_at=datetime.datetime.utcnow(),
-            genesis_hash=peer.chain_info.genesis_hash,
+            genesis_hash=peer.get_chain_info().genesis_hash,
             protocol=peer.sub_proto.name,
             protocol_version=peer.sub_proto.version,
-            network_id=peer.chain_info.network_id,
+            network_id=peer.get_chain_info().network_id,
         )
 
     @abstractmethod

--- a/trinity/protocol/common/boot.py
+++ b/trinity/protocol/common/boot.py
@@ -61,7 +61,7 @@ class DAOCheckBootManager(BasePeerBootManager):
             start_block = cast(BlockNumber, dao_fork_num - 1)
 
             try:
-                headers = await self.peer.chain_api.get_block_headers(
+                headers = await self.peer.get_chain_api().get_block_headers(
                     start_block,
                     max_headers=2,
                     reverse=False,
@@ -100,8 +100,8 @@ class DAOCheckBootManager(BasePeerBootManager):
 
     async def _get_tip_header(self) -> BlockHeader:
         try:
-            headers = await self.peer.chain_api.get_block_headers(
-                self.peer.head_info.head_hash,
+            headers = await self.peer.get_chain_api().get_block_headers(
+                self.peer.get_head_info().head_hash,
                 max_headers=1,
                 timeout=CHAIN_SPLIT_CHECK_TIMEOUT,
             )

--- a/trinity/protocol/common/peer.py
+++ b/trinity/protocol/common/peer.py
@@ -1,7 +1,6 @@
 from abc import abstractmethod
 import asyncio
 import functools
-import operator
 import random
 from typing import (
     Container,
@@ -19,7 +18,6 @@ from lahja import EndpointAPI
 from pyformance.meters import SimpleGauge
 
 from eth_utils.toolz import (
-    excepts,
     groupby,
 )
 
@@ -39,7 +37,6 @@ from p2p.exceptions import (
     MalformedMessage,
     NoConnectedPeers,
     PeerConnectionLost,
-    UnknownAPI,
 )
 from p2p.metrics import (
     PeerReporterRegistry,
@@ -93,16 +90,46 @@ class BaseChainPeer(BasePeer):
     boot_manager_class = DAOCheckBootManager
     context: ChainContext
 
+    def get_chain_api(self) -> AnyETHLESAPI:
+        """
+        Returns the ETH/LES API for this peer.
+
+        Raises PeerConnectionLost if the peer is no longer alive.
+        """
+        if not self.is_alive:
+            raise PeerConnectionLost(f"{self} is no longer alive")
+        return self._chain_api
+
+    def get_head_info(self) -> HeadInfoAPI:
+        """
+        Returns the HeadInfoAPI for this peer.
+
+        Raises PeerConnectionLost if the peer is no longer alive.
+        """
+        if not self.is_alive:
+            raise PeerConnectionLost(f"{self} is no longer alive")
+        return self._head_info
+
+    def get_chain_info(self) -> ChainInfoAPI:
+        """
+        Returns the ChainInfoAPI for this peer.
+
+        Raises PeerConnectionLost if the peer is no longer alive.
+        """
+        if not self.is_alive:
+            raise PeerConnectionLost(f"{self} is no longer alive")
+        return self._chain_info
+
     @cached_property
-    def chain_api(self) -> AnyETHLESAPI:
+    def _chain_api(self) -> AnyETHLESAPI:
         return choose_eth_or_les_api(self.connection)
 
     @cached_property
-    def head_info(self) -> HeadInfoAPI:
+    def _head_info(self) -> HeadInfoAPI:
         return self.connection.get_logic(HeadInfo.name, HeadInfo)
 
     @cached_property
-    def chain_info(self) -> ChainInfoAPI:
+    def _chain_info(self) -> ChainInfoAPI:
         return self.connection.get_logic(ChainInfo.name, ChainInfo)
 
     def get_behaviors(self) -> Tuple[BehaviorAPI, ...]:
@@ -165,7 +192,7 @@ class BaseChainPeerReporterRegistry(PeerReporterRegistry[BaseChainPeer]):
         td_gauge = self._get_td_gauge(peer_id)
 
         try:
-            head_info = peer.head_info
+            head_info = peer.get_head_info()
         except PeerConnectionLost:
             head_gauge.set_value(0)
             td_gauge.set_value(0)
@@ -264,11 +291,12 @@ class BaseChainPeerPool(BasePeerPool):
         if not peers:
             raise NoConnectedPeers("No connected peers")
 
-        td_getter = excepts(
-            (PeerConnectionLost, UnknownAPI),
-            operator.attrgetter('head_info.head_td'),
-            lambda _: 0,
-        )
+        def td_getter(peer: BaseChainPeer) -> int:
+            try:
+                return peer.get_head_info().head_td
+            except PeerConnectionLost:
+                return 0
+
         peers_by_td = groupby(td_getter, peers)
         max_td = max(peers_by_td.keys())
         return random.choice(peers_by_td[max_td])
@@ -278,7 +306,7 @@ class BaseChainPeerPool(BasePeerPool):
         # harder for callsites to get a list of peers while making blocking calls, as those peers
         # might disconnect in the meantime.
         peers = tuple(self.connected_nodes.values())
-        return [peer for peer in peers if peer.head_info.head_td >= min_td]
+        return [peer for peer in peers if peer.get_head_info().head_td >= min_td]
 
     def setup_connection_tracker(self) -> BaseConnectionTracker:
         if self.has_event_bus:

--- a/trinity/protocol/common/peer_pool_event_bus.py
+++ b/trinity/protocol/common/peer_pool_event_bus.py
@@ -152,7 +152,7 @@ class PeerPoolEventServer(Service, PeerSubscriber, Generic[TPeer]):
             )
             raise PeerConnectionLost(f"Peer at {session} is gone from the pool")
         else:
-            if not peer.manager.is_running:
+            if not peer.is_alive:
                 self.logger.debug("Peer %s is not operational when selecting from pool", peer)
                 raise PeerConnectionLost(f"{peer} is no longer operational")
             else:

--- a/trinity/sync/beam/backfill.py
+++ b/trinity/sync/beam/backfill.py
@@ -507,7 +507,7 @@ class BeamStateBackfill(Service, QueenTrackerAPI):
         self._num_requests_by_peer[peer] += 1
         request_hashes = tuple(set(request.node_hash for request in request_data))
         try:
-            nodes = await peer.eth_api.get_node_data(request_hashes)
+            nodes = await peer.get_eth_api().get_node_data(request_hashes)
         except asyncio.TimeoutError:
             self._queening_queue.readd_peasant(peer, GAP_BETWEEN_TESTS * 2)
         except PeerConnectionLost:

--- a/trinity/sync/beam/queen.py
+++ b/trinity/sync/beam/queen.py
@@ -8,7 +8,6 @@ from async_service import Service
 from p2p.abc import CommandAPI
 from p2p.exceptions import (
     PeerConnectionLost,
-    UnknownAPI,
 )
 from p2p.exchange import PerformanceAPI
 from p2p.peer import BasePeer, PeerSubscriber
@@ -24,7 +23,10 @@ def queen_peer_performance_sort(tracker: PerformanceAPI) -> float:
 
 
 def _peer_sort_key(peer: ETHPeer) -> float:
-    return queen_peer_performance_sort(peer.eth_api.get_node_data.tracker)
+    # May raise PeerConnectionLost if the peer is no longer alive
+    # FIXME: This should not be hard-coded to get_node_data as we could, in theory, be used to
+    # request other types of data.
+    return queen_peer_performance_sort(peer.get_eth_api().get_node_data.tracker)
 
 
 class QueenTrackerAPI(ABC):
@@ -101,7 +103,7 @@ class QueeningQueue(Service, PeerSubscriber, QueenTrackerAPI):
         """
         while self.manager.is_running:
             peer = await self._waiting_peers.get_fastest()
-            if not peer.manager.is_running:
+            if not peer.is_alive:
                 # drop any peers that aren't alive anymore
                 self.logger.info("Dropping %s from beam peers, as no longer active", peer)
                 if peer == self._queen_peer:
@@ -114,17 +116,19 @@ class QueeningQueue(Service, PeerSubscriber, QueenTrackerAPI):
                 continue
 
             try:
-                peer_is_requesting_nodes = peer.eth_api.get_node_data.is_requesting
+                # FIXME: This should not be hard-coded to get_node_data as we could, in theory, be
+                # used to request other types of data.
+                peer_is_requesting = peer.get_eth_api().get_node_data.is_requesting
             except PeerConnectionLost:
-                self.logger.debug("QueenQueuer is skipping disconnecting peer %s", peer)
-                # Don't bother re-adding to _waiting_peers, since the peer is disconnected
-            else:
-                if peer_is_requesting_nodes:
-                    # skip the peer if there's an active request
-                    self.logger.debug("QueenQueuer is skipping active peer %s", peer)
-                    loop = asyncio.get_event_loop()
-                    loop.call_later(10, functools.partial(self._insert_peer, peer))
-                    continue
+                self.logger.debug("QueenQueuer skipping %s as it is no longer connected", peer)
+                continue
+
+            if peer_is_requesting:
+                # skip the peer if there's an active request
+                self.logger.debug("QueenQueuer is skipping active peer %s", peer)
+                loop = asyncio.get_event_loop()
+                loop.call_later(10, functools.partial(self._insert_peer, peer))
+                continue
 
             return peer
         # This should never happen as we run as a daemon and if we return before our caller it'd
@@ -153,6 +157,9 @@ class QueeningQueue(Service, PeerSubscriber, QueenTrackerAPI):
             loop.call_later(delay, functools.partial(self._insert_peer, peer))
 
     def _should_be_queen(self, peer: ETHPeer) -> bool:
+        if not peer.is_alive:
+            raise ValueError(f"{peer} is no longer alive")
+
         if self._queen_peer is None:
             return True
         elif peer == self._queen_peer:
@@ -160,13 +167,13 @@ class QueeningQueue(Service, PeerSubscriber, QueenTrackerAPI):
         else:
             try:
                 new_peer_quality = _peer_sort_key(peer)
-            except (UnknownAPI, PeerConnectionLost) as exc:
+            except PeerConnectionLost as exc:
                 self.logger.debug("Invalid %s, because we can't get speed stats: %r", peer, exc)
                 return False
 
             try:
                 current_queen_quality = _peer_sort_key(self._queen_peer)
-            except (UnknownAPI, PeerConnectionLost) as exc:
+            except PeerConnectionLost as exc:
                 self.logger.debug(
                     "Invalid queen %s, because we can't get speed stats: %r",
                     self._queen_peer,
@@ -182,7 +189,14 @@ class QueeningQueue(Service, PeerSubscriber, QueenTrackerAPI):
         """
         Add peer as ready to receive requests. Check if it should be queen, and promote if
         appropriate. Otherwise, insert to be drawn as a peasant.
+
+        If the given peer is no longer running, do nothing. This is needed because we're sometimes
+        called via loop.call_later().
         """
+        if not peer.is_alive:
+            self.logger.debug("Peer %s is no longer alive, not adding to queue", peer)
+            return
+
         if self._should_be_queen(peer):
             old_queen, self._queen_peer = self._queen_peer, peer
             if peer != old_queen:

--- a/trinity/sync/beam/state.py
+++ b/trinity/sync/beam/state.py
@@ -298,7 +298,13 @@ class BeamDownloader(Service, PeerSubscriber):
             # Get best peer, by GetNodeData speed
             peer = await self._queen_tracker.get_queen_peer()
 
-            if urgent_batch_id is not None and peer.eth_api.get_node_data.is_requesting:
+            try:
+                peer_is_requesting = peer.get_eth_api().get_node_data.is_requesting
+            except PeerConnectionLost:
+                self.logger.debug("%s disconnected before we could request nodes", peer)
+                continue
+
+            if urgent_batch_id is not None and peer_is_requesting:
                 # Our best peer for node data has an in-flight GetNodeData request
                 # Probably, backfill is asking this peer for data
                 # This is right in the critical path, so we'd prefer this never happen
@@ -373,7 +379,6 @@ class BeamDownloader(Service, PeerSubscriber):
             urgent_node_hashes: Tuple[Hash32, ...],
             predictive_node_hashes: Tuple[Hash32, ...],
             predictive_batch_id: int) -> None:
-
         nodes = await self._request_nodes(peer, node_hashes)
 
         urgent_nodes = {
@@ -446,9 +451,13 @@ class BeamDownloader(Service, PeerSubscriber):
     async def _request_nodes(
             self,
             peer: ETHPeer,
-            node_hashes: Tuple[Hash32, ...]) -> NodeDataBundles:
+            original_node_hashes: Tuple[Hash32, ...]) -> NodeDataBundles:
+        node_hashes = tuple(set(original_node_hashes))
+        num_nodes = len(node_hashes)
+        self.logger.debug2("Requesting %d nodes from %s", num_nodes, peer)
         try:
-            completed_nodes = await self._make_node_request(peer, node_hashes)
+            completed_nodes = await peer.get_eth_api().get_node_data(
+                node_hashes, timeout=self._reply_timeout)
         except PeerConnectionLost:
             self.logger.debug("%s went away, cancelling the nodes request and moving on...", peer)
             self._queen_tracker.penalize_queen(peer)
@@ -462,6 +471,13 @@ class BeamDownloader(Service, PeerSubscriber):
             self.logger.debug("Pending nodes call to %r future cancelled", peer)
             self._queen_tracker.penalize_queen(peer)
             raise
+        except asyncio.TimeoutError:
+            # This kind of exception shouldn't necessarily *drop* the peer,
+            # so capture error, log and swallow
+            self.logger.debug("Timed out requesting %d nodes from %s", num_nodes, peer)
+            self._queen_tracker.penalize_queen(peer)
+            self._total_timeouts += 1
+            return tuple()
         except Exception as exc:
             self.logger.info("Unexpected err while downloading nodes from %s: %s", peer, exc)
             self.logger.debug(
@@ -480,22 +496,6 @@ class BeamDownloader(Service, PeerSubscriber):
                 self.logger.debug("%s returned 0 state trie nodes, penalize...", peer)
                 self._queen_tracker.penalize_queen(peer)
             return completed_nodes
-
-    async def _make_node_request(
-            self,
-            peer: ETHPeer,
-            original_node_hashes: Tuple[Hash32, ...]) -> NodeDataBundles:
-        node_hashes = tuple(set(original_node_hashes))
-        num_nodes = len(node_hashes)
-        self.logger.debug2("Requesting %d nodes from %s", num_nodes, peer)
-        try:
-            return await peer.eth_api.get_node_data(node_hashes, timeout=self._reply_timeout)
-        except asyncio.TimeoutError:
-            # This kind of exception shouldn't necessarily *drop* the peer,
-            # so capture error, log and swallow
-            self.logger.debug("Timed out requesting %d nodes from %s", num_nodes, peer)
-            self._total_timeouts += 1
-            return tuple()
 
     async def run(self) -> None:
         """

--- a/trinity/sync/common/peers.py
+++ b/trinity/sync/common/peers.py
@@ -64,7 +64,7 @@ class WaitingPeers(Generic[TChainPeer]):
     def _get_peer_rank(self, peer: TChainPeer) -> float:
         scores = [
             self._sort_key(exchange.tracker)
-            for exchange in peer.chain_api.exchanges
+            for exchange in peer.get_chain_api().exchanges
             if issubclass(exchange.get_response_cmd_type(), self._response_command_type)
         ]
 
@@ -86,7 +86,7 @@ class WaitingPeers(Generic[TChainPeer]):
         peer = wrapped_peer.original
 
         # make sure the peer has not gone offline while waiting in the queue
-        while not peer.manager.is_running:
+        while not peer.is_alive:
             # if so, look for the next best peer
             wrapped_peer = await self._waiting_peers.get()
             peer = wrapped_peer.original

--- a/trinity/sync/common/strategies.py
+++ b/trinity/sync/common/strategies.py
@@ -164,7 +164,7 @@ class FromCheckpointLaunchStrategy(SyncLaunchStrategyAPI):
                 continue
 
             try:
-                headers = await peer.chain_api.get_block_headers(
+                headers = await peer.get_chain_api().get_block_headers(
                     self._checkpoint.block_hash,
                     max_headers=FULL_BLOCKS_NEEDED_TO_START_BEAM,
                     skip=0,

--- a/trinity/sync/full/chain.py
+++ b/trinity/sync/full/chain.py
@@ -52,7 +52,7 @@ from eth.exceptions import HeaderNotFound
 
 from p2p.abc import CommandAPI
 from p2p.disconnect import DisconnectReason
-from p2p.exceptions import BaseP2PError, PeerConnectionLost, UnknownAPI
+from p2p.exceptions import BaseP2PError, PeerConnectionLost
 from p2p.peer import BasePeer, PeerSubscriber
 from p2p.stats.ema import EMA
 from p2p.token_bucket import TokenBucket
@@ -419,7 +419,7 @@ class BaseBodyChainSyncer(Service, PeerSubscriber):
         """
         self.logger.debug("Requesting block bodies for %d headers from %s", len(batch), peer)
         try:
-            block_body_bundles = await peer.eth_api.get_block_bodies(tuple(batch))
+            block_body_bundles = await peer.get_eth_api().get_block_bodies(tuple(batch))
         except asyncio.TimeoutError:
             self.logger.debug(
                 "Timed out requesting block bodies for %d headers from %s", len(batch), peer,
@@ -430,12 +430,6 @@ class BaseBodyChainSyncer(Service, PeerSubscriber):
             return tuple()
         except PeerConnectionLost:
             self.logger.debug("Peer went away, cancelling the block body request and moving on...")
-            return tuple()
-        except UnknownAPI as exc:
-            self.logger.debug(
-                "Peer was missing API, cancelling the block body request and moving on... %r",
-                exc,
-            )
             return tuple()
         except Exception:
             self.logger.exception("Unknown error when getting block bodies from %s", peer)
@@ -952,7 +946,7 @@ class FastChainBodySyncer(BaseBodyChainSyncer):
         """
         self.logger.debug("Requesting receipts for %d headers from %s", len(batch), peer)
         try:
-            receipt_bundles = await peer.eth_api.get_receipts(tuple(batch))
+            receipt_bundles = await peer.get_eth_api().get_receipts(tuple(batch))
         except asyncio.TimeoutError:
             self.logger.debug(
                 "Timed out requesting receipts for %d headers from %s", len(batch), peer,

--- a/trinity/sync/light/service.py
+++ b/trinity/sync/light/service.py
@@ -301,7 +301,7 @@ class LightPeerChain(PeerSubscriber, Service, BaseLightPeerChain):
             # our best peer doesn't have the header we want, there are no eligible peers.
             raise NoEligiblePeers(f"Our best peer does not have the header {block_hash.hex()}")
 
-        head_number = peer.head_info.head_number
+        head_number = peer.get_head_info().head_number
         if head_number - header.block_number > MAX_REORG_DEPTH:
             # The peer claims to be far ahead of the header we requested
             if await self.headerdb.coro_get_canonical_block_hash(header.block_number) == block_hash:
@@ -335,13 +335,14 @@ class LightPeerChain(PeerSubscriber, Service, BaseLightPeerChain):
         A single attempt to get the block header from the given peer.
 
         :raise BadLESResponse: if the peer replies with a header that has a different hash
+        :raise PeerConnectionLost: if the peer is no longer alive.
         """
         self.logger.debug("Fetching header %s from %s", encode_hex(block_hash), peer)
         max_headers = 1
 
         # TODO: Figure out why mypy thinks the first parameter to `get_block_headers`
         # should be of type `int`
-        headers = await peer.chain_api.get_block_headers(
+        headers = await peer.get_chain_api().get_block_headers(
             block_hash,
             max_headers,
             skip=0,


### PR DESCRIPTION
These will hopefully make it less likely for us to introduce new code that leaks PeerConnectionLost exceptions

- Peer.p2p_api is now private

- properties that can raise PeerConnectionLost are now methods

- the methods above will now raise a PeerConnectionLost if the peer
  is not running or if the conn is closing (before it'd only happen when
  the conn was closing)