### PR TITLE
ensure fast bls backend and always compute keys on demand

### DIFF
--- a/tests/eth2/conftest.py
+++ b/tests/eth2/conftest.py
@@ -177,7 +177,11 @@ def privkeys(_key_cache):
 
 
 @pytest.fixture(scope="session")
-def keymap(_key_cache):
+def keymap(_key_cache, pubkeys):
+    # NOTE: ensure some keys are in the cache,
+    # in lieu of emulating an "on-demand" ``dict`` instance.
+    pubkeys[:10]
+
     return _key_cache._mapping_view()
 
 


### PR DESCRIPTION
Avoiding an issue with cache seen in CI environment

### How was it fixed?

Disable the cache. The cache was used when generating keys was much more expensive than it is w/ a native code backend (`py_ecc` vs. `milagro`)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://imgc.artprintimages.com/img/print/portrait-of-a-furry-cute-koala-with-huge-ears-sitting-in-a-tree-fork_u-l-p8bl2n0.jpg?p=0)
