### PR TITLE
Backfill all accounts during beam sync

### DIFF
--- a/newsfragments/1846.bugfix.rst
+++ b/newsfragments/1846.bugfix.rst
@@ -1,0 +1,1 @@
+Catch and resolve PeerConnectionLost during stream_transport_messages()

--- a/newsfragments/854.feature.rst
+++ b/newsfragments/854.feature.rst
@@ -1,0 +1,6 @@
+During Beam Sync, Trinity now collects account data that is not touched by
+active blocks. We often call this "state backfill".
+Storage and Bytecode backfill are not yet included, but will be shortly.
+Obtaining the full state is the best way to make sure that your node cannot be
+knocked offline with a Denial-of-Service attack that accesses a bunch of state
+in a series of blocks.

--- a/p2p/multiplexer.py
+++ b/p2p/multiplexer.py
@@ -31,6 +31,7 @@ from p2p.abc import (
 )
 from p2p.exceptions import (
     MalformedMessage,
+    PeerConnectionLost,
     UnknownProtocol,
     UnknownProtocolCommand,
 )
@@ -53,7 +54,11 @@ async def stream_transport_messages(transport: TransportAPI,
     command_id_cache: Dict[int, ProtocolAPI] = {}
 
     while not transport.is_closing:
-        msg = await transport.recv()
+        try:
+            msg = await transport.recv()
+        except PeerConnectionLost:
+            return
+
         command_id = msg.command_id
 
         if msg.command_id not in command_id_cache:

--- a/setup.py
+++ b/setup.py
@@ -33,11 +33,8 @@ deps = {
         "cachetools>=3.1.0,<4.0.0",
         "coincurve>=10.0.0,<11.0.0",
         "eth-utils>=1.8.4,<2",
-        # Fixing this dependency due to: requests 2.20.1 has requirement
-        # idna<2.8,>=2.5, but you'll have idna 2.8 which is incompatible.
-        "idna==2.7",
-        # idna 2.7 is not supported by requests 2.18
-        "requests>=2.20,<3",
+        # requests 2.21 is required to support idna 2.8 which is required elsewhere
+        "requests>=2.21,<3",
         "ipython>=7.8.0,<7.10.0",  # attach fails with v7.10.{0,1}
         "plyvel==1.2.0",
         PYEVM_DEPENDENCY,

--- a/tests/core/task-queue-utils/test_ordered_task_preparation.py
+++ b/tests/core/task-queue-utils/test_ordered_task_preparation.py
@@ -690,7 +690,7 @@ async def test_wait_to_prune_until_yielded():
     ),
     st.integers(min_value=1, max_value=4),
 )
-@settings(max_examples=1000)
+@settings(max_examples=1000, deadline=500)
 @example(task_series=[1, 2, 0, 3], prune_depth=1)
 @example(task_series=[0, 1, 2, 3, 0, 4], prune_depth=1)
 @example(task_series=[0, 4, 2, 1, 5], prune_depth=1)

--- a/trinity/sync/beam/backfill.py
+++ b/trinity/sync/beam/backfill.py
@@ -1,25 +1,47 @@
+from __future__ import annotations
 import asyncio
 from collections import Counter
+from functools import partial
 import typing
 from typing import (
+    AsyncIterator,
+    AsyncIterable,
     Iterable,
-    List,
+    NamedTuple,
+    Optional,
     Set,
     Tuple,
 )
 
 from async_service import Service
 
-from eth.abc import AtomicDatabaseAPI
+from eth.abc import (
+    AtomicDatabaseAPI,
+    BlockHeaderAPI,
+)
 from eth_typing import Hash32
-import rlp
+from trie import (
+    HexaryTrie,
+    exceptions as trie_exceptions,
+    fog,
+)
+from trie.utils.nibbles import (
+    bytes_to_nibbles,
+)
+from trie.typing import (
+    HexaryTrieNode,
+    Nibbles,
+)
 
 from p2p.exceptions import BaseP2PError, PeerConnectionLost
 
 from trinity.protocol.eth.peer import ETHPeer, ETHPeerPool
 from trinity.sync.beam.constants import (
+    EPOCH_BLOCK_LENGTH,
     GAP_BETWEEN_TESTS,
+    PAUSE_SECONDS_IF_STATE_BACKFILL_STARVED,
 )
+from trinity._utils.async_iter import async_take
 from trinity._utils.logging import get_logger
 
 from .queen import (
@@ -52,9 +74,6 @@ class BeamStateBackfill(Service, QueenTrackerAPI):
         self.logger = get_logger('trinity.sync.beam.backfill.BeamStateBackfill')
         self._db = db
 
-        # Pending nodes to download
-        self._node_hashes: List[Hash32] = []
-
         self._peer_pool = peer_pool
 
         self._is_missing: Set[Hash32] = set()
@@ -62,6 +81,13 @@ class BeamStateBackfill(Service, QueenTrackerAPI):
         self._num_requests_by_peer = Counter()
 
         self._queening_queue = QueeningQueue(peer_pool)
+
+        # Track the nodes that we are requesting in the account trie
+        self._account_tracker = TrieNodeRequestTracker()
+
+        # The most recent root hash to use to navigate the trie
+        self._next_trie_root_hash: Optional[Hash32] = None
+        self._begin_backfill = asyncio.Event()
 
     async def get_queen_peer(self) -> ETHPeer:
         return await self._queening_queue.get_queen_peer()
@@ -77,44 +103,192 @@ class BeamStateBackfill(Service, QueenTrackerAPI):
         await self._run_backfill()
 
     async def _run_backfill(self) -> None:
+        await self._begin_backfill.wait()
+        if self._next_trie_root_hash is None:
+            raise RuntimeError("Cannot start backfill when a recent trie root hash is unknown")
+
         while self.manager.is_running:
             peer = await self._queening_queue.pop_fastest_peasant()
 
             # collect node hashes that might be missing
-            await self._walk()
+            required_data = tuple([
+                request async for request in async_take(REQUEST_SIZE, self._missing_trie_hashes())
+            ])
 
-            self._node_hashes, on_deck = (
-                self._node_hashes[:-1 * REQUEST_SIZE],
-                tuple(self._node_hashes[-1 * REQUEST_SIZE:]),
-            )
+            if len(required_data) == 0:
+                # Nothing available to request, for one of two reasons:
+                if self._is_complete():
+                    self.logger.info("Downloaded all account state")
+                    return
+                else:
+                    # There are active requests to peers, and we don't have enough information to
+                    #   ask for any more trie nodes (for example, near the beginning, when the top
+                    #   of the trie isn't available).
+                    self._queening_queue.readd_peasant(peer)
+                    self.logger.debug(
+                        "Backfill is waiting for more hashes to arrive, putting %s back in queue",
+                        peer,
+                    )
+                    await asyncio.sleep(PAUSE_SECONDS_IF_STATE_BACKFILL_STARVED)
+                    continue
 
-            if len(on_deck) == 0:
-                # Nothing left to request, break and wait for new data to come in
-                self._queening_queue.readd_peasant(peer)
-                self.logger.debug("Backfill is waiting for more hashes to arrive")
-                await asyncio.sleep(2)
-                continue
+            self.manager.run_task(self._make_request, peer, required_data)
 
-            self.manager.run_task(self._make_request, peer, on_deck)
+    def _is_complete(self) -> bool:
+        if self._account_tracker.is_complete:
+            return True
+        else:
+            # At least one account trie node is missing
+            return False
 
-    async def _make_request(self, peer: ETHPeer, request_hashes: Tuple[Hash32, ...]) -> None:
+    async def _missing_trie_hashes(self) -> AsyncIterator[TrackedRequest]:
+        """
+        Walks through the full state trie, yielding one missing node hash/prefix
+        at a time.
+
+        The yielded node info is wrapped in a TrackedRequest. The hash is
+        marked as active until it is explicitly marked for review again. The
+        hash/prefix will be marked for review asking a peer for the data.
+
+        Will exit when all known node hashes are already actively being
+        requested, or if there are no more missing nodes.
+        """
+        while self.manager.is_running:
+            try:
+                starting_root_hash = self._next_trie_root_hash
+                account_iterator = self._request_tracking_trie_items(
+                    self._account_tracker,
+                    starting_root_hash,
+                )
+                async for path_to_leaf, _, _ in account_iterator:
+                    self._account_tracker.confirm_leaf(path_to_leaf)
+
+            except trie_exceptions.MissingTraversalNode as exc:
+                self.logger.debug2("Requesting account node: %s", exc)
+                yield self._account_tracker.generate_request(
+                    exc.missing_node_hash,
+                    exc.nibbles_traversed,
+                )
+            else:
+                # Possible scenarios:
+                #   1. We have completed backfill
+                #   2. We have iterated the available nodes, and only their children are missing,
+                #       for example: if 0 nodes are available, and we walk to the root and request
+                #       the root from a peer, we do not have any available information to ask for
+                #       more nodes.
+                #
+                # In response to these situations, we might like to:
+                #   1. Log and celebrate that the full state has been downloaded
+                #   2. Exit this search and sleep a bit, waiting for new trie nodes to arrive
+                #
+                # 1 and 2 are a little more cleanly handled outside this iterator, so we just
+                #   exit and let the caller deal with it.
+                return
+
+    async def _request_tracking_trie_items(
+            self,
+            request_tracker: TrieNodeRequestTracker,
+            root_hash: Hash32) -> AsyncIterable[Tuple[Nibbles, Nibbles, bytes]]:
+        """
+        Walk through the supplied trie, yielding the request tracker and node
+        request for any missing trie nodes.
+
+        :yield: path to leaf node, a key (as nibbles), and the value found in the trie
+        :raise: MissingTraversalNode if a node is missing while walking the trie
+        """
+        if self._next_trie_root_hash is None:
+            # We haven't started beam syncing, so don't know which root to start at
+            return
+        trie = HexaryTrie(self._db, root_hash)
+
+        starting_index = bytes_to_nibbles(root_hash)
+
+        while self.manager.is_running:
+            try:
+                path_to_node = request_tracker.next_path_to_explore(starting_index)
+            except trie_exceptions.PerfectVisibility:
+                # This doesn't necessarily mean we are finished.
+                # Any active prefixes might still be hiding some significant portion of the trie
+                # But it's all we're able to explore for now, until more node data arrives
+                return
+
+            try:
+                cached_node, uncached_key = request_tracker.get_cached_parent(path_to_node)
+            except KeyError:
+                cached_node = None
+                node_getter = partial(trie.traverse, path_to_node)
+            else:
+                node_getter = partial(trie.traverse_from, cached_node, uncached_key)
+
+            try:
+                node = node_getter()
+            except trie_exceptions.MissingTraversalNode as exc:
+                # Found missing account trie node
+                if path_to_node == exc.nibbles_traversed:
+                    raise
+                elif cached_node is None:
+                    # The path and nibbles traversed should always match in a non-cached traversal
+                    raise RuntimeError(
+                        f"Unexpected: on a non-cached traversal to {path_to_node}, the"
+                        f" exception only claimed to traverse {exc.nibbles_traversed} -- {exc}"
+                    ) from exc
+                else:
+                    # We need to re-raise a version of the exception that includes the whole path
+                    #   from the root node (when using cached nodes, we only have the path from
+                    #   the parent node to the child node)
+                    # We could always raise this re-wrapped version, but skipping it (probably?)
+                    #   improves performance.
+                    missing_hash = exc.missing_node_hash
+                    raise trie_exceptions.MissingTraversalNode(missing_hash, path_to_node) from exc
+            except trie_exceptions.TraversedPartialPath as exc:
+                node = exc.simulated_node
+
+            if node.value:
+                full_key_nibbles = path_to_node + node.suffix
+
+                if len(node.sub_segments):
+                    # It shouldn't be a problem to skip handling this case, because all keys are
+                    #   hashed 32 bytes.
+                    raise NotImplementedError(
+                        "The state backfiller doesn't handle keys of different lengths, where"
+                        f" one key is a prefix of another. But found {node} in trie with"
+                        f" {root_hash!r}"
+                    )
+
+                yield path_to_node, full_key_nibbles, node.value
+                # Note that we do not mark value nodes as completed. It is up to the caller
+                #   to do that when it is ready. For example, the storage iterator will
+                #   immediately treat the key as completed. The account iterator will
+                #   not treat the key as completed until all of its storage and bytecode
+                #   are also marked as complete.
+            else:
+                # If this is just an intermediate node, then we can mark it as confirmed.
+                request_tracker.confirm_prefix(path_to_node, node)
+
+    async def _make_request(
+            self,
+            peer: ETHPeer,
+            request_data: Iterable[TrackedRequest]) -> None:
+
         self._num_requests_by_peer[peer] += 1
+        request_hashes = tuple(set(request.node_hash for request in request_data))
         try:
             nodes = await peer.eth_api.get_node_data(request_hashes)
         except asyncio.TimeoutError:
-            self._node_hashes.extend(request_hashes)
             self._queening_queue.readd_peasant(peer, GAP_BETWEEN_TESTS * 2)
         except PeerConnectionLost:
             # Something unhappy, but we don't really care, peer will be gone by next loop
-            self._node_hashes.extend(request_hashes)
+            pass
         except (BaseP2PError, Exception) as exc:
             self.logger.info("Unexpected err while getting background nodes from %s: %s", peer, exc)
             self.logger.debug("Problem downloading background nodes from peer...", exc_info=True)
-            self._node_hashes.extend(request_hashes)
             self._queening_queue.readd_peasant(peer, GAP_BETWEEN_TESTS * 2)
         else:
             self._queening_queue.readd_peasant(peer, GAP_BETWEEN_TESTS)
             self._insert_results(request_hashes, nodes)
+        finally:
+            for request in request_data:
+                request.tracker.mark_for_review(request.prefix)
 
     def _insert_results(
             self,
@@ -129,85 +303,22 @@ class BeamStateBackfill(Service, QueenTrackerAPI):
                     self._total_processed_nodes += 1
                     encoded_node = returned_nodes[requested_hash]
                     write_batch[requested_hash] = encoded_node
-                    self._is_missing.discard(requested_hash)
-                    self._node_hashes.extend(self._get_children(encoded_node))
                 else:
                     self._num_missed += 1
-                    self._node_hashes.append(requested_hash)
 
-    def _has_full_request_worth_of_queued_hashes(self) -> bool:
-        if len(self._node_hashes) < REQUEST_SIZE:
-            # there are too few hashes available
-            return False
-
-        next_request_preview = self._node_hashes[-1 * REQUEST_SIZE:]
-
-        # confirm that all queued hashes are missing from the database
-        # self._is_missing is cached to avoid excessive I/O of checking repeatedly
-        return all(node_hash not in self._is_missing for node_hash in next_request_preview)
-
-    async def _walk(self) -> None:
-        """
-        Evaluate queued node hashes, checking which ones are locally available. For
-        anything that is locally available, load it up and put its children on the queue.
-        """
-        while not self._has_full_request_worth_of_queued_hashes():
-            for reversed_idx, node_hash in enumerate(reversed(self._node_hashes)):
-                if node_hash in self._is_missing:
-                    continue
-
-                try:
-                    encoded_node = self._db[node_hash]
-                except KeyError:
-                    self._is_missing.add(node_hash)
-                    # release the event loop, because doing a bunch of db reads is slow
-                    await asyncio.sleep(0)
-                    continue
-                else:
-                    # found a node to expand out
-                    remove_idx = len(self._node_hashes) - reversed_idx - 1
-                    break
-            else:
-                # Didn't find any nodes to expand. Give up the walk
-                return
-
-            # remove the already-present node hash
-            del self._node_hashes[remove_idx]
-
-            # Expand out the node that's already present
-            self._node_hashes.extend(self._get_children(encoded_node))
-
-            # Release the event loop, because this could be long
-            await asyncio.sleep(0)
-
-            # Continue until the pending stack is big enough
-
-    def _get_children(self, encoded_node: bytes) -> Iterable[Hash32]:
-        try:
-            decoded_node = rlp.decode(encoded_node)
-        except rlp.DecodingError:
-            # Could not decode rlp, it's probably a bytecode, carry on...
-            return set()
-
-        if len(decoded_node) == 17:
-            # branch node
-            return set(node_hash for node_hash in decoded_node[:16] if len(node_hash) == 32)
-        elif len(decoded_node) == 2 and len(decoded_node[1]) == 32:
-            # leaf or extension node
-            return {decoded_node[1]}
-        else:
-            # final value, ignore
-            return set()
-
-    def set_root_hash(self, root_hash: Hash32) -> None:
-        if len(self._node_hashes) < REQUEST_SIZE:
-            self._node_hashes.append(root_hash)
+    def set_root_hash(self, header: BlockHeaderAPI, root_hash: Hash32) -> None:
+        if self._next_trie_root_hash is None:
+            self._next_trie_root_hash = root_hash
+            self._begin_backfill.set()
+        elif header.block_number % EPOCH_BLOCK_LENGTH == 1:
+            # This is the root hash of the *parent* of the header, so use modulus equals 1
+            self._next_trie_root_hash = root_hash
 
     async def _periodically_report_progress(self) -> None:
         while self.manager.is_running:
             await asyncio.sleep(self._report_interval)
 
-            if len(self._node_hashes) == 0:
+            if not self._begin_backfill.is_set():
                 self.logger.debug("Beam-Backfill: waiting for new state root")
                 continue
 
@@ -228,3 +339,93 @@ class BeamStateBackfill(Service, QueenTrackerAPI):
                 self._num_requests_by_peer.most_common(show_top_n_peers),
             )
             self._num_requests_by_peer.clear()
+
+
+class TrieNodeRequestTracker:
+    def __init__(self) -> None:
+        self._trie_fog = fog.HexaryTrieFog()
+        self._active_prefixes: Set[Nibbles] = set()
+
+        # cache of nodes used to speed up trie walking
+        self._node_frontier_cache = fog.TrieFrontierCache()
+
+    def mark_for_review(self, prefix: Nibbles) -> None:
+        # Calling this does not mean that the nodes were returned, only that they are eligible again
+        #   for review (either they were returned or we can ask a different peer for them)
+        self._active_prefixes.remove(prefix)
+
+    def pause_review(self, prefix: Nibbles) -> None:
+        """
+        Stop iterating this node, until mark_for_review() is called
+        """
+        self._active_prefixes.add(prefix)
+
+    def _get_eligible_fog(self) -> fog.HexaryTrieFog:
+        """
+        Return the Trie Fog that can be searched, ignoring any nodes that are currently
+        being requested.
+        """
+        return self._trie_fog.mark_all_complete(self._active_prefixes)
+
+    def next_path_to_explore(self, starting_index: Nibbles) -> Nibbles:
+        return self._get_eligible_fog().nearest_unknown(starting_index)
+
+    def confirm_prefix(
+            self,
+            confirmed_prefix: Nibbles,
+            node: fog.HexaryTrieFog) -> None:
+
+        if node.sub_segments:
+            # No nodes have both value and sub_segments, so we can wait to update the cache
+            self.add_cache(confirmed_prefix, node, node.sub_segments)
+        elif node.value:
+            # If we are confirming a leaf, use confirm_leaf(). We do not attempt to handle a
+            #   situation where one key is a prefix of another key, and simply error out.
+            raise ValueError("Do not handle case where prefix of another key has a value")
+        else:
+            # We don't have to look up this node anymore, so can delete it from our cache
+            self.delete_cache(confirmed_prefix)
+
+        self._trie_fog = self._trie_fog.explore(confirmed_prefix, node.sub_segments)
+
+    def confirm_leaf(self, path_to_leaf: Nibbles) -> None:
+        # We don't handle keys that are subkeys of other keys (because
+        #   all keys are 32 bytes), so we can just hard-code that there
+        #   are no children of this address.
+        self.delete_cache(path_to_leaf)
+        self._trie_fog = self._trie_fog.explore(path_to_leaf, ())
+
+    def generate_request(
+            self,
+            node_hash: Hash32,
+            prefix: Nibbles) -> TrackedRequest:
+
+        self.pause_review(prefix)
+        return TrackedRequest(self, node_hash, prefix)
+
+    @property
+    def has_active_requests(self) -> bool:
+        return len(self._active_prefixes) > 0
+
+    def get_cached_parent(self, prefix: Nibbles) -> Tuple[HexaryTrieNode, Nibbles]:
+        return self._node_frontier_cache.get(prefix)
+
+    def add_cache(
+            self,
+            prefix: Nibbles,
+            node: HexaryTrieNode,
+            sub_segments: Iterable[Nibbles]) -> None:
+        self._node_frontier_cache.add(prefix, node, sub_segments)
+
+    def delete_cache(self, prefix: Nibbles) -> None:
+        self._node_frontier_cache.delete(prefix)
+
+    @property
+    def is_complete(self) -> bool:
+        return self._trie_fog.is_complete
+
+
+class TrackedRequest(NamedTuple):
+    tracker: TrieNodeRequestTracker
+    node_hash: Hash32
+    prefix: Nibbles

--- a/trinity/sync/beam/chain.py
+++ b/trinity/sync/beam/chain.py
@@ -763,7 +763,7 @@ class BeamBlockImporter(BaseBlockImporter, Service):
             FIRE_AND_FORGET_BROADCASTING
         )
 
-        self._backfiller.set_root_hash(parent_state_root)
+        self._backfiller.set_root_hash(header, parent_state_root)
 
     async def _preview_address_load(
             self,

--- a/trinity/sync/beam/constants.py
+++ b/trinity/sync/beam/constants.py
@@ -65,6 +65,19 @@ MAX_LAG_TO_RESUME_BACKFILL = 0
 # The number of blocks that, when lagged behind, will cause backfill to pause
 MAX_LAG_TO_PAUSE_BACKFILL = 5
 
+# If there is still unknown state to request, but we don't have any available hashes
+#   to ask for a peer (all known hashes are already being actively requested), then
+#   pause this long before asking any other peer for more state hashes.
+PAUSE_SECONDS_IF_STATE_BACKFILL_STARVED = 2
+
+# Rotate the state backfill key to a new state root once every epoch. The key is
+#   used to have beam syncing nodes generally be able to help each other backfill.
+#   Otherwise, they might all haphazardly try to fill in different parts of the trie
+#   at the same time, and not have the nodes needed to supply each other. So all
+#   nodes try to get nodes near the key defined by the state root on every block with
+#   block_number % EPOCH_BLOCK_LENGTH == 0.
+EPOCH_BLOCK_LENGTH = 32
+
 # The time that the block backfill should idle when there are concurrently no blocks to fill.
 # Once gaps are closed they can only re-occur when beam sync pivots so it's ok to idle a fair while.
 BLOCK_BACKFILL_IDLE_TIME = PREDICTED_BLOCK_TIME * 500


### PR DESCRIPTION
### What was wrong?

Related to #854 


### How was it fixed?

- Includes test of account backfill with cold state database
- Does not include bytecode or storage backfill

(Skipped bytecode/storage to make the PR a bit more manageable)

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

[//]: # (See: https://trinity-client.readthedocs.io/en/latest/contributing.html#pull-requests)
- [x] Add entry to the [release notes](https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)
- [x] Fixes #1846 (add release note)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://www.caninejournal.com/wp-content/uploads/dog-digging-hole.jpg)