### PR TITLE
Ensure BLS keys are always present in the "mapping view" of the pytest cache

### DIFF
--- a/tests/eth2/conftest.py
+++ b/tests/eth2/conftest.py
@@ -177,7 +177,11 @@ def privkeys(_key_cache):
 
 
 @pytest.fixture(scope="session")
-def keymap(_key_cache):
+def keymap(_key_cache, pubkeys):
+    # NOTE: ensure some keys are in the cache,
+    # in lieu of emulating an "on-demand" ``dict`` instance.
+    pubkeys[:10]
+
     return _key_cache._mapping_view()
 
 


### PR DESCRIPTION
Ensure (some) keys are always in the cache.


### How was it fixed?

Ensure that keys are always present in the "mapping view". Depending on test order, the backing dict may have not been populated yet, so we seed a few keys in this dict before handing it off to callers.


#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://imgc.artprintimages.com/img/print/portrait-of-a-furry-cute-koala-with-huge-ears-sitting-in-a-tree-fork_u-l-p8bl2n0.jpg?p=0)
