### PR TITLE
Pin `anyio` version to avoid conflict in recent update

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -118,6 +118,7 @@ deps = {
         PYEVM_DEPENDENCY,
         "ssz==0.2.4",
         "asks>=2.3.6,<3",  # validator client
+        "anyio>1.3,<1.4",
         "eth-keyfile",  # validator client
     ],
     'eth2-extra': [


### PR DESCRIPTION
### What was wrong?

`anyio` updated w/in the last 24 hours to `v1.4.0` which requires the dependency `idna` at `v2.8`.

We have (several?) other dependencies which require `idna@v2.7`.

### How was it fixed?

Pin `anyio` to the previous version to allow the acceptable version of `idna`.

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://images.unsplash.com/photo-1570131669750-8003614b97f6?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&w=1000&q=80)
