### PR TITLE
Fix a crasher + flaky test with BodyChainGapSyncer

### DIFF
--- a/tests/core/p2p-proto/test_sync.py
+++ b/tests/core/p2p-proto/test_sync.py
@@ -649,7 +649,7 @@ async def test_block_gapfill_syncer(request,
                 syncer.pause()
                 # We need to give async code a moment to settle before we save the progress to
                 # ensure it has stabilized before we save it.
-                await asyncio.sleep(0.01)
+                await asyncio.sleep(0.25)
                 paused_chain_gaps = chain_with_gaps.chaindb.get_chain_gaps()
 
                 # Consider it victory if after 0.5s no new blocks were written to the database
@@ -668,7 +668,7 @@ async def test_block_gapfill_syncer(request,
 
                 # We need to give the async calls a moment to settle before we can read the updated
                 # chain gaps.
-                await asyncio.sleep(0.1)
+                await asyncio.sleep(0.25)
                 assert chain_with_gaps.chaindb.get_chain_gaps() == ((), 1001)
 
 


### PR DESCRIPTION
### What was wrong?

As reported in #1838 there's a crash when `pause()` is called on a `BodyChainGapSyncer` that is still asynchronously setting itself up.

This also fixes #1839 (flaky test) by increasing two timeouts.

### How was it fixed?

1. Do not assume that the service is already setup in `pause()`
2. Cover the scenario in the existing test
3. Make the idle time of the service configurable and drastically reduce it in the test
4. Increase two timeouts that were too sensitive

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

[//]: # (See: https://trinity-client.readthedocs.io/en/latest/contributing.html#pull-requests)
- unreleased bug (no changelog entry)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://www.theportugalnews.com/uploads/news/wild_boar_1.jpg)
