### PR TITLE
Ensure the Syncer component exits if the Node service does so

### DIFF
--- a/tests/core/p2p-proto/test_server.py
+++ b/tests/core/p2p-proto/test_server.py
@@ -214,7 +214,10 @@ async def test_peer_pool_answers_connect_commands(event_bus, server, receiver_re
                 TO_NETWORKING_BROADCAST_CONFIG
             )
 
-            # This test was maybe 30% flaky at 0.1 sleep
-            await asyncio.sleep(0.2)
-
-            assert len(server.peer_pool.connected_nodes) == 1
+            # This test was maybe 30% flaky at 0.1 sleep, so wait in a loop.
+            for _ in range(5):
+                await asyncio.sleep(0.1)
+                if len(server.peer_pool.connected_nodes) == 1:
+                    break
+            else:
+                assert len(server.peer_pool.connected_nodes) == 1


### PR DESCRIPTION
### What was wrong?

The Syncer used to run the Node service in the background and wait
on the sync task (which runs forever) before calling
node_manager.wait(). As a result, if the Node crashed the sync task
would continue running but do nothing because the PeerPool (part of
the Node's functionalities) would never have any peers.

### How was it fixed?

Wait for both the Node and the Syncer, and exit as soon as either of
them does so.