### PR TITLE
Rename some beam sync constants

### DIFF
--- a/trinity/sync/beam/chain.py
+++ b/trinity/sync/beam/chain.py
@@ -41,8 +41,8 @@ from trinity.sync.beam.constants import (
     BLOCK_BACKFILL_IDLE_TIME,
     ESTIMATED_BEAMABLE_SECONDS,
     FULL_BLOCKS_NEEDED_TO_START_BEAM,
-    MAX_LAG_TO_PAUSE_BACKFILL,
-    MAX_LAG_TO_RESUME_BACKFILL,
+    PAUSE_BACKFILL_AT_LAG,
+    RESUME_BACKFILL_AT_LAG,
     PREDICTED_BLOCK_TIME,
 )
 from trinity.sync.common.checkpoint import (
@@ -339,13 +339,13 @@ class BeamSyncer(Service):
                 return
             else:
                 lag = self.get_block_count_lag()
-                if lag >= MAX_LAG_TO_PAUSE_BACKFILL and not self._block_backfill.is_paused:
+                if lag >= PAUSE_BACKFILL_AT_LAG and not self._block_backfill.is_paused:
                     self.logger.debug(
                         "Pausing historical block sync because we lag %s blocks",
                         lag,
                     )
                     self._block_backfill.pause()
-                elif lag <= MAX_LAG_TO_RESUME_BACKFILL and self._block_backfill.is_paused:
+                elif lag <= RESUME_BACKFILL_AT_LAG and self._block_backfill.is_paused:
                     self.logger.debug(
                         "Resuming historical block sync because we lag %s blocks",
                         lag,

--- a/trinity/sync/beam/constants.py
+++ b/trinity/sync/beam/constants.py
@@ -59,11 +59,11 @@ BEAM_PIVOT_BUFFER_FRACTION = 1 / 2
 # We need to request one more header, to set the starting tip
 FULL_BLOCKS_NEEDED_TO_START_BEAM = MAX_UNCLE_DEPTH + 2
 
-# The number of blocks that beam sync is allowed to lag behind when resuming backfill
-MAX_LAG_TO_RESUME_BACKFILL = 0
+# If backfill is paused, resume when the lag has reduced to this number of blocks.
+RESUME_BACKFILL_AT_LAG = 0
 
-# The number of blocks that, when lagged behind, will cause backfill to pause
-MAX_LAG_TO_PAUSE_BACKFILL = 5
+# Pause backfill if sync starts lagging behind this number of blocks
+PAUSE_BACKFILL_AT_LAG = 5
 
 # If there is still unknown state to request, but we don't have any available hashes
 #   to ask for a peer (all known hashes are already being actively requested), then


### PR DESCRIPTION
### What was wrong?

Some constants weren't named as clear as they could be.

### How was it fixed?

:writing_hand: 

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

[//]: # (See: https://trinity-client.readthedocs.io/en/latest/contributing.html#pull-requests)
- [ ] Add entry to the [release notes](https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://img.rawpixel.com/s3fs-private/rawpixel_images/website_content/a005-scottw-134539.jpg?w=800&dpr=1&fit=default&crop=default&q=65&vib=3&con=3&usm=15&bg=F4F4F3&ixlib=js-2.2.1&s=2ac7813715000f10f2c5ab4e98d25170)
