### PR TITLE
Lengthen test timeout, for high-variance CI times

### DIFF
--- a/tests/core/p2p-proto/test_server.py
+++ b/tests/core/p2p-proto/test_server.py
@@ -189,7 +189,7 @@ async def test_peer_pool_connect(monkeypatch, server, receiver_remote):
         await manager.wait_started()
         await initiator_peer_pool.connect_to_nodes(nodes)
 
-        await asyncio.wait_for(peer_started.wait(), timeout=1)
+        await asyncio.wait_for(peer_started.wait(), timeout=5)
 
         assert len(initiator_peer_pool.connected_nodes) == 1
 

--- a/tests/core/p2p-proto/test_sync.py
+++ b/tests/core/p2p-proto/test_sync.py
@@ -347,7 +347,7 @@ async def test_beam_syncer_loads_recent_state_root(
         target_head = chaindb_churner.get_canonical_block_header_by_number(
             target_block_number,
         )
-        await wait_for_head(chaindb_fresh, target_head, sync_timeout=5)
+        await wait_for_head(chaindb_fresh, target_head, sync_timeout=10)
         assert target_head.state_root in chaindb_fresh.db
 
 


### PR DESCRIPTION
### What was wrong?

Fixes #1860 

test_beam_syncer_loads_recent_state_root[1] failed with a timeout in:
https://app.circleci.com/pipelines/github/ethereum/trinity/6709/workflows/fcd83ecc-4f06-478f-9fd9-b872d1960b84/jobs/252645/steps

### How was it fixed?

Increase the timeout from 5 to 10.

Also, found another timeout to increase.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

[//]: # (See: https://trinity-client.readthedocs.io/en/latest/contributing.html#pull-requests)
- [x] ~Add entry to the [release notes](https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)~

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://i.pinimg.com/originals/3b/9b/51/3b9b5196b38d03187e387210e9433d7b.jpg)
