### PR TITLE
--genesis-state param added to create-network subcommand

### DIFF
--- a/eth2/configs.py
+++ b/eth2/configs.py
@@ -91,7 +91,7 @@ class Eth2Config:
     @to_dict
     def to_formatted_dict(self) -> Iterable[Tuple[str, EncodedConfigTypes]]:
         for field in fields(self):
-            if field.type is bytes:
+            if field.type in (bytes, Version):
                 encoded_value = encode_hex(getattr(self, field.name))
             else:
                 encoded_value = getattr(self, field.name)

--- a/eth2/genesis.py
+++ b/eth2/genesis.py
@@ -1,14 +1,12 @@
 from pathlib import Path
-from typing import Any, Dict
+from typing import Any, Dict, Iterable
 
 from eth.constants import ZERO_HASH32
 from eth_utils import encode_hex
 from ssz.tools.dump import to_formatted_dict
-from ssz.tools.parse import from_formatted_dict
 from typing_extensions import Literal
 
 from eth2.beacon.genesis import initialize_beacon_state_from_eth1
-from eth2.beacon.state_machines.forks.altona.configs import ALTONA_CONFIG
 from eth2.beacon.state_machines.forks.serenity.configs import SERENITY_CONFIG
 from eth2.beacon.state_machines.forks.skeleton_lake.configs import (
     MINIMAL_SERENITY_CONFIG,
@@ -25,26 +23,8 @@ from eth2.beacon.typing import Timestamp
 from eth2.configs import Eth2Config
 
 
-def update_genesis_config_with_time(
-    config: Dict[str, Any], genesis_time: Timestamp
-) -> Dict[str, Any]:
-    config_profile = config["profile"]
-    eth2_config = _get_eth2_config(config_profile)
-    override_lengths(eth2_config)
-
-    existing_state = from_formatted_dict(config["genesis_state"], BeaconState)
-
-    genesis_state = existing_state.set("genesis_time", genesis_time)
-
-    updates = {
-        "genesis_state_root": encode_hex(genesis_state.hash_tree_root),
-        "genesis_state": to_formatted_dict(genesis_state),
-    }
-    return {**config, **updates}
-
-
-def generate_genesis_config(
-    config_profile: Literal["minimal", "mainnet", "altona"], genesis_time: Timestamp
+def genesis_config_with_validators(
+    config_profile: Literal["minimal", "mainnet"], genesis_time: Timestamp = None
 ) -> Dict[str, Any]:
     eth2_config = _get_eth2_config(config_profile)
     override_lengths(eth2_config)
@@ -60,28 +40,25 @@ def generate_genesis_config(
     )
     eth1_block_hash = ZERO_HASH32
     eth1_timestamp = eth2_config.MIN_GENESIS_TIME
-    initial_state = initialize_beacon_state_from_eth1(
+    genesis_state = initialize_beacon_state_from_eth1(
         eth1_block_hash=eth1_block_hash,
         eth1_timestamp=Timestamp(eth1_timestamp),
         deposits=deposits,
         config=eth2_config,
     )
 
-    genesis_state = initial_state.set("genesis_time", genesis_time)
+    if genesis_time:
+        genesis_state = genesis_state.set("genesis_time", genesis_time)
 
-    return {
-        "profile": config_profile,
-        "eth2_config": eth2_config.to_formatted_dict(),
-        "genesis_validator_key_pairs": mk_genesis_key_map(
-            validator_key_pairs, genesis_state
-        ),
-        "genesis_state_root": encode_hex(genesis_state.hash_tree_root),
-        "genesis_state": to_formatted_dict(genesis_state),
-    }
+    key_pairs = mk_genesis_key_map(validator_key_pairs, genesis_state)
+
+    return _create_genesis_config(config_profile, eth2_config, genesis_state, key_pairs)
 
 
-def genesis_config_from_state(
-    config_profile: Literal["minimal", "mainnet", "altona"], genesis_state_path: Path
+def genesis_config_from_state_file(
+    config_profile: Literal["minimal", "mainnet"],
+    genesis_state_path: Path,
+    genesis_time: Timestamp = None,
 ) -> Dict[str, Any]:
     eth2_config = _get_eth2_config(config_profile)
     override_lengths(eth2_config)
@@ -89,18 +66,48 @@ def genesis_config_from_state(
     with open(genesis_state_path, "rb") as genesis_state_file:
         genesis_state = BeaconState.deserialize(genesis_state_file.read())
 
+    if genesis_time:
+        genesis_state = genesis_state.set("genesis_time", genesis_time)
+
+    return _create_genesis_config(config_profile, eth2_config, genesis_state, ())
+
+
+def genesis_config_with_default_state(
+    config_profile: Literal["minimal", "mainnet"], genesis_time: Timestamp = None
+) -> Dict[str, Any]:
+    eth2_config = _get_eth2_config(config_profile)
+    override_lengths(eth2_config)
+
+    genesis_state = BeaconState.create(config=eth2_config)
+
+    if genesis_time:
+        genesis_state = genesis_state.set("genesis_time", genesis_time)
+
+    return _create_genesis_config(config_profile, eth2_config, genesis_state, ())
+
+
+def format_genesis_config(config: Dict[str, Any]) -> str:
+    profile = config["profile"]
+    root = config["genesis_state_root"]
+    genesis_time = config["genesis_state"]["genesis_time"]
+
+    return f"[profile: {profile}, " f"root: {root}, " f"genesis_time: {genesis_time}]"
+
+
+def _create_genesis_config(
+    config_profile: Literal["minimal", "mainnet"],
+    eth2_config: Eth2Config,
+    genesis_state: BeaconState,
+    key_pairs: Iterable[Dict[str, str]],
+) -> Dict[str, Any]:
     return {
         "profile": config_profile,
         "eth2_config": eth2_config.to_formatted_dict(),
-        "genesis_validator_key_pairs": (),
         "genesis_state_root": encode_hex(genesis_state.hash_tree_root),
+        "genesis_validator_key_pairs": key_pairs,
         "genesis_state": to_formatted_dict(genesis_state),
     }
 
 
 def _get_eth2_config(profile: str) -> Eth2Config:
-    return {
-        "minimal": MINIMAL_SERENITY_CONFIG,
-        "mainnet": SERENITY_CONFIG,
-        "altona": ALTONA_CONFIG,
-    }[profile]
+    return {"minimal": MINIMAL_SERENITY_CONFIG, "mainnet": SERENITY_CONFIG}[profile]

--- a/trinity/components/eth2/network_generator/component.py
+++ b/trinity/components/eth2/network_generator/component.py
@@ -1,10 +1,15 @@
 from argparse import ArgumentParser, Namespace, _SubParsersAction
 import json
+from json import JSONDecodeError
 import logging
 import pathlib
 import time
 
-from eth2.genesis import generate_genesis_config, update_genesis_config_with_time
+from eth2.genesis import (
+    generate_genesis_config,
+    genesis_config_from_state,
+    update_genesis_config_with_time,
+)
 from trinity.config import BeaconChainConfig, TrinityConfig
 from trinity.extensibility import Application
 
@@ -14,6 +19,13 @@ Produces a genesis state and a set of private keys for validators in the genesis
 CONFIG_PROFILE_HELP = """
 Use this profile of configuration to determine minimal parameters in the system.
 """
+
+
+class BytesJsonEncoder(json.JSONEncoder):
+    def default(self, obj: object) -> str:
+        if isinstance(obj, bytes):
+            return obj.hex()
+        return super().default(obj)
 
 
 def _get_network_config_path_for(profile: str) -> pathlib.Path:
@@ -38,22 +50,27 @@ class NetworkGeneratorComponent(Application):
         network_generator_parser.add_argument(
             "--config-profile",
             help=CONFIG_PROFILE_HELP,
-            choices=("minimal", "mainnet"),
+            choices=("minimal", "mainnet", "altona"),
             default="minimal",
         )
         network_generator_parser.add_argument(
             "--output", type=pathlib.Path, help="where to save the output configuration"
         )
-        genesis_time_group = network_generator_parser.add_mutually_exclusive_group(
+        genesis_group = network_generator_parser.add_mutually_exclusive_group(
             required=True
         )
-        genesis_time_group.add_argument(
+        genesis_group.add_argument(
             "--genesis-time", type=int, help="Unix timestamp to use as the genesis time"
         )
-        genesis_time_group.add_argument(
+        genesis_group.add_argument(
             "--genesis-delay",
             type=int,
             help="Delay in seconds to use as the genesis time from time of execution",
+        )
+        genesis_group.add_argument(
+            "--genesis-state",
+            type=pathlib.Path,
+            help="Path to an SSZ file that contains the initial chain state",
         )
 
         network_generator_parser.set_defaults(func=cls._generate_network_as_json)
@@ -62,16 +79,6 @@ class NetworkGeneratorComponent(Application):
     def _generate_network_as_json(
         cls, args: Namespace, trinity_config: TrinityConfig
     ) -> None:
-        if args.genesis_time:
-            genesis_time = args.genesis_time
-            cls.logger.info("genesis time specified from config: %d", genesis_time)
-        else:
-            # this arm is guaranteed given the argparse config...
-            genesis_time = int(time.time()) + args.genesis_delay
-            cls.logger.info(
-                "genesis delay specified from config: %d", args.genesis_delay
-            )
-
         cls.logger.info("using config profile: %s", args.config_profile)
 
         if args.output:
@@ -81,12 +88,33 @@ class NetworkGeneratorComponent(Application):
 
         if output_file_path.exists():
             with open(output_file_path, "r") as config_file:
-                existing_genesis_config = json.load(config_file)
-                genesis_config = update_genesis_config_with_time(
-                    existing_genesis_config, genesis_time
-                )
-        else:
+                try:
+                    existing_genesis_config = json.load(config_file)
+                except JSONDecodeError as e:
+                    existing_genesis_config = None
+                    cls.logger.warning("failed to load existing config as json: %s", e)
+
+        if args.genesis_time:
+            genesis_time = args.genesis_time
+            cls.logger.info("genesis time specified from config: %d", genesis_time)
+        elif args.genesis_delay:
+            genesis_time = int(time.time()) + args.genesis_delay
+            cls.logger.info(
+                "genesis delay specified from config: %d", args.genesis_delay
+            )
+
+        if (args.genesis_time or args.genesis_delay) and existing_genesis_config:
+            genesis_config = update_genesis_config_with_time(
+                existing_genesis_config, genesis_time
+            )
+        elif args.genesis_time or args.genesis_delay:
             genesis_config = generate_genesis_config(args.config_profile, genesis_time)
+        else:
+            genesis_config = genesis_config_from_state(
+                args.config_profile, args.genesis_state
+            )
+
+        genesis_time = genesis_config["genesis_state"]["genesis_time"]
         cls.logger.info(
             "configuration generated; genesis state has root %s with genesis time %d (%s); "
             "writing to '%s'",
@@ -97,4 +125,4 @@ class NetworkGeneratorComponent(Application):
         )
         output_file_path.parent.mkdir(parents=True, exist_ok=True)
         with open(output_file_path, "w") as output_file:
-            json.dump(genesis_config, output_file)
+            json.dump(genesis_config, output_file, cls=BytesJsonEncoder)

--- a/trinity/config.py
+++ b/trinity/config.py
@@ -14,7 +14,6 @@ import json
 from pathlib import (
     Path,
 )
-import time
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -69,9 +68,6 @@ from eth2.beacon.typing import (
 )
 from eth2.configs import (
     Eth2Config,
-)
-from eth2.genesis import (
-    generate_genesis_config,
 )
 from p2p.kademlia import (
     Node as KademliaNode,
@@ -732,9 +728,8 @@ class BeaconChainConfig:
         try:
             with open(_get_eth2_genesis_config_file_path("minimal")) as config_file:
                 genesis_config = json.load(config_file)
-        except FileNotFoundError:
-            genesis_time = Timestamp(int(time.time()))
-            genesis_config = generate_genesis_config("minimal", genesis_time)
+        except FileNotFoundError as e:
+            raise Exception("unable to load genesis config: %s", e)
 
         eth2_config = Eth2Config.from_formatted_dict(genesis_config["eth2_config"])
         # NOTE: have to ``override_lengths`` before we can parse the ``BeaconState``

--- a/trinity/main_validator.py
+++ b/trinity/main_validator.py
@@ -1,5 +1,4 @@
 import json
-import time
 import logging
 from pathlib import Path
 from typing import Any, Dict
@@ -10,9 +9,8 @@ import trio
 from eth2.beacon.tools.builder.initializer import load_genesis_key_map
 from eth2.beacon.tools.misc.ssz_vector import override_lengths
 from eth2.beacon.types.states import BeaconState
-from eth2.beacon.typing import Slot, Timestamp
+from eth2.beacon.typing import Slot
 from eth2.configs import Eth2Config
-from eth2.genesis import generate_genesis_config
 from eth2.validator_client.cli_parser import parse_cli_args
 from eth2.validator_client.config import Config
 from eth2.validator_client.tools.directory import create_dir_if_missing
@@ -67,9 +65,8 @@ def main_validator() -> None:
         genesis_config = _load_genesis_config_at(
             validator_client_app_config.genesis_config_path
         )
-    except FileNotFoundError:
-        genesis_time = Timestamp(int(time.time()))
-        genesis_config = generate_genesis_config("minimal", genesis_time)
+    except FileNotFoundError as e:
+        raise Exception("unable to load genesis config: %s", e)
 
     eth2_config = Eth2Config.from_formatted_dict(genesis_config["eth2_config"])
     override_lengths(eth2_config)


### PR DESCRIPTION
### What was wrong?

We need to be able to set the initial state of the beacon chain.

### How was it fixed?

Added a parameter to the `create-network` subcommand that allows you to set the genesis state of the chain you're configuring.

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://i.redd.it/97nn8ze11q951.jpg)
