### PR TITLE
Use INFO as the default level for async-service's logger

### DIFF
--- a/tests/integration/test_trinity_cli.py
+++ b/tests/integration/test_trinity_cli.py
@@ -312,9 +312,9 @@ async def test_does_not_throw_errors_on_short_run(command, unused_tcp_port):
         pytest.param(
             # Enable DEBUG2 logs for everything except discovery which is reduced to ERROR logs
             ('trinity', '-l=DEBUG2', '-l', 'p2p.discovery=ERROR'),
-            {'Started main process', '<Manager[ConnectionTrackerServer] flags=SRcfe>: running root task run[daemon=False]'},  # noqa: E501
+            {'Started main process', 'RemoteEndpoint connection established'},
             {'>>> ping'},
-            {'Started main process', '<Manager[ConnectionTrackerServer] flags=SRcfe>: running root task run[daemon=False]'},  # noqa: E501
+            {'Started main process', 'RemoteEndpoint connection established'},
             {'>>> ping'},
             id="all>=debug2,p2p>=error:starts-both,manager_debug-both,ping-none",
         ),

--- a/trinity/bootstrap.py
+++ b/trinity/bootstrap.py
@@ -199,6 +199,10 @@ def install_logging(args: argparse.Namespace,
 
     # Set the individual logger levels that have been specified.
     logger_levels = {} if args.log_levels is None else args.log_levels
+    # async-service's DEBUG logs completely drowns our stuff (i.e. more than 95% of all our DEBUG
+    # logs), so unless explicitly overridden, we limit it to INFO.
+    if 'async_service' not in logger_levels:
+        logger_levels['async_service'] = logging.INFO
     set_logger_levels(logger_levels)
 
     min_log_level = min(


### PR DESCRIPTION
async-service's DEBUG logs completely drowns everything else as it
accounts for more than 95% of all our DEBUG logs, so by default set it
to INFO.

Also change the number of backup log files we keep from 10 to 20