### PR TITLE
A few tweaks to try and find more reachable/compatible peers

### DIFF
--- a/tests/p2p/test_connection_tracker_timeout_for_failure.py
+++ b/tests/p2p/test_connection_tracker_timeout_for_failure.py
@@ -4,7 +4,11 @@ import pytest
 
 from p2p.exceptions import (
     HandshakeFailure,
+    HandshakeFailureTooManyPeers,
+    MalformedMessage,
+    NoMatchingPeerCapabilities,
 )
+from p2p.peer_pool import COMMON_PEER_CONNECTION_EXCEPTIONS
 from p2p.tracking.connection import (
     get_timeout_for_failure,
     register_error,
@@ -30,8 +34,12 @@ def _prevent_global_mutation_of_registry():
     assert connection.FAILURE_TIMEOUTS == original
 
 
-def test_get_timeout_for_failure_with_HandshakeFailure():
-    assert get_timeout_for_failure(HandshakeFailure()) == 10
+def test_get_timeout_for_common_handshake_exceptions():
+    common_exc_types = COMMON_PEER_CONNECTION_EXCEPTIONS + (
+        HandshakeFailure, HandshakeFailureTooManyPeers, MalformedMessage,
+        NoMatchingPeerCapabilities)
+    for exc_type in common_exc_types:
+        assert get_timeout_for_failure(exc_type()) <= (60 * 60)
 
 
 def test_get_timeout_for_failure_with_unknown_exception():

--- a/trinity/_utils/ipc.py
+++ b/trinity/_utils/ipc.py
@@ -1,5 +1,4 @@
 from logging import Logger
-from multiprocessing import Process
 import os
 import pathlib
 import signal
@@ -51,14 +50,6 @@ def remove_dangling_ipc_files(logger: Logger,
 
 DEFAULT_SIGINT_TIMEOUT = 10
 DEFAULT_SIGTERM_TIMEOUT = 5
-
-
-def kill_process_gracefully(
-        process: Process,
-        logger: Logger,
-        SIGINT_timeout: int = DEFAULT_SIGINT_TIMEOUT,
-        SIGTERM_timeout: int = DEFAULT_SIGTERM_TIMEOUT) -> None:
-    kill_process_id_gracefully(process.pid, process.join, logger, SIGINT_timeout, SIGTERM_timeout)
 
 
 def kill_popen_gracefully(

--- a/trinity/constants.py
+++ b/trinity/constants.py
@@ -90,8 +90,7 @@ DEFAULT_PREFERRED_NODES: Dict[int, Tuple[Node, ...]] = {
     ),
 }
 
-# Amount of time a peer will be blacklisted if their network or genesis hash does not match
-BLACKLIST_SECONDS_WRONG_NETWORK_OR_GENESIS = 600
-
-# Enables connection when clients launch from another process on the shell
-AUTH_KEY = b"not secure, but only connect over IPC"
+# Number of seconds a peer will be blacklisted if we get an error during handshake.
+# These are not failures that we expect to be transient, so no point in retrying frequently.
+BLACKLIST_SECONDS_WRONG_NETWORK_OR_GENESIS = 60 * 60
+BLACKLIST_SECONDS_DAO_FORK_CHECK_FAILURE = 60 * 60

--- a/trinity/exceptions.py
+++ b/trinity/exceptions.py
@@ -1,9 +1,15 @@
 import pathlib
 
-from p2p.exceptions import HandshakeFailure
+from p2p.exceptions import (
+    BaseP2PError,
+    HandshakeFailure,
+)
 from p2p.tracking.connection import register_error
 
-from trinity.constants import BLACKLIST_SECONDS_WRONG_NETWORK_OR_GENESIS
+from trinity.constants import (
+    BLACKLIST_SECONDS_DAO_FORK_CHECK_FAILURE,
+    BLACKLIST_SECONDS_WRONG_NETWORK_OR_GENESIS,
+)
 
 
 class BaseTrinityError(Exception):
@@ -43,11 +49,14 @@ class OversizeObject(BaseTrinityError):
     pass
 
 
-class DAOForkCheckFailure(BaseTrinityError):
+class DAOForkCheckFailure(BaseP2PError):
     """
     Raised when the DAO fork check with a certain peer is unsuccessful.
     """
     pass
+
+
+register_error(DAOForkCheckFailure, BLACKLIST_SECONDS_DAO_FORK_CHECK_FAILURE)
 
 
 class BadDatabaseError(BaseTrinityError):

--- a/trinity/protocol/common/boot.py
+++ b/trinity/protocol/common/boot.py
@@ -28,6 +28,7 @@ class DAOCheckBootManager(BasePeerBootManager):
             await self.ensure_same_side_on_dao_fork()
         except DAOForkCheckFailure as err:
             self.logger.debug("DAO fork check with %s failed: %s", self.peer, err)
+            self.peer.connection_tracker.record_failure(self.peer.remote, err)
             self.peer.disconnect_nowait(DisconnectReason.USELESS_PEER)
 
     async def ensure_same_side_on_dao_fork(self) -> None:

--- a/trinity/protocol/common/peer.py
+++ b/trinity/protocol/common/peer.py
@@ -322,7 +322,7 @@ def skip_candidate_if_on_list_or_fork_mismatch(
     try:
         candidate_forkid = extract_forkid(candidate.enr)
     except ENRMissingForkID:
-        p2p_logger.debug("Accepting connection candidate (%s) with no ForkID", candidate)
+        p2p_logger.debug2("Accepting connection candidate (%s) with no ForkID", candidate)
         return False
     except MalformedMessage as e:
         # Logging as a warning just in case there's a bug in our code that fails to deserialize
@@ -338,8 +338,9 @@ def skip_candidate_if_on_list_or_fork_mismatch(
     try:
         validate_forkid(candidate_forkid, genesis_hash, head, fork_blocks)
     except BaseForkIDValidationError as e:
-        p2p_logger.debug("Skipping forkid-incompatible connection candidate (%s): %s", candidate, e)
+        p2p_logger.debug2(
+            "Skipping forkid-incompatible connection candidate (%s): %s", candidate, e)
         return True
 
-    p2p_logger.debug("Accepting forkid-compatible connection candidate (%s)", candidate)
+    p2p_logger.debug2("Accepting forkid-compatible connection candidate (%s)", candidate)
     return False


### PR DESCRIPTION
The main cause I've identified for us not connecting to enough peers was that we were constantly retrying peers that we had already failed to connect to, instead of trying to find and connect to new ones. With the following changes we'll discover more compatible peers and attempt to connect to them before retrying old ones

- Blacklist peers that are unreachable, timeout or have no matching caps (those account for ~60% of handshake errors)

- Blacklist peers that fail the DAO check

- Increase blacklist timeout for all handshake errors. Most of them were set to 10s, effectively causing us to retry these before we had a chance of trying new ones.

- PeerPool now requests a larger batch of peer candidates on every iteration, effectively pushing DiscoveryService # to trigger new peer lookups in order to find enough compatible peers to fulfill our request