### PR TITLE
Connecting to bootstrap nodes.

### DIFF
--- a/tests-trio/conftest.py
+++ b/tests-trio/conftest.py
@@ -227,6 +227,7 @@ def beacon_node(
         p2p_maddr,
         "a",
         (),
+        (),
     )
 
 

--- a/trinity/components/eth2/beacon_trio/component.py
+++ b/trinity/components/eth2/beacon_trio/component.py
@@ -30,7 +30,10 @@ class BeaconNodeComponent(TrioComponent):
         trinity_config = self._boot_info.trinity_config
         beacon_app_config = trinity_config.get_app_config(BeaconAppConfig)
         config = BeaconNodeConfig.from_platform_config(
-            trinity_config, beacon_app_config, boot_info.args.validator_api_port
+            trinity_config,
+            beacon_app_config,
+            boot_info.args.validator_api_port,
+            boot_info.args.bootstrap_nodes,
         )
         node = BeaconNode.from_config(config)
         self._node = node

--- a/trinity/nodes/beacon/config.py
+++ b/trinity/nodes/beacon/config.py
@@ -42,12 +42,13 @@ class BeaconNodeConfig:
         trinity_config: TrinityConfig,
         beacon_app_config: BeaconAppConfig,
         validator_api_port: int,
+        bootstrap_nodes: Collection[Multiaddr],
     ) -> "BeaconNodeConfig":
         chain_config = beacon_app_config.get_chain_config()
         return cls(
             beacon_app_config.database_dir,
             beacon_app_config.orchestration_profile,
-            beacon_app_config.bootstrap_nodes,
+            bootstrap_nodes,
             beacon_app_config.preferred_nodes,
             chain_config,
             trinity_config.nodekey,


### PR DESCRIPTION
### What was wrong?

Bootstrap nodes passed into the `beacon-node-trio` component are ignored.


### How was it fixed?

We now connect to these nodes.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

[//]: # (See: https://trinity-client.readthedocs.io/en/latest/contributing.html#pull-requests)
- [ ] Add entry to the [release notes](https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://preview.redd.it/qh9rh644j0a51.jpg?width=640&crop=smart&auto=webp&s=c90eeb492805245b1b261fd3f0d4d893da98b7f8)
