### PR TITLE
Do not dump whole traceback on console for RPCErrors

### DIFF
--- a/newsfragments/1870.bugfix.rst
+++ b/newsfragments/1870.bugfix.rst
@@ -1,0 +1,1 @@
+Log a user-friendly message on JSON-RPC API errors


### PR DESCRIPTION
### What was wrong?

Two things:

1. The `RPCServer` logs everything on the `root` logger.

2. When we raise a well defined `RPCError` such as `Block 4711 is not in the canonical chain` we dump the whole traceback on the console which makes it look as if something horrible has gone wrong e.g.

```
    INFO  2020-07-10 18:16:33,649                  root  RPC method caused exception
Traceback (most recent call last):
  File "/home/cburgdorf/Documents/hacking/ef/py-evm/eth/db/chain.py", line 369, in get_transaction_index
    encoded_key = self.db[key]
  File "/home/cburgdorf/Documents/hacking/ef/trinity/trinity/db/manager.py", line 291, in __getitem__
    raise KeyError(key)
KeyError: b'transaction-hash-to-block:[\x9eeV#e\x98Y\x9a\xce\xb2\xbeW5\x7f\xc6\xf7\x85\x8f\xea!\xc4=\xc0\x04W\x02\x91\x1cCZ\xc3'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/cburgdorf/Documents/hacking/ef/trinity/trinity/rpc/modules/eth.py", line 297, in getTransactionReceipt
    transaction_hash,
  File "/home/cburgdorf/Documents/hacking/ef/trinity/trinity/_utils/async_dispatch.py", line 25, in wrapper
    *args
  File "/usr/lib/python3.7/concurrent/futures/thread.py", line 57, in run
    result = self.fn(*self.args, **self.kwargs)
  File "/home/cburgdorf/Documents/hacking/ef/py-evm/eth/chains/base.py", line 369, in get_canonical_transaction_index
    return self.chaindb.get_transaction_index(transaction_hash)
  File "/home/cburgdorf/Documents/hacking/ef/py-evm/eth/db/chain.py", line 372, in get_transaction_index
    f"Transaction {encode_hex(transaction_hash)} not found in canonical chain"
eth.exceptions.TransactionNotFound: Transaction 0x5b9e6556236598599aceb2be57357fc6f7858fea21c43dc0045702911c435ac3 not found in canonical chain

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/home/cburgdorf/Documents/hacking/ef/trinity/trinity/rpc/main.py", line 121, in _get_result
    self.event_bus, method, params, self.chain,
  File "/home/cburgdorf/Documents/hacking/ef/trinity/trinity/rpc/retry.py", line 110, in execute_with_retries
    return await func(*params)
  File "/home/cburgdorf/Documents/hacking/ef/trinity/trinity/rpc/format.py", line 213, in formatted_func
    return await func(self, *formatted)
  File "/home/cburgdorf/Documents/hacking/ef/trinity/trinity/rpc/modules/eth.py", line 302, in getTransactionReceipt
    ) from exc
trinity.exceptions.RpcError: Transaction 0x5b9e6556236598599aceb2be57357fc6f7858fea21c43dc0045702911c435ac3 is not in the canonical chain
    INFO  2020-07-10 18:16:33,696                  root  RPC method caused exception
Traceback (most recent call last):
  File "/home/cburgdorf/Documents/hacking/ef/py-evm/eth/db/chain.py", line 369, in get_transaction_index
    encoded_key = self.db[key]
  File "/home/cburgdorf/Documents/hacking/ef/trinity/trinity/db/manager.py", line 291, in __getitem__
    raise KeyError(key)
KeyError: b'transaction-hash-to-block:[\x9eeV#e\x98Y\x9a\xce\xb2\xbeW5\x7f\xc6\xf7\x85\x8f\xea!\xc4=\xc0\x04W\x02\x91\x1cCZ\xc3'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/cburgdorf/Documents/hacking/ef/trinity/trinity/rpc/modules/eth.py", line 297, in getTransactionReceipt
    transaction_hash,
  File "/home/cburgdorf/Documents/hacking/ef/trinity/trinity/_utils/async_dispatch.py", line 25, in wrapper
    *args
  File "/usr/lib/python3.7/concurrent/futures/thread.py", line 57, in run
    result = self.fn(*self.args, **self.kwargs)
  File "/home/cburgdorf/Documents/hacking/ef/py-evm/eth/chains/base.py", line 369, in get_canonical_transaction_index
    return self.chaindb.get_transaction_index(transaction_hash)
  File "/home/cburgdorf/Documents/hacking/ef/py-evm/eth/db/chain.py", line 372, in get_transaction_index
    f"Transaction {encode_hex(transaction_hash)} not found in canonical chain"
eth.exceptions.TransactionNotFound: Transaction 0x5b9e6556236598599aceb2be57357fc6f7858fea21c43dc0045702911c435ac3 not found in canonical chain

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/home/cburgdorf/Documents/hacking/ef/trinity/trinity/rpc/main.py", line 121, in _get_result
    self.event_bus, method, params, self.chain,
  File "/home/cburgdorf/Documents/hacking/ef/trinity/trinity/rpc/retry.py", line 110, in execute_with_retries
    return await func(*params)
  File "/home/cburgdorf/Documents/hacking/ef/trinity/trinity/rpc/format.py", line 213, in formatted_func
    return await func(self, *formatted)
  File "/home/cburgdorf/Documents/hacking/ef/trinity/trinity/rpc/modules/eth.py", line 302, in getTransactionReceipt
    ) from exc
trinity.exceptions.RpcError: Transaction 0x5b9e6556236598599aceb2be57357fc6f7858fea21c43dc0045702911c435ac3 is not in the canonical chain
```
### How was it fixed?

1. The `RPCServer` does now define its own child logger.

2. We catch `RPCError` separately and only log the exception message as `INFO` e.g.

```
 INFO  2020-07-10 18:29:21,310             RPCServer  Transaction 0x948332a48152d67946551bb2067a03f2b4eb256aaf3e93d64ced545210e16762 is not in the canonical chain

```

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

[//]: # (See: https://trinity-client.readthedocs.io/en/latest/contributing.html#pull-requests)
- [x] Add entry to the [release notes](https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://i.redd.it/0prby8ixnlo21.jpg)
