### PR TITLE
Catch exception in eth_getTransactionReceipt API

### DIFF
--- a/newsfragments/1871.bugfix.rst
+++ b/newsfragments/1871.bugfix.rst
@@ -1,0 +1,2 @@
+Catch exception and present user friendly error when a request for an receipt
+to an unknown transaction is send to the ``eth_getTransactionReceipt`` API.

--- a/trinity/rpc/modules/eth.py
+++ b/trinity/rpc/modules/eth.py
@@ -271,9 +271,14 @@ class Eth(Eth1ChainRPCModule):
     async def getTransactionReceipt(self,
                                     transaction_hash: Hash32) -> RpcReceiptResponse:
 
-        tx_block_number, tx_index = await self.chain.coro_get_canonical_transaction_index(
-            transaction_hash,
-        )
+        try:
+            tx_block_number, tx_index = await self.chain.coro_get_canonical_transaction_index(
+                transaction_hash,
+            )
+        except TransactionNotFound as exc:
+            raise RpcError(
+                f"Transaction {encode_hex(transaction_hash)} is not in the canonical chain"
+            ) from exc
 
         try:
             block_header = await self.chain.coro_get_canonical_block_header_by_number(


### PR DESCRIPTION
### What was wrong?

There's an exception escaping the `eth_getTransactionReceipt` API for when a receipt to an unknown transaction is requested.

### How was it fixed?

Catch the error and raise an `RPCError`

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

[//]: # (See: https://trinity-client.readthedocs.io/en/latest/contributing.html#pull-requests)
- [x] Add entry to the [release notes](https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://i.pinimg.com/originals/99/18/d5/9918d5e4dffe8002a5f33f17db686b00.jpg)
