### PR TITLE
Ensure eth_* JSON-RPC APIs work with all block identifier during beam sync

### DIFF
--- a/newsfragments/1873.bugfix.rst
+++ b/newsfragments/1873.bugfix.rst
@@ -1,0 +1,1 @@
+Ensure JSON-RPC API do work with hexadecimal block identifier during beam sync

--- a/newsfragments/1873.feature.rst
+++ b/newsfragments/1873.feature.rst
@@ -1,0 +1,1 @@
+Make ``eth_getTransactionCount`` work during beam sync by requesting state on-demand from peers.

--- a/tests/core/json-rpc/test_rpc_during_beam_sync.py
+++ b/tests/core/json-rpc/test_rpc_during_beam_sync.py
@@ -201,9 +201,6 @@ def fake_beam_syncer(chain, event_bus):
     return fake_beam_sync
 
 
-# Test that eth_getBalance works during beam sync
-
-
 @pytest.mark.parametrize(
     "at_block", ('latest', '0x0', 0)
 )
@@ -234,8 +231,6 @@ async def test_getBalance_during_beam_sync(
         assert 'error' not in response
         assert response['result'] == hex(funded_address_initial_balance)
 
-
-# Test that eth_getTransactionCount works during beam sync
 
 @pytest.mark.parametrize(
     "at_block", ('latest', '0x0', 0)
@@ -298,9 +293,6 @@ async def test_getCode_during_beam_sync(
         response = await ipc_request('eth_getCode', [simple_contract_address.hex(), at_block])
         assert 'error' not in response
         assert keccak(decode_hex(response['result'])) == contract_code_hash
-
-
-# Test that eth_getStorageAt works during Beam Sync
 
 
 @pytest.fixture

--- a/trinity/rpc/modules/eth.py
+++ b/trinity/rpc/modules/eth.py
@@ -280,8 +280,10 @@ class Eth(Eth1ChainRPCModule):
         transaction = block.transactions[index]
         return transaction_to_dict(transaction)
 
+    @retryable(which_block_arg_name='at_block')
     @format_params(decode_hex, to_int_if_hex)
     async def getTransactionCount(self, address: Address, at_block: Union[str, int]) -> str:
+
         state = await state_at_block(self.chain, at_block)
         nonce = state.get_nonce(address)
         return hex(nonce)

--- a/trinity/rpc/modules/eth.py
+++ b/trinity/rpc/modules/eth.py
@@ -173,8 +173,8 @@ class Eth(Eth1ChainRPCModule):
         num = self.chain.get_canonical_head().block_number
         return hex(num)
 
-    @retryable(which_block_arg_name='at_block')
     @format_params(identity, to_int_if_hex)
+    @retryable(which_block_arg_name='at_block')
     async def call(self, txn_dict: Dict[str, Any], at_block: Union[str, int]) -> str:
         header = await get_header(self.chain, at_block)
         validate_transaction_call_dict(txn_dict, self.chain.get_vm(header))
@@ -185,8 +185,8 @@ class Eth(Eth1ChainRPCModule):
     async def coinbase(self) -> str:
         raise NotImplementedError("Trinity does not support mining")
 
-    @retryable(which_block_arg_name='at_block')
     @format_params(identity, to_int_if_hex)
+    @retryable(which_block_arg_name='at_block')
     async def estimateGas(self, txn_dict: Dict[str, Any], at_block: Union[str, int]) -> str:
         header = await get_header(self.chain, at_block)
         validate_transaction_gas_estimation_dict(txn_dict, self.chain.get_vm(header))
@@ -197,8 +197,8 @@ class Eth(Eth1ChainRPCModule):
     async def gasPrice(self) -> str:
         return hex(int(os.environ.get('TRINITY_GAS_PRICE', to_wei(1, 'gwei'))))
 
-    @retryable(which_block_arg_name='at_block')
     @format_params(decode_hex, to_int_if_hex)
+    @retryable(which_block_arg_name='at_block')
     async def getBalance(self, address: Address, at_block: Union[str, int]) -> str:
         state = await state_at_block(self.chain, at_block)
         balance = state.get_balance(address)
@@ -240,15 +240,15 @@ class Eth(Eth1ChainRPCModule):
         block = await get_block_at_number(self.chain, at_block)
         return hex(len(block.transactions))
 
-    @retryable(which_block_arg_name='at_block')
     @format_params(decode_hex, to_int_if_hex)
+    @retryable(which_block_arg_name='at_block')
     async def getCode(self, address: Address, at_block: Union[str, int]) -> str:
         state = await state_at_block(self.chain, at_block)
         code = state.get_code(address)
         return encode_hex(code)
 
-    @retryable(which_block_arg_name='at_block')
     @format_params(decode_hex, to_int_if_hex, to_int_if_hex)
+    @retryable(which_block_arg_name='at_block')
     async def getStorageAt(self, address: Address, position: int, at_block: Union[str, int]) -> str:
         if not is_integer(position) or position < 0:
             raise TypeError("Position of storage must be a whole number, but was: %r" % position)
@@ -280,8 +280,8 @@ class Eth(Eth1ChainRPCModule):
         transaction = block.transactions[index]
         return transaction_to_dict(transaction)
 
-    @retryable(which_block_arg_name='at_block')
     @format_params(decode_hex, to_int_if_hex)
+    @retryable(which_block_arg_name='at_block')
     async def getTransactionCount(self, address: Address, at_block: Union[str, int]) -> str:
 
         state = await state_at_block(self.chain, at_block)

--- a/trinity/rpc/retry.py
+++ b/trinity/rpc/retry.py
@@ -24,6 +24,7 @@ from eth.vm.interrupt import (
 
 from trinity.chains.base import AsyncChainAPI
 from trinity.db.beacon.chain import BaseAsyncBeaconChainDB
+from trinity.rpc.format import to_int_if_hex
 from trinity.sync.common.events import (
     CollectMissingAccount,
     CollectMissingBytecode,
@@ -83,7 +84,8 @@ async def check_requested_block_age(chain: Union[AsyncChainAPI, BaseAsyncBeaconC
 
     # Beacon chain doesn't support it
     if not isinstance(chain, BaseAsyncBeaconChainDB):
-        at_block = params.arguments[at_block_name]
+        at_block = to_int_if_hex(params.arguments[at_block_name])
+
         requested_header = await get_header(chain, at_block)
         requested_block = requested_header.block_number
         current_block = chain.get_canonical_head().block_number


### PR DESCRIPTION
### What was wrong?

During beam sync there's some extra machinery that ensures state dependent `eth_*` JSON-RPC API calls fetch missing state on demand from peers.

This extra machinery did not work when the block was specified via a hex string.

### How was it fixed?

1. Added a call to `to_int_if_hex` in `trinity/rpc/retry.py`

2. Added tests that ensure these APIs work with all kinds of valid block identifier.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

[//]: # (See: https://trinity-client.readthedocs.io/en/latest/contributing.html#pull-requests)
- [x] Add entry to the [release notes](https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://encrypted-tbn0.gstatic.com/images?q=tbn%3AANd9GcSfp6oHacjOPtgv6oZXxjkpo48CV7QNaHlygQ&usqp=CAU)
