### PR TITLE
Peer.run() no longer crashes if self._p2p_api is not set

### DIFF
--- a/p2p/logic.py
+++ b/p2p/logic.py
@@ -90,7 +90,8 @@ async def wait_first(futures: Sequence[asyncio.Future[None]]) -> None:
         await cancel_futures(futures)
         raise
     else:
-        await cancel_futures(pending)
+        if pending:
+            await cancel_futures(pending)
         if len(done) != 1:
             raise Exception(
                 "Invariant: asyncio.wait() returned more than one future even "

--- a/p2p/peer_pool.py
+++ b/p2p/peer_pool.py
@@ -404,7 +404,7 @@ class BasePeerPool(Service, AsyncIterable[BasePeer]):
             if not batch:
                 return
 
-            self.logger.info(
+            self.logger.debug(
                 'Initiating %d peer connection attempts with %d open peer slots',
                 len(batch),
                 self.available_slots,


### PR DESCRIPTION
The finally: block in Peer.run() could, in some cases, execute without
self._p2p_api being set, causing it to crash. That is now fixed.

Also, if a Peer behavior crashes unexpectedly, we now propagate that
instead of silently terminating.

Closes: #1875
Closes: #1874
Closes: #1877 