### PR TITLE
Implement pause/resume for header backfill

### DIFF
--- a/newsfragments/1879.bugfix.rst
+++ b/newsfragments/1879.bugfix.rst
@@ -1,0 +1,3 @@
+Fix ``ConnectionBusy`` exception taking whole node down. The fix makes it so
+that additional``GetBlockHeaders`` request (for historical backfill) are allowed
+to be queued up.

--- a/newsfragments/1879.feature.rst
+++ b/newsfragments/1879.feature.rst
@@ -1,0 +1,2 @@
+Implement pause/resume for historical header backfill. The backfill will pause
+if beam sync starts lagging too far behind and will resume as it catches up again.

--- a/p2p/exchange/constants.py
+++ b/p2p/exchange/constants.py
@@ -10,4 +10,4 @@ ROUND_TRIP_TIMEOUT = 20.0
 # they are sent. This is an estimate of how many get queued locally. The reason we
 # estimate the queue length is to determine how long a timeout to use when
 # waiting for the lock to send the next queued peer request.
-NUM_QUEUED_REQUESTS = 3
+NUM_QUEUED_REQUESTS = 4

--- a/trinity/_utils/pauser.py
+++ b/trinity/_utils/pauser.py
@@ -1,0 +1,49 @@
+import asyncio
+
+
+class Pauser:
+    """
+    A helper class to provide pause / resume functionality to other classes.
+    """
+
+    def __init__(self) -> None:
+        self._paused = False
+        self._resumed = asyncio.Event()
+
+    @property
+    def is_paused(self) -> bool:
+        """
+        Return ``True`` if the state of managed operation is paused, otherwise ``False``.
+        """
+        return self._paused
+
+    def pause(self) -> None:
+        """
+        Pause the managed operation.
+        """
+        if self._paused:
+            raise RuntimeError(
+                "Invalid action. Can not pause an operation that is already paused."
+            )
+
+        self._paused = True
+
+    def resume(self) -> None:
+        """
+        Resume the operation.
+        """
+        if not self._paused:
+            raise RuntimeError("Invalid action. Can not resume operation that isn't paused.")
+
+        self._paused = False
+        self._resumed.set()
+
+    async def await_resume(self) -> None:
+        """
+        Await until ``resume()`` is called. Throw if called when the operation is not paused.
+        """
+        if not self._paused:
+            raise RuntimeError("Can not await resume on operation that isn't paused.")
+
+        await self._resumed.wait()
+        self._resumed.clear()

--- a/trinity/sync/beam/chain.py
+++ b/trinity/sync/beam/chain.py
@@ -76,6 +76,7 @@ from trinity.sync.full.chain import (
     FastChainBodySyncer,
     RegularChainBodySyncer,
 )
+from trinity.sync.header.chain import SequentialHeaderChainGapSyncer
 from trinity.sync.beam.state import (
     BeamDownloader,
 )
@@ -84,7 +85,6 @@ from trinity._utils.logging import get_logger
 from trinity._utils.headers import body_for_header_exists
 
 from .backfill import BeamStateBackfill
-from ..header.chain import SequentialHeaderChainGapSyncer
 
 
 STATS_DISPLAY_PERIOD = 10

--- a/trinity/sync/common/constants.py
+++ b/trinity/sync/common/constants.py
@@ -5,6 +5,10 @@ EMPTY_PEER_RESPONSE_PENALTY = 15.0
 # which covers about 6 days at 15s blocks
 MAX_SKELETON_REORG_DEPTH = 35000
 
+# The maximum number of headers that the backfill can sync in one uninterrupted stretch.
+# Depending on the lag, the job may get paused but will continue until the current stretch
+# has processed this number of headers.
+MAX_BACKFILL_HEADERS_AT_ONCE = 100_000
 
 # How many headers/blocks should we queue up waiting to be persisted?
 # This buffer size is estimated using: NUM_BLOCKS_PERSISTED_PER_SEC * BUFFER_SECONDS * MARGIN


### PR DESCRIPTION
### What was wrong?

As discussed in #1797 Trinity is taken down by a `ConnectionBusy` error if the tip syncer + the historical header backfill syncer both operate on the same peer at the same time.

### How was it fixed?

1. Allow additional `GetBlockHeaders` requests to queue up

2. Implement pause/resume for the historical header backfill and let it be governed by beam syncs lag monitoring. If we lag too far behind the historical backfill will pause.

3. The logic has some overlap with pause/resume of the block backfill so there's a bit of additional refactoring to reduce boilerplate.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

[//]: # (See: https://trinity-client.readthedocs.io/en/latest/contributing.html#pull-requests)
- [x] Add entry to the [release notes](https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://i.pinimg.com/originals/08/c7/ba/08c7bad5610c5bc023a2e2ae00715b5b.jpg)
