### PR TITLE
Log backfill stats to info

### DIFF
--- a/newsfragments/1872.feature.rst
+++ b/newsfragments/1872.feature.rst
@@ -1,0 +1,1 @@
+Show state backfill progress as info logs

--- a/p2p/peer.py
+++ b/p2p/peer.py
@@ -295,9 +295,10 @@ class BasePeer(Service):
         finally:
             for callback in self._finished_callbacks:
                 callback(self)
-            if (self.p2p_api.local_disconnect_reason is None and
-                    self.p2p_api.remote_disconnect_reason is None):
-                self._send_disconnect(DisconnectReason.CLIENT_QUITTING)
+            if hasattr(self, 'p2p_api'):
+                if (self.p2p_api.local_disconnect_reason is None and
+                        self.p2p_api.remote_disconnect_reason is None):
+                    self._send_disconnect(DisconnectReason.CLIENT_QUITTING)
             # We run as a child service of the connection, but we don't want to leave a connection
             # open if somebody cancels just us, so this ensures the connection gets closed as well.
             if not self.connection.get_manager().is_cancelled:

--- a/p2p/peer_pool.py
+++ b/p2p/peer_pool.py
@@ -474,7 +474,7 @@ class BasePeerPool(Service, AsyncIterable[BasePeer]):
         This is passed as a callback to be called when a peer finishes.
         """
         if peer.session in self.connected_nodes:
-            self.logger.info(
+            self.logger.debug(
                 "Removing %s from pool: local_reason=%s remote_reason=%s",
                 peer,
                 peer.p2p_api.local_disconnect_reason,

--- a/p2p/peer_pool.py
+++ b/p2p/peer_pool.py
@@ -404,7 +404,7 @@ class BasePeerPool(Service, AsyncIterable[BasePeer]):
             if not batch:
                 return
 
-            self.logger.info(
+            self.logger.debug(
                 'Initiating %d peer connection attempts with %d open peer slots',
                 len(batch),
                 self.available_slots,

--- a/trinity/sync/beam/constants.py
+++ b/trinity/sync/beam/constants.py
@@ -42,8 +42,8 @@ GAP_BETWEEN_TESTS = 0.25
 # to establish it (partially because we measure using an exponential average).
 
 # About how long after a block can we request trie data from peers?
-# The value is configurable by client, but tends to be around 120 blocks.
-ESTIMATED_BEAMABLE_BLOCKS = 120
+# The value is configurable by client, but tends to be around 75 blocks.
+ESTIMATED_BEAMABLE_BLOCKS = 75
 
 # It's also useful to estimate the amount of time covered by those beamable blocks.
 PREDICTED_BLOCK_TIME = 14

--- a/trinity/sync/beam/service.py
+++ b/trinity/sync/beam/service.py
@@ -100,7 +100,14 @@ class BeamSyncService(Service):
                         logger = self.logger.info
                     else:
                         logger = self.logger.debug
-                    logger("Beam Sync is lagging behind the latest known header by %d blocks", lag)
+                    logger(
+                        (
+                            "Beam Sync is lagging behind the latest known header by %d blocks,"
+                            " will pivot at %d"
+                        ),
+                        lag,
+                        ESTIMATED_BEAMABLE_BLOCKS,
+                    )
 
                     # Keep monitoring
                     continue

--- a/trinity/sync/beam/state.py
+++ b/trinity/sync/beam/state.py
@@ -526,7 +526,7 @@ class BeamDownloader(Service, PeerSubscriber):
             # log peer counts
             show_top_n_peers = 3
             self.logger.debug(
-                "Beam-Sync-Peer-Usage-Top-%d: urgent=%s, predictive=%s",
+                "beam-queen-usage-top-%d: urgent=%s, predictive=%s",
                 show_top_n_peers,
                 self._num_urgent_requests_by_peer.most_common(show_top_n_peers),
                 self._num_predictive_requests_by_peer.most_common(show_top_n_peers),

--- a/trinity/sync/full/chain.py
+++ b/trinity/sync/full/chain.py
@@ -73,15 +73,13 @@ from trinity.sync.common.chain import (
     SimpleBlockImporter,
 )
 from trinity.sync.common.constants import (
+    BLOCK_IMPORT_QUEUE_SIZE,
+    BLOCK_QUEUE_SIZE_TARGET,
     EMPTY_PEER_RESPONSE_PENALTY,
+    HEADER_QUEUE_SIZE_TARGET,
 )
 from trinity.sync.common.headers import HeaderSyncerAPI
 from trinity.sync.common.peers import WaitingPeers
-from trinity.sync.common.constants import (
-    HEADER_QUEUE_SIZE_TARGET,
-    BLOCK_QUEUE_SIZE_TARGET,
-    BLOCK_IMPORT_QUEUE_SIZE,
-)
 from trinity._utils.datastructures import (
     BaseOrderedTaskPreparation,
     DuplicateTasks,


### PR DESCRIPTION
### What was wrong?

Will fix #1872 

### How was it fixed?

Estimate using the account trie.

Show the completion near the backfill index key as parts per million so that you can see progress every 30s.

Other tiny fixes.

Note that this still doesn't work very well, until #1825 is applied.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

[//]: # (See: https://trinity-client.readthedocs.io/en/latest/contributing.html#pull-requests)
- [x] Add entry to the [release notes](https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://i.pinimg.com/originals/85/a5/3f/85a53f2e590bf93662b326680917fcfb.jpg)