### PR TITLE
A few improvements to how Connection behaviors are handled

### DIFF
--- a/p2p/abc.py
+++ b/p2p/abc.py
@@ -595,6 +595,13 @@ class BehaviorAPI(ABC):
         ...
 
     @abstractmethod
+    def post_apply(self) -> None:
+        """
+        Called after all behaviors have been applied to the Connection.
+        """
+        ...
+
+    @abstractmethod
     @contextlib.asynccontextmanager
     def apply(self, connection: 'ConnectionAPI') -> AsyncIterator[asyncio.Future[None]]:
         """
@@ -624,6 +631,7 @@ class ConnectionAPI(ServiceAPI):
     #
     # Primary properties of the connection
     #
+    behaviors_applied: asyncio.Event
     is_dial_out: bool
 
     @property

--- a/p2p/behaviors.py
+++ b/p2p/behaviors.py
@@ -37,6 +37,9 @@ class Behavior(BehaviorAPI):
         # mypy bug: https://github.com/python/mypy/issues/708
         return self.qualifier(connection, self.logic)  # type: ignore
 
+    def post_apply(self) -> None:
+        self.logic.post_apply()
+
     @contextlib.asynccontextmanager
     async def apply(self, connection: ConnectionAPI) -> AsyncIterator[asyncio.Future[None]]:
         if self._applied_to is not None:

--- a/p2p/connection.py
+++ b/p2p/connection.py
@@ -1,10 +1,12 @@
 import asyncio
 import collections
+import contextlib
 import functools
 from typing import (
     Any,
     DefaultDict,
     Dict,
+    List,
     Sequence,
     Set,
     Tuple,
@@ -20,6 +22,7 @@ from cached_property import cached_property
 from eth_keys import keys
 
 from p2p.abc import (
+    BehaviorAPI,
     CommandAPI,
     ConnectionAPI,
     HandlerFn,
@@ -45,6 +48,7 @@ from p2p.exceptions import (
     UnknownProtocol,
     UnknownProtocolCommand,
 )
+from p2p.logic import wait_first
 from p2p.subscription import Subscription
 from p2p.p2p_proto import BaseP2PProtocol, DevP2PReceipt, Disconnect
 from p2p.typing import Capabilities
@@ -91,6 +95,8 @@ class Connection(ConnectionAPI, Service):
         # before all necessary handlers have been added
         self._handlers_ready = asyncio.Event()
 
+        self.behaviors_applied = asyncio.Event()
+
         self._logics = {}
 
     def __str__(self) -> str:
@@ -102,6 +108,26 @@ class Connection(ConnectionAPI, Service):
     def start_protocol_streams(self) -> None:
         self._handlers_ready.set()
 
+    async def run_behaviors(self, behaviors: Tuple[BehaviorAPI, ...]) -> None:
+        async with contextlib.AsyncExitStack() as stack:
+            futures: List[asyncio.Future[None]] = [
+                asyncio.create_task(self.manager.wait_finished())]
+            for behavior in behaviors:
+                if behavior.should_apply_to(self):
+                    behavior_exit = await stack.enter_async_context(behavior.apply(self))
+                    futures.append(behavior_exit)
+
+            self.behaviors_applied.set()
+            try:
+                for behavior in behaviors:
+                    behavior.post_apply()
+                await wait_first(futures)
+            except PeerConnectionLost:
+                # Any of our behaviors may propagate a PeerConnectionLost, which is to be expected
+                # as many Connection APIs used by them can raise that. To avoid a DaemonTaskExit
+                # since we're returning silently, ensure we're cancelled.
+                self.manager.cancel()
+
     async def run_peer(self, peer: 'BasePeer') -> None:
         """
         Run the peer as a child service.
@@ -109,6 +135,9 @@ class Connection(ConnectionAPI, Service):
         A peer must always run as a child of the connection so that it has an open connection
         until it finishes its cleanup.
         """
+        self.manager.run_daemon_task(self.run_behaviors, peer.get_behaviors())
+        await self.behaviors_applied.wait()
+
         self.manager.run_daemon_child_service(peer)
         await asyncio.wait_for(peer.manager.wait_started(), timeout=PEER_READY_TIMEOUT)
         await asyncio.wait_for(peer.ready.wait(), timeout=PEER_READY_TIMEOUT)
@@ -277,6 +306,8 @@ class Connection(ConnectionAPI, Service):
 
     def has_logic(self, name: str) -> bool:
         if self.is_closing:
+            # This is a safety net, really, as the Peer should never call this if it is no longer
+            # alive.
             raise PeerConnectionLost("Cannot look up subprotocol when connection is closing")
         return name in self._logics
 

--- a/p2p/kademlia.py
+++ b/p2p/kademlia.py
@@ -322,22 +322,22 @@ class KademliaRoutingTable:
         is_node_in_bucket = node_id in bucket
 
         if not is_node_in_bucket and not is_bucket_full:
-            self.logger.debug("Adding %s to bucket %d", encode_hex(node_id), bucket_index)
+            self.logger.debug2("Adding %s to bucket %d", encode_hex(node_id), bucket_index)
             self.update_bucket_unchecked(node_id)
             eviction_candidate = None
         elif is_node_in_bucket:
-            self.logger.debug("Updating %s in bucket %d", encode_hex(node_id), bucket_index)
+            self.logger.debug2("Updating %s in bucket %d", encode_hex(node_id), bucket_index)
             self.update_bucket_unchecked(node_id)
             eviction_candidate = None
         elif not is_node_in_bucket and is_bucket_full:
             if node_id not in replacement_cache:
-                self.logger.debug(
+                self.logger.debug2(
                     "Adding %s to replacement cache of bucket %d",
                     encode_hex(node_id),
                     bucket_index,
                 )
             else:
-                self.logger.debug(
+                self.logger.debug2(
                     "Updating %s in replacement cache of bucket %d",
                     encode_hex(node_id),
                     bucket_index,

--- a/p2p/logic.py
+++ b/p2p/logic.py
@@ -39,6 +39,9 @@ class BaseLogic(LogicAPI):
             qualifier = self.qualifier  # type: ignore
         return Behavior(qualifier, self)
 
+    def post_apply(self) -> None:
+        pass
+
 
 class CommandHandler(BaseLogic, Generic[TCommand]):
     """
@@ -90,7 +93,8 @@ async def wait_first(futures: Sequence[asyncio.Future[None]]) -> None:
         await cancel_futures(futures)
         raise
     else:
-        await cancel_futures(pending)
+        if pending:
+            await cancel_futures(pending)
         if len(done) != 1:
             raise Exception(
                 "Invariant: asyncio.wait() returned more than one future even "

--- a/p2p/peer_pool.py
+++ b/p2p/peer_pool.py
@@ -477,8 +477,8 @@ class BasePeerPool(Service, AsyncIterable[BasePeer]):
             self.logger.debug(
                 "Removing %s from pool: local_reason=%s remote_reason=%s",
                 peer,
-                peer.p2p_api.local_disconnect_reason,
-                peer.p2p_api.remote_disconnect_reason,
+                peer.local_disconnect_reason,
+                peer.remote_disconnect_reason,
             )
             self.connected_nodes.pop(peer.session)
         else:
@@ -537,7 +537,7 @@ class BasePeerPool(Service, AsyncIterable[BasePeer]):
                 )
                 self.logger.debug(
                     "client_version_string='%s'",
-                    peer.p2p_api.safe_client_version_string,
+                    peer.safe_client_version_string,
                 )
                 try:
                     for line in peer.get_extra_stats():

--- a/tests/p2p/test_peer.py
+++ b/tests/p2p/test_peer.py
@@ -22,7 +22,7 @@ async def test_disconnect_on_cancellation():
         bob.connection.add_command_handler(Disconnect, _handle_disconnect)
         await alice.manager.stop()
         await asyncio.wait_for(got_disconnect.wait(), timeout=1)
-        assert bob.p2p_api.remote_disconnect_reason == DisconnectReason.CLIENT_QUITTING
+        assert bob.remote_disconnect_reason == DisconnectReason.CLIENT_QUITTING
 
 
 @pytest.mark.asyncio
@@ -40,10 +40,10 @@ async def test_cancels_on_received_disconnect():
         # cancel itself even if alice accidentally leaves her connection open. If we used
         # alice.cancel() to send the Disconnect msg, alice would also close its connection,
         # causing bob to detect it, close its own and cause the peer to be cancelled.
-        alice.p2p_api.disconnect(DisconnectReason.CLIENT_QUITTING)
+        alice._p2p_api.disconnect(DisconnectReason.CLIENT_QUITTING)
         await asyncio.wait_for(bob.connection.manager.wait_finished(), timeout=1)
         assert bob.connection.is_closing
-        assert bob.p2p_api.remote_disconnect_reason == DisconnectReason.CLIENT_QUITTING
+        assert bob.remote_disconnect_reason == DisconnectReason.CLIENT_QUITTING
 
 
 class BehaviorCrash(Exception):
@@ -60,12 +60,14 @@ class CrashingLogic(BaseLogic):
 
 
 @pytest.mark.asyncio
-async def test_stops_if_behavior_crashes(monkeypatch):
+async def test_propagates_behavior_crashes(monkeypatch):
 
     def init(self):
         self.add_child_behavior(CrashingLogic().as_behavior(always))
 
     monkeypatch.setattr(ParagonAPI, '__init__', init)
-    async with ParagonPeerPairFactory() as (alice, _):
-        await asyncio.wait_for(alice.ready.wait(), timeout=0.5)
-        assert alice.manager.is_cancelled
+    with pytest.raises(BehaviorCrash):
+        async with ParagonPeerPairFactory() as (alice, _):
+            await asyncio.wait_for(alice.manager.wait_finished(), timeout=0.5)
+
+    assert alice.manager.is_cancelled

--- a/tests/p2p/test_peer_pair_factory.py
+++ b/tests/p2p/test_peer_pair_factory.py
@@ -14,7 +14,7 @@ async def test_connection_factory_with_ParagonPeer():
 
         async def handle_ping(conn, msg):
             got_ping.set()
-            bob.p2p_api.send_pong()
+            bob._p2p_api.send_pong()
 
         async def handle_pong(conn, msg):
             got_pong.set()
@@ -22,7 +22,7 @@ async def test_connection_factory_with_ParagonPeer():
         alice.connection.add_command_handler(Pong, handle_pong)
         bob.connection.add_command_handler(Ping, handle_ping)
 
-        alice.p2p_api.send_ping()
+        alice._p2p_api.send_ping()
 
         await asyncio.wait_for(got_ping.wait(), timeout=1)
         await asyncio.wait_for(got_pong.wait(), timeout=1)

--- a/trinity/components/builtin/network_db/eth1_peer_db/tracker.py
+++ b/trinity/components/builtin/network_db/eth1_peer_db/tracker.py
@@ -125,7 +125,7 @@ class BaseEth1PeerTracker(BasePeerBackend, PeerSubscriber):
         # prevent circular import
         from trinity.protocol.common.peer import BaseChainPeer
         peer = cast(BaseChainPeer, peer)
-        if peer.p2p_api.remote_disconnect_reason is None and peer.p2p_api.remote_disconnect_reason is None:  # noqa: E501
+        if peer.remote_disconnect_reason is None:
             # we don't care about peers that don't properly disconnect
             self.logger.debug(
                 'Not tracking disconnecting peer %s[%s] missing disconnect reason',
@@ -139,7 +139,7 @@ class BaseEth1PeerTracker(BasePeerBackend, PeerSubscriber):
             self.logger.debug(
                 'Not tracking disconnecting peer %s[%s][%s] due to insufficient uptime (%s < %s)',
                 peer,
-                peer.p2p_api.local_disconnect_reason,
+                peer.local_disconnect_reason,
                 'inbound' if peer.inbound else 'outbound',
                 humanize_seconds(peer.uptime),
                 humanize_seconds(MIN_QUALIFYING_UPTIME),
@@ -150,7 +150,7 @@ class BaseEth1PeerTracker(BasePeerBackend, PeerSubscriber):
                 'Tracking disconnecting peer %s[%s][%s] with uptime: %s',
                 peer,
                 'inbound' if peer.inbound else 'outbound',
-                peer.p2p_api.local_disconnect_reason,
+                peer.local_disconnect_reason,
                 humanize_seconds(peer.uptime),
             )
 

--- a/trinity/protocol/common/abc.py
+++ b/trinity/protocol/common/abc.py
@@ -4,18 +4,15 @@ from eth_typing import BlockNumber, Hash32
 
 
 class ChainInfoAPI(ABC):
-    @property
-    @abstractmethod
-    def network_id(self) -> int:
-        ...
-
-    @property
-    @abstractmethod
-    def genesis_hash(self) -> Hash32:
-        ...
+    network_id: int
+    genesis_hash: Hash32
 
 
 class HeadInfoAPI(ABC):
+    """
+    NOTE: Accessing any of the attributes here can raise PeerConnectionLost!
+    """
+
     @property
     @abstractmethod
     def head_td(self) -> int:

--- a/trinity/protocol/common/api.py
+++ b/trinity/protocol/common/api.py
@@ -42,16 +42,13 @@ class ChainInfo(Application, ChainInfoAPI):
 
     qualifier = AnyETHLES
 
-    @cached_property
-    def network_id(self) -> int:
-        return self._get_logic().network_id
-
-    @cached_property
-    def genesis_hash(self) -> Hash32:
-        return self._get_logic().genesis_hash
-
-    def _get_logic(self) -> AnyETHLESAPI:
-        return choose_eth_or_les_api(self.connection)
+    def post_apply(self) -> None:
+        logic = choose_eth_or_les_api(self.connection)
+        # These things don't change so by storing them as instance variables we free our callsites
+        # from having to deal with PeerConnectionLost errors, which can be raised by
+        # choose_eth_or_les_api().
+        self.network_id = logic.network_id
+        self.genesis_hash = logic.genesis_hash
 
 
 class HeadInfo(Application, HeadInfoAPI):

--- a/trinity/protocol/common/peer_pool_event_bus.py
+++ b/trinity/protocol/common/peer_pool_event_bus.py
@@ -152,7 +152,7 @@ class PeerPoolEventServer(Service, PeerSubscriber, Generic[TPeer]):
             )
             raise PeerConnectionLost(f"Peer at {session} is gone from the pool")
         else:
-            if not peer.manager.is_running:
+            if not peer.is_alive:
                 self.logger.debug("Peer %s is not operational when selecting from pool", peer)
                 raise PeerConnectionLost(f"{peer} is no longer operational")
             else:

--- a/trinity/sync/beam/queen.py
+++ b/trinity/sync/beam/queen.py
@@ -6,10 +6,6 @@ from typing import Any, FrozenSet, Optional, Type
 from async_service import Service
 
 from p2p.abc import CommandAPI
-from p2p.exceptions import (
-    PeerConnectionLost,
-    UnknownAPI,
-)
 from p2p.exchange import PerformanceAPI
 from p2p.peer import BasePeer, PeerSubscriber
 from trinity.protocol.eth.commands import NodeDataV65
@@ -24,6 +20,8 @@ def queen_peer_performance_sort(tracker: PerformanceAPI) -> float:
 
 
 def _peer_sort_key(peer: ETHPeer) -> float:
+    # FIXME: This should not be hard-coded to get_node_data as we could, in theory, be used to
+    # request other types of data.
     return queen_peer_performance_sort(peer.eth_api.get_node_data.tracker)
 
 
@@ -101,7 +99,7 @@ class QueeningQueue(Service, PeerSubscriber, QueenTrackerAPI):
         """
         while self.manager.is_running:
             peer = await self._waiting_peers.get_fastest()
-            if not peer.manager.is_running:
+            if not peer.is_alive:
                 # drop any peers that aren't alive anymore
                 self.logger.info("Dropping %s from beam peers, as no longer active", peer)
                 if peer == self._queen_peer:
@@ -113,18 +111,16 @@ class QueeningQueue(Service, PeerSubscriber, QueenTrackerAPI):
                 self._insert_peer(peer)
                 continue
 
-            try:
-                peer_is_requesting_nodes = peer.eth_api.get_node_data.is_requesting
-            except PeerConnectionLost:
-                self.logger.debug("QueenQueuer is skipping disconnecting peer %s", peer)
-                # Don't bother re-adding to _waiting_peers, since the peer is disconnected
-            else:
-                if peer_is_requesting_nodes:
-                    # skip the peer if there's an active request
-                    self.logger.debug("QueenQueuer is skipping active peer %s", peer)
-                    loop = asyncio.get_event_loop()
-                    loop.call_later(10, functools.partial(self._insert_peer, peer))
-                    continue
+            # FIXME: This should not be hard-coded to get_node_data as we could, in theory, be
+            # used to request other types of data.
+            peer_is_requesting = peer.eth_api.get_node_data.is_requesting
+
+            if peer_is_requesting:
+                # skip the peer if there's an active request
+                self.logger.debug("QueenQueuer is skipping active peer %s", peer)
+                loop = asyncio.get_event_loop()
+                loop.call_later(10, functools.partial(self._insert_peer, peer))
+                continue
 
             return peer
         # This should never happen as we run as a daemon and if we return before our caller it'd
@@ -153,36 +149,34 @@ class QueeningQueue(Service, PeerSubscriber, QueenTrackerAPI):
             loop.call_later(delay, functools.partial(self._insert_peer, peer))
 
     def _should_be_queen(self, peer: ETHPeer) -> bool:
+        if not peer.is_alive:
+            raise ValueError(f"{peer} is no longer alive")
+
         if self._queen_peer is None:
+            return True
+        elif not self._queen_peer.is_alive:
             return True
         elif peer == self._queen_peer:
             return True
         else:
-            try:
-                new_peer_quality = _peer_sort_key(peer)
-            except (UnknownAPI, PeerConnectionLost) as exc:
-                self.logger.debug("Invalid %s, because we can't get speed stats: %r", peer, exc)
-                return False
-
-            try:
-                current_queen_quality = _peer_sort_key(self._queen_peer)
-            except (UnknownAPI, PeerConnectionLost) as exc:
-                self.logger.debug(
-                    "Invalid queen %s, because we can't get speed stats: %r",
-                    self._queen_peer,
-                    exc,
-                )
-                return True
-            else:
-                # Quality is designed so that an ascending sort puts the best quality at the front
-                #   of a sequence. So, a lower value means a better quality.
-                return new_peer_quality < current_queen_quality
+            new_peer_quality = _peer_sort_key(peer)
+            current_queen_quality = _peer_sort_key(self._queen_peer)
+            # Quality is designed so that an ascending sort puts the best quality at the front
+            #   of a sequence. So, a lower value means a better quality.
+            return new_peer_quality < current_queen_quality
 
     def _insert_peer(self, peer: ETHPeer) -> None:
         """
         Add peer as ready to receive requests. Check if it should be queen, and promote if
         appropriate. Otherwise, insert to be drawn as a peasant.
+
+        If the given peer is no longer running, do nothing. This is needed because we're sometimes
+        called via loop.call_later().
         """
+        if not peer.is_alive:
+            self.logger.debug("Peer %s is no longer alive, not adding to queue", peer)
+            return
+
         if self._should_be_queen(peer):
             old_queen, self._queen_peer = self._queen_peer, peer
             if peer != old_queen:

--- a/trinity/sync/beam/state.py
+++ b/trinity/sync/beam/state.py
@@ -298,7 +298,9 @@ class BeamDownloader(Service, PeerSubscriber):
             # Get best peer, by GetNodeData speed
             peer = await self._queen_tracker.get_queen_peer()
 
-            if urgent_batch_id is not None and peer.eth_api.get_node_data.is_requesting:
+            peer_is_requesting = peer.eth_api.get_node_data.is_requesting
+
+            if urgent_batch_id is not None and peer_is_requesting:
                 # Our best peer for node data has an in-flight GetNodeData request
                 # Probably, backfill is asking this peer for data
                 # This is right in the critical path, so we'd prefer this never happen
@@ -373,7 +375,6 @@ class BeamDownloader(Service, PeerSubscriber):
             urgent_node_hashes: Tuple[Hash32, ...],
             predictive_node_hashes: Tuple[Hash32, ...],
             predictive_batch_id: int) -> None:
-
         nodes = await self._request_nodes(peer, node_hashes)
 
         urgent_nodes = {
@@ -446,9 +447,13 @@ class BeamDownloader(Service, PeerSubscriber):
     async def _request_nodes(
             self,
             peer: ETHPeer,
-            node_hashes: Tuple[Hash32, ...]) -> NodeDataBundles:
+            original_node_hashes: Tuple[Hash32, ...]) -> NodeDataBundles:
+        node_hashes = tuple(set(original_node_hashes))
+        num_nodes = len(node_hashes)
+        self.logger.debug2("Requesting %d nodes from %s", num_nodes, peer)
         try:
-            completed_nodes = await self._make_node_request(peer, node_hashes)
+            completed_nodes = await peer.eth_api.get_node_data(
+                node_hashes, timeout=self._reply_timeout)
         except PeerConnectionLost:
             self.logger.debug("%s went away, cancelling the nodes request and moving on...", peer)
             self._queen_tracker.penalize_queen(peer)
@@ -462,6 +467,13 @@ class BeamDownloader(Service, PeerSubscriber):
             self.logger.debug("Pending nodes call to %r future cancelled", peer)
             self._queen_tracker.penalize_queen(peer)
             raise
+        except asyncio.TimeoutError:
+            # This kind of exception shouldn't necessarily *drop* the peer,
+            # so capture error, log and swallow
+            self.logger.debug("Timed out requesting %d nodes from %s", num_nodes, peer)
+            self._queen_tracker.penalize_queen(peer)
+            self._total_timeouts += 1
+            return tuple()
         except Exception as exc:
             self.logger.info("Unexpected err while downloading nodes from %s: %s", peer, exc)
             self.logger.debug(
@@ -480,22 +492,6 @@ class BeamDownloader(Service, PeerSubscriber):
                 self.logger.debug("%s returned 0 state trie nodes, penalize...", peer)
                 self._queen_tracker.penalize_queen(peer)
             return completed_nodes
-
-    async def _make_node_request(
-            self,
-            peer: ETHPeer,
-            original_node_hashes: Tuple[Hash32, ...]) -> NodeDataBundles:
-        node_hashes = tuple(set(original_node_hashes))
-        num_nodes = len(node_hashes)
-        self.logger.debug2("Requesting %d nodes from %s", num_nodes, peer)
-        try:
-            return await peer.eth_api.get_node_data(node_hashes, timeout=self._reply_timeout)
-        except asyncio.TimeoutError:
-            # This kind of exception shouldn't necessarily *drop* the peer,
-            # so capture error, log and swallow
-            self.logger.debug("Timed out requesting %d nodes from %s", num_nodes, peer)
-            self._total_timeouts += 1
-            return tuple()
 
     async def run(self) -> None:
         """

--- a/trinity/sync/common/headers.py
+++ b/trinity/sync/common/headers.py
@@ -445,7 +445,7 @@ class SkeletonSyncer(Service, Generic[TChainPeer]):
             max_headers: int = None,
             skip: int = None) -> Tuple[BlockHeaderAPI, ...]:
 
-        if not peer.manager.is_running:
+        if not peer.is_alive:
             self.logger.info("%s disconnected while fetching headers", peer)
             return tuple()
 
@@ -703,9 +703,9 @@ class HeaderMeatSyncer(Service, PeerSubscriber, Generic[TChainPeer]):
             if not self.sync_progress:
                 await self._init_sync_progress(parent_header, peer)
 
-            if not peer.manager.is_running:
+            if not peer.is_alive:
                 self.logger.debug(
-                    "Tried to fetch headers from %s but it is no longer running", peer)
+                    "Tried to fetch headers from %s but it is no longer alive", peer)
                 continue
 
             peer.manager.run_task(
@@ -1057,7 +1057,10 @@ class BaseHeaderChainSyncer(Service, HeaderSyncerAPI, Generic[TChainPeer]):
     async def _validate_peer_is_ahead(self, peer: BaseChainPeer) -> None:
         head = await self._db.coro_get_canonical_head()
         head_td = await self._db.coro_get_score(head.hash)
-        if peer.head_info.head_td <= head_td:
+        # Since we yielded above, we could've lost the peer connection.
+        if not peer.is_alive:
+            raise _PeerBehind(f"{peer} is no longer alive, not a valid target for sync")
+        elif peer.head_info.head_td <= head_td:
             self.logger.debug(
                 "Head TD (%d) announced by %s not higher than ours (%d), not syncing",
                 peer.head_info.head_td, peer, head_td)

--- a/trinity/sync/common/peers.py
+++ b/trinity/sync/common/peers.py
@@ -91,7 +91,7 @@ class WaitingPeers(Generic[TChainPeer]):
         peer = wrapped_peer.original
 
         # make sure the peer has not gone offline while waiting in the queue
-        while not peer.manager.is_running:
+        while not peer.is_alive:
             # if so, look for the next best peer
             wrapped_peer = await self._waiting_peers.get()
             peer = wrapped_peer.original

--- a/trinity/sync/full/chain.py
+++ b/trinity/sync/full/chain.py
@@ -52,7 +52,7 @@ from eth.exceptions import HeaderNotFound
 
 from p2p.abc import CommandAPI
 from p2p.disconnect import DisconnectReason
-from p2p.exceptions import BaseP2PError, PeerConnectionLost, UnknownAPI
+from p2p.exceptions import BaseP2PError, PeerConnectionLost
 from p2p.peer import BasePeer, PeerSubscriber
 from p2p.stats.ema import EMA
 from p2p.token_bucket import TokenBucket
@@ -428,12 +428,6 @@ class BaseBodyChainSyncer(Service, PeerSubscriber):
             return tuple()
         except PeerConnectionLost:
             self.logger.debug("Peer went away, cancelling the block body request and moving on...")
-            return tuple()
-        except UnknownAPI as exc:
-            self.logger.debug(
-                "Peer was missing API, cancelling the block body request and moving on... %r",
-                exc,
-            )
             return tuple()
         except Exception:
             self.logger.exception("Unknown error when getting block bodies from %s", peer)

--- a/trinity/sync/light/service.py
+++ b/trinity/sync/light/service.py
@@ -335,6 +335,7 @@ class LightPeerChain(PeerSubscriber, Service, BaseLightPeerChain):
         A single attempt to get the block header from the given peer.
 
         :raise BadLESResponse: if the peer replies with a header that has a different hash
+        :raise PeerConnectionLost: if the peer is no longer alive.
         """
         self.logger.debug("Fetching header %s from %s", encode_hex(block_hash), peer)
         max_headers = 1


### PR DESCRIPTION
These will hopefully make it less likely for us to introduce new code
that leaks PeerConnectionLost exceptions

- Behaviors are now applied/monitored by Connection, ensuring they're
  applied before a Peer starts and only removed after the Peer terminates

- Do not use cached_properties for Peer.head_info & co as if they are
  called while the Peer is being terminated (e.g. as the connection
  tracker does) they can raise a PeerConnectionLost/UnknownAPI

- Peer will not attempt to send a Disconnect if it's crashed before
  the self._p2_api attribute has been set

Closes: #1874
Closes: #1875