### PR TITLE
Apply UPNP to TCP as well

### DIFF
--- a/newsfragments/1829.bugfix.rst
+++ b/newsfragments/1829.bugfix.rst
@@ -1,0 +1,1 @@
+Apply UPnP to TCP as well.


### PR DESCRIPTION
### What was wrong?

UPNP was only being applied to UDP.

### How was it fixed?

Expanded to apply it to TCP as well.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

[//]: # (See: https://trinity-client.readthedocs.io/en/latest/contributing.html#pull-requests)
- [ ] Add entry to the [release notes](https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![tumblr_lkxo8lyf6z1qjehv2o1_400](https://user-images.githubusercontent.com/824194/87458648-83493c00-c5c7-11ea-9fe0-4935b68cc906.jpg)

