### PR TITLE
add endpoint to return the head (slot, root) pair

### DIFF
--- a/eth2/api/http/validator.py
+++ b/eth2/api/http/validator.py
@@ -9,7 +9,7 @@ from typing import Collection, Iterable, Optional, Set
 
 from eth.exceptions import BlockNotFound
 from eth_typing import BLSPubkey, BLSSignature
-from eth_utils import decode_hex, encode_hex, to_tuple
+from eth_utils import decode_hex, encode_hex, humanize_hash, to_tuple
 from ssz.tools.dump import to_formatted_dict
 from ssz.tools.parse import from_formatted_dict
 
@@ -62,6 +62,7 @@ def _get_target_checkpoint(
 
 @unique
 class Paths(Enum):
+    chain_info = "/chain/info"
     node_version = "/node/version"
     genesis_time = "/node/genesis_time"
     sync_status = "/node/syncing"
@@ -329,11 +330,17 @@ async def _post_attestation(context: Context, request: Request) -> Response:
     return await context.broadcast_attestation(attestation)
 
 
+async def _get_chain_info(context: Context, request: Request) -> Response:
+    head = context.chain.get_canonical_head()
+    return {"slot": head.slot, "root": humanize_hash(head.hash_tree_root)}
+
+
 GET = "GET"
 POST = "POST"
 
 
 ServerHandlers = {
+    Paths.chain_info.value: {GET: _get_chain_info},
     Paths.node_version.value: {GET: _get_node_version},
     Paths.genesis_time.value: {GET: _get_genesis_time},
     Paths.sync_status.value: {GET: _get_sync_status},


### PR DESCRIPTION
Adds basic HTTP endpoint to beacon node so that we can read the head (without having to necessarily parse logs...)


#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://catsanddice.com/wp-content/uploads/2019/05/Roll-Those-Dice-Kitty.jpg)
