### PR TITLE
--config-profile param for beacon node.

### DIFF
--- a/eth2/beacon/chains/testnet/altona.py
+++ b/eth2/beacon/chains/testnet/altona.py
@@ -14,7 +14,10 @@ from eth2.beacon.db.chain2 import BeaconChainDB, StateNotFound
 from eth2.beacon.epoch_processing_helpers import get_attesting_indices
 from eth2.beacon.fork_choice.abc import BaseForkChoice, BlockSink
 from eth2.beacon.state_machines.abc import BaseBeaconStateMachine
-from eth2.beacon.state_machines.forks.altona.state_machine import AltonaStateMachine
+from eth2.beacon.state_machines.forks.altona.state_machine import (
+    AltonaStateMachine,
+    AltonaStateMachineTest,
+)
 from eth2.beacon.tools.misc.ssz_vector import override_lengths
 from eth2.beacon.types.attestations import Attestation
 from eth2.beacon.types.blocks import (
@@ -394,3 +397,7 @@ class BeaconChain(BaseBeaconChain):
         """
         fork_choice = self._get_fork_choice(attestation.data.slot)
         self._update_fork_choice_with_attestation(fork_choice, attestation)
+
+
+class BeaconChainTest(BeaconChain):
+    _sm_configuration = ((GENESIS_SLOT, AltonaStateMachineTest),)

--- a/eth2/beacon/state_machines/forks/altona/state_machine.py
+++ b/eth2/beacon/state_machines/forks/altona/state_machine.py
@@ -3,12 +3,11 @@ from typing import Tuple, Type  # noqa: F401
 from eth2.beacon.fork_choice.abc import BaseForkChoice
 from eth2.beacon.fork_choice.lmd_ghost2 import LMDGHOSTForkChoice
 from eth2.beacon.state_machines.abc import BaseBeaconStateMachine
+from eth2.beacon.state_machines.forks.altona.configs import ALTONA_CONFIG
 from eth2.beacon.state_machines.forks.serenity.state_transitions import (
     apply_state_transition,
 )
-from eth2.beacon.state_machines.forks.skeleton_lake.configs import (
-    MINIMAL_SERENITY_CONFIG,
-)
+from eth2.beacon.state_machines.forks.skeleton_lake import MINIMAL_SERENITY_CONFIG
 from eth2.beacon.types.blocks import (
     BaseBeaconBlock,
     BaseSignedBeaconBlock,
@@ -20,7 +19,7 @@ from eth2.beacon.typing import Slot
 
 
 class AltonaStateMachine(BaseBeaconStateMachine):
-    config = MINIMAL_SERENITY_CONFIG
+    config = ALTONA_CONFIG
     block_class: Type[BaseBeaconBlock] = BeaconBlock
     signed_block_class: Type[BaseSignedBeaconBlock] = SignedBeaconBlock
     state_class: Type[BeaconState] = BeaconState
@@ -43,3 +42,7 @@ class AltonaStateMachine(BaseBeaconStateMachine):
             )
 
         return state, signed_block
+
+
+class AltonaStateMachineTest(AltonaStateMachine):
+    config = MINIMAL_SERENITY_CONFIG

--- a/eth2/configs.py
+++ b/eth2/configs.py
@@ -28,7 +28,7 @@ def _decoder(
         elif field.type is bytes:
             yield field.name, decode_hex(cast(str, data[field.name]))
         elif field.type is Version:
-            yield field.name, decode_hex(cast(str, data[field.name]))
+            yield field.name, Version(decode_hex(cast(str, data[field.name])))
         else:
             yield field.name, int(data[field.name])
 

--- a/eth2/genesis.py
+++ b/eth2/genesis.py
@@ -7,6 +7,7 @@ from ssz.tools.dump import to_formatted_dict
 from typing_extensions import Literal
 
 from eth2.beacon.genesis import initialize_beacon_state_from_eth1
+from eth2.beacon.state_machines.forks.altona.configs import ALTONA_CONFIG
 from eth2.beacon.state_machines.forks.serenity.configs import SERENITY_CONFIG
 from eth2.beacon.state_machines.forks.skeleton_lake.configs import (
     MINIMAL_SERENITY_CONFIG,
@@ -73,7 +74,8 @@ def genesis_config_from_state_file(
 
 
 def genesis_config_with_default_state(
-    config_profile: Literal["minimal", "mainnet"], genesis_time: Timestamp = None
+    config_profile: Literal["minimal", "mainnet", "altona"],
+    genesis_time: Timestamp = None,
 ) -> Dict[str, Any]:
     eth2_config = _get_eth2_config(config_profile)
     override_lengths(eth2_config)
@@ -95,7 +97,7 @@ def format_genesis_config(config: Dict[str, Any]) -> str:
 
 
 def _create_genesis_config(
-    config_profile: Literal["minimal", "mainnet"],
+    config_profile: Literal["minimal", "mainnet", "altona"],
     eth2_config: Eth2Config,
     genesis_state: BeaconState,
     key_pairs: Iterable[Dict[str, str]],
@@ -110,4 +112,8 @@ def _create_genesis_config(
 
 
 def _get_eth2_config(profile: str) -> Eth2Config:
-    return {"minimal": MINIMAL_SERENITY_CONFIG, "mainnet": SERENITY_CONFIG}[profile]
+    return {
+        "minimal": MINIMAL_SERENITY_CONFIG,
+        "mainnet": SERENITY_CONFIG,
+        "altona": ALTONA_CONFIG,
+    }[profile]

--- a/tests-trio/conftest.py
+++ b/tests-trio/conftest.py
@@ -3,6 +3,7 @@ import secrets
 import tempfile
 import uuid
 
+from eth2.beacon.state_machines.forks.skeleton_lake import MINIMAL_SERENITY_CONFIG
 from eth_keys.datatypes import PrivateKey
 from lahja import ConnectionConfig
 from lahja.trio.endpoint import TrioEndpoint
@@ -13,11 +14,8 @@ import pytest
 import trio
 
 from eth2._utils.bls import Eth2BLS, bls
-from eth2.beacon.chains.testnet.altona import BeaconChain
+from eth2.beacon.chains.testnet.altona import BeaconChainTest
 from eth2.beacon.constants import FAR_FUTURE_EPOCH
-from eth2.beacon.state_machines.forks.skeleton_lake.configs import (
-    MINIMAL_SERENITY_CONFIG,
-)
 from eth2.beacon.tools.builder.initializer import create_key_pairs_for
 from eth2.beacon.tools.misc.ssz_vector import override_lengths
 from eth2.beacon.types.blocks import BeaconBlockBody, BeaconBlockHeader, BeaconBlock
@@ -114,8 +112,8 @@ def genesis_block(genesis_state):
 
 
 @pytest.fixture
-def chain_config(genesis_state, eth2_config):
-    return BeaconChainConfig(genesis_state, eth2_config, {})
+def chain_config(genesis_state, eth2_config, chain_class):
+    return BeaconChainConfig(genesis_state, eth2_config, {}, beacon_chain_class=chain_class)
 
 
 @pytest.fixture
@@ -125,7 +123,7 @@ def database_dir(tmp_path):
 
 @pytest.fixture
 def chain_class():
-    return BeaconChain
+    return BeaconChainTest
 
 
 @pytest.fixture

--- a/trinity/components/eth2/beacon_trio/component.py
+++ b/trinity/components/eth2/beacon_trio/component.py
@@ -30,6 +30,7 @@ class BeaconNodeComponent(TrioComponent):
         trinity_config = self._boot_info.trinity_config
         beacon_app_config = trinity_config.get_app_config(BeaconAppConfig)
         config = BeaconNodeConfig.from_platform_config(
+            boot_info.args.config_profile,
             trinity_config,
             beacon_app_config,
             boot_info.args.validator_api_port,
@@ -74,6 +75,13 @@ class BeaconNodeComponent(TrioComponent):
             "--orchestration-profile",
             help="[temporary developer option] manage several beacon nodes on one machine",
             default="a",
+        )
+
+        arg_parser.add_argument(
+            "--config-profile",
+            help="the profile used to generate the genesis config",
+            choices=("minimal", "mainnet", "altona"),
+            default="minimal",
         )
 
     @property

--- a/trinity/components/eth2/beacon_trio/component.py
+++ b/trinity/components/eth2/beacon_trio/component.py
@@ -6,7 +6,7 @@ from eth_utils import to_tuple
 from multiaddr import Multiaddr
 
 from trinity.boot_info import BootInfo
-from trinity.config import BeaconAppConfig
+from trinity.config import BeaconTrioAppConfig
 from trinity.constants import BEACON_TESTNET_NETWORK_ID
 from trinity.extensibility import TrioComponent
 from trinity.nodes.beacon.config import BeaconNodeConfig
@@ -27,8 +27,12 @@ class BeaconNodeComponent(TrioComponent):
     def __init__(self, boot_info: BootInfo) -> None:
         super().__init__(boot_info)
 
+        config_profile = boot_info.args.config_profile
+        if config_profile != "altona":
+            raise NotImplementedError(f"config profile not supported: {config_profile}")
+
         trinity_config = self._boot_info.trinity_config
-        beacon_app_config = trinity_config.get_app_config(BeaconAppConfig)
+        beacon_app_config = trinity_config.get_app_config(BeaconTrioAppConfig)
         config = BeaconNodeConfig.from_platform_config(
             boot_info.args.config_profile,
             trinity_config,
@@ -86,7 +90,7 @@ class BeaconNodeComponent(TrioComponent):
 
     @property
     def is_enabled(self) -> bool:
-        return self._boot_info.trinity_config.has_app_config(BeaconAppConfig)
+        return self._boot_info.trinity_config.has_app_config(BeaconTrioAppConfig)
 
     async def run(self) -> None:
         logging.getLogger("libp2p.pubsub").setLevel(logging.INFO)

--- a/trinity/components/eth2/network_generator/component.py
+++ b/trinity/components/eth2/network_generator/component.py
@@ -43,7 +43,7 @@ class NetworkGeneratorComponent(Application):
         network_generator_parser.add_argument(
             "--config-profile",
             help=CONFIG_PROFILE_HELP,
-            choices=("minimal", "mainnet"),
+            choices=("minimal", "mainnet", "altona"),
             default="minimal",
         )
         network_generator_parser.add_argument(

--- a/trinity/initialization.py
+++ b/trinity/initialization.py
@@ -14,6 +14,8 @@ from trinity.config import (
     Eth1AppConfig,
     Eth1ChainConfig,
     TrinityConfig,
+    BeaconTrioAppConfig,
+    BeaconTrioChainConfig,
 )
 from eth2.beacon.db.chain import BaseBeaconChainDB
 from trinity.exceptions import (
@@ -148,11 +150,25 @@ def initialize_beacon_database(chain_config: BeaconChainConfig,
         chain_config.initialize_chain(base_db)
 
 
+def initialize_beacon_trio_database(chain_config: BeaconTrioChainConfig,
+                                    chaindb: BaseBeaconChainDB,
+                                    base_db: AtomicDatabaseAPI) -> None:
+    try:
+        chaindb.get_canonical_head_root()
+    except CanonicalHeadNotFound:
+        chain_config.initialize_chain(base_db)
+
+
 def ensure_eth1_dirs(app_config: Eth1AppConfig) -> None:
     if not app_config.database_dir.exists():
         app_config.database_dir.mkdir(parents=True, exist_ok=True)
 
 
 def ensure_beacon_dirs(app_config: BeaconAppConfig) -> None:
+    if not app_config.database_dir.exists():
+        app_config.database_dir.mkdir(parents=True, exist_ok=True)
+
+
+def ensure_beacon_trio_dirs(app_config: BeaconTrioAppConfig) -> None:
     if not app_config.database_dir.exists():
         app_config.database_dir.mkdir(parents=True, exist_ok=True)

--- a/trinity/main_beacon_trio.py
+++ b/trinity/main_beacon_trio.py
@@ -40,7 +40,7 @@ def _initialize_beacon_filesystem_and_db(boot_info: BootInfo) -> None:
     ensure_beacon_dirs(app_config)
 
     base_db = LevelDB(db_path=app_config.database_dir)
-    chain_config = app_config.get_chain_config()
+    chain_config = app_config.get_chain_config(boot_info.args.config_profile)
     chaindb = BeaconChainDB(base_db)
 
     if not is_beacon_database_initialized(chaindb):

--- a/trinity/main_beacon_trio.py
+++ b/trinity/main_beacon_trio.py
@@ -11,14 +11,12 @@ from trinity._utils.version import construct_trinity_client_identifier
 from trinity.boot_info import BootInfo
 from trinity.bootstrap import construct_boot_info
 from trinity.components.registry import get_components_for_trio_beacon_client
-from trinity.config import BaseAppConfig, BeaconAppConfig
+from trinity.config import BaseAppConfig, BeaconTrioAppConfig
 from trinity.constants import APP_IDENTIFIER_BEACON
 from trinity.extensibility import BaseComponentAPI
 from trinity.extensibility.trio import TrioComponent
 from trinity.initialization import (
-    ensure_beacon_dirs,
-    initialize_beacon_database,
-    is_beacon_database_initialized,
+    is_beacon_database_initialized, ensure_beacon_trio_dirs, initialize_beacon_trio_database,
 )
 
 
@@ -36,15 +34,15 @@ async def _run_trio_components_until_interrupt(
 
 
 def _initialize_beacon_filesystem_and_db(boot_info: BootInfo) -> None:
-    app_config = boot_info.trinity_config.get_app_config(BeaconAppConfig)
-    ensure_beacon_dirs(app_config)
+    app_config = boot_info.trinity_config.get_app_config(BeaconTrioAppConfig)
+    ensure_beacon_trio_dirs(app_config)
 
     base_db = LevelDB(db_path=app_config.database_dir)
     chain_config = app_config.get_chain_config(boot_info.args.config_profile)
     chaindb = BeaconChainDB(base_db)
 
     if not is_beacon_database_initialized(chaindb):
-        initialize_beacon_database(chain_config, chaindb, base_db)
+        initialize_beacon_trio_database(chain_config, chaindb, base_db)
 
 
 def main_entry_trio(
@@ -83,5 +81,5 @@ def main_entry_trio(
 def main_beacon() -> None:
     app_identifier = APP_IDENTIFIER_BEACON
     component_types = get_components_for_trio_beacon_client()
-    sub_configs = (BeaconAppConfig,)
+    sub_configs = (BeaconTrioAppConfig,)
     main_entry_trio(app_identifier, component_types, sub_configs)

--- a/trinity/nodes/beacon/config.py
+++ b/trinity/nodes/beacon/config.py
@@ -4,9 +4,9 @@ from typing import Collection, Type
 from eth_keys.datatypes import PrivateKey
 from multiaddr import Multiaddr
 
-from eth2.beacon.chains.base import BaseBeaconChain
+from eth2.beacon.chains.abc import BaseBeaconChain
 from eth2.configs import Eth2Config
-from trinity.config import BeaconAppConfig, BeaconChainConfig, TrinityConfig
+from trinity.config import TrinityConfig, BeaconTrioAppConfig, BeaconTrioChainConfig
 
 
 class BeaconNodeConfig:
@@ -16,7 +16,7 @@ class BeaconNodeConfig:
         orchestration_profile: str,
         bootstrap_nodes: Collection[Multiaddr],
         preferred_nodes: Collection[Multiaddr],
-        chain_config: BeaconChainConfig,
+        chain_config: BeaconTrioChainConfig,
         local_node_key: PrivateKey,
         validator_api_port: int,
         eth2_config: Eth2Config,
@@ -41,7 +41,7 @@ class BeaconNodeConfig:
         cls,
         config_profile: str,
         trinity_config: TrinityConfig,
-        beacon_app_config: BeaconAppConfig,
+        beacon_app_config: BeaconTrioAppConfig,
         validator_api_port: int,
         bootstrap_nodes: Collection[Multiaddr],
     ) -> "BeaconNodeConfig":

--- a/trinity/nodes/beacon/config.py
+++ b/trinity/nodes/beacon/config.py
@@ -1,10 +1,10 @@
 from pathlib import Path
-from typing import Collection
+from typing import Collection, Type
 
 from eth_keys.datatypes import PrivateKey
 from multiaddr import Multiaddr
 
-from eth2.beacon.chains.testnet.altona import BeaconChain
+from eth2.beacon.chains.base import BaseBeaconChain
 from eth2.configs import Eth2Config
 from trinity.config import BeaconAppConfig, BeaconChainConfig, TrinityConfig
 
@@ -22,6 +22,7 @@ class BeaconNodeConfig:
         eth2_config: Eth2Config,
         client_identifier: str,
         p2p_maddr: Multiaddr,
+        chain_class: Type[BaseBeaconChain]
     ) -> None:
         self.database_dir = database_dir
         self.orchestration_profile = orchestration_profile
@@ -33,18 +34,18 @@ class BeaconNodeConfig:
         self.eth2_config = eth2_config
         self.client_identifier = client_identifier
         self.p2p_maddr = p2p_maddr
-
-        self.chain_class = BeaconChain
+        self.chain_class = chain_class
 
     @classmethod
     def from_platform_config(
         cls,
+        config_profile: str,
         trinity_config: TrinityConfig,
         beacon_app_config: BeaconAppConfig,
         validator_api_port: int,
         bootstrap_nodes: Collection[Multiaddr],
     ) -> "BeaconNodeConfig":
-        chain_config = beacon_app_config.get_chain_config()
+        chain_config = beacon_app_config.get_chain_config(config_profile)
         return cls(
             beacon_app_config.database_dir,
             beacon_app_config.orchestration_profile,
@@ -56,4 +57,5 @@ class BeaconNodeConfig:
             chain_config._eth2_config,
             beacon_app_config.client_identifier,
             beacon_app_config.p2p_maddr,
+            chain_config.beacon_chain_class,
         )

--- a/trinity/nodes/beacon/full.py
+++ b/trinity/nodes/beacon/full.py
@@ -25,7 +25,7 @@ from eth2.beacon.typing import Epoch, ForkDigest, Root, Slot
 from eth2.clock import Clock, Tick, TimeProvider, get_unix_time
 from eth2.configs import Eth2Config
 from trinity._utils.trio_utils import JSONHTTPServer
-from trinity.config import BeaconChainConfig
+from trinity.config import BeaconTrioChainConfig
 from trinity.nodes.beacon.config import BeaconNodeConfig
 from trinity.nodes.beacon.host import Host
 from trinity.nodes.beacon.metadata import MetaData
@@ -97,7 +97,7 @@ class BeaconNode:
         self,
         local_node_key: PrivateKey,
         eth2_config: Eth2Config,
-        chain_config: BeaconChainConfig,
+        chain_config: BeaconTrioChainConfig,
         database_dir: Path,
         chain_class: Type[BaseBeaconChain],
         clock: Clock,
@@ -189,10 +189,7 @@ class BeaconNode:
             config.eth2_config,
             config.chain_config,
             config.database_dir,
-            # TODO: (g-r-a-n-t) We have two different `BaseBeaconChain` classes, which are
-            # used by different chains. This causes some typing issues, which we'll just ignore
-            # until the older one is removed and all chains use the same base class.
-            config.chain_class,  # type: ignore
+            config.chain_class,
             clock,
             config.validator_api_port,
             config.client_identifier,

--- a/trinity/nodes/beacon/full.py
+++ b/trinity/nodes/beacon/full.py
@@ -189,7 +189,10 @@ class BeaconNode:
             config.eth2_config,
             config.chain_config,
             config.database_dir,
-            config.chain_class,
+            # TODO: (g-r-a-n-t) We have two different `BaseBeaconChain` classes, which are
+            # used by different chains. This causes some typing issues, which we'll just ignore
+            # until the older one is removed and all chains use the same base class.
+            config.chain_class,  # type: ignore
             clock,
             config.validator_api_port,
             config.client_identifier,


### PR DESCRIPTION
### What was wrong?
It wasn't possible to select a chain or genesis config when booting up the beacon node, these values were hardcoded.

### How was it fixed?
Added a `--config-profile` param to beacon node that can be used to select the chain on which you would like to run and the genesis config that you would like to use.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

[//]: # (See: https://trinity-client.readthedocs.io/en/latest/contributing.html#pull-requests)
- [ ] Add entry to the [release notes](https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://preview.redd.it/1zsei888v7b51.jpg?width=960&crop=smart&auto=webp&s=075c5cee2305ecc6eff1a9cf6c07414ed29bf55f)
