### PR TITLE
Handle error in metrics reporting

### DIFF
--- a/newsfragments/1903.bugfix.rst
+++ b/newsfragments/1903.bugfix.rst
@@ -1,0 +1,2 @@
+Handle error (don't crash Trinity) when metrics can't be written to the InfluxDB
+because of any connection errors.

--- a/tests-trio/p2p-trio/test_trio_utils.py
+++ b/tests-trio/p2p-trio/test_trio_utils.py
@@ -1,3 +1,5 @@
+from functools import partial
+
 import pytest
 
 import trio
@@ -6,6 +8,7 @@ from p2p.trio_utils import (
     every,
     gather,
 )
+from trinity._utils.trio_utils import wait_first
 
 
 @pytest.mark.trio
@@ -97,3 +100,16 @@ async def test_every_late(autojump_clock):
     third_time = await every_generator.__anext__()
     assert third_time == pytest.approx(second_time + 2)
     assert trio.current_time() == pytest.approx(third_time)
+
+
+@pytest.mark.trio
+async def test_wait_first(autojump_clock):
+    count = 0
+
+    async def _sleep_and_count(duration):
+        await trio.sleep(duration)
+        nonlocal count
+        count += 1
+
+    await wait_first([partial(_sleep_and_count, 1), partial(_sleep_and_count, 2)])
+    assert count == 1

--- a/tests/integration/test_trinity_cli.py
+++ b/tests/integration/test_trinity_cli.py
@@ -274,6 +274,9 @@ async def test_web3_commands_via_attached_console(command,
         # ropsten
         ('trinity', '--ropsten',),
         ('trinity', '--sync-mode=light', '--ropsten',),
+        # with metrics enabled. We do not have a proper integration test yet and deliberately
+        # test against an invalid host for now. We only care about Trinity not crashing.
+        ('trinity', '--enable-metrics', '--metrics-host=ci', '--metrics-influx-server=_.com'),
     )
 )
 @pytest.mark.asyncio

--- a/trinity/_utils/services.py
+++ b/trinity/_utils/services.py
@@ -1,36 +1,38 @@
 import asyncio
 import contextlib
-from typing import AsyncContextManager, Callable, Sequence
+from typing import Sequence
 
 from async_service import (
     background_asyncio_service,
     background_trio_service,
-    ManagerAPI,
     ServiceAPI,
 )
 
-from p2p.asyncio_utils import wait_first
+from p2p.asyncio_utils import wait_first as wait_first_asyncio
+from trinity._utils.trio_utils import wait_first as wait_first_trio
 
 
 async def run_background_asyncio_services(services: Sequence[ServiceAPI]) -> None:
-    await _run_background_services(services, background_asyncio_service)
-
-
-async def run_background_trio_services(services: Sequence[ServiceAPI]) -> None:
-    await _run_background_services(services, background_trio_service)
-
-
-async def _run_background_services(
-        services: Sequence[ServiceAPI],
-        runner: Callable[[ServiceAPI], AsyncContextManager[ManagerAPI]]
-) -> None:
     async with contextlib.AsyncExitStack() as stack:
         managers = tuple([
-            await stack.enter_async_context(runner(service))
+            await stack.enter_async_context(background_asyncio_service(service))
             for service in services
         ])
         # If any of the services terminate, we do so as well.
-        await wait_first([
+        await wait_first_asyncio([
             asyncio.create_task(manager.wait_finished())
+            for manager in managers
+        ])
+
+
+async def run_background_trio_services(services: Sequence[ServiceAPI]) -> None:
+    async with contextlib.AsyncExitStack() as stack:
+        managers = tuple([
+            await stack.enter_async_context(background_trio_service(service))
+            for service in services
+        ])
+        # If any of the services terminate, we do so as well.
+        await wait_first_trio([
+            manager.wait_finished
             for manager in managers
         ])

--- a/trinity/_utils/trio_utils.py
+++ b/trinity/_utils/trio_utils.py
@@ -22,6 +22,18 @@ import trio
 from trio_typing import TaskStatus
 
 
+async def wait_first(callables: Sequence[Callable[[], Awaitable[Any]]]) -> None:
+    """
+    Run any number of tasks but cancel out any outstanding tasks as soon as the first one finishes.
+    """
+    async with trio.open_nursery() as nursery:
+        for task in callables:
+            async def _run_then_cancel() -> None:
+                await task()
+                nursery.cancel_scope.cancel()
+            nursery.start_soon(_run_then_cancel)
+
+
 async def wait_for_interrupts() -> None:
     with trio.open_signal_receiver(signal.SIGINT, signal.SIGTERM) as stream:
         async for _ in stream:

--- a/trinity/components/builtin/metrics/service/asyncio.py
+++ b/trinity/components/builtin/metrics/service/asyncio.py
@@ -7,5 +7,5 @@ class AsyncioMetricsService(BaseMetricsService):
 
     async def continuously_report(self) -> None:
         while self.manager.is_running:
-            self._reporter.report_now()
+            super().report_now()
             await asyncio.sleep(self._reporting_frequency)

--- a/trinity/components/builtin/metrics/service/base.py
+++ b/trinity/components/builtin/metrics/service/base.py
@@ -1,4 +1,6 @@
+import time
 from abc import abstractmethod
+from http.client import HTTPException
 
 from async_service import Service
 from pyformance.reporters import InfluxReporter
@@ -14,6 +16,8 @@ class BaseMetricsService(Service, MetricsServiceAPI):
     It continuously reports metrics to the specified InfluxDB instance.
     """
 
+    MIN_SECONDS_BETWEEN_ERROR_LOGS = 60
+
     def __init__(self,
                  influx_server: str,
                  influx_user: str,
@@ -23,6 +27,8 @@ class BaseMetricsService(Service, MetricsServiceAPI):
                  port: int,
                  protocol: str,
                  reporting_frequency: int):
+        self._unreported_error: Exception = None
+        self._last_time_reported: float = 0.0
         self._influx_server = influx_server
         self._reporting_frequency = reporting_frequency
         self._registry = HostMetricsRegistry(host)
@@ -50,6 +56,38 @@ class BaseMetricsService(Service, MetricsServiceAPI):
         self.logger.info("Reporting metrics to %s", self._influx_server)
         self.manager.run_daemon_task(self.continuously_report)
         await self.manager.wait_finished()
+
+    def report_now(self) -> None:
+        try:
+            self._reporter.report_now()
+        except (HTTPException, ConnectionError) as exc:
+
+            # This method is usually called every few seconds. If there's an issue with the
+            # connection we do not want to flood the log and tame down warnings.
+
+            # 1. We log the first instance of an exception immediately
+            # 2. We log follow up exceptions only after a minimum time has elapsed
+            # This means that we also might overwrite exceptions for different errors
+
+            if self._is_justified_to_log_error():
+                self._log_and_clear(exc)
+            else:
+                self._unreported_error = exc
+        else:
+            # If errors disappear, we want to make sure we eventually report the last instance
+            if self._unreported_error is not None and self._is_justified_to_log_error():
+                self._log_and_clear(self._unreported_error)
+
+    def _log_and_clear(self, error: Exception) -> None:
+        self.logger.warning("Unable to report metrics: %s", error)
+        self._unreported_error = None
+        self._last_time_reported = time.monotonic()
+
+    def _is_justified_to_log_error(self) -> bool:
+        return (
+            self._last_time_reported == 0.0 or
+            time.monotonic() - self._last_time_reported > self.MIN_SECONDS_BETWEEN_ERROR_LOGS
+        )
 
     @abstractmethod
     async def continuously_report(self) -> None:

--- a/trinity/components/builtin/metrics/service/trio.py
+++ b/trinity/components/builtin/metrics/service/trio.py
@@ -7,4 +7,4 @@ class TrioMetricsService(BaseMetricsService):
 
     async def continuously_report(self) -> None:
         async for _ in trio_utils.every(self._reporting_frequency):
-            self._reporter.report_now()
+            super().report_now()


### PR DESCRIPTION
### What was wrong?

Currently, Trinity will crash if metrics can't be written to the InfluxDB because of some connection / http errors.

### How was it fixed?

Catch `ConnectionError` and `HttpError` and report them as warnings. The fix also ensures we do at most log one warning every minute.

Fixes #1903

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

[//]: # (See: https://trinity-client.readthedocs.io/en/latest/contributing.html#pull-requests)
- [x] Add entry to the [release notes](https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://i.pinimg.com/originals/98/b7/91/98b791503be6d060b38e3401c0a5f30c.jpg)
