### PR TITLE
Ensure DappNode dashboard shows Trinity

### DIFF
--- a/dappnode/dappnode_package.json
+++ b/dappnode/dappnode_package.json
@@ -3,7 +3,8 @@
   "version": "0.1.3",
   "description": "Ethereum Python Client (experimental)",
   "avatar": "/ipfs/QmRyJJwuCEYHPf7xkRcoPJqiHQgAN3ay2voSCTrAY1nMet",
-  "type": "service",
+  "type": "library",
+  "chain": "ethereum",
   "image": {
     "path": "trinity.public.dappnode.eth_0.1.3.tar.xz",
     "hash": "/ipfs/QmZfnAJNHoGESss7gQAjfiyV9RP3Rt1bEh4Btcz2LNFAVh",
@@ -18,7 +19,7 @@
       "trinity_src:/usr/src/app"
     ],
     "environment": [
-      "EXTRA_OPTS=--trinity-root-dir /trinity"
+      "EXTRA_OPTS=--trinity-root-dir /trinity --enable-http"
     ],
     "restart": "always"
   },

--- a/newsfragments/1909.feature.rst
+++ b/newsfragments/1909.feature.rst
@@ -1,0 +1,1 @@
+Trinity on DappNode: Ensure sync progress is displayed on the dashboard.


### PR DESCRIPTION
### What was wrong?

When running Trinity via the dappnode package, the current sync status isn't listed on the dashboard"

### How was it fixed?

1. Make configurations in manifest
2. Enable http (the dashboard requests the current head via the JSON-RPC API)

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

[//]: # (See: https://trinity-client.readthedocs.io/en/latest/contributing.html#pull-requests)
- [x] Add entry to the [release notes](https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://i.imgur.com/NHVgoC5.jpg)
