### PR TITLE
Only start streaming protocol messages after Peer is fully setup

### DIFF
--- a/p2p/abc.py
+++ b/p2p/abc.py
@@ -665,6 +665,11 @@ class ConnectionAPI(ServiceAPI):
     def start_protocol_streams(self) -> None:
         ...
 
+    @property
+    @abstractmethod
+    def is_streaming_messages(self) -> bool:
+        ...
+
     @abstractmethod
     def add_protocol_handler(self,
                              protocol_type: Type[ProtocolAPI],

--- a/p2p/connection.py
+++ b/p2p/connection.py
@@ -105,6 +105,10 @@ class Connection(ConnectionAPI, Service):
     def __repr__(self) -> str:
         return f"<Connection {self.session!r} {self._multiplexer!r} dial_out={self.is_dial_out}>"
 
+    @property
+    def is_streaming_messages(self) -> bool:
+        return self._handlers_ready.is_set()
+
     def start_protocol_streams(self) -> None:
         self._handlers_ready.set()
 
@@ -207,7 +211,7 @@ class Connection(ConnectionAPI, Service):
         try:
             await asyncio.wait_for(self._handlers_ready.wait(), timeout=10)
         except asyncio.TimeoutError as err:
-            self.logger.info('Timedout waiting for handler ready signal')
+            self.logger.warning('Timedout waiting for handler ready signal')
             raise asyncio.TimeoutError(
                 "The handlers ready event was never set.  Ensure that "
                 "`Connection.start_protocol_streams()` is being called"

--- a/p2p/tools/factories/peer.py
+++ b/p2p/tools/factories/peer.py
@@ -56,6 +56,7 @@ async def PeerPairFactory(*,
         bob_private_key=bob_private_key,
         bob_client_version=bob_client_version,
         bob_p2p_version=bob_p2p_version,
+        start_streams=False,
     )
 
     async with connection_pair as (alice_connection, bob_connection):
@@ -66,6 +67,8 @@ async def PeerPairFactory(*,
         await bob_connection.run_peer(bob)
         await asyncio.wait_for(alice.ready.wait(), timeout=1)
         await asyncio.wait_for(bob.ready.wait(), timeout=1)
+        alice.start_protocol_streams()
+        bob.start_protocol_streams()
         yield alice, bob
 
 

--- a/p2p/tools/paragon/__init__.py
+++ b/p2p/tools/paragon/__init__.py
@@ -1,3 +1,6 @@
+from .api import (  # noqa: F401
+    ParagonAPI,
+)
 from .commands import (  # noqa: F401
     BroadcastData,
     GetSum,

--- a/tests/p2p/test_peer.py
+++ b/tests/p2p/test_peer.py
@@ -52,6 +52,9 @@ class BehaviorCrash(Exception):
 
 class CrashingLogic(BaseLogic):
     async def crash(self):
+        # If we crash immediately the peer may not have enough time to start and the test will
+        # fail, so wait a bit before crashing.
+        await asyncio.sleep(0.01)
         raise BehaviorCrash()
 
     @contextlib.asynccontextmanager


### PR DESCRIPTION
We used to start streaming protocol messages in the Peer.run() method,
but that happens before the PeerPool adds its subscribers to the Peer,
so messages could be dropped and that could cause remotes to disconnect
from us. Now it's the PeerPool that starts the streaming after adding
its subscribers, and it is also clearly documented that the streaming
should not start until the peer has subscribers

Closes: #1907 