### PR TITLE
Make it configurable which JSON-RPC APIs are exposed via HTTP

### DIFF
--- a/docs/api/api.cli.rst
+++ b/docs/api/api.cli.rst
@@ -13,7 +13,8 @@ We can also generate an always up-to-date version of them by running ``trinity -
                    [--network-id NETWORK_ID | --ropsten | --goerli]
                    [--preferred-node PREFERRED_NODES] [--max-peers MAX_PEERS]
                    [--genesis GENESIS] [--data-dir DATA_DIR] [--nodekey NODEKEY]
-                   [--profile] [--disable-rpc] [--enable-http]
+                   [--profile] [--disable-rpc]
+                   [--enable-http-apis ENABLE_HTTP_APIS]
                    [--http-listen-address HTTP_LISTEN_ADDRESS]
                    [--http-port HTTP_PORT]
                    [--network-tracking-backend {sqlite3,memory,do-not-track}]
@@ -62,7 +63,11 @@ We can also generate an always up-to-date version of them by running ``trinity -
     optional arguments:
       -h, --help            show this help message and exit
       --disable-rpc         Disables the JSON-RPC server
-      --enable-http         Enables the HTTP server
+      --enable-http-apis ENABLE_HTTP_APIS
+                            Enable HTTP access to specified JSON-RPC APIs (e.g.
+                            'eth,net'). Use '*' to enable HTTP access to all
+                            modules (including eth_admin).
+
       --http-listen-address HTTP_LISTEN_ADDRESS
                             Address for the HTTP server to listen on
       --http-port HTTP_PORT

--- a/eth2/beacon/scripts/run_beacon_nodes.py
+++ b/eth2/beacon/scripts/run_beacon_nodes.py
@@ -131,7 +131,7 @@ class Node:
             f"--beacon-nodekey={remove_0x_prefix(encode_hex(self.node_privkey.to_bytes()))}",
             f"--preferred_nodes={','.join(str(node.maddr) for node in self.preferred_nodes)}",
             f"--http-port={self.http_port}",
-            "--enable-http",
+            "--enable-http-apis='beacon'",
             "--enable-metrics",
             "--enable-api",
             f"--api-port={self.api_port}",

--- a/newsfragments/1911.feature.rst
+++ b/newsfragments/1911.feature.rst
@@ -1,0 +1,6 @@
+Make it configurable which JSON-RPC modules are exposed via HTTP.
+Prior to this change, every JSON-RPC module was exposed via HTTP if Trinity was
+instructed to run with the HTTP server enabled. With this change, the HTTP
+server is enabled via the ``--enable-http-apis`` flag which takes a string
+value of either ``"*"`` to expose every module via HTTP or a comma seperated
+list of module names e.g. ``"eth, net"``.

--- a/newsfragments/1911.removal.rst
+++ b/newsfragments/1911.removal.rst
@@ -1,0 +1,2 @@
+BREAKING CHANGE: The ``--enable-http`` flag is no longer supported, use ``--enable-http-apis``
+instead. Read the "feature" section for more additional information.

--- a/tests/core/json-rpc/test_rpc_server.py
+++ b/tests/core/json-rpc/test_rpc_server.py
@@ -1,0 +1,54 @@
+import json
+import random
+
+import pytest
+from eth import MainnetChain
+
+from trinity.chains.full import FullChain
+from trinity.config import TrinityConfig
+from trinity.rpc import RPCServer
+from trinity.rpc.modules import initialize_eth1_modules, Admin, Net
+
+
+def build_request(method, params):
+    return {"jsonrpc": "2.0", "method": method, "params": params, "id": random.randrange(1000)}
+
+
+def result_from_response(response_str):
+    response = json.loads(response_str)
+    return (response.get('result', None), response.get('error', None))
+
+
+class MainnetFullChain(FullChain):
+    vm_configuration = MainnetChain.vm_configuration
+    chain_id = MainnetChain.chain_id
+
+
+@pytest.mark.parametrize(
+    "api, param, disabled_modules, expected_result, expected_error",
+    (
+        (
+            ("net_listening", (), (), True, None),
+            ("net_listening", (), (Admin,), True, None),
+            ("net_listening", (), (Net,), None, "Access of net module prohibited"),
+            ("net_listening", (), (Admin, Net,), None, "Access of net module prohibited"),
+        )
+    )
+)
+@pytest.mark.asyncio
+async def test_access_control(event_bus,
+                              api,
+                              param,
+                              disabled_modules,
+                              expected_result,
+                              expected_error):
+
+    chain = MainnetFullChain(None)
+    trinity_config = TrinityConfig(app_identifier="eth1", network_id=1)
+    rpc = RPCServer(initialize_eth1_modules(chain, event_bus, trinity_config), chain, event_bus)
+
+    request = build_request(api, param)
+    response = await rpc.execute_with_access_control(disabled_modules, request)
+    result, error = result_from_response(response)
+    assert result == expected_result
+    assert error == expected_error

--- a/trinity/rpc/modules/main.py
+++ b/trinity/rpc/modules/main.py
@@ -26,12 +26,12 @@ class ChainReplacementEvent(BaseEvent, Generic[TChain]):
 
 class BaseRPCModule(ABC):
 
-    @property
-    def name(self) -> str:
+    @classmethod
+    def get_name(cls) -> str:
         # By default the name is the lower-case class name.
         # This encourages a standard name of the module, but can
         # be overridden if necessary.
-        return self.__class__.__name__.lower()
+        return cls.__name__.lower()
 
 
 class ChainBasedRPCModule(BaseRPCModule, Generic[TChain]):


### PR DESCRIPTION
### What was wrong?

As mentioned in #1626, running Trinity with the JSON-RPC API accessible via HTTP is currently follows an all-or-nothing approach. This is unfortunate and even has security implications (even more so, once we implement `admin_removePeer`) as it may expose sensible administrative APIs to be misused by external attackers. 

### How was it fixed?

1. Remove the `--enable-http` flag
2. Add a `--enable-http-apis` flag that takes either `"*"` as a wildcard (current behavior) or a comma separated list of modules to expose e.g. `"net, eth"`
3. The `RPCServer` has a new `execute_with_access_control` API that allows passing disabled modules. The old `execute` API still exists but delegates to `execute_with_access_control` without any blocked modules. The `IPCServer` continues to use the existing `execute` API as it does not restrict module access.
4. The HTTP server uses the `execute_with_access_control` API and passes in the disabled modules (enabled modules from the CLI are translated into disabled modules in the process). Note: It felt more natural to me to have the RPCServer demand a configuration of disabled modules but have the CLI be focused on which modules are enabled.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

[//]: # (See: https://trinity-client.readthedocs.io/en/latest/contributing.html#pull-requests)
- [x] Add entry to the [release notes](https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://dress-fr.techinfus.com/images/article/orig/2019/03/kak-priruchit-shinshillu-k-rukam-6.jpg)
