### PR TITLE
Log slots per second eth2 syncing

### DIFF
--- a/trinity/main_beacon_trio.py
+++ b/trinity/main_beacon_trio.py
@@ -1,4 +1,5 @@
 import logging
+import os
 import shutil
 from typing import Collection, Sequence, Tuple, Type
 
@@ -63,8 +64,10 @@ def main_entry_trio(
     _initialize_beacon_filesystem_and_db(boot_info)
 
     logger = logging.getLogger("trinity")
+    pid = os.getpid()
+    identifier = construct_trinity_client_identifier()
     logger.info(
-        "Booted client with identifier: %s", construct_trinity_client_identifier()
+        "Booted client with identifier: %s and process id %d", identifier, pid
     )
 
     runtime_component_types = tuple(


### PR DESCRIPTION
Logs slots per second now while syncing.

Also adds process id to boot logs (e.g. so we can attach `py-spy` while running).

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://i.ytimg.com/vi/CObVbNCDk1s/maxresdefault.jpg)
