### PR TITLE
Longer queen penalty & logging tweaks

### DIFF
--- a/newsfragments/1916.doc.rst
+++ b/newsfragments/1916.doc.rst
@@ -1,0 +1,1 @@
+Now logs more information during beam sync about the intermediate progress in the middle of a block.

--- a/tests/p2p/test_token_bucket.py
+++ b/tests/p2p/test_token_bucket.py
@@ -87,9 +87,9 @@ async def test_token_bucket_refills_itself():
     # since the capacity should have been fully refilled, second loop time
     # should take near zero time
     expected = await measure_zero(10)
-    # drift is allowed to be up to 200% since we're working with very small
-    # numbers.
-    assert_fuzzy_equal(delta, expected, allowed_drift=2)
+    # drift is allowed to be up to 300% since we're working with very small
+    # numbers, and the performance in CI varies widely.
+    assert_fuzzy_equal(delta, expected, allowed_drift=3)
 
 
 @pytest.mark.asyncio

--- a/trinity/sync/beam/backfill.py
+++ b/trinity/sync/beam/backfill.py
@@ -49,6 +49,7 @@ from trinity.protocol.eth.peer import ETHPeer, ETHPeerPool
 from trinity.sync.beam.constants import (
     EPOCH_BLOCK_LENGTH,
     GAP_BETWEEN_TESTS,
+    NON_IDEAL_RESPONSE_PENALTY,
     PAUSE_SECONDS_IF_STATE_BACKFILL_STARVED,
 )
 from trinity._utils.async_iter import async_take
@@ -108,8 +109,8 @@ class BeamStateBackfill(Service, QueenTrackerAPI):
     async def get_queen_peer(self) -> ETHPeer:
         return await self._queening_queue.get_queen_peer()
 
-    def penalize_queen(self, peer: ETHPeer) -> None:
-        self._queening_queue.penalize_queen(peer)
+    def penalize_queen(self, peer: ETHPeer, delay: float = NON_IDEAL_RESPONSE_PENALTY) -> None:
+        self._queening_queue.penalize_queen(peer, delay=delay)
 
     async def run(self) -> None:
         self.manager.run_daemon_task(self._periodically_report_progress)

--- a/trinity/sync/beam/chain.py
+++ b/trinity/sync/beam/chain.py
@@ -719,7 +719,12 @@ class BeamBlockImporter(BaseBlockImporter, Service):
     async def import_block(
             self,
             block: BlockAPI) -> BlockImportResult:
-        self.logger.info("Beam importing %s (%d txns) ...", block.header, len(block.transactions))
+        self.logger.debug(
+            "Beam importing %s (%d txns, %s gas) ...",
+            block.header,
+            len(block.transactions),
+            f'{block.header.gas_used:,d}',
+        )
 
         parent_header = await self._chain.coro_get_block_header_by_hash(block.header.parent_hash)
         new_account_nodes, collection_time = await self._load_address_state(

--- a/trinity/sync/beam/constants.py
+++ b/trinity/sync/beam/constants.py
@@ -27,7 +27,7 @@ MAX_SPECULATIVE_EXECUTIONS_PER_PROCESS = MAX_CONCURRENT_SPECULATIVE_EXECUTIONS /
 # If a peer does something not ideal, give it a little time to breath,
 # and maybe to try out another peeer. Then reinsert it relatively soon.
 # Measured in seconds.
-NON_IDEAL_RESPONSE_PENALTY = 0.5
+NON_IDEAL_RESPONSE_PENALTY = 2.0
 
 # If Beam Sync wants to use a queen, but is stuck waiting for it to show up,
 #   then log a warning if it's been too long. If it's been more than this

--- a/trinity/sync/beam/constants.py
+++ b/trinity/sync/beam/constants.py
@@ -24,6 +24,10 @@ NUM_PREVIEW_SHARDS = 4
 MAX_CONCURRENT_SPECULATIVE_EXECUTIONS = 40
 MAX_SPECULATIVE_EXECUTIONS_PER_PROCESS = MAX_CONCURRENT_SPECULATIVE_EXECUTIONS // NUM_PREVIEW_SHARDS
 
+# How many seconds to wait in between each progress log, in the middle of a block
+#   Intuition: somewhere around the time it takes to import a block
+MIN_GAS_LOG_WAIT = PREDICTED_BLOCK_TIME
+
 # If a peer does something not ideal, give it a little time to breath,
 # and maybe to try out another peeer. Then reinsert it relatively soon.
 # Measured in seconds.

--- a/trinity/sync/beam/importer.py
+++ b/trinity/sync/beam/importer.py
@@ -285,6 +285,14 @@ def pausing_vm_decorator(
                         loop,
                     )
                     account_event = account_future.result(timeout=self.node_retrieval_timeout)
+                    if urgent:
+                        self.logger.debug(
+                            "Paused for account nodes (%d) for %.3fs, %.3fs avg (starts on %s)",
+                            account_event.num_nodes_collected,
+                            t.elapsed,
+                            t.elapsed / (account_event.num_nodes_collected or 1),
+                            exc.missing_node_hash[:2].hex(),
+                        )
 
                     # Collect the amount of paused time before checking if we should exit, so
                     #   it shows up in logged statistics.
@@ -303,6 +311,12 @@ def pausing_vm_decorator(
                         loop,
                     )
                     bytecode_event = bytecode_future.result(timeout=self.node_retrieval_timeout)
+                    if urgent:
+                        self.logger.debug(
+                            "Got bytecode to importer in %.3fs (%s)",
+                            t.elapsed,
+                            exc.missing_code_hash[:2].hex(),
+                        )
                     self.stats_counter.data_pause_time += t.elapsed
                     if not bytecode_event.is_retry_acceptable:
                         raise StateUnretrievable("Server asked us to stop trying")
@@ -320,6 +334,14 @@ def pausing_vm_decorator(
                         loop,
                     )
                     storage_event = storage_future.result(timeout=self.node_retrieval_timeout)
+                    if urgent:
+                        self.logger.debug(
+                            "Paused for storage nodes (%d) for %.3fs, %.3fs avg (starts on %s)",
+                            storage_event.num_nodes_collected,
+                            t.elapsed,
+                            t.elapsed / (storage_event.num_nodes_collected or 1),
+                            exc.missing_node_hash[:2].hex(),
+                        )
                     self.stats_counter.data_pause_time += t.elapsed
                     if not storage_event.is_retry_acceptable:
                         raise StateUnretrievable("Server asked us to stop trying")

--- a/trinity/sync/beam/queen.py
+++ b/trinity/sync/beam/queen.py
@@ -38,7 +38,7 @@ class QueenTrackerAPI(ABC):
         ...
 
     @abstractmethod
-    def penalize_queen(self, peer: ETHPeer) -> None:
+    def penalize_queen(self, peer: ETHPeer, delay: float = NON_IDEAL_RESPONSE_PENALTY) -> None:
         ...
 
 
@@ -91,7 +91,7 @@ class QueeningQueue(Service, PeerSubscriber, QueenTrackerAPI):
 
         queen_starve_time = t.elapsed
         if queen_starve_time > WARN_AFTER_QUEEN_STARVED:
-            self.logger.info(
+            self.logger.debug(
                 "Blocked for %.2fs waiting for queen=%s",
                 queen_starve_time,
                 self._queen_peer,

--- a/trinity/sync/beam/service.py
+++ b/trinity/sync/beam/service.py
@@ -103,7 +103,7 @@ class BeamSyncService(Service):
                     logger(
                         (
                             "Beam Sync is lagging behind the latest known header by %d blocks,"
-                            " will pivot at %d"
+                            " will pivot above %d"
                         ),
                         lag,
                         ESTIMATED_BEAMABLE_BLOCKS,

--- a/trinity/sync/beam/state.py
+++ b/trinity/sync/beam/state.py
@@ -419,13 +419,14 @@ class BeamDownloader(Service, PeerSubscriber):
         if urgent_batch_id is not None:
             time_on_urgent = urgent_timer.elapsed
             self.logger.debug(
-                "beam-rtt: got %d/%d urgent nodes in %.3fs with %d/%d predictive from %s",
+                "beam-rtt: got %d/%d urgent nodes in %.3fs with %d/%d predictive from %s (%s)",
                 len(urgent_nodes),
                 len(urgent_node_hashes),
                 time_on_urgent,
                 len(predictive_nodes),
                 len(predictive_node_hashes),
                 peer.remote,
+                urgent_node_hashes[0][:2].hex()
             )
             self._time_on_urgent += time_on_urgent
 


### PR DESCRIPTION
### What was wrong?

If your queen peer is fast at answering data, but giving empty responses, we penalize it. If RTT is ~0.5s, then a 0.5s penalty means that we are still using it as a queen about every other request.

### How was it fixed?

Bump up the penalty to ~2s. A large penalty was more painful when we had a hard time connecting to peers, but now shouldn't have too big an impact.

Also, logging more info about time spent waiting on the missing trie nodes, and intermediate progress during long beam imports.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

[//]: # (See: https://trinity-client.readthedocs.io/en/latest/contributing.html#pull-requests)
- [x] Add entry to the [release notes](https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://i.pinimg.com/236x/b1/fd/01/b1fd012ff3291c5a8ec0dff47ffa414b--time-out-bull-dog.jpg)
