### PR TITLE
Update jsonschema to work with the latest web3

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ deps = {
         "termcolor>=1.1.0,<2.0.0",
         "uvloop==0.14.0;platform_system=='Linux' or platform_system=='Darwin' or platform_system=='FreeBSD'",  # noqa: E501
         "websockets>=8.1.0",
-        "jsonschema==3.0.1",
+        "jsonschema>=3.2,<4",
         "mypy-extensions>=0.4.3,<0.5.0",
         "ruamel.yaml==0.16.10",
         "argcomplete>=1.10.0,<2",


### PR DESCRIPTION
### What was wrong?

This is originally from #1916 and hopefully addresses the current CI breakage with the beacon chain docker job.

### How was it fixed?

Update dependency of `jsonschema`

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

[//]: # (See: https://trinity-client.readthedocs.io/en/latest/contributing.html#pull-requests)
- [ ] Add entry to the [release notes](https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://www.top13.net/wp-content/uploads/2017/01/baby-chinchillas-cutest-7.jpg)
