### PR TITLE
Ensure Connection.run_behaviors() doesn't leak pending asyncio tasks

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -1,5 +1,5 @@
 [mypy]
-warn_unused_ignores = True
+warn_unused_ignores = False
 ignore_missing_imports = True
 strict_optional = False
 check_untyped_defs = True

--- a/p2p/asyncio_utils.py
+++ b/p2p/asyncio_utils.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+import asyncio
+import contextlib
+import sys
+from typing import Awaitable, Sequence, Iterable, List, TypeVar
+
+from trio import MultiError
+
+from eth_utils.toolz import first
+
+
+TReturn = TypeVar('TReturn')
+
+
+def create_task(coro: Awaitable[TReturn], name: str) -> asyncio.Task[TReturn]:
+    if sys.version_info >= (3, 8):
+        # Our version of mypy doesn't know about the name argument to create_task()
+        return asyncio.create_task(coro, name=name)  # type: ignore
+    else:
+        return asyncio.create_task(coro)
+
+
+async def wait_first(futures: Sequence[asyncio.Future[None]]) -> None:
+    """
+    Wait for the first of the given futures to complete, then cancels all others.
+
+    If the completed future raised an exception, re-raise it.
+
+    If the task running us is cancelled, all futures will be cancelled.
+    """
+    for future in futures:
+        if not isinstance(future, asyncio.Future):
+            raise ValueError(f"{future} is not an asyncio.Future")
+
+    try:
+        done, pending = await asyncio.wait(futures, return_when=asyncio.FIRST_COMPLETED)
+    except asyncio.CancelledError:
+        await cancel_futures(futures)
+        raise
+    else:
+        if pending:
+            await cancel_futures(pending)
+        if len(done) != 1:
+            raise Exception(
+                "Invariant: asyncio.wait() returned more than one future even "
+                "though we used return_when=asyncio.FIRST_COMPLETED: %s", done)
+        done_future = first(done)
+        if done_future.exception():
+            raise done_future.exception()
+
+
+async def cancel_futures(futures: Iterable[asyncio.Future[None]]) -> None:
+    """
+    Cancel and await for the given futures, ignoring any asyncio.CancelledErrors.
+    """
+    for fut in futures:
+        fut.cancel()
+
+    errors: List[BaseException] = []
+    # Wait for all futures in parallel so if any of them catches CancelledError and performs a
+    # slow cleanup the othders don't have to wait for it. The timeout is long as our component
+    # tasks can do a lot of stuff during their cleanup.
+    done, pending = await asyncio.wait(futures, timeout=5)
+    if pending:
+        errors.append(
+            asyncio.TimeoutError("Tasks never returned after being cancelled: %s", pending))
+    for task in done:
+        # task.exception() will raise a CancelledError if the task was cancelled by us above, so
+        # we must suppress that here.
+        with contextlib.suppress(asyncio.CancelledError):
+            if task.exception():
+                errors.append(task.exception())
+    if errors:
+        raise MultiError(errors)

--- a/p2p/connection.py
+++ b/p2p/connection.py
@@ -16,6 +16,7 @@ from typing import (
 )
 
 from async_service import Service
+from async_service.asyncio import cleanup_tasks
 
 from cached_property import cached_property
 
@@ -48,7 +49,7 @@ from p2p.exceptions import (
     UnknownProtocol,
     UnknownProtocolCommand,
 )
-from p2p.logic import wait_first
+from p2p.asyncio_utils import create_task, wait_first
 from p2p.subscription import Subscription
 from p2p.p2p_proto import BaseP2PProtocol, DevP2PReceipt, Disconnect
 from p2p.typing import Capabilities
@@ -115,22 +116,26 @@ class Connection(ConnectionAPI, Service):
     async def run_behaviors(self, behaviors: Tuple[BehaviorAPI, ...]) -> None:
         async with contextlib.AsyncExitStack() as stack:
             futures: List[asyncio.Future[None]] = [
-                asyncio.create_task(self.manager.wait_finished())]
+                create_task(self.manager.wait_finished(), 'Connection/run_behaviors/wait_finished')]
             for behavior in behaviors:
                 if behavior.should_apply_to(self):
                     behavior_exit = await stack.enter_async_context(behavior.apply(self))
                     futures.append(behavior_exit)
 
             self.behaviors_applied.set()
-            try:
-                for behavior in behaviors:
-                    behavior.post_apply()
-                await wait_first(futures)
-            except PeerConnectionLost:
-                # Any of our behaviors may propagate a PeerConnectionLost, which is to be expected
-                # as many Connection APIs used by them can raise that. To avoid a DaemonTaskExit
-                # since we're returning silently, ensure we're cancelled.
-                self.manager.cancel()
+            # If wait_first() is called, cleanup_tasks() will be a no-op, but if any post_apply()
+            # calls raise an exception, it will ensure we don't leak pending tasks that would
+            # cause asyncio to complain.
+            async with cleanup_tasks(*futures):
+                try:
+                    for behavior in behaviors:
+                        behavior.post_apply()
+                    await wait_first(futures)
+                except PeerConnectionLost:
+                    # Any of our behaviors may propagate a PeerConnectionLost, which is to be
+                    # expected as many Connection APIs used by them can raise that. To avoid a
+                    # DaemonTaskExit since we're returning silently, ensure we're cancelled.
+                    self.manager.cancel()
 
     async def run_peer(self, peer: 'BasePeer') -> None:
         """

--- a/p2p/exchange/exchange.py
+++ b/p2p/exchange/exchange.py
@@ -11,6 +11,7 @@ from typing import (
 from async_service import background_asyncio_service
 
 from p2p.abc import ConnectionAPI
+from p2p.asyncio_utils import create_task
 
 from .abc import ExchangeAPI, NormalizerAPI, ValidatorAPI
 from .candidate_stream import ResponseCandidateStream
@@ -42,7 +43,8 @@ class BaseExchange(ExchangeAPI[TRequestCommand, TResponseCommand, TResult]):
                 connection,
                 response_stream,
             )
-            yield asyncio.create_task(response_stream_manager.wait_finished())
+            name = f'{self.__class__.__name__}/{connection.remote}'
+            yield create_task(response_stream_manager.wait_finished(), name=name)
 
     async def get_result(
             self,

--- a/p2p/p2p_api.py
+++ b/p2p/p2p_api.py
@@ -11,6 +11,7 @@ from async_service import (
 )
 
 from p2p.abc import CommandAPI, ConnectionAPI, HandlerFn
+from p2p.asyncio_utils import create_task
 from p2p import constants
 from p2p.disconnect import DisconnectReason
 from p2p.exceptions import PeerConnectionLost
@@ -98,7 +99,8 @@ class DisconnectIfIdle(BaseLogic):
     async def apply(self, connection: ConnectionAPI) -> AsyncIterator[asyncio.Future[None]]:
         service = PingAndDisconnectIfIdle(connection, self.idle_timeout)
         async with background_asyncio_service(service) as manager:
-            yield asyncio.create_task(manager.wait_finished())
+            task_name = f'PingAndDisconnectIfIdleService/{connection.remote}'
+            yield create_task(manager.wait_finished(), name=task_name)
 
 
 class P2PAPI(Application):

--- a/p2p/peer_pool.py
+++ b/p2p/peer_pool.py
@@ -37,6 +37,7 @@ from lahja import (
 from pyformance import MetricsRegistry
 
 from p2p.abc import NodeAPI, SessionAPI
+from p2p.asyncio_utils import create_task
 from p2p.constants import (
     DEFAULT_MAX_PEERS,
     DEFAULT_PEER_BOOT_TIMEOUT,
@@ -351,7 +352,8 @@ class BasePeerPool(Service, AsyncIterable[BasePeer]):
 
         try:
             self.logger.debug("Connecting to %s...", remote)
-            task = asyncio.ensure_future(self.get_peer_factory().handshake(remote))
+            task_name = f'PeerPool/Handshake/{remote}'
+            task = create_task(self.get_peer_factory().handshake(remote), task_name)
             return await asyncio.wait_for(task, timeout=HANDSHAKE_TIMEOUT)
         except BadAckMessage:
             # This is kept separate from the

--- a/trinity/_utils/services.py
+++ b/trinity/_utils/services.py
@@ -9,7 +9,7 @@ from async_service import (
     ServiceAPI,
 )
 
-from p2p.logic import wait_first
+from p2p.asyncio_utils import wait_first
 
 
 async def run_background_asyncio_services(services: Sequence[ServiceAPI]) -> None:

--- a/trinity/contextgroup.py
+++ b/trinity/contextgroup.py
@@ -5,6 +5,8 @@ from typing import Any, AsyncContextManager, List, Optional, Sequence, Tuple, Ty
 
 from trio import MultiError
 
+from p2p.asyncio_utils import create_task
+
 
 class AsyncContextGroup:
 
@@ -13,7 +15,7 @@ class AsyncContextGroup:
         self.cms_to_exit: Sequence[AsyncContextManager[Any]] = tuple()
 
     async def __aenter__(self) -> Tuple[Any, ...]:
-        futures = [asyncio.ensure_future(cm.__aenter__()) for cm in self.cms]
+        futures = [create_task(cm.__aenter__(), f'AsyncContextGroup/{repr(cm)}') for cm in self.cms]
         await asyncio.wait(futures)
         # Exclude futures not successfully entered from the list so that we don't attempt to exit
         # them.

--- a/trinity/extensibility/component.py
+++ b/trinity/extensibility/component.py
@@ -260,7 +260,7 @@ async def _run_eventbus_for_component(
 
 def run_asyncio_eth1_component(component_type: Type['AsyncioIsolatedComponent']) -> None:
     import asyncio
-    from p2p.logic import wait_first
+    from p2p.asyncio_utils import wait_first
     loop = asyncio.get_event_loop()
     got_sigint = asyncio.Event()
     loop.add_signal_handler(signal.SIGINT, got_sigint.set)

--- a/trinity/extensibility/component_manager.py
+++ b/trinity/extensibility/component_manager.py
@@ -84,7 +84,7 @@ class ComponentManager(Service):
 
             # a little bit of extra try/finally structure here to produce good
             # logging messages about the component lifecycle.
-            from p2p.logic import wait_first
+            from p2p.asyncio_utils import wait_first
             try:
                 self.logger.info(
                     "Starting components: %s",


### PR DESCRIPTION
If one of our behaviors raised an exception in their post_apply(),
run_behaviors() would leak pending asyncio tasks, causing asyncio
to complain. This fixes that by ensuring all tasks are done/cancelled

Closes: #1919