### PR TITLE
Some baseline eth2 performance optimizations

### DIFF
--- a/eth2/beacon/committee_helpers.py
+++ b/eth2/beacon/committee_helpers.py
@@ -1,3 +1,4 @@
+from functools import lru_cache
 import logging
 from typing import Iterable, Sequence, Tuple
 
@@ -85,6 +86,9 @@ def compute_proposer_index(
         i += 1
 
 
+# size the cache to remember the proposer across one set of slots in a given epoch.
+# NOTE: maxsize == 32 is tuned to mainnet configuration (refer: SLOTS_PER_EPOCH)
+@lru_cache(maxsize=32)
 def get_beacon_proposer_index(state: BeaconState, config: Eth2Config) -> ValidatorIndex:
     """
     Return the current beacon proposer index.
@@ -170,6 +174,9 @@ def _compute_committee(
         yield indices[shuffled_index]
 
 
+# NOTE: cache of 1024 covers "worst case" of every committee
+# getting an attestation on-chain at 4mm ETH at stake.
+@lru_cache(maxsize=1024)
 def get_beacon_committee(
     state: BeaconState, slot: Slot, index: CommitteeIndex, config: Eth2Config
 ) -> Tuple[ValidatorIndex, ...]:

--- a/eth2/beacon/epoch_processing_helpers.py
+++ b/eth2/beacon/epoch_processing_helpers.py
@@ -1,3 +1,4 @@
+from functools import lru_cache
 from typing import Iterable, Sequence, Set, Tuple
 
 from eth_utils import to_tuple
@@ -36,6 +37,9 @@ def decrease_balance(
     )
 
 
+# NOTE: cache of 1024 covers "worst case" of every committee
+# getting an attestation on-chain at 4mm ETH at stake.
+@lru_cache(maxsize=1024)
 def get_attesting_indices(
     state: BeaconState,
     attestation_data: AttestationData,
@@ -87,6 +91,9 @@ def get_validator_churn_limit(state: BeaconState, config: Eth2Config) -> int:
     )
 
 
+# Cache the balance in a given epoch (maxsize == 1).
+# A bigger cache size here would only help when processing e.g. a re-org across many epochs.
+@lru_cache(maxsize=1)
 def get_total_active_balance(state: BeaconState, config: Eth2Config) -> Gwei:
     current_epoch = state.current_epoch(config.SLOTS_PER_EPOCH)
     active_validator_indices = get_active_validator_indices(
@@ -131,6 +138,9 @@ def get_matching_head_attestations(
             yield a
 
 
+# NOTE: cache of 1024 covers "worst case" of every committee
+# getting an attestation on-chain at 4mm ETH at stake.
+@lru_cache(maxsize=1024)
 def get_unslashed_attesting_indices(
     state: BeaconState, attestations: Sequence[PendingAttestation], config: Eth2Config
 ) -> Set[ValidatorIndex]:
@@ -142,6 +152,9 @@ def get_unslashed_attesting_indices(
     return set(filter(lambda index: not state.validators[index].slashed, output))
 
 
+# NOTE: cache of 1024 covers "worst case" of every committee
+# getting an attestation on-chain at 4mm ETH at stake.
+@lru_cache(maxsize=1024)
 def get_attesting_balance(
     state: BeaconState, attestations: Sequence[PendingAttestation], config: Eth2Config
 ) -> Gwei:

--- a/eth2/beacon/helpers.py
+++ b/eth2/beacon/helpers.py
@@ -1,3 +1,4 @@
+from functools import lru_cache
 from typing import TYPE_CHECKING, Callable, Sequence, Set, Tuple
 
 from eth_typing import Hash32
@@ -37,6 +38,9 @@ def compute_start_slot_at_epoch(epoch: Epoch, slots_per_epoch: int) -> Slot:
     return Slot(epoch * slots_per_epoch)
 
 
+# Cache the active validators in a given epoch (maxsize == 1).
+# A bigger cache size here would only help when processing e.g. a re-org across many epochs.
+@lru_cache(maxsize=1)
 def get_active_validator_indices(
     validators: Sequence[Validator], epoch: Epoch
 ) -> Tuple[ValidatorIndex, ...]:

--- a/eth2/configs.py
+++ b/eth2/configs.py
@@ -33,7 +33,7 @@ def _decoder(
             yield field.name, int(data[field.name])
 
 
-@dataclass
+@dataclass(eq=True, frozen=True)
 class Eth2Config:
     # Misc
     MAX_COMMITTEES_PER_SLOT: int


### PR DESCRIPTION
### What was wrong?

We did not cache things that should definitely be cached to avoid recomputing values during an epoch transition.

We also had some obviously inefficient code given the size of the validator set on mainnet-like configurations.

### How was it fixed?

1. Add basic `functools.lru_cache` caching to the functions that do not change over a single epoch.
2. Skip the "immutability penalty" when making a large number of changes to a list of balances.

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://pbs.twimg.com/profile_images/920839442373287937/BMAePt0n.jpg)
