### PR TITLE
Fix hex literal in config

### DIFF
--- a/eth2/beacon/state_machines/forks/altona/configs.py
+++ b/eth2/beacon/state_machines/forks/altona/configs.py
@@ -24,7 +24,7 @@ ALTONA_CONFIG = Eth2Config(
     EJECTION_BALANCE=Gwei(2 ** 4 * GWEI_PER_ETH),  # (= 16,000,000,000) Gwei
     EFFECTIVE_BALANCE_INCREMENT=Gwei(2 ** 0 * GWEI_PER_ETH),  # (= 1,000,000,000) Gwei
     # Initial values
-    GENESIS_FORK_VERSION=Version(b"\x00000121"),
+    GENESIS_FORK_VERSION=Version(b"\x00\x00\x01\x21"),
     BLS_WITHDRAWAL_PREFIX=b"\x00",
     # Time parameters
     GENESIS_DELAY=Second(172800),


### PR DESCRIPTION
### What was wrong?

We had the fork version incorrectly written so when we went to process deposits, the state transition failed.

### How was it fixed?

Just update the config literal.

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://ih1.redbubble.net/image.804314130.6182/flat,800x800,075,f.u1.jpg)
