### PR TITLE
Spread Beam: Ask more peers for the same urgent trie node, to reduce latency

### DIFF
--- a/newsfragments/1101.performance.rst
+++ b/newsfragments/1101.performance.rst
@@ -1,0 +1,2 @@
+Speed up block import during Beam Sync using "Spread Beam". It asks multiple peers for the trie
+node data that's on the critical path for importing the current block.

--- a/p2p/asyncio_utils.py
+++ b/p2p/asyncio_utils.py
@@ -69,7 +69,7 @@ async def cancel_tasks(tasks: Iterable[asyncio.Task[Any]]) -> None:
     # Wait for all tasks in parallel so if any of them catches CancelledError and performs a
     # slow cleanup the othders don't have to wait for it. The timeout is long as our component
     # tasks can do a lot of stuff during their cleanup.
-    done, pending = await asyncio.wait(tasks, timeout=5)
+    done, pending = await asyncio.wait(tasks, timeout=10)
     if pending:
         errors.append(
             asyncio.TimeoutError("Tasks never returned after being cancelled: %s", pending))

--- a/pytest.ini
+++ b/pytest.ini
@@ -6,3 +6,4 @@ log_format = %(levelname)8s  %(asctime)s  %(filename)20s  %(message)s
 log_date_format = %m-%d %H:%M:%S
 markers =
   slow: test is known to be excessively slow...
+timeout = 300

--- a/setup.py
+++ b/setup.py
@@ -65,6 +65,7 @@ deps = {
         "pytest-cov>=2.8.1,<2.9",
         "pytest-mock>=1.12.1,<1.13",
         "pytest-randomly>=3.1.0,<3.2",
+        "pytest-timeout>=1.4.2,<2",
         "pytest-watch>=4.2.0,<4.3",
         # xdist pinned at <1.29 due to: https://github.com/pytest-dev/pytest-xdist/issues/472
         "pytest-xdist>=1.29.0,<1.30",

--- a/trinity/sync/beam/backfill.py
+++ b/trinity/sync/beam/backfill.py
@@ -128,6 +128,12 @@ class BeamStateBackfill(Service, QueenTrackerAPI):
         async with self._external_peasant_usage.make_noise():
             return await self._queening_queue.pop_fastest_peasant()
 
+    def pop_knights(self) -> Iterable[ETHPeer]:
+        return self._queening_queue.pop_knights()
+
+    def set_desired_knight_count(self, desired_knights: int) -> None:
+        self._queening_queue.set_desired_knight_count(desired_knights)
+
     async def run(self) -> None:
         self.manager.run_daemon_task(self._periodically_report_progress)
 

--- a/trinity/sync/beam/constants.py
+++ b/trinity/sync/beam/constants.py
@@ -2,11 +2,13 @@ from eth.constants import MAX_UNCLE_DEPTH
 
 from trinity.sync.common.constants import PREDICTED_BLOCK_TIME
 
-# Peers are typically expected to have predicted nodes available,
-#   so it's reasonable to ask for all-predictive nodes from a peer.
-# Urgent node requests usually come in pretty fast, so
-#   even at a small value (like 1ms), this timeout is rarely triggered.
-DELAY_BEFORE_NON_URGENT_REQUEST = 0.05
+# If we are waiting for predictive nodes requests to come in and
+#   they don't for this long, then reduce the minimum predictive
+#   peer response.
+# Also, if we are waiting for a peer to ask for predictive nodes
+#   for this long, then maybe increase the number of predictive peers.
+# Picked this value from thin air.
+TOO_LONG_PREDICTIVE_PEER_DELAY = 2.0
 
 # How much large should our buffer be? This is a multiplier on how many
 # nodes we can request at once from a single peer.
@@ -33,6 +35,16 @@ MIN_GAS_LOG_WAIT = PREDICTED_BLOCK_TIME / 5
 # and maybe to try out another peeer. Then reinsert it relatively soon.
 # Measured in seconds.
 NON_IDEAL_RESPONSE_PENALTY = 2.0
+
+# Sometimes, Beam Sync will ask for the "urgent" trie node from more than one
+#   peer, to reduce the latency. We call this "Spread Beam". When a request for
+#   a single urgent node takes longer than this many seconds to return, we
+#   increase the number of peers that we ask for urgent nodes, the spread beam factor.
+# Where did this number come from? Rough estimates: say that we need to import
+#   a block within a pivot, which happens every ~120 blocks. At 13 seconds per block,
+#   that's ~1500 seconds. We download ~4000 new trie nodes, with high variance on the
+#   block. 1500 / 4000 ~= 0.4
+MAX_ACCEPTABLE_WAIT_FOR_URGENT_NODE = 0.4
 
 # If Beam Sync wants to use a queen, but is stuck waiting for it to show up,
 #   then log a warning if it's been too long. If it's been more than this

--- a/trinity/sync/common/peers.py
+++ b/trinity/sync/common/peers.py
@@ -97,3 +97,21 @@ class WaitingPeers(Generic[TChainPeer]):
             peer = wrapped_peer.original
 
         return peer
+
+    def pop_nowait(self) -> TChainPeer:
+        """
+        :raise QueueEmpty: if no peer is available
+        """
+        wrapped_peer = self._waiting_peers.get_nowait()
+        peer = wrapped_peer.original
+
+        # make sure the peer has not gone offline while waiting in the queue
+        while not peer.is_alive:
+            # if so, look for the next best peer
+            wrapped_peer = self._waiting_peers.get_nowait()
+            peer = wrapped_peer.original
+
+        return peer
+
+    def __len__(self) -> int:
+        return self._waiting_peers.qsize()


### PR DESCRIPTION
### What was wrong?

Fixes #1101 

### How was it fixed?

Added a new protected category of peer besides the queen and peasants, called "knights". These are reserved for use, in this case, to ask for the same urgent node that we ask the queen for.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

[//]: # (See: https://trinity-client.readthedocs.io/en/latest/contributing.html#pull-requests)
- [x] Add entry to the [release notes](https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://i.pinimg.com/originals/82/e1/5f/82e15fecbacdfb8cc45cc30e06f71173.jpg)
