### PR TITLE
Delay backfill start until Beam Sync launch

### DIFF
--- a/trinity/sync/beam/chain.py
+++ b/trinity/sync/beam/chain.py
@@ -445,6 +445,7 @@ class BodyChainGapSyncer(Service):
             launch_header_fn=_get_launch_header,
             should_skip_header_fn=body_for_header_exists(self._db, self._chain)
         )
+        self._body_syncer.logger = self.logger
 
     def _get_next_gap(self) -> BlockRange:
         gaps, future_tip_block = self._db.get_chain_gaps()

--- a/trinity/sync/beam/chain.py
+++ b/trinity/sync/beam/chain.py
@@ -473,7 +473,7 @@ class BodyChainGapSyncer(Service):
             else:
                 raise ValidationError("No gaps in the chain of blocks")
         else:
-            return gaps[0]
+            return gaps[-1]
 
     @property
     def is_paused(self) -> bool:

--- a/trinity/sync/common/constants.py
+++ b/trinity/sync/common/constants.py
@@ -10,6 +10,9 @@ MAX_SKELETON_REORG_DEPTH = 35000
 # has processed this number of headers.
 MAX_BACKFILL_HEADERS_AT_ONCE = 100_000
 
+# Maximum block bodies to sync at once, prefering the most recent ones.
+MAX_BACKFILL_BLOCK_BODIES_AT_ONCE = MAX_BACKFILL_HEADERS_AT_ONCE
+
 # Estimated time in between each block
 PREDICTED_BLOCK_TIME = 13
 

--- a/trinity/sync/full/chain.py
+++ b/trinity/sync/full/chain.py
@@ -590,6 +590,7 @@ class FastChainBodySyncer(BaseBodyChainSyncer):
                  should_skip_header_fn: Callable[[BlockHeaderAPI], Awaitable[bool]] = None,
                  ) -> None:
         super().__init__(chain, db, peer_pool, header_syncer)
+        self.logger = get_logger('trinity.sync.full.chain.FastChainBodySyncer')
 
         if launch_header_fn is None:
             self._launch_header_fn: Callable[


### PR DESCRIPTION
### What was wrong?

Block backfill can slow down Beam Sync (occasionally, dramatically). It's not urgent, so better to wait until Beam Sync is fully launched.

Also, fixes #1936 

### How was it fixed?

Pause the backfillers at the beginning. Delay the resume/pause monitor until Beam Sync has collected all the data it needs to launch.

I haven't had a chance to manually test it yet.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

[//]: # (See: https://trinity-client.readthedocs.io/en/latest/contributing.html#pull-requests)
- [ ] ~Add entry to the [release notes](https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)~ *not necessary?*

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://media.tenor.com/images/f5d9c9b977efee821efcf9268a715a8e/tenor.gif)
