### PR TITLE
State backfill improvements

### DIFF
--- a/tests/core/p2p-proto/test_sync.py
+++ b/tests/core/p2p-proto/test_sync.py
@@ -167,11 +167,13 @@ async def test_fast_syncer(request, event_loop, event_bus, chaindb_fresh, chaind
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize('enable_state_backfill', [False, True])
 async def test_beam_syncer_with_checkpoint_too_close_to_tip(
         caplog,
         request,
         event_loop,
         event_bus,
+        enable_state_backfill,
         chaindb_fresh,
         chaindb_churner):
 
@@ -189,6 +191,7 @@ async def test_beam_syncer_with_checkpoint_too_close_to_tip(
             chaindb_fresh,
             chaindb_churner,
             beam_to_block=66,
+            enable_state_backfill=enable_state_backfill,
             checkpoint=checkpoint,
         )
     except asyncio.TimeoutError:
@@ -198,10 +201,12 @@ async def test_beam_syncer_with_checkpoint_too_close_to_tip(
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize('enable_state_backfill', [False, True])
 async def test_beam_syncer_with_checkpoint(
         request,
         event_loop,
         event_bus,
+        enable_state_backfill,
         chaindb_fresh,
         chaindb_churner):
 
@@ -217,6 +222,7 @@ async def test_beam_syncer_with_checkpoint(
         chaindb_fresh,
         chaindb_churner,
         beam_to_block=66,
+        enable_state_backfill=enable_state_backfill,
         checkpoint=checkpoint,
     )
 
@@ -231,6 +237,7 @@ async def _beam_syncing(
         beam_to_block,
         checkpoint=None,
         VM_at_0=PetersburgVM,
+        enable_state_backfill=False,
 ):
 
     client_context = ChainContextFactory(headerdb__db=chaindb_fresh.db)
@@ -291,6 +298,7 @@ async def _beam_syncing(
                 gatherer_endpoint,
                 force_beam_block_number=beam_to_block,
                 checkpoint=checkpoint,
+                enable_state_backfill=enable_state_backfill,
                 enable_backfill=False,
             )
 
@@ -325,6 +333,7 @@ async def _beam_syncing(
 # range(1, 130) for beam_to_block. (and optionally follow the instructions at target_head)
 @pytest.mark.asyncio
 @pytest.mark.parametrize('beam_to_block', [1, 2, 7, 66, 68, 129])
+@pytest.mark.parametrize('enable_state_backfill', [False, True])
 async def test_beam_syncer_loads_recent_state_root(
         request,
         event_loop,
@@ -332,6 +341,7 @@ async def test_beam_syncer_loads_recent_state_root(
         chaindb_fresh,
         chaindb_churner,
         beam_to_block,
+        enable_state_backfill,
         checkpoint=None):
 
     sync_test_service = _beam_syncing(
@@ -395,6 +405,7 @@ async def test_beam_syncer_backfills_all_state(
         beam_to_block,
         checkpoint,
         VM_at_0=MuirGlacierVM,
+        enable_state_backfill=True,
     )
 
     caplog.set_level(logging.INFO)

--- a/tests/core/p2p-proto/test_sync.py
+++ b/tests/core/p2p-proto/test_sync.py
@@ -295,7 +295,7 @@ async def _beam_syncing(
             )
 
             client_peer.logger.info("%s is serving churner blocks", client_peer)
-            backfill_peer.logger.info("%s is serving backfill state", client_peer)
+            backfill_peer.logger.info("%s is serving backfill state", backfill_peer)
             server_peer.logger.info("%s is syncing up churner blocks", server_peer)
 
             import_server = BlockImportServer(

--- a/tests/core/p2p-proto/test_sync.py
+++ b/tests/core/p2p-proto/test_sync.py
@@ -411,7 +411,7 @@ async def test_beam_syncer_backfills_all_state(
     caplog.set_level(logging.INFO)
     async with sync_test_service as beam_syncer:
         # Manually verify that all state is in the state database now
-        await wait_for_full_state_db(chaindb_fresh, beam_to_block, timeout=10)
+        await wait_for_full_state_db(chaindb_fresh, beam_to_block, timeout=20)
         beam_syncer.logger.info("State DB complete by manual inspection")
 
         # Check that backfiller exits on state completion

--- a/trinity/sync/beam/backfill.py
+++ b/trinity/sync/beam/backfill.py
@@ -595,7 +595,6 @@ class BeamStateBackfill(Service, QueenTrackerAPI):
                 show_top_n_peers,
                 self._num_requests_by_peer.most_common(show_top_n_peers),
             )
-            self._num_requests_by_peer.clear()
 
             # For now, report every 30s (1/3 as often as the debug report above)
             if step % 3 == 0:
@@ -622,10 +621,16 @@ class BeamStateBackfill(Service, QueenTrackerAPI):
                 #       total account trie)
                 #   - tnps: trie nodes collected per second, since the last debug log (in the
                 #       last 10 seconds, at comment time)
-                self.logger.info(
+                num_requests = sum(self._num_requests_by_peer.values())
+                if num_requests == 0:
+                    log = self.logger.debug
+                else:
+                    log = self.logger.info
+
+                log(
                     (
                         "State Stats: nodes=%d accts=%d prog=%.2f%% stores=%d"
-                        " storing=%.1f%% of %d walked=%.1fppm tnps=%.0f"
+                        " storing=%.1f%% of %d walked=%.1fppm tnps=%.0f req=%d"
                     ),
                     self._total_added_nodes,
                     self._num_accounts_completed,
@@ -635,7 +640,10 @@ class BeamStateBackfill(Service, QueenTrackerAPI):
                     num_storage_trackers,
                     self._contiguous_accounts_complete_fraction() * 1e6,
                     self._num_added / timer.elapsed,
+                    num_requests,
                 )
+
+            self._num_requests_by_peer.clear()
 
     def _complete_trie_fraction(self, tracker: TrieNodeRequestTracker) -> float:
         """

--- a/trinity/sync/beam/backfill.py
+++ b/trinity/sync/beam/backfill.py
@@ -398,11 +398,11 @@ class BeamStateBackfill(Service, QueenTrackerAPI):
             return
 
         storage_tracker = self._get_storage_tracker(address_hash_nibbles)
-        storage_iterator = self._request_tracking_trie_items(
-            storage_tracker,
-            storage_root,
-        )
         while self.manager.is_running:
+            storage_iterator = self._request_tracking_trie_items(
+                storage_tracker,
+                storage_root,
+            )
             try:
                 async for path_to_leaf, hashed_key, _storage_value in storage_iterator:
                     # We don't actually care to look at the storage keys/values during backfill

--- a/trinity/sync/beam/chain.py
+++ b/trinity/sync/beam/chain.py
@@ -559,7 +559,8 @@ class HeaderLaunchpointSyncer(HeaderSyncerAPI):
         await self._at_launchpoint.wait()
 
         self.logger.info(
-            "Choosing %s as launchpoint headers to sync from", self._launchpoint_headers
+            "Choosing %s as launchpoint headers to sync from",
+            [str(header) for header in self._launchpoint_headers],
         )
         yield self._launchpoint_headers
 

--- a/trinity/sync/beam/queen.py
+++ b/trinity/sync/beam/queen.py
@@ -1,9 +1,9 @@
-from abc import ABC, abstractmethod
+from abc import abstractmethod
 import asyncio
 import functools
 from typing import Any, FrozenSet, Optional, Type
 
-from async_service import Service
+from async_service import Service, ServiceAPI
 
 from p2p.abc import CommandAPI
 from p2p.exchange import PerformanceAPI
@@ -29,7 +29,7 @@ def _peer_sort_key(peer: ETHPeer) -> float:
     return queen_peer_performance_sort(peer.eth_api.get_node_data.tracker)
 
 
-class QueenTrackerAPI(ABC):
+class QueenTrackerAPI(ServiceAPI):
     """
     Keep track of the single best peer
     """


### PR DESCRIPTION
### Changes

Key change: state backfill does a better job of grouping up storage nodes now (it was only ever asking each peer for up to one storage node). Now it asks for many storage nodes at once, from a single peer. This affects test time, and should make `walked=...ppm` increase a bit faster.

- Count how many total requests were made during the logged period for state backfill
- Only display state backfill log if at least one request was made (a precursor for potentially starving backfill of peers during predictive requests, or "spread beam" requests)
- Fixed a log that displayed the wrong peer's information during a test
- Can now turn state backfill on and off, just for the tests (it's a bad idea to turn it off during real operation for now)
- Make a state backfill test a little less likely to be flaky
- Bonus: The beam launchpoint log was really noisy, printing the full repr of a bunch of headers. Converted to string for shorter log

These are fairly independent commits. Reviewing them individually probably makes sense.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

[//]: # (See: https://trinity-client.readthedocs.io/en/latest/contributing.html#pull-requests)
- [x] ~Add entry to the [release notes](https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)~ fixing unreleased bugs

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://i.pinimg.com/236x/c5/49/bd/c549bdc64244c99bc5a577a6d3fef092--the-photo-adorable-animals.jpg)
