### PR TITLE
accept all possible "goodbye reason" values

### DIFF
--- a/tests-trio/trinity/nodes/beacon/test_host.py
+++ b/tests-trio/trinity/nodes/beacon/test_host.py
@@ -4,7 +4,7 @@ import pytest
 import trio
 
 from eth2.beacon.types.blocks import BeaconBlock, SignedBeaconBlock
-from trinity.nodes.beacon.request_responder import GoodbyeReason
+from trinity.nodes.beacon.request_responder import SHUTTING_DOWN_CODE, GoodbyeReason
 
 
 @asynccontextmanager
@@ -92,6 +92,6 @@ async def test_hosts_can_do_req_resp(host_factory):
                 b_metadata = await host_a.get_metadata(peer_b)
                 assert b_metadata.seq_number == b_seq_number
 
-                await host_a.send_goodbye_to(peer_b, GoodbyeReason.shutting_down)
+                await host_a.send_goodbye_to(peer_b, GoodbyeReason(SHUTTING_DOWN_CODE))
                 assert len(host_a.get_network().connections) == 0
                 assert len(host_b.get_network().connections) == 0


### PR DESCRIPTION
### What was wrong?

We only accepted the few values of the `IntEnum` as "goodbye reason codes" when any 8-byte value is a possibility.

### How was it fixed?

Just subclass `Int` instead.

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://p0.pikist.com/photos/1017/940/cat-the-code-in-the-snapshot-hare-mackerel-health-service-korean-cat-republic-of-korea-cat-towers-cattower-cute-pet.jpg)
