### PR TITLE
Do not start beacon node from scratch everytime

### DIFF
--- a/eth2/api/http/validator.py
+++ b/eth2/api/http/validator.py
@@ -26,7 +26,7 @@ from eth2.beacon.types.attestations import Attestation, AttestationData
 from eth2.beacon.types.blocks import BeaconBlock, SignedBeaconBlock
 from eth2.beacon.types.checkpoints import Checkpoint
 from eth2.beacon.types.states import BeaconState
-from eth2.beacon.typing import Bitfield, CommitteeIndex, Epoch, Root, Slot
+from eth2.beacon.typing import Bitfield, CommitteeIndex, Epoch, Root, Slot, Timestamp
 from eth2.clock import Clock
 from eth2.configs import Eth2Config
 from trinity._utils.trio_utils import Request, Response
@@ -99,13 +99,16 @@ class ValidatorDuty:
 @dataclass
 class Context:
     client_identifier: str
-    genesis_time: int  # Unix timestamp
     eth2_config: Eth2Config
     syncer: SyncerAPI
     chain: BaseBeaconChain
     clock: Clock
     block_broadcaster: BlockBroadcasterAPI
     _broadcast_operations: Set[Root] = field(default_factory=set)
+
+    @property
+    def genesis_time(self) -> Timestamp:
+        return self.clock.genesis_time
 
     async def get_sync_status(self) -> SyncStatus:
         return await self.syncer.get_status()

--- a/eth2/beacon/chains/abc.py
+++ b/eth2/beacon/chains/abc.py
@@ -1,8 +1,6 @@
 from abc import ABC, abstractmethod
 from typing import Optional
 
-from eth.abc import AtomicDatabaseAPI
-
 from eth2.beacon.db.abc import BaseBeaconChainDB
 from eth2.beacon.state_machines.abc import BaseBeaconStateMachine
 from eth2.beacon.types.attestations import Attestation
@@ -15,8 +13,8 @@ from eth2.clock import Tick
 class BaseBeaconChain(ABC):
     @classmethod
     @abstractmethod
-    def from_genesis(
-        cls, base_db: AtomicDatabaseAPI, genesis_state: BeaconState
+    def from_recent_state(
+        cls, chain_db: BaseBeaconChainDB, recent_state: BeaconState
     ) -> "BaseBeaconChain":
         ...
 

--- a/eth2/beacon/db/abc.py
+++ b/eth2/beacon/db/abc.py
@@ -65,6 +65,14 @@ class BaseBeaconChainDB(ABC):
         ...
 
     @abstractmethod
+    def mark_justified_head(self, block: BaseBeaconBlock) -> None:
+        ...
+
+    @abstractmethod
+    def get_justified_head(self, block_class: Type[BaseBeaconBlock]) -> BaseBeaconBlock:
+        ...
+
+    @abstractmethod
     def mark_finalized_head(self, block: BaseBeaconBlock) -> None:
         ...
 

--- a/eth2/beacon/db/abc.py
+++ b/eth2/beacon/db/abc.py
@@ -25,14 +25,12 @@ class BaseBeaconChainDB(ABC):
     def __init__(self, db: AtomicDatabaseAPI) -> None:
         ...
 
-    @classmethod
     @abstractmethod
-    def from_genesis(
-        cls,
-        db: AtomicDatabaseAPI,
+    def register_genesis(
+        self,
         genesis_state: BeaconState,
         signed_block_class: Type[BaseSignedBeaconBlock],
-    ) -> "BaseBeaconChainDB":
+    ) -> None:
         ...
 
     @abstractmethod
@@ -84,6 +82,14 @@ class BaseBeaconChainDB(ABC):
     def get_state_by_root(
         self, state_root: Root, state_class: Type[BeaconState]
     ) -> BeaconState:
+        ...
+
+    @abstractmethod
+    def get_weak_subjectivity_state(self) -> Optional[BeaconState]:
+        ...
+
+    @abstractmethod
+    def persist_weak_subjectivity_state_root(self, state_root: Root) -> None:
         ...
 
     @abstractmethod

--- a/eth2/beacon/db/abc.py
+++ b/eth2/beacon/db/abc.py
@@ -58,7 +58,7 @@ class BaseBeaconChainDB(ABC):
         ...
 
     @abstractmethod
-    def mark_canonical_block(self, block: BaseBeaconBlock) -> None:
+    def mark_canonical_block(self, slot: Slot, root: Root) -> None:
         """
         Record the ``block`` as part of the canonical ("finalized") chain.
         """

--- a/eth2/beacon/db/chain2.py
+++ b/eth2/beacon/db/chain2.py
@@ -46,6 +46,7 @@ class BeaconChainDB(BaseBeaconChainDB):
         self.persist_state(genesis_state)
 
         self.mark_canonical_block(genesis_block.slot, genesis_block.hash_tree_root)
+        self.mark_justified_head(genesis_block)
         self.mark_finalized_head(genesis_block)
 
     def get_block_by_slot(
@@ -107,6 +108,15 @@ class BeaconChainDB(BaseBeaconChainDB):
         block = self.get_block_by_root(root, BeaconBlock)
         slot_to_state_root = SchemaV1.slot_to_state_root(slot)
         self.db[slot_to_state_root] = block.state_root
+
+    def mark_justified_head(self, block: BaseBeaconBlock) -> None:
+        justified_head_root = SchemaV1.justified_head_root()
+        self.db[justified_head_root] = block.hash_tree_root
+
+    def get_justified_head(self, block_class: Type[BaseBeaconBlock]) -> BaseBeaconBlock:
+        justified_head_root_key = SchemaV1.justified_head_root()
+        justified_head_root = Root(Hash32(self.db[justified_head_root_key]))
+        return self.get_block_by_root(justified_head_root, block_class)
 
     def mark_finalized_head(self, block: BaseBeaconBlock) -> None:
         finalized_head_root = SchemaV1.finalized_head_root()

--- a/eth2/beacon/db/schema2.py
+++ b/eth2/beacon/db/schema2.py
@@ -3,6 +3,10 @@ import ssz
 from eth2.beacon.typing import Root, Slot
 
 
+def justified_head_root() -> bytes:
+    return b"v1:beacon:justified-head-root"
+
+
 def finalized_head_root() -> bytes:
     return b"v1:beacon:finalized-head-root"
 

--- a/eth2/beacon/db/schema2.py
+++ b/eth2/beacon/db/schema2.py
@@ -25,3 +25,7 @@ def slot_to_state_root(slot: Slot) -> bytes:
 
 def state_root_to_state(root: Root) -> bytes:
     return b"v1:beacon:state-root-to-state:" + root
+
+
+def weak_subjectivity_state_root() -> bytes:
+    return b"v1:beacon:weak-subjectivity-state-root"

--- a/eth2/beacon/fork_choice/abc.py
+++ b/eth2/beacon/fork_choice/abc.py
@@ -6,7 +6,6 @@ from typing_extensions import Protocol
 from eth2.beacon.types.blocks import BaseBeaconBlock
 from eth2.beacon.types.states import BeaconState
 from eth2.beacon.typing import Epoch, Root, Slot, ValidatorIndex
-from eth2.configs import Eth2Config
 
 
 class BlockSink(Protocol):
@@ -19,19 +18,6 @@ class BlockSink(Protocol):
 
 
 class BaseForkChoice(ABC):
-    @classmethod
-    @abstractmethod
-    def from_recent_state(
-        cls, recent_state: BeaconState, config: Eth2Config, block_sink: BlockSink
-    ) -> "BaseForkChoice":
-        ...
-
-    # @abstractmethod
-    # def load_context(
-    #     cls, chain_db: BaseBeaconChainDB, config: Eth2Config, block_sink: BlockSink
-    # ) -> "BaseForkChoice":
-    #     ...
-
     @abstractmethod
     def update_justified(self, state: BeaconState) -> None:
         ...

--- a/eth2/beacon/fork_choice/abc.py
+++ b/eth2/beacon/fork_choice/abc.py
@@ -1,17 +1,16 @@
 from abc import ABC, abstractmethod
-from typing import Iterable
+from typing import Iterable, Tuple
 
 from typing_extensions import Protocol
 
-from eth2.beacon.db.abc import BaseBeaconChainDB
 from eth2.beacon.types.blocks import BaseBeaconBlock
 from eth2.beacon.types.states import BeaconState
-from eth2.beacon.typing import Epoch, Root, ValidatorIndex
+from eth2.beacon.typing import Epoch, Root, Slot, ValidatorIndex
 from eth2.configs import Eth2Config
 
 
 class BlockSink(Protocol):
-    def on_pruned_block(self, block: BaseBeaconBlock, canonical: bool) -> None:
+    def on_pruned_block(self, slot: Slot, block_root: Root, canonical: bool) -> None:
         """
         When a block is not part of fork-choice anymore.
         If canonical, it is finalized. If not canonical, it is orphaned.
@@ -27,19 +26,18 @@ class BaseForkChoice(ABC):
     ) -> "BaseForkChoice":
         ...
 
-    @classmethod
-    @abstractmethod
-    def from_db(
-        cls, chain_db: BaseBeaconChainDB, config: Eth2Config, block_sink: BlockSink
-    ) -> "BaseForkChoice":
-        ...
+    # @abstractmethod
+    # def load_context(
+    #     cls, chain_db: BaseBeaconChainDB, config: Eth2Config, block_sink: BlockSink
+    # ) -> "BaseForkChoice":
+    #     ...
 
     @abstractmethod
     def update_justified(self, state: BeaconState) -> None:
         ...
 
     @abstractmethod
-    def get_canonical_chain(self) -> Iterable[BaseBeaconBlock]:
+    def get_canonical_chain(self) -> Iterable[Tuple[Slot, Root]]:
         ...
 
     @abstractmethod
@@ -56,5 +54,5 @@ class BaseForkChoice(ABC):
         ...
 
     @abstractmethod
-    def find_head(self) -> BaseBeaconBlock:
+    def find_head(self) -> Root:
         ...

--- a/eth2/beacon/fork_choice/abc.py
+++ b/eth2/beacon/fork_choice/abc.py
@@ -22,8 +22,8 @@ class BlockSink(Protocol):
 class BaseForkChoice(ABC):
     @classmethod
     @abstractmethod
-    def from_genesis(
-        cls, genesis_state: BeaconState, config: Eth2Config, block_sink: BlockSink
+    def from_recent_state(
+        cls, recent_state: BeaconState, config: Eth2Config, block_sink: BlockSink
     ) -> "BaseForkChoice":
         ...
 

--- a/eth2/beacon/types/states.py
+++ b/eth2/beacon/types/states.py
@@ -208,3 +208,16 @@ class BeaconState(HashableContainer):
                 return ValidatorIndex(index)
         else:
             return None
+
+    def get_block_header(self) -> BeaconBlockHeader:
+        """
+        Return the beacon block header contained in this state.
+
+        NOTE: we have to patch the state root of the header
+        if it is the empty root.
+        """
+        header = self.latest_block_header
+        if header.state_root == default_root:
+            return header.set("state_root", self.hash_tree_root)
+        else:
+            return header

--- a/setup.py
+++ b/setup.py
@@ -198,8 +198,7 @@ setup(
     entry_points={
         'console_scripts': [
             'trinity=trinity:main',
-            'trinity-beacon=trinity:main_beacon',
-            'trinity-beacon-trio=trinity:main_beacon_trio',
+            'trinity-beacon=trinity:main_beacon_trio',
             'trinity-validator=trinity:main_validator'
         ],
     },

--- a/trinity/components/eth2/beacon_trio/component.py
+++ b/trinity/components/eth2/beacon_trio/component.py
@@ -73,7 +73,7 @@ class BeaconNodeComponent(TrioComponent):
         arg_parser.add_argument(
             "--recent-state-ssz",
             type=Path,
-            help="path to a recent ssz-encoded state (for use in weak subjectivity)",
+            help="path to a recent finalized ssz-encoded state (for use in weak subjectivity)",
         )
 
         network_description_group = arg_parser.add_mutually_exclusive_group()

--- a/trinity/components/eth2/beacon_trio/component.py
+++ b/trinity/components/eth2/beacon_trio/component.py
@@ -1,13 +1,13 @@
 from argparse import ArgumentParser, _SubParsersAction
 import logging
+from pathlib import Path
 from typing import Iterable
 
-from eth_utils import to_tuple
+from eth_utils import humanize_hash, to_tuple
 from multiaddr import Multiaddr
 
 from trinity.boot_info import BootInfo
-from trinity.config import BeaconTrioAppConfig
-from trinity.constants import BEACON_TESTNET_NETWORK_ID
+from trinity.config import ETH2_NETWORKS, BeaconTrioAppConfig
 from trinity.extensibility import TrioComponent
 from trinity.nodes.beacon.config import BeaconNodeConfig
 from trinity.nodes.beacon.full import BeaconNode
@@ -27,18 +27,17 @@ class BeaconNodeComponent(TrioComponent):
     def __init__(self, boot_info: BootInfo) -> None:
         super().__init__(boot_info)
 
-        config_profile = boot_info.args.config_profile
-        if config_profile != "altona":
-            raise NotImplementedError(f"config profile not supported: {config_profile}")
-
         trinity_config = self._boot_info.trinity_config
         beacon_app_config = trinity_config.get_app_config(BeaconTrioAppConfig)
         config = BeaconNodeConfig.from_platform_config(
-            boot_info.args.config_profile,
-            trinity_config,
-            beacon_app_config,
-            boot_info.args.validator_api_port,
-            boot_info.args.bootstrap_nodes,
+            trinity_config, beacon_app_config
+        )
+        self.logger.info(
+            "using peer identity %s",
+            humanize_hash(config.local_node_key.public_key.to_bytes()),
+        )
+        self.logger.info(
+            "booting beacon node on network: %s", beacon_app_config.network_name
         )
         node = BeaconNode.from_config(config)
         self._node = node
@@ -47,45 +46,46 @@ class BeaconNodeComponent(TrioComponent):
     def configure_parser(
         cls, arg_parser: ArgumentParser, subparser: _SubParsersAction
     ) -> None:
-        # NOTE: this workaround puts the testnet data into its own `datadir`
-        # TODO integrate into the greater trinity config so we do not need workarounds like this
-        arg_parser.set_defaults(network_id=BEACON_TESTNET_NETWORK_ID)
-
         arg_parser.add_argument(
-            "--bootstrap-nodes",
-            type=_parse_multiaddrs_from_args,
-            help="bootstrap nodes",
-            default=(),
+            "--nodekey-seed", help="hex-encoded seed to use for local node key"
         )
-        arg_parser.add_argument(
-            "--preferred-nodes",
-            type=_parse_multiaddrs_from_args,
-            help="preferred nodes",
-            default=(),
-        )
-
-        arg_parser.add_argument(
-            "--validator-api-port", type=int, help="API server port", default=5005
-        )
-
         arg_parser.add_argument(
             "--p2p-maddr",
             type=Multiaddr,
             help="p2p host multiaddress",
             default="/ip4/127.0.0.1/tcp/13000",
         )
-
         arg_parser.add_argument(
-            "--orchestration-profile",
-            help="[temporary developer option] manage several beacon nodes on one machine",
-            default="a",
+            "--bootstrap-maddrs",
+            type=_parse_multiaddrs_from_args,
+            help="comma-separated list of maddrs for bootstrap nodes",
+            default=(),
+        )
+        arg_parser.add_argument(
+            "--preferred-maddrs",
+            type=_parse_multiaddrs_from_args,
+            help="comma-separated list of maddrs for preferred nodes",
+            default=(),
+        )
+        arg_parser.add_argument(
+            "--validator-api-port", type=int, help="API server port", default=5005
+        )
+        arg_parser.add_argument(
+            "--recent-state-ssz",
+            type=Path,
+            help="path to a recent ssz-encoded state (for use in weak subjectivity)",
         )
 
-        arg_parser.add_argument(
-            "--config-profile",
-            help="the profile used to generate the genesis config",
-            choices=("minimal", "mainnet", "altona"),
-            default="minimal",
+        network_description_group = arg_parser.add_mutually_exclusive_group()
+        network_description_group.add_argument(
+            "--network",
+            choices=ETH2_NETWORKS.keys(),
+            default="altona",
+            help="Name of a pre-defined network",
+        )
+        network_description_group.add_argument(
+            "--network-config",
+            help="Path to a YAML configuration file describing a network",
         )
 
     @property

--- a/trinity/config.py
+++ b/trinity/config.py
@@ -119,6 +119,8 @@ from eth2.beacon.db.chain2 import BeaconChainDB as AltonaChainDB
 from eth2.beacon.chains.testnet.altona import BeaconChain as AltonaChain
 from eth2.beacon.state_machines.forks.altona.configs import ALTONA_CONFIG
 from eth2.beacon.state_machines.forks.serenity.configs import SERENITY_CONFIG
+from eth2.beacon.chains.abc import BaseBeaconChain as ABCBaseBeaconChain
+from eth2.beacon.chains.base import BaseBeaconChain
 
 
 if TYPE_CHECKING:
@@ -126,9 +128,7 @@ if TYPE_CHECKING:
     from trinity.nodes.base import Node  # noqa: F401
     from trinity.chains.full import FullChain  # noqa: F401
     from trinity.chains.light import LightDispatchChain  # noqa: F401
-    from eth2.beacon.chains.abc import BaseBeaconChain as ABCBaseBeaconChain  # noqa: F401
-    from eth2.beacon.chains.base import BaseBeaconChain  # noqa: F401
-    from eth2.beacon.state_machines.base import BaseBeaconStateMachine  # noqa: F401
+
 
 DATABASE_DIR_NAME = 'chain'
 

--- a/trinity/config.py
+++ b/trinity/config.py
@@ -10,6 +10,7 @@ from enum import (
     Enum,
     auto,
 )
+import hashlib
 import json
 from pathlib import (
     Path,
@@ -19,6 +20,7 @@ from typing import (
     Any,
     Dict,
     Iterable,
+    Optional,
     Tuple,
     Type,
     TypeVar,
@@ -48,6 +50,7 @@ from eth_keys import (
 from eth_keys.datatypes import (
     PrivateKey,
 )
+from eth_utils import encode_hex
 from eth_typing import (
     Address,
     BLSPubkey,
@@ -67,6 +70,7 @@ from eth2.beacon.typing import (
 from eth2.configs import (
     Eth2Config,
 )
+import p2p.ecies as ecies
 from p2p.kademlia import (
     Node as KademliaNode,
 )
@@ -110,7 +114,11 @@ from trinity.network_configurations import (
 )
 
 from eth2.beacon.chains.base import BeaconChain
+from eth2.beacon.db.abc import BaseBeaconChainDB
+from eth2.beacon.db.chain2 import BeaconChainDB as AltonaChainDB
 from eth2.beacon.chains.testnet.altona import BeaconChain as AltonaChain
+from eth2.beacon.state_machines.forks.altona.configs import ALTONA_CONFIG
+from eth2.beacon.state_machines.forks.serenity.configs import SERENITY_CONFIG
 
 
 if TYPE_CHECKING:
@@ -816,92 +824,151 @@ class BeaconAppConfig(BaseEth2AppConfig):
         return BeaconChainConfig.from_genesis_config(config_profile)
 
 
-class BeaconTrioChainConfig:
-    _genesis_state: BeaconState
-    _beacon_chain_class: Type['ABCBaseBeaconChain'] = None
-    _genesis_config: Eth2Config = None
-    _key_map: Dict[BLSPubkey, int]
+    # _genesis_state: BeaconState
+    # _beacon_chain_class: Type['ABCBaseBeaconChain'] = None
+    # _genesis_config: Eth2Config = None
+    # _key_map: Dict[BLSPubkey, int]
 
-    def __init__(self,
-                 genesis_state: BeaconState,
-                 genesis_config: Eth2Config,
-                 genesis_validator_key_map: Dict[BLSPubkey, int],
-                 beacon_chain_class: Type['ABCBaseBeaconChain'] = AltonaChain) -> None:
-        self._genesis_state = genesis_state
-        self._eth2_config = genesis_config
-        self._key_map = genesis_validator_key_map
-        self._beacon_chain_class = beacon_chain_class
+    # def __init__(self,
+    #              genesis_state: BeaconState,
+    #              genesis_config: Eth2Config,
+    #              genesis_validator_key_map: Dict[BLSPubkey, int],
+    #              beacon_chain_class: Type['ABCBaseBeaconChain'] = AltonaChain) -> None:
+    #     self._genesis_state = genesis_state
+    #     self._eth2_config = genesis_config
+    #     self._key_map = genesis_validator_key_map
+    #     self._beacon_chain_class = beacon_chain_class
 
-    @property
-    def genesis_config(self) -> Eth2Config:
-        """
-        NOTE: this ``genesis_config`` means something slightly different from the
-        genesis config referenced in other places in this class...
-        TODO:(ralexstokes) patch up the names here...
-        """
-        return self._eth2_config
+    # @property
+    # def genesis_config(self) -> Eth2Config:
+    #     """
+    #     NOTE: this ``genesis_config`` means something slightly different from the
+    #     genesis config referenced in other places in this class...
+    #     TODO:(ralexstokes) patch up the names here...
+    #     """
+    #     return self._eth2_config
 
-    @property
-    def genesis_time(self) -> Timestamp:
-        return self._genesis_state.genesis_time
+    # @property
+    # def genesis_time(self) -> Timestamp:
+    #     return self._genesis_state.genesis_time
 
-    @property
-    def beacon_chain_class(self) -> Type['ABCBaseBeaconChain']:
-        return self._beacon_chain_class
+    # @property
+    # def beacon_chain_class(self) -> Type['ABCBaseBeaconChain']:
+    #     return self._beacon_chain_class
 
-    @classmethod
-    def from_genesis_config(cls, config_profile: str) -> 'BeaconTrioChainConfig':
-        """
-        Construct an instance of ``cls`` reading the genesis configuration
-        data under the local data directory.
-        """
-        try:
-            with open(_get_eth2_genesis_config_file_path(config_profile)) as config_file:
-                genesis_config = json.load(config_file)
-        except FileNotFoundError as e:
-            raise Exception("unable to load genesis config: %s", e)
+    # @classmethod
+    # def from_genesis_config(cls, config_profile: str) -> 'BeaconTrioChainConfig':
+    #     """
+    #     Construct an instance of ``cls`` reading the genesis configuration
+    #     data under the local data directory.
+    #     """
+    #     try:
+    #         with open(_get_eth2_genesis_config_file_path(config_profile)) as config_file:
+    #             genesis_config = json.load(config_file)
+    #     except FileNotFoundError as e:
+    #         raise Exception("unable to load genesis config: %s", e)
 
-        eth2_config = Eth2Config.from_formatted_dict(genesis_config["eth2_config"])
-        # NOTE: have to ``override_lengths`` before we can parse the ``BeaconState``
-        override_lengths(eth2_config)
+    #     eth2_config = Eth2Config.from_formatted_dict(genesis_config["eth2_config"])
+    #     # NOTE: have to ``override_lengths`` before we can parse the ``BeaconState``
+    #     override_lengths(eth2_config)
 
-        genesis_state = from_formatted_dict(genesis_config["genesis_state"], BeaconState)
-        genesis_validator_key_map = load_genesis_key_map(
-            genesis_config["genesis_validator_key_pairs"]
-        )
-        return cls(
-            genesis_state,
-            eth2_config,
-            genesis_validator_key_map,
-        )
+    #     genesis_state = from_formatted_dict(genesis_config["genesis_state"], BeaconState)
+    #     genesis_validator_key_map = load_genesis_key_map(
+    #         genesis_config["genesis_validator_key_pairs"]
+    #     )
+    #     return cls(
+    #         genesis_state,
+    #         eth2_config,
+    #         genesis_validator_key_map,
+    #     )
 
-    @classmethod
-    def get_genesis_config_file_path(cls, profile: str) -> Path:
-        return _get_eth2_genesis_config_file_path(profile)
+    # @classmethod
+    # def get_genesis_config_file_path(cls, profile: str) -> Path:
+    #     return _get_eth2_genesis_config_file_path(profile)
 
-    def initialize_chain(self,
-                         base_db: AtomicDatabaseAPI) -> 'ABCBaseBeaconChain':
-        return self.beacon_chain_class.from_genesis(
-            base_db=base_db,
-            genesis_state=self._genesis_state,
-        )
+    # def initialize_chain(self,
+    #                      base_db: AtomicDatabaseAPI) -> 'ABCBaseBeaconChain':
+    #     return self.beacon_chain_class.from_genesis(
+    #         base_db=base_db,
+    #         genesis_state=self._genesis_state,
+    #     )
+
+
+class BeaconTrioChainConfig(ABC):
+    pass
+
+
+class AltonaChainConfig(BeaconTrioChainConfig):
+    chain_db_class: Type[BaseBeaconChainDB] = AltonaChainDB
+    chain_class: Type[ABCBaseBeaconChain] = AltonaChain
+
+
+class MainnetChainConfig(BeaconTrioChainConfig):
+    # TODO: update to mainnet instances
+    chain_db_class: Type[BaseBeaconChainDB] = AltonaChainDB
+    chain_class: Type[ABCBaseBeaconChain] = AltonaChain
+
+
+ETH2_NETWORKS = {
+    "altona": ALTONA_CONFIG,
+    # "medalla": ...,
+    "mainnet": SERENITY_CONFIG,
+}
+
+ETH2_CHAIN_CONFIGS = {
+    "altona": AltonaChainConfig,
+    # "medalla": ...,
+    "mainnet": MainnetChainConfig
+}
+
+
+def _load_predefined_eth2_network(network: str) -> Eth2Config:
+    """
+    NOTE: ``network`` should exist given the argparse configuration
+    which references ``ETH2_NETWORKS``.
+    """
+    return ETH2_NETWORKS[network]
+
+
+def _load_eth2_network_from_yaml(network_config_path: str) -> Eth2Config:
+    raise NotImplementedError("loading network from YAML config is unsupported")
+
+
+def _resolve_node_key(trinity_config: TrinityConfig, nodekey_seed: Optional[str]) -> PrivateKey:
+    if nodekey_seed:
+        private_key_bytes = hashlib.sha256(nodekey_seed.encode()).digest()
+        nodekey = PrivateKey(private_key_bytes)
+        trinity_config.nodekey = nodekey
+        return
+
+    if trinity_config.nodekey is None:
+        nodekey = ecies.generate_privkey()
+        with open(trinity_config.nodekey_path, 'wb') as nodekey_file:
+            nodekey_file.write(nodekey.to_bytes())
+        trinity_config.nodekey = nodekey
 
 
 class BeaconTrioAppConfig(BaseEth2AppConfig):
     def __init__(
         self,
         config: TrinityConfig,
+        network_name: str,
+        network_config: Eth2Config,
         p2p_maddr: Multiaddr,
-        orchestration_profile: str,
+        validator_api_port: int,
         bootstrap_nodes: Tuple[Multiaddr, ...] = (),
         preferred_nodes: Tuple[Multiaddr, ...] = (),
+        recent_state_ssz: Optional[Path] = None,
     ) -> None:
         super().__init__(config)
         self.p2p_maddr = p2p_maddr
-        self.bootstrap_nodes = config.bootstrap_nodes
-        self.preferred_nodes = config.preferred_nodes
+        self.network_name = network_name
+        self.network_config = network_config
+        self.validator_api_port = validator_api_port
+        self.bootstrap_nodes = bootstrap_nodes
+        self.preferred_nodes = preferred_nodes
         self.client_identifier = construct_trinity_client_identifier()
-        self.orchestration_profile = orchestration_profile
+        self.recent_state_ssz = recent_state_ssz
 
     @classmethod
     def from_parser_args(
@@ -911,16 +978,35 @@ class BeaconTrioAppConfig(BaseEth2AppConfig):
         Initialize from the namespace object produced by
         an ``argparse.ArgumentParser`` and the :class:`~trinity.config.TrinityConfig`
         """
-        bootstrap_nodes = args.bootstrap_nodes
-        preferred_nodes = args.preferred_nodes
+        # NOTE: ``args.network`` has a default so check for an override in
+        # the ``network_config`` first...
+        if args.network_config:
+            network_config = _load_eth2_network_from_yaml(args.network_config)
+            network_name = "custom network"
+        else:
+            network_config = _load_predefined_eth2_network(args.network)
+            network_name = args.network
+
+        # NOTE: required for SSZ types to work correctly...
+        override_lengths(network_config)
+
         p2p_maddr = args.p2p_maddr
+        bootstrap_nodes = args.bootstrap_maddrs
+        preferred_nodes = args.preferred_maddrs
+        validator_api_port = args.validator_api_port
+        recent_state_ssz = args.recent_state_ssz
+
+        _resolve_node_key(trinity_config, args.nodekey_seed)
 
         return cls(
             trinity_config,
+            network_name,
+            network_config,
             p2p_maddr,
-            args.orchestration_profile,
+            validator_api_port,
             bootstrap_nodes,
-            preferred_nodes
+            preferred_nodes,
+            recent_state_ssz,
         )
 
     @property
@@ -930,14 +1016,27 @@ class BeaconTrioAppConfig(BaseEth2AppConfig):
 
         This is resolved relative to the ``data_dir``
         """
-        path = self.trinity_config.data_dir / DATABASE_DIR_NAME
-        return self.trinity_config.with_app_suffix(path) / f"full_{self.orchestration_profile}"
+        root_dir = self.trinity_config.trinity_root_dir
+        path = self.trinity_config.with_app_suffix(root_dir)
+        network_identifier = _build_network_identifier(self.network_config)
+        peer_identifier = self.trinity_config.nodekey.to_hex()[2:]
+        return path / network_identifier / peer_identifier
 
-    def get_chain_config(self, config_profile: str = "altona") -> BeaconTrioChainConfig:
-        """
-        Return the :class:`~trinity.config.BeaconChainConfig` that is derived from the genesis file
-        """
-        return BeaconTrioChainConfig.from_genesis_config(config_profile)
+    def get_chain_config(self) -> BeaconTrioChainConfig:
+        if self.network_name in ETH2_CHAIN_CONFIGS:
+            return ETH2_CHAIN_CONFIGS[self.network_name]
+        raise Exception(
+            f"unknown chain config for network name {self.network_name}."
+            " please define before use."
+        )
+
+
+def _build_network_identifier(config: Eth2Config) -> str:
+    return (
+        f"{config.DEPOSIT_CHAIN_ID}"
+        f"{config.DEPOSIT_NETWORK_ID}"
+        f"{encode_hex(config.DEPOSIT_CONTRACT_ADDRESS)[2:]}"
+    )
 
 
 class ValidatorClientAppConfig(BaseEth2AppConfig):

--- a/trinity/main_beacon_trio.py
+++ b/trinity/main_beacon_trio.py
@@ -1,12 +1,9 @@
-import logging
-import os
 import shutil
 from typing import Collection, Sequence, Tuple, Type
 
 import trio
 
 from trinity._utils.trio_utils import wait_for_interrupts
-from trinity._utils.version import construct_trinity_client_identifier
 from trinity.boot_info import BootInfo
 from trinity.bootstrap import construct_boot_info
 from trinity.components.registry import get_components_for_trio_beacon_client
@@ -51,11 +48,6 @@ def main_entry_trio(
         return
 
     _initialize_beacon_filesystem(boot_info)
-
-    logger = logging.getLogger("trinity")
-    pid = os.getpid()
-    identifier = construct_trinity_client_identifier()
-    logger.info("Booted client with identifier: %s and process id %d", identifier, pid)
 
     runtime_component_types = tuple(
         component_cls


### PR DESCRIPTION
### What was wrong?

We had no facility for starting a beacon node from existing chain state, instead re-starting from genesis every time.


### How was it fixed?

NOTE: depends on #1956.

We address this issue by restoring the node's context from any data available in the underlying DB.

This PR is also a good opportunity to upgrade the "start from genesis" semantics to "start from a recent state" semantics to lay the ground work for starting from arbitrary weak subjectivity states (see https://notes.ethereum.org/@adiasg/weak-subjectvity-eth2 for more info).

And along the way I tried to tidy up and/or simplify some of the configuration from the outer layers of the app down to the beacon node (as a `Component` on the `Trinity` platform).

### To-Do

- finish handling restoring fork choice
- test that it all works!
- add issue to properly handle arbitrary "recent state"; right now, need to run genesis before a future state... ideally can use any trusted state but it looks like we would have to track canonical block roots, rather than the full blocks
- add issue about "restarting" from our finalized head every time... can do better by keeping track of the canonical chain segment after the finalized head (but this means the fork choice can store/load this "context" and it looks like our sync may not handle this in the best way)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://static.boredpanda.com/blog/wp-content/uploads/2019/04/dirty-cat-unique-fur-markings-5cc6a449dd76e__700.jpg)
