### PR TITLE
Quieter backfill when predictive beam sync active

### DIFF
--- a/tests/core/_utils/test_priority.py
+++ b/tests/core/_utils/test_priority.py
@@ -1,0 +1,31 @@
+import asyncio
+
+import pytest
+
+from trinity._utils.priority import SilenceObserver
+
+
+@pytest.mark.asyncio
+async def test_silence_observer_waits_until_silence():
+    observer = SilenceObserver(minimum_silence_duration=0.03)
+
+    async def noise_maker():
+        async with observer.make_noise():
+            await asyncio.sleep(0.02)
+
+    asyncio.ensure_future(noise_maker())
+    asyncio.ensure_future(noise_maker())
+    asyncio.ensure_future(noise_maker())
+
+    # Allow the noise makers to start
+    await asyncio.sleep(0)
+
+    # Noise makers might have stopped, but minimum_silence_duration hasn't ended
+    with pytest.raises(asyncio.TimeoutError):
+        await asyncio.wait_for(observer.until_silence(), timeout=0.03)
+
+    # Already waited 0.03, so only need another 0.02, but leave a little extra for CI
+    await asyncio.wait_for(
+        observer.until_silence(),
+        timeout=0.05,
+    )

--- a/tests/core/p2p-proto/test_server.py
+++ b/tests/core/p2p-proto/test_server.py
@@ -100,13 +100,13 @@ async def test_server_incoming_connection(server, receiver_remote):
         pubkey=INITIATOR_PUBKEY,
         address__ip='127.0.0.1',
     )
-    for _ in range(10):
+    for num_retries in range(10):
         # The server isn't listening immediately so we give it a short grace
         # period while trying to connect.
         try:
             reader, writer = await initiator.connect()
         except ConnectionRefusedError:
-            await asyncio.sleep(0)
+            await asyncio.sleep(0 + 0.001 * num_retries)
         else:
             break
     else:

--- a/trinity/_utils/priority.py
+++ b/trinity/_utils/priority.py
@@ -1,0 +1,70 @@
+import asyncio
+from contextlib import asynccontextmanager
+import time
+from typing import AsyncIterator
+
+
+class SilenceObserver:
+    """
+    This class is helpful for actions that happen in the background, with no urgency.
+    Additionally, we might have urgent tasks that are competing for some shared resource.
+
+    SilenceObserver is used like so:
+    - initialize with a parameter defining how long to wait since some urgent
+          task finished before starting the non-urgent task. This would wait
+          for half a second:
+          ``observer = SilenceObserver(minimum_silence_duration=0.5)``
+    - urgent tasks are called within an ``async with observer.make_noise():`` context
+    - non-urgent tasks block on ``await observer.until_silence()`` before acting
+
+    The until_silence() method won't release until no urgent task has made
+    noise for 0.5s in the example above.
+    """
+    def __init__(self, minimum_silence_duration: float) -> None:
+        self._minimum_silence_duration = minimum_silence_duration
+        self._noise_makers = 0
+        self._last_noise_at = 0.0
+        # Trigger an event when there are no noise makers left
+        self._inactive = asyncio.Event()
+        # We start with no noise makers, so trigger immediately
+        self._inactive.set()
+
+    @asynccontextmanager
+    async def make_noise(self) -> AsyncIterator[None]:
+        """Wrap urgent tasks in this context"""
+        self._noise_makers += 1
+        self._inactive.clear()
+        try:
+            yield
+        finally:
+            self._last_noise_at = time.monotonic()
+            self._noise_makers -= 1
+
+            # Notify anyone waiting if the noise makers have dropped to 0
+            if self._noise_makers == 0:
+                self._inactive.set()
+            elif self._noise_makers < 0:
+                raise ValueError(f"Invalid state: {self._noise_makers} noise makers")
+            else:
+                # No action to take when there are still noise makers left
+                pass
+
+    def _check_silence(self) -> bool:
+        if self._noise_makers > 0:
+            # There are current noise makers, do not trigger silence
+            return False
+        else:
+            time_since_noise = time.monotonic() - self._last_noise_at
+            return time_since_noise > self._minimum_silence_duration
+
+    async def until_silence(self) -> None:
+        """
+        Non-urgent tasks block on this coro. It waits until all the noise
+        makers have gone quiet.
+
+        To avoid churn, wait until there has been no noise for
+        minimum_silence_duration.
+        """
+        while not self._check_silence():
+            await self._inactive.wait()
+            await asyncio.sleep(self._minimum_silence_duration)

--- a/trinity/sync/beam/backfill.py
+++ b/trinity/sync/beam/backfill.py
@@ -45,6 +45,9 @@ from trie.typing import (
 
 from p2p.exceptions import BaseP2PError, PeerConnectionLost
 
+from trinity.protocol.eth.constants import (
+    MAX_STATE_FETCH,
+)
 from trinity.protocol.eth.peer import ETHPeer, ETHPeerPool
 from trinity.sync.beam.constants import (
     EPOCH_BLOCK_LENGTH,
@@ -62,7 +65,8 @@ from .queen import (
     QueenTrackerAPI,
 )
 
-REQUEST_SIZE = 16
+# How many trie nodes to request in each backfill message to peers:
+REQUEST_SIZE = MAX_STATE_FETCH
 
 
 class BeamStateBackfill(Service, QueenTrackerAPI):

--- a/trinity/sync/beam/constants.py
+++ b/trinity/sync/beam/constants.py
@@ -53,8 +53,8 @@ GAP_BETWEEN_TESTS = 0.25
 # to establish it (partially because we measure using an exponential average).
 
 # About how long after a block can we request trie data from peers?
-# The value is configurable by client, but tends to be around 75 blocks.
-ESTIMATED_BEAMABLE_BLOCKS = 75
+# The value is configurable by client, but tends to be around 120 blocks.
+ESTIMATED_BEAMABLE_BLOCKS = 120
 
 # It's also useful to estimate the amount of time covered by those beamable blocks.
 ESTIMATED_BEAMABLE_SECONDS = ESTIMATED_BEAMABLE_BLOCKS * PREDICTED_BLOCK_TIME

--- a/trinity/sync/beam/constants.py
+++ b/trinity/sync/beam/constants.py
@@ -25,8 +25,9 @@ MAX_CONCURRENT_SPECULATIVE_EXECUTIONS = 40
 MAX_SPECULATIVE_EXECUTIONS_PER_PROCESS = MAX_CONCURRENT_SPECULATIVE_EXECUTIONS // NUM_PREVIEW_SHARDS
 
 # How many seconds to wait in between each progress log, in the middle of a block
-#   Intuition: somewhere around the time it takes to import a block
-MIN_GAS_LOG_WAIT = PREDICTED_BLOCK_TIME
+#   Intuition: Report about 5 times per block. If progressing in at least real time,
+#   then we should see the % jump by ~20% in each report.
+MIN_GAS_LOG_WAIT = PREDICTED_BLOCK_TIME / 5
 
 # If a peer does something not ideal, give it a little time to breath,
 # and maybe to try out another peeer. Then reinsert it relatively soon.

--- a/trinity/sync/full/chain.py
+++ b/trinity/sync/full/chain.py
@@ -331,7 +331,7 @@ class BaseBodyChainSyncer(Service, PeerSubscriber):
             if len(non_trivial_headers) == 0:
                 # peer had nothing to do, so have it get back in line for processing
                 self._body_peers.put_nowait(peer)
-            elif len(completed_headers) > 0:
+            elif len(received_headers) > 0:
                 # peer completed with at least 1 result, so have it get back in line for processing
                 self._body_peers.put_nowait(peer)
             else:


### PR DESCRIPTION
### What was wrong?

#1947 depends on peasant peers for predictive nodes, which adds contention with backfill. Predictive nodes should clearly be the higher priority.

### How was it fixed?

Pause backfill if there was any recent predictive node requests.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

[//]: # (See: https://trinity-client.readthedocs.io/en/latest/contributing.html#pull-requests)
- [x] Add entry to the [release notes](https://github.com/ethereum/trinity/blob/master/newsfragments/README.md) -- hmm, I guess this needs a note? naaah

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://i.pinimg.com/originals/04/a6/75/04a6753c1cda02fe40321a701adbc081.jpg)