### PR TITLE
yield to the event loop inside of async iterator implementations

### DIFF
--- a/p2p/multiplexer.py
+++ b/p2p/multiplexer.py
@@ -278,15 +278,8 @@ class Multiplexer(MultiplexerAPI):
             self.raise_if_streaming_error()
             msg_queue = self._protocol_queues[protocol_class]
             while self.is_streaming:
-                try:
-                    # We use an optimistic strategy here of using
-                    # `get_nowait()` to reduce the number of times we yield to
-                    # the event loop.  Since this is an async generator it will
-                    # yield to the loop each time it returns a value so we
-                    # don't have to worry about this blocking other processes.
-                    yield msg_queue.get_nowait()
-                except asyncio.QueueEmpty:
-                    yield await msg_queue.get()
+                await asyncio.sleep(0)
+                yield await msg_queue.get()
 
     #
     # Message reading and streaming API

--- a/p2p/token_bucket.py
+++ b/p2p/token_bucket.py
@@ -2,7 +2,7 @@ import asyncio
 import time
 from typing import (
     Union,
-    AsyncGenerator,
+    AsyncIterator,
 )
 
 
@@ -25,7 +25,7 @@ class TokenBucket:
         self._seconds_per_token = 1 / self._rate
         self._take_lock = asyncio.Lock()
 
-    async def __aiter__(self) -> AsyncGenerator[None, None]:
+    async def __aiter__(self) -> AsyncIterator[None]:
         """
         Can be used as an async iterator to limit the rate at which a loop can
         run.
@@ -79,6 +79,8 @@ class TokenBucket:
         if self._num_tokens < 0:
             sleep_for = abs(self._num_tokens) * self._seconds_per_token
             await asyncio.sleep(sleep_for)
+        else:
+            await asyncio.sleep(0)
 
     def take_nowait(self, num: Union[int, float] = 1) -> None:
         # we calculate this value locally to ensure that in the case of not

--- a/trinity/_utils/async_iter.py
+++ b/trinity/_utils/async_iter.py
@@ -1,3 +1,4 @@
+import asyncio
 from typing import (
     AsyncIterable,
     Set,
@@ -39,3 +40,4 @@ async def async_take(take_count: int, iterator: AsyncIterable[TYield]) -> AsyncI
             yield val
             if taken == take_count:
                 break
+            await asyncio.sleep(0)

--- a/trinity/components/eth2/eth1_monitor/eth1_monitor.py
+++ b/trinity/components/eth2/eth1_monitor/eth1_monitor.py
@@ -303,6 +303,7 @@ class Eth1Monitor(Service):
                             f"Block does not exist for block number={block_number}"
                         )
                     yield block
+                    await trio.hazmat.checkpoint()
             await trio.sleep(self._polling_period)
 
     def _handle_block_data(self, block: Eth1Block) -> None:

--- a/trinity/protocol/common/servers.py
+++ b/trinity/protocol/common/servers.py
@@ -136,6 +136,7 @@ class BasePeerRequestHandler:
         Generates the headers requested, halting on the first header that is not locally available.
         """
         for block_num in block_numbers:
+            await asyncio.sleep(0)
             try:
                 yield await self.db.coro_get_canonical_block_header_by_number(block_num)
             except HeaderNotFound:

--- a/trinity/sync/beam/backfill.py
+++ b/trinity/sync/beam/backfill.py
@@ -201,6 +201,8 @@ class BeamStateBackfill(Service, QueenTrackerAPI):
 
         try:
             while self.manager.is_running:
+                await asyncio.sleep(0)
+
                 # Get the next account
 
                 # We have to rebuild the account iterator every time because...
@@ -295,6 +297,8 @@ class BeamStateBackfill(Service, QueenTrackerAPI):
         starting_index = bytes_to_nibbles(root_hash)
 
         while self.manager.is_running:
+            await asyncio.sleep(0)
+
             try:
                 path_to_node = request_tracker.next_path_to_explore(starting_index)
             except trie_exceptions.PerfectVisibility:
@@ -405,6 +409,8 @@ class BeamStateBackfill(Service, QueenTrackerAPI):
 
         storage_tracker = self._get_storage_tracker(address_hash_nibbles)
         while self.manager.is_running:
+            await asyncio.sleep(0)
+
             storage_iterator = self._request_tracking_trie_items(
                 storage_tracker,
                 storage_root,
@@ -460,6 +466,8 @@ class BeamStateBackfill(Service, QueenTrackerAPI):
         if bytecode_tracker.is_complete:
             # All bytecode has been collected
             return
+
+        await asyncio.sleep(0)
 
         # If there is an active request (for now, there can only be one), then skip
         #   any database checks until the active request is resolved.

--- a/trinity/sync/beam/chain.py
+++ b/trinity/sync/beam/chain.py
@@ -340,6 +340,7 @@ class BeamSyncer(Service):
             yield parent
             headers_returned += 1
             header = parent
+            await asyncio.sleep(0)
 
     async def _all_verification_bodies_present(
             self,
@@ -574,9 +575,11 @@ class HeaderLaunchpointSyncer(HeaderSyncerAPI):
             [str(header) for header in self._launchpoint_headers],
         )
         yield self._launchpoint_headers
+        await asyncio.sleep(0)
 
         async for headers in self._real_syncer.new_sync_headers(max_batch_size):
             yield headers
+            await asyncio.sleep(0)
 
     def get_target_header_hash(self) -> Hash32:
         return self._real_syncer.get_target_header_hash()

--- a/trinity/sync/full/chain.py
+++ b/trinity/sync/full/chain.py
@@ -184,6 +184,7 @@ class BaseBodyChainSyncer(Service, PeerSubscriber):
         highest_block_num = -1
 
         async for headers in get_headers_coro:
+            await asyncio.sleep(0)
             self._got_first_header.set()
             for h in headers:
                 self._block_hash_to_state_root[h.hash] = h.state_root


### PR DESCRIPTION
### What was wrong?

Multiple async iterator implementations were not yielding to the event loop during iteration.

### How was it fixed?

Updated the various implementations of `AsyncIterator` to include `asyncio.sleep(0)` calls.

#### Cute Animal Picture

![chicken-red-head](https://user-images.githubusercontent.com/824194/88988192-62eed200-d295-11ea-9298-142aee423ce5.jpg)

