### PR TITLE
Eth2fastspec config cleanup.

### DIFF
--- a/eth2/beacon/state_machines/forks/altona/fast_state_transition.py
+++ b/eth2/beacon/state_machines/forks/altona/fast_state_transition.py
@@ -6,10 +6,12 @@ from eth2.beacon.state_machines.forks.altona.eth2fastspec import (
 from eth2.beacon.types.blocks import BaseSignedBeaconBlock
 from eth2.beacon.types.states import BeaconState
 from eth2.beacon.typing import Slot
+from eth2.configs import Eth2Config
 
 
 def apply_fast_state_transition(
     epochs_ctx: EpochsContext,
+    config: Eth2Config,
     state: BeaconState,
     signed_block: BaseSignedBeaconBlock = None,
     future_slot: Slot = None,
@@ -23,12 +25,12 @@ def apply_fast_state_transition(
     target_slot = signed_block.message.slot if signed_block else future_slot
     assert target_slot is not None
 
-    state = process_slots(epochs_ctx, state, target_slot)
+    state = process_slots(epochs_ctx, state, target_slot, config)
 
     if signed_block:
         if check_proposer_signature:
             # validate_proposer_signature(state, signed_block)
             pass
-        state = process_block(epochs_ctx, state, signed_block.message)
+        state = process_block(epochs_ctx, state, signed_block.message, config)
 
     return state

--- a/eth2/beacon/state_machines/forks/altona/state_machine.py
+++ b/eth2/beacon/state_machines/forks/altona/state_machine.py
@@ -59,11 +59,16 @@ class AltonaStateMachineFast(AltonaStateMachine):
         check_proposer_signature: bool = True,
     ) -> Tuple[BeaconState, BaseSignedBeaconBlock]:
         if not self._epochs_ctx:
-            self._epochs_ctx = EpochsContext()
+            self._epochs_ctx = EpochsContext(self.config)
             self._epochs_ctx.load_state(state)
 
         state = apply_fast_state_transition(
-            self._epochs_ctx, state, signed_block, future_slot, check_proposer_signature
+            self._epochs_ctx,
+            self.config,
+            state,
+            signed_block,
+            future_slot,
+            check_proposer_signature,
         )
 
         if signed_block:


### PR DESCRIPTION
### What was wrong?

Config values were hardcoded into the eth2fastspec state transition. 

### How was it fixed?

Config values are now passed down through each helper function (when needed).

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

[//]: # (See: https://trinity-client.readthedocs.io/en/latest/contributing.html#pull-requests)
- [ ] Add entry to the [release notes](https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://i.redd.it/5y358rgnote51.jpg)
