### PR TITLE
Unnecessary block read removed.

### DIFF
--- a/eth2/beacon/chains/testnet/medalla.py
+++ b/eth2/beacon/chains/testnet/medalla.py
@@ -361,10 +361,7 @@ class BeaconChain(BaseBeaconChain):
     def _get_indices_from_attestation(
         self, attestation: Attestation
     ) -> Collection[ValidatorIndex]:
-        target_block = self._chain_db.get_block_by_root(
-            attestation.data.target.root, BeaconBlock
-        )
-        sm = self.get_state_machine(target_block.slot)
+        sm = self.get_state_machine(attestation.data.slot)
         return get_attesting_indices(
             sm._epochs_ctx, attestation.data, attestation.aggregation_bits
         )


### PR DESCRIPTION
### What was wrong?

Fork choice processing would fail with a `BlockNotFound` exception when encountering an attestation with an unknown target root.

### How was it fixed?

We now catch the exception, log a message, and continue without processing the attestation.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

[//]: # (See: https://trinity-client.readthedocs.io/en/latest/contributing.html#pull-requests)
- [ ] Add entry to the [release notes](https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://ilsi.org/wp-content/uploads/2019/02/baby-sloth.jpg)
