### PR TITLE
Run a task to try and detect when the event loop is overloaded

### DIFF
--- a/trinity/components/builtin/network_db/component.py
+++ b/trinity/components/builtin/network_db/component.py
@@ -42,7 +42,6 @@ from trinity.components.builtin.network_db.eth1_peer_db.tracker import (
     SQLiteEth1PeerTracker,
     MemoryEth1PeerTracker,
 )
-from trinity._utils.logging import get_logger
 from trinity._utils.services import run_background_asyncio_services
 
 
@@ -50,8 +49,6 @@ class NetworkDBComponent(AsyncioIsolatedComponent):
     name = "Network Database"
 
     endpoint_name = "network-db"
-
-    logger = get_logger('trinity.components.network_db.NetworkDB')
 
     @property
     def is_enabled(self) -> bool:

--- a/trinity/components/builtin/syncer/component.py
+++ b/trinity/components/builtin/syncer/component.py
@@ -75,7 +75,6 @@ from trinity.sync.header.chain import (
 from trinity.sync.light.chain import (
     LightChainSyncer,
 )
-from trinity._utils.logging import get_logger
 
 
 def add_shared_argument(arg_group: _ArgumentGroup, arg_name: str, **kwargs: Any) -> None:
@@ -292,8 +291,6 @@ class SyncerComponent(AsyncioIsolatedComponent):
 
     endpoint_name = NETWORKING_EVENTBUS_ENDPOINT
 
-    logger = get_logger('trinity.components.sync.Sync')
-
     @property
     def is_enabled(self) -> bool:
         return True
@@ -380,8 +377,7 @@ class SyncerComponent(AsyncioIsolatedComponent):
                 node_manager.wait_finished(), f'{NodeClass.__name__} wait_finished() task')
             await wait_first([sync_task, node_manager_task])
 
-    @classmethod
-    async def launch_sync(cls,
+    async def launch_sync(self,
                           node: Node[BasePeer],
                           strategy: BaseSyncStrategy,
                           boot_info: BootInfo,
@@ -389,7 +385,7 @@ class SyncerComponent(AsyncioIsolatedComponent):
         await node.get_manager().wait_started()
         await strategy.sync(
             boot_info.args,
-            cls.logger,
+            self.logger,
             node.get_chain(),
             node.base_db,
             node.get_peer_pool(),

--- a/trinity/components/builtin/tx_pool/component.py
+++ b/trinity/components/builtin/tx_pool/component.py
@@ -26,14 +26,11 @@ from trinity.components.builtin.tx_pool.pool import (
     TxPool,
 )
 from trinity.protocol.eth.peer import ETHProxyPeerPool
-from trinity._utils.logging import get_logger
 from trinity._utils.transactions import DefaultTransactionValidator
 
 
 class TxComponent(AsyncioIsolatedComponent):
     name = "TxComponent"
-
-    logger = get_logger('trinity.components.tx_pool.TxPool')
 
     @classmethod
     def configure_parser(cls, arg_parser: ArgumentParser, subparser: _SubParsersAction) -> None:

--- a/trinity/components/builtin/tx_pool/pool.py
+++ b/trinity/components/builtin/tx_pool/pool.py
@@ -54,13 +54,13 @@ class TxPool(Service):
         This is a minimal viable implementation that only relays transactions but doesn't actually
         hold on to them yet. It's still missing many features of a grown up transaction pool.
     """
-    logger = get_logger('trinity.components.txpool.TxPool')
 
     def __init__(self,
                  event_bus: EndpointAPI,
                  peer_pool: ETHProxyPeerPool,
                  tx_validation_fn: Callable[[SignedTransactionAPI], bool],
                  ) -> None:
+        self.logger = get_logger('trinity.components.txpool.TxPoolService')
         self._event_bus = event_bus
         self._peer_pool = peer_pool
 

--- a/trinity/components/eth2/beacon_trio/component.py
+++ b/trinity/components/eth2/beacon_trio/component.py
@@ -5,6 +5,7 @@ from typing import Iterable
 from eth_utils import to_tuple
 from multiaddr import Multiaddr
 
+from trinity._utils.logging import get_logger
 from trinity.boot_info import BootInfo
 from trinity.config import BeaconTrioAppConfig
 from trinity.constants import BEACON_TESTNET_NETWORK_ID
@@ -22,7 +23,7 @@ def _parse_multiaddrs_from_args(multiaddrs: str) -> Iterable[Multiaddr]:
 class BeaconNodeComponent(TrioComponent):
     name = "Beacon Node"
 
-    logger = logging.getLogger("trinity.components.beacon.BeaconNode[trio]")
+    logger = get_logger("trinity.components.beacon.BeaconNode[trio]")
 
     def __init__(self, boot_info: BootInfo) -> None:
         super().__init__(boot_info)

--- a/trinity/extensibility/asyncio.py
+++ b/trinity/extensibility/asyncio.py
@@ -1,4 +1,5 @@
 from abc import abstractmethod
+import asyncio
 from typing import (
     Any,
     Callable,
@@ -7,18 +8,20 @@ from typing import (
 from asyncio_run_in_process import run_in_process
 from asyncio_run_in_process.typing import SubprocessKwargs
 from async_service import background_asyncio_service
+from async_service.asyncio import cleanup_tasks
 from lahja import EndpointAPI
 
+from p2p.asyncio_utils import create_task
 
-from trinity._utils.logging import child_process_logging, get_logger
+from trinity._utils.logging import child_process_logging
 from trinity._utils.profiling import profiler
+from trinity._utils.timer import Timer
 
 from .component import BaseIsolatedComponent, TReturn
 from .event_bus import AsyncioEventBusService
 
 
 class AsyncioIsolatedComponent(BaseIsolatedComponent):
-    logger = get_logger('trinity.extensibility.asyncio.AsyncioIsolatedComponent')
 
     async def _run_in_process(
             self,
@@ -28,6 +31,28 @@ class AsyncioIsolatedComponent(BaseIsolatedComponent):
     ) -> TReturn:
         return await run_in_process(async_fn, *args, subprocess_kwargs=subprocess_kwargs)
 
+    # FIXME: Disabled by default
+    async def _loop_monitoring_task(self) -> None:
+        debug_log_since = 0
+        while True:
+            timer = Timer()
+            await asyncio.sleep(self.loop_monitoring_wakeup_interval)
+            delay = timer.elapsed - self.loop_monitoring_wakeup_interval
+            # FIXME: Ideally we'd use a debug2 here, but because of
+            # https://github.com/ethereum/trinity/issues/1971 we need to use debug so only log
+            # every 10th time we're called.
+            debug_log_since += 1
+            if debug_log_since == 10:
+                self.logger.debug("Loop monitoring task called; delay=%.3fs", delay)
+                debug_log_since = 0
+            if delay > self.loop_monitoring_max_delay:
+                pending_tasks = len([task for task in asyncio.all_tasks() if not task.done()])
+                self.logger.warning(
+                    "Event loop blocked or overloaded: delay=%.3fs, tasks=%d",
+                    delay,
+                    pending_tasks,
+                )
+
     async def _do_run(self) -> None:
         with child_process_logging(self._boot_info):
             endpoint_name = self.get_endpoint_name()
@@ -35,28 +60,34 @@ class AsyncioIsolatedComponent(BaseIsolatedComponent):
                 self._boot_info.trinity_config,
                 endpoint_name,
             )
-            async with background_asyncio_service(event_bus_service):
-                event_bus = await event_bus_service.get_event_bus()
+            loop_monitoring_task = create_task(
+                self._loop_monitoring_task(),
+                f'AsyncioIsolatedComponent/{self.name}/loop_monitoring_task')
+            # FIXME: Must terminate component if loop_monitoring_task terminates.
+            async with cleanup_tasks(loop_monitoring_task):
+                # FIXME: Must terminate component if event_bus_service terminates.
+                async with background_asyncio_service(event_bus_service):
+                    event_bus = await event_bus_service.get_event_bus()
 
-                try:
-                    if self._boot_info.profile:
-                        with profiler(f'profile_{self.get_endpoint_name()}'):
+                    try:
+                        if self._boot_info.profile:
+                            with profiler(f'profile_{self.get_endpoint_name()}'):
+                                await self.do_run(event_bus)
+                        else:
+                            # XXX: When open_in_process() injects a KeyboardInterrupt into us (via
+                            # coro.throw()), we hang forever here, until open_in_process() times
+                            # out and sends us a SIGTERM, at which point we exit without executing
+                            # either the except or the finally blocks below.
+                            # See https://github.com/ethereum/trinity/issues/1711 for more.
                             await self.do_run(event_bus)
-                    else:
-                        # XXX: When open_in_process() injects a KeyboardInterrupt into us (via
-                        # coro.throw()), we hang forever here, until open_in_process() times out
-                        # and sends us a SIGTERM, at which point we exit without executing either
-                        # the except or the finally blocks below.
-                        # See https://github.com/ethereum/trinity/issues/1711 for more.
-                        await self.do_run(event_bus)
-                except KeyboardInterrupt:
-                    # Currently we never reach this code path, but when we fix the issue above it
-                    # will be needed.
-                    return
-                finally:
-                    # Once we start seeing this in the logs after a Ctrl-C, we'll likely have
-                    # figured out the issue above.
-                    self.logger.debug("%s: do_run() finished", self)
+                    except KeyboardInterrupt:
+                        # Currently we never reach this code path, but when we fix the issue above
+                        # it will be needed.
+                        return
+                    finally:
+                        # Once we start seeing this in the logs after a Ctrl-C, we'll likely have
+                        # figured out the issue above.
+                        self.logger.debug("%s: do_run() finished", self)
 
     @abstractmethod
     async def do_run(self, event_bus: EndpointAPI) -> None:

--- a/trinity/extensibility/trio.py
+++ b/trinity/extensibility/trio.py
@@ -12,8 +12,9 @@ from lahja import EndpointAPI
 from asyncio_run_in_process import run_in_process_with_trio
 from asyncio_run_in_process.typing import SubprocessKwargs
 
-from trinity._utils.logging import child_process_logging, get_logger
+from trinity._utils.logging import child_process_logging
 from trinity._utils.profiling import profiler
+from trinity._utils.timer import Timer
 
 from .component import BaseComponent, BaseIsolatedComponent, TReturn
 from .event_bus import TrioEventBusService
@@ -31,7 +32,6 @@ class TrioComponent(BaseComponent):
 
 
 class TrioIsolatedComponent(BaseIsolatedComponent):
-    logger = get_logger('trinity.extensibility.TrioIsolatedComponent')
 
     async def _run_in_process(
             self,
@@ -52,6 +52,29 @@ class TrioIsolatedComponent(BaseIsolatedComponent):
             # These are expected, when trinity is terminating because of a Ctrl-C
             raise
 
+    # FIXME: Disabled by default
+    async def _loop_monitoring_task(self) -> None:
+        debug_log_since = 0
+        while True:
+            timer = Timer()
+            await trio.sleep(self.loop_monitoring_wakeup_interval)
+            delay = timer.elapsed - self.loop_monitoring_wakeup_interval
+            # FIXME: Ideally we'd use a debug2 here, but because of
+            # https://github.com/ethereum/trinity/issues/1971 we need to use debug so only log
+            # every 10th time we're called.
+            debug_log_since += 1
+            if debug_log_since == 10:
+                self.logger.debug("Loop monitoring task called; delay=%.3fs", delay)
+                debug_log_since = 0
+            if delay > self.loop_monitoring_max_delay:
+                stats = trio.hazmat.current_statistics()
+                self.logger.warning(
+                    "Event loop blocked or overloaded: delay=%.3fs, tasks=%d, stats=%s",
+                    delay,
+                    stats.tasks_living,
+                    stats.io_statistics,
+                )
+
     async def _do_run(self) -> None:
         with child_process_logging(self._boot_info):
             event_bus_service = TrioEventBusService(
@@ -61,6 +84,7 @@ class TrioIsolatedComponent(BaseIsolatedComponent):
             async with background_trio_service(event_bus_service):
                 event_bus = await event_bus_service.get_event_bus()
                 async with trio.open_nursery() as nursery:
+                    nursery.start_soon(self._loop_monitoring_task)
                     nursery.start_soon(self.run_process, event_bus)
                     try:
                         await trio.sleep_forever()


### PR DESCRIPTION
Every component now runs a task that wakes up periodically and
emits a warning log with some statistics if the difference between the
time it should have executed and the actual time it was executed is
greater than a certain threshold.

Closes: #1962