### PR TITLE
Ignore delay when inserting a queen-able peasant (plus bonus code)

### DIFF
--- a/trinity/sync/beam/backfill.py
+++ b/trinity/sync/beam/backfill.py
@@ -382,6 +382,10 @@ class BeamStateBackfill(Service, QueenTrackerAPI):
                 # If this is just an intermediate node, then we can mark it as confirmed.
                 request_tracker.confirm_prefix(path_to_node, node)
 
+            # We made some DB calls and didn't find anything missing. Yield to the event loop
+            # too avoid holding it for too long.
+            await asyncio.sleep(0)
+
     async def _missing_subcomponent_hashes(
             self,
             address_hash_nibbles: Nibbles,

--- a/trinity/sync/beam/constants.py
+++ b/trinity/sync/beam/constants.py
@@ -46,6 +46,10 @@ NON_IDEAL_RESPONSE_PENALTY = 2.0
 #   block. 1500 / 4000 ~= 0.4
 MAX_ACCEPTABLE_WAIT_FOR_URGENT_NODE = 0.4
 
+# How long before the block importer gives up on waiting for a missing trie
+#   node, and reissues the event to request it again.
+BLOCK_IMPORT_MISSING_STATE_TIMEOUT = 600
+
 # If Beam Sync wants to use a queen, but is stuck waiting for it to show up,
 #   then log a warning if it's been too long. If it's been more than this
 #   many seconds, then log the warning:

--- a/trinity/sync/beam/importer.py
+++ b/trinity/sync/beam/importer.py
@@ -55,6 +55,7 @@ from trinity._utils.timer import Timer
 from trinity.chains.full import FullChain
 from trinity.exceptions import StateUnretrievable
 from trinity.sync.beam.constants import (
+    BLOCK_IMPORT_MISSING_STATE_TIMEOUT,
     MAX_SPECULATIVE_EXECUTIONS_PER_PROCESS,
     MIN_GAS_LOG_WAIT,
     NUM_PREVIEW_SHARDS,
@@ -234,7 +235,7 @@ def pausing_vm_decorator(
         A custom version of VMState that pauses EVM execution when required data is missing.
         """
         stats_counter: BeamStats
-        node_retrieval_timeout = 20
+        node_retrieval_timeout = BLOCK_IMPORT_MISSING_STATE_TIMEOUT
 
         def __init__(self, *args: Any, **kwargs: Any) -> None:
             super().__init__(*args, **kwargs)

--- a/trinity/sync/beam/queen.py
+++ b/trinity/sync/beam/queen.py
@@ -210,7 +210,13 @@ class QueeningQueue(Service, PeerSubscriber, QueenTrackerAPI):
         raise asyncio.CancelledError()
 
     def insert_peer(self, peer: ETHPeer, delay: float = 0) -> None:
-        if delay > 0:
+        if not peer.is_alive:
+            # Peer exited, dropping it...
+            return
+        elif self._should_be_queen(peer):
+            self.logger.debug("Fast-tracking peasant to promote to queen: %s", peer)
+            self._insert_peer(peer)
+        elif delay > 0:
             loop = asyncio.get_event_loop()
             loop.call_later(delay, functools.partial(self._insert_peer, peer))
         else:

--- a/trinity/sync/beam/state.py
+++ b/trinity/sync/beam/state.py
@@ -58,13 +58,11 @@ from trinity.sync.beam.queen import (
     QueenTrackerAPI,
 )
 from trinity.sync.beam.constants import (
-    TOO_LONG_PREDICTIVE_PEER_DELAY,
+    BLOCK_IMPORT_MISSING_STATE_TIMEOUT,
     ESTIMATED_BEAMABLE_SECONDS,
     MAX_ACCEPTABLE_WAIT_FOR_URGENT_NODE,
     REQUEST_BUFFER_MULTIPLIER,
-)
-from trinity.sync.common.constants import (
-    PREDICTED_BLOCK_TIME,
+    TOO_LONG_PREDICTIVE_PEER_DELAY,
 )
 
 
@@ -156,7 +154,7 @@ class BeamDownloader(Service, PeerSubscriber):
             num_nodes_found = await self._wait_for_nodes(
                 node_hashes,
                 self._node_tasks,
-                PREDICTED_BLOCK_TIME,
+                BLOCK_IMPORT_MISSING_STATE_TIMEOUT,
             )
             # If it took to long to get a single urgent node, then increase "spread" factor
             if len(node_hashes) == 1 and t.elapsed > MAX_ACCEPTABLE_WAIT_FOR_URGENT_NODE:
@@ -178,7 +176,7 @@ class BeamDownloader(Service, PeerSubscriber):
             num_nodes_found = await self._wait_for_nodes(
                 node_hashes,
                 self._maybe_useful_nodes,
-                PREDICTED_BLOCK_TIME * 10,
+                BLOCK_IMPORT_MISSING_STATE_TIMEOUT,
             )
 
         return num_nodes_found


### PR DESCRIPTION
### What was wrong?

If we are blocked waiting for a queen, we want to resolve the situation as quickly as possible. (or if we have a candidate who is a faster queen) Currently, when we re-insert a peasant with a delay, it is always delayed.

### How was it fixed?

So if we are inserting a peasant, but it will be promoted to queen, then insert it immediately, even if the insert was called with a delay. This helps unblock the critical path to collect urgent trie nodes.

Bonus additions:
- Don't block the critical path of collecting urgent trie nodes on a missing queen peer as often
- Better tracking of the number of trie nodes received. (Before, during a timeout, we would consider the nodes as received in the returned count of received nodes) Mostly just relevant to logging.
- Release event loop in state backfill more often.

Changes are nicely isolated by commit.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

[//]: # (See: https://trinity-client.readthedocs.io/en/latest/contributing.html#pull-requests)
- [ ] Add entry to the [release notes](https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://i.pinimg.com/originals/0b/78/ef/0b78efa5769f301904501b81946108be.jpg)
