### PR TITLE
Eth2fastspec validation cleanup.

### DIFF
--- a/eth2/beacon/state_machines/forks/medalla/fast_state_transition.py
+++ b/eth2/beacon/state_machines/forks/medalla/fast_state_transition.py
@@ -3,6 +3,9 @@ from eth2.beacon.state_machines.forks.medalla.eth2fastspec import (
     process_block,
     process_slots,
 )
+from eth2.beacon.state_machines.forks.serenity.block_validation import (
+    validate_proposer_signature,
+)
 from eth2.beacon.types.blocks import BaseSignedBeaconBlock
 from eth2.beacon.types.states import BeaconState
 from eth2.beacon.typing import Slot
@@ -29,8 +32,7 @@ def apply_fast_state_transition(
 
     if signed_block:
         if check_proposer_signature:
-            # validate_proposer_signature(state, signed_block)
-            pass
+            validate_proposer_signature(state, signed_block, config)
         state = process_block(epochs_ctx, state, signed_block.message, config)
 
     return state

--- a/setup.py
+++ b/setup.py
@@ -118,6 +118,8 @@ deps = {
         "asks>=2.3.6,<3",  # validator client
         "anyio>1.3,<1.4",
         "eth-keyfile",  # validator client
+    ],
+    'eth2-extra': [
         "milagro-bls-binding==1.3.0",
     ],
     'eth2-lint': [
@@ -157,6 +159,7 @@ deps['dev'] = (
 deps['eth2-dev'] = (
     deps['dev'] +
     deps['eth2'] +
+    deps['eth2-extra'] +
     deps['eth2-lint']
 )
 


### PR DESCRIPTION
### What was wrong?

See #1960 for more context.

We should be raising validation errors instead of assertion errors when processing the state transitions.

### How was it fixed?

- replaced assertions with existing validation functions when possible
- used our existing BLS module for signature validation

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

[//]: # (See: https://trinity-client.readthedocs.io/en/latest/contributing.html#pull-requests)
- [ ] Add entry to the [release notes](https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://i.imgur.com/aDwklHj.jpeg)
