### PR TITLE
Save trie nodes outside the event loop

### DIFF
--- a/newsfragments/1984.performance.rst
+++ b/newsfragments/1984.performance.rst
@@ -1,0 +1,2 @@
+Stop holding the event loop for so long when downloading state for Beam Sync.
+It was causing performance issues.


### PR DESCRIPTION
### What was wrong?

Related to #1980 

The event loop is held by `_store_nodes()` for too long.

### How was it fixed?

Save trie nodes outside the event loop. Also, compressed all the `asyncio.Event`s that notify about new data being received down to a single one. I don't see/remember the benefit to having one for each waiting coro.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

[//]: # (See: https://trinity-client.readthedocs.io/en/latest/contributing.html#pull-requests)
- [x] Add entry to the [release notes](https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://i.pinimg.com/736x/98/c3/b4/98c3b48a6e7573a965e4756639268222--helping-hands-helping-others.jpg)