### PR TITLE
Some improvements to p2p.asyncio_utils

### DIFF
--- a/p2p/asyncio_utils.py
+++ b/p2p/asyncio_utils.py
@@ -6,11 +6,8 @@ from typing import (
     Any,
     AsyncIterator,
     Awaitable,
-    cast,
-    Iterable,
     List,
     Sequence,
-    Set,
     TypeVar,
 )
 
@@ -31,66 +28,91 @@ def create_task(coro: Awaitable[TReturn], name: str) -> asyncio.Task[TReturn]:
         return asyncio.create_task(coro)
 
 
-async def wait_first(tasks: Sequence[asyncio.Task[Any]]) -> None:
+async def wait_first(
+        tasks: Sequence[asyncio.Task[Any]], max_wait_after_cancellation: float) -> None:
     """
     Wait for the first of the given tasks to complete, then cancels all others.
 
-    If the completed task raised an exception, re-raise it.
+    If the completed task raised an exception, that is re-raised.
 
-    If the task running us is cancelled, all tasks will be cancelled.
+    If the task running us is cancelled, all tasks will be cancelled, in no specific order.
+
+    If we get an exception from any of the cancelled tasks, they are re-raised as a
+    trio.MultiError, which will include the exception from the completed task (if any) in their
+    context.
+
+    If the cancelled tasks don't return in max_wait_after_cancellation seconds, a TimeoutError
+    will be raised.
     """
     for task in tasks:
         if not isinstance(task, asyncio.Task):
             raise ValueError(f"{task} is not an asyncio.Task")
 
     logger = get_logger('p2p.asyncio_utils.wait_first')
+    async with cancel_pending_tasks(*tasks, timeout=max_wait_after_cancellation):
+        try:
+            done, pending = await asyncio.wait(tasks, return_when=asyncio.FIRST_COMPLETED)
+        except (KeyboardInterrupt, asyncio.CancelledError) as err:
+            logger.debug("Got %r waiting for %s, cancelling them all", err, tasks)
+            raise
+        except BaseException:
+            logger.exception("Unexpected error waiting for %s, cancelling them all", tasks)
+            raise
+        else:
+            logger.debug("Task %s finished, cancelling pending ones: %s", done, pending)
+            if len(done) != 1:
+                raise Exception(
+                    "Invariant: asyncio.wait() returned more than one task even "
+                    "though we used return_when=asyncio.FIRST_COMPLETED: %s", done)
+            done_task = first(done)
+            if done_task.exception():
+                raise done_task.exception()
+
+
+@contextlib.asynccontextmanager
+async def cancel_pending_tasks(*tasks: asyncio.Task[Any], timeout: int) -> AsyncIterator[None]:
+    """
+    Cancel and await for all of the given tasks that are still pending, in no specific order.
+
+    If all cancelled tasks have not completed after the given timeout, raise a TimeoutError.
+
+    Ignores any asyncio.CancelledErrors.
+    """
     try:
-        done, pending = await asyncio.wait(tasks, return_when=asyncio.FIRST_COMPLETED)
-    except (KeyboardInterrupt, asyncio.CancelledError) as err:
-        logger.debug("Got %r waiting for %s, cancelling them all", err, tasks)
-        await cancel_tasks(tasks)
-        raise
-    except BaseException:
-        logger.exception("Unexpected error waiting for %s", tasks)
-        await cancel_tasks(tasks)
-        raise
-    else:
-        logger.debug("Task %s finished, cancelling remaining ones: %s", done, pending)
-        if pending:
-            await cancel_tasks(cast(Set['asyncio.Task[Any]'], pending))
-        if len(done) != 1:
-            raise Exception(
-                "Invariant: asyncio.wait() returned more than one task even "
-                "though we used return_when=asyncio.FIRST_COMPLETED: %s", done)
-        done_task = first(done)
-        if done_task.exception():
-            raise done_task.exception()
+        yield
+    finally:
+        logger = get_logger('p2p.asyncio_utils.cancel_pending_tasks')
+        cancelled: List[asyncio.Task[Any]] = []
+        for task in tasks:
+            if not task.done():
+                task.cancel()
+                cancelled.append(task)
 
-
-async def cancel_tasks(tasks: Iterable[asyncio.Task[Any]]) -> None:
-    """
-    Cancel and await for the given tasks, ignoring any asyncio.CancelledErrors.
-    """
-    for task in tasks:
-        task.cancel()
-
-    errors: List[BaseException] = []
-    # Wait for all tasks in parallel so if any of them catches CancelledError and performs a
-    # slow cleanup the othders don't have to wait for it. The timeout is long as our component
-    # tasks can do a lot of stuff during their cleanup.
-    done, pending = await asyncio.wait(tasks, timeout=10)
-    if pending:
-        errors.append(
-            asyncio.TimeoutError("Tasks never returned after being cancelled: %s", pending))
-    # We use future as the variable name here because that's what asyncio.wait returns above.
-    for future in done:
-        # future.exception() will raise a CancelledError if the future was cancelled by us above, so
-        # we must suppress that here.
-        with contextlib.suppress(asyncio.CancelledError):
-            if future.exception():
-                errors.append(future.exception())
-    if errors:
-        raise MultiError(errors)
+        # It'd save us one indentation level on the block of code below if we had an early return
+        # in case there are no cancelled tasks, but it turns out an early return inside a finally:
+        # block silently cancels an active exception being raised, so we use an if/else to avoid
+        # having to check if there is an active exception and re-raising it.
+        if cancelled:
+            logger.debug("Cancelled tasks %s, now waiting for them to return", task)
+            errors: List[BaseException] = []
+            # Wait for all tasks in parallel so if any of them catches CancelledError and performs a
+            # slow cleanup the othders don't have to wait for it.
+            done, pending = await asyncio.wait(cancelled, timeout=timeout)
+            if pending:
+                errors.append(
+                    asyncio.TimeoutError("Tasks never returned after being cancelled: %s", pending))
+            # We use future as the variable name here because that's what asyncio.wait returns
+            # above.
+            for future in done:
+                # future.exception() will raise a CancelledError if the future was cancelled by us
+                # above, so we must suppress that here.
+                with contextlib.suppress(asyncio.CancelledError):
+                    if future.exception():
+                        errors.append(future.exception())
+            if errors:
+                raise MultiError(errors)
+        else:
+            logger.debug("No pending tasks in %s, returning", task)
 
 
 # Ripped from async_service/asyncio.py at v0.1.0-alpha.8

--- a/p2p/connection.py
+++ b/p2p/connection.py
@@ -130,7 +130,7 @@ class Connection(ConnectionAPI, Service):
                 try:
                     for behavior in behaviors:
                         behavior.post_apply()
-                    await wait_first(futures)
+                    await wait_first(futures, max_wait_after_cancellation=2)
                 except PeerConnectionLost:
                     # Any of our behaviors may propagate a PeerConnectionLost, which is to be
                     # expected as many Connection APIs used by them can raise that. To avoid a

--- a/p2p/logic.py
+++ b/p2p/logic.py
@@ -116,7 +116,10 @@ class Application(BaseLogic):
             # Now register ourselves with the connection.
             with connection.add_logic(self.name, self):
                 name = f'Application/{self.name}/apply/{connection.remote}'
-                yield create_task(wait_first(futures), name=name)
+                yield create_task(
+                    wait_first(futures, max_wait_after_cancellation=2),
+                    name=name,
+                )
 
 
 async def _never_ending_coro() -> None:

--- a/tests/p2p/test_asyncio_utils.py
+++ b/tests/p2p/test_asyncio_utils.py
@@ -1,0 +1,107 @@
+import asyncio
+
+import pytest
+
+from p2p.asyncio_utils import create_task, wait_first
+
+
+class TaskException(Exception):
+    pass
+
+
+class AfterCancellationException(Exception):
+    pass
+
+
+def create_sleep0_task():
+    return create_task(asyncio.sleep(0), 'sleep-0')
+
+
+def create_raising_task():
+    async def _raise():
+        raise TaskException()
+
+    return create_task(_raise(), 'raising-task')
+
+
+def create_sleep_forever_task():
+    async def _sleep_forever():
+        await asyncio.Future()
+
+    return create_task(_sleep_forever(), 'sleep-forever')
+
+
+def create_raising_after_cancellation_task():
+    async def _raise_after_cancellation():
+        try:
+            await asyncio.Future()
+        except asyncio.CancelledError:
+            raise AfterCancellationException()
+
+    return create_task(_raise_after_cancellation(), 'raising-after-cancellation')
+
+
+def create_rogue_task(sleep_after_cancellation):
+    async def _rogue(sleep_after_cancellation):
+        try:
+            await asyncio.Future()
+        except asyncio.CancelledError:
+            await asyncio.sleep(sleep_after_cancellation)
+
+    return create_task(_rogue(sleep_after_cancellation), 'rogue-task')
+
+
+@pytest.mark.asyncio
+async def test_wait_first():
+    sleep0_task = create_sleep0_task()
+    sleep_forever_task = create_sleep_forever_task()
+    await wait_first([sleep0_task, sleep_forever_task], max_wait_after_cancellation=0.1)
+
+    assert sleep0_task.done()
+    assert not sleep0_task.cancelled()
+    assert sleep_forever_task.done()
+    assert sleep_forever_task.cancelled()
+
+
+@pytest.mark.asyncio
+async def test_wait_first_task_exception():
+    raising_task = create_raising_task()
+    with pytest.raises(TaskException):
+        await wait_first([raising_task], max_wait_after_cancellation=0.1)
+
+    raising_task = create_raising_task()
+    sleep_forever_task = create_sleep_forever_task()
+    with pytest.raises(TaskException):
+        await wait_first([raising_task, sleep_forever_task], max_wait_after_cancellation=0.1)
+
+
+@pytest.mark.asyncio
+async def test_wait_first_cancelled_task_exception():
+    raising_task = create_raising_task()
+    raising_after_cancellation_task = create_raising_after_cancellation_task()
+    with pytest.raises(AfterCancellationException) as exc:
+        await wait_first(
+            [raising_task, raising_after_cancellation_task],
+            max_wait_after_cancellation=0.1
+        )
+    # Even though we get the exception from the cancelled task, it will have the exception from
+    # the task that completed as its context.
+    assert isinstance(exc.value.__context__, TaskException)
+
+
+@pytest.mark.asyncio
+async def test_wait_first_rogue_task():
+    sleep_after_cancellation = 0.2
+    sleep0_task = create_sleep0_task()
+    rogue_task = create_rogue_task(sleep_after_cancellation)
+    sleep_forever_task = create_sleep_forever_task()
+
+    # If a task doesn't return after being cancelled, we get a TimeoutError
+    with pytest.raises(asyncio.TimeoutError):
+        await wait_first(
+            [sleep0_task, rogue_task, sleep_forever_task],
+            max_wait_after_cancellation=sleep_after_cancellation / 2,
+        )
+
+    # Await for our rogue task to finish otherwise we'll get asyncio warnings.
+    await rogue_task

--- a/trinity/_utils/services.py
+++ b/trinity/_utils/services.py
@@ -19,10 +19,10 @@ async def run_background_asyncio_services(services: Sequence[ServiceAPI]) -> Non
             for service in services
         ])
         # If any of the services terminate, we do so as well.
-        await wait_first_asyncio([
-            asyncio.create_task(manager.wait_finished())
-            for manager in managers
-        ])
+        await wait_first_asyncio(
+            [asyncio.create_task(manager.wait_finished()) for manager in managers],
+            max_wait_after_cancellation=2
+        )
 
 
 async def run_background_trio_services(services: Sequence[ServiceAPI]) -> None:

--- a/trinity/components/builtin/syncer/component.py
+++ b/trinity/components/builtin/syncer/component.py
@@ -375,7 +375,7 @@ class SyncerComponent(AsyncioIsolatedComponent):
             # returns.
             node_manager_task = create_task(
                 node_manager.wait_finished(), f'{NodeClass.__name__} wait_finished() task')
-            await wait_first([sync_task, node_manager_task])
+            await wait_first([sync_task, node_manager_task], max_wait_after_cancellation=2)
 
     async def launch_sync(self,
                           node: Node[BasePeer],

--- a/trinity/extensibility/component.py
+++ b/trinity/extensibility/component.py
@@ -264,7 +264,7 @@ def run_asyncio_eth1_component(component_type: Type['AsyncioIsolatedComponent'])
         async with _run_eventbus_for_component(component, connect_to_endpoints) as event_bus:
             async with _run_asyncio_component_in_proc(component, event_bus) as component_task:
                 sigint_task = asyncio.create_task(got_sigint.wait())
-                await wait_first([component_task, sigint_task])
+                await wait_first([component_task, sigint_task], max_wait_after_cancellation=2)
 
     loop.run_until_complete(run())
 

--- a/trinity/extensibility/component_manager.py
+++ b/trinity/extensibility/component_manager.py
@@ -100,7 +100,9 @@ class ComponentManager(Service):
                 tasks.append(asyncio.create_task(self._trigger_component_exit.wait()))
                 self.logger.info("Components started")
                 try:
-                    await wait_first(tasks)
+                    # The timeout is long as our component tasks can do a lot of stuff during
+                    # their cleanup.
+                    await wait_first(tasks, max_wait_after_cancellation=10)
                 finally:
                     self.logger.info("Stopping components")
             finally:


### PR DESCRIPTION
Simplify wait_first(), document some things that were not obvious and
require the max wait after cancellation to be provided by callsites instead
of using a hard-coded 10s.

Also turn cancel_tasks() into a contextmanager and add a bunch of tests to
wait_first()