### PR TITLE
Persist/restore fork choice

### DIFF
--- a/eth2/beacon/chains/abc.py
+++ b/eth2/beacon/chains/abc.py
@@ -4,6 +4,7 @@ from typing import Optional
 from eth.abc import AtomicDatabaseAPI
 
 from eth2.beacon.db.abc import BaseBeaconChainDB
+from eth2.beacon.fork_choice.abc import BaseForkChoice
 from eth2.beacon.state_machines.abc import BaseBeaconStateMachine
 from eth2.beacon.types.attestations import Attestation
 from eth2.beacon.types.blocks import BaseSignedBeaconBlock, BeaconBlock
@@ -13,6 +14,12 @@ from eth2.clock import Tick
 
 
 class BaseBeaconChain(ABC):
+    @abstractmethod
+    def __init__(
+        self, chain_db: BaseBeaconChainDB, fork_choice: BaseForkChoice
+    ) -> None:
+        ...
+
     @classmethod
     @abstractmethod
     def from_genesis(

--- a/eth2/beacon/chains/testnet/medalla.py
+++ b/eth2/beacon/chains/testnet/medalla.py
@@ -281,6 +281,7 @@ class BeaconChain(BaseBeaconChain):
     def _update_head_if_new(self, block: BeaconBlock) -> None:
         if block != self._current_head:
             self._current_head = block
+            self._chain_db.mark_canonical_head(block)
             self.logger.debug("new head of chain: %s", block)
 
     def _update_fork_choice_with_block(self, block: BeaconBlock) -> None:

--- a/eth2/beacon/chains/testnet/medalla.py
+++ b/eth2/beacon/chains/testnet/medalla.py
@@ -265,6 +265,10 @@ class BeaconChain(BaseBeaconChain):
 
         if justified_checkpoint.epoch > self._justified_checkpoint.epoch:
             self._justified_checkpoint = justified_checkpoint
+            justified_head = self._chain_db.get_block_by_root(
+                self._justified_checkpoint.root, BeaconBlock
+            )
+            self._chain_db.mark_justified_head(justified_head)
             self._fork_choice.update_justified(state)
 
         if finalized_checkpoint.epoch > self._finalized_checkpoint.epoch:

--- a/eth2/beacon/db/abc.py
+++ b/eth2/beacon/db/abc.py
@@ -69,6 +69,20 @@ class BaseBeaconChainDB(ABC):
         ...
 
     @abstractmethod
+    def mark_canonical_head(self, block: BaseBeaconBlock) -> None:
+        ...
+
+    @abstractmethod
+    def get_canonical_head(self, block: BaseBeaconBlock) -> None:
+        """
+        Prefer to read the canonical head from the fork choice module.
+
+        This method primarily exists to help the fork choice module restore
+        context from disk, e.g. in between periods of running a beacon node.
+        """
+        ...
+
+    @abstractmethod
     def mark_justified_head(self, block: BaseBeaconBlock) -> None:
         ...
 

--- a/eth2/beacon/db/abc.py
+++ b/eth2/beacon/db/abc.py
@@ -69,6 +69,14 @@ class BaseBeaconChainDB(ABC):
         ...
 
     @abstractmethod
+    def mark_justified_head(self, block: BaseBeaconBlock) -> None:
+        ...
+
+    @abstractmethod
+    def get_justified_head(self, block_class: Type[BaseBeaconBlock]) -> BaseBeaconBlock:
+        ...
+
+    @abstractmethod
     def mark_finalized_head(self, block: BaseBeaconBlock) -> None:
         ...
 

--- a/eth2/beacon/db/abc.py
+++ b/eth2/beacon/db/abc.py
@@ -5,7 +5,7 @@ from eth.abc import AtomicDatabaseAPI
 
 from eth2.beacon.types.blocks import BaseBeaconBlock, BaseSignedBeaconBlock
 from eth2.beacon.types.states import BeaconState
-from eth2.beacon.typing import BLSSignature, Root, Slot
+from eth2.beacon.typing import BLSSignature, Root, Slot, Timestamp
 from eth2.configs import Eth2Config
 
 
@@ -21,6 +21,8 @@ class BaseBeaconChainDB(ABC):
     NOTE: Blocks and states are not stored by slot until they have
     been finalized. To get data for non-finalized slots, defer to the fork choice computation.
     """
+
+    genesis_time: Timestamp
 
     @abstractmethod
     def __init__(self, db: AtomicDatabaseAPI) -> None:
@@ -73,7 +75,7 @@ class BaseBeaconChainDB(ABC):
         ...
 
     @abstractmethod
-    def get_canonical_head(self, block: BaseBeaconBlock) -> None:
+    def get_canonical_head(self, block_class: Type[BaseBeaconBlock]) -> BaseBeaconBlock:
         """
         Prefer to read the canonical head from the fork choice module.
 

--- a/eth2/beacon/db/chain2.py
+++ b/eth2/beacon/db/chain2.py
@@ -52,7 +52,7 @@ class BeaconChainDB(BaseBeaconChainDB):
         self._state_cache = LRU(STATE_CACHE_SIZE)
         self._state_bytes_written = 0
 
-        self._genesis_time, self._genesis_validators_root = self._get_genesis_data()
+        self.genesis_time, self._genesis_validators_root = self._get_genesis_data()
 
     @classmethod
     def from_genesis(

--- a/eth2/beacon/db/chain2.py
+++ b/eth2/beacon/db/chain2.py
@@ -73,6 +73,7 @@ class BeaconChainDB(BaseBeaconChainDB):
         chain_db.persist_state(genesis_state, config)
 
         chain_db.mark_canonical_block(genesis_block)
+        chain_db.mark_justified_head(genesis_block)
         chain_db.mark_finalized_head(genesis_block)
 
         return chain_db
@@ -130,6 +131,15 @@ class BeaconChainDB(BaseBeaconChainDB):
 
         slot_to_state_root = SchemaV1.slot_to_state_root(block.slot)
         self.db[slot_to_state_root] = block.state_root
+
+    def mark_justified_head(self, block: BaseBeaconBlock) -> None:
+        justified_head_root = SchemaV1.justified_head_root()
+        self.db[justified_head_root] = block.hash_tree_root
+
+    def get_justified_head(self, block_class: Type[BaseBeaconBlock]) -> BaseBeaconBlock:
+        justified_head_root_key = SchemaV1.justified_head_root()
+        justified_head_root = Root(Hash32(self.db[justified_head_root_key]))
+        return self.get_block_by_root(justified_head_root, block_class)
 
     def mark_finalized_head(self, block: BaseBeaconBlock) -> None:
         finalized_head_root = SchemaV1.finalized_head_root()

--- a/eth2/beacon/db/chain2.py
+++ b/eth2/beacon/db/chain2.py
@@ -132,6 +132,15 @@ class BeaconChainDB(BaseBeaconChainDB):
         slot_to_state_root = SchemaV1.slot_to_state_root(block.slot)
         self.db[slot_to_state_root] = block.state_root
 
+    def mark_canonical_head(self, block: BaseBeaconBlock) -> None:
+        canonical_head_root = SchemaV1.canonical_head_root()
+        self.db[canonical_head_root] = block.hash_tree_root
+
+    def get_canonical_head(self, block_class: Type[BaseBeaconBlock]) -> BaseBeaconBlock:
+        canonical_head_root_key = SchemaV1.canonical_head_root()
+        canonical_head_root = Root(Hash32(self.db[canonical_head_root_key]))
+        return self.get_block_by_root(canonical_head_root, block_class)
+
     def mark_justified_head(self, block: BaseBeaconBlock) -> None:
         justified_head_root = SchemaV1.justified_head_root()
         self.db[justified_head_root] = block.hash_tree_root

--- a/eth2/beacon/db/schema2.py
+++ b/eth2/beacon/db/schema2.py
@@ -3,6 +3,10 @@ import ssz
 from eth2.beacon.typing import Root, Slot
 
 
+def canonical_head_root() -> bytes:
+    return b"v1:beacon:canonical-head-root"
+
+
 def justified_head_root() -> bytes:
     return b"v1:beacon:justified-head-root"
 

--- a/eth2/beacon/db/schema2.py
+++ b/eth2/beacon/db/schema2.py
@@ -3,6 +3,10 @@ import ssz
 from eth2.beacon.typing import Root, Slot
 
 
+def justified_head_root() -> bytes:
+    return b"v1:beacon:justified-head-root"
+
+
 def finalized_head_root() -> bytes:
     return b"v1:beacon:finalized-head-root"
 

--- a/eth2/beacon/fork_choice/lmd_ghost2.py
+++ b/eth2/beacon/fork_choice/lmd_ghost2.py
@@ -7,10 +7,12 @@ from typing import (
     NewType,
     Optional,
     Sequence,
+    Tuple,
     TypeVar,
     cast,
 )
 
+from eth2.beacon.constants import GENESIS_SLOT
 from eth2.beacon.db.abc import BaseBeaconChainDB
 from eth2.beacon.epoch_processing_helpers import get_active_validator_indices
 from eth2.beacon.fork_choice.abc import BaseForkChoice, BlockSink
@@ -531,26 +533,41 @@ def _block_node_to_block(node: BlockNode[T]) -> BaseBeaconBlock:
 
 
 def _block_to_block_node(block: BaseBeaconBlock) -> BlockNode[BaseBeaconBlock]:
-    return BlockNode(block.slot, block.hash_tree_root, block)
+    if block.slot == GENESIS_SLOT:
+        root = default_root
+    else:
+        root = block.hash_tree_root
+
+    return BlockNode(block.slot, root, block)
 
 
 class LMDGHOSTForkChoice(BaseForkChoice):
     def __init__(
         self,
         finalized_block_node: BlockNode[BaseBeaconBlock],
-        finalized_state: BeaconState,
+        justified_checkpoint: Checkpoint,
+        justified_state: BeaconState,
         config: Eth2Config,
         block_sink: BlockSink,
     ) -> None:
         self._config = config
+        finalized_checkpoint = Checkpoint.create(
+            epoch=compute_epoch_at_slot(
+                finalized_block_node.slot, config.SLOTS_PER_EPOCH
+            ),
+            root=finalized_block_node.root,
+        )
         self._impl = ProtoArrayForkChoice(
             finalized_block_node,
-            finalized_state.finalized_checkpoint,
-            finalized_state.current_justified_checkpoint,
+            finalized_checkpoint,
+            justified_checkpoint,
             block_sink,
             config,
         )
-        self.update_justified(finalized_state)
+        self._justified = justified_checkpoint
+        self._finalized = finalized_checkpoint
+
+        self.update_justified(justified_state)
 
     @classmethod
     def from_genesis(
@@ -559,27 +576,63 @@ class LMDGHOSTForkChoice(BaseForkChoice):
         # NOTE: patch up genesis state to reflect the genesis block as an initial checkpoint
         # this only has to be patched once at genesis
         genesis_block = get_genesis_block(genesis_state.hash_tree_root, BeaconBlock)
-        genesis_block_node = BlockNode(genesis_block.slot, default_root, genesis_block)
-        return cls(genesis_block_node, genesis_state, config, block_sink)
+        genesis_block_node = _block_to_block_node(genesis_block)
+        justified_checkpoint = Checkpoint.create()
+        return cls(
+            genesis_block_node, justified_checkpoint, genesis_state, config, block_sink
+        )
 
     @classmethod
     def from_db(
         cls, chain_db: BaseBeaconChainDB, config: Eth2Config, block_sink: BlockSink
     ) -> "LMDGHOSTForkChoice":
+        canonical_head = chain_db.get_canonical_head(BeaconBlock)
+        justified_head = chain_db.get_justified_head(BeaconBlock)
         finalized_head = chain_db.get_finalized_head(BeaconBlock)
-        finalized_state = chain_db.get_state_by_root(
-            finalized_head.state_root, BeaconState
-        )
+
+        assert canonical_head.slot >= justified_head.slot >= finalized_head.slot
+
         finalized_head_node = _block_to_block_node(finalized_head)
-        # TODO: need genesis patch up here as well....
-        return cls(finalized_head_node, finalized_state, config, block_sink)
+        justified_checkpoint = Checkpoint.create(
+            epoch=compute_epoch_at_slot(justified_head.slot, config.SLOTS_PER_EPOCH),
+            root=justified_head.hash_tree_root,
+        )
+        justified_state = chain_db.get_state_by_root(
+            justified_head.state_root, BeaconState
+        )
+        fork_choice = cls(
+            finalized_head_node,
+            justified_checkpoint,
+            justified_state,
+            config,
+            block_sink,
+        )
+
+        is_consistent_with_justified = False
+        parent_root = canonical_head.parent_root
+        chain: Tuple[BaseBeaconBlock, ...] = (canonical_head,)
+        while parent_root != finalized_head.hash_tree_root:
+            if parent_root == justified_head.hash_tree_root:
+                is_consistent_with_justified = True
+            parent = chain_db.get_block_by_root(parent_root, BeaconBlock)
+            chain += (parent,)
+            parent_root = parent.parent_root
+
+        assert is_consistent_with_justified
+
+        for block in reversed(chain):
+            fork_choice.on_block(block)
+
+        return fork_choice
 
     def update_justified(self, state: BeaconState) -> None:
         """
         Call when a new ``state`` is justified.
         """
-        self._justified = state.current_justified_checkpoint
-        self._finalized = state.finalized_checkpoint
+        if state.current_justified_checkpoint.epoch > self._justified.epoch:
+            self._justified = state.current_justified_checkpoint
+        if state.finalized_checkpoint.epoch > self._finalized.epoch:
+            self._finalized = state.finalized_checkpoint
 
         # NOTE: prune before updating justified as it touches some internal state...
         self._impl.on_prune(self._finalized.root)

--- a/eth2/beacon/state_machines/forks/medalla/state_machine.py
+++ b/eth2/beacon/state_machines/forks/medalla/state_machine.py
@@ -62,6 +62,11 @@ class MedallaStateMachineFast(MedallaStateMachine):
             self._epochs_ctx = EpochsContext(self.config)
             self._epochs_ctx.load_state(state)
 
+        if self._epochs_ctx.current_shuffling.epoch != state.current_epoch(
+            self.config.SLOTS_PER_EPOCH
+        ):
+            self._epochs_ctx.load_state(state)
+
         state = apply_fast_state_transition(
             self._epochs_ctx,
             self.config,

--- a/eth2/beacon/tools/builder/validator.py
+++ b/eth2/beacon/tools/builder/validator.py
@@ -644,7 +644,7 @@ def create_mock_signed_attestations_at_slot(
             target=Checkpoint.create(root=target_root, epoch=target_epoch),
         )
 
-        num_voted_attesters = int(len(committee) * voted_attesters_ratio)
+        num_voted_attesters = max(int(len(committee) * voted_attesters_ratio), 1)
 
         yield _create_mock_signed_attestation(
             state,

--- a/tests/eth2/core/beacon/chains/test_lmd_ghost_chain.py
+++ b/tests/eth2/core/beacon/chains/test_lmd_ghost_chain.py
@@ -7,11 +7,20 @@ from eth2.beacon.chains.exceptions import SlashableBlockError
 from eth2.beacon.chains.testnet.medalla import BeaconChain
 from eth2.beacon.committee_helpers import get_beacon_proposer_index
 from eth2.beacon.constants import ZERO_HASH32
+from eth2.beacon.fork_choice.lmd_ghost2 import LMDGHOSTForkChoice
+from eth2.beacon.state_machines.forks.medalla.configs import MEDALLA_CONFIG
 from eth2.beacon.tools.builder.proposer import create_block, generate_randao_reveal
 from eth2.beacon.tools.builder.validator import create_mock_signed_attestations_at_slot
+from eth2.beacon.types.blocks import BeaconBlock
 from eth2.beacon.types.eth1_data import Eth1Data
 from eth2.beacon.typing import Epoch, Slot
 from eth2.clock import Tick
+from trinity.nodes.beacon.full import ChainDBBlockSink
+
+
+@pytest.fixture(scope="module")
+def config():
+    return MEDALLA_CONFIG
 
 
 @pytest.fixture(scope="module")
@@ -20,7 +29,7 @@ def validator_count():
     NOTE: overriding here for fork choice test where
     it is easier to test weights with more validators
     """
-    return 64
+    return 2048
 
 
 def _build_chain_of_blocks_with_states(
@@ -108,6 +117,75 @@ def test_chain_can_track_canonical_head_without_attestations(
 
 
 @pytest.mark.slow
+def test_chain_can_track_canonical_head_across_restarts(
+    base_db, genesis_state, genesis_block, config, keymap
+):
+    """
+    This test is essentially an integration test for the ability to
+    restore the fork choice context from any state saved in the database.
+
+    1. Build a chain of many epochs
+    2. Advance beyond the genesis condition
+       (can get to first change in finalized head plus a few slots)
+    3. Tear down the ``chain`` instance.
+    4. Make a new one from the database state
+    5. Ensure we can recover last state.
+    6. Import rest of chain and ensure normal operation.
+    """
+    chain = BeaconChain.from_genesis(base_db, genesis_state)
+
+    genesis_head = chain.get_canonical_head()
+    assert genesis_head == genesis_block.message
+
+    some_epochs = 8
+    some_slots = some_epochs * config.SLOTS_PER_EPOCH
+    blocks, _ = _build_chain_of_blocks_with_states(
+        chain, genesis_state, genesis_block.message, some_slots, config, keymap
+    )
+    segment_slot = 4 * config.SLOTS_PER_EPOCH + 3
+    first_segment = ()
+    second_segment = ()
+    for block in blocks:
+        if block.slot <= segment_slot:
+            first_segment += (block,)
+        else:
+            second_segment += (block,)
+
+    for block in first_segment:
+        chain.on_block(block)
+
+    finalized_head = chain.db.get_finalized_head(BeaconBlock)
+    justified_head = chain.db.get_justified_head(BeaconBlock)
+    canonical_head = chain.get_canonical_head()
+    assert finalized_head != genesis_head
+    assert canonical_head == first_segment[-1].message
+
+    chain_db = chain.db
+    del chain
+
+    block_sink = ChainDBBlockSink(chain_db)
+    fork_choice = LMDGHOSTForkChoice.from_db(chain_db, config, block_sink)
+    chain = BeaconChain(chain_db, fork_choice)
+    restored_canonical_head = chain.get_canonical_head()
+    assert canonical_head == restored_canonical_head
+    restored_justified_head = chain.db.get_justified_head(BeaconBlock)
+    assert justified_head == restored_justified_head
+    restored_finalized_head = chain.db.get_finalized_head(BeaconBlock)
+    assert finalized_head == restored_finalized_head
+
+    for block in second_segment:
+        chain.on_block(block)
+
+    finalized_head = chain.db.get_finalized_head(BeaconBlock)
+    justified_head = chain.db.get_justified_head(BeaconBlock)
+    canonical_head = chain.get_canonical_head()
+    assert finalized_head != restored_finalized_head
+    assert justified_head != restored_justified_head
+    assert canonical_head != restored_canonical_head
+    assert canonical_head == second_segment[-1].message
+
+
+@pytest.mark.slow
 def test_chain_can_track_canonical_head(
     base_db, genesis_state, genesis_block, config, keymap
 ):
@@ -163,7 +241,7 @@ def test_chain_can_reorg_with_attestations(
         some_slots,
         config,
         keymap,
-        attestation_participation=0.25,
+        attestation_participation=0.01,
     )
     for block in blocks:
         chain.on_block(block)


### PR DESCRIPTION
Depends on #1981.

Refinement of #1958 to simplify that PR.

### What was wrong?

We did not persist any of the context from the fork choice.

This effectively meant the node would only be able to start, e.g. syncing, from the finalized head. Esp. on testnets, times between updates to finality can take a while and in the syncing use case that means re-syncing potentially large segments of the chain.

### How was it fixed?

Store the canonical chain as seen by fork choice to disk when we shut down the node.

Part of this state concerns the justified head so we persist it as well to help the "long re-sync" situation above by keeping more of the chain context in the event that we can't shut down the fork choice module properly (e.g. crash or some other unclean shutdown).

Reference this state when booting the node and considering when and what to sync.

### To-Do

- [x] refuse to boot if the genesis data is missing (and otherwise, do not require if present)
- [x] add some tests for persistence of justified head
- [x] add some tests for persistence of canonical head
- [x] ensure sync respects present chain history

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://www.washingtonian.com/wp-content/uploads/2019/02/milada-vigerova-1295750-unsplash-scaled.jpg)
