### PR TITLE
Upgrade rlp to faster version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ import os
 import re
 from setuptools import setup, find_packages
 
-PYEVM_DEPENDENCY = "py-evm==0.3.0a18"
+PYEVM_DEPENDENCY = "py-evm@git+https://github.com/cburgdorf/py-evm.git@christoph/upgrade/pyrlp"
 
 
 deps = {
@@ -25,6 +25,7 @@ deps = {
         'trio>=0.13.0,<0.14',
         'trio-typing>=0.3.0,<0.4',
         "upnpclient>=0.0.8,<1",
+        "rlp@git+https://github.com/cburgdorf/pyrlp.git@christoph/feat/rusty-backend",
     ],
     'trinity': [
         "aiohttp==3.6.0",


### PR DESCRIPTION
### What was wrong?

Upcoming version of rlp uses a rust based backend to speed things up. This is just to catch any potential problems that may slipped through.

### How was it fixed?


### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

[//]: # (See: https://trinity-client.readthedocs.io/en/latest/contributing.html#pull-requests)
- [ ] Add entry to the [release notes](https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses]()
