### PR TITLE
Don't block for long on generating a log

### DIFF
--- a/newsfragments/1989.performance.rst
+++ b/newsfragments/1989.performance.rst
@@ -1,0 +1,2 @@
+Transmit the logs to the logging aggregator process in a separate thread. This
+helps avoid holding the async event loop for too long.


### PR DESCRIPTION
### What was wrong?

Related to #1980 

Slow log emission was causing `BasePeerPool._periodically_report_stats()` to hold the event loop for too long.

### How was it fixed?

Push all logs into a queue, and push them into the socket in a different thread.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

[//]: # (See: https://trinity-client.readthedocs.io/en/latest/contributing.html#pull-requests)
- [x] Add entry to the [release notes](https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://i.pinimg.com/236x/c2/3a/a3/c23aa324a2067659d2116c08022fcdc8--teamwork-bestfriends.jpg)
