### PR TITLE
Move command decoding out of the event loop

### DIFF
--- a/newsfragments/1991.performance.rst
+++ b/newsfragments/1991.performance.rst
@@ -1,0 +1,1 @@
+Move command decoding out of the event loop.

--- a/p2p/constants.py
+++ b/p2p/constants.py
@@ -227,3 +227,8 @@ NUM_ROUTING_TABLE_BUCKETS = 256  # number of buckets in the routing table
 #   - should be big enough not to clip typical logs (On a test DEBUG2 run
 #       on mainnet, the largest logs were <2k characters)
 LONGEST_ALLOWED_LOG_STRING = 10000
+
+# Decoding long messages can take a while. We don't want to hold the event
+#   loop for too long. So we push the decoding into a thread pool if the
+#   encoded message is more than this many bytes:
+MAX_IN_LOOP_DECODE_SIZE = 2000


### PR DESCRIPTION
### What was wrong?

Related to #1980 

`_do_multiplexing()->stream_transport_messages->command_type.decode()` was regularly taking 1-1.5 seconds on mainnet tests. Several times in the span of a single block import.

### How was it fixed?

Pushed the decoding into a thread pool.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

[//]: # (See: https://trinity-client.readthedocs.io/en/latest/contributing.html#pull-requests)
- [x] Add entry to the [release notes](https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://i.pinimg.com/236x/6f/ed/2b/6fed2bdda73e852f08ddc086e4f4c912--helping-hands-helping-others.jpg)
