### PR TITLE
Let go of the event loop more often

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -9,8 +9,8 @@ COPY . /usr/src/app
 RUN apt-get update
 RUN apt-get -y install libsnappy-dev
 
-RUN pip install -e .[dev]  --no-cache-dir
-RUN pip install -U trinity --no-cache-dir
+RUN pip install -e .[dev]  --no-cache-dir --use-feature=2020-resolver
+RUN pip install -U trinity --no-cache-dir --use-feature=2020-resolver
 
 RUN echo "Type \`trinity\` to boot or \`trinity --help\` for an overview of commands"
 

--- a/docker/beacon.Dockerfile
+++ b/docker/beacon.Dockerfile
@@ -8,7 +8,7 @@ RUN apt-get update
 RUN apt-get -y install libsnappy-dev gcc g++ cmake
 
 RUN git clone https://github.com/ethereum/trinity.git .
-RUN pip install -e .[eth2-dev] --no-cache-dir
+RUN pip install -e .[eth2-dev] --no-cache-dir --use-feature=2020-resolver
 
 RUN echo "Type \`trinity-beacon\` to boot or \`trinity-beacon --help\` for an overview of commands"
 

--- a/newsfragments/1992.performance.rst
+++ b/newsfragments/1992.performance.rst
@@ -1,0 +1,1 @@
+More cooperative asyncio coroutines in a few places.

--- a/p2p/multiplexer.py
+++ b/p2p/multiplexer.py
@@ -294,10 +294,12 @@ class Multiplexer(MultiplexerAPI):
                 try:
                     # We use an optimistic strategy here of using
                     # `get_nowait()` to reduce the number of times we yield to
-                    # the event loop.  Since this is an async generator it will
-                    # yield to the loop each time it returns a value so we
-                    # don't have to worry about this blocking other processes.
+                    # the event loop.
                     yield msg_queue.get_nowait()
+
+                    # Manually release the event loop if it won't happen during
+                    #   the queue get().
+                    await asyncio.sleep(0)
                 except asyncio.QueueEmpty:
                     yield await msg_queue.get()
 

--- a/p2p/peer.py
+++ b/p2p/peer.py
@@ -328,6 +328,7 @@ class BasePeer(Service):
         for subscriber in self._subscribers:
             self.logger.debug2("Adding %s msg to queue of %s", type(cmd), subscriber)
             subscriber.add_msg(subscriber_msg)
+            await asyncio.sleep(0)
 
     async def disconnect(self, reason: DisconnectReason) -> None:
         """

--- a/setup.py
+++ b/setup.py
@@ -55,6 +55,9 @@ deps = {
         "libp2p==0.1.5",
         # The direct dependency resolves a version conflict between multiaddr and libp2p
         "base58>=1.0.3,<2.0.0",
+        # Temporary patch to match a py-trie pin. After it's loosened in py-evm, drop the
+        #   typing-extensions requirement altogether.
+        "typing-extensions==3.7.4.2",
     ],
     'test': [
         "async-timeout>=3.0.1,<4",
@@ -118,6 +121,9 @@ deps = {
         "asks>=2.3.6,<3",  # validator client
         "anyio>1.3,<1.4",
         "eth-keyfile",  # validator client
+        # Temporary patch to match a py-trie pin. After it's loosened in py-evm, drop the
+        #   typing-extensions requirement altogether.
+        "typing-extensions==3.7.4.2",
     ],
     'eth2-extra': [
         "milagro-bls-binding==1.3.0",

--- a/trinity/sync/beam/backfill.py
+++ b/trinity/sync/beam/backfill.py
@@ -795,7 +795,9 @@ class TrieNodeRequestTracker:
         Return the Trie Fog that can be searched, ignoring any nodes that are currently
         being requested.
         """
-        return self._trie_fog.mark_all_complete(self._active_prefixes)
+        # Must pass in a copy of prefixes, so the set doesn't get modified while
+        #   mark_all_complete is iterating over it.
+        return self._trie_fog.mark_all_complete(self._active_prefixes.copy())
 
     def next_path_to_explore(self, starting_index: Nibbles) -> Nibbles:
         return self._get_eligible_fog().nearest_unknown(starting_index)


### PR DESCRIPTION
### What was wrong?

Related to #1980 

### How was it fixed?

- Push some more long-running methods out of the event loop
- Release the event loop in the middle of executing a series of methods

Bonuses:
- Fix bug where `set` was modified while `trie_fog` was using it to mark some prefixes as complete
- Improve the mid-import log during Beam Sync

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

[//]: # (See: https://trinity-client.readthedocs.io/en/latest/contributing.html#pull-requests)
- [x] Add entry to the [release notes](https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://i.chzbgr.com/full/4533329664/hFB5F65A2/teamwork)
