### PR TITLE
ensure v0.2.x of `sphinxcontrib-asyncio`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -97,7 +97,7 @@ deps = {
         # Sphinx pined to `<1.8.0`: https://github.com/sphinx-doc/sphinx/issues/3494
         "Sphinx>=1.5.5,<1.8.0",
         "sphinx_rtd_theme>=0.1.9",
-        "sphinxcontrib-asyncio>=0.2.0",
+        "sphinxcontrib-asyncio>=0.2.0,<0.3",
         "towncrier>=19.2.0, <20",
     ],
     'dev': [


### PR DESCRIPTION
Recent update seems to have broken our CI


#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://i.pinimg.com/236x/f4/f8/6f/f4f86f5c347b7b1227a8657754a1c322--public-libraries-the-library.jpg)
