### PR TITLE
Fix a crash when handling invalid records in NEIGHBORS packets

### DIFF
--- a/newsfragments/1995.bugfix.rst
+++ b/newsfragments/1995.bugfix.rst
@@ -1,0 +1,2 @@
+Fix a crash when a NEIGHBORS packet contains invalid node records.
+We also no longer process unsolicited NEIGHBORS packets.


### PR DESCRIPTION
A NEIGHBORS packet containing invalid node records would cause trinity
to crash, and that could be used by a malicious actor as we were
processing unsolicited NEIGHBORS packets.

Issue originally reported by Martin Ortner via the bug bounty program