### PR TITLE
Switch TaskQueue.complete() to async

### DIFF
--- a/newsfragments/1997.internal.rst
+++ b/newsfragments/1997.internal.rst
@@ -1,0 +1,1 @@
+Make TaskQueue.complete() async

--- a/trinity/_utils/datastructures.py
+++ b/trinity/_utils/datastructures.py
@@ -170,9 +170,8 @@ class TaskQueue(Generic[TTask]):
                 # wait until there is room in the queue
                 await self._full_lock.acquire()
 
-                # the current number of tasks has changed, can't reuse num_tasks
-                num_tasks = len(self._tasks)
-                open_slots = self._maxsize - num_tasks
+                # the current number of tasks has changed, restart attempt
+                continue
 
             queueing, remaining = remaining[:open_slots], remaining[open_slots:]
 
@@ -235,7 +234,7 @@ class TaskQueue(Generic[TTask]):
 
         return (next_id, pending_tasks)
 
-    def complete(self, batch_id: int, completed: Collection[TTask]) -> None:
+    async def complete(self, batch_id: int, completed: Collection[TTask]) -> None:
         if batch_id not in self._in_progress:
             raise ValidationError(f"batch id {batch_id} not recognized, with tasks {completed!r}")
 
@@ -251,8 +250,17 @@ class TaskQueue(Generic[TTask]):
         incomplete = set(attempted).difference(completed)
 
         for task in incomplete:
-            # These tasks are already counted in the total task count, so there will be room
-            self._open_queue.put_nowait(self._task_wrapper(task))
+            # It seems like there should always be room here, so that a put_nowait would work,
+            #   but for some undiagnosed reason, it occasionally raises QueueFull. See:
+            #   https://github.com/ethereum/trinity/issues/1972
+            wrapped_task = self._task_wrapper(task)
+            try:
+                self._open_queue.put_nowait(wrapped_task)
+            except asyncio.QueueFull:
+                await self._open_queue.put(wrapped_task)
+            else:
+                # Make sure to release the event loop regularly. Sometimes _task_wrapper is slow.
+                await asyncio.sleep(0)
 
         self._tasks.difference_update(completed)
 

--- a/trinity/sync/beam/state.py
+++ b/trinity/sync/beam/state.py
@@ -483,7 +483,8 @@ class BeamDownloader(Service, PeerSubscriber):
         self._time_on_urgent += time_on_urgent
 
         # Complete the task in the TaskQueue
-        self._node_tasks.complete(batch_id, tuple(node_hash for node_hash, _ in nodes_returned))
+        task_hashes = tuple(node_hash for node_hash, _ in nodes_returned)
+        await self._node_tasks.complete(batch_id, task_hashes)
 
         # Re-insert the peers for the next request
         for knight in knights:
@@ -537,7 +538,7 @@ class BeamDownloader(Service, PeerSubscriber):
                     self._min_predictive_peers = new_predictive_peers
 
                 # Prepare to restart
-                self._maybe_useful_nodes.complete(batch_id, ())
+                await self._maybe_useful_nodes.complete(batch_id, ())
                 continue
 
             self._num_predictive_requests_by_peer[peer] += 1
@@ -561,7 +562,8 @@ class BeamDownloader(Service, PeerSubscriber):
         self._total_processed_nodes += len(nodes)
         self._predictive_processed_nodes += len(new_nodes)
 
-        self._maybe_useful_nodes.complete(batch_id, tuple(node_hash for node_hash, _ in nodes))
+        task_hashes = tuple(node_hash for node_hash, _ in nodes)
+        await self._maybe_useful_nodes.complete(batch_id, task_hashes)
 
         # Re-insert the peasant into the tracker
         self._queen_tracker.insert_peer(peer)

--- a/trinity/sync/full/chain.py
+++ b/trinity/sync/full/chain.py
@@ -341,13 +341,13 @@ class BaseBodyChainSyncer(Service, PeerSubscriber):
                 loop = asyncio.get_event_loop()
                 loop.call_later(delay, partial(self._body_peers.put_nowait, peer))
         finally:
-            self._mark_body_download_complete(batch_id, completed_headers)
+            await self._mark_body_download_complete(batch_id, completed_headers)
 
-    def _mark_body_download_complete(
+    async def _mark_body_download_complete(
             self,
             batch_id: int,
             completed_headers: Sequence[BlockHeaderAPI]) -> None:
-        self._block_body_tasks.complete(batch_id, completed_headers)
+        await self._block_body_tasks.complete(batch_id, completed_headers)
 
     async def _get_block_bodies(
             self,
@@ -774,11 +774,11 @@ class FastChainBodySyncer(BaseBodyChainSyncer):
             # stopped and run_task() will raise a LifecycleError.
             peer.manager.run_task(self._run_receipt_download_batch, peer, batch_id, headers)
 
-    def _mark_body_download_complete(
+    async def _mark_body_download_complete(
             self,
             batch_id: int,
             completed_headers: Sequence[BlockHeaderAPI]) -> None:
-        super()._mark_body_download_complete(batch_id, completed_headers)
+        await super()._mark_body_download_complete(batch_id, completed_headers)
         self._block_persist_tracker.finish_prereq(
             BlockPersistPrereqs.STORE_BLOCK_BODIES,
             completed_headers,
@@ -818,7 +818,7 @@ class FastChainBodySyncer(BaseBodyChainSyncer):
                 loop = asyncio.get_event_loop()
                 loop.call_later(delay, partial(self._receipt_peers.put_nowait, peer))
         finally:
-            self._receipt_tasks.complete(batch_id, completed_headers)
+            await self._receipt_tasks.complete(batch_id, completed_headers)
 
     async def _block_body_bundle_processing(self, bundles: Tuple[BlockBodyBundle, ...]) -> None:
         """
@@ -1063,11 +1063,11 @@ class RegularChainBodySyncer(BaseBodyChainSyncer):
             # if the output queue gets full, hang until there is room
             await self._block_body_tasks.add(new_headers)
 
-    def _mark_body_download_complete(
+    async def _mark_body_download_complete(
             self,
             batch_id: int,
             completed_headers: Sequence[BlockHeaderAPI]) -> None:
-        super()._mark_body_download_complete(batch_id, completed_headers)
+        await super()._mark_body_download_complete(batch_id, completed_headers)
         self._block_import_tracker.finish_prereq(
             BlockImportPrereqs.STORE_BLOCK_BODIES,
             completed_headers,

--- a/trinity/sync/full/chain.py
+++ b/trinity/sync/full/chain.py
@@ -101,7 +101,7 @@ from trinity._utils.timer import Timer
 ReceiptBundle = Tuple[Tuple[ReceiptAPI, ...], Tuple[Hash32, Dict[Hash32, bytes]]]
 # (BlockBody, (txn_root, txn_trie_data), uncles_hash)
 BlockBodyBundle = Tuple[
-    BlockBody,
+    BlockAPI,
     Tuple[Hash32, Dict[Hash32, bytes]],
     Hash32,
 ]


### PR DESCRIPTION
### What was wrong?

Fix #1972 

### How was it fixed?

Sometimes the queue gets full. Instead of figuring out why, just switch the `put_nowait()` to a `put()`. This had some knock-on effects, of having to switch some other methods to async.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

[//]: # (See: https://trinity-client.readthedocs.io/en/latest/contributing.html#pull-requests)
- [x] Add entry to the [release notes](https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://i.insider.com/5eb1c3d83dac9a14247eb8b8?width=1100&format=jpeg&auto=webp)
