### PR TITLE
Upgrade py-evm to v0.3.0a19

### DIFF
--- a/newsfragments/2004.feature.rst
+++ b/newsfragments/2004.feature.rst
@@ -1,0 +1,2 @@
+Upgrade py-evm to `v0.3.0-alpha.19
+<https://py-evm.readthedocs.io/en/latest/release_notes.html#py-evm-0-3-0-alpha-19-2020-08-31>`

--- a/scripts/peer.py
+++ b/scripts/peer.py
@@ -104,7 +104,7 @@ async def _main() -> None:
             peer = cast(LESPeer, peer)
             headers = await peer.les_api.get_block_headers(BlockNumber(2440319), max_headers=100)
             peer.les_api.send_get_block_bodies(list(hashes))
-            peer.les_api.send_get_receipts(hashes[0])
+            peer.les_api.send_get_receipts(hashes[:1])
 
     async with background_asyncio_service(peer_pool) as manager:
         for sig in [signal.SIGINT, signal.SIGTERM]:

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ import os
 import re
 from setuptools import setup, find_packages
 
-PYEVM_DEPENDENCY = "py-evm==0.3.0a18"
+PYEVM_DEPENDENCY = "py-evm==0.3.0a19"
 
 
 deps = {
@@ -38,7 +38,7 @@ deps = {
         "ipython>=7.8.0,<7.10.0",  # attach fails with v7.10.{0,1}
         "plyvel==1.2.0",
         PYEVM_DEPENDENCY,
-        "web3>=5.10.0,<6",
+        "web3>=5.12.1,<6",
         "lahja>=0.16.0,<0.17",
         "termcolor>=1.1.0,<2.0.0",
         "uvloop==0.14.0;platform_system=='Linux' or platform_system=='Darwin' or platform_system=='FreeBSD'",  # noqa: E501
@@ -55,9 +55,6 @@ deps = {
         "libp2p==0.1.5",
         # The direct dependency resolves a version conflict between multiaddr and libp2p
         "base58>=1.0.3,<2.0.0",
-        # Temporary patch to match a py-trie pin. After it's loosened in py-evm, drop the
-        #   typing-extensions requirement altogether.
-        "typing-extensions==3.7.4.2",
     ],
     'test': [
         "async-timeout>=3.0.1,<4",
@@ -72,7 +69,7 @@ deps = {
         "pytest-watch>=4.2.0,<4.3",
         # xdist pinned at <1.29 due to: https://github.com/pytest-dev/pytest-xdist/issues/472
         "pytest-xdist>=1.29.0,<1.30",
-        "eth-tester==0.4.0b2",
+        "eth-tester==0.5.0b2",
     ],
     # We have to keep some separation between trio and asyncio based tests
     # because `pytest-asyncio` is greedy and tries to run all asyncio fixtures.

--- a/trinity/_utils/validation.py
+++ b/trinity/_utils/validation.py
@@ -1,6 +1,7 @@
 from typing import (
     Any,
     Dict,
+    Set,
 )
 
 from eth_utils import (
@@ -22,7 +23,8 @@ def validate_transaction_gas_estimation_dict(transaction_dict: Dict[str, Any],
     """Validate a transaction dictionary supplied for an RPC method call"""
     transaction_class = vm.get_transaction_class()
 
-    all_keys = set(transaction_class._meta.field_names)
+    # TODO make meta values, (field names specifically) publicly accessible on RLP objects
+    all_keys: Set[str] = set(transaction_class._meta.field_names)  # type: ignore
     allowed_keys = all_keys.difference(FORBIDDEN_KEYS).union(DERIVED_KEYS)
     spec_keys = set(RENAMED_KEYS.get(field_name, field_name) for field_name in allowed_keys)
 

--- a/trinity/protocol/common/boot.py
+++ b/trinity/protocol/common/boot.py
@@ -3,8 +3,10 @@ from typing import cast, TYPE_CHECKING
 
 from eth_utils import ValidationError
 
-from eth.abc import BlockNumber
-from eth.rlp.headers import BlockHeader
+from eth.abc import (
+    BlockHeaderAPI,
+    BlockNumber,
+)
 from eth.vm.forks import HomesteadVM
 
 from p2p.disconnect import DisconnectReason
@@ -99,7 +101,7 @@ class DAOCheckBootManager(BasePeerBootManager):
             except ValidationError as err:
                 raise DAOForkCheckFailure(f"{self.peer} failed DAO fork check validation: {err}")
 
-    async def _get_tip_header(self) -> BlockHeader:
+    async def _get_tip_header(self) -> BlockHeaderAPI:
         try:
             headers = await self.peer.chain_api.get_block_headers(
                 self.peer.head_info.head_hash,

--- a/trinity/protocol/eth/commands.py
+++ b/trinity/protocol/eth/commands.py
@@ -1,8 +1,7 @@
 from typing import Tuple
 
 from eth_typing import Hash32
-# For some weird reason mypy thinks eth_utils.curried doesn't have those, but it clearly does.
-from eth_utils.curried import (  # type: ignore
+from eth_utils.curried import (
     apply_formatter_at_index,
     apply_formatter_to_array,
 )

--- a/trinity/protocol/les/commands.py
+++ b/trinity/protocol/les/commands.py
@@ -12,8 +12,7 @@ from eth_utils import (
     to_tuple,
     ValidationError,
 )
-# For some weird reason mypy thinks eth_utils.curried doesn't have those, but it clearly does.
-from eth_utils.curried import (  # type: ignore
+from eth_utils.curried import (
     apply_formatter_at_index,
     apply_formatter_to_array,
 )

--- a/trinity/protocol/les/peer.py
+++ b/trinity/protocol/les/peer.py
@@ -141,12 +141,12 @@ class LESPeerFactory(BaseChainPeerFactory):
         v1_handshake_params = StatusPayload(
             version=1,
             announce_type=None,
-            **handshake_params_kwargs,
+            **handshake_params_kwargs,  # type: ignore
         )
         v2_handshake_params = StatusPayload(
             version=2,
             announce_type=2,
-            **handshake_params_kwargs
+            **handshake_params_kwargs,  # type: ignore
         )
 
         return (

--- a/trinity/sync/light/service.py
+++ b/trinity/sync/light/service.py
@@ -39,6 +39,9 @@ from eth_utils import (
 from trie import HexaryTrie
 from trie.exceptions import BadTrieProof
 
+from eth.abc import (
+    BlockHeaderAPI,
+)
 from eth.exceptions import (
     BlockNotFound,
     HeaderNotFound,
@@ -330,7 +333,7 @@ class LightPeerChain(PeerSubscriber, Service, BaseLightPeerChain):
                 f"It is on number {head_number}, maybe an uncle. Retry with an older block hash."
             )
 
-    async def _get_block_header_by_hash(self, block_hash: Hash32, peer: LESPeer) -> BlockHeader:
+    async def _get_block_header_by_hash(self, block_hash: Hash32, peer: LESPeer) -> BlockHeaderAPI:
         """
         A single attempt to get the block header from the given peer.
 


### PR DESCRIPTION
Wanted the latest py-evm for fixes, speed, and improved logging. (Importantly, the rust-based rlp)

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

[//]: # (See: https://trinity-client.readthedocs.io/en/latest/contributing.html#pull-requests)
- [x] Add entry to the [release notes](https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://cdn.ppcorn.com/wp-content/uploads/sites/14/2018/09/aaa-1074x636.jpg)