### PR TITLE
Sync tweaks

### DIFF
--- a/p2p/asyncio_utils.py
+++ b/p2p/asyncio_utils.py
@@ -99,8 +99,11 @@ async def cancel_pending_tasks(*tasks: asyncio.Task[Any], timeout: int) -> Async
             # slow cleanup the othders don't have to wait for it.
             done, pending = await asyncio.wait(cancelled, timeout=timeout)
             if pending:
+                # These tasks might need to be pickled to pass across the process boundary
+                unfinished = [repr(task) for task in pending]
                 errors.append(
-                    asyncio.TimeoutError("Tasks never returned after being cancelled: %s", pending))
+                    asyncio.TimeoutError("Tasks never returned after being cancelled", unfinished),
+                )
             # We use future as the variable name here because that's what asyncio.wait returns
             # above.
             for future in done:

--- a/trinity/sync/beam/backfill.py
+++ b/trinity/sync/beam/backfill.py
@@ -638,9 +638,12 @@ class BeamStateBackfill(Service, QueenTrackerAPI):
             if step % 3 == 0:
                 num_storage_trackers = len(self._storage_trackers)
                 if num_storage_trackers:
+                    # Need a copy to avoid changes to the dict in other threads,
+                    #   while the generator loops.
+                    trackers = tuple(self._storage_trackers.values())
                     active_storage_completion = sum(
                         self._complete_trie_fraction(store_tracker)
-                        for store_tracker in self._storage_trackers.values()
+                        for store_tracker in trackers
                     ) / num_storage_trackers
                 else:
                     active_storage_completion = 0

--- a/trinity/sync/beam/chain.py
+++ b/trinity/sync/beam/chain.py
@@ -947,7 +947,11 @@ class MissingDataEventHandler(Service):
     async def _provide_missing_account_tries(self) -> None:
         async for event in self._event_bus.stream(CollectMissingAccount):
             # If a request is coming in from an import on a block that's too old, cancel it
-            if event.block_number >= self.minimum_beam_block_number:
+            should_respond = (
+                event.block_number > self.minimum_beam_block_number
+                or (event.urgent and event.block_number == self.minimum_beam_block_number)
+            )
+            if should_respond:
                 self.manager.run_task(self._hang_until_account_served, event)
             else:
                 await self._event_bus.broadcast(
@@ -957,7 +961,11 @@ class MissingDataEventHandler(Service):
 
     async def _provide_missing_bytecode(self) -> None:
         async for event in self._event_bus.stream(CollectMissingBytecode):
-            if event.block_number >= self.minimum_beam_block_number:
+            should_respond = (
+                event.block_number > self.minimum_beam_block_number
+                or (event.urgent and event.block_number == self.minimum_beam_block_number)
+            )
+            if should_respond:
                 self.manager.run_task(self._hang_until_bytecode_served, event)
             else:
                 await self._event_bus.broadcast(
@@ -967,7 +975,11 @@ class MissingDataEventHandler(Service):
 
     async def _provide_missing_storage(self) -> None:
         async for event in self._event_bus.stream(CollectMissingStorage):
-            if event.block_number >= self.minimum_beam_block_number:
+            should_respond = (
+                event.block_number > self.minimum_beam_block_number
+                or (event.urgent and event.block_number == self.minimum_beam_block_number)
+            )
+            if should_respond:
                 self.manager.run_task(self._hang_until_storage_served, event)
             else:
                 await self._event_bus.broadcast(

--- a/trinity/sync/beam/state.py
+++ b/trinity/sync/beam/state.py
@@ -566,7 +566,11 @@ class BeamDownloader(Service, PeerSubscriber):
         await self._maybe_useful_nodes.complete(batch_id, task_hashes)
 
         # Re-insert the peasant into the tracker
-        self._queen_tracker.insert_peer(peer)
+        if len(nodes):
+            delay = 0.0
+        else:
+            delay = 8.0
+        self._queen_tracker.insert_peer(peer, delay)
 
     async def _get_nodes(
             self,

--- a/trinity/sync/beam/state.py
+++ b/trinity/sync/beam/state.py
@@ -150,28 +150,11 @@ class BeamDownloader(Service, PeerSubscriber):
         :return: how many nodes had to be downloaded
         """
         if urgent:
-            t = Timer()
             num_nodes_found = await self._wait_for_nodes(
                 node_hashes,
                 self._node_tasks,
                 BLOCK_IMPORT_MISSING_STATE_TIMEOUT,
             )
-            # If it took to long to get a single urgent node, then increase "spread" factor
-            if len(node_hashes) == 1 and t.elapsed > MAX_ACCEPTABLE_WAIT_FOR_URGENT_NODE:
-                new_spread_factor = clamp(
-                    0,
-                    self._max_spread_beam_factor(),
-                    self._spread_factor + 1,
-                )
-                if new_spread_factor != self._spread_factor:
-                    self.logger.debug(
-                        "spread-beam-update: Urgent node latency=%.3fs, update factor %d to %d",
-                        t.elapsed,
-                        self._spread_factor,
-                        new_spread_factor,
-                    )
-                    self._queen_tracker.set_desired_knight_count(new_spread_factor)
-                    self._spread_factor = new_spread_factor
         else:
             num_nodes_found = await self._wait_for_nodes(
                 node_hashes,
@@ -481,6 +464,23 @@ class BeamDownloader(Service, PeerSubscriber):
         self._total_processed_nodes += len(new_nodes)
         self._urgent_processed_nodes += len(new_nodes)
         self._time_on_urgent += time_on_urgent
+
+        # If it took to long to get a single urgent node, then increase "spread" factor
+        if len(urgent_hashes) == 1 and time_on_urgent > MAX_ACCEPTABLE_WAIT_FOR_URGENT_NODE:
+            new_spread_factor = clamp(
+                0,
+                self._max_spread_beam_factor(),
+                self._spread_factor + 1,
+            )
+            if new_spread_factor != self._spread_factor:
+                self.logger.debug(
+                    "spread-beam-update: Urgent node latency=%.3fs, update factor %d to %d",
+                    time_on_urgent,
+                    self._spread_factor,
+                    new_spread_factor,
+                )
+                self._queen_tracker.set_desired_knight_count(new_spread_factor)
+                self._spread_factor = new_spread_factor
 
         # Complete the task in the TaskQueue
         task_hashes = tuple(node_hash for node_hash, _ in nodes_returned)


### PR DESCRIPTION
### What was wrong?

- thread unsafe operation crash
- time spent waiting on DB was affecting our perception of the speed of our queen peer
- bad-acting peasants were un-penalized
- when `cancel_pending_tasks` fails due to timeout in another process, it tries to pickle `asyncio.Task` objects and fails
- the block previews run even when the block is being actively (urgently) imported

### How was it fixed?

- copy dict before iterating it
- measure time waiting on queen with *only* the network request
- penalize bad-acting peasants
- include the `repr` of the `Task` instead of the original object, so it's pickle-able
- cancel the block preview when the same block has started importing urgently

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

[//]: # (See: https://trinity-client.readthedocs.io/en/latest/contributing.html#pull-requests)
- [x] ~Add entry to the [release notes](https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)~ None of these bugs were released

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://ichef.bbci.co.uk/news/1024/cpsprodpb/147E0/production/_111063938_i.jpg)
