### PR TITLE
Some improvements to the DappNode package

### DIFF
--- a/dappnode/dappnode_package.json
+++ b/dappnode/dappnode_package.json
@@ -30,7 +30,8 @@
     "Developer Tools"
   ],
   "links": {
-    "homepage": "http://trinity.ethereum.org"
+    "homepage": "http://trinity.ethereum.org",
+    "api": "http://trinity.public.dappnode:8545"
   },
   "license": "MIT"
 }

--- a/dappnode/dappnode_package.json
+++ b/dappnode/dappnode_package.json
@@ -19,7 +19,7 @@
       "trinity_src:/usr/src/app"
     ],
     "environment": [
-      "EXTRA_OPTS=--trinity-root-dir /trinity --enable-http"
+      "EXTRA_OPTS=--trinity-root-dir /trinity --enable-http-apis=net,eth"
     ],
     "restart": "always"
   },

--- a/newsfragments/2009.doc.rst
+++ b/newsfragments/2009.doc.rst
@@ -1,0 +1,1 @@
+Display the JSON-RPC API URL on the DappNode package view


### PR DESCRIPTION
### What was wrong?

1. It's hard to guess the endpoint for the JSON-RPC requests

2. The `--enable-http` flag is gone and `--enable-http-apis` need to be used.

### How was it fixed?

1. Display the JSON-RPC API URL on the package view
2. Enable `eth` and `net` JSON-RPC APIs by default (needed to visualize syncing progress on the dashboard)

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

[//]: # (See: https://trinity-client.readthedocs.io/en/latest/contributing.html#pull-requests)
- [ ] Add entry to the [release notes](https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://i.pinimg.com/originals/ea/d4/19/ead419254596eb93b31be082a7885b9d.webp)
