### PR TITLE
Beam Sync download speedups

### DIFF
--- a/trinity/sync/beam/constants.py
+++ b/trinity/sync/beam/constants.py
@@ -108,3 +108,7 @@ EPOCH_BLOCK_LENGTH = 32
 # The time that the block backfill should idle when there are concurrently no blocks to fill.
 # Once gaps are closed they can only re-occur when beam sync pivots so it's ok to idle a fair while.
 BLOCK_BACKFILL_IDLE_TIME = PREDICTED_BLOCK_TIME * 500
+
+# Preview blocks might be paused, waiting on data that comes in through another avenue, like
+#   urgent data requests, or backfill. Use the following period to check for new data.
+CHECK_PREVIEW_STATE_TIMEOUT = 20.0


### PR DESCRIPTION
Generally, we want to make the urgent nodes resolve as quickly as possible, and keep preview nodes out of the way. So this code splits the two scenarios to make sure we run predictive nodes in a separate thread, and urgent nodes in the event loop.

Also, it was expensive to wake up all those coros every time some new data came in. So now when urgent data comes in, it only wakes up the urgent coros. When predictive data comes in, it only wakes up the relevant predictive coros.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

[//]: # (See: https://trinity-client.readthedocs.io/en/latest/contributing.html#pull-requests)
- [ ] Add entry to the [release notes](https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://www.thesprucepets.com/thmb/YKsWwVabxFCWm3d9gxCTt2ilqcU=/2400x2400/smart/filters:no_upscale()/front-view-closeup-of-black-and-white-spotted-piglet-on-hay-on-a-sunny-day-881477548-5c8ba7b746e0fb000187a286.jpg)
