### PR TITLE
update cryptography dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ deps = {
         "cached-property>=1.5.1,<2",
         "coincurve>=10.0.0,<11.0.0",
         # cryptography does not use semver and allows breaking changes within `0.3` version bumps.
-        "cryptography>=2.5,<2.9",
+        "cryptography>=3.0,<3.2",
         "eth-enr>=0.3.0,<0.4",
         "eth-hash>=0.1.4,<1",
         "eth-keys>=0.3.3,<0.4.0",


### PR DESCRIPTION
### What was wrong?

The `cryptography` library has had some updates.

### How was it fixed?

Updated the dependency.

#### Cute Animal Picture

![funny-animals-get-stuck 16](https://user-images.githubusercontent.com/824194/92185941-6afcdd00-ee12-11ea-99dc-82750f70feba.jpg)

