### PR TITLE
Reduce log level of event loop canary to DEBUG

### DIFF
--- a/trinity/extensibility/component.py
+++ b/trinity/extensibility/component.py
@@ -114,7 +114,8 @@ class BaseIsolatedComponent(BaseComponent):
     """
     endpoint_name: str = None
     loop_monitoring_wakeup_interval = 2
-    loop_monitoring_max_delay = 0.1
+    loop_monitoring_max_delay_debug = 0.1
+    loop_monitoring_max_delay_warning = 1
 
     @abstractmethod
     async def run_in_process(self) -> None:


### PR DESCRIPTION
### What was wrong?

This is what watching my Trinity node looks like

![image](https://user-images.githubusercontent.com/521109/92222526-73e7c000-ee9f-11ea-96f8-dcc262b4d209.png)

The event loop being overloaded hints at a real problem that we will have to continue to tackle but I don't think that these logs should be that prominent for the end user.

### How was it fixed?

Reduce log level to DEBUG.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

[//]: # (See: https://trinity-client.readthedocs.io/en/latest/contributing.html#pull-requests)
- [ ] Add entry to the [release notes](https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://www.bl.uk/britishlibrary/~/media/bl/global/language%20of%20birds/top%20ten%20birdsong.jpg?crop=1&cropX=583&cropY=94&cropW=2942&cropH=1654&cropcachekey=15839429421654&w=685&h=386&dispW=685&dispH=386&hash=7CC1DAFF7C469F7938CDECD24E2B1A6F)
