### PR TITLE
Update trio (and related dependencies)

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -51,7 +51,7 @@ autodoc_default_options = {
 }
 
 autodoc_member_order = 'groupwise'
-autodoc_mock_imports = ["snappy", "libp2p"]
+autodoc_mock_imports = ["snappy"]
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ PYEVM_DEPENDENCY = "py-evm==0.3.0a19"
 
 deps = {
     'p2p': [
-        "async-service==0.1.0a8",
+        "async-service==0.1.0a9",
         "asyncio-cancel-token>=0.2,<0.3",
         "async_lru>=0.1.0,<1.0.0",
         "cached-property>=1.5.1,<2",
@@ -25,13 +25,13 @@ deps = {
         "pysha3>=1.0.0,<2.0.0",
         "python-snappy>=0.5.3",
         "SQLAlchemy>=1.3.3,<2",
-        'trio>=0.13.0,<0.14',
-        'trio-typing>=0.3.0,<0.4',
+        'trio>=0.16.0,<0.17',
+        'trio-typing>=0.5.0,<0.6',
         "upnpclient>=0.0.8,<1",
     ],
     'trinity': [
         "aiohttp==3.6.0",
-        "asyncio-run-in-process==0.1.0a8",
+        "asyncio-run-in-process==0.1.0a9",
         "bloom-filter==1.3",
         "cachetools>=3.1.0,<4.0.0",
         "coincurve>=10.0.0,<11.0.0",
@@ -42,7 +42,7 @@ deps = {
         "plyvel==1.2.0",
         PYEVM_DEPENDENCY,
         "web3>=5.12.1,<6",
-        "lahja>=0.16.0,<0.17",
+        "lahja>=0.17.0,<0.18",
         "termcolor>=1.1.0,<2.0.0",
         "uvloop==0.14.0;platform_system=='Linux' or platform_system=='Darwin' or platform_system=='FreeBSD'",  # noqa: E501
         "websockets>=8.1.0",
@@ -55,9 +55,6 @@ deps = {
         "pyformance==0.4",
         "pymultihash>=0.8.2",
         "psutil>=5.7.0, <6",
-        "libp2p==0.1.5",
-        # The direct dependency resolves a version conflict between multiaddr and libp2p
-        "base58>=1.0.3,<2.0.0",
     ],
     'test': [
         "async-timeout>=3.0.1,<4",
@@ -85,7 +82,7 @@ deps = {
         "pytest-aiohttp>=0.3.0,<0.4",
     ],
     'test-trio': [
-        "pytest-trio>=0.5.2,<0.6",
+        "pytest-trio==0.6.0",
     ],
     'lint': [
         "flake8==3.7.9",
@@ -126,7 +123,6 @@ def filter_dependencies(package_list, *package_name):
 # RTD system so we have to exclude these dependencies when we are in an RTD environment.
 if os.environ.get('READTHEDOCS', False):
     deps['p2p'] = filter_dependencies(deps['p2p'], 'python-snappy')
-    deps['trinity'] = filter_dependencies(deps['trinity'], 'libp2p')
 
 deps['dev'] = (
     deps['dev'] +

--- a/tests-trio/p2p-trio/conftest.py
+++ b/tests-trio/p2p-trio/conftest.py
@@ -51,7 +51,7 @@ async def _manually_driven_discovery(seed, socket, nursery):
         # Wait until we're fully initialized (i.e. until the ENR stub created in the constructor
         # is replaced with the real one).
         while discovery.this_node.enr.sequence_number == 0:
-            await trio.hazmat.checkpoint()
+            await trio.lowlevel.checkpoint()
         yield discovery
 
 
@@ -85,4 +85,4 @@ class ManuallyDrivenDiscoveryService(DiscoveryService):
         # Our parent's consume_datagram() starts a background task to process the msg, so we yield
         # control here to give that a chance to run. This avoid us having to do so in every test
         # that calls consume_datagram().
-        await trio.hazmat.checkpoint()
+        await trio.lowlevel.checkpoint()

--- a/tests-trio/p2p-trio/test_trio_utils.py
+++ b/tests-trio/p2p-trio/test_trio_utils.py
@@ -37,7 +37,7 @@ async def test_gather_sorted(autojump_clock):
 @pytest.mark.trio
 async def test_gather_args():
     async def return_args(*args):
-        await trio.hazmat.checkpoint()
+        await trio.lowlevel.checkpoint()
         return args
 
     results = await gather(

--- a/trinity/extensibility/trio.py
+++ b/trinity/extensibility/trio.py
@@ -54,7 +54,7 @@ class TrioIsolatedComponent(BaseIsolatedComponent):
             else:
                 log_fn = self.logger.debug
 
-            stats = trio.hazmat.current_statistics()
+            stats = trio.lowlevel.current_statistics()
             log_fn(
                 "Event loop blocked or overloaded: delay=%.3fs, tasks=%d, stats=%s",
                 delay,


### PR DESCRIPTION
### What was wrong?

We were using an old version of trio.

### How was it fixed?

Updated it (along with the dependent libraries)

I also removed a few leftover dependencies from the beacon/eth2 implementation that are no longer needed.

#### Cute Animal Picture

![animals-stuck-15](https://user-images.githubusercontent.com/824194/92267388-db9d0b80-ee9d-11ea-95c3-5c48c41ef519.jpg)

