### PR TITLE
Do not let timeout errors escape from wait_first

### DIFF
--- a/p2p/connection.py
+++ b/p2p/connection.py
@@ -131,10 +131,17 @@ class Connection(ConnectionAPI, Service):
                     for behavior in behaviors:
                         behavior.post_apply()
                     await wait_first(futures, max_wait_after_cancellation=2)
+                except asyncio.TimeoutError:
+                    self.logger.warning(
+                        "Timed out waiting for tasks to terminate after cancellation: %s",
+                        futures
+                    )
                 except PeerConnectionLost:
                     # Any of our behaviors may propagate a PeerConnectionLost, which is to be
                     # expected as many Connection APIs used by them can raise that. To avoid a
                     # DaemonTaskExit since we're returning silently, ensure we're cancelled.
+                    pass
+                finally:
                     self.manager.cancel()
 
     async def run_peer(self, peer: 'BasePeer') -> None:

--- a/trinity/components/builtin/syncer/component.py
+++ b/trinity/components/builtin/syncer/component.py
@@ -375,7 +375,14 @@ class SyncerComponent(AsyncioIsolatedComponent):
             # returns.
             node_manager_task = create_task(
                 node_manager.wait_finished(), f'{NodeClass.__name__} wait_finished() task')
-            await wait_first([sync_task, node_manager_task], max_wait_after_cancellation=2)
+            tasks = [sync_task, node_manager_task]
+            try:
+                await wait_first(tasks, max_wait_after_cancellation=2)
+            except asyncio.TimeoutError:
+                self.logger.warning(
+                    "Timed out waiting for tasks to terminate after cancellation: %s",
+                    tasks
+                )
 
     async def launch_sync(self,
                           node: Node[BasePeer],

--- a/trinity/extensibility/asyncio.py
+++ b/trinity/extensibility/asyncio.py
@@ -56,22 +56,38 @@ class AsyncioIsolatedComponent(BaseIsolatedComponent):
                     f'AsyncioIsolatedComponent/{self.name}/eventbus/wait_finished')
                 try:
                     max_wait_after_cancellation = 2
+                    tasks = [do_run_task, eventbus_task, loop_monitoring_task]
                     if self._boot_info.profile:
                         with profiler(f'profile_{self.get_endpoint_name()}'):
-                            await wait_first(
-                                [do_run_task, eventbus_task, loop_monitoring_task],
-                                max_wait_after_cancellation,
-                            )
+                            try:
+                                await wait_first(
+                                    tasks,
+                                    max_wait_after_cancellation,
+                                )
+                            except asyncio.TimeoutError:
+                                self.logger.warning(
+                                    "Timed out waiting for tasks to "
+                                    "terminate after cancellation: %s",
+                                    tasks
+                                )
+
                     else:
                         # XXX: When open_in_process() injects a KeyboardInterrupt into us (via
                         # coro.throw()), we hang forever here, until open_in_process() times
                         # out and sends us a SIGTERM, at which point we exit without executing
                         # either the except or the finally blocks below.
                         # See https://github.com/ethereum/trinity/issues/1711 for more.
-                        await wait_first(
-                            [do_run_task, eventbus_task, loop_monitoring_task],
-                            max_wait_after_cancellation,
-                        )
+                        try:
+                            await wait_first(
+                                tasks,
+                                max_wait_after_cancellation,
+                            )
+                        except asyncio.TimeoutError:
+                            self.logger.warning(
+                                "Timed out waiting for tasks to terminate after cancellation: %s",
+                                tasks
+                            )
+
                 except KeyboardInterrupt:
                     self.logger.debug("%s: KeyboardInterrupt", self)
                     # Currently we never reach this code path, but when we fix the issue above

--- a/trinity/extensibility/component.py
+++ b/trinity/extensibility/component.py
@@ -262,7 +262,14 @@ def run_asyncio_eth1_component(component_type: Type['AsyncioIsolatedComponent'])
         async with _run_eventbus_for_component(component, connect_to_endpoints) as event_bus:
             async with _run_asyncio_component_in_proc(component, event_bus) as component_task:
                 sigint_task = asyncio.create_task(got_sigint.wait())
-                await wait_first([component_task, sigint_task], max_wait_after_cancellation=2)
+                tasks = [component_task, sigint_task]
+                try:
+                    await wait_first(tasks, max_wait_after_cancellation=2)
+                except asyncio.TimeoutError:
+                    logger.warning(
+                        "Timed out waiting for tasks to terminate after cancellation: %s",
+                        tasks
+                    )
 
     loop.run_until_complete(run())
 


### PR DESCRIPTION
### What was wrong?

None of the places that used `wait_first` caught the possible `asyncio.TimeoutError` that is being raised when the cancelled task isn't stopping in the appropriate timeframe.

### How was it fixed?

Citing @gsalgado from #2018 

>We should probably catch TimeoutError and log it as a warning/error wherever we call wait_first(). These could be caused by a bug when terminating any long-running-task/service but may also happen when the event loop is overloaded, so we probably don't want to let them crash a component.

Caught `asyncio.TimeoutError` and logged it as a warning.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

[//]: # (See: https://trinity-client.readthedocs.io/en/latest/contributing.html#pull-requests)
- [ ] ~~Add entry to the [release notes](https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)~~ (I think the bug is only in master)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://live.staticflickr.com/3093/2649846657_3425a0e70c.jpg)
