### PR TITLE
Catch possible exception in trio_utils.wait_first

### DIFF
--- a/trinity/_utils/trio_utils.py
+++ b/trinity/_utils/trio_utils.py
@@ -16,5 +16,9 @@ async def wait_first(callables: Sequence[Callable[[], Awaitable[Any]]]) -> None:
         for task in callables:
             async def _run_then_cancel() -> None:
                 await task()
-                nursery.cancel_scope.cancel()
+                try:
+                    nursery.cancel_scope.cancel()
+                except trio.Cancelled:
+                    # Suppress exception in case the scope was already cancelled
+                    pass
             nursery.start_soon(_run_then_cancel)


### PR DESCRIPTION
### What was wrong?

I investigated this [crash on CI](https://app.circleci.com/pipelines/github/ethereum/trinity/7381/workflows/dbd59a4c-8439-4481-b62a-943209c3afe9/jobs/281501)

```
DEBUG  09-04 20:07:41  async_process_runner.py  b'    INFO  2020-09-04 20:07:41,779        MetricsService  Reporting metrics to _.com\n'
   DEBUG  09-04 20:07:41  async_process_runner.py  b'\x1b[1m\x1b[33m WARNING  2020-09-04 20:07:41,815                influx  Cannot write to _.com: [Errno -2] Name or service not known\x1b[0m\n'
   DEBUG  09-04 20:07:41  async_process_runner.py  b'<bound method TrioIsolatedComponent._do_run of <trinity.components.builtin.metrics.component.MetricsComponent object at 0x7fa13f401ad0>> raised an unexpected exception\n'
   DEBUG  09-04 20:07:41  async_process_runner.py  b'Traceback (most recent call last):\n'
   DEBUG  09-04 20:07:41  async_process_runner.py  b'  File "/home/circleci/repo/.tox/py37-wheel-cli/lib/python3.7/site-packages/async_service/trio.py", line 409, in background_trio_service\n'
   DEBUG  09-04 20:07:41  async_process_runner.py  b'    yield manager\n'
   DEBUG  09-04 20:07:41  async_process_runner.py  b'  File "/home/circleci/repo/trinity/_utils/services.py", line 37, in run_background_trio_services\n'
   DEBUG  09-04 20:07:41  async_process_runner.py  b'    for manager in managers\n'
   DEBUG  09-04 20:07:41  async_process_runner.py  b'  File "/home/circleci/repo/trinity/_utils/trio_utils.py", line 20, in wait_first\n'
   DEBUG  09-04 20:07:41  async_process_runner.py  b'    nursery.start_soon(_run_then_cancel)\n'
   DEBUG  09-04 20:07:41  async_process_runner.py  b'  File "/home/circleci/repo/.tox/py37-wheel-cli/lib/python3.7/site-packages/trio/_core/_run.py", line 730, in __aexit__\n'
   DEBUG  09-04 20:07:41  async_process_runner.py  b'    raise combined_error_from_nursery\n'
   DEBUG  09-04 20:07:41  async_process_runner.py  b'trio.MultiError: Cancelled(), Cancelled(), Cancelled(), Cancelled()\n'
   DEBUG  09-04 20:07:41  async_process_runner.py  b'\n'
   DEBUG  09-04 20:07:41  async_process_runner.py  b'Details of embedded exception 1:\n'
   DEBUG  09-04 20:07:41  async_process_runner.py  b'\n'
   DEBUG  09-04 20:07:41  async_process_runner.py  b'  Traceback (most recent call last):\n'
   DEBUG  09-04 20:07:41  async_process_runner.py  b'    File "/home/circleci/repo/.tox/py37-wheel-cli/lib/python3.7/site-packages/trio/_core/_run.py", line 1072, in raise_cancel\n'
   DEBUG  09-04 20:07:41  async_process_runner.py  b'      raise Cancelled._create()\n'
   DEBUG  09-04 20:07:41  async_process_runner.py  b'  trio.Cancelled: Cancelled\n'
   DEBUG  09-04 20:07:41  async_process_runner.py  b'\n'
   DEBUG  09-04 20:07:41  async_process_runner.py  b'Details of embedded exception 2:\n'
   DEBUG  09-04 20:07:41  async_process_runner.py  b'\n'
   DEBUG  09-04 20:07:41  async_process_runner.py  b'  Traceback (most recent call last):\n'
   DEBUG  09-04 20:07:41  async_process_runner.py  b'    File "/home/circleci/repo/trinity/_utils/trio_utils.py", line 18, in _run_then_cancel\n'
   DEBUG  09-04 20:07:41  async_process_runner.py  b'      await task()\n'
   DEBUG  09-04 20:07:41  async_process_runner.py  b'    File "/home/circleci/repo/.tox/py37-wheel-cli/lib/python3.7/site-packages/async_service/trio.py", line 245, in wait_finished\n'
   DEBUG  09-04 20:07:41  async_process_runner.py  b'      await self._finished.wait()\n'
   DEBUG  09-04 20:07:41  async_process_runner.py  b'    File "/home/circleci/repo/.tox/py37-wheel-cli/lib/python3.7/site-packages/trio/_sync.py", line 83, in wait\n'
   DEBUG  09-04 20:07:41  async_process_runner.py  b'      await self._lot.park()\n'
   DEBUG  09-04 20:07:41  async_process_runner.py  b'    File "/home/circleci/repo/.tox/py37-wheel-cli/lib/python3.7/site-packages/trio/_core/_parking_lot.py", line 137, in park\n'
   DEBUG  09-04 20:07:41  async_process_runner.py  b'      await _core.wait_task_rescheduled(abort_fn)\n'
   DEBUG  09-04 20:07:41  async_process_runner.py  b'    File "/home/circleci/repo/.tox/py37-wheel-cli/lib/python3.7/site-packages/trio/_core/_traps.py", line 165, in wait_task_rescheduled\n'
   DEBUG  09-04 20:07:41  async_process_runner.py  b'      return (await _async_yield(WaitTaskRescheduled(abort_func))).unwrap()\n'
   DEBUG  09-04 20:07:41  async_process_runner.py  b'    File "/home/circleci/repo/.tox/py37-wheel-cli/lib/python3.7/site-packages/outcome/_sync.py", line 111, in unwrap\n'
   DEBUG  09-04 20:07:41  async_process_runner.py  b'      raise captured_error\n'
   DEBUG  09-04 20:07:41  async_process_runner.py  b'    File "/home/circleci/repo/.tox/py37-wheel-cli/lib/python3.7/site-packages/trio/_core/_run.py", line 1072, in raise_cancel\n'
   DEBUG  09-04 20:07:41  async_process_runner.py  b'      raise Cancelled._create()\n'
   DEBUG  09-04 20:07:41  async_process_runner.py  b'  trio.Cancelled: Cancelled\n'
   DEBUG  09-04 20:07:41  async_process_runner.py  b'\n'
   DEBUG  09-04 20:07:41  async_process_runner.py  b'Details of embedded exception 3:\n'
   DEBUG  09-04 20:07:41  async_process_runner.py  b'\n'
   DEBUG  09-04 20:07:41  async_process_runner.py  b'  Traceback (most recent call last):\n'
   DEBUG  09-04 20:07:41  async_process_runner.py  b'    File "/home/circleci/repo/trinity/_utils/trio_utils.py", line 18, in _run_then_cancel\n'
   DEBUG  09-04 20:07:41  async_process_runner.py  b'      await task()\n'
   DEBUG  09-04 20:07:41  async_process_runner.py  b'    File "/home/circleci/repo/.tox/py37-wheel-cli/lib/python3.7/site-packages/async_service/trio.py", line 245, in wait_finished\n'
   DEBUG  09-04 20:07:41  async_process_runner.py  b'      await self._finished.wait()\n'
   DEBUG  09-04 20:07:41  async_process_runner.py  b'    File "/home/circleci/repo/.tox/py37-wheel-cli/lib/python3.7/site-packages/trio/_sync.py", line 83, in wait\n'
   DEBUG  09-04 20:07:41  async_process_runner.py  b'      await self._lot.park()\n'
   DEBUG  09-04 20:07:41  async_process_runner.py  b'    File "/home/circleci/repo/.tox/py37-wheel-cli/lib/python3.7/site-packages/trio/_core/_parking_lot.py", line 137, in park\n'
   DEBUG  09-04 20:07:41  async_process_runner.py  b'      await _core.wait_task_rescheduled(abort_fn)\n'
   DEBUG  09-04 20:07:41  async_process_runner.py  b'    File "/home/circleci/repo/.tox/py37-wheel-cli/lib/python3.7/site-packages/trio/_core/_traps.py", line 165, in wait_task_rescheduled\n'
   DEBUG  09-04 20:07:41  async_process_runner.py  b'      return (await _async_yield(WaitTaskRescheduled(abort_func))).unwrap()\n'
   DEBUG  09-04 20:07:41  async_process_runner.py  b'    File "/home/circleci/repo/.tox/py37-wheel-cli/lib/python3.7/site-packages/outcome/_sync.py", line 111, in unwrap\n'
   DEBUG  09-04 20:07:41  async_process_runner.py  b'      raise captured_error\n'
   DEBUG  09-04 20:07:41  async_process_runner.py  b'    File "/home/circleci/repo/.tox/py37-wheel-cli/lib/python3.7/site-packages/trio/_core/_run.py", line 1072, in raise_cancel\n'
   DEBUG  09-04 20:07:41  async_process_runner.py  b'      raise Cancelled._create()\n'
   DEBUG  09-04 20:07:41  async_process_runner.py  b'  trio.Cancelled: Cancelled\n'
   DEBUG  09-04 20:07:41  async_process_runner.py  b'\n'
   DEBUG  09-04 20:07:41  async_process_runner.py  b'Details of embedded exception 4:\n'
   DEBUG  09-04 20:07:41  async_process_runner.py  b'\n'
   DEBUG  09-04 20:07:41  async_process_runner.py  b'  Traceback (most recent call last):\n'
   DEBUG  09-04 20:07:41  async_process_runner.py  b'    File "/home/circleci/repo/trinity/_utils/trio_utils.py", line 18, in _run_then_cancel\n'
   DEBUG  09-04 20:07:41  async_process_runner.py  b'      await task()\n'
   DEBUG  09-04 20:07:41  async_process_runner.py  b'    File "/home/circleci/repo/.tox/py37-wheel-cli/lib/python3.7/site-packages/async_service/trio.py", line 245, in wait_finished\n'
   DEBUG  09-04 20:07:41  async_process_runner.py  b'      await self._finished.wait()\n'
   DEBUG  09-04 20:07:41  async_process_runner.py  b'    File "/home/circleci/repo/.tox/py37-wheel-cli/lib/python3.7/site-packages/trio/_sync.py", line 83, in wait\n'
   DEBUG  09-04 20:07:41  async_process_runner.py  b'      await self._lot.park()\n'
   DEBUG  09-04 20:07:41  async_process_runner.py  b'    File "/home/circleci/repo/.tox/py37-wheel-cli/lib/python3.7/site-packages/trio/_core/_parking_lot.py", line 137, in park\n'
   DEBUG  09-04 20:07:41  async_process_runner.py  b'      await _core.wait_task_rescheduled(abort_fn)\n'
   DEBUG  09-04 20:07:41  async_process_runner.py  b'    File "/home/circleci/repo/.tox/py37-wheel-cli/lib/python3.7/site-packages/trio/_core/_traps.py", line 165, in wait_task_rescheduled\n'
   DEBUG  09-04 20:07:41  async_process_runner.py  b'      return (await _async_yield(WaitTaskRescheduled(abort_func))).unwrap()\n'
   DEBUG  09-04 20:07:41  async_process_runner.py  b'    File "/home/circleci/repo/.tox/py37-wheel-cli/lib/python3.7/site-packages/outcome/_sync.py", line 111, in unwrap\n'
   DEBUG  09-04 20:07:41  async_process_runner.py  b'      raise captured_error\n'
   DEBUG  09-04 20:07:41  async_process_runner.py  b'    File "/home/circleci/repo/.tox/py37-wheel-cli/lib/python3.7/site-packages/trio/_core/_run.py", line 1072, in raise_cancel\n'
   DEBUG  09-04 20:07:41  async_process_runner.py  b'      raise Cancelled._create()\n'
   DEBUG  09-04 20:07:41  async_process_runner.py  b'  trio.Cancelled: Cancelled\n'
   DEBUG  09-04 20:07:41  async_process_runner.py  b'\n'
   DEBUG  09-04 20:07:41  async_process_runner.py  b'During handling of the above exception, another exception occurred:\n'
   DEBUG  09-04 20:07:41  async_process_runner.py  b'\n'
   DEBUG  09-04 20:07:41  async_process_runner.py  b'Traceback (most recent call last):\n'
   DEBUG  09-04 20:07:41  async_process_runner.py  b'  File "/home/circleci/repo/.tox/py37-wheel-cli/lib/python3.7/site-packages/async_service/trio.py", line 409, in background_trio_service\n'
   DEBUG  09-04 20:07:41  async_process_runner.py  b'    yield manager\n'
   DEBUG  09-04 20:07:41  async_process_runner.py  b'  File "/usr/local/lib/python3.7/contextlib.py", line 661, in __aexit__\n'
   DEBUG  09-04 20:07:41  async_process_runner.py  b'    cb_suppress = await cb(*exc_details)\n'
   DEBUG  09-04 20:07:41  async_process_runner.py  b'  File "/usr/local/lib/python3.7/contextlib.py", line 552, in _exit_wrapper\n'
   DEBUG  09-04 20:07:41  async_process_runner.py  b'    return await cm_exit(cm, exc_type, exc, tb)\n'
   DEBUG  09-04 20:07:41  async_process_runner.py  b'  File "/home/circleci/repo/.tox/py37-wheel-cli/lib/python3.7/site-packages/async_generator/_util.py", line 53, in __aexit__\n'
   DEBUG  09-04 20:07:41  async_process_runner.py  b'    await self._agen.athrow(type, value, traceback)\n'
   DEBUG  09-04 20:07:41  async_process_runner.py  b'  File "/home/circleci/repo/.tox/py37-wheel-cli/lib/python3.7/site-packages/async_service/trio.py", line 411, in background_trio_service\n'
   DEBUG  09-04 20:07:41  async_process_runner.py  b'    await manager.stop()\n'
   DEBUG  09-04 20:07:41  async_process_runner.py  b'  File "/home/circleci/repo/.tox/py37-wheel-cli/lib/python3.7/site-packages/trio/_core/_run.py", line 730, in __aexit__\n'
   DEBUG  09-04 20:07:41  async_process_runner.py  b'    raise combined_error_from_nursery\n'
   DEBUG  09-04 20:07:41  async_process_runner.py  b'trio.MultiError: <MultiError: <MultiError: Cancelled(), Cancelled()>, Cancelled(), Cancelled()>, Cancelled(), Cancelled()\n'
   DEBUG  09-04 20:07:41  async_process_runner.py  b'\n'
   DEBUG  09-04 20:07:41  async_process_runner.py  b'Details of embedded exception 1:\n'
   DEBUG  09-04 20:07:41  async_process_runner.py  b'\n'
   DEBUG  09-04 20:07:41  async_process_runner.py  b'  Traceback (most recent call last):\n'
   DEBUG  09-04 20:07:41  async_process_runner.py  b'    File "/home/circleci/repo/.tox/py37-wheel-cli/lib/python3.7/site-packages/async_service/trio.py", line 194, in run\n'
   DEBUG  09-04 20:07:41  async_process_runner.py  b'      system_nursery.cancel_scope.cancel()\n'
   DEBUG  09-04 20:07:41  async_process_runner.py  b'    File "/home/circleci/repo/.tox/py37-wheel-cli/lib/python3.7/site-packages/trio/_core/_run.py", line 730, in __aexit__\n'
   DEBUG  09-04 20:07:41  async_process_runner.py  b'      raise combined_error_from_nursery\n'
   DEBUG  09-04 20:07:41  async_process_runner.py  b'  trio.MultiError: <MultiError: Cancelled(), Cancelled()>, Cancelled(), Cancelled()\n'
```

The test can be run via `pytest tests/integration/test_trinity_cli.py -k 'test_does_not_throw_errors_on_short_run[command4]'` and it is supposed to ensure that Trinity won't crash if the metrics server is unreachable.

First of all, I haven't had any luck trying to reproduce the failure. However, there's a hint in there (`nursery.start_soon(_run_then_cancel)` that the error may originate from here on line 19 if for some reason the scope was already cancelled at the point where we try to cancel it.

https://github.com/ethereum/trinity/blob/0418105378facd76537ef10b47548d094ca4d6b4/trinity/_utils/trio_utils.py#L17-L19

I don't have strong evidence to back this but it's pretty much the only thing I can think of and without being able to reproduce the issue, this is what I got.

### How was it fixed?

Caught `trio.Cancelled` in `_run_then_cancel` of `wait_first`

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

[//]: # (See: https://trinity-client.readthedocs.io/en/latest/contributing.html#pull-requests)
- [ ] Add entry to the [release notes](https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://static.boredpanda.com/blog/wp-content/uploads/2014/02/sleeping-animals-pillows-coverimage.jpg)
