### PR TITLE
Increase timeout to combat flaky test

### DIFF
--- a/tests/p2p/test_peer.py
+++ b/tests/p2p/test_peer.py
@@ -72,6 +72,6 @@ async def test_propagates_behavior_crashes(monkeypatch):
     monkeypatch.setattr(ParagonAPI, '__init__', init)
     with pytest.raises(BehaviorCrash):
         async with ParagonPeerPairFactory() as (alice, _):
-            await asyncio.wait_for(alice.manager.wait_finished(), timeout=0.5)
+            await asyncio.wait_for(alice.manager.wait_finished(), timeout=1)
 
     assert alice.manager.is_cancelled


### PR DESCRIPTION
### What was wrong?

Flaky test https://app.circleci.com/pipelines/github/ethereum/trinity/7403/workflows/6aeacef8-2477-4e7c-86dd-38a0a4939b93/jobs/282319

```
with pytest.raises(BehaviorCrash):
            async with ParagonPeerPairFactory() as (alice, _):
>               await asyncio.wait_for(alice.manager.wait_finished(), timeout=0.5)
E               Failed: DID NOT RAISE <class 'tests.p2p.test_peer.BehaviorCrash'>
```

### How was it fixed?

Increased timeout so that we don't get our crash masqueraded as a `TimeoutError` 

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

[//]: # (See: https://trinity-client.readthedocs.io/en/latest/contributing.html#pull-requests)
- [ ] Add entry to the [release notes](https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://myanimals.com/wp-content/uploads/2018/05/koala-habits.jpg)
