### PR TITLE
Create create-dev-dappnode-image command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -88,6 +88,17 @@ create-dappnode-image: clean
 	cd ./dappnode && dappnodesdk increase $(dappnode_bump)
 	cd ./dappnode && dappnodesdk build
 
+create-dev-dappnode-image: clean
+	# There's currently no way for us to cut dev releases from local files other than pushing these
+	# to GitHub first and then fetching from there. This takes the commit from the current HEAD and
+	# pushes it into a `dappnode_<shortref>` branch in the provided repository (e.g cburgdorf/trinity).
+	git push https://github.com/$(repository).git $(shell git rev-parse HEAD):refs/heads/dappnode_$(shell git rev-parse --short HEAD)
+	sed -i -e 's@ARG GIT_REPOSITORY=.*@ARG GIT_REPOSITORY=$(repository)@g' ./dappnode/build/Dockerfile
+	sed -i -e 's/ARG GITREF=.*/ARG GITREF=dappnode_$(shell git rev-parse --short HEAD)/g' ./dappnode/build/Dockerfile
+	cd ./dappnode && dappnodesdk increase patch
+	cd ./dappnode && dappnodesdk build
+
+
 sdist: clean
 	python setup.py sdist bdist_wheel
 	ls -l dist

--- a/dappnode/build/Dockerfile
+++ b/dappnode/build/Dockerfile
@@ -2,15 +2,14 @@ FROM python:3.7
 
 WORKDIR /usr/src/app
 
-COPY . /usr/src/app
-
 # Install deps
 RUN apt-get update
 RUN apt-get -y install libsnappy-dev gcc g++ cmake
 
+ARG GIT_REPOSITORY=ethereum/trinity
 ARG GITREF=v0.1.0-alpha.36
 
-RUN git clone https://github.com/ethereum/trinity.git
+RUN git clone https://github.com/$GIT_REPOSITORY.git
 RUN cd trinity && git checkout $GITREF && pip install -e .[dev] --no-cache-dir
 
 EXPOSE 30303 30303/udp

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -197,13 +197,13 @@ Prerequisites:
 
     make create-dappnode-image trinity_version=<version> dappnode_bump=<major|minor|patch>
 
-Please note that the dappnode image follows it's own versioning and that the `trinity_version`
-must refer to either a `tag` or a `commit` from this repository. The `dappnode_bump` must be
-either `major`, `minor` or `patch` and should be chosen as follows:
+Please note that the dappnode image follows its own versioning and that the ``trinity_version``
+must refer to either a ``tag`` or a ``commit`` from this repository. The ``dappnode_bump`` must be
+either ``major``, ``minor`` or ``patch`` and should be chosen as follows:
 
 - If the only change in the image is the pinned Trinity version, it should bump the same part
   as the Trinity version bump. E.g. if the image carries a new Trinity patch version, then the
-  dappnode image should also be created with `dappnode_bump=patch`.
+  dappnode image should also be created with ``dappnode_bump=patch``.
 
 - If the image contains other changes (e.g. a fix in the dappnode image itself), then the
   traditional semver rules apply.
@@ -216,8 +216,27 @@ Use the reported `Install link` to install the image on a DappNode.
 
 If the image works as intended, publish it to the APM registry using the Dappnode UI.
 
-- Dappnode Package Name: `trinity.public.dappnode.eth`
-- Next version: `<version-of-dappnode-image>`
-- Manifest hash: `<manifest-hash-as-reported-on-the-console>`
+- Dappnode Package Name: ``trinity.public.dappnode.eth``
+- Next version: ``<version-of-dappnode-image>``
+- Manifest hash: ``<manifest-hash-as-reported-on-the-console>``
 
 Use MetaMask to publish the transaction and wait for it to get included in the chain.
+
+
+How to release *development* dappnode images
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+There's currently no way to create a dappnode package directly from the local source code without it touching
+GitHub first. The following command pushes the current ``HEAD`` commit into the specified GitHub repository
+under the branch name ``dappnode_<short-ref-of-head>``. It then builds a DappNode package that fetches the code
+from that branch.
+
+1. Create the package by invoking the command with a specified repository (e. g ``repository=cburgdorf/trinity``)
+
+.. code:: sh
+
+    make create-dev-dappnode-image repository=<github-account>/<github-repo>
+
+2. Ensure the image can be installed and works
+
+Use the reported `Install link` to install the image on a DappNode.

--- a/newsfragments/2030.doc.rst
+++ b/newsfragments/2030.doc.rst
@@ -1,0 +1,2 @@
+Create ``make create-dev-dappnode-image`` command to make the creation of temporary
+dappnode packages easier and reduce the chances of human error.


### PR DESCRIPTION
### What was wrong?

This is addressing two issues that have recently caused my some trouble.

1. Creating subsequent DappNode images from the same branch name runs into [caching issues on the Dockerfile level](https://stackoverflow.com/questions/36996046/how-to-prevent-dockerfile-caching-git-clone).

2. The current workflow for cutting these releases is cumbersome and involves me pushing branches directly into (ethereum/trinity) which isn't ideal (I clean them up and so far nobody notices but still unfortunate :sweat_smile: )

### How was it fixed?

I'm not super excited about this solution because ideally I would have liked a solution where I would just use `COPY` in the `Dockerfile` to move local files into the image but due to restrictions with file organization and the `dappnodesdk` command that is taking care of dealing with docker that doesn't seem to be easily possible.

What this does instead is that it

1. Makes the `Dockerfile` slightly more flexible by introducing a `GIT_REPOSITORY` variable that defaults to `ethereum/trinity` but can be overwritten to any other repo.

2. It then further creates an additional command `create-dev-dappnode-image` which expects a `repository` parameter that can be set to any personal repository (e.g. `create-dev-dappnode-image repository=cburgdorf/trinity`. The command takes the commit of the current `HEAD` and pushes it into a branch `dappnode_<short-ref-of-head>` and constructs the `Dockerfile` to use that as the `GITREF` and the given `repository` as the `GIT_REPOSITORY`.

This ensures that a.) the cache is always busted (because the `<short-ref-of-head>` changes with every distinct deployment) and b.) development releases do not abuse the `ethereum/trinity` repository as they do today.

Instead, this modifies our existing Dockerfile:

3. It also updates the documentation and kills one unnecessary `COPY` from the `Dockerfile`

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

[//]: # (See: https://trinity-client.readthedocs.io/en/latest/contributing.html#pull-requests)
- [x] Add entry to the [release notes](https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://static.boredpanda.com/blog/wp-content/uploads/2016/01/cute-sleeping-animals-932__605.jpg)
