### PR TITLE
Report beam sync pivot rate and events via metrics

### DIFF
--- a/newsfragments/2040.feature.rst
+++ b/newsfragments/2040.feature.rst
@@ -1,0 +1,1 @@
+Report beam sync pivot rate to metrics for visualization on grafana dashboard.

--- a/trinity/components/builtin/metrics/abc.py
+++ b/trinity/components/builtin/metrics/abc.py
@@ -22,3 +22,7 @@ class MetricsServiceAPI(ServiceAPI):
     @abstractmethod
     def registry(self) -> MetricsRegistry:
         ...
+
+    @abstractmethod
+    async def send_annotation(self, annotation_data: str) -> None:
+        ...

--- a/trinity/components/builtin/metrics/service/noop.py
+++ b/trinity/components/builtin/metrics/service/noop.py
@@ -39,5 +39,8 @@ class NoopMetricsService(Service, MetricsServiceAPI):
     async def continuously_report(self) -> None:
         pass
 
+    async def send_annotation(self, annotation_data: str) -> None:
+        pass
+
 
 NOOP_METRICS_SERVICE = NoopMetricsService()

--- a/trinity/components/builtin/metrics/sync_metrics_registry.py
+++ b/trinity/components/builtin/metrics/sync_metrics_registry.py
@@ -1,0 +1,24 @@
+import time
+
+from eth_typing import BlockNumber
+
+from trinity.components.builtin.metrics.abc import MetricsServiceAPI
+
+
+class SyncMetricsRegistry:
+    """
+    Registry to track weighted moving average of pivot events, and report to InfluxDB.
+    """
+    def __init__(self, metrics_service: MetricsServiceAPI) -> None:
+        self.metrics_service = metrics_service
+        self.pivot_meter = metrics_service.registry.meter('trinity.p2p/sync/pivot_rate.meter')
+
+    async def record_pivot(self, block_number: BlockNumber) -> None:
+        # record pivot and send event annotation to influxdb
+        self.pivot_meter.mark()
+        pivot_time = int(time.time())
+        post_data = (
+            f'events title="beam pivot @ block {block_number}",'
+            f'text="pivot event",tags="{self.metrics_service.registry.host}" {pivot_time}'
+        )
+        await self.metrics_service.send_annotation(post_data)

--- a/trinity/components/builtin/syncer/component.py
+++ b/trinity/components/builtin/syncer/component.py
@@ -34,8 +34,10 @@ from trinity.boot_info import BootInfo
 from trinity.config import (
     Eth1AppConfig,
 )
+from trinity.components.builtin.metrics.abc import MetricsServiceAPI
 from trinity.components.builtin.metrics.component import metrics_service_from_args
 from trinity.components.builtin.metrics.service.asyncio import AsyncioMetricsService
+from trinity.components.builtin.metrics.sync_metrics_registry import SyncMetricsRegistry
 from trinity.components.builtin.metrics.service.noop import NOOP_METRICS_SERVICE
 from trinity.constants import (
     NETWORKING_EVENTBUS_ENDPOINT,
@@ -136,7 +138,8 @@ class BaseSyncStrategy(ABC):
                    chain: AsyncChainAPI,
                    base_db: AtomicDatabaseAPI,
                    peer_pool: BasePeerPool,
-                   event_bus: EndpointAPI) -> None:
+                   event_bus: EndpointAPI,
+                   metrics_service: MetricsServiceAPI = None) -> None:
         ...
 
 
@@ -152,7 +155,8 @@ class NoopSyncStrategy(BaseSyncStrategy):
                    chain: AsyncChainAPI,
                    base_db: AtomicDatabaseAPI,
                    peer_pool: BasePeerPool,
-                   event_bus: EndpointAPI) -> None:
+                   event_bus: EndpointAPI,
+                   metrics_service: MetricsServiceAPI = None) -> None:
 
         logger.info("Node running without sync (--sync-mode=%s)", self.get_sync_mode())
         await asyncio.Future()
@@ -170,7 +174,8 @@ class FullSyncStrategy(BaseSyncStrategy):
                    chain: AsyncChainAPI,
                    base_db: AtomicDatabaseAPI,
                    peer_pool: BasePeerPool,
-                   event_bus: EndpointAPI) -> None:
+                   event_bus: EndpointAPI,
+                   metrics_service: MetricsServiceAPI = None) -> None:
 
         syncer = FullChainSyncer(
             chain,
@@ -205,7 +210,11 @@ class BeamSyncStrategy(BaseSyncStrategy):
                    chain: AsyncChainAPI,
                    base_db: AtomicDatabaseAPI,
                    peer_pool: BasePeerPool,
-                   event_bus: EndpointAPI) -> None:
+                   event_bus: EndpointAPI,
+                   metrics_service: MetricsServiceAPI = None) -> None:
+
+        # create registry for tracking pivot metrics
+        sync_metrics_registry = SyncMetricsRegistry(metrics_service)
 
         syncer = BeamSyncService(
             chain,
@@ -215,7 +224,8 @@ class BeamSyncStrategy(BaseSyncStrategy):
             event_bus,
             args.sync_from_checkpoint,
             args.force_beam_block_number,
-            not args.disable_backfill
+            not args.disable_backfill,
+            sync_metrics_registry,
         )
 
         async with background_asyncio_service(syncer) as manager:
@@ -239,7 +249,8 @@ class HeaderSyncStrategy(BaseSyncStrategy):
                    chain: AsyncChainAPI,
                    base_db: AtomicDatabaseAPI,
                    peer_pool: BasePeerPool,
-                   event_bus: EndpointAPI) -> None:
+                   event_bus: EndpointAPI,
+                   metrics_service: MetricsServiceAPI = None) -> None:
 
         syncer = HeaderChainSyncer(
             chain,
@@ -265,7 +276,8 @@ class LightSyncStrategy(BaseSyncStrategy):
                    chain: AsyncChainAPI,
                    base_db: AtomicDatabaseAPI,
                    peer_pool: BasePeerPool,
-                   event_bus: EndpointAPI) -> None:
+                   event_bus: EndpointAPI,
+                   metrics_service: MetricsServiceAPI = None) -> None:
 
         syncer = LightChainSyncer(
             chain,
@@ -397,6 +409,7 @@ class SyncerComponent(AsyncioIsolatedComponent):
             node.base_db,
             node.get_peer_pool(),
             event_bus,
+            node.metrics_service,
         )
 
 

--- a/trinity/sync/beam/service.py
+++ b/trinity/sync/beam/service.py
@@ -8,6 +8,7 @@ from eth_typing import BlockNumber
 from eth.abc import AtomicDatabaseAPI
 
 from trinity.chains.base import AsyncChainAPI
+from trinity.components.builtin.metrics.sync_metrics_registry import SyncMetricsRegistry
 from trinity.db.eth1.chain import BaseAsyncChainDB
 from trinity.protocol.eth.peer import ETHPeerPool
 from trinity.sync.beam.constants import (
@@ -31,7 +32,8 @@ class BeamSyncService(Service):
             event_bus: EndpointAPI,
             checkpoint: Checkpoint = None,
             force_beam_block_number: BlockNumber = None,
-            enable_header_backfill: bool = False) -> None:
+            enable_header_backfill: bool = False,
+            sync_metrics_registry: SyncMetricsRegistry = None) -> None:
         self.logger = get_logger('trinity.sync.beam.service.BeamSyncService')
         self.chain = chain
         self.chaindb = chaindb
@@ -41,6 +43,7 @@ class BeamSyncService(Service):
         self.checkpoint = checkpoint
         self.force_beam_block_number = force_beam_block_number
         self.enable_header_backfill = enable_header_backfill
+        self.sync_metrics_registry = sync_metrics_registry
 
     async def run(self) -> None:
         head = await self.chaindb.coro_get_canonical_head()
@@ -72,6 +75,9 @@ class BeamSyncService(Service):
             do_pivot = await self._monitor_for_pivot(beam_syncer)
             if do_pivot:
                 self.logger.info("Pivoting Beam Sync to a newer header...")
+                if self.sync_metrics_registry:
+                    latest_block = beam_syncer._body_syncer._latest_block_number
+                    await self.sync_metrics_registry.record_pivot(latest_block)
             else:
                 self.logger.info("No pivot requested. Leaving Beam Syncer closed...")
                 break

--- a/trinity/sync/full/chain.py
+++ b/trinity/sync/full/chain.py
@@ -160,10 +160,10 @@ class BaseBodyChainSyncer(Service, PeerSubscriber):
         # Keep track of some statistics, which is useful for deciding if syncing has stalled
 
         # What is the largest block number reported by a header? (before importing the block)
-        self._highest_header_number = 0
+        self._highest_header_number = BlockNumber(0)
 
         # What is the most recently imported block number? (after importing the block)
-        self._latest_block_number = 0
+        self._latest_block_number = BlockNumber(0)
 
     async def run(self) -> None:
         with self.subscribe(self._peer_pool):


### PR DESCRIPTION
### What was wrong?
Track the number of pivots/hour


### How was it fixed?
Create an event that gets triggered every time a pivot happens. Subscribe to this event and track the rate of pivots with the builtin pyformance weighted moving average, and also send an "annotation" to influxdb to display to event as a red line on the graphs.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

[//]: # (See: https://trinity-client.readthedocs.io/en/latest/contributing.html#pull-requests)
- [x] Add entry to the [release notes](https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

#### Cute Animal Picture
![image](https://user-images.githubusercontent.com/9753150/93112262-668bbc00-f67d-11ea-99b3-d555db796a8c.png)
