### PR TITLE
wait_first() no longer raises TimeoutError when there are rogue tasks

### DIFF
--- a/p2p/connection.py
+++ b/p2p/connection.py
@@ -131,11 +131,6 @@ class Connection(ConnectionAPI, Service):
                     for behavior in behaviors:
                         behavior.post_apply()
                     await wait_first(futures, max_wait_after_cancellation=2)
-                except asyncio.TimeoutError:
-                    self.logger.warning(
-                        "Timed out waiting for tasks to terminate after cancellation: %s",
-                        futures
-                    )
                 except PeerConnectionLost:
                     # Any of our behaviors may propagate a PeerConnectionLost, which is to be
                     # expected as many Connection APIs used by them can raise that. To avoid a

--- a/tests/p2p/test_asyncio_utils.py
+++ b/tests/p2p/test_asyncio_utils.py
@@ -92,14 +92,14 @@ async def test_wait_first_cancelled_task_exception():
 @pytest.mark.asyncio
 async def test_wait_first_rogue_task():
     sleep_after_cancellation = 0.2
-    sleep0_task = create_sleep0_task()
+    raising_task = create_raising_task()
     rogue_task = create_rogue_task(sleep_after_cancellation)
-    sleep_forever_task = create_sleep_forever_task()
 
-    # If a task doesn't return after being cancelled, we get a TimeoutError
-    with pytest.raises(asyncio.TimeoutError):
+    # If a task doesn't return after being cancelled, we still get the exception from the
+    # completed task.
+    with pytest.raises(TaskException):
         await wait_first(
-            [sleep0_task, rogue_task, sleep_forever_task],
+            [raising_task, rogue_task],
             max_wait_after_cancellation=sleep_after_cancellation / 2,
         )
 

--- a/trinity/components/builtin/syncer/component.py
+++ b/trinity/components/builtin/syncer/component.py
@@ -376,13 +376,7 @@ class SyncerComponent(AsyncioIsolatedComponent):
             node_manager_task = create_task(
                 node_manager.wait_finished(), f'{NodeClass.__name__} wait_finished() task')
             tasks = [sync_task, node_manager_task]
-            try:
-                await wait_first(tasks, max_wait_after_cancellation=2)
-            except asyncio.TimeoutError:
-                self.logger.warning(
-                    "Timed out waiting for tasks to terminate after cancellation: %s",
-                    tasks
-                )
+            await wait_first(tasks, max_wait_after_cancellation=2)
 
     async def launch_sync(self,
                           node: Node[BasePeer],

--- a/trinity/extensibility/asyncio.py
+++ b/trinity/extensibility/asyncio.py
@@ -67,17 +67,7 @@ class AsyncioIsolatedComponent(BaseIsolatedComponent):
                     tasks = [do_run_task, eventbus_task, loop_monitoring_task]
                     if self._boot_info.profile:
                         with profiler(f'profile_{self.get_endpoint_name()}'):
-                            try:
-                                await wait_first(
-                                    tasks,
-                                    max_wait_after_cancellation,
-                                )
-                            except asyncio.TimeoutError:
-                                self.logger.warning(
-                                    "Timed out waiting for tasks to "
-                                    "terminate after cancellation: %s",
-                                    tasks
-                                )
+                            await wait_first(tasks, max_wait_after_cancellation)
 
                     else:
                         # XXX: When open_in_process() injects a KeyboardInterrupt into us (via

--- a/trinity/extensibility/component.py
+++ b/trinity/extensibility/component.py
@@ -264,13 +264,7 @@ def run_asyncio_eth1_component(component_type: Type['AsyncioIsolatedComponent'])
             async with _run_asyncio_component_in_proc(component, event_bus) as component_task:
                 sigint_task = asyncio.create_task(got_sigint.wait())
                 tasks = [component_task, sigint_task]
-                try:
-                    await wait_first(tasks, max_wait_after_cancellation=2)
-                except asyncio.TimeoutError:
-                    logger.warning(
-                        "Timed out waiting for tasks to terminate after cancellation: %s",
-                        tasks
-                    )
+                await wait_first(tasks, max_wait_after_cancellation=2)
 
     loop.run_until_complete(run())
 


### PR DESCRIPTION
If any tasks don't return after being cancelled, we simply log a warning
now. That's consistent with asyncio's behavior of logging a warning in
case a task terminates but its result/exception are ignored.