### PR TITLE
Ensure stream_protocol_messages() returns when multiplexer stops streaming

### DIFF
--- a/p2p/auth.py
+++ b/p2p/auth.py
@@ -60,14 +60,9 @@ async def handshake(
         aes_secret, mac_secret, egress_mac, ingress_mac = await _handshake(
             initiator, reader, writer)
     except BaseException:
-        # Note: This is one of two places where we manually handle closing the
-        # reader/writer connection pair in the event of an error during the
-        # peer connection and handshake process.
-        # See `p2p.peer.handshake` for the other.
         if not reader.at_eof():
             reader.feed_eof()
         writer.close()
-        await asyncio.sleep(0)
         raise
 
     return aes_secret, mac_secret, egress_mac, ingress_mac, reader, writer

--- a/p2p/constants.py
+++ b/p2p/constants.py
@@ -35,7 +35,7 @@ MAC_LEN = 16
 # The amount of seconds a connection can be idle.
 CONN_IDLE_TIMEOUT = 30
 
-# The amount of seconds a connection can be idle.
+# The amount of seconds a p2p handshake can take.
 HANDSHAKE_TIMEOUT = 10
 
 # Timeout used when waiting for a reply from a remote node.

--- a/p2p/handshake.py
+++ b/p2p/handshake.py
@@ -367,22 +367,14 @@ async def receive_dial_in(reader: asyncio.StreamReader,
         writer=writer,
         private_key=private_key,
     )
-    try:
-        multiplexer, devp2p_receipt, protocol_receipts = await negotiate_protocol_handshakes(
-            transport=transport,
-            p2p_handshake_params=p2p_handshake_params,
-            protocol_handshakers=protocol_handshakers,
-        )
-    except BaseException:
-        # Note: This is one of two places where we manually handle closing the
-        # reader/writer connection pair in the event of an error during the
-        # peer connection and handshake process.
-        # See `p2p.auth.handshake` for the other.
-        try:
-            await transport.close()
-        except ConnectionResetError:
-            transport.logger.debug("Could not wait for transport to close")
-        raise
+
+    # In case of any errors, negotiate_protocol_handshakes() will close the multiplexer,
+    # which in turn closes the transport, so we don't need to worry about that here.
+    multiplexer, devp2p_receipt, protocol_receipts = await negotiate_protocol_handshakes(
+        transport=transport,
+        p2p_handshake_params=p2p_handshake_params,
+        protocol_handshakers=protocol_handshakers,
+    )
 
     connection = Connection(
         multiplexer=multiplexer,

--- a/p2p/tools/memory_transport.py
+++ b/p2p/tools/memory_transport.py
@@ -6,7 +6,7 @@ from cached_property import cached_property
 from eth_keys import datatypes
 
 from p2p.abc import MessageAPI, NodeAPI, TransportAPI
-from p2p.constants import CONN_IDLE_TIMEOUT
+from p2p import constants
 from p2p.exceptions import PeerConnectionLost
 from p2p.message import Message
 from p2p.session import Session
@@ -62,7 +62,8 @@ class MemoryTransport(TransportAPI):
     async def read(self, n: int) -> bytes:
         self.logger.debug2("Waiting for %s bytes from %s", n, self.remote)
         try:
-            return await asyncio.wait_for(self._reader.readexactly(n), timeout=CONN_IDLE_TIMEOUT)
+            return await asyncio.wait_for(
+                self._reader.readexactly(n), timeout=constants.CONN_IDLE_TIMEOUT)
         except CONNECTION_LOST_ERRORS as err:
             raise PeerConnectionLost from err
 
@@ -91,9 +92,8 @@ class MemoryTransport(TransportAPI):
         self.write(encoded_sizes + message.header + message.body)
 
     async def close(self) -> None:
-        """Close this peer's writer stream.
-
-        This will cause the peer to stop in case it is running.
+        """
+        Close this transport's writer stream.
         """
         await self._writer.drain()
         self._writer.close()

--- a/p2p/transport.py
+++ b/p2p/transport.py
@@ -281,9 +281,8 @@ class Transport(TransportAPI):
         self.write(self._encrypt(header, body))
 
     async def close(self) -> None:
-        """Close this peer's writer stream.
-
-        This will cause the peer to stop in case it is running.
+        """
+        Close this transport's writer stream.
         """
         try:
             await self._writer.drain()

--- a/tests/p2p/test_auth.py
+++ b/tests/p2p/test_auth.py
@@ -39,7 +39,6 @@ from tests.p2p.auth_constants import (
 
 @pytest.mark.asyncio
 async def test_handshake():
-    # TODO: this test should be re-written to not depend on functionality in the `ETHPeer` class.
     use_eip8 = False
     initiator_remote = kademlia.Node.from_pubkey_and_addr(
         keys.PrivateKey(test_values['receiver_private_key']).public_key,


### PR DESCRIPTION
That method could end up waiting forever on a queue.get() call if the
multiplexer stops streaming (i.e. adding items to the queue), and then
asyncio.BaseServer would eventually throw a GeneratorExit into it
(https://bugs.python.org/issue30083) causing a lot of cryptic errors

Closes: #1895