### PR TITLE
Write component to support preferred nodes with discovery disabled

### DIFF
--- a/newsfragments/2051.feature.rst
+++ b/newsfragments/2051.feature.rst
@@ -1,0 +1,1 @@
+Implement a preferred node component to support preferred nodes with discovery disabled.

--- a/trinity/components/builtin/peer_discovery/component.py
+++ b/trinity/components/builtin/peer_discovery/component.py
@@ -29,7 +29,7 @@ from p2p.constants import (
 )
 from p2p.discovery import (
     PreferredNodeDiscoveryService,
-    StaticDiscoveryService,
+    NoopDiscoveryService,
 )
 
 from trinity.config import Eth1AppConfig
@@ -69,9 +69,8 @@ class PeerDiscoveryComponent(TrioIsolatedComponent):
         db = DBClient.connect(config.database_ipc_path)
 
         if boot_info.args.disable_discovery:
-            discovery_service: async_service.Service = StaticDiscoveryService(
+            discovery_service: async_service.Service = NoopDiscoveryService(
                 event_bus,
-                config.preferred_nodes,
             )
         else:
             vm_config = config.get_app_config(Eth1AppConfig).get_chain_config().vm_configuration

--- a/trinity/components/builtin/preferred_node/component.py
+++ b/trinity/components/builtin/preferred_node/component.py
@@ -1,0 +1,122 @@
+import random
+import time
+from typing import Dict, Iterator, List
+
+from async_service import Service, background_trio_service
+from eth_utils import to_tuple
+from lahja import EndpointAPI
+
+from p2p import trio_utils
+from p2p.abc import NodeAPI
+from p2p.constants import DEFAULT_MAX_PEERS
+from trinity._utils.logging import get_logger
+from trinity.constants import TO_NETWORKING_BROADCAST_CONFIG
+from trinity.extensibility import TrioIsolatedComponent
+from trinity.protocol.common.events import (
+    ConnectToNodeCommand,
+    GetConnectedPeersRequest,
+)
+
+
+class PreferredNodeComponent(TrioIsolatedComponent):
+    """
+    Monitor peer pool and attempt to connect to a preferred node
+    when the pool is not at full capacity.
+    """
+    name = "PreferredNode"
+
+    @property
+    def is_enabled(self) -> bool:
+        return bool(self.preferred_nodes)
+
+    @property
+    def max_peers(self) -> int:
+        if self._boot_info.args.max_peers is not None:
+            return self._boot_info.args.max_peers
+        return DEFAULT_MAX_PEERS
+
+    @property
+    def preferred_nodes(self) -> List[NodeAPI]:
+        return self._boot_info.args.preferred_nodes
+
+    async def do_run(self, event_bus: EndpointAPI) -> None:
+        service = PreferredNodeService(event_bus, self.preferred_nodes, self.max_peers)
+        async with background_trio_service(service) as manager:
+            await manager.wait_finished()
+
+
+class PreferredNodeService(Service):
+    preferred_node_recycle_time: int = 300
+    pool_availability_check_period: int = 5
+    _preferred_node_tracker: Dict[NodeAPI, float] = None
+
+    def __init__(
+        self, event_bus: EndpointAPI, preferred_nodes: List[NodeAPI], max_peers: int
+    ) -> None:
+        self.event_bus = event_bus
+        self.max_peers = max_peers
+        self.preferred_nodes = preferred_nodes
+        self._preferred_node_tracker = {}
+        self.logger = get_logger('trinity.components.preferred_node.PreferredNodeService')
+
+    async def run(self) -> None:
+        while self.manager.is_running:
+            await self.periodically_try_to_fill_pool_with_preferred_nodes()
+
+    async def periodically_try_to_fill_pool_with_preferred_nodes(self) -> None:
+        """
+        Check pool for available peer slots, and brodacast command to connect
+        to preferred nodes if there's room in the pool.
+        """
+        # seed _preferred_node_tracker so all preferred nodes are considered eligible initially
+        for node in self.preferred_nodes:
+            self._preferred_node_tracker[node] = time.monotonic() - self.preferred_node_recycle_time
+
+        await self.event_bus.wait_until_any_endpoint_subscribed_to(GetConnectedPeersRequest)
+
+        async for _ in trio_utils.every(self.pool_availability_check_period):
+            response = await self.event_bus.request(GetConnectedPeersRequest())
+            available_slots = self.max_peers - len(response.peers)
+            if available_slots > 0:
+                connected_peers = [peer.session.remote for peer in response.peers]
+                eligible_nodes = self._sample_eligible_preferred_nodes(
+                    connected_peers,
+                    available_slots
+                )
+                for node in eligible_nodes:
+                    await self._connect_to_preferred_node(node)
+
+    async def _connect_to_preferred_node(self, node: NodeAPI) -> None:
+        """
+        Broadcast a command for peer pool to connect to a preferred node,
+        and track the time of attempted connection.
+        """
+        self._preferred_node_tracker[node] = time.monotonic()
+        await self.event_bus.broadcast(
+            ConnectToNodeCommand(node),
+            TO_NETWORKING_BROADCAST_CONFIG,
+        )
+
+    def _sample_eligible_preferred_nodes(
+            self,
+            connected_peers: List[NodeAPI],
+            available_slots: int) -> List[NodeAPI]:
+        """
+        Return a random sampling of preferred_nodes that are eligible for a connection attempt.
+        Sample size attempts to fill all available slots in the peer pool.
+        """
+        eligible_nodes = self._get_eligible_nodes(connected_peers)
+        sample_size = min(available_slots, len(eligible_nodes))
+        return random.sample(eligible_nodes, sample_size)
+
+    @to_tuple
+    def _get_eligible_nodes(self, connected_peers: List[NodeAPI]) -> Iterator[NodeAPI]:
+        """
+        Return all preferred nodes that are not currently connected and have exceeded the recycle
+        time since the last connection attempt.
+        """
+        missing_preferred = [node for node in self.preferred_nodes if node not in connected_peers]
+        for node in missing_preferred:
+            last_used = self._preferred_node_tracker[node]
+            if time.monotonic() - last_used > self.preferred_node_recycle_time:
+                yield node

--- a/trinity/components/registry.py
+++ b/trinity/components/registry.py
@@ -40,6 +40,9 @@ from trinity.components.builtin.network_db.component import (
 from trinity.components.builtin.peer_discovery.component import (
     PeerDiscoveryComponent,
 )
+from trinity.components.builtin.preferred_node.component import (
+    PreferredNodeComponent,
+)
 from trinity.components.builtin.request_server.component import (
     RequestServerComponent,
 )
@@ -61,6 +64,7 @@ BASE_COMPONENTS: Tuple[Type[BaseComponentAPI], ...] = (
     JsonRpcServerComponent,
     NetworkDBComponent,
     PeerDiscoveryComponent,
+    PreferredNodeComponent,
     UpnpComponent,
 )
 


### PR DESCRIPTION
### What was wrong?
Plugin written that continuously pings the peer pool for its connected peers. If there's room in the pool, connect to an eligible, preferred peer. Isolates the concept of "preferred nodes" from discovery, so that a user can supply a `--preferred-node` with `--discovery-disabled`.

Fixes #440 

### How was it fixed?
- Removed the `StaticDiscoveryService` that was a temporary stopgap from #436
- Wrote a `PreferredNodeComponent` that will send a `ConnectToNodeCommand` for a preferred node to the peer pool if the pool is not full.
- It's not obvious to me that this requires its own test since the use case seems to be covered in [this test](https://github.com/ethereum/trinity/blob/a525735d342366a6d987a66a7f90b47ae4832d51/tests/integration/test_trinity_cli.py#L72).

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

[//]: # (See: https://trinity-client.readthedocs.io/en/latest/contributing.html#pull-requests)
- [ ] Add entry to the [release notes](https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

#### Cute Animal Picture
![image](https://user-images.githubusercontent.com/9753150/93638151-67de2100-f9bc-11ea-9562-c8625251b46e.png)

