### PR TITLE
Fix flaky P2P server tests

### DIFF
--- a/p2p/peer_pool.py
+++ b/p2p/peer_pool.py
@@ -110,6 +110,10 @@ class BasePeerPool(Service, AsyncIterable[BasePeer]):
     _report_metrics_interval = 15  # for influxdb/grafana reporting
     _peer_boot_timeout = DEFAULT_PEER_BOOT_TIMEOUT
     _event_bus: EndpointAPI = None
+    # If set to True, any exceptions in ALLOWED_PEER_CONNECTION_EXCEPTIONS will be logged and
+    # suppressed. Should only be set to False in tests we we want to ensure a connection is
+    # successful.
+    _suppress_allowed_connection_exceptions: bool = True
 
     _handshake_locks: ResourceLock[NodeAPI]
     peer_reporter_registry_class: Type[PeerReporterRegistry[Any]] = PeerReporterRegistry[BasePeer]
@@ -488,7 +492,7 @@ class BasePeerPool(Service, AsyncIterable[BasePeer]):
 
         if self._handshake_locks.is_locked(node):
             self.logger.info(
-                "Asked to connect to node when handshake lock is already locked, will wait")
+                "Asked to connect to %s when handshake lock is already locked, will wait", node)
 
         async with self.lock_node_for_handshake(node):
             if self.is_connected_to_node(node):
@@ -502,7 +506,13 @@ class BasePeerPool(Service, AsyncIterable[BasePeer]):
                 async with self._connection_attempt_lock:
                     peer = await self.connect(node)
             except ALLOWED_PEER_CONNECTION_EXCEPTIONS:
-                return
+                if self._suppress_allowed_connection_exceptions:
+                    # These are all logged in self.connect(), so we simply return.
+                    return
+                raise
+            except Exception:
+                self.logger.exception("Unexpected error connecting to %s", node)
+                raise
 
             await self.add_outbound_peer(peer)
 

--- a/p2p/tools/paragon/peer.py
+++ b/p2p/tools/paragon/peer.py
@@ -65,6 +65,7 @@ class ParagonPeerFactory(BasePeerFactory):
 
 
 class ParagonPeerPool(BasePeerPool):
+    _suppress_allowed_connection_exceptions = False
     peer_factory_class = ParagonPeerFactory
     context: ParagonContext
 

--- a/p2p/tools/paragon/peer.py
+++ b/p2p/tools/paragon/peer.py
@@ -65,7 +65,7 @@ class ParagonPeerFactory(BasePeerFactory):
 
 
 class ParagonPeerPool(BasePeerPool):
-    _suppress_allowed_connection_exceptions = False
+    _suppress_connection_exceptions = False
     peer_factory_class = ParagonPeerFactory
     context: ParagonContext
 

--- a/tests/core/p2p-proto/test_server.py
+++ b/tests/core/p2p-proto/test_server.py
@@ -89,6 +89,7 @@ def receiver_remote():
 async def server(event_bus, receiver_remote):
     server = get_server(RECEIVER_PRIVKEY, receiver_remote.address, event_bus)
     async with background_asyncio_service(server):
+        await asyncio.wait_for(server.ready.wait(), timeout=2)
         yield server
 
 
@@ -201,7 +202,7 @@ async def test_peer_pool_connect(monkeypatch, server, receiver_remote):
         await manager.wait_started()
         await initiator_peer_pool.connect_to_nodes(nodes)
 
-        await asyncio.wait_for(peer_started.wait(), timeout=10)
+        await asyncio.wait_for(peer_started.wait(), timeout=2)
 
         assert len(initiator_peer_pool.connected_nodes) == 1
 

--- a/trinity/protocol/common/peer.py
+++ b/trinity/protocol/common/peer.py
@@ -222,20 +222,11 @@ class BaseChainPeerPool(BasePeerPool):
                     "only peers that are blacklisted or already connected to")
                 should_skip = skip_candidate_if_on_list  # type: ignore
 
-            try:
-                candidate_counts = await asyncio.gather(*(
-                    self._add_peers_from_backend(backend, should_skip)
-                    for backend in self.peer_backends
-                ))
-                last_candidates_count = sum(candidate_counts)
-            except asyncio.CancelledError:
-                # no need to log this exception, this is expected
-                raise
-            except Exception:
-                self.logger.exception("unexpected error during peer connection")
-                # Continue trying to connect to peers, even if there was a
-                # surprising failure during one of the attempts.
-                continue
+            candidate_counts = await asyncio.gather(*(
+                self._add_peers_from_backend(backend, should_skip)
+                for backend in self.peer_backends
+            ))
+            last_candidates_count = sum(candidate_counts)
 
     @property
     def vm_configuration(self) -> Tuple[Tuple[BlockNumber, Type[VirtualMachineAPI]], ...]:

--- a/trinity/server.py
+++ b/trinity/server.py
@@ -92,6 +92,7 @@ class BaseServer(Service, Generic[TPeerPool]):
         self.network_id = network_id
         self.max_peers = max_peers
 
+        self.ready = asyncio.Event()
         # child services
         self.peer_pool = self._make_peer_pool()
 
@@ -119,6 +120,7 @@ class BaseServer(Service, Generic[TPeerPool]):
         try:
             async with tcp_listener:
                 self.manager.run_daemon_child_service(self.peer_pool)
+                self.ready.set()
                 await tcp_listener.serve_forever()
         finally:
             self.logger.info("TCP Listener finished, cancelling Server")


### PR DESCRIPTION
    A couple tests could sometimes attempt to connect to a server
    before it was actually listening, and since the PeerPool
    suppresses the UnreachableError (as it is expected), the tests would
    then fail with a TimeoutError, Now the test fixture will only yield
    once the server is listening and the PeerPool used in tests does
    not suppress any errors when connecting.
    
    Also better logs on PeerPool to help debugging and better asyncio
    task names for connection behaviors.

Closes: #1504
