### PR TITLE
Prevent QueueFull error in task queue

### DIFF
--- a/newsfragments/2027.bugfix.rst
+++ b/newsfragments/2027.bugfix.rst
@@ -1,0 +1,1 @@
+Fix the QueueFull error raised occasionally during sync.

--- a/trinity/_utils/datastructures.py
+++ b/trinity/_utils/datastructures.py
@@ -176,19 +176,7 @@ class TaskQueue(Generic[TTask]):
             queueing, remaining = remaining[:open_slots], remaining[open_slots:]
 
             for task in queueing:
-                # There will always be room in _open_queue until _maxsize is reached
-                try:
-                    self._open_queue.put_nowait(task)
-                except asyncio.QueueFull as exc:
-                    task_idx = queueing.index(task)
-                    qsize = self._open_queue.qsize()
-                    raise asyncio.QueueFull(
-                        f'TaskQueue unsuccessful in adding task {task.original!r} ',
-                        f'because qsize={qsize}, '
-                        f'num_tasks={num_tasks}, maxsize={self._maxsize}, open_slots={open_slots}, '
-                        f'num queueing={len(queueing)}, len(_tasks)={len(self._tasks)}, task_idx='
-                        f'{task_idx}, queuing={queueing}, original msg: {exc}',
-                    )
+                await self._open_queue.put(task)
 
             original_queued = tuple(task.original for task in queueing)
             self._tasks.update(original_queued)


### PR DESCRIPTION
### What was wrong?

Fix #2027 

### How was it fixed?

Do an `await q.put()` instead of `q.put_nowait()`.

Still no insight into why it would be possible, but at this point preventing the error is more important.

Eventually, dig into why https://github.com/ethereum/trinity/issues/2027 is happening.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

[//]: # (See: https://trinity-client.readthedocs.io/en/latest/contributing.html#pull-requests)
- [x] Add entry to the [release notes](https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://images.boredomfiles.com/wp-content/uploads/2015/03/19-confused-animals.jpg)
