### PR TITLE
Asyncify metrics reporting to influx

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -30,6 +30,7 @@ deps = {
     ],
     'trinity': [
         "aiohttp==3.6.0",
+        "asks>=2.4.8,<3",
         "argcomplete>=1.10.0,<2",
         "asyncio-run-in-process==0.1.0a10",
         "bloom-filter==1.3",

--- a/tests/integration/test_trinity_cli.py
+++ b/tests/integration/test_trinity_cli.py
@@ -276,7 +276,7 @@ async def test_web3_commands_via_attached_console(command,
         ('trinity', '--sync-mode=light', '--ropsten',),
         # with metrics enabled. We do not have a proper integration test yet and deliberately
         # test against an invalid host for now. We only care about Trinity not crashing.
-        ('trinity', '--enable-metrics', '--metrics-host=ci', '--metrics-influx-server=_.com'),
+        ('trinity', '--enable-metrics', '--metrics-host=ci', '--metrics-influx-server=www.foo.com'),
     )
 )
 @pytest.mark.asyncio

--- a/trinity/components/builtin/metrics/service/asyncio.py
+++ b/trinity/components/builtin/metrics/service/asyncio.py
@@ -7,5 +7,5 @@ class AsyncioMetricsService(BaseMetricsService):
 
     async def continuously_report(self) -> None:
         while self.manager.is_running:
-            super().report_now()
+            await self.report_now()
             await asyncio.sleep(self._reporting_frequency)

--- a/trinity/components/builtin/metrics/service/trio.py
+++ b/trinity/components/builtin/metrics/service/trio.py
@@ -7,4 +7,4 @@ class TrioMetricsService(BaseMetricsService):
 
     async def continuously_report(self) -> None:
         async for _ in trio_utils.every(self._reporting_frequency):
-            super().report_now()
+            await self.report_now()


### PR DESCRIPTION
### What was wrong?
Fixes #2048

Posting metrics to influxdb via the `pyformance.InfluxReporter` was done synchronously, and would be better if it was async.

### How was it fixed?
Due to compatibility issues between `trio` and `aiohttp`, I had to introduce the [`asks`](https://asks.readthedocs.io/en/latest/) library in order to execute calls to influxdb asynchronously.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

[//]: # (See: https://trinity-client.readthedocs.io/en/latest/contributing.html#pull-requests)
- [ ] Add entry to the [release notes](https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

#### Cute Animal Picture
![image](https://user-images.githubusercontent.com/9753150/94074992-fa693080-fdbf-11ea-81b3-997d93c046ae.png)

