### PR TITLE
Fix QueeningQueue to not manually raise CancelledError

### DIFF
--- a/trinity/sync/beam/state.py
+++ b/trinity/sync/beam/state.py
@@ -538,7 +538,9 @@ class BeamDownloader(Service, PeerSubscriber):
         for them. Without waiting for a response from the peer, continue and check if more
         predictive trie nodes are requested. Repeat indefinitely.
         """
-        while self.manager.is_running:
+        # If self._queen_tracker terminates we need to exit as well, so check that on every
+        # iteration.
+        while self.manager.is_running and self._queen_tracker.get_manager().is_running:
             try:
                 batch_id, hashes = await asyncio.wait_for(
                     self._maybe_useful_nodes.get(eth_constants.MAX_STATE_FETCH),


### PR DESCRIPTION
QueeningQueue.pop_fastest_peasant() would raise a CancelledError when the
service finished, but that method runs in a task created by QueeningQueue's
parent service (e.g. BeamDownloader), so that CancelledError would cause
the parent service to terminate as well

This was triggering a bug in async-service that was ultimately causing our
test suite to hang: https://github.com/ethereum/trinity/issues/2053