### PR TITLE
Use aiohttp for reporting metrics annotations

### DIFF
--- a/newsfragments/2069.bugfix.rst
+++ b/newsfragments/2069.bugfix.rst
@@ -1,0 +1,1 @@
+Use asks library for asyncio service http requests.

--- a/trinity/components/builtin/metrics/service/asyncio.py
+++ b/trinity/components/builtin/metrics/service/asyncio.py
@@ -1,9 +1,16 @@
+import aiohttp
 import asyncio
 
 from trinity.components.builtin.metrics.service.base import BaseMetricsService
 
 
 class AsyncioMetricsService(BaseMetricsService):
+    async def async_post(self, data: str) -> None:
+        # use asyncio-compatible aiohttp for async http calls
+        url = self.reporter._get_post_url()
+        auth_header = self.reporter._generate_auth_header()
+        async with aiohttp.ClientSession() as session:
+            await session.post(url, data=data, headers=auth_header)
 
     async def continuously_report(self) -> None:
         while self.manager.is_running:

--- a/trinity/components/builtin/metrics/service/trio.py
+++ b/trinity/components/builtin/metrics/service/trio.py
@@ -1,9 +1,37 @@
+import functools
+from typing import (
+    Callable,
+    TypeVar,
+)
+
+from asks import Session
+
 from p2p import trio_utils
 
 from trinity.components.builtin.metrics.service.base import BaseMetricsService
 
 
+T = TypeVar('T')
+
+
+# temporary workaround to support decorator typing until we can use
+# @functools.cached_property with python version >= 3.8
+# https://github.com/python/mypy/issues/5858
+def cache(func: Callable[..., T]) -> T:
+    return functools.lru_cache()(func)  # type: ignore
+
+
 class TrioMetricsService(BaseMetricsService):
+    @property  # type: ignore
+    @cache
+    def session(self) -> Session:
+        url = self.reporter._get_post_url()
+        auth_header = self.reporter._generate_auth_header()
+        return Session(url, headers=auth_header)
+
+    async def async_post(self, data: str) -> None:
+        # use trio-compatible asks library for async http calls
+        await self.session.post(data=data)
 
     async def continuously_report(self) -> None:
         async for _ in trio_utils.every(self._reporting_frequency):


### PR DESCRIPTION
### What was wrong?
Fixes https://github.com/ethereum/trinity/issues/2068


### How was it fixed?
The `asks` library is incompatible within an asyncio service, so it was updated to use `aiohttp`.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

[//]: # (See: https://trinity-client.readthedocs.io/en/latest/contributing.html#pull-requests)
- [x] Add entry to the [release notes](https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

#### Cute Animal Picture
![image](https://user-images.githubusercontent.com/9753150/94796045-d8654480-03a3-11eb-887b-7e116370888c.png)

