### PR TITLE
#1785 - On Clique, checkpoints need to be aligned with Clique checkpoints

### DIFF
--- a/newsfragments/2072.feature.rst
+++ b/newsfragments/2072.feature.rst
@@ -1,0 +1,1 @@
+Ensure Clique checkpoints align to epoch length when resolving via etherscan.

--- a/tests/integration/test_etherscan_checkpoint_resolver.py
+++ b/tests/integration/test_etherscan_checkpoint_resolver.py
@@ -39,7 +39,7 @@ def test_parse_checkpoint(uri, network_id, min_expected_score):
 @pytest.mark.parametrize(
     'network_id, epoch_length',
     (
-        (GOERLI_NETWORK_ID, 30000),
+        (GOERLI_NETWORK_ID, 30000), # https://eips.ethereum.org/EIPS/eip-225#specification
     )
 )
 def test_get_clique_checkpoint_block_number(network_id, epoch_length):

--- a/tests/integration/test_etherscan_checkpoint_resolver.py
+++ b/tests/integration/test_etherscan_checkpoint_resolver.py
@@ -39,7 +39,7 @@ def test_parse_checkpoint(uri, network_id, min_expected_score):
 @pytest.mark.parametrize(
     'network_id, epoch_length',
     (
-        (GOERLI_NETWORK_ID, 30000), # https://eips.ethereum.org/EIPS/eip-225#specification
+        (GOERLI_NETWORK_ID, 30000),  # https://eips.ethereum.org/EIPS/eip-225#specification
     )
 )
 def test_get_clique_checkpoint_block_number(network_id, epoch_length):

--- a/tests/integration/test_etherscan_checkpoint_resolver.py
+++ b/tests/integration/test_etherscan_checkpoint_resolver.py
@@ -1,9 +1,13 @@
 import pytest
 
-from eth_utils import encode_hex
+from eth_utils import (
+    encode_hex,
+    to_int,
+)
 from trinity.components.builtin.syncer.cli import (
     parse_checkpoint_uri,
     is_block_hash,
+    get_checkpoint_block_byetherscan,
 )
 from trinity.constants import (
     MAINNET_NETWORK_ID,
@@ -30,3 +34,14 @@ def test_parse_checkpoint(uri, network_id, min_expected_score):
     checkpoint = parse_checkpoint_uri(uri, network_id)
     assert checkpoint.score >= min_expected_score
     assert is_block_hash(encode_hex(checkpoint.block_hash))
+
+
+@pytest.mark.parametrize(
+    'network_id, epoch_length',
+    (
+        (GOERLI_NETWORK_ID, 30000),
+    )
+)
+def test_get_clique_checkpoint_block_number(network_id, epoch_length):
+    block = get_checkpoint_block_byetherscan(network_id)
+    assert to_int(hexstr=block.get('number')) % epoch_length == 0

--- a/trinity/_utils/eip1085.py
+++ b/trinity/_utils/eip1085.py
@@ -1,6 +1,3 @@
-from enum import (
-    Enum,
-)
 import json
 from pathlib import Path
 from typing import (
@@ -60,6 +57,10 @@ from eth.vm.forks import (
     MuirGlacierVM,
 )
 
+from trinity.network_configurations import (
+    MiningMethod
+)
+
 
 RawEIP1085Dict = Dict[str, Any]
 
@@ -97,13 +98,6 @@ class GenesisParams(NamedTuple):
             'extra_data': self.extra_data,
             'gas_limit': self.gas_limit,
         }
-
-
-class MiningMethod(Enum):
-
-    NoProof = "noproof"
-    Ethash = "ethash"
-    Clique = "clique"
 
 
 class GenesisData(NamedTuple):

--- a/trinity/components/builtin/syncer/cli.py
+++ b/trinity/components/builtin/syncer/cli.py
@@ -5,6 +5,7 @@ import re
 import urllib
 from typing import (
     Any,
+    Dict,
 )
 
 from eth.consensus.clique.constants import (
@@ -72,8 +73,7 @@ def parse_checkpoint_uri(uri: str, network_id: int) -> Checkpoint:
 BLOCKS_FROM_TIP = 5000
 
 
-def parse_byetherscan_uri(parsed: urllib.parse.ParseResult, network_id: int) -> Checkpoint:
-
+def get_checkpoint_block_byetherscan(network_id: int) -> Dict[str, Any]:
     try:
         network = Network(network_id)
     except ValueError:
@@ -101,7 +101,12 @@ def parse_byetherscan_uri(parsed: urllib.parse.ParseResult, network_id: int) -> 
     else:
         checkpoint_block_number = latest_block_number - BLOCKS_FROM_TIP
 
-    checkpoint_block_response = etherscan_api.get_block_by_number(checkpoint_block_number, network)
+    return etherscan_api.get_block_by_number(checkpoint_block_number, network)
+
+
+def parse_byetherscan_uri(parsed: urllib.parse.ParseResult, network_id: int) -> Checkpoint:
+    checkpoint_block_response = get_checkpoint_block_byetherscan(network_id)
+
     checkpoint_score = to_int(hexstr=checkpoint_block_response['totalDifficulty'])
     checkpoint_hash = checkpoint_block_response['hash']
 

--- a/trinity/components/builtin/syncer/cli.py
+++ b/trinity/components/builtin/syncer/cli.py
@@ -7,6 +7,10 @@ from typing import (
     Any,
 )
 
+from eth.consensus.clique.constants import (
+    EPOCH_LENGTH
+)
+
 from eth_typing import (
     Hash32,
     HexStr,
@@ -20,16 +24,16 @@ from eth_utils import (
     ValidationError,
 )
 
+from trinity.network_configurations import (
+    MiningMethod,
+    PRECONFIGURED_NETWORKS,
+)
+
 from trinity.sync.common.checkpoint import Checkpoint
 
 from .etherscan_api import (
     Etherscan,
     Network,
-)
-
-from trinity.constants import (
-    NETWORK_CONSENSUS_ALGO,
-    CLIQUE_ALGO,
 )
 
 
@@ -42,12 +46,11 @@ def remove_non_digits(value: str) -> str:
 
 
 def get_latest_clique_checkpoint_block_number(network_id: int, latest_block_number: int) -> int:
-    epoch_length = NETWORK_CONSENSUS_ALGO[network_id].get('epoch_length')
     latest_clique_checkpoint_block_number = latest_block_number
 
-    if epoch_length > 0:
+    if EPOCH_LENGTH > 0:
         for block_number in range(latest_block_number, 0, -1):
-            if block_number % epoch_length == 0:
+            if block_number % EPOCH_LENGTH == 0:
                 latest_clique_checkpoint_block_number = block_number
                 break
 
@@ -94,7 +97,7 @@ def parse_byetherscan_uri(parsed: urllib.parse.ParseResult, network_id: int) -> 
 
     latest_block_number = etherscan_api.get_latest_block(network)
 
-    if NETWORK_CONSENSUS_ALGO[network_id].get('name') == CLIQUE_ALGO:
+    if PRECONFIGURED_NETWORKS[network_id].mining_method == MiningMethod.Clique:
         checkpoint_block_number = get_latest_clique_checkpoint_block_number(
             network_id,
             latest_block_number - BLOCKS_FROM_TIP

--- a/trinity/components/builtin/syncer/cli.py
+++ b/trinity/components/builtin/syncer/cli.py
@@ -45,16 +45,13 @@ def remove_non_digits(value: str) -> str:
     return re.sub(r"\D", "", value)
 
 
-def get_latest_clique_checkpoint_block_number(network_id: int, latest_block_number: int) -> int:
-    latest_clique_checkpoint_block_number = latest_block_number
-
+def get_latest_clique_checkpoint_block_number(latest_block_number: int) -> int:
     if EPOCH_LENGTH > 0:
         for block_number in range(latest_block_number, 0, -1):
             if block_number % EPOCH_LENGTH == 0:
-                latest_clique_checkpoint_block_number = block_number
-                break
+                return block_number
 
-    return latest_clique_checkpoint_block_number
+    return latest_block_number
 
 
 def parse_checkpoint_uri(uri: str, network_id: int) -> Checkpoint:
@@ -99,8 +96,7 @@ def parse_byetherscan_uri(parsed: urllib.parse.ParseResult, network_id: int) -> 
 
     if PRECONFIGURED_NETWORKS[network_id].mining_method == MiningMethod.Clique:
         checkpoint_block_number = get_latest_clique_checkpoint_block_number(
-            network_id,
-            latest_block_number - BLOCKS_FROM_TIP
+            latest_block_number - BLOCKS_FROM_TIP,
         )
     else:
         checkpoint_block_number = latest_block_number - BLOCKS_FROM_TIP

--- a/trinity/components/builtin/syncer/cli.py
+++ b/trinity/components/builtin/syncer/cli.py
@@ -95,7 +95,10 @@ def parse_byetherscan_uri(parsed: urllib.parse.ParseResult, network_id: int) -> 
     latest_block_number = etherscan_api.get_latest_block(network)
 
     if NETWORK_CONSENSUS_ALGO[network_id].get('name') == CLIQUE_ALGO:
-        checkpoint_block_number = get_latest_clique_checkpoint_block_number(network_id, latest_block_number - BLOCKS_FROM_TIP)
+        checkpoint_block_number = get_latest_clique_checkpoint_block_number(
+            network_id,
+            latest_block_number - BLOCKS_FROM_TIP
+        )
     else:
         checkpoint_block_number = latest_block_number - BLOCKS_FROM_TIP
 

--- a/trinity/components/builtin/syncer/cli.py
+++ b/trinity/components/builtin/syncer/cli.py
@@ -47,9 +47,9 @@ def get_latest_clique_checkpoint_block_number(network_id: int, latest_block_numb
 
     if epoch_length > 0:
         for block_number in range(latest_block_number, 0, -1):
-                if block_number % epoch_length == 0:
-                    latest_clique_checkpoint_block_number = block_number
-                    break
+            if block_number % epoch_length == 0:
+                latest_clique_checkpoint_block_number = block_number
+                break
 
     return latest_clique_checkpoint_block_number
 

--- a/trinity/config.py
+++ b/trinity/config.py
@@ -68,7 +68,6 @@ from trinity._utils.eip1085 import (
     Account,
     GenesisData,
     GenesisParams,
-    MiningMethod,
     extract_genesis_data,
 )
 from trinity._utils.filesystem import (
@@ -88,7 +87,8 @@ from trinity.constants import (
     SYNC_LIGHT,
 )
 from trinity.network_configurations import (
-    PRECONFIGURED_NETWORKS
+    MiningMethod,
+    PRECONFIGURED_NETWORKS,
 )
 
 

--- a/trinity/constants.py
+++ b/trinity/constants.py
@@ -1,5 +1,9 @@
 from pathlib import Path
-from typing import Dict, Tuple
+from typing import Dict, Tuple, Optional
+
+from mypy_extensions import (
+    TypedDict,
+)
 
 from lahja import (
     BroadcastConfig,
@@ -45,6 +49,30 @@ FIRE_AND_FORGET_BROADCASTING = BroadcastConfig(require_subscriber=False)
 MAINNET_NETWORK_ID = 1
 ROPSTEN_NETWORK_ID = 3
 GOERLI_NETWORK_ID = 5
+
+# Network Consensus Algorithms
+ETHASH_ALGO = 'ethash'
+CLIQUE_ALGO = 'clique'
+
+class ConsensusAlgoDict(TypedDict):
+    name: str
+    epoch_length: Optional[int]
+
+NETWORK_CONSENSUS_ALGO: Dict[int, ConsensusAlgoDict] = {
+    MAINNET_NETWORK_ID: {
+        'name': ETHASH_ALGO,
+        'epoch_length': None,
+    },
+    ROPSTEN_NETWORK_ID: {
+        'name': ETHASH_ALGO,
+        'epoch_length': None,
+    },
+    GOERLI_NETWORK_ID: {
+        'name': CLIQUE_ALGO,
+        'epoch_length': 30000,   # https://eips.ethereum.org/EIPS/eip-225
+    },
+}
+
 
 # Default preferred enodes
 DEFAULT_PREFERRED_NODES: Dict[int, Tuple[Node, ...]] = {

--- a/trinity/constants.py
+++ b/trinity/constants.py
@@ -58,6 +58,7 @@ class ConsensusAlgoDict(TypedDict):
     name: str
     epoch_length: Optional[int]
 
+
 NETWORK_CONSENSUS_ALGO: Dict[int, ConsensusAlgoDict] = {
     MAINNET_NETWORK_ID: {
         'name': ETHASH_ALGO,

--- a/trinity/constants.py
+++ b/trinity/constants.py
@@ -54,6 +54,7 @@ GOERLI_NETWORK_ID = 5
 ETHASH_ALGO = 'ethash'
 CLIQUE_ALGO = 'clique'
 
+
 class ConsensusAlgoDict(TypedDict):
     name: str
     epoch_length: Optional[int]

--- a/trinity/constants.py
+++ b/trinity/constants.py
@@ -1,9 +1,5 @@
 from pathlib import Path
-from typing import Dict, Tuple, Optional
-
-from mypy_extensions import (
-    TypedDict,
-)
+from typing import Dict, Tuple
 
 from lahja import (
     BroadcastConfig,
@@ -49,32 +45,6 @@ FIRE_AND_FORGET_BROADCASTING = BroadcastConfig(require_subscriber=False)
 MAINNET_NETWORK_ID = 1
 ROPSTEN_NETWORK_ID = 3
 GOERLI_NETWORK_ID = 5
-
-# Network Consensus Algorithms
-ETHASH_ALGO = 'ethash'
-CLIQUE_ALGO = 'clique'
-
-
-class ConsensusAlgoDict(TypedDict):
-    name: str
-    epoch_length: Optional[int]
-
-
-NETWORK_CONSENSUS_ALGO: Dict[int, ConsensusAlgoDict] = {
-    MAINNET_NETWORK_ID: {
-        'name': ETHASH_ALGO,
-        'epoch_length': None,
-    },
-    ROPSTEN_NETWORK_ID: {
-        'name': ETHASH_ALGO,
-        'epoch_length': None,
-    },
-    GOERLI_NETWORK_ID: {
-        'name': CLIQUE_ALGO,
-        'epoch_length': 30000,   # https://eips.ethereum.org/EIPS/eip-225
-    },
-}
-
 
 # Default preferred enodes
 DEFAULT_PREFERRED_NODES: Dict[int, Tuple[Node, ...]] = {

--- a/trinity/network_configurations.py
+++ b/trinity/network_configurations.py
@@ -1,3 +1,7 @@
+from enum import (
+    Enum,
+)
+
 from typing import (
     NamedTuple,
     Tuple,
@@ -35,6 +39,13 @@ from trinity.constants import (
 )
 
 
+class MiningMethod(Enum):
+
+    NoProof = "noproof"
+    Ethash = "ethash"
+    Clique = "clique"
+
+
 class Eth1NetworkConfiguration(NamedTuple):
 
     network_id: int
@@ -44,6 +55,7 @@ class Eth1NetworkConfiguration(NamedTuple):
     bootnodes: Tuple[str, ...]
     genesis_header: BlockHeader
     vm_configuration: Tuple[Tuple[BlockNumber, Type[VirtualMachineAPI]], ...]
+    mining_method: MiningMethod
 
 
 PRECONFIGURED_NETWORKS = {
@@ -55,6 +67,7 @@ PRECONFIGURED_NETWORKS = {
         GOERLI_BOOTNODES,
         GOERLI_GENESIS_HEADER,
         GOERLI_VM_CONFIGURATION,
+        MiningMethod.Clique,
     ),
     MAINNET_NETWORK_ID: Eth1NetworkConfiguration(
         MAINNET_NETWORK_ID,
@@ -64,6 +77,7 @@ PRECONFIGURED_NETWORKS = {
         MAINNET_BOOTNODES,
         MAINNET_GENESIS_HEADER,
         MAINNET_VM_CONFIGURATION,
+        MiningMethod.Ethash,
     ),
     ROPSTEN_NETWORK_ID: Eth1NetworkConfiguration(
         ROPSTEN_NETWORK_ID,
@@ -73,5 +87,6 @@ PRECONFIGURED_NETWORKS = {
         ROPSTEN_BOOTNODES,
         ROPSTEN_GENESIS_HEADER,
         ROPSTEN_VM_CONFIGURATION,
+        MiningMethod.Ethash,
     ),
 }


### PR DESCRIPTION
### What was wrong?
Using --sync-from-checkpoint eth://block/byetherscan/latest on Clique networks, like Görli, crashed the application with unexpected exceptions like SnapshotNotFound.


### How was it fixed?
 - The consensus algorithm name was added for each network supported by Trinity, ethash for Mainnet and Ropsten, clique for Görli as constants in trinity/constants.py, along with the epoch_length.
- When retrieving the latest block number for a clique network, Trinity will now search for the latest block number satisfying blocknumber % epoch_length == 0


### To-Do

- First things first : overall, is it a correct way to solve the issue ?
- I've set the new constants, along with a new typing hint class in trinity/constants.py, with the network ids. Is it the right place ?
- I thought of adding a unit test in trinity/tests/integration/test_trinity_cli.py, similar to test_does_not_throw_errors_on_short_run, but that would mean to set the timeout at roughly 120s to be sure the SnapshotNotFound exception is not raised. But it feels a bit too long to me for a unit test ...
Maybe I just should go for a test about the new method get_latest_clique_checkpoint_block_number  in /trinity/tests/integration/test_etherscan_checkpoint_resolver.py ?
- Last point : I tried to read all coding guidelines, but ... maybe I miss some of them ?

#### Cute Animal Picture
Love this section !! :-)
![put a cute animal picture link inside the parentheses](https://toocuteanimal.files.wordpress.com/2017/07/image3.jpg)
