### PR TITLE
Install RLP rust backend explicitly

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -48,6 +48,8 @@ deps = {
         "pyformance==0.4",
         # requests 2.21 is required to support idna 2.8 which is required elsewhere
         "requests>=2.21,<3",
+        # rlp supports an *optional* Rust backend which is why we install it explicitly here
+        "rlp[rust-backend]>=2,<3",
         "termcolor>=1.1.0,<2.0.0",
         "upnp-port-forward>=0.1.1,<0.2",
         "uvloop==0.14.0;platform_system=='Linux' or platform_system=='Darwin' or platform_system=='FreeBSD'",  # noqa: E501


### PR DESCRIPTION
### What was wrong?

`rlp 2.0.0a1` came with a fix dependency against a binary library written in Rust. Unfortunately, the supported binaries leave some platforms unsupported (all 32 bit, ARM etc). A new version `rlp 2.0.0a2` addresses that by making the rust backend entirely optional. That in turn means it has to be enabled explicitly on an application level (e.g. Trinity).

### How was it fixed?

Added dependency against `"rlp[rust-backend]>=2.0.0-alpha.2, <3"`

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

[//]: # (See: https://trinity-client.readthedocs.io/en/latest/contributing.html#pull-requests)
- [ ] Add entry to the [release notes](https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://imgs.abduzeedo.com/files/articles/baby-animals/Baby-Animals-001.jpg)
