### PR TITLE
Handle NoSuchProcess exception when collecting python processes in metrics component

### DIFF
--- a/trinity/components/builtin/metrics/system_metrics_collector.py
+++ b/trinity/components/builtin/metrics/system_metrics_collector.py
@@ -92,6 +92,8 @@ def get_all_python_processes() -> Iterator[psutil.Process]:
     for process in psutil.process_iter():
         try:
             commands = process.cmdline()
+        except psutil.NoSuchProcess:
+            continue
         except psutil.AccessDenied:
             continue
         except psutil.ZombieProcess:


### PR DESCRIPTION
### What was wrong?
Fixes https://github.com/ethereum/trinity/issues/2070


### How was it fixed?
I was unable to reproduce the bug, and I'm guessing it's somewhat rare since I've personally never seen it before. From the stack trace, it seems quite obvious to me how to correctly handle this error and simply ignore the process that no longer exists.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

[//]: # (See: https://trinity-client.readthedocs.io/en/latest/contributing.html#pull-requests)
- [ ] Add entry to the [release notes](https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

#### Cute Animal Picture
![image](https://user-images.githubusercontent.com/9753150/95462816-a2910480-093d-11eb-8750-22102b73f2c7.png)

