### PR TITLE
Add eth_chainId rpc endpoint

### DIFF
--- a/newsfragments/2076.feature.rst
+++ b/newsfragments/2076.feature.rst
@@ -1,0 +1,1 @@
+Add support for the ``eth_chainId`` RPC endpoint.

--- a/tests/core/json-rpc/test_ipc.py
+++ b/tests/core/json-rpc/test_ipc.py
@@ -195,6 +195,10 @@ def uint256_to_bytes(uint):
             {'result': [], 'id': 3, 'jsonrpc': '2.0'},
         ),
         (
+            build_request('eth_chainId'),
+            {'result': '0x539', 'id': 3, 'jsonrpc': '2.0'},
+        ),
+        (
             build_request('eth_mining'),
             {'result': False, 'id': 3, 'jsonrpc': '2.0'},
         ),

--- a/trinity/rpc/modules/eth.py
+++ b/trinity/rpc/modules/eth.py
@@ -30,6 +30,7 @@ from eth_utils import (
     encode_hex,
     int_to_big_endian,
     is_integer,
+    to_hex,
     to_wei,
     ValidationError,
 )
@@ -172,6 +173,10 @@ class Eth(Eth1ChainRPCModule):
     async def blockNumber(self) -> str:
         num = self.chain.get_canonical_head().block_number
         return hex(num)
+
+    async def chainId(self) -> str:
+        chain_id = self.chain.chain_id
+        return to_hex(chain_id)
 
     @format_params(identity, to_int_if_hex)
     @retryable(which_block_arg_name='at_block')


### PR DESCRIPTION
### What was wrong?
Adds support for the `eth_chainId` rpc endpoint.
Fixes https://github.com/ethereum/trinity/issues/1912

### How was it fixed?
It now reports the chain id.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

[//]: # (See: https://trinity-client.readthedocs.io/en/latest/contributing.html#pull-requests)
- [x] Add entry to the [release notes](https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

#### Cute Animal Picture
![image](https://user-images.githubusercontent.com/9753150/95737035-b2b22800-0c4c-11eb-9b33-f9676a4581f6.png)

