### PR TITLE
Support admin_removePeer RPC endpoint

### DIFF
--- a/newsfragments/2077.feature.rst
+++ b/newsfragments/2077.feature.rst
@@ -1,0 +1,1 @@
+Support admin_removePeer RPC endpoint.

--- a/p2p/peer_pool.py
+++ b/p2p/peer_pool.py
@@ -284,6 +284,16 @@ class BasePeerPool(Service, AsyncIterable[BasePeer]):
             peer.connection.get_manager().wait_started(), timeout=PEER_READY_TIMEOUT)
         await peer.connection.run_peer(peer)
 
+    async def disconnect_from_peer(
+        self, peer_session: SessionAPI, reason: DisconnectReason
+    ) -> None:
+        if peer_session in self.connected_nodes:
+            peer = self.connected_nodes[peer_session]
+            self.logger.info("Disconnecting from %s.", peer)
+            await peer.disconnect(reason)
+        else:
+            self.logger.info("Unable to disconnect from %s, since peer is not connected to.", peer)
+
     async def add_inbound_peer(self, peer: BasePeer) -> None:
         try:
             await self._start_peer(peer)

--- a/trinity/protocol/common/events.py
+++ b/trinity/protocol/common/events.py
@@ -20,12 +20,28 @@ from p2p.peer import BasePeer
 from p2p.typing import Capabilities
 
 
+class PeerInfo(NamedTuple):
+    session: SessionAPI
+    capabilities: Capabilities
+    client_version_string: str
+    inbound: bool
+
+
 @dataclass
 class ConnectToNodeCommand(BaseEvent):
     """
     Event that wraps a node URI that the pool should connect to.
     """
     remote: NodeAPI
+
+
+@dataclass
+class DisconnectFromPeerCommand(BaseEvent):
+    """
+    Command to wrap a node session that the pool should disconnect from.
+    """
+    peer_info: PeerInfo
+    reason: DisconnectReason
 
 
 @dataclass
@@ -70,13 +86,6 @@ class PeerLeftEvent(BaseEvent):
     Event broadcasted when a peer left the pool.
     """
     session: SessionAPI
-
-
-class PeerInfo(NamedTuple):
-    session: SessionAPI
-    capabilities: Capabilities
-    client_version_string: str
-    inbound: bool
 
 
 @dataclass


### PR DESCRIPTION
### What was wrong?
JSONRPC support for `admin_removePeer`

Fixes https://github.com/ethereum/trinity/issues/1905

[besu implementation](https://besu.hyperledger.org/en/1.2.1/Reference/Pantheon-API-Methods/#admin_removepeer)
[geth implementation](https://github.com/ethereum/go-ethereum/blob/c0c01612e95dd20f125154646b38283ab780f357/node/api.go#L81)

### How was it fixed?
Added `admin_removePeer` RPC endpoint.
Returns `True` if peer was found in peer pool and an attempt to disconnect was made, `False` otherwise.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

[//]: # (See: https://trinity-client.readthedocs.io/en/latest/contributing.html#pull-requests)
- [x] Add entry to the [release notes](https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

#### Cute Animal Picture
![image](https://user-images.githubusercontent.com/9753150/95985103-ca72e300-0de9-11eb-97f8-78ad96501c5d.png)

