### PR TITLE
Fix flaky tests

### DIFF
--- a/trinity/components/builtin/new_block/component.py
+++ b/trinity/components/builtin/new_block/component.py
@@ -123,6 +123,7 @@ class NewBlockService(Service):
             self._peer_block_tracker[block.hash].append(str(target_peer))
             # add checkpoint here to guarantee the event loop is released per iteration
             await trio.sleep(0)
+        return
 
     async def _broadcast_newly_seen_block(self, header: BlockHeaderAPI) -> None:
         """


### PR DESCRIPTION
### What was wrong?
The `wheel-cli` tests were acting flaky since the introduction of the `NewBlock` component in #2058 


### How was it fixed?
Added an explicit return to an async function in the `NewBlock` component.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

[//]: # (See: https://trinity-client.readthedocs.io/en/latest/contributing.html#pull-requests)
- [ ] Add entry to the [release notes](https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses]()
