### PR TITLE
Handle exception for dead processes in system metrics collecting

### DIFF
--- a/newsfragments/2083.bugfix.rst
+++ b/newsfragments/2083.bugfix.rst
@@ -1,0 +1,1 @@
+Handle error in system metrics collecting for dead processes.

--- a/trinity/components/builtin/metrics/system_metrics_collector.py
+++ b/trinity/components/builtin/metrics/system_metrics_collector.py
@@ -1,5 +1,6 @@
 from typing import (
     Iterator,
+    List,
     NamedTuple,
 )
 
@@ -114,12 +115,21 @@ def read_process_stats() -> ProcessStats:
     main_trinity_process = get_main_trinity_process()
     child_processes = main_trinity_process.children(recursive=True)
     num_processes = len(child_processes) + 1
-    num_child_threads = sum([process.num_threads() for process in child_processes])
+    num_child_threads = sum(collect_thread_counts_for_processes(child_processes))
     num_threads = num_child_threads + main_trinity_process.num_threads()
     return ProcessStats(
         process_count=num_processes,
         thread_count=num_threads,
     )
+
+
+@to_tuple
+def collect_thread_counts_for_processes(all_processes: List[psutil.Process]) -> Iterator[int]:
+    for process in all_processes:
+        try:
+            yield process.num_threads()
+        except psutil.NoSuchProcess:
+            continue
 
 
 @as_service


### PR DESCRIPTION
### What was wrong?
Bug in system metrics collecting causing flaky tests in ci. 

https://app.circleci.com/pipelines/github/ethereum/trinity/7670/workflows/f9029533-eff7-43df-8563-79c4722ca100/jobs/290328

```sh
DEBUG  10-14 09:58:48  async_process_runner.py  b'Traceback (most recent call last):\n'
   DEBUG  10-14 09:58:48  async_process_runner.py  b'  File "/home/circleci/repo/.tox/py37-wheel-cli/lib/python3.7/site-packages/async_service/base.py", line 324, in _run_and_manage_task\n'
   DEBUG  10-14 09:58:48  async_process_runner.py  b'    await task.run()\n'
   DEBUG  10-14 09:58:48  async_process_runner.py  b'  File "/home/circleci/repo/.tox/py37-wheel-cli/lib/python3.7/site-packages/async_service/trio.py", line 76, in run\n'
   DEBUG  10-14 09:58:48  async_process_runner.py  b'    await self._async_fn(*self._async_fn_args)\n'
   DEBUG  10-14 09:58:48  async_process_runner.py  b'  File "/home/circleci/repo/.tox/py37-wheel-cli/lib/python3.7/site-packages/async_service/base.py", line 75, in run\n'
   DEBUG  10-14 09:58:48  async_process_runner.py  b'    await service_fn(self.manager, *self._args, **self._kwargs)\n'
   DEBUG  10-14 09:58:48  async_process_runner.py  b'  File "/home/circleci/repo/trinity/components/builtin/metrics/system_metrics_collector.py", line 149, in collect_process_metrics\n'
   DEBUG  10-14 09:58:48  async_process_runner.py  b'    process_stats=read_process_stats(),\n'
   DEBUG  10-14 09:58:48  async_process_runner.py  b'  File "/home/circleci/repo/trinity/components/builtin/metrics/system_metrics_collector.py", line 117, in read_process_stats\n'
   DEBUG  10-14 09:58:48  async_process_runner.py  b'    num_child_threads = sum([process.num_threads() for process in child_processes])\n'
   DEBUG  10-14 09:58:48  async_process_runner.py  b'  File "/home/circleci/repo/trinity/components/builtin/metrics/system_metrics_collector.py", line 117, in <listcomp>\n'
   DEBUG  10-14 09:58:48  async_process_runner.py  b'    num_child_threads = sum([process.num_threads() for process in child_processes])\n'
   DEBUG  10-14 09:58:48  async_process_runner.py  b'  File "/home/circleci/repo/.tox/py37-wheel-cli/lib/python3.7/site-packages/psutil/__init__.py", line 880, in num_threads\n'
   DEBUG  10-14 09:58:48  async_process_runner.py  b'    return self._proc.num_threads()\n'
   DEBUG  10-14 09:58:48  async_process_runner.py  b'  File "/home/circleci/repo/.tox/py37-wheel-cli/lib/python3.7/site-packages/psutil/_pslinux.py", line 1515, in wrapper\n'
   DEBUG  10-14 09:58:48  async_process_runner.py  b'    return fun(self, *args, **kwargs)\n'
   DEBUG  10-14 09:58:48  async_process_runner.py  b'  File "/home/circleci/repo/.tox/py37-wheel-cli/lib/python3.7/site-packages/psutil/_pslinux.py", line 1889, in num_threads\n'
   DEBUG  10-14 09:58:48  async_process_runner.py  b'    data = self._read_status_file()\n'
   DEBUG  10-14 09:58:48  async_process_runner.py  b'  File "/home/circleci/repo/.tox/py37-wheel-cli/lib/python3.7/site-packages/psutil/_pslinux.py", line 1522, in wrapper\n'
   DEBUG  10-14 09:58:48  async_process_runner.py  b'    raise NoSuchProcess(self.pid, self._name)\n'
   DEBUG  10-14 09:58:48  async_process_runner.py  b'psutil.NoSuchProcess: psutil.NoSuchProcess process no longer exists (pid=3221)\n'
```


### How was it fixed?
Handle exception if child process is dead.


### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

[//]: # (See: https://trinity-client.readthedocs.io/en/latest/contributing.html#pull-requests)
- [x] Add entry to the [release notes](https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

#### Cute Animal Picture
![image](https://user-images.githubusercontent.com/9753150/95979128-c7bfc000-0de0-11eb-9bf2-8fdeb4a7e8b1.png)

