### PR TITLE
Update eip1085 schema to enforce account formatting

### DIFF
--- a/newsfragments/2086.bugfix.rst
+++ b/newsfragments/2086.bugfix.rst
@@ -1,0 +1,1 @@
+Update EIP1085 validation utils to strictly enforce address formatting.

--- a/trinity/assets/eip1085.schema.json
+++ b/trinity/assets/eip1085.schema.json
@@ -136,6 +136,9 @@
     "Accounts": {
       "title": "Genesis account states",
       "type": "object",
+      "propertyNames": {
+        "pattern": "^0x([0-9a-fA-F]{2}){20}$"
+      },
       "patternProperties": {
         "^0x([0-9a-fA-F]{2}){20}$": {
           "$ref": "#/definitions/Account"


### PR DESCRIPTION
### What was wrong?
In jsonschema a `"propertyNames"` [field](https://json-schema.org/understanding-json-schema/reference/object.html#property-names) is required to enforce that all of an object's keys conform to a pattern. Without this addition to the jsonschema - it wasn't properly enforcing that all keys in `Accounts` were `0x`-prefixed addresses.


### How was it fixed?
Added the necessary field.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

[//]: # (See: https://trinity-client.readthedocs.io/en/latest/contributing.html#pull-requests)
- [x] Add entry to the [release notes](https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

#### Cute Animal Picture
![image](https://user-images.githubusercontent.com/9753150/96611502-5a210180-12c2-11eb-81ba-b5490e2e2fa1.png)
