### PR TITLE
Disable resolver in dockerfile for consistent builds

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -9,8 +9,8 @@ COPY . /usr/src/app
 RUN apt-get update
 RUN apt-get -y install libsnappy-dev
 
-RUN pip install -e .[dev]  --no-cache-dir --use-feature=2020-resolver
-RUN pip install -U trinity --no-cache-dir --use-feature=2020-resolver
+RUN pip install -e .[dev]  --no-cache-dir
+RUN pip install -U trinity --no-cache-dir
 
 RUN echo "Type \`trinity\` to boot or \`trinity --help\` for an overview of commands"
 


### PR DESCRIPTION
### What was wrong?
The `docker-trinity-image-build-test` CI run has been consistently flaky for me recently.

It seems to me that the problem is similar to the one described [in this issue](https://github.com/pypa/pip/issues/8713) - where essentially the `--use-feature=2020-resolver` pytest flag is very slow and inefficient. I've seen multiple instances of the resolver installing many different versions of the same dependency while trying to resolve the dependency tree. This poor performance is acknowledged and is under active improvements [by the pip team](https://github.com/pypa/pip/issues/8664). The `docker-trinity-image-build-test` consistently times out during the install step with the `2020-resolver` enabled.

The pip team has already released some improvements to the resolver in `pip==20.2.4`, but  it seems like whatever improvements were included in `20.2.4` are not sufficient to prevent timeouts in the docker install step. They intend to release further improvements in `20.3`.

### How was it fixed?

The solution here is to just remove the `--use-feature=2020-resolver` flag for the time being. This results in consistently quick & passing CI tests. 

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

[//]: # (See: https://trinity-client.readthedocs.io/en/latest/contributing.html#pull-requests)
- [ ] Add entry to the [release notes](https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

#### Cute Animal Picture
![image](https://user-images.githubusercontent.com/9753150/96888101-e100e600-144a-11eb-9f15-ff1b18f13276.png)
