### PR TITLE
issue #1998 - raise friendly error when checkpoint too close from tip

### DIFF
--- a/newsfragments/2091.bugfix.rst
+++ b/newsfragments/2091.bugfix.rst
@@ -1,0 +1,1 @@
+Fix crash when Trinity was launched with a checkpoint too close from tip in Beam Sync mode

--- a/tests/core/p2p-proto/test_sync.py
+++ b/tests/core/p2p-proto/test_sync.py
@@ -747,9 +747,7 @@ async def test_block_gapfill_syncer(request,
 
 
 @pytest.mark.asyncio
-async def test_block_gapfill_from_checkpoint_syncer(request,
-                                                    event_loop,
-                                                    event_bus,
+async def test_block_gapfill_from_checkpoint_syncer(event_bus,
                                                     chaindb_with_headers_from_checkpoint,
                                                     chaindb_1000):
     client_context = ChainContextFactory(headerdb__db=chaindb_with_headers_from_checkpoint.db)
@@ -779,7 +777,7 @@ async def test_block_gapfill_from_checkpoint_syncer(request,
         header_gaps, _ = chain_with_gaps.chaindb.get_header_chain_gaps()
         with pytest.raises(NoActionableGap):
             # no actionable block gap at the moment
-            actionable_gaps = syncer.get_topmost_actionable_gap(gaps, header_gaps)
+            syncer.get_topmost_actionable_gap(gaps, header_gaps)
 
         # Add enough headers to have an actionable gap:
         fat_chain = LatestTestChain(chaindb_1000.db)

--- a/tests/core/p2p-proto/test_sync.py
+++ b/tests/core/p2p-proto/test_sync.py
@@ -60,6 +60,7 @@ from trinity.protocol.les.peer import (
 from trinity.sync.beam.chain import (
     BeamSyncer,
     BodyChainGapSyncer,
+    FromCheckpointBodyChainGapSyncer,
 )
 from trinity.sync.beam.queen import QueeningQueue
 from trinity.sync.header.chain import (
@@ -131,6 +132,29 @@ def chaindb_with_block_gaps(chaindb_fresh, chaindb_1000):
         chaindb_fresh.persist_unexecuted_block(block, receipts)
 
     assert chaindb_fresh.get_chain_gaps() == (((1, 249), (251, 499)), 501)
+    yield chaindb_fresh
+
+
+@pytest.fixture
+def chaindb_with_headers_from_checkpoint(chaindb_fresh, chaindb_1000):
+    # Make a chain with gaps. This fixture can not be used in a test alongside `chaindb_fresh`
+    # because it alters the `chaindb_fresh` fixture.
+    for block_number in range(970, 1001):
+        header_at = chaindb_1000.get_canonical_block_header_by_number(block_number)
+        score_at = chaindb_1000.get_score(header_at.hash)
+        chaindb_fresh.persist_checkpoint_header(header_at, score_at)
+
+    assert chaindb_fresh.get_header_chain_gaps() == (((1, 969),), 1001)
+
+    # The below is a bit of a hack to make the following assert True.
+    # i.e: without it, get_chain_gaps() does not retrieve any gaps
+    fat_chain = LatestTestChain(chaindb_1000.db)
+    block_number = 1000
+    block = fat_chain.get_canonical_block_by_number(block_number)
+    receipts = block.get_receipts(chaindb_1000)
+    chaindb_fresh.persist_unexecuted_block(block, receipts)
+
+    assert chaindb_fresh.get_chain_gaps() == (((1, 999),), 1001)
     yield chaindb_fresh
 
 
@@ -722,6 +746,99 @@ async def test_block_gapfill_syncer(request,
                 # chain gaps.
                 await asyncio.sleep(0.25)
                 assert chain_with_gaps.chaindb.get_chain_gaps() == ((), 1001)
+
+
+@pytest.mark.asyncio
+async def test_block_gapfill_from_checkpoint_syncer_1(event_bus,
+                                                      chaindb_with_headers_from_checkpoint,
+                                                      chaindb_1000):
+    client_context = ChainContextFactory(headerdb__db=chaindb_with_headers_from_checkpoint.db)
+    server_context = ChainContextFactory(headerdb__db=chaindb_1000.db)
+    peer_pair = LatestETHPeerPairFactory(
+        alice_peer_context=client_context,
+        bob_peer_context=server_context,
+        event_bus=event_bus,
+    )
+    async with peer_pair as (client_peer, server_peer):
+        chain_with_gaps = LatestTestChain(chaindb_with_headers_from_checkpoint.db)
+
+        syncer = BodyChainGapSyncer(
+            chain_with_gaps,
+            chaindb_with_headers_from_checkpoint,
+            MockPeerPoolWithConnectedPeers([client_peer], event_bus=event_bus),
+        )
+
+        # In production, this would be the block time but we want our test to pause/resume swiftly
+        syncer._idle_time = 0.01
+        server_peer_pool = MockPeerPoolWithConnectedPeers([server_peer], event_bus=event_bus)
+
+        syncer._max_backfill_block_bodies_at_once = 100
+
+        async with run_peer_pool_event_server(
+            event_bus, server_peer_pool, handler_type=ETHPeerPoolEventServer
+        ), background_asyncio_service(ETHRequestServer(
+            event_bus, TO_NETWORKING_BROADCAST_CONFIG, AsyncChainDB(chaindb_1000.db),
+        )):
+
+            server_peer.logger.info("%s is serving 1000 blocks", server_peer)
+            client_peer.logger.info("%s is syncing up 1000", client_peer)
+
+            async with background_asyncio_service(syncer):
+                fat_chain = LatestTestChain(chaindb_1000.db)
+
+                # Wait for blocks backfilling
+                await wait_for_block(
+                    chain_with_gaps, fat_chain.get_canonical_block_by_number(999), sync_timeout=20)
+
+                await asyncio.sleep(0.25)
+                assert chain_with_gaps.chaindb.get_chain_gaps() == (((1, 970),), 1001)
+
+
+@pytest.mark.asyncio
+async def test_block_gapfill_from_checkpoint_syncer_2(event_bus,
+                                                      chaindb_with_headers_from_checkpoint,
+                                                      chaindb_1000):
+    client_context = ChainContextFactory(headerdb__db=chaindb_with_headers_from_checkpoint.db)
+    server_context = ChainContextFactory(headerdb__db=chaindb_1000.db)
+    peer_pair = LatestETHPeerPairFactory(
+        alice_peer_context=client_context,
+        bob_peer_context=server_context,
+        event_bus=event_bus,
+    )
+    async with peer_pair as (client_peer, server_peer):
+        chain_with_gaps = LatestTestChain(chaindb_with_headers_from_checkpoint.db)
+
+        syncer = FromCheckpointBodyChainGapSyncer(
+            chain_with_gaps,
+            chaindb_with_headers_from_checkpoint,
+            MockPeerPoolWithConnectedPeers([client_peer], event_bus=event_bus),
+            970,
+        )
+
+        # In production, this would be the block time but we want our test to pause/resume swiftly
+        syncer._idle_time = 0.01
+        server_peer_pool = MockPeerPoolWithConnectedPeers([server_peer], event_bus=event_bus)
+
+        syncer._max_backfill_block_bodies_at_once = 100
+
+        async with run_peer_pool_event_server(
+            event_bus, server_peer_pool, handler_type=ETHPeerPoolEventServer
+        ), background_asyncio_service(ETHRequestServer(
+            event_bus, TO_NETWORKING_BROADCAST_CONFIG, AsyncChainDB(chaindb_1000.db),
+        )):
+
+            server_peer.logger.info("%s is serving 1000 blocks", server_peer)
+            client_peer.logger.info("%s is syncing up 1000", client_peer)
+
+            async with background_asyncio_service(syncer):
+                fat_chain = LatestTestChain(chaindb_1000.db)
+
+                # Wait for blocks backfilling
+                await wait_for_block(
+                    chain_with_gaps, fat_chain.get_canonical_block_by_number(999), sync_timeout=20)
+
+                await asyncio.sleep(0.25)
+                assert chain_with_gaps.chaindb.get_chain_gaps() == (((1, 970),), 1001)
 
 
 @pytest.mark.asyncio

--- a/trinity/sync/beam/chain.py
+++ b/trinity/sync/beam/chain.py
@@ -38,7 +38,10 @@ from trinity.components.builtin.metrics.registry import NoopMetricsRegistry
 from trinity.constants import FIRE_AND_FORGET_BROADCASTING
 from trinity.db.eth1.chain import BaseAsyncChainDB
 from trinity.db.eth1.header import BaseAsyncHeaderDB
-from trinity.exceptions import WitnessHashesUnavailable
+from trinity.exceptions import (
+    WitnessHashesUnavailable,
+    BaseTrinityError,
+)
 from trinity.protocol.eth.peer import ETHPeerPool
 from trinity.protocol.eth.sync import ETHHeaderChainSyncer
 from trinity.protocol.wit.db import AsyncWitnessDB
@@ -577,7 +580,7 @@ class BodyChainGapSyncer(Service):
                 await self.manager.run_service(self._body_syncer)
 
 
-class NoActionableGap(Exception):
+class NoActionableGap(BaseTrinityError):
     """
     Raised when no actionable gap of blocks is found.
     """

--- a/trinity/sync/beam/chain.py
+++ b/trinity/sync/beam/chain.py
@@ -520,7 +520,7 @@ class BodyChainGapSyncer(Service):
         for gap in gaps[::-1]:
             if gap[1] - gap[0] > self._max_backfill_block_bodies_at_once:
                 gap = (BlockNumber(gap[1] - self._max_backfill_block_bodies_at_once), gap[1])
-            #We want to be sure the header preceding the block gap is in DB
+            # We want to be sure the header preceding the block gap is in DB
             gap_with_prev_block = (BlockNumber(gap[0] - 1), gap[1])
             for header_gap in header_gaps[::-1]:
                 if not self._have_empty_intersection(gap_with_prev_block, header_gap):

--- a/trinity/sync/beam/chain.py
+++ b/trinity/sync/beam/chain.py
@@ -515,13 +515,15 @@ class BodyChainGapSyncer(Service):
                                    header_gaps: Tuple[BlockRange, ...]) -> BlockRange:
         '''
         Returns the most recent gap of blocks of max size = _max_backfill_block_bodies_at_once
-        for which the headers exist in DB.
+        for which the headers exist in DB, along with the header preceding the gap.
         '''
         for gap in gaps[::-1]:
             if gap[1] - gap[0] > self._max_backfill_block_bodies_at_once:
                 gap = (BlockNumber(gap[1] - self._max_backfill_block_bodies_at_once), gap[1])
+            #We want to be sure the header preceding the block gap is in DB
+            gap_with_prev_block = (BlockNumber(gap[0] - 1), gap[1])
             for header_gap in header_gaps[::-1]:
-                if not self._have_empty_intersection(gap, header_gap):
+                if not self._have_empty_intersection(gap_with_prev_block, header_gap):
                     break
             else:
                 return gap
@@ -580,6 +582,7 @@ class NoActionableGap(Exception):
     Raised when no actionable gap of blocks is found.
     """
     pass
+
 
 class HeaderLaunchpointSyncer(HeaderSyncerAPI):
     """

--- a/trinity/sync/beam/chain.py
+++ b/trinity/sync/beam/chain.py
@@ -470,12 +470,13 @@ class BodyChainGapSyncer(Service):
         self._peer_pool = peer_pool
         self._pauser = Pauser()
         self._body_syncer: FastChainBodySyncer = None
+        self._max_backfill_block_bodies_at_once = MAX_BACKFILL_BLOCK_BODIES_AT_ONCE
 
     async def _setup_for_next_gap(self) -> None:
         gap_start, gap_end = self._get_next_gap()
         fill_start = BlockNumber(max(
             gap_start,
-            gap_end - MAX_BACKFILL_BLOCK_BODIES_AT_ONCE,
+            gap_end - self._max_backfill_block_bodies_at_once,
         ))
         start_num = BlockNumber(fill_start - 1)
         _starting_tip = await self._db.coro_get_canonical_block_header_by_number(start_num)


### PR DESCRIPTION
### What was wrong?
Issue #1998 

Trinity crashes with a HeaderNotFound exception when launched with `--sync-from-checkpoint eth://block/byhash/` with the checkpoint too close from the chain's tip.

The issue concerns the beam sync when the checkpoint is not strictly more than `MAX_BACKFILL_BLOCK_BODIES_AT_ONCE` (100 000) blocks away from the tip.

The reason is because the beam sync backfills block by chunks of  `MAX_BACKFILL_BLOCK_BODIES_AT_ONCE` and looks first into the DB for their headers.

So, if the specified checkpoint is not before that, some headers will be missing which will trigger the crash.

### How was it fixed?
~~As soon as we get the block number of the chain's tip, we check the checkpoint is strictly before the tip - `MAX_BACKFILL_BLOCK_BODIES_AT_ONCE`.
If not, we end the application with a clear error message.~~

We ensure the block backfiller `BodyChainGapSyncer` fills the most recent actionable gap if one is available, where an actionable gap is as block gap for which:
 - the headers are already in DB
 - the header preceding this block gap is also in DB
 - the size of the gap is <= `MAX_BACKFILL_BLOCK_BODIES_AT_ONCE`

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Add a specific unit test.

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

[//]: # (See: https://trinity-client.readthedocs.io/en/latest/contributing.html#pull-requests)
- [x] Add entry to the [release notes](https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://assets.rebelmouse.io/eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpbWFnZSI6Imh0dHBzOi8vYXNzZXRzLnJibC5tcy8xNjUyNzI2Ni9vcmlnaW4uanBnIiwiZXhwaXJlc19hdCI6MTYxNjgzNDAzMH0.89rYdzbSeojy65TYo1CLIDTYdCy5NIvtkt46YGQQEOk/img.jpg?width=980)
