### PR TITLE
Fix a couple bugs in NewBlockComponent

### DIFF
--- a/trinity/protocol/eth/events.py
+++ b/trinity/protocol/eth/events.py
@@ -156,6 +156,26 @@ class SendBlockBodiesEvent(PeerPoolMessageEvent):
 
 
 @dataclass
+class SendNewBlockHashesEvent(PeerPoolMessageEvent):
+    """
+    Event to proxy a ``ETHPeer.sub_proto.send_new_block_hashes`` call from a proxy peer to the
+    actual peer that sits in the peer pool.
+    """
+    session: SessionAPI
+    command: NewBlockHashes
+
+
+@dataclass
+class SendNewBlockEvent(PeerPoolMessageEvent):
+    """
+    Event to proxy a ``ETHProxyPeer.send_new_block`` call to the actual peer that sits in the peer
+    pool.
+    """
+    session: SessionAPI
+    command: NewBlock
+
+
+@dataclass
 class SendNodeDataEvent(PeerPoolMessageEvent):
     """
     Event to proxy a ``ETHPeer.sub_proto.send_node_data`` call from a proxy peer to the actual

--- a/trinity/protocol/eth/peer.py
+++ b/trinity/protocol/eth/peer.py
@@ -51,6 +51,8 @@ from .constants import MAX_HEADERS_FETCH
 from .events import (
     SendBlockHeadersEvent,
     SendBlockBodiesEvent,
+    SendNewBlockEvent,
+    SendNewBlockHashesEvent,
     SendNodeDataEvent,
     SendReceiptsEvent,
     GetBlockHeadersRequest,
@@ -210,6 +212,8 @@ class ETHPeerPoolEventServer(PeerPoolEventServer[ETHPeer]):
     send_event_types = frozenset({
         SendBlockHeadersEvent,
         SendBlockBodiesEvent,
+        SendNewBlockEvent,
+        SendNewBlockHashesEvent,
         SendNodeDataEvent,
         SendReceiptsEvent,
         SendPooledTransactionsEvent,

--- a/trinity/protocol/eth/proxy.py
+++ b/trinity/protocol/eth/proxy.py
@@ -32,6 +32,7 @@ from trinity.rlp.block_body import BlockBody
 from .commands import (
     BlockBodiesV65,
     BlockHeadersV65,
+    NewBlock,
     NewBlockHashes,
     NodeDataV65,
     ReceiptsV65,
@@ -43,16 +44,17 @@ from .events import (
     GetBlockHeadersRequest,
     GetNodeDataRequest,
     GetReceiptsRequest,
-    NewBlockHashesEvent,
     SendBlockBodiesEvent,
     SendBlockHeadersEvent,
+    SendNewBlockEvent,
+    SendNewBlockHashesEvent,
     SendNodeDataEvent,
     SendReceiptsEvent,
     SendTransactionsEvent,
     GetPooledTransactionsRequest,
     SendPooledTransactionsEvent,
 )
-from .payloads import NewBlockHash
+from .payloads import BlockFields, NewBlockHash, NewBlockPayload
 
 
 class ProxyETHAPI:
@@ -224,7 +226,14 @@ class ProxyETHAPI:
     def send_new_block_hashes(self, new_block_hashes: Sequence[NewBlockHash]) -> None:
         command = NewBlockHashes(tuple(new_block_hashes))
         self._event_bus.broadcast_nowait(
-            NewBlockHashesEvent(self.session, command),
+            SendNewBlockHashesEvent(self.session, command),
+            self._broadcast_config,
+        )
+
+    def send_new_block(self, block_fields: BlockFields, total_difficulty: int) -> None:
+        command = NewBlock(NewBlockPayload(block_fields, total_difficulty))
+        self._event_bus.broadcast_nowait(
+            SendNewBlockEvent(self.session, command),
             self._broadcast_config,
         )
 


### PR DESCRIPTION
- Upon receiving a NewBlock msg, broadcast a NewBlock msg instead of
  BlockHeadersV65

- Actually send NewBlockHashes msgs. Before it was simply firing a
  NewBlockHashesEvent, which is meant to be used when we receive a
  msg of that type

Closes: #2096

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses]()