### PR TITLE
Download block witnesses upon receiving a NewBlock msg

### DIFF
--- a/trinity/protocol/eth/peer.py
+++ b/trinity/protocol/eth/peer.py
@@ -304,7 +304,9 @@ class ETHPeerPoolEventServer(PeerPoolEventServer[ETHPeer]):
             event: GetBlockWitnessHashesRequest) -> Tuple[Hash32, ...]:
         peer = self.get_peer(event.session)
         if not hasattr(peer, 'wit_api'):
-            self.logger.error(
+            # Currently this is expected to happen as NewBlockComponent doesn't know which peers
+            # support the witness protocol so it always tries to fetch witnesses.
+            self.logger.debug(
                 "Cannot get witness hashes from %s, it does not support the Witness protocol", peer)
             return tuple()
         return await peer.wit_api.get_block_witness_hashes(event.block_hash, event.timeout)

--- a/trinity/protocol/wit/api.py
+++ b/trinity/protocol/wit/api.py
@@ -19,7 +19,6 @@ from p2p.qualifiers import HasProtocol
 from trinity._utils.les import (
     gen_request_id,
 )
-
 from trinity.protocol.common.validators import (
     match_payload_request_id,
 )

--- a/trinity/sync/beam/state.py
+++ b/trinity/sync/beam/state.py
@@ -160,13 +160,16 @@ class BeamDownloader(Service, PeerSubscriber):
         Wait until the nodes that are the preimages of `node_hashes` are available in the database.
         If one is not available in the first check, request it from peers.
 
+        If any nodes cannot be downloaded in BLOCK_IMPORT_MISSING_STATE_TIMEOUT seconds, return
+        anyway.
+
         :param urgent: Should this node be downloaded urgently? If False, download as backfill
 
         Note that if your ultimate goal is an account or storage data, it's probably better to use
         download_account or download_storage. This method is useful for other
         scenarios, like bytecode lookups or intermediate node lookups.
 
-        :return: how many nodes had to be downloaded
+        :return: how many nodes were downloaded
         """
         if urgent:
             num_nodes_found = await self._wait_for_nodes(

--- a/trinity/sync/common/events.py
+++ b/trinity/sync/common/events.py
@@ -127,6 +127,28 @@ class CollectMissingStorage(BaseRequestResponseEvent[MissingStorageResult]):
 
 
 @dataclass
+class MissingTrieNodesResult(BaseEvent):
+    num_nodes_collected: int = 0
+
+
+@dataclass
+class CollectMissingTrieNodes(BaseRequestResponseEvent[MissingTrieNodesResult]):
+    """
+    A request for the syncer to download the trie nodes with the given hashes.
+
+    Generally the type-specific events like CollectMissingStorage should be used but in some cases
+    (i.e. when downloading block witnesses) we don't know their type so need to use this.
+    """
+    node_hashes: Tuple[Hash32, ...]
+    urgent: bool
+    block_number: BlockNumber
+
+    @staticmethod
+    def expected_response_type() -> Type[MissingTrieNodesResult]:
+        return MissingTrieNodesResult
+
+
+@dataclass
 class StatelessBlockImportDone(BaseEvent):
     """
     Response to :cls:`DoStatelessBlockImport`, emitted only after the block has


### PR DESCRIPTION
First download the witness hashes, then emit an event to
cause the BeamSyncer to download the actual trie nodes