### PR TITLE
Fetch block witness upon receipt of NewBlockHashes msgs

### DIFF
--- a/trinity/sync/full/chain.py
+++ b/trinity/sync/full/chain.py
@@ -366,7 +366,7 @@ class BaseBodyChainSyncer(Service, PeerSubscriber):
 
         if len(block_body_bundles) == 0:
             self.logger.debug(
-                "Got block bodies for 0/%d headers from %s, from %r..%r",
+                "Got block bodies for 0/%d headers from %s, from %s..%s",
                 len(headers),
                 peer,
                 headers[0],
@@ -394,7 +394,7 @@ class BaseBodyChainSyncer(Service, PeerSubscriber):
         self._pending_bodies = merge(self._pending_bodies, pending_bodies)
 
         self.logger.debug(
-            "Got block bodies for %d/%d headers from %s, from %r..%r",
+            "Got block bodies for %d/%d headers from %s, from %s..%s",
             len(completed_header_roots),
             len(headers),
             peer,


### PR DESCRIPTION
Before we were fetching upon receipt of NewBlock msgs, but those are only
forwarded to a subset of the peers (per the spec), so if we didn't get them
from a peer that supports the wit protocol we'd end up missing witnesses
for certain blocks

Also ensures we do not fetch witness hashes again if they are already in our DB

Includes #2106