### PR TITLE
Store union of hashes for block witness

### DIFF
--- a/tests/core/p2p-proto/test_wit_db.py
+++ b/tests/core/p2p-proto/test_wit_db.py
@@ -48,6 +48,50 @@ async def test_witness_for_recent_blocks():
 
 
 @pytest.mark.asyncio
+async def test_witness_history_on_repeat_blocks():
+    """
+    Repeated blocks should not consume more slots in the limited history of block witnesses
+    """
+    wit_db = AsyncWitnessDB(MemoryDB())
+    hash1 = Hash32Factory()
+    hash1_witnesses = tuple(Hash32Factory.create_batch(5))
+    await wit_db.coro_persist_witness_hashes(hash1, hash1_witnesses)
+
+    hash2 = Hash32Factory()
+    await wit_db.coro_persist_witness_hashes(hash2, tuple(Hash32Factory.create_batch(5)))
+
+    # *almost* push the first witness out of history
+    for _ in range(wit_db._max_witness_history - 2):
+        await wit_db.coro_persist_witness_hashes(Hash32Factory(), Hash32Factory.create_batch(2))
+
+    # It should still be there...
+    loaded_hashes = await wit_db.coro_get_witness_hashes(hash1)
+    assert set(loaded_hashes) == set(hash1_witnesses)
+
+    # Add one more new witness, for an existing block
+    await wit_db.coro_persist_witness_hashes(hash2, Hash32Factory.create_batch(2))
+
+    # That new witness should *not* consume a block slot in history, so the first hash's
+    #   witness should still be available.
+    loaded_hashes = await wit_db.coro_get_witness_hashes(hash1)
+    assert set(loaded_hashes) == set(hash1_witnesses)
+
+
+@pytest.mark.asyncio
+async def test_witness_eviction_on_repeat_blocks():
+    """
+    After witnesses are persisted twice for the same block, make sure that eviction
+    does not cause any failures.
+    """
+    wit_db = AsyncWitnessDB(MemoryDB())
+    hash_ = Hash32Factory()
+    await wit_db.coro_persist_witness_hashes(hash_, Hash32Factory.create_batch(2))
+    await wit_db.coro_persist_witness_hashes(hash_, Hash32Factory.create_batch(2))
+    for _ in range(wit_db._max_witness_history):
+        await wit_db.coro_persist_witness_hashes(Hash32Factory(), Hash32Factory.create_batch(2))
+
+
+@pytest.mark.asyncio
 async def test_witness_union():
     wit_db = AsyncWitnessDB(MemoryDB())
     hash1 = Hash32Factory()

--- a/tests/core/p2p-proto/test_wit_db.py
+++ b/tests/core/p2p-proto/test_wit_db.py
@@ -17,7 +17,9 @@ async def test_persisting_and_looking_up():
 
     hash1_witnesses = tuple(Hash32Factory.create_batch(5))
     await wit_db.coro_persist_witness_hashes(hash1, hash1_witnesses)
-    assert await wit_db.coro_get_witness_hashes(hash1) == hash1_witnesses
+    loaded_hashes = await wit_db.coro_get_witness_hashes(hash1)
+
+    assert set(loaded_hashes) == set(hash1_witnesses)
 
 
 @pytest.mark.asyncio
@@ -32,7 +34,8 @@ async def test_witness_for_recent_blocks():
         await wit_db.coro_persist_witness_hashes(Hash32Factory(), Hash32Factory.create_batch(2))
 
     # It should still be there...
-    assert await wit_db.coro_get_witness_hashes(hash1) == hash1_witnesses
+    loaded_hashes = await wit_db.coro_get_witness_hashes(hash1)
+    assert set(loaded_hashes) == set(hash1_witnesses)
 
     # Until one more new witness is added.
     await wit_db.coro_persist_witness_hashes(Hash32Factory(), Hash32Factory.create_batch(2))
@@ -42,3 +45,22 @@ async def test_witness_for_recent_blocks():
         await wit_db.coro_get_witness_hashes(hash1)
 
     assert len(wit_db._get_recent_blocks_with_witnesses()) == wit_db._max_witness_history
+
+
+@pytest.mark.asyncio
+async def test_witness_union():
+    wit_db = AsyncWitnessDB(MemoryDB())
+    hash1 = Hash32Factory()
+    hash1_witnesses_unique1 = set(Hash32Factory.create_batch(3))
+    hash1_witnesses_unique2 = set(Hash32Factory.create_batch(3))
+    hash1_witnesses_both = set(Hash32Factory.create_batch(2))
+    hash1_witnesses1 = tuple(hash1_witnesses_unique1 | hash1_witnesses_both)
+    hash1_witnesses2 = tuple(hash1_witnesses_unique2 | hash1_witnesses_both)
+
+    await wit_db.coro_persist_witness_hashes(hash1, hash1_witnesses1)
+    await wit_db.coro_persist_witness_hashes(hash1, hash1_witnesses2)
+
+    stored_hashes = await wit_db.coro_get_witness_hashes(hash1)
+
+    expected = hash1_witnesses_unique1 | hash1_witnesses_both | hash1_witnesses_unique2
+    assert set(stored_hashes) == expected

--- a/tests/core/p2p-proto/test_wit_db.py
+++ b/tests/core/p2p-proto/test_wit_db.py
@@ -1,6 +1,6 @@
 import pytest
 
-from eth.db.atomic import AtomicDB
+from eth.db.backends.memory import MemoryDB
 
 from trinity.exceptions import WitnessHashesUnavailable
 from trinity.protocol.wit.db import AsyncWitnessDB
@@ -9,7 +9,7 @@ from trinity.tools.factories import Hash32Factory
 
 @pytest.mark.asyncio
 async def test_persisting_and_looking_up():
-    wit_db = AsyncWitnessDB(AtomicDB())
+    wit_db = AsyncWitnessDB(MemoryDB())
 
     hash1 = Hash32Factory()
     with pytest.raises(WitnessHashesUnavailable):
@@ -22,7 +22,7 @@ async def test_persisting_and_looking_up():
 
 @pytest.mark.asyncio
 async def test_witness_for_recent_blocks():
-    wit_db = AsyncWitnessDB(AtomicDB())
+    wit_db = AsyncWitnessDB(MemoryDB())
     hash1 = Hash32Factory()
     hash1_witnesses = tuple(Hash32Factory.create_batch(5))
     await wit_db.coro_persist_witness_hashes(hash1, hash1_witnesses)

--- a/trinity/sync/beam/importer.py
+++ b/trinity/sync/beam/importer.py
@@ -103,13 +103,13 @@ class BeamStats:
     def __str__(self) -> str:
         avg_rtt = self.avg_rtt
 
-        wait_time = humanize_seconds(self.data_pause_time)
+        wait_time = self.data_pause_time
 
         return (
             f"BeamStat: accts={self.num_accounts}, "
             f"a_nodes={self.num_account_nodes}, codes={self.num_bytecodes}, "
             f"strg={self.num_storages}, s_nodes={self.num_storage_nodes}, "
-            f"nodes={self.num_nodes}, rtt={avg_rtt:.3f}s, wait={wait_time}"
+            f"nodes={self.num_nodes}, rtt={avg_rtt:.3f}s, wait={wait_time:.1f}s"
         )
 
     def __repr__(self) -> str:


### PR DESCRIPTION
### What was wrong?

Fixes #2105 

### How was it fixed?

Store union of the witness hashes, when witness metadata comes in for the same block.

### To-Do

- [x] ~Test where two persists interleave their database accesses, to force the race condition that one witness overwrites the other~
- [x] ~Add a lock to pass ^ test~
- [ ] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

[//]: # (See: https://trinity-client.readthedocs.io/en/latest/contributing.html#pull-requests)
- [x] ~Add entry to the [release notes](https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)~

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://i.pinimg.com/originals/b2/fb/19/b2fb195935593827ae6dd157139c1208.jpg)