### PR TITLE
More peer/sync metrics

### DIFF
--- a/trinity/components/builtin/metrics/instruments.py
+++ b/trinity/components/builtin/metrics/instruments.py
@@ -73,6 +73,15 @@ class NoopMeter(Meter):
         return 0
 
 
+class NoopTimerContext:
+
+    def __enter__(self) -> None:
+        pass
+
+    def __exit__(self, t, v, tb):  # type: ignore
+        pass
+
+
 class NoopTimer(Timer):
 
     def __init__(self) -> None:
@@ -114,8 +123,8 @@ class NoopTimer(Timer):
     def get_fifteen_minute_rate(self) -> int:
         return 0
 
-    def time(self, *args: Any, **kwargs: Any) -> None:
-        raise NotImplementedError("time() isn't implemented on NoopTimer")
+    def time(self, *args: Any, **kwargs: Any) -> NoopTimerContext:
+        return NoopTimerContext()
 
     def clear(self) -> None:
         pass

--- a/trinity/components/builtin/metrics/sync_metrics_registry.py
+++ b/trinity/components/builtin/metrics/sync_metrics_registry.py
@@ -13,6 +13,9 @@ class SyncMetricsRegistry:
         self.metrics_service = metrics_service
         self.pivot_meter = metrics_service.registry.meter('trinity.p2p/sync/pivot_rate.meter')
 
+    def record_lag(self, lag: int) -> None:
+        self.metrics_service.registry.gauge('trinity.sync/chain_head_lag').set_value(lag)
+
     async def record_pivot(self, block_number: BlockNumber) -> None:
         # record pivot and send event annotation to influxdb
         self.pivot_meter.mark()

--- a/trinity/components/builtin/new_block/component.py
+++ b/trinity/components/builtin/new_block/component.py
@@ -224,7 +224,7 @@ async def fetch_witnesses(
     Fetch witness hashes for the given block from the given peer and emit a
     CollectMissingTrieNodes event to trigger the download of the trie nodes referred by them.
     """
-    block_str = f"Block #{block_number}-0x{humanize_hash(block_hash)}"
+    block_str = f"<Block #{block_number}-0x{humanize_hash(block_hash)}>"
     try:
         logger.debug(
             "Attempting to fetch witness hashes for %s from %s", block_str, peer)
@@ -239,7 +239,6 @@ async def fetch_witnesses(
         return tuple()
     else:
         if witness_hashes:
-            metrics_registry.counter('trinity.sync/block_witness_hashes.hit').inc()
             logger.debug(
                 "Got witness hashes for %s, asking BeamSyncer to fetch them", block_str)
             # XXX: Consider using urgent=False if the new block is more than a couple blocks ahead
@@ -265,7 +264,10 @@ async def fetch_witnesses(
                 wit_db = AsyncWitnessDB(base_db)
                 wit_db.persist_witness_hashes(block_hash, witness_hashes)
         else:
-            metrics_registry.counter('trinity.sync/block_witness_hashes.miss').inc()
             logger.debug(
-                "%s announced %s but doesn't have witness hashes for it", peer, block_str)
+                "%s announced %s but doesn't have witness hashes for it. "
+                "This could be a peer that does not support the wit protocol, though",
+                peer,
+                block_str,
+            )
         return witness_hashes

--- a/trinity/sync/beam/chain.py
+++ b/trinity/sync/beam/chain.py
@@ -808,7 +808,8 @@ class BeamBlockImporter(BaseBlockImporter, Service):
             try:
                 wit_hashes = wit_db.get_witness_hashes(block.hash)
             except WitnessHashesUnavailable:
-                self.logger.debug("No witness hashes for block %s. Import will be slow", block)
+                self.logger.info("No witness hashes for block %s. Import will be slow", block)
+                self.metrics_registry.counter('trinity.sync/block_witness_hashes_missing').inc()
             else:
                 block_witness_uncollected = self._state_downloader._get_unique_missing_hashes(
                     wit_hashes)

--- a/trinity/sync/beam/importer.py
+++ b/trinity/sync/beam/importer.py
@@ -436,7 +436,8 @@ def pausing_vm_decorator(
             missing_account_metrics_counter.clear()
             missing_bytecode_metrics_counter.clear()
             missing_storage_metrics_counter.clear()
-            return super().import_block(block)
+            with metrics_registry.timer('trinity.sync/block_import_time').time():
+                return super().import_block(block)
 
         @classmethod
         def get_state_class(cls) -> Type[StateAPI]:

--- a/trinity/sync/beam/service.py
+++ b/trinity/sync/beam/service.py
@@ -99,6 +99,8 @@ class BeamSyncService(Service):
                 return False
             else:
                 lag = beam_syncer.get_block_count_lag()
+                if self.sync_metrics_registry:
+                    self.sync_metrics_registry.record_lag(lag)
                 if lag > MAX_BEAM_SYNC_LAG:
                     self.logger.warning(
                         "Beam Sync is lagging by %d blocks. Pivoting...",


### PR DESCRIPTION
    - Beam sync lag (in number of blocks)
    - Block import time
    - Peer count with/without witness support

Includes #2112 