### PR TITLE
Fix argcomplete version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ deps = {
     'trinity': [
         "aiohttp==3.6.0",
         "asks>=2.4.8,<3",
-        "argcomplete>=1.10.0,<2",
+        "argcomplete>=1.12.2,<2",
         "asyncio-run-in-process==0.1.0a10",
         "bloom-filter==1.3",
         "cachetools>=3.1.0,<4.0.0",


### PR DESCRIPTION
### What was wrong?
CI py37 tests were failing with the following `ContextualVersionConflict`:

```
ERROR: invocation failed (exit code 2), logfile: /home/circleci/repo/.tox/py37-p2p/log/py37-p2p-4.log
================================== log start ===================================
Obtaining file:///home/circleci/repo
  Installing build dependencies: started
  Installing build dependencies: finished with status 'done'
  Getting requirements to build wheel: started
  Getting requirements to build wheel: finished with status 'done'
    Preparing wheel metadata: started
    Preparing wheel metadata: finished with status 'done'
ERROR: Exception:
Traceback (most recent call last):
  File "/home/circleci/repo/.tox/py37-p2p/lib/python3.7/site-packages/pip/_internal/cli/base_command.py", line 228, in _main
    status = self.run(options, args)
  File "/home/circleci/repo/.tox/py37-p2p/lib/python3.7/site-packages/pip/_internal/cli/req_command.py", line 182, in wrapper
    return func(self, options, args)
  File "/home/circleci/repo/.tox/py37-p2p/lib/python3.7/site-packages/pip/_internal/commands/install.py", line 324, in run
    reqs, check_supported_wheels=not options.target_dir
  File "/home/circleci/repo/.tox/py37-p2p/lib/python3.7/site-packages/pip/_internal/resolution/legacy/resolver.py", line 183, in resolve
    discovered_reqs.extend(self._resolve_one(requirement_set, req))
  File "/home/circleci/repo/.tox/py37-p2p/lib/python3.7/site-packages/pip/_internal/resolution/legacy/resolver.py", line 388, in _resolve_one
    abstract_dist = self._get_abstract_dist_for(req_to_install)
  File "/home/circleci/repo/.tox/py37-p2p/lib/python3.7/site-packages/pip/_internal/resolution/legacy/resolver.py", line 326, in _get_abstract_dist_for
    return self.preparer.prepare_editable_requirement(req)
  File "/home/circleci/repo/.tox/py37-p2p/lib/python3.7/site-packages/pip/_internal/operations/prepare.py", line 531, in prepare_editable_requirement
    req.check_if_exists(self.use_user_site)
  File "/home/circleci/repo/.tox/py37-p2p/lib/python3.7/site-packages/pip/_internal/req/req_install.py", line 433, in check_if_exists
    existing_dist = get_distribution(self.req.name)
  File "/home/circleci/repo/.tox/py37-p2p/lib/python3.7/site-packages/pip/_internal/utils/misc.py", line 531, in get_distribution
    pkg_resources.working_set.require(req_name)
  File "/home/circleci/repo/.tox/py37-p2p/lib/python3.7/site-packages/pip/_vendor/pkg_resources/__init__.py", line 900, in require
    needed = self.resolve(parse_requirements(requirements))
  File "/home/circleci/repo/.tox/py37-p2p/lib/python3.7/site-packages/pip/_vendor/pkg_resources/__init__.py", line 791, in resolve
    raise VersionConflict(dist, req).with_context(dependent_req)
pip._vendor.pkg_resources.ContextualVersionConflict: (importlib-metadata 3.0.0 (/home/circleci/repo/.tox/py37-p2p/lib/python3.7/site-packages), Requirement.parse('importlib-metadata<3,>=0.23; python_version == "3.7"'), {'argcomplete'})
```

### How was it fixed?
The conflict was between `importlib-metadata` and 'argcomplete'. For more details on the root cause, see https://github.com/ethereum/trinity/pull/2091#issuecomment-734500915

The issue is fixed by forcing the version of 'argcomplete' to be >= 1.12.2

### To-Do

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

[//]: # (See: https://trinity-client.readthedocs.io/en/latest/contributing.html#pull-requests)
- [ ] Add entry to the [release notes](https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](http://www.awesomelycute.com/gallery/2013/06/super-cute-animals-2162.jpg)
