### PR TITLE
Issue #1959 easier upnp support

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,6 @@ deps = {
         "SQLAlchemy>=1.3.3,<2",
         'trio>=0.16.0,<0.17',
         'trio-typing>=0.5.0,<0.6',
-        "upnpclient>=0.0.8,<1",
     ],
     'trinity': [
         "aiohttp==3.6.0",

--- a/trinity/components/builtin/upnp/component.py
+++ b/trinity/components/builtin/upnp/component.py
@@ -7,10 +7,8 @@ import logging
 
 from async_service import background_trio_service
 from lahja import EndpointAPI
-from upnp_port_forward import (
-    fetch_add_portmapping_services,
-    NoPortMapServiceFound,
-)
+from upnp_port_forward import NoPortMapServiceFound
+from upnp_port_forward.tools.export import fetch_add_portmapping_services
 
 from trinity.config import TrinityConfig
 from trinity.extensibility import (
@@ -45,13 +43,16 @@ class UpnpComponent(TrioIsolatedComponent):
 
         arg_parser.add_argument(
             "--upnp-service-name",
-            action="store",
+            action="append",
             help="upnp service name for port mapping",
         )
 
     async def do_run(self, event_bus: EndpointAPI) -> None:
         port = self._boot_info.trinity_config.port
-        upnp_service_name = self._boot_info.args.upnp_service_name
+        if self._boot_info.args.upnp_service_name:
+            upnp_service_name = tuple(self._boot_info.args.upnp_service_name)
+        else:
+            upnp_service_name = None
         upnp_service = UPnPService(port, event_bus, upnp_service_name)
 
         async with background_trio_service(upnp_service) as manager:

--- a/trinity/components/builtin/upnp/component.py
+++ b/trinity/components/builtin/upnp/component.py
@@ -35,9 +35,16 @@ class UpnpComponent(TrioIsolatedComponent):
             help="Disable upnp mapping",
         )
 
+        arg_parser.add_argument(
+            "--upnp-service-name",
+            action="store",
+            help="upnp service name for port mapping",
+        )
+
     async def do_run(self, event_bus: EndpointAPI) -> None:
         port = self._boot_info.trinity_config.port
-        upnp_service = UPnPService(port, event_bus)
+        upnp_service_name = self._boot_info.args.upnp_service_name
+        upnp_service = UPnPService(port, event_bus, upnp_service_name)
 
         async with background_trio_service(upnp_service) as manager:
             await manager.wait_finished()

--- a/trinity/components/builtin/upnp/nat.py
+++ b/trinity/components/builtin/upnp/nat.py
@@ -22,13 +22,14 @@ logger = get_logger('trinity.components.upnp')
 class UPnPService(Service):
     logger = get_logger('trinity.components.upnp.UPnPService')
 
-    def __init__(self, port: int, event_bus: EndpointAPI) -> None:
+    def __init__(self, port: int, event_bus: EndpointAPI, upnp_service_name: str = None) -> None:
         """
         :param port: The port that a server wants to bind to on this machine, and
         make publicly accessible.
         """
         self.port = port
         self.event_bus = event_bus
+        self.upnp_service_name = upnp_service_name
 
     async def run(self) -> None:
         """Run an infinite loop refreshing our NAT port mapping.
@@ -44,6 +45,7 @@ class UPnPService(Service):
                             setup_port_map,
                             self.port,
                             UPNP_PORTMAP_DURATION,
+                            self.upnp_service_name,
                         )
                         event = UPnPMapping(str(external_ip))
                         self.logger.debug(

--- a/trinity/components/builtin/upnp/nat.py
+++ b/trinity/components/builtin/upnp/nat.py
@@ -1,3 +1,5 @@
+from typing import Optional, Tuple
+
 from lahja import EndpointAPI
 import trio
 
@@ -22,14 +24,17 @@ logger = get_logger('trinity.components.upnp')
 class UPnPService(Service):
     logger = get_logger('trinity.components.upnp.UPnPService')
 
-    def __init__(self, port: int, event_bus: EndpointAPI, upnp_service_name: str = None) -> None:
+    def __init__(self,
+                 port: int,
+                 event_bus: EndpointAPI,
+                 upnp_service_names: Optional[Tuple[str, ...]] = None) -> None:
         """
         :param port: The port that a server wants to bind to on this machine, and
         make publicly accessible.
         """
         self.port = port
         self.event_bus = event_bus
-        self.upnp_service_name = upnp_service_name
+        self.upnp_service_names = upnp_service_names
 
     async def run(self) -> None:
         """Run an infinite loop refreshing our NAT port mapping.
@@ -45,7 +50,7 @@ class UPnPService(Service):
                             setup_port_map,
                             self.port,
                             UPNP_PORTMAP_DURATION,
-                            self.upnp_service_name,
+                            self.upnp_service_names,
                         )
                         event = UPnPMapping(str(external_ip))
                         self.logger.debug(

--- a/trinity/components/registry.py
+++ b/trinity/components/registry.py
@@ -53,7 +53,7 @@ from trinity.components.builtin.syncer.component import (
     SyncerComponent,
 )
 from trinity.components.builtin.upnp.component import (
-    UpnpComponent,
+    UpnpComponent, UpnpServiceNamesComponent,
 )
 from trinity.components.builtin.tx_pool.component import (
     TxComponent,
@@ -69,6 +69,7 @@ BASE_COMPONENTS: Tuple[Type[BaseComponentAPI], ...] = (
     PeerDiscoveryComponent,
     PreferredNodeComponent,
     UpnpComponent,
+    UpnpServiceNamesComponent,
 )
 
 ETH1_NODE_COMPONENTS: Tuple[Type[BaseComponentAPI], ...] = (


### PR DESCRIPTION
## What was wrong?
Only a limited number of upnp services are listed to setup portforwarding.
The list is hardcoded, it is not straight forward for users to identify the one used by their routers, and it is currently not possible to provide a specific one to Trinity.
See Trinity Issue https://github.com/ethereum/trinity/issues/1959 for more details

## How was it fixed?
The proposed enhancement is divided in 2 parts:

 1/ In ethereum/upnp-port-forward/client.py:
 - A new method `fetch_add_portmapping_services` retrieves and returns all available services which can map ports.
 - The method `setup_port_map` can now receive a service name as a new argument and uses it first to when it tries to map a port.
This part has been submitted with the PR https://github.com/ethereum/upnp-port-forward/pull/5

 2/ In ethereum/trinity:
 - A new component `UpnpServiceNamesComponent` exposes the new command line positional argument `export-upnp-info`, calls `fetch_add_portmapping_services` and print the results, if any, on the terminal.
 - The component `UpnpComponent` exposes now a new command line optional argument `--upnp-service-name` which allows the user to provide a upnp service name to Trinity. This service name is provided to the function `setup_port_map`.

### To-Do

**This PR depends on https://github.com/ethereum/upnp-port-forward/pull/5 to pass the CI tests.**

[//]: # (Stay ahead of things, add list items here!)
- [ ] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/upnp-port-forward/blob/master/newsfragments/README.md)

[//]: # (See: https://upnp-port-forward.readthedocs.io/en/latest/contributing.html#pull-requests)
- [ ] Add entry to the [release notes](https://github.com/ethereum/upnp-port-forward/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://www.pixelstalk.net/wp-content/uploads/2016/03/Cute-animal-hd-wallpaper-download-free.jpg)
