### PR TITLE
Update quickstart.rst to specify correct pythondev version

### DIFF
--- a/docs/guides/quickstart.rst
+++ b/docs/guides/quickstart.rst
@@ -17,7 +17,7 @@ Trinity requires Python 3.7 as well as some tools to compile its dependencies. O
 
 .. code:: sh
 
-  apt-get install python3.6-dev
+  apt-get install python3.7-dev
 
 Trinity is installed through the pip package manager, if pip isn't available on the system already,
 we need to install the ``python3-pip`` package through the following command.


### PR DESCRIPTION
the command to install python3.7-dev actually referenced python3.6-dev

### What was wrong?



### How was it fixed?


### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

[//]: # (See: https://trinity-client.readthedocs.io/en/latest/contributing.html#pull-requests)
- [ ] Add entry to the [release notes](https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses]()
