### PR TITLE
Handle transactions as opaque objects of bytes or List[bytes] until VM can deterministically decode them

### DIFF
--- a/newsfragments/2215.internal.rst
+++ b/newsfragments/2215.internal.rst
@@ -1,0 +1,3 @@
+Refactored transaction handling into an obaque blob. Previousy, code assumed a fixed transaction
+shape of a list of bytes, which is no longer accurate (as of EIP-2930). Also, don't default
+maxfail=10 locally, and squash a couple test warnings.

--- a/pytest.ini
+++ b/pytest.ini
@@ -7,4 +7,3 @@ log_date_format = %m-%d %H:%M:%S
 markers =
   slow: test is known to be excessively slow...
 timeout = 300
-timeout_method = thread

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,5 +1,5 @@
 [pytest]
-addopts= --showlocals --durations 50 --maxfail 10
+addopts= --showlocals --durations 50
 python_paths= .
 xfail_strict=true
 log_format = %(levelname)8s  %(asctime)s  %(filename)20s  %(message)s

--- a/tests/core/json-rpc/test_ipc.py
+++ b/tests/core/json-rpc/test_ipc.py
@@ -727,7 +727,7 @@ async def test_admin_addPeer_fires_message(
     )
     assert result == {'id': 3, 'jsonrpc': '2.0', 'result': None}
 
-    event = await asyncio.wait_for(future, timeout=0.1, loop=event_loop)
+    event = await asyncio.wait_for(future, timeout=0.1)
     assert event.remote.uri() == enode
 
 
@@ -757,7 +757,7 @@ async def test_admin_removePeer_fires_message(
             )
             assert result == {'id': 3, 'jsonrpc': '2.0', 'result': True}
 
-            event = await asyncio.wait_for(future, timeout=5, loop=event_loop)
+            event = await asyncio.wait_for(future, timeout=5)
             assert event.peer_info.session.remote.uri() == bob.session.remote.uri()
 
 

--- a/tests/core/p2p-proto/test_eth_proto.py
+++ b/tests/core/p2p-proto/test_eth_proto.py
@@ -20,11 +20,11 @@ from trinity.protocol.eth.commands import (
 )
 
 from trinity.tools.factories import (
-    BaseTransactionFieldsFactory,
     BlockBodyFactory,
     BlockHashFactory,
     BlockHeaderFactory,
     ReceiptFactory,
+    SerializedTransactionFactory,
 )
 from trinity.tools.factories.common import (
     BlockHeadersQueryFactory,
@@ -43,7 +43,7 @@ from trinity.tools.factories.eth import (
         (StatusV63, StatusV63PayloadFactory()),
         (Status, StatusPayloadFactory()),
         (NewBlockHashes, tuple(NewBlockHashFactory.create_batch(2))),
-        (Transactions, tuple(BaseTransactionFieldsFactory.create_batch(2))),
+        (Transactions, tuple(SerializedTransactionFactory.create_batch(2))),
         (GetBlockHeadersV65, BlockHeadersQueryFactory()),
         (GetBlockHeadersV65, BlockHeadersQueryFactory(block_number_or_hash=BlockHashFactory())),
         (BlockHeadersV65, tuple(BlockHeaderFactory.create_batch(2))),

--- a/tests/core/p2p-proto/test_peer_block_body_validator_api.py
+++ b/tests/core/p2p-proto/test_peer_block_body_validator_api.py
@@ -1,6 +1,5 @@
 import asyncio
 import os
-import random
 import time
 
 import pytest
@@ -8,18 +7,17 @@ import pytest
 import rlp
 
 from eth_utils import (
-    big_endian_to_int,
     keccak,
     to_tuple,
 )
 
 from eth.db.trie import make_trie_root_and_nodes
 from eth.rlp.headers import BlockHeader
-from eth.rlp.transactions import BaseTransactionFields
 
 from trinity.rlp.block_body import BlockBody
 
 from trinity.tools.factories import LatestETHPeerPairFactory
+from trinity.tools.factories.transactions import SerializedTransactionFactory
 
 
 def mk_uncle(block_number):
@@ -33,17 +31,7 @@ def mk_uncle(block_number):
 
 
 def mk_transaction():
-    return BaseTransactionFields(
-        nonce=0,
-        gas=21000,
-        gas_price=1,
-        to=os.urandom(20),
-        value=random.randint(0, 100),
-        data=b'',
-        v=27,
-        r=big_endian_to_int(os.urandom(32)),
-        s=big_endian_to_int(os.urandom(32)),
-    )
+    return SerializedTransactionFactory()
 
 
 def mk_header_and_body(block_number, num_transactions, num_uncles):

--- a/tox.ini
+++ b/tox.ini
@@ -29,27 +29,27 @@ setenv =
 passenv =
     TRAVIS_EVENT_TYPE
 commands=
-    eth1-core: pytest --forked -n 4 {posargs:tests/core/}
-    p2p: pytest --forked -n 4 {posargs:tests/p2p}
-    p2p-trio: pytest --forked -n 4 {posargs:tests-trio/p2p-trio}
-    eth1-components: pytest --forked -n 4 {posargs:tests/components/tx_pool/}
+    eth1-core: pytest --tx '4*popen//execmodel=eventlet' {posargs:tests/core/}
+    p2p: pytest --tx '4*popen//execmodel=eventlet' {posargs:tests/p2p}
+    p2p-trio: pytest --tx '4*popen//execmodel=eventlet' {posargs:tests-trio/p2p-trio}
+    eth1-components: pytest --tx '4*popen//execmodel=eventlet' {posargs:tests/components/tx_pool/}
     # Fixtures that test transitioning from one VM to another. These are otherwise filtered out by
     # the --fork <ForkName> mechanism because they have a fork such as `FrontierToHomesteadAt5`
-    rpc-state-fork-transition: pytest --forked -n 4 {posargs:tests/json-fixtures-over-rpc/test_rpc_fixtures.py -k 'BlockchainTests/TransitionTests'}
+    rpc-state-fork-transition: pytest --tx '4*popen//execmodel=eventlet' {posargs:tests/json-fixtures-over-rpc/test_rpc_fixtures.py -k 'BlockchainTests/TransitionTests'}
     # Fork/VM-specific state transition tests; long-running categories run separately!
-    rpc-state-frontier: pytest --forked -n 4 {posargs:tests/json-fixtures-over-rpc/test_rpc_fixtures.py --fork Frontier -k 'not stQuadraticComplexityTest and not stSStoreTest and not stZeroKnowledge'}
-    rpc-state-homestead: pytest --forked -n 4 {posargs:tests/json-fixtures-over-rpc/test_rpc_fixtures.py --fork Homestead -k 'not stQuadraticComplexityTest and not stSStoreTest and not stZeroKnowledge'}
-    rpc-state-tangerine_whistle: pytest --forked -n 4 {posargs:tests/json-fixtures-over-rpc/test_rpc_fixtures.py --fork EIP150 -k 'not stQuadraticComplexityTest and not stSStoreTest and not stZeroKnowledge'}
-    rpc-state-spurious_dragon: pytest --forked -n 4 {posargs:tests/json-fixtures-over-rpc/test_rpc_fixtures.py --fork EIP158 -k 'not stQuadraticComplexityTest and not stSStoreTest and not stZeroKnowledge'}
+    rpc-state-frontier: pytest --tx '4*popen//execmodel=eventlet' {posargs:tests/json-fixtures-over-rpc/test_rpc_fixtures.py --fork Frontier -k 'not stQuadraticComplexityTest and not stSStoreTest and not stZeroKnowledge'}
+    rpc-state-homestead: pytest --tx '4*popen//execmodel=eventlet' {posargs:tests/json-fixtures-over-rpc/test_rpc_fixtures.py --fork Homestead -k 'not stQuadraticComplexityTest and not stSStoreTest and not stZeroKnowledge'}
+    rpc-state-tangerine_whistle: pytest --tx '4*popen//execmodel=eventlet' {posargs:tests/json-fixtures-over-rpc/test_rpc_fixtures.py --fork EIP150 -k 'not stQuadraticComplexityTest and not stSStoreTest and not stZeroKnowledge'}
+    rpc-state-spurious_dragon: pytest --tx '4*popen//execmodel=eventlet' {posargs:tests/json-fixtures-over-rpc/test_rpc_fixtures.py --fork EIP158 -k 'not stQuadraticComplexityTest and not stSStoreTest and not stZeroKnowledge'}
     # The following test seems to consume a lot of memory. Restricting to 3 processes reduces crashes
-    rpc-state-byzantium: pytest --forked -n 3 {posargs:tests/json-fixtures-over-rpc/test_rpc_fixtures.py --fork Byzantium -k 'not stQuadraticComplexityTest and not stSStoreTest and not stZeroKnowledge'}
-    rpc-state-constantinople: pytest --forked -n 3 {posargs:tests/json-fixtures-over-rpc/test_rpc_fixtures.py --fork Constantinople -k 'not stQuadraticComplexityTest and not stSStoreTest and not stZeroKnowledge'}
-    rpc-state-petersburg: pytest --forked -n 3 {posargs:tests/json-fixtures-over-rpc/test_rpc_fixtures.py --fork ConstantinopleFix -k 'not stQuadraticComplexityTest and not stSStoreTest and not stZeroKnowledge'}
-    rpc-state-istanbul: pytest --forked -n 2 {posargs:tests/json-fixtures-over-rpc/test_rpc_fixtures.py --fork Istanbul -k 'not stQuadraticComplexityTest and not stSStoreTest and not stZeroKnowledge'}
+    rpc-state-byzantium: pytest --tx '3*popen//execmodel=eventlet' {posargs:tests/json-fixtures-over-rpc/test_rpc_fixtures.py --fork Byzantium -k 'not stQuadraticComplexityTest and not stSStoreTest and not stZeroKnowledge'}
+    rpc-state-constantinople: pytest --tx '3*popen//execmodel=eventlet' {posargs:tests/json-fixtures-over-rpc/test_rpc_fixtures.py --fork Constantinople -k 'not stQuadraticComplexityTest and not stSStoreTest and not stZeroKnowledge'}
+    rpc-state-petersburg: pytest --tx '3*popen//execmodel=eventlet' {posargs:tests/json-fixtures-over-rpc/test_rpc_fixtures.py --fork ConstantinopleFix -k 'not stQuadraticComplexityTest and not stSStoreTest and not stZeroKnowledge'}
+    rpc-state-istanbul: pytest --tx '2*popen//execmodel=eventlet' {posargs:tests/json-fixtures-over-rpc/test_rpc_fixtures.py --fork Istanbul -k 'not stQuadraticComplexityTest and not stSStoreTest and not stZeroKnowledge'}
     # Long-running categories.
-    rpc-state-quadratic: pytest --forked -n 4 {posargs:tests/json-fixtures-over-rpc/test_rpc_fixtures.py -k 'GeneralStateTests and stQuadraticComplexityTest'}
-    rpc-state-sstore: pytest --forked -n 4 {posargs:tests/json-fixtures-over-rpc/test_rpc_fixtures.py -k 'GeneralStateTests and stSStoreTest'}
-    rpc-state-zero_knowledge: pytest --forked -n 4 {posargs:tests/json-fixtures-over-rpc/test_rpc_fixtures.py -k 'GeneralStateTests and stZeroKnowledge'}
+    rpc-state-quadratic: pytest --tx '4*popen//execmodel=eventlet' {posargs:tests/json-fixtures-over-rpc/test_rpc_fixtures.py -k 'GeneralStateTests and stQuadraticComplexityTest'}
+    rpc-state-sstore: pytest --tx '4*popen//execmodel=eventlet' {posargs:tests/json-fixtures-over-rpc/test_rpc_fixtures.py -k 'GeneralStateTests and stSStoreTest'}
+    rpc-state-zero_knowledge: pytest --tx '4*popen//execmodel=eventlet' {posargs:tests/json-fixtures-over-rpc/test_rpc_fixtures.py -k 'GeneralStateTests and stZeroKnowledge'}
     sync_integration: pytest -s --integration {posargs:tests/integration/test_sync.py --log-cli-level=debug}
 
 deps = .[p2p,trinity,test,test-asyncio]
@@ -60,11 +60,11 @@ basepython =
 
 [testenv:py38-p2p-trio]
 deps = .[p2p,test,test-trio]
-commands = pytest --forked -n 4 {posargs:tests-trio/p2p-trio}
+commands = pytest --tx '4*popen//execmodel=eventlet' {posargs:tests-trio/p2p-trio}
 
 [testenv:py37-p2p-trio]
 deps = .[p2p,test,test-trio]
-commands = pytest --forked -n 4 {posargs:tests-trio/p2p-trio}
+commands = pytest --tx '4*popen//execmodel=eventlet' {posargs:tests-trio/p2p-trio}
 
 [testenv:py37-docs]
 whitelist_externals=

--- a/trinity/protocol/eth/commands.py
+++ b/trinity/protocol/eth/commands.py
@@ -11,13 +11,12 @@ from rlp import sedes
 from eth.abc import BlockHeaderAPI, ReceiptAPI, SignedTransactionAPI
 from eth.rlp.headers import BlockHeader
 from eth.rlp.receipts import Receipt
-from eth.rlp.transactions import BaseTransactionFields
 
 from p2p.commands import BaseCommand, RLPCodec
 
 from trinity.protocol.common.payloads import BlockHeadersQuery
 from trinity.rlp.block_body import BlockBody
-from trinity.rlp.sedes import HashOrNumber, hash_sedes
+from trinity.rlp.sedes import AnyRLP, HashOrNumber, hash_sedes, SerializedTransaction
 from .forkid import ForkID
 
 from .payloads import (
@@ -70,10 +69,10 @@ class NewBlockHashes(BaseCommand[Tuple[NewBlockHash, ...]]):
     )
 
 
-class Transactions(BaseCommand[Tuple[SignedTransactionAPI, ...]]):
+class Transactions(BaseCommand[Tuple[SerializedTransaction, ...]]):
     protocol_command_id = 2
-    serialization_codec: RLPCodec[Tuple[SignedTransactionAPI, ...]] = RLPCodec(
-        sedes=sedes.CountableList(BaseTransactionFields),
+    serialization_codec: RLPCodec[Tuple[SerializedTransaction, ...]] = RLPCodec(
+        sedes=sedes.CountableList(AnyRLP),
     )
 
 
@@ -117,7 +116,7 @@ class NewBlock(BaseCommand[NewBlockPayload]):
         sedes=sedes.List((
             sedes.List((
                 BlockHeader,
-                sedes.CountableList(BaseTransactionFields),
+                sedes.CountableList(AnyRLP),  # SerializedTransaction
                 sedes.CountableList(BlockHeader)
             )),
             sedes.big_endian_int

--- a/trinity/protocol/eth/payloads.py
+++ b/trinity/protocol/eth/payloads.py
@@ -2,9 +2,10 @@ from typing import NamedTuple, Tuple
 
 from eth_typing import BlockNumber, Hash32
 
-from eth.abc import BlockHeaderAPI, TransactionFieldsAPI
+from eth.abc import BlockHeaderAPI
 
 from trinity.protocol.eth.forkid import ForkID
+from trinity.rlp.sedes import SerializedTransaction
 
 
 class StatusV63Payload(NamedTuple):
@@ -31,7 +32,7 @@ class NewBlockHash(NamedTuple):
 
 class BlockFields(NamedTuple):
     header: BlockHeaderAPI
-    transactions: Tuple[TransactionFieldsAPI, ...]
+    transactions: Tuple[SerializedTransaction, ...]
     uncles: Tuple[BlockHeaderAPI, ...]
 
 

--- a/trinity/protocol/eth/proxy.py
+++ b/trinity/protocol/eth/proxy.py
@@ -28,6 +28,7 @@ from trinity.protocol.common.typing import (
     ReceiptsBundles,
 )
 from trinity.rlp.block_body import BlockBody
+from trinity.rlp.sedes import SerializedTransaction
 
 from .commands import (
     BlockBodiesV65,
@@ -201,7 +202,7 @@ class ProxyETHAPI:
         return response.transactions
 
     def send_transactions(self,
-                          txns: Sequence[SignedTransactionAPI]) -> None:
+                          txns: Sequence[SerializedTransaction]) -> None:
         command = Transactions(tuple(txns))
         self._event_bus.broadcast_nowait(
             SendTransactionsEvent(self.session, command),

--- a/trinity/protocol/eth/servers.py
+++ b/trinity/protocol/eth/servers.py
@@ -35,7 +35,6 @@ from trinity.protocol.eth.peer import (
 )
 
 from eth.rlp.receipts import Receipt
-from eth.rlp.transactions import BaseTransactionFields
 
 from trinity.protocol.eth.constants import (
     MAX_BODIES_FETCH,
@@ -85,7 +84,7 @@ class ETHPeerRequestHandler(BasePeerRequestHandler):
             try:
                 transactions = await self.db.coro_get_block_transactions(
                     header,
-                    BaseTransactionFields,
+                    None,
                 )
             except MissingTrieNode as exc:
                 self.logger.debug(

--- a/trinity/rlp/block_body.py
+++ b/trinity/rlp/block_body.py
@@ -1,13 +1,29 @@
+from typing import (
+    Iterable,
+    Union,
+)
+
+from eth.abc import (
+    BlockHeaderAPI,
+    SignedTransactionAPI,
+)
+from eth.rlp.headers import BlockHeader
 import rlp
 from rlp import sedes
 
-
-from eth.rlp.headers import BlockHeader
-from eth.rlp.transactions import BaseTransactionFields
+from .sedes import AnyRLP, SerializedTransaction
 
 
 class BlockBody(rlp.Serializable):
     fields = [
-        ('transactions', sedes.CountableList(BaseTransactionFields)),
+        ('transactions', sedes.CountableList(AnyRLP)),
         ('uncles', sedes.CountableList(BlockHeader))
     ]
+
+    def __init__(
+            self,
+            transactions: Iterable[Union[SerializedTransaction, SignedTransactionAPI]],
+            uncles: Iterable[BlockHeaderAPI]) -> None:
+        if not isinstance(transactions, (list, bytes)):
+            transactions = rlp.decode(rlp.encode(transactions))
+        super().__init__(transactions, uncles)

--- a/trinity/rlp/sedes.py
+++ b/trinity/rlp/sedes.py
@@ -1,4 +1,20 @@
+from typing import (
+    Any,
+    List,
+    Union,
+)
+
 from rlp import sedes
+
+
+class AnyRLP:
+    @classmethod
+    def serialize(cls, obj: Any) -> Union[bytes, List[bytes]]:
+        return obj
+
+    @classmethod
+    def deserialize(cls, encoded: Union[bytes, List[bytes]]) -> Any:
+        return encoded
 
 
 class HashOrNumber:
@@ -15,3 +31,8 @@ class HashOrNumber:
 
 
 hash_sedes = sedes.Binary(min_length=32, max_length=32)
+
+# We often have to rlp-decode without knowing ahead of time how to interpret the values.
+#   So we just pass around uninterpreted bytes (or list of bytes, for legacy txns),
+#   until the moment that we can use the VM to decode the serialized values.
+SerializedTransaction = Union[bytes, List[bytes]]

--- a/trinity/tools/factories/__init__.py
+++ b/trinity/tools/factories/__init__.py
@@ -23,4 +23,6 @@ from .eth.proto import (  # noqa: F401
 )
 from .headers import BlockHeaderFactory  # noqa: F401
 from .receipts import ReceiptFactory  # noqa: F401
-from .transactions import BaseTransactionFieldsFactory  # noqa: F401
+from .transactions import (  # noqa: F401
+    SerializedTransactionFactory,
+)

--- a/trinity/tools/factories/block_body.py
+++ b/trinity/tools/factories/block_body.py
@@ -6,12 +6,12 @@ except ImportError:
 from trinity.rlp.block_body import BlockBody
 
 from .headers import BlockHeaderFactory
-from .transactions import BaseTransactionFieldsFactory
+from .transactions import SerializedTransactionFactory
 
 
 class BlockBodyFactory(factory.Factory):
     class Meta:
         model = BlockBody
 
-    transactions = factory.LazyFunction(lambda: BaseTransactionFieldsFactory.create_batch(2))
+    transactions = factory.LazyFunction(lambda: SerializedTransactionFactory.create_batch(5))
     uncles = factory.LazyFunction(lambda: BlockHeaderFactory.create_batch(2))

--- a/trinity/tools/factories/eth/payloads.py
+++ b/trinity/tools/factories/eth/payloads.py
@@ -27,7 +27,9 @@ from trinity.protocol.eth.proto import ETHProtocolV63, ETHProtocolV65
 
 from trinity.tools.factories.block_hash import BlockHashFactory
 from trinity.tools.factories.headers import BlockHeaderFactory
-from trinity.tools.factories.transactions import BaseTransactionFieldsFactory
+from trinity.tools.factories.transactions import (
+    SerializedTransactionFactory,
+)
 
 
 class StatusV63PayloadFactory(factory.Factory):
@@ -91,7 +93,7 @@ class BlockFieldsFactory(factory.Factory):
         model = BlockFields
 
     header = factory.SubFactory(BlockHeaderFactory)
-    transactions = factory.LazyFunction(lambda: tuple(BaseTransactionFieldsFactory.create_batch(2)))
+    transactions = factory.LazyFunction(lambda: tuple(SerializedTransactionFactory.create_batch(2)))
     uncles = factory.LazyFunction(lambda: tuple(BlockHeaderFactory.create_batch(2)))
 
 

--- a/trinity/tools/factories/transactions.py
+++ b/trinity/tools/factories/transactions.py
@@ -1,18 +1,37 @@
 try:
     import factory
+    from faker import Faker
 except ImportError:
     raise ImportError("The p2p.tools.factories module requires the `factory_boy` library.")
 
-from typing import Any, Type
+from typing import Any, List, Type, Union
 
 from eth.constants import ZERO_ADDRESS
 from eth.rlp.transactions import BaseTransactionFields
 from eth.vm.forks.frontier.transactions import FrontierUnsignedTransaction
+import rlp
 
 from p2p.tools.factories import PrivateKeyFactory
 
 
-class BaseTransactionFieldsFactory(factory.Factory):
+class SerializedTransactionFactory(factory.Factory):
+    class Meta:
+        model = list
+
+    __faker = Faker()
+    @classmethod
+    def _create(cls,
+                model_class: List[bytes],
+                *args: Any,
+                **kwargs: Any) -> Union[bytes, List[bytes]]:
+
+        if cls.__faker.boolean():
+            return b'\x01' + cls.__faker.pyint().to_bytes(length=64, byteorder='big')
+        else:
+            return rlp.encode(_BaseTransactionFieldsFactory())
+
+
+class _BaseTransactionFieldsFactory(factory.Factory):
     class Meta:
         model = BaseTransactionFields
 


### PR DESCRIPTION
### What was wrong?

Trinity assumes that it knows the shape of a transaction (that it is an rlp decoded list of values). This is all broken in Berlin.

### How was it fixed?

Generalize the transaction handling, before trying to do the Berlin upgrade.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

[//]: # (See: https://trinity-client.readthedocs.io/en/latest/contributing.html#pull-requests)
- [x] Add entry to the [release notes](https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://www.warrenphotographic.co.uk/photography/bigs/43618-Pet-animal-line-up-white-background.jpg)