### PR TITLE
Fix small typo in docs

### DIFF
--- a/docs/guides/quickstart.rst
+++ b/docs/guides/quickstart.rst
@@ -17,7 +17,7 @@ Trinity requires Python 3.7 as well as some tools to compile its dependencies. O
 
 .. code:: sh
 
-  apt-get install python3.6-dev
+  apt-get install python3.7-dev
 
 Trinity is installed through the pip package manager, if pip isn't available on the system already,
 we need to install the ``python3-pip`` package through the following command.


### PR DESCRIPTION
### What was wrong?

Small typo in `docs/guide/quickstart.rs`

### How was it fixed?

Corrects the Python version so it's consistent across the guide

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://www.wallpapergeeks.com/wp-content/uploads/2014/02/Hedgehog-Spiny-Mammal-Wallpaper.jpg)
