### PR TITLE
Make Block Backfilling configurable

### DIFF
--- a/trinity/components/builtin/syncer/component.py
+++ b/trinity/components/builtin/syncer/component.py
@@ -117,6 +117,16 @@ def add_disable_backfill_arg(arg_group: _ArgumentGroup) -> None:
     )
 
 
+def add_disable_block_backfill_arg(arg_group: _ArgumentGroup) -> None:
+    add_shared_argument(
+        arg_group,
+        '--disable-block-backfill',
+        action="store_true",
+        help="Disable only backfilling of blocks (maintaining historical headers)",
+        default=False,
+    )
+
+
 class BaseSyncStrategy(ABC):
 
     @classmethod
@@ -202,6 +212,7 @@ class BeamSyncStrategy(BaseSyncStrategy):
             default=None,
         )
         add_disable_backfill_arg(arg_group)
+        add_disable_block_backfill_arg(arg_group)
         add_sync_from_checkpoint_arg(arg_group)
 
     async def sync(self,
@@ -228,6 +239,7 @@ class BeamSyncStrategy(BaseSyncStrategy):
             args.sync_from_checkpoint,
             args.force_beam_block_number,
             not args.disable_backfill,
+            not args.disable_block_backfill,
             sync_metrics_registry,
         )
 

--- a/trinity/sync/beam/chain.py
+++ b/trinity/sync/beam/chain.py
@@ -138,7 +138,8 @@ class BeamSyncer(Service):
             checkpoint: Checkpoint = None,
             force_beam_block_number: BlockNumber = None,
             enable_backfill: bool = True,
-            enable_state_backfill: bool = True) -> None:
+            enable_state_backfill: bool = True,
+            enable_block_backfill: bool = True) -> None:
         self.logger = get_logger('trinity.sync.beam.chain.BeamSyncer')
 
         self.metrics_registry = metrics_registry
@@ -230,8 +231,9 @@ class BeamSyncer(Service):
             self.manager.cancel()
             return
 
-        self.manager.run_daemon_child_service(self._block_importer)
-        self.manager.run_daemon_child_service(self._header_syncer)
+        if self.enable_block_backfill:
+            self.manager.run_daemon_child_service(self._block_importer)
+            self.manager.run_daemon_child_service(self._header_syncer)
 
         # Kick off the body syncer early (it hangs on the launchpoint header syncer anyway)
         # It needs to start early because we want to "re-run" the header at the tip,

--- a/trinity/sync/beam/service.py
+++ b/trinity/sync/beam/service.py
@@ -50,6 +50,7 @@ class BeamSyncService(Service):
             checkpoint: Checkpoint = None,
             force_beam_block_number: BlockNumber = None,
             enable_header_backfill: bool = False,
+            enable_block_backfill: bool = False,
             sync_metrics_registry: SyncMetricsRegistry = None) -> None:
         self.logger = get_logger('trinity.sync.beam.service.BeamSyncService')
         self.chain = chain
@@ -60,6 +61,7 @@ class BeamSyncService(Service):
         self.checkpoint = checkpoint
         self.force_beam_block_number = force_beam_block_number
         self.enable_header_backfill = enable_header_backfill
+        self.enable_block_backfill = enable_block_backfill
         self.sync_metrics_registry = sync_metrics_registry
 
     @cached_property
@@ -98,6 +100,7 @@ class BeamSyncService(Service):
                 self.checkpoint,
                 self.force_beam_block_number,
                 self.enable_header_backfill,
+                self.enable_block_backfill,
             )
             self.manager.run_child_service(beam_syncer)
             do_pivot = await self._monitor_for_pivot(beam_syncer)


### PR DESCRIPTION
### What was wrong?
As explained in #1832, Trinity does currently not allow disabling only backfilling of blocks (maintaining headers). This should be configureable.


### How was it fixed?
1. Added a flag ```--disable-block-backfill``` in the ```trinity/components/syncer/component.py```
2. Passed a variable called ```enable_block_backfill``` to ```BeamSyncer``` class
3. When ```enable_block_backfill == False```, disable Block Importer and Headers Syncer services 


### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

[//]: # (See: https://trinity-client.readthedocs.io/en/latest/contributing.html#pull-requests)
- [ ] Add entry to the [release notes](https://github.com/ethereum/trinity/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://protecaoanimal.curitiba.pr.gov.br/images/animais-silvestres/vertebrados/mamiferos/79.capivara-Morato-n-68.jpg)
